### PR TITLE
Backport PR #12154: Avoid triggering deprecation warnings with pytest 3.8.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,8 +66,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.6.0,<3.8" "pytest-cov>=2.3.1"
-    pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.6.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest!=3.3.0,>=3.2.0,<3.8" "pytest-cov>=2.3.1"
+  - pip install -q "pytest>=3.6.0,<3.8" "pytest-cov>=2.3.1"
     pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.6.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.6.1" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,8 @@ env:
     - PANDAS=
     - PILLOW=pillow
     - PYPARSING=pyparsing
-    - PYTEST='pytest>=3.6,<3.8'
+    - PYTEST='pytest>=3.6'
     - PYTEST_COV=pytest-cov
-    - PYTEST_RERUNFAILURES=pytest-rerunfailures
     - PYTEST_PEP8=
     - PYTEST_TIMEOUT=pytest-timeout
     - SPHINX=sphinx
@@ -81,7 +80,6 @@ matrix:
         - PYTEST=pytest==3.6.0
         - PYTEST_COV=pytest-cov==2.3.1
         - PYTEST_TIMEOUT=pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest <3.4.
-        - PYTEST_RERUNFAILURES='pytest-rerunfailures<5'  # 5 needs pytest>=3.6
         - SPHINX=sphinx==1.3
     - python: 3.4
       env: PYTHON_ARGS=-OO
@@ -177,7 +175,7 @@ install:
         $PYTEST_COV \
         pytest-faulthandler \
         $PYTEST_PEP8 \
-        $PYTEST_RERUNFAILURES \
+        pytest-rerunfailures \
         $PYTEST_TIMEOUT \
         pytest-xdist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ env:
     - PANDAS=
     - PILLOW=pillow
     - PYPARSING=pyparsing
-    - PYTEST='pytest>=3.6'
+    - PYTEST='pytest>=3.6.1'
     - PYTEST_COV=pytest-cov
     - PYTEST_PEP8=
     - PYTEST_TIMEOUT=pytest-timeout
@@ -73,6 +73,7 @@ matrix:
   include:
     - python: 2.7
       # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124.
+      # pytest>=3.6.1 due to https://github.com/pytest-dev/pytest/commit/b5a94d8e6c49201c8c79a7c52b8466e020e6d6b8
       env:
         - CYCLER=cycler==0.10
         - DATEUTIL=python-dateutil==2.1
@@ -81,7 +82,7 @@ matrix:
         - NUMPY=numpy==1.7.1
         - PANDAS='pandas<0.21.0'
         - PYPARSING=pyparsing==2.0.1
-        - PYTEST=pytest==3.6.0
+        - PYTEST=pytest==3.6.1
         - PYTEST_COV=pytest-cov==2.3.1
         - PYTEST_TIMEOUT=pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest <3.4.
         - SPHINX=sphinx==1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 dist: xenial
 sudo: false
 
+services:
+  - xvfb
+  
 branches:
   except:
   - /^auto-backport-of-pr-\d*/
@@ -186,12 +189,6 @@ install:
     # Install matplotlib
     pip install -ve .
 
-before_script:
-  - |
-    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
-      export DISPLAY=:99.0
-      systemctl start Xvfb.service
-    fi
 
 script: ci/travis/test_script.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ env:
     - PYPARSING=pyparsing
     - PYTEST='pytest>=3.6.1'
     - PYTEST_COV=pytest-cov
+    - PYTEST_RERUNFAILURES=pytest-rerunfailures
     - PYTEST_PEP8=
     - PYTEST_TIMEOUT=pytest-timeout
     - SPHINX=sphinx
@@ -84,6 +85,7 @@ matrix:
         - PYPARSING=pyparsing==2.0.1
         - PYTEST=pytest==3.6.1
         - PYTEST_COV=pytest-cov==2.3.1
+        - PYTEST_RERUNFAILURES='pytest-rerunfailures<6'  # 6 needs pytest >=3.8
         - PYTEST_TIMEOUT=pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest <3.4.
         - SPHINX=sphinx==1.3
     - python: 3.4
@@ -180,7 +182,7 @@ install:
         $PYTEST_COV \
         pytest-faulthandler \
         $PYTEST_PEP8 \
-        pytest-rerunfailures \
+        $PYTEST_RERUNFAILURES \
         $PYTEST_TIMEOUT \
         pytest-xdist
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,7 @@ before_script:
   - |
     if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
       export DISPLAY=:99.0
-      sh -e /etc/init.d/xvfb start
+      systemctl start Xvfb.service
     fi
 
 script: ci/travis/test_script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,6 @@ env:
     - PANDAS=
     - PILLOW=pillow
     - PYPARSING=pyparsing
-    # pytest-timeout master depends on pytest>=3.6.  Testing with pytest 3.1 is
-    # still supported; this is tested by the first matrix entry.
     - PYTEST='pytest>=3.6,<3.8'
     - PYTEST_COV=pytest-cov
     - PYTEST_RERUNFAILURES=pytest-rerunfailures
@@ -80,7 +78,7 @@ matrix:
         - NUMPY=numpy==1.7.1
         - PANDAS='pandas<0.21.0'
         - PYPARSING=pyparsing==2.0.1
-        - PYTEST=pytest==3.1.0
+        - PYTEST=pytest==3.6.0
         - PYTEST_COV=pytest-cov==2.3.1
         - PYTEST_TIMEOUT=pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest <3.4.
         - PYTEST_RERUNFAILURES='pytest-rerunfailures<5'  # 5 needs pytest>=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
       - texlive-latex-extra
       - texlive-latex-recommended
       - texlive-xetex
+      - xvfb
 
 env:
   global:

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -109,7 +109,7 @@ value.
 Installing Matplotlib in developer mode
 ---------------------------------------
 
-To install Matplotlib (and compile the c-extensions) run the following
+To install Matplotlib (and compile the C-extensions) run the following
 command from the top-level directory ::
 
    python -mpip install -ve .
@@ -148,11 +148,11 @@ environment is set up properly::
 .. _pep8: https://pep8.readthedocs.io/en/latest/
 .. _mock: https://docs.python.org/dev/library/unittest.mock.html
 .. _Ghostscript: https://www.ghostscript.com/
-.. _Inkscape: https://inkscape.org>
+.. _Inkscape: https://inkscape.org/
 
 .. note::
 
-  **Additional dependencies for testing**: pytest_ (version 3.1 or later),
+  **Additional dependencies for testing**: pytest_ (version 3.6 or later),
   mock_ (if Python 2), Ghostscript_, Inkscape_
 
 .. seealso::

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -22,11 +22,11 @@ Requirements
 
 Install the latest version of Matplotlib as documented in
 :ref:`installing_for_devs` In particular, follow the instructions to use a
-local FreeType build
+local FreeType build.
 
 The following software is required to run the tests:
 
-  - pytest_ (>=3.1)
+  - pytest_ (>=3.6)
   - mock_, when running Python 2
   - Ghostscript_ (to render PDF files)
   - Inkscape_ (to render SVG files)

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -391,7 +391,7 @@ class RendererAgg(RendererBase):
         self._update_methods()
 
         if w > 0 and h > 0:
-            img = np.fromstring(buffer, np.uint8)
+            img = np.frombuffer(buffer, np.uint8)
             img, ox, oy = post_processing(img.reshape((h, w, 4)) / 255.,
                                           self.dpi)
             gc = self.new_gc()

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1369,10 +1369,9 @@ class AutoDateLocator(DateLocator):
         else:
             locator = MicrosecondLocator(interval, tz=self.tz)
             if dmin.year > 20 and interval < 1000:
-                _log.warn('Plotting microsecond time intervals is not'
-                          ' well supported. Please see the'
-                          ' MicrosecondLocator documentation'
-                          ' for details.')
+                _log.warning('Plotting microsecond time intervals is not well '
+                             'supported. Please see the MicrosecondLocator '
+                             'documentation for details.')
 
         locator.set_axis(self.axis)
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1447,9 +1447,9 @@ def pil_to_array(pilImage):
         # return MxN luminance array of uint16
         raw = pilImage.tobytes('raw', pilImage.mode)
         if pilImage.mode.endswith('B'):
-            x = np.fromstring(raw, '>u2')
+            x = np.frombuffer(raw, '>u2')
         else:
-            x = np.fromstring(raw, '<u2')
+            x = np.frombuffer(raw, '<u2')
         return x.reshape(pilImage.size[::-1]).astype('=u2')
     else:  # try to convert to an rgba image
         try:

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -24,19 +24,19 @@ def mpl_test_settings(request):
     original_settings = matplotlib.rcParams.copy()
 
     backend = None
-    backend_marker = request.keywords.get('backend')
+    backend_marker = request.node.get_closest_marker('backend')
     if backend_marker is not None:
         assert len(backend_marker.args) == 1, \
             "Marker 'backend' must specify 1 backend."
-        backend = backend_marker.args[0]
+        backend, = backend_marker.args
         prev_backend = matplotlib.get_backend()
 
     style = '_classic_test'  # Default of cleanup and image_comparison too.
-    style_marker = request.keywords.get('style')
+    style_marker = request.node.get_closest_marker('style')
     if style_marker is not None:
         assert len(style_marker.args) == 1, \
             "Marker 'style' must specify 1 style."
-        style = style_marker.args[0]
+        style, = style_marker.args
 
     matplotlib.testing.setup()
     if backend is not None:
@@ -64,7 +64,7 @@ def mpl_image_comparison_parameters(request, extension):
     # pytest won't get confused.
     # We annotate the decorated function with any parameters captured by this
     # fixture so that they can be used by the wrapper in image_comparison.
-    baseline_images = request.keywords['baseline_images'].args[0]
+    baseline_images, = request.node.get_closest_marker('baseline_images').args
     if baseline_images is None:
         # Allow baseline image list to be produced on the fly based on current
         # parametrization.

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -223,12 +223,18 @@ def _xfail_if_format_is_uncomparable(extension):
 
 def _mark_xfail_if_format_is_uncomparable(extension):
     if isinstance(extension, six.string_types):
-        will_fail = extension not in comparable_formats()
+        name = extension
+    elif isinstance(extension, tuple):
+        # Extension might be a pytest ParameterSet instead of a plain string.
+        # Unfortunately, this type is not exposed, so since it's a namedtuple,
+        # check for a tuple instead.
+        name = extension.values[0]
     else:
         # Extension might be a pytest marker instead of a plain string.
-        will_fail = extension.args[0] not in comparable_formats()
-    if will_fail:
-        fail_msg = 'Cannot compare %s files on this system' % extension
+        name = extension.args[0]
+
+    if name not in comparable_formats():
+        fail_msg = 'Cannot compare %s files on this system' % (name, )
         import pytest
         return pytest.mark.xfail(extension, reason=fail_msg, strict=False,
                                  raises=ImageComparisonFailure)

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -224,20 +224,24 @@ def _xfail_if_format_is_uncomparable(extension):
 def _mark_xfail_if_format_is_uncomparable(extension):
     if isinstance(extension, six.string_types):
         name = extension
+        marks = []
     elif isinstance(extension, tuple):
         # Extension might be a pytest ParameterSet instead of a plain string.
         # Unfortunately, this type is not exposed, so since it's a namedtuple,
         # check for a tuple instead.
         name = extension.values[0]
+        marks = list(extension.marks)
     else:
         # Extension might be a pytest marker instead of a plain string.
         name = extension.args[0]
+        marks = [extension.mark]
 
     if name not in comparable_formats():
         fail_msg = 'Cannot compare %s files on this system' % (name, )
         import pytest
-        return pytest.mark.xfail(extension, reason=fail_msg, strict=False,
-                                 raises=ImageComparisonFailure)
+        marks += [pytest.mark.xfail(reason=fail_msg, strict=False,
+                                    raises=ImageComparisonFailure)]
+        return pytest.param(name, marks=marks)
     else:
         return extension
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -8,6 +8,7 @@ import io
 import os
 import sys
 import tempfile
+import warnings
 
 import numpy as np
 import pytest
@@ -20,9 +21,11 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_usetex = pytest.mark.skipif(
-    not checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    needs_usetex = pytest.mark.skipif(
+        not checkdep_usetex(True),
+        reason="This test needs a TeX installation")
 
 
 @image_comparison(baseline_images=['pdf_use14corefonts'],

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -20,7 +20,7 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -17,12 +17,10 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_ghostscript = pytest.mark.xfail(
+needs_ghostscript = pytest.mark.skipif(
     matplotlib.checkdep_ghostscript()[0] is None,
     reason="This test needs a ghostscript installation")
-
-
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -31,13 +31,16 @@ needs_usetex = pytest.mark.xfail(
 @pytest.mark.flaky(reruns=3)
 @pytest.mark.parametrize('format, use_log, rcParams', [
     ('ps', False, {}),
-    needs_ghostscript(('ps', False, {'ps.usedistiller': 'ghostscript'})),
-    needs_usetex(needs_ghostscript(('ps', False, {'text.latex.unicode': True,
-                                                  'text.usetex': True}))),
+    pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
+                 marks=needs_ghostscript),
+    pytest.param('ps', False, {'text.latex.unicode': True,
+                               'text.usetex': True},
+                 marks=[needs_ghostscript, needs_usetex]),
     ('eps', False, {}),
     ('eps', True, {'ps.useafm': True}),
-    needs_usetex(needs_ghostscript(('eps', False, {'text.latex.unicode': True,
-                                                   'text.usetex': True}))),
+    pytest.param('eps', False, {'text.latex.unicode': True,
+                                'text.usetex': True},
+                 marks=[needs_ghostscript, needs_usetex]),
 ], ids=[
     'ps',
     'ps with distiller',

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 import io
 import re
+import warnings
 
 import numpy as np
 import pytest
@@ -17,12 +18,14 @@ from matplotlib.testing.determinism import (_determinism_source_date_epoch,
                                             _determinism_check)
 
 
-needs_ghostscript = pytest.mark.skipif(
-    matplotlib.checkdep_ghostscript()[0] is None,
-    reason="This test needs a ghostscript installation")
-needs_usetex = pytest.mark.skipif(
-    not matplotlib.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    needs_ghostscript = pytest.mark.skipif(
+        matplotlib.checkdep_ghostscript()[0] is None,
+        reason="This test needs a ghostscript installation")
+    needs_usetex = pytest.mark.skipif(
+        not matplotlib.checkdep_usetex(True),
+        reason="This test needs a TeX installation")
 
 
 # This tests tends to hit a TeX cache lock on AppVeyor.

--- a/lib/matplotlib/tests/test_backend_qt4.py
+++ b/lib/matplotlib/tests/test_backend_qt4.py
@@ -29,7 +29,7 @@ except AttributeError:
     py_qt_ver = QtCore.__version_info__[0]
 
 if py_qt_ver != 4:
-    pytestmark = pytest.mark.xfail(reason='Qt4 is not available')
+    pytestmark = pytest.mark.skipif(reason='Qt4 is not available')
 
 
 @pytest.mark.backend('Qt4Agg')

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -16,7 +16,7 @@ import matplotlib
 from matplotlib import dviread
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -130,7 +130,7 @@ def _test_determinism_save(filename, usetex):
     "filename, usetex",
     # unique filenames to allow for parallel testing
     [("determinism_notex.svg", False),
-     needs_usetex(("determinism_tex.svg", True))])
+     pytest.param("determinism_tex.svg", True, marks=needs_usetex)])
 def test_determinism(filename, usetex):
     import sys
     from subprocess import check_output, STDOUT, CalledProcessError

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -6,6 +6,7 @@ import numpy as np
 from io import BytesIO
 import os
 import tempfile
+import warnings
 import xml.parsers.expat
 
 import pytest
@@ -16,9 +17,11 @@ import matplotlib
 from matplotlib import dviread
 
 
-needs_usetex = pytest.mark.skipif(
-    not matplotlib.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    needs_usetex = pytest.mark.skipif(
+        not matplotlib.checkdep_usetex(True),
+        reason="This test needs a TeX installation")
 
 
 def test_visibility():

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -31,8 +31,10 @@ def _get_testable_interactive_backends():
             reason = "No $DISPLAY"
         elif any(importlib.util.find_spec(dep) is None for dep in deps):
             reason = "Missing dependency"
-        backends.append(pytest.mark.skip(reason=reason)(backend) if reason
-                        else backend)
+        if reason:
+            backend = pytest.param(
+                backend, marks=pytest.mark.skip(reason=reason))
+        backends.append(backend)
     return backends
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -23,14 +23,6 @@ from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
 import pytest
 
 
-try:
-    from PIL import Image
-    HAS_PIL = True
-except ImportError:
-    HAS_PIL = False
-needs_pillow = pytest.mark.xfail(not HAS_PIL, reason='Test requires Pillow')
-
-
 @image_comparison(baseline_images=['image_interps'], style='mpl20')
 def test_image_interps():
     'make the basic nearest, bilinear and bicubic interps'
@@ -113,8 +105,8 @@ def test_image_python_io():
     plt.imread(buffer)
 
 
-@needs_pillow
 def test_imread_pil_uint16():
+    pytest.importorskip("PIL")
     img = plt.imread(os.path.join(os.path.dirname(__file__),
                      'baseline_images', 'test_image', 'uint16.tif'))
     assert (img.dtype == np.uint16)
@@ -122,8 +114,8 @@ def test_imread_pil_uint16():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason="requires Python 3.6+")
-@needs_pillow
 def test_imread_fspath():
+    pytest.importorskip("PIL")
     from pathlib import Path
     img = plt.imread(
         Path(__file__).parent / 'baseline_images/test_image/uint16.tif')
@@ -497,8 +489,8 @@ def test_nonuniformimage_setnorm():
     im.set_norm(plt.Normalize())
 
 
-@needs_pillow
 def test_jpeg_2d():
+    Image = pytest.importorskip('PIL.Image')
     # smoke test that mode-L pillow images work.
     imd = np.ones((10, 10), dtype='uint8')
     for i in range(10):
@@ -509,8 +501,9 @@ def test_jpeg_2d():
     ax.imshow(im)
 
 
-@needs_pillow
 def test_jpeg_alpha():
+    Image = pytest.importorskip('PIL.Image')
+
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
     # the alpha channel from left to right.

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -271,7 +271,7 @@ def test_single_minus_sign():
 
     buff = io.BytesIO()
     plt.savefig(buff, format="rgba", dpi=1000)
-    array = np.fromstring(buff.getvalue(), dtype=np.uint8)
+    array = np.frombuffer(buff.getvalue(), dtype=np.uint8)
 
     # If this fails, it would be all white
     assert not np.all(array == 0xff)

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -273,7 +273,7 @@ AAj1//+nPwAA/////w=="""
         # Python 2 case
         decodebytes = base64.decodestring
 
-    verts = np.fromstring(decodebytes(data), dtype='<i4')
+    verts = np.frombuffer(decodebytes(data), dtype='<i4')
     verts = verts.reshape((len(verts) // 2, 2))
     path = Path(verts)
     segs = path.iter_segments(transforms.IdentityTransform(),

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -14,9 +14,11 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-needs_usetex = pytest.mark.skipif(
-    not matplotlib.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    needs_usetex = pytest.mark.skipif(
+        not matplotlib.checkdep_usetex(True),
+        reason="This test needs a TeX installation")
 
 
 @image_comparison(baseline_images=['font_styles'])

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-needs_usetex = pytest.mark.xfail(
+needs_usetex = pytest.mark.skipif(
     not matplotlib.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+import warnings
 
 import pytest
 
@@ -7,8 +8,14 @@ from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 
 
-@pytest.mark.skipif(not matplotlib.checkdep_usetex(True),
-                    reason='Missing TeX or Ghostscript or dvipng')
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    needs_usetex = pytest.mark.skipif(
+        not matplotlib.checkdep_usetex(True),
+        reason='Missing TeX of Ghostscript or dvipng')
+
+
+@needs_usetex
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
                   tol=0.3)

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -581,9 +581,9 @@ class CubicTriInterpolator(TriInterpolator):
               The so-called eccentricity parameters [1] needed for
               HCT triangular element.
         """
-        a = np.expand_dims(tris_pts[:, 2, :]-tris_pts[:, 1, :], axis=2)
-        b = np.expand_dims(tris_pts[:, 0, :]-tris_pts[:, 2, :], axis=2)
-        c = np.expand_dims(tris_pts[:, 1, :]-tris_pts[:, 0, :], axis=2)
+        a = np.expand_dims(tris_pts[:, 2, :] - tris_pts[:, 1, :], axis=2)
+        b = np.expand_dims(tris_pts[:, 0, :] - tris_pts[:, 2, :], axis=2)
+        c = np.expand_dims(tris_pts[:, 1, :] - tris_pts[:, 0, :], axis=2)
         # Do not use np.squeeze, this is dangerous if only one triangle
         # in the triangulation...
         dot_a = _prod_vectorized(_transpose_vectorized(a), a)[:, 0, 0]
@@ -1071,9 +1071,9 @@ class _DOF_estimator():
         J1 = _prod_vectorized(_ReducedHCT_Element.J0_to_J1, J)
         J2 = _prod_vectorized(_ReducedHCT_Element.J0_to_J2, J)
 
-        col0 = _prod_vectorized(J, np.expand_dims(tri_dz[:, 0, :], axis=3))
-        col1 = _prod_vectorized(J1, np.expand_dims(tri_dz[:, 1, :], axis=3))
-        col2 = _prod_vectorized(J2, np.expand_dims(tri_dz[:, 2, :], axis=3))
+        col0 = _prod_vectorized(J, np.expand_dims(tri_dz[:, 0, :], axis=2))
+        col1 = _prod_vectorized(J1, np.expand_dims(tri_dz[:, 1, :], axis=2))
+        col2 = _prod_vectorized(J2, np.expand_dims(tri_dz[:, 2, :], axis=2))
 
         dfdksi = _to_matrix_vectorized([
             [col0[:, 0, 0], col1[:, 0, 0], col2[:, 0, 0]],

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -125,9 +125,10 @@ def test_lines3d():
 
 
 # Reason for flakiness of SVG test is still unknown.
-@image_comparison(baseline_images=['mixedsubplot'], remove_text=True,
-                  extensions=['png', 'pdf',
-                              pytest.mark.xfail('svg', strict=False)])
+@image_comparison(
+    baseline_images=['mixedsubplot'], remove_text=True,
+    extensions=['png', 'pdf',
+                pytest.param('svg', marks=pytest.mark.xfail(strict=False))])
 def test_mixedsubplots():
     def f(t):
         s1 = np.cos(2*np.pi*t)

--- a/setupext.py
+++ b/setupext.py
@@ -785,7 +785,7 @@ class Toolkits(OptionalPackage):
 
 class Tests(OptionalPackage):
     name = "tests"
-    pytest_min_version = '3.1'
+    pytest_min_version = '3.6'
     default_config = False
 
     def check(self):


### PR DESCRIPTION
Once merged, a follow-up PR should revert https://github.com/matplotlib/matplotlib/commit/d7e378974b7b0a739d209994b27fe465616788fa as was done in https://github.com/matplotlib/matplotlib/pull/13159 for v3.0.x.

My only fear is that bumping `pytest` requirement could be seen as an issue (based on my interpretation on https://github.com/matplotlib/matplotlib/pull/13159#issuecomment-453739099).