### PR TITLE
FIX: bar mixed units, allow ValueError as well

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2057,7 +2057,7 @@ class Axes(_AxesBase):
             dx = [convert(x0 + ddx) - x for ddx in dx]
             if delist:
                 dx = dx[0]
-        except (ValueEerror, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError):
             # if the above fails (for any reason) just fallback to what
             # we do by default and convert dx by iteslf.
             dx = convert(dx)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2057,7 +2057,7 @@ class Axes(_AxesBase):
             dx = [convert(x0 + ddx) - x for ddx in dx]
             if delist:
                 dx = dx[0]
-        except Exception:
+        except (ValueEerror, TypeError, AttributeError):
             # if the above fails (for any reason) just fallback to what
             # we do by default and convert dx by iteslf.
             dx = convert(dx)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2057,9 +2057,9 @@ class Axes(_AxesBase):
             dx = [convert(x0 + ddx) - x for ddx in dx]
             if delist:
                 dx = dx[0]
-        except (TypeError, AttributeError) as e:
-            # but doesn't work for 'string' + float, so just
-            # see if the converter works on the float.
+        except Exception:
+            # if the above fails (for any reason) just fallback to what
+            # we do by default and convert dx by iteslf.
             dx = convert(dx)
         return dx
 


### PR DESCRIPTION
## PR Summary

Closes #13186

Follow up to #12903 where we try and do math first for `bar` (x+dx) before units conversion.  Pandas throws a `ValueError` for a previously working case.  This adds that to the allowable `excepts`...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->