### PR TITLE
Deprecate "default" and "constant" as synonyms to "mean" detrending.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -63,3 +63,11 @@ it via the *cmap* parameter:
 ``DateFormatter.illegal_s``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This attribute is unused and deprecated.
+
+"default" and "constant" detrending
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing "default" or "constant" as synonyms of "mean" as the detrending
+method for the various spectral functions (`.Axes.psd`, `.mlab.detrend`,
+etc.) is deprecated.  This is because the default detrending method of all
+these functions is actually "none" and *not* "default"/"mean", except for
+`.mlab.detrend` which does default to "mean".

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -150,12 +150,12 @@ def detrend(x, key=None, axis=None):
     x : array or sequence
         Array or sequence containing the data.
 
-    key : {'default', 'constant', 'mean', 'linear', 'none'} or function
-        The detrending algorithm to use. 'default', 'mean', and 'constant' are
-        the same as `detrend_mean`. 'linear' is the same as `detrend_linear`.
-        'none' is the same as `detrend_none`. The default is 'mean'. See the
-        corresponding functions for more details regarding the algorithms. Can
-        also be a function that carries out the detrend operation.
+    key : {'mean', 'linear', 'none'} or callable, default: 'mean'
+        The function that performs the detrending.  The string values 'mean'
+        (the default), 'linear' and 'none' respectively correspond to the
+        functions `detrend_mean`, `detrend_linear`, and `detrend_none`; see the
+        docstrings of these functions for additional details.  'constant' and
+        'default' are deprecated synonyms for 'mean'.
 
     axis : int
         The axis along which to do the detrending.
@@ -167,6 +167,11 @@ def detrend(x, key=None, axis=None):
     detrend_none : Implementation of the 'none' algorithm.
     '''
     if key is None or key in ['constant', 'mean', 'default']:
+        if key in ['constant', 'default']:
+            cbook.warn_deprecated(
+                "3.3", name=repr(key),
+                obj_type="string value for the 'key' argument to detrend()",
+                alternative="'mean'")
         return detrend(x, key=detrend_mean, axis=axis)
     elif key == 'linear':
         return detrend(x, key=detrend_linear, axis=axis)

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -760,7 +760,7 @@ class TestDetrend:
         assert_allclose(res, targ,
                         atol=1e-08)
 
-    def test_detrend_str_constant_2D_none_T(self):
+    def test_detrend_str_constant_2D_none_T(self, recwarn):
         arri = [self.sig_off,
                 self.sig_base + self.sig_off]
         arrt = [self.sig_zeros,
@@ -771,7 +771,7 @@ class TestDetrend:
         assert_allclose(res.T, targ,
                         atol=1e-08)
 
-    def test_detrend_str_default_2D_axis1(self):
+    def test_detrend_str_default_2D_axis1(self, recwarn):
         arri = [self.sig_base,
                 self.sig_base + self.sig_off,
                 self.sig_base + self.sig_slope,


### PR DESCRIPTION
## PR Summary

See rationale in deprecation notice.

Goes on top of #13177 (https://github.com/matplotlib/matplotlib/pull/13177#discussion_r248549789).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
