### PR TITLE
Allow saving PNGs through Pillow instead of the builtin _png module.

### DIFF
--- a/doc/users/next_whats_new/2018-01-03-AL.rst
+++ b/doc/users/next_whats_new/2018-01-03-AL.rst
@@ -4,3 +4,7 @@
 Matplotlib uses Pillow to handle saving to the JPEG and TIFF formats.  The
 `~Figure.savefig()` function gained a *pil_kwargs* keyword argument, which can
 be used to forward arguments to Pillow's `PIL.Image.save()`.
+
+The *pil_kwargs* argument can also be used when saving to PNG.  In that case,
+Matplotlib also uses Pillow's `PIL.Image.save()` instead of going through its
+own builtin PNG support.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2106,7 +2106,8 @@ default: 'top'
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to `PIL.Image.save`
             when saving the figure.  Only applicable for formats that are saved
-            using Pillow, i.e. JPEG and TIFF.
+            using Pillow, i.e. JPEG, TIFF, and (if the keyword is set to a
+            non-None value) PNG.
         """
 
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -241,7 +241,18 @@ def test_jpeg_dpi():
     assert im.info['dpi'] == (200, 200)
 
 
-def test_pil_kwargs():
+def test_pil_kwargs_png():
+    Image = pytest.importorskip("PIL.Image")
+    from PIL.PngImagePlugin import PngInfo
+    buf = io.BytesIO()
+    pnginfo = PngInfo()
+    pnginfo.add_text("Software", "test")
+    plt.figure().savefig(buf, format="png", pil_kwargs={"pnginfo": pnginfo})
+    im = Image.open(buf)
+    assert im.info["Software"] == "test"
+
+
+def test_pil_kwargs_tiff():
     Image = pytest.importorskip("PIL.Image")
     from PIL.TiffTags import TAGS_V2 as TAGS
     buf = io.BytesIO()


### PR DESCRIPTION
## PR Summary

(Because Pillow exposes more (most?) PNG options.)
Closes #5397.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
