### PR TITLE
Deprecate case-insensitive colors.

### DIFF
--- a/doc/api/next_api_changes/2019-01-19-AL.rst
+++ b/doc/api/next_api_changes/2019-01-19-AL.rst
@@ -1,0 +1,10 @@
+Deprecations
+````````````
+
+Support for passing colors as UPPERCASE strings is deprecated; color names will
+become case-sensitive (all-lowercase) after the deprecation period has passed.
+
+The goal is to decrease the number of ambiguous cases when using the ``data``
+keyword to plotting methods; e.g. ``plot("X", "Y", data={"X": ..., "Y": ...})``
+will not warn about "Y" possibly being a color anymore after the deprecation
+period has passed.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -194,9 +194,17 @@ def _to_rgba_no_colorcycle(c, alpha=None):
         # Named color.
         try:
             # This may turn c into a non-string, so we check again below.
-            c = _colors_full_map[c.lower()]
+            c = _colors_full_map[c]
         except KeyError:
-            pass
+            try:
+                c = _colors_full_map[c.lower()]
+            except KeyError:
+                pass
+            else:
+                cbook.warn_deprecated(
+                    "3.1", message="Support for case-insensitive colors is "
+                    "deprecated since Matplotlib %(since)s and will be "
+                    "removed %(removal)s.")
     if isinstance(c, str):
         # hex color with no alpha.
         match = re.match(r"\A#[a-fA-F0-9]{6}\Z", c)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6036,3 +6036,11 @@ def test_annotate_across_transforms():
     ax.annotate("", xy=(x[150], y[150]), xycoords=ax.transData,
             xytext=(1, 0), textcoords=axins.transAxes,
             arrowprops=dict(arrowstyle="->"))
+
+
+def test_deprecated_uppercase_colors():
+    # Remove after end of deprecation period.
+    fig, ax = plt.subplots()
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ax.plot([1, 2], color="B")
+        fig.canvas.draw()


### PR DESCRIPTION
The motivation is explained in the changelog entry.

Note that even though

    plt.plot([1, 2], [3, 4], "Y")

"worked" so far,

    plt.plot([1, 2], [3, 4], "Yo")

(for example), i.e. additionally passing a marker spec, has not worked
at least since matplotlib 1.5 (a ValueError is thrown).  As this does
not appear to have ever been raised on the issue tracker, I believe the
number of users of UPPERCASE colors must be limited.

(noted while working on #13210, where I had to use "Y0" instead of "Y"...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
