### PR TITLE
Broadcast 'orientations' arg to Sankey.add.

### DIFF
--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -443,12 +443,14 @@ class Sankey(object):
             # In the code below, angles are expressed in deg/90.
             rotation /= 90.0
         if orientations is None:
-            orientations = [0, 0]
-        if len(orientations) != n:
+            orientations = 0
+        try:
+            orientations = np.broadcast_to(orientations, n)
+        except ValueError:
             raise ValueError(
-            "orientations and flows must have the same length.\n"
-            "orientations has length %d, but flows has length %d."
-            % (len(orientations), n))
+                f"The shapes of 'flows' {np.shape(flows)} and 'orientations' "
+                f"{np.shape(orientations)} are incompatible"
+            ) from None
         if not cbook.is_scalar_or_string(labels) and len(labels) != n:
             raise ValueError(
                 "If labels is a list, then labels and flows must have the "


### PR DESCRIPTION
## PR Summary

Closes the issue reported by the OP in https://github.com/matplotlib/matplotlib/issues/13184, but not https://github.com/matplotlib/matplotlib/issues/13184#issuecomment-455353339.

I know there's no tests, and am not volunteering to write them.  (But you can manually check that this fixes the OP's issues.)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
