### PR TITLE
Fix checking of 'labels' argument to Sankey.add.

### DIFF
--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -10,7 +10,7 @@ import numpy as np
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 from matplotlib.transforms import Affine2D
-from matplotlib import cbook, docstring
+from matplotlib import docstring
 from matplotlib import rcParams
 
 _log = logging.getLogger(__name__)
@@ -453,12 +453,13 @@ class Sankey(object):
                 f"The shapes of 'flows' {np.shape(flows)} and 'orientations' "
                 f"{np.shape(orientations)} are incompatible"
             ) from None
-        if not cbook.is_scalar_or_string(labels) and len(labels) != n:
+        try:
+            labels = np.broadcast_to(labels, n)
+        except ValueError:
             raise ValueError(
-                f"The lengths of 'flows' ({n}) and 'labels' ({len(labels)}) "
-                f"are incompatible")
-        else:
-            labels = [labels] * n
+                f"The shapes of 'flows' {np.shape(flows)} and 'labels' "
+                f"{np.shape(labels)} are incompatible"
+            ) from None
         if trunklength < 0:
             raise ValueError(
                 "'trunklength' is negative, which is not allowed because it "

--- a/lib/matplotlib/tests/test_sankey.py
+++ b/lib/matplotlib/tests/test_sankey.py
@@ -5,3 +5,8 @@ def test_sankey():
     # lets just create a sankey instance and check the code runs
     sankey = Sankey()
     sankey.add()
+
+
+def test_label():
+    s = Sankey(flows=[0.25], labels=['First'], orientations=[-1])
+    assert s.diagrams[0].texts[0].get_text() == 'First\n0.25'


### PR DESCRIPTION
Test by manually running the sankey examples.

Closes https://github.com/matplotlib/matplotlib/pull/11974#issuecomment-455493614.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
