### PR TITLE
Fix a warning in the doc build.

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -29,13 +29,14 @@ class ScaleBase(object):
         r"""
         Construct a new scale.
 
-        Note
-        ----
+        Notes
+        -----
         The following note is for scale implementors.
 
-        For back-compatibility reasons, scales take an `~.Axis` object as first
-        argument.  However, this argument should not be used: a single scale
-        object should be usable by multiple `~.Axis`\es at the same time.
+        For back-compatibility reasons, scales take an `~matplotlib.axis.Axis`
+        object as first argument.  However, this argument should not
+        be used: a single scale object should be usable by multiple
+        `~matplotlib.axis.Axis`\es at the same time.
         """
 
     def get_transform(self):
@@ -70,6 +71,14 @@ class LinearScale(ScaleBase):
     """
 
     name = 'linear'
+
+    def __init__(self, axis, **kwargs):
+        # This method is present only to prevent inheritance of the base class'
+        # constructor docstring, which would otherwise end up interpolated into
+        # the docstring of Axis.set_scale.
+        """
+        """
+        super().__init__(axis, **kwargs)
 
     def set_default_locators_and_formatters(self, axis):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -840,6 +840,7 @@ class Axes3D(Axes):
         ACCEPTS: [%(scale)s]
 
         Different kwargs are accepted, depending on the scale:
+
         %(scale_docs)s
 
         .. note ::


### PR DESCRIPTION
## PR Summary

Search for
> /home/circleci/.local/lib/python3.7/site-packages/numpydoc/docscrape.py:377: UserWarning: Unknown section Note in the docstring of <class 'matplotlib.scale.ScaleBase'> in /home/circleci/project/lib/matplotlib/scale.py.

in https://circleci.com/gh/matplotlib/matplotlib/17517 (for example).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
