### PR TITLE
Avoid triggering warnings in mandelbrot example.

### DIFF
--- a/examples/showcase/mandelbrot.py
+++ b/examples/showcase/mandelbrot.py
@@ -33,11 +33,11 @@ if __name__ == '__main__':
     from matplotlib import colors
     import matplotlib.pyplot as plt
 
-    xmin, xmax, xn = -2.25, +0.75, 3000/2
-    ymin, ymax, yn = -1.25, +1.25, 2500/2
+    xmin, xmax, xn = -2.25, +0.75, 3000 // 2
+    ymin, ymax, yn = -1.25, +1.25, 2500 // 2
     maxiter = 200
     horizon = 2.0 ** 40
-    log_horizon = np.log(np.log(horizon))/np.log(2)
+    log_horizon = np.log2(np.log(horizon))
     Z, N = mandelbrot_set(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon)
 
     # Normalized recount as explained in:
@@ -47,15 +47,13 @@ if __name__ == '__main__':
     # This line will generate warnings for null values but it is faster to
     # process them afterwards using the nan_to_num
     with np.errstate(invalid='ignore'):
-        M = np.nan_to_num(N + 1 -
-                          np.log(np.log(abs(Z)))/np.log(2) +
-                          log_horizon)
+        M = np.nan_to_num(N + 1 - np.log2(np.log(abs(Z))) + log_horizon)
 
     dpi = 72
     width = 10
     height = 10*yn/xn
     fig = plt.figure(figsize=(width, height), dpi=dpi)
-    ax = fig.add_axes([0.0, 0.0, 1.0, 1.0], frameon=False, aspect=1)
+    ax = fig.add_axes([0, 0, 1, 1], frameon=False, aspect=1)
 
     # Shaded rendering
     light = colors.LightSource(azdeg=315, altdeg=10)


### PR DESCRIPTION
... namely
```
examples/showcase/mandelbrot.py:17: DeprecationWarning: object of type <class 'float'> cannot be safely interpreted as an integer.
  X = np.linspace(xmin, xmax, xn).astype(np.float32)
examples/showcase/mandelbrot.py:18: DeprecationWarning: object of type <class 'float'> cannot be safely interpreted as an integer.
  Y = np.linspace(ymin, ymax, yn).astype(np.float32)
```

plus some minor cleanups.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
