### PR TITLE
Make color lowercase in example to avoid warning.

### DIFF
--- a/examples/statistics/barchart_demo.py
+++ b/examples/statistics/barchart_demo.py
@@ -28,9 +28,9 @@ width = 0.35  # the width of the bars
 
 fig, ax = plt.subplots()
 rects1 = ax.bar(ind - width/2, men_means, width, yerr=men_std,
-                color='SkyBlue', label='Men')
+                color='skyblue', label='Men')
 rects2 = ax.bar(ind + width/2, women_means, width, yerr=women_std,
-                color='IndianRed', label='Women')
+                color='indianred', label='Women')
 
 # Add some text for labels, title and custom x-axis tick labels, etc.
 ax.set_ylabel('Scores')

--- a/examples/ticks_and_spines/tick-locators.py
+++ b/examples/ticks_and_spines/tick-locators.py
@@ -66,7 +66,7 @@ ax.text(0.0, 0.1, "LinearLocator(numticks=3)",
 # Index Locator
 ax = plt.subplot(n, 1, 5)
 setup(ax)
-ax.plot(range(0, 5), [0]*5, color='White')
+ax.plot(range(0, 5), [0]*5, color='white')
 ax.xaxis.set_major_locator(ticker.IndexLocator(base=.5, offset=.25))
 ax.text(0.0, 0.1, "IndexLocator(base=0.5, offset=0.25)",
         fontsize=14, transform=ax.transAxes)


### PR DESCRIPTION
## PR Summary

Missed that in #13211.

I guess there may be some argument in favor of keeping case-insensitive colors (CSS spec says that CSS colors are case-insensitive, and of course there's no XKCD colors spec :)), *except* for the 1-letter shorthands (for the rationale given in #13211, i.e. collision with potentially useful key names when using the data kwarg)...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
