### PR TITLE
Prevent exception when running animation on Agg backend.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1613,6 +1613,7 @@ class FuncAnimation(TimedAnimation):
         else:
             self._args = ()
         self._func = func
+        self._init_func = init_func
 
         # Amount of framedata to keep around for saving movies. This is only
         # used if we don't know how many frames there will be: in the case
@@ -1644,7 +1645,7 @@ class FuncAnimation(TimedAnimation):
             # As a workaround, convert save_count to a native python int.
             self.save_count = int(self.save_count)
 
-        self._init_func = init_func
+        self._cache_frame_data = cache_frame_data
 
         # Needs to be initialized so the draw functions work without checking
         self._save_seq = []
@@ -1654,8 +1655,6 @@ class FuncAnimation(TimedAnimation):
         # Need to reset the saved seq, since right now it will contain data
         # for a single frame from init, which is not what we want.
         self._save_seq = []
-
-        self._cache_frame_data = cache_frame_data
 
     def new_frame_seq(self):
         # Use the generating function to generate a new frame sequence


### PR DESCRIPTION
Currently, running e.g. the strip_chart example using the agg backend
(not a particularly interesting use case, but done in particular by the
doc build) causes a "AttributeError: 'FuncAnimation' object has no
attribute '_cache_frame_data'" exception.

This is fixed by moving the setting of the `_cache_frame_data` attribute
to before the `super().__init__` call.

Also move the setting of `_init_func` next to the one of `_func`, which
seems to be a logical grouping.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
