### PR TITLE
FIX: allow colorbar mappable norm to change and do right thing

### DIFF
--- a/doc/api/next_api_changes/2019-01-27-JMK.rst
+++ b/doc/api/next_api_changes/2019-01-27-JMK.rst
@@ -1,0 +1,12 @@
+`matplotlib.colorbar.ColorbarBase` is no longer a subclass of `.ScalarMappable`
+-------------------------------------------------------------------------------
+
+This inheritance lead to a confusing situation where the
+`ScalarMappable` passed to `matplotlib.colorbar.Colorbar` (`~.Figure.colorbar`)
+had a ``set_norm`` method, as did the colorbar.  The colorbar is now purely a
+slave to the `ScalarMappable` norm and colormap, and the old inherited methods
+`~matplotlib.colorbar.ColorbarBase.set_norm`,
+`~matplotlib.colorbar.ColorbarBase.set_cmap`,
+`~matplotlib.colorbar.ColorbarBase.set_clim` are deprecated, as are the
+getter versions of those calls.  To set the norm associated with a colorbar do
+``colorbar.mappable.set_norm()`` etc.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -349,6 +349,13 @@ class ScalarMappable(object):
         Parameters
         ----------
         norm : `.Normalize`
+
+        Notes
+        -----
+        If there are any colorbars using the mappable for this norm, setting
+        the norm of the mappable will reset the norm, locator, and formatters
+        on the colorbar to default.
+
         """
         if norm is None:
             norm = colors.Normalize()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -304,7 +304,47 @@ class _ColorbarLogLocator(ticker.LogLocator):
         return ticks
 
 
-class ColorbarBase(cm.ScalarMappable):
+class _ColorbarMappableDummy(object):
+    """
+    Private class to hold deprecated ColorbarBase methods that used to be
+    inhereted from ScalarMappable.
+    """
+    @cbook.deprecated("3.1", alternative="ScalarMappable.set_norm")
+    def set_norm(self, norm):
+        """
+        `.colorbar.Colorbar.set_norm` does nothing; set the norm on
+        the mappable associated with this colorbar.
+        """
+        pass
+
+    @cbook.deprecated("3.1", alternative="ScalarMappable.set_cmap")
+    def set_cmap(self, cmap):
+        """
+        `.colorbar.Colorbar.set_cmap` does nothing; set the norm on
+        the mappable associated with this colorbar.
+        """
+        pass
+
+    @cbook.deprecated("3.1", alternative="ScalarMappable.set_clim")
+    def set_clim(self, cmap):
+        """
+        `.colorbar.Colorbar.set_clim` does nothing; set the limits on
+        the mappable associated with this colorbar.
+        """
+        pass
+
+    @cbook.deprecated("3.1", alternative="ScalarMappable.get_cmap")
+    def get_cmap(self):
+        'return the colormap'
+        return self.cmap
+
+    @cbook.deprecated("3.1", alternative="ScalarMappable.get_clim")
+    def get_clim(self):
+        'return the min, max of the color limits for image scaling'
+        return self.norm.vmin, self.norm.vmax
+
+
+class ColorbarBase(_ColorbarMappableDummy):
     '''
     Draw a colorbar in an existing axes.
 
@@ -371,7 +411,8 @@ class ColorbarBase(cm.ScalarMappable):
         if norm is None:
             norm = colors.Normalize()
         self.alpha = alpha
-        cm.ScalarMappable.__init__(self, cmap=cmap, norm=norm)
+        self.cmap = cmap
+        self.norm = norm
         self.values = values
         self.boundaries = boundaries
         self.extend = extend
@@ -387,6 +428,8 @@ class ColorbarBase(cm.ScalarMappable):
         self.outline = None
         self.patch = None
         self.dividers = None
+        self.locator = None
+        self.formatter = None
         self._manual_tick_data_values = None
 
         if ticklocation == 'auto':
@@ -394,23 +437,17 @@ class ColorbarBase(cm.ScalarMappable):
         self.ticklocation = ticklocation
 
         self.set_label(label)
+        self._reset_locator_formatter_scale()
+
         if np.iterable(ticks):
             self.locator = ticker.FixedLocator(ticks, nbins=len(ticks))
         else:
             self.locator = ticks    # Handle default in _ticker()
-        if format is None:
-            if isinstance(self.norm, colors.LogNorm):
-                self.formatter = ticker.LogFormatterSciNotation()
-            elif isinstance(self.norm, colors.SymLogNorm):
-                self.formatter = ticker.LogFormatterSciNotation(
-                                        linthresh=self.norm.linthresh)
-            else:
-                self.formatter = ticker.ScalarFormatter()
-        elif isinstance(format, str):
+
+        if isinstance(format, str):
             self.formatter = ticker.FormatStrFormatter(format)
         else:
-            self.formatter = format  # Assume it is a Formatter
-        # The rest is in a method so we can recalculate when clim changes.
+            self.formatter = format  # Assume it is a Formatter or None
         self.draw_all()
 
     def _extend_lower(self):
@@ -432,7 +469,6 @@ class ColorbarBase(cm.ScalarMappable):
         Calculate any free parameters based on the current cmap and norm,
         and do all the drawing.
         '''
-
         # sets self._boundaries and self._values in real data units.
         # takes into account extend values:
         self._process_values()
@@ -451,12 +487,6 @@ class ColorbarBase(cm.ScalarMappable):
 
     def config_axis(self):
         ax = self.ax
-        if (isinstance(self.norm, colors.LogNorm)
-                and self._use_auto_colorbar_locator()):
-            # *both* axes are made log so that determining the
-            # mid point is easier.
-            ax.set_xscale('log')
-            ax.set_yscale('log')
 
         if self.orientation == 'vertical':
             long_axis, short_axis = ax.yaxis, ax.xaxis
@@ -504,6 +534,20 @@ class ColorbarBase(cm.ScalarMappable):
             else:
                 b = self._boundaries[self._inside]
                 locator = ticker.FixedLocator(b, nbins=10)
+
+        if formatter is None:
+            if isinstance(self.norm, colors.LogNorm):
+                formatter = ticker.LogFormatterSciNotation()
+            elif isinstance(self.norm, colors.SymLogNorm):
+                formatter = ticker.LogFormatterSciNotation(
+                                        linthresh=self.norm.linthresh)
+            else:
+                formatter = ticker.ScalarFormatter()
+        else:
+            formatter = self.formatter
+
+        self.locator = locator
+        self.formatter = formatter
         _log.debug('locator: %r', locator)
         return locator, formatter
 
@@ -517,6 +561,24 @@ class ColorbarBase(cm.ScalarMappable):
                 and ((type(self.norm) == colors.Normalize)
                     or (type(self.norm) == colors.LogNorm)))
 
+    def _reset_locator_formatter_scale(self):
+        """
+        Reset the locator et al to defaults.  Any user-hardcoded changes
+        need to be re-entered if this gets called (either at init, or when
+        the mappable normal gets changed: Colorbar.update_normal)
+        """
+        self.locator = None
+        self.formatter = None
+        if (isinstance(self.norm, colors.LogNorm)
+                and self._use_auto_colorbar_locator()):
+            # *both* axes are made log so that determining the
+            # mid point is easier.
+            self.ax.set_xscale('log')
+            self.ax.set_yscale('log')
+        else:
+            self.ax.set_xscale('linear')
+            self.ax.set_yscale('linear')
+
     def update_ticks(self):
         """
         Force the update of the ticks and ticklabels. This must be
@@ -526,7 +588,6 @@ class ColorbarBase(cm.ScalarMappable):
         # get the locator and formatter.  Defaults to
         # self.locator if not None..
         locator, formatter = self._get_ticker_locator_formatter()
-
         if self.orientation == 'vertical':
             long_axis, short_axis = ax.yaxis, ax.xaxis
         else:
@@ -1102,7 +1163,6 @@ class Colorbar(ColorbarBase):
             kw['boundaries'] = CS._levels
             kw['values'] = CS.cvalues
             kw['extend'] = CS.extend
-            #kw['ticks'] = CS._levels
             kw.setdefault('ticks', ticker.FixedLocator(CS.levels, nbins=10))
             kw['filled'] = CS.filled
             ColorbarBase.__init__(self, ax, **kw)
@@ -1125,8 +1185,7 @@ class Colorbar(ColorbarBase):
         by :func:`colorbar_factory` and should not be called manually.
 
         """
-        self.set_cmap(mappable.get_cmap())
-        self.set_clim(mappable.get_clim())
+        _log.debug('colorbar mappable changed')
         self.update_normal(mappable)
 
     def add_lines(self, CS, erase=True):
@@ -1156,9 +1215,24 @@ class Colorbar(ColorbarBase):
         Update solid patches, lines, etc.
 
         Unlike `.update_bruteforce`, this does not clear the axes.  This is
-        meant to be called when the image or contour plot to which this
-        colorbar belongs changes.
+        meant to be called when the norm of the image or contour plot to which
+        this colorbar belongs changes.
+
+        If the norm on the mappable is different than before, this resets the
+        locator and formatter for the axis, so if these have been customized,
+        they will need to be customized again.  However, if the norm only
+        changes values of *vmin*, *vmax* or *cmap* then the old formatter
+        and locator will be preserved.
         """
+
+        _log.debug('colorbar update normal %r %r', mappable.norm, self.norm)
+        self.mappable = mappable
+        self.set_alpha(mappable.get_alpha())
+        self.cmap = mappable.cmap
+        if mappable.norm != self.norm:
+            self.norm = mappable.norm
+            self._reset_locator_formatter_scale()
+
         self.draw_all()
         if isinstance(self.mappable, contour.ContourSet):
             CS = self.mappable
@@ -1180,15 +1254,16 @@ class Colorbar(ColorbarBase):
         # properties have been changed by methods other than the
         # colorbar methods, those changes will be lost.
         self.ax.cla()
+        self.locator = None
+        self.formatter = None
+
         # clearing the axes will delete outline, patch, solids, and lines:
         self.outline = None
         self.patch = None
         self.solids = None
         self.lines = list()
         self.dividers = None
-        self.set_alpha(mappable.get_alpha())
-        self.cmap = mappable.cmap
-        self.norm = mappable.norm
+        self.update_normal(mappable)
         self.draw_all()
         if isinstance(self.mappable, contour.ContourSet):
             CS = self.mappable

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -335,12 +335,16 @@ class _ColorbarMappableDummy(object):
 
     @cbook.deprecated("3.1", alternative="ScalarMappable.get_cmap")
     def get_cmap(self):
-        'return the colormap'
+        """
+        return the colormap
+        """
         return self.cmap
 
     @cbook.deprecated("3.1", alternative="ScalarMappable.get_clim")
     def get_clim(self):
-        'return the min, max of the color limits for image scaling'
+        """
+        return the min, max of the color limits for image scaling
+        """
         return self.norm.vmin, self.norm.vmax
 
 

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -8,12 +8,10 @@ This tutorial shows how to build colorbars without an attached plot.
 Customized Colorbars
 ====================
 
-:class:`~matplotlib.colorbar.ColorbarBase` derives from
-:mod:`~matplotlib.cm.ScalarMappable` and puts a colorbar in a specified axes,
-so it has everything needed for a standalone colorbar. It can be used as-is to
-make a colorbar for a given colormap; it does not need a mappable object like
-an image. In this tutorial we will explore what can be done with standalone
-colorbar.
+`~matplotlib.colorbar.ColorbarBase` puts a colorbar in a specified axes,
+and can make a colorbar for a given colormap; it does not need a mappable
+object like an image. In this tutorial we will explore what can be done with
+standalone colorbar.
 
 Basic continuous colorbar
 -------------------------


### PR DESCRIPTION
## PR Summary

Closes #13228 

```python

import matplotlib.pyplot as plt
import matplotlib as mpl
import numpy as np

N = 100
X, Y = np.mgrid[0:3:complex(0, N), 0:2:complex(0, N)]
Z1 = (1 + np.sin(Y * 10.)) * X**(2.)
data = Z1

fig, ax = plt.subplots()
cax = ax.pcolormesh(data, cmap='RdBu_r', rasterized=True)
cbar = fig.colorbar(cax, ax=ax)
cax.set_norm(mpl.colors.PowerNorm(gamma=2, vmin=0.001, vmax=18))

```

## Before

Note this colorbar is simply wrong...

![before](https://user-images.githubusercontent.com/1562854/51433940-7aaeba00-1c0b-11e9-90e2-90aa31359f6a.png)


## After
![new](https://user-images.githubusercontent.com/1562854/51433935-6074dc00-1c0b-11e9-97d3-9c1f6c54c6b0.png)

# Changing norm erases colorbar formatter and locator...

If the norm is changed, then any formatter and locator settings are also lost.  This is new behaviour, but I think reasonable if the user has changed the norm.  Here we illustrate this just by setting the ticks (which changes the Locator to FixedLocator).  Note that when the norm is set the locator goes back to the automatic locator.  

```python
fig, ax = plt.subplots()
cax = ax.pcolormesh(data, cmap='RdBu_r', rasterized=True)
cbar = fig.colorbar(cax, ax=ax)

print('original', cbar.locator)
cbar.set_ticks([0, 10, 20])
print('first set ticks', cbar.locator)
cax.set_norm(mpl.colors.PowerNorm(gamma=2, vmin=0.001, vmax=18))
print('after norm changed', cbar.locator)
cbar.set_ticks(np.arange(0, 20, 2))
print('after ticks set second time', cbar.locator)
plt.show()
```


```
original <matplotlib.colorbar._ColorbarAutoLocator object at 0x127311be0>
first set ticks <matplotlib.ticker.FixedLocator object at 0x127351320>
after norm changed <matplotlib.colorbar._ColorbarAutoLocator object at 0x127311d68>
after ticks set second time <matplotlib.ticker.FixedLocator object at 0x1272f1080>
```

# Next issue: Reset scale if norm changes...

The axis scale wasn't being reset if the norm changed, but it needs to be reset as well...

```python
print('changing norm', cbar.ax.yaxis.get_scale())
pcm.set_norm(mcolors.LogNorm(vmin=1, vmax=100))
print('norm changed', cbar.ax.yaxis.get_scale())
pcm.set_norm(mcolors.Normalize(vmin=-20, vmax=20))
print('norm changed', cbar.ax.yaxis.get_scale())
```

### Before
```
changing norm linear
norm changed linear
norm changed linear
```

### After
```
changing norm linear
norm changed log
norm changed linear
```

I'm marking WIP until @LevN0 lets us know we squashed all the bugs...

# Next Issue: format='%1.4e' now works...

See new test...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->