### PR TITLE
FIX: spelling error of local variable in category

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -210,18 +210,18 @@ class UnitData(object):
         """
         data = np.atleast_1d(np.array(data, dtype=object))
 
-        # check if convertable to number:
-        convertable = True
+        # check if convertible to number:
+        convertible = True
         for val in OrderedDict.fromkeys(data):
             # OrderedDict just iterates over unique values in data.
             if not isinstance(val, (str, bytes)):
                 raise TypeError("{val!r} is not a string".format(val=val))
-            if convertable:
-                # this will only be called so long as convertable is True.
-                convertable = self._str_is_convertible(val)
+            if convertible:
+                # this will only be called so long as convertible is True.
+                convertible = self._str_is_convertible(val)
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
-        if convertable:
+        if convertible:
             _log.info('Using categorical units to plot a list of strings '
                       'that are all parsable as floats or dates. If these '
                       'strings should be plotted as numbers, cast to the '


### PR DESCRIPTION
## PR Summary

Fix spelling error as noted by @anntzer (https://github.com/matplotlib/matplotlib/pull/13026#discussion_r249277048)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->