### PR TITLE
Simplify and optimize png writing in backend_pdf.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1345,22 +1345,16 @@ end"""
         Write the image *data* into the pdf file using png
         predictors with Flate compression.
         """
-
         buffer = BytesIO()
         _png.write_png(data, buffer)
         buffer.seek(8)
-        written = 0
-        header = bytearray(8)
         while True:
-            n = buffer.readinto(header)
-            assert n == 8
-            length, type = struct.unpack(b'!L4s', bytes(header))
+            length, type = struct.unpack(b'!L4s', buffer.read(8))
             if type == b'IDAT':
-                data = bytearray(length)
-                n = buffer.readinto(data)
-                assert n == length
-                self.currentstream.write(bytes(data))
-                written += n
+                data = buffer.read(length)
+                if len(data) != length:
+                    raise RuntimeError("truncated data")
+                self.currentstream.write(data)
             elif type == b'IEND':
                 break
             else:


### PR DESCRIPTION
The old code would first read into a bytesarray, and then create a copy
by calling bytes() on it.  Don't bother with the copy.

Also, `written` is unused.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
