### PR TITLE
Replace safezip() by more informative error message in errorbar().

### DIFF
--- a/doc/api/next_api_changes/2018-01-21-AL.rst
+++ b/doc/api/next_api_changes/2018-01-21-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``cbook.safezip`` is deprecated (manually check the lengths of the inputs
+instead, or rely on numpy to do it).

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3200,8 +3200,13 @@ class Axes(_AxesBase):
                 raise ValueError(
                     "err must be a scalar or a 1D or (2, n) array-like")
             # Using list comprehensions rather than arrays to preserve units.
-            low = [v - e for v, e in cbook.safezip(data, a)]
-            high = [v + e for v, e in cbook.safezip(data, b)]
+            for e in [a, b]:
+                if len(data) != len(e):
+                    raise ValueError(
+                        f"The lengths of the data ({len(data)}) and the "
+                        f"error {len(e)} do not match")
+            low = [v - e for v, e in zip(data, a)]
+            high = [v + e for v, e in zip(data, b)]
             return low, high
 
         if xerr is not None:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -776,6 +776,7 @@ def report_memory(i=0):  # argument may go away
 _safezip_msg = 'In safezip, len(args[0])=%d but len(args[%d])=%d'
 
 
+@deprecated("3.1")
 def safezip(*args):
     """make sure *args* are equal len before zipping"""
     Nx = len(args[0])


### PR DESCRIPTION
Currently, the error for mismatched shapes in errorbar is
```
ValueError: In safezip, len(args[0])=2 but len(args[1])=3
```
Replace it by
```
ValueError: The lengths of the data (2) and the error (3) do not match
```
and deprecate the not-so-informatively-named safezip.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
