### PR TITLE
Improve docs for format determination in savefig()/imsave().

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2009,17 +2009,17 @@ default: 'top'
         Parameters
         ----------
 
-        fname : str or file-like object
-            A string containing a path to a filename, or a Python
-            file-like object, or possibly some backend-dependent object
-            such as :class:`~matplotlib.backends.backend_pdf.PdfPages`.
+        fname : str or PathLike or file-like object
+            A path, or a Python file-like object, or
+            possibly some backend-dependent object such as
+            `matplotlib.backends.backend_pdf.PdfPages`.
 
-            If *format* is *None* and *fname* is a string, the output
-            format is deduced from the extension of the filename. If
-            the filename has no extension, :rc:`savefig.format` is used.
+            If *format* is not set, then the output format is inferred from
+            the extension of *fname*, if any, and from :rc:`savefig.format`
+            otherwise.  If *format* is set, it determines the output format.
 
-            If *fname* is not a string, remember to specify *format* to
-            ensure that the correct backend is used.
+            Hence, if *fname* is not a path or has no extension, remember to
+            specify *format* to ensure that the correct backend is used.
 
         Other Parameters
         ----------------
@@ -2063,8 +2063,8 @@ default: 'top'
             output.
 
         format : str
-            One of the file extensions supported by the active
-            backend.  Most backends support png, pdf, ps, eps and svg.
+            The file format, e.g. 'png', 'pdf', 'svg', ... The behavior when
+            this is unset is documented under *fname*.
 
         transparent : bool
             If *True*, the axes patches will all be transparent; the

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1398,16 +1398,15 @@ def imread(fname, format=None):
 def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
            origin=None, dpi=100):
     """
-    Save an array as in image file.
-
-    The output formats available depend on the backend being used.
+    Save an array as an image file.
 
     Parameters
     ----------
-    fname : str or file-like
-        The filename or a Python file-like object to store the image in.
-        The necessary output format is inferred from the filename extension
-        but may be explicitly overwritten using *format*.
+    fname : str or PathLike file-like
+        A path or a Python file-like object to store the image in.
+        If *format* is not set, then the output format is inferred from the
+        extension of *fname*, if any, and from :rc:`savefig.format` otherwise.
+        If *format* is set, it determines the output format.
     arr : array-like
         The image data. The shape can be one of
         MxN (luminance), MxNx3 (RGB) or MxNx4 (RGBA).
@@ -1421,9 +1420,8 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
         maps scalar data to colors. It is ignored for RGB(A) data.
         Defaults to :rc:`image.cmap` ('viridis').
     format : str, optional
-        The file format, e.g. 'png', 'pdf', 'svg', ... . If not given, the
-        format is deduced form the filename extension in *fname*.
-        See `.Figure.savefig` for details.
+        The file format, e.g. 'png', 'pdf', 'svg', ...  The behavior when this
+        is unset is documented under *fname*.
     origin : {'upper', 'lower'}, optional
         Indicates whether the ``(0, 0)`` index of the array is in the upper
         left or lower left corner of the axes.  Defaults to :rc:`image.origin`


### PR DESCRIPTION
Most importantly, the current backend is mostly irrelevant (unlike what
the docs state), because we handle backend switching transparently.

Preliminary work for https://github.com/matplotlib/matplotlib/issues/13253#issuecomment-456206875.

Note that the actual behavior is actually slightly different from the documented one: if the active canvas is PDF, PS or SVG and a format cannot be derived from `fname` or from `format`, then the format used will be pdf/ps/svg (respectively) rather than rcParams["savefig.format"].  I would like to change that to instead always use the rcParam, but that'll wait for https://github.com/matplotlib/matplotlib/pull/12760 first (for rebase reasons).  (Why allow saving to png when using a pdf canvas?  Because to me that's similar as allowing to save to pdf when using an agg (=raster) canvas, and transparently handling the backend switching.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
