### PR TITLE
In imsave()'s Pillow-handled case, don't create a temporary figure.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from math import ceil
 import os
 import logging
+from pathlib import Path
 import urllib.parse
 import urllib.request
 
@@ -1432,24 +1433,48 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
         The DPI to store in the metadata of the file.  This does not affect the
         resolution of the output image.
     """
-    from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
     from matplotlib.figure import Figure
     if isinstance(fname, os.PathLike):
         fname = os.fspath(fname)
-    if (format == 'png'
-        or (format is None
-            and isinstance(fname, str)
-            and fname.lower().endswith('.png'))):
-        image = AxesImage(None, cmap=cmap, origin=origin)
-        image.set_data(arr)
-        image.set_clim(vmin, vmax)
-        image.write_png(fname)
-    else:
+    if format is None:
+        format = (Path(fname).suffix[1:] if isinstance(fname, str)
+                  else rcParams["savefig.format"]).lower()
+    if format in ["pdf", "ps", "eps", "svg"]:
+        # Vector formats that are not handled by PIL.
         fig = Figure(dpi=dpi, frameon=False)
-        FigureCanvas(fig)
         fig.figimage(arr, cmap=cmap, vmin=vmin, vmax=vmax, origin=origin,
                      resize=True)
         fig.savefig(fname, dpi=dpi, format=format, transparent=True)
+    else:
+        # Don't bother creating an image; this avoids rounding errors on the
+        # size when dividing and then multiplying by dpi.
+        sm = cm.ScalarMappable(cmap=cmap)
+        sm.set_clim(vmin, vmax)
+        if origin is None:
+            origin = rcParams["image.origin"]
+        if origin == "lower":
+            arr = arr[::-1]
+        rgba = sm.to_rgba(arr, bytes=True)
+        if format == "png":
+            _png.write_png(rgba, fname, dpi=dpi)
+        else:
+            try:
+                from PIL import Image
+            except ImportError as exc:
+                raise ImportError(
+                    f"Saving to {format} requires Pillow") from exc
+            pil_shape = (rgba.shape[1], rgba.shape[0])
+            image = Image.frombuffer(
+                "RGBA", pil_shape, rgba, "raw", "RGBA", 0, 1)
+            if format in ["jpg", "jpeg"]:
+                format = "jpeg"  # Pillow doesn't recognize "jpg".
+                color = tuple(
+                    int(x * 255)
+                    for x in mcolors.to_rgb(rcParams["savefig.facecolor"]))
+                background = Image.new("RGB", pil_shape, color)
+                background.paste(image, image)
+                image = background
+            image.save(fname, format=format, dpi=(dpi, dpi))
 
 
 def pil_to_array(pilImage):


### PR DESCRIPTION
Avoids accidentally changing the image shape when dividing and
multiplying by dpi.

Closes #13253.

(Probably the complexity of the solution can later be paid back by having FigureCanvasAgg.print_{jpeg,tiff} just defer to imsave()...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
