### PR TITLE
Allow turning off minor ticks on Colorbar with LogNorm

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -538,11 +538,7 @@ class ColorbarBase(cm.ScalarMappable):
             long_axis.set_major_locator(locator)
             long_axis.set_major_formatter(formatter)
             if type(self.norm) == colors.LogNorm:
-                long_axis.set_minor_locator(_ColorbarLogLocator(self,
-                            base=10., subs='auto'))
-                long_axis.set_minor_formatter(
-                    ticker.LogFormatterSciNotation()
-                )
+                self.minorticks_on()
         else:
             _log.debug('Using fixed locator on colorbar')
             ticks, ticklabels, offset_string = self._ticker(locator, formatter)
@@ -601,6 +597,30 @@ class ColorbarBase(cm.ScalarMappable):
         else:
             cbook._warn_external("set_ticks() must have been called.")
         self.stale = True
+
+    def minorticks_on(self):
+        """
+        Turns on the minor ticks on the colorbar without extruding
+        into the "extend regions".
+        """
+        ax = self.ax
+        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
+
+        if long_axis.get_scale() == 'log':
+            long_axis.set_minor_locator(_ColorbarLogLocator(self,
+                                                            base=10., subs='auto'))
+            long_axis.set_minor_formatter(ticker.LogFormatterSciNotation())
+        else:
+            long_axis.set_minor_locator(_ColorbarAutoMinorLocator(self))
+
+    def minorticks_off(self):
+        """
+        Turns off the minor ticks on the colorbar.
+        """
+        ax = self.ax
+        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
+
+        long_axis.set_minor_locator(ticker.NullLocator())
 
     def _config_axes(self, X, Y):
         '''
@@ -1208,29 +1228,6 @@ class Colorbar(ColorbarBase):
         else:
             # use_gridspec was True
             ax.set_subplotspec(subplotspec)
-
-    def minorticks_on(self):
-        """
-        Turns on the minor ticks on the colorbar without extruding
-        into the "extend regions".
-        """
-        ax = self.ax
-        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
-
-        if long_axis.get_scale() == 'log':
-            cbook._warn_external('minorticks_on() has no effect on a '
-                                 'logarithmic colorbar axis')
-        else:
-            long_axis.set_minor_locator(_ColorbarAutoMinorLocator(self))
-
-    def minorticks_off(self):
-        """
-        Turns off the minor ticks on the colorbar.
-        """
-        ax = self.ax
-        long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
-
-        long_axis.set_minor_locator(ticker.NullLocator())
 
 
 @docstring.Substitution(make_axes_kw_doc)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -607,8 +607,8 @@ class ColorbarBase(cm.ScalarMappable):
         long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
 
         if long_axis.get_scale() == 'log':
-            long_axis.set_minor_locator(_ColorbarLogLocator(self,
-                                                            base=10., subs='auto'))
+            long_axis.set_minor_locator(_ColorbarLogLocator(self, base=10.,
+                                                            subs='auto'))
             long_axis.set_minor_formatter(ticker.LogFormatterSciNotation())
         else:
             long_axis.set_minor_locator(_ColorbarAutoMinorLocator(self))

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1230,11 +1230,7 @@ class Colorbar(ColorbarBase):
         ax = self.ax
         long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
 
-        if long_axis.get_scale() == 'log':
-            cbook._warn_external('minorticks_off() has no effect on a '
-                                 'logarithmic colorbar axis')
-        else:
-            long_axis.set_minor_locator(ticker.NullLocator())
+        long_axis.set_minor_locator(ticker.NullLocator())
 
 
 @docstring.Substitution(make_axes_kw_doc)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -307,6 +307,24 @@ def test_colorbar_minorticks_on_off():
         np.testing.assert_almost_equal(cbar.ax.yaxis.get_minorticklocs(),
                                        correct_minorticklocs)
 
+    # tests for github issue #13257 and PR #13265
+    data = np.random.uniform(low=1, high=10, size=(20, 20))
+
+    fig, ax = plt.subplots()
+    im = ax.pcolormesh(data, norm=LogNorm())
+    cbar = fig.colorbar(im)
+    default_minorticklocks = cbar.ax.yaxis.get_minorticklocs()
+
+    # test that minorticks turn off for LogNorm
+    cbar.minorticks_off()
+    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
+                          np.array([]))
+
+    # test that minorticks turn back on for LogNorm
+    cbar.minorticks_on()
+    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
+                          default_minorticklocks)
+
 
 def test_colorbar_autoticks():
     # Test new autotick modes. Needs to be classic because


### PR DESCRIPTION
Allow turning off minor ticks on Colorbar with LogNorm

## PR Summary

Closes #13257. 

Allows disabling minor ticks for Colorbar when it has LogNorm. 

## Before

Minor ticks can be disabled for all norms except LogNorm.

The following example is intended to show that when having arbitrary major tick marks, the minor tick marks add rather than remove confusion. Example,

```python

fig, ax = plt.subplots()

data = np.clip(randn(250, 250)*1000, 0, 1000)

cax = ax.imshow(data, norm=mpl.colors.LogNorm(vmin=1, vmax=1000))
cbar = fig.colorbar(cax, format='%d', ticks=[5, 50, 500])
```

Produces,

![](https://user-images.githubusercontent.com/15056721/51500919-e3c63700-1d9d-11e9-949b-116b466c60c3.png)

## After

Once minor ticks can be disabled even for LogNorm, calling cbar.minorticks_off() will leave only major ticks in the above figure.

## Allow minorticks back on for LogNorm as well

Since minor ticks can now be turned off for LogNorm, makes sense to allow turning them back on for LogNorm too. 

Previously they would be enabled in ``ColorbarBase.update_ticks`` for LogNorm by default, however minorticks_off and minorticks_off was in ``Colorbar``. These have been moved, in part so that ``update_ticks`` can take advantage of them.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
