### PR TITLE
Add SubplotSpec.add_subplot.

### DIFF
--- a/doc/users/next_whats_new/2018-01-24-AL-subplotspec-add_subplot.rst
+++ b/doc/users/next_whats_new/2018-01-24-AL-subplotspec-add_subplot.rst
@@ -1,0 +1,8 @@
+GridSpec items can now add subplots to their parent Figure directly
+```````````````````````````````````````````````````````````````````
+
+`SubplotSpec` gained an ``add_subplot`` method, which allows one to write ::
+
+   fig = plt.figure()
+   gs = fig.add_gridspec(2, 2)
+   gs[0, 0].add_subplot()  # instead of `fig.add_subplot(gs[0, 0])`

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -371,6 +371,10 @@ class GridSpecFromSubplotSpec(GridSpecBase):
                     name=subspeclb.name + '.gridspec' + layoutbox.seq_id(),
                     artist=self)
 
+    @property
+    def figure(self):
+        return self.get_topmost_subplotspec().gridspec.figure
+
     def get_subplot_params(self, figure=None):
         """Return a dictionary of subplot layout parameters.
         """
@@ -542,3 +546,23 @@ class SubplotSpec(object):
         """
 
         return GridSpecFromSubplotSpec(nrows, ncols, self, **kwargs)
+
+    def add_subplot(self, **kwargs):
+        """
+        Add the subplot specified by *self* to the parent figure.
+
+        Note that the parent `GridSpec` must have its ``.parent`` attribute set
+        for this method to work; otherwise, a ValueError is raised.
+
+        Keyword arguments are forwarded to `Figure.add_subplot`.
+
+        Example
+        -------
+
+            gs = plt.figure().add_gridspec(2, 2)
+            ax = gs[0, 0].add_subplot()
+        """
+        if self._gridspec.figure is None:
+            raise ValueError("add_subplot() only works for GridSpecs created "
+                             "with a parent Figure")
+        return self._gridspec.figure.add_subplot(self, **kwargs)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -992,9 +992,9 @@ def subplot(*args, **kwargs):
     two subplots that are otherwise identical to be added to the figure,
     make sure you give them unique labels.
 
-    In rare circumstances, `.add_subplot` may be called with a single
-    argument, a subplot axes instance already created in the
-    present figure but not in the figure's list of axes.
+    In rare circumstances, `.subplot` may be called with a single argument, a
+    subplot axes instance already created in the present figure but not in the
+    figure's list of axes.
 
     See Also
     --------

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -107,10 +107,10 @@ def test_tight_layout6():
 
         gs1.tight_layout(fig, rect=[0, 0, 0.5, 1])
 
-        gs2 = gridspec.GridSpec(3, 1)
+        gs2 = fig.add_gridspec(3, 1)
 
         for ss in gs2:
-            ax = fig.add_subplot(ss)
+            ax = ss.add_subplot()
             example_plot(ax)
             ax.set_title("")
             ax.set_xlabel("")


### PR DESCRIPTION
Looking for comments about the proposed new API.

-----

Now that the preferred(?) method of creating GridSpecs attaches the
GridSpec to a given figure (figure.add_gridspec), calling
`fig.add_subplot(gs[...])` effectively specifies the figure information
twice.  Hence, allow one to do
```
gs = fig.add_gridspec(2, 2)
gs[0, 0].add_subplot()
```
as a synonym for
```
gs = fig.add_gridspec(2, 2)
fig.add_subplot(gs[0, 0])
```

Ideally, this should ultimately allow one to deprecate the somewhat
unwieldy subplot2grid, replacing
```
plt.subplot2grid((3, 3), (0, 0))
plt.subplot2grid((3, 3), (1, 1), rowspan=2, colspan=2)
```
by
```
plt.figure().add_grispec(3, 3)[0, 0].add_subplot()
plt.figure().add_grispec(3, 3)[1:, 1:].add_subplot()
```
or, after implementing a plt.add_gridspec() that operates on gcf(),
```
gs = plt.add_gridspec(3, 3)
gs[0, 0].add_subplot()
gs[1:, 1:].add_subplot()
```

A similar API change would be to make GridSpec.tight_layout() lose its
`figure` argument (or rather, it could become optional).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
