### PR TITLE
MAINT install of pinned vers for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,8 @@ install:
     python -mpip install --upgrade pip setuptools wheel
   - |
     # Install dependencies from PyPI.
-    python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
+    python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS
+    python -mpip install --upgrade -r $PINNEDVERS
     # GUI toolkits are pip-installable only for some versions of Python so
     # don't fail if we can't install them.  Make it easier to check whether the
     # install was successful by trying to import the toolkit (sometimes, the


### PR DESCRIPTION
Pinned version of dependencies need to be installed *after* the rest of
the packages. This will downgrade them. Else, sometimes, pip tries to installs
the wrong version of the package, and fails.

(forward port of #13281 )
