### PR TITLE
Fix doc style in add_gridspec()

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2610,7 +2610,8 @@ default: 'top'
 
         Other Parameters
         ----------------
-        *kwargs* are passed to `.GridSpec`.
+        **kwargs
+            Keyword arguments are passed to `.GridSpec`.
 
         See Also
         --------


### PR DESCRIPTION
## PR Summary

## PR Checklist

numpydoc "Other Parameters" sections need to be formated as the "Parameters" section.