### PR TITLE
Defer checking of tex install to when it is actually used.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -968,8 +968,6 @@ with warnings.catch_warnings():
 rcParams['ps.usedistiller'] = checkdep_ps_distiller(
                       rcParams['ps.usedistiller'])
 
-rcParams['text.usetex'] = checkdep_usetex(rcParams['text.usetex'])
-
 if rcParams['axes.formatter.use_locale']:
     locale.setlocale(locale.LC_ALL, '')
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -302,6 +302,10 @@ class TexManager(object):
             report = subprocess.check_output(command,
                                              cwd=self.texcache,
                                              stderr=subprocess.STDOUT)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                'Failed to process string with tex because {} could not be '
+                'found'.format(command[0])) from exc
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(
                 '{prog} was not able to process the following string:\n'
@@ -310,7 +314,7 @@ class TexManager(object):
                 '{exc}\n\n'.format(
                     prog=command[0],
                     tex=tex.encode('unicode_escape'),
-                    exc=exc.output.decode('utf-8')))
+                    exc=exc.output.decode('utf-8'))) from exc
         _log.debug(report)
         return report
 


### PR DESCRIPTION
The call to checkdep_usetex() in `__init__.py` doesn't help for people
explicitly passing usetex=True.  Moreover, it slows down import time
for those who *do* have text.usetex set to True in their rcfile by ~20ms
(when timing this, note that checkdep_ghostscript (which checkdep_usetex
calls) has a cache, which should be disabled for timing purposes.

Moreover, checkdep_usetex is overly broad, always requiring dvipng
(which is not required for pdf/ps output) and ghostscript (which is not
required for raster output).

Instead, move the check to texmanager.py, which will provide a more
meaningful error message to end users, speed up import time (20ms is
similar to the import time of pyparsing or urllib.request, for example)
and avoid the inaccuracies above.

xref #13284 (if the OP indeed is missing a tex installation).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
