### PR TITLE
Simplify some calculations in polar.py.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -598,24 +598,13 @@ class RadialTick(maxis.YTick):
             angle = (axes.get_rlabel_position() * direction +
                      offset) % 360 - 90
             tick_angle = 0
-            if angle > 90:
-                text_angle = angle - 180
-            elif angle < -90:
-                text_angle = angle + 180
-            else:
-                text_angle = angle
         else:
             angle = (thetamin * direction + offset) % 360 - 90
             if direction > 0:
                 tick_angle = np.deg2rad(angle)
             else:
                 tick_angle = np.deg2rad(angle + 180)
-            if angle > 90:
-                text_angle = angle - 180
-            elif angle < -90:
-                text_angle = angle + 180
-            else:
-                text_angle = angle
+        text_angle = (angle + 90) % 180 - 90  # between -90 and +90.
         mode, user_angle = self._labelrotation
         if mode == 'auto':
             text_angle += user_angle
@@ -646,18 +635,12 @@ class RadialTick(maxis.YTick):
         if full:
             self.label2.set_visible(False)
             self.tick2line.set_visible(False)
+        angle = (thetamax * direction + offset) % 360 - 90
+        if direction > 0:
+            tick_angle = np.deg2rad(angle)
         else:
-            angle = (thetamax * direction + offset) % 360 - 90
-            if direction > 0:
-                tick_angle = np.deg2rad(angle)
-            else:
-                tick_angle = np.deg2rad(angle + 180)
-            if angle > 90:
-                text_angle = angle - 180
-            elif angle < -90:
-                text_angle = angle + 180
-            else:
-                text_angle = angle
+            tick_angle = np.deg2rad(angle + 180)
+        text_angle = (angle + 90) % 180 - 90  # between -90 and +90.
         mode, user_angle = self._labelrotation
         if mode == 'auto':
             text_angle += user_angle
@@ -792,15 +775,8 @@ class _WedgeBbox(mtransforms.Bbox):
 
             # Ensure equal aspect ratio.
             w, h = self._points[1] - self._points[0]
-            if h < w:
-                deltah = (w - h) / 2.0
-                deltaw = 0.0
-            elif w < h:
-                deltah = 0.0
-                deltaw = (h - w) / 2.0
-            else:
-                deltah = 0.0
-                deltaw = 0.0
+            deltah = max(w - h, 0) / 2
+            deltaw = max(h - w, 0) / 2
             self._points += np.array([[-deltaw, -deltah], [deltaw, deltah]])
 
             self._invalid = 0


### PR DESCRIPTION
(For the second modifications to RadialTick: the angle/tick_angle
calculations are moved outside of the if block to not inherit the
incorrect text_angle from the code above, even though in practice it
didn't really matter as label2 (to which the angle is applied) is set to
invisible in the other side of the if block.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
