### PR TITLE
TST: deregister pandas

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -91,17 +91,8 @@ def pd():
     pd = pytest.importorskip('pandas')
     try:
         from pandas.plotting import (
-            register_matplotlib_converters as register)
+            deregister_matplotlib_converters as deregister)
+        deregister()
     except ImportError:
-        from pandas.tseries.converter import register
-    register()
-    try:
-        yield pd
-    finally:
-        try:
-            from pandas.plotting import (
-                deregister_matplotlib_converters as deregister)
-        except ImportError:
-            pass
-        else:
-            deregister()
+        pass
+    return pd


### PR DESCRIPTION
## PR Summary

Pandas is planning to drop automatic registration of their converters for matplotlib so that `import pandas` no longer imports them.  In preparation for that, we should deregister the pandas converters.  

Note this should work fine for any of the tests.  pandas converters were mainly for datetime, and I think our datetime converters now handle most of the cases properly.  

Of course if we want to test pandas converters, separate tests could call `pandas.plotting.register_matplotlib_converters()`.  

https://github.com/matplotlib/matplotlib/issues/11391#issuecomment-457954022

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->