### PR TITLE
Qt5: SIGINT kills just the mpl window and not the process itself

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -402,7 +402,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             timer = QtCore.QTimer.singleShot(int(timeout * 1000),
                                              event_loop.quit)
 
-        with _maybe_allow_interrupt(qApp):
+        with _maybe_allow_interrupt(event_loop):
             qt_compat._exec(event_loop)
 
     def stop_event_loop(self, event=None):

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -233,10 +233,8 @@ def _maybe_allow_interrupt(qapp):
             rsock.fileno(), _enum('QtCore.QSocketNotifier.Type').Read
         )
 
-        @sn.activated.connect
-        def on_signal(*args):
-            rsock.recv(
-                sys.getsizeof(int))  # clear the socket to re-arm the notifier
+        # Clear the socket to re-arm the notifier.
+        sn.activated.connect(lambda *args: rsock.recv(1))
 
         def handle(*args):
             nonlocal handler_args

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -197,7 +197,7 @@ def _setDevicePixelRatio(obj, val):
 
 @contextlib.contextmanager
 def _maybe_allow_interrupt(qapp):
-    '''
+    """
     This manager allows to terminate a plot by sending a SIGINT. It is
     necessary because the running Qt backend prevents Python interpreter to
     run and process signals (i.e., to raise KeyboardInterrupt exception). To
@@ -218,7 +218,7 @@ def _maybe_allow_interrupt(qapp):
     We do this only if the old handler for SIGINT was not None, which means
     that a non-python handler was installed, i.e. in Julia, and not SIG_IGN
     which means we should ignore the interrupts.
-    '''
+    """
     old_sigint_handler = signal.getsignal(signal.SIGINT)
     handler_args = None
     skip = False

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -76,12 +76,8 @@ def test_sigint(qt_core, platform_simulate_ctrl_c, target,
         platform_simulate_ctrl_c()
 
     qt_core.QTimer.singleShot(100, fire_signal)
-    try:
+    with pytest.raises(KeyboardInterrupt):
         target(**kwargs)
-    except KeyboardInterrupt as e:
-        assert True
-    else:
-        assert False  # KeyboardInterrupt must be raised
 
 
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)
@@ -107,12 +103,11 @@ def test_other_signal_before_sigint(qt_core, platform_simulate_ctrl_c,
 
     qt_core.QTimer.singleShot(50, fire_other_signal)
     qt_core.QTimer.singleShot(100, fire_sigint)
-    try:
+
+    with pytest.raises(KeyboardInterrupt):
         target(**kwargs)
-    except KeyboardInterrupt as e:
-        assert sigcld_caught
-    else:
-        assert False  # KeyboardInterrupt must be raised
+
+    assert sigcld_caught
 
 
 @pytest.mark.backend('Qt5Agg')

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -93,14 +93,14 @@ def test_other_signal_before_sigint(qt_core, platform_simulate_ctrl_c,
                                     target, kwargs):
     plt.figure()
 
-    sigpipe_caught = False
+    sigcld_caught = False
     def custom_sigpipe_handler(signum, frame):
-        nonlocal sigpipe_caught
-        sigpipe_caught = True
-    signal.signal(signal.SIGPIPE, custom_sigpipe_handler)
+        nonlocal sigcld_caught
+        sigcld_caught = True
+    signal.signal(signal.SIGCLD, custom_sigpipe_handler)
 
     def fire_other_signal():
-        os.kill(os.getpid(), signal.SIGPIPE)
+        os.kill(os.getpid(), signal.SIGCLD)
 
     def fire_sigint():
         platform_simulate_ctrl_c()
@@ -110,7 +110,7 @@ def test_other_signal_before_sigint(qt_core, platform_simulate_ctrl_c,
     try:
         target(**kwargs)
     except KeyboardInterrupt as e:
-        assert sigpipe_caught
+        assert sigcld_caught
     else:
         assert False  # KeyboardInterrupt must be raised
 


### PR DESCRIPTION
## PR Summary

This pull request fixes issue #13302 using `signal.set_wakeup_fd()`. 

The implemented `test_fig_sigint()` uses the example from the aforementioned issue. It's rather an integration test, though. It does not fail with the previous behaviour, but never passes either hanging the whole testing process.

I also changed `test_fig_signals()` to pass with the new code.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
