### PR TITLE
bezier cleanups.

### DIFF
--- a/doc/api/next_api_changes/2018-01-10-AL.rst
+++ b/doc/api/next_api_changes/2018-01-10-AL.rst
@@ -5,7 +5,19 @@ Changes in parameter names
 - The ``normed`` parameter to `Axes.hist2d` has been renamed to ``density``.
 - The ``s`` parameter to `Annotation` (and indirectly `Axes.annotation`) has
   been renamed to ``text``.
+- The ``tolerence`` parameter to
+  `bezier.find_bezier_t_intersecting_with_closedpath`,
+  `bezier.split_bezier_intersecting_with_closedpath`,
+  `bezier.find_r_to_boundary_of_closedpath`,
+  `bezier.split_path_inout` and `bezier.check_if_parallel` has been renamed to
+  ``tolerance``.
 
 In each case, the old parameter name remains supported (it cannot be used
 simultaneously with the new name), but suppport for it will be dropped in
 Matplotlib 3.3.
+
+Deprecations
+````````````
+
+The ``bezier.find_r_to_boundary_of_closedpath`` function is deprecated (it has
+always returned None instead of the requested radius).

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -94,16 +94,15 @@ def split_de_casteljau(beta, t):
     return left_beta, right_beta
 
 
-# FIXME spelling mistake in the name of the parameter ``tolerence``
-def find_bezier_t_intersecting_with_closedpath(bezier_point_at_t,
-                                               inside_closedpath,
-                                               t0=0., t1=1., tolerence=0.01):
+@cbook._rename_parameter("3.1", "tolerence", "tolerance")
+def find_bezier_t_intersecting_with_closedpath(
+        bezier_point_at_t, inside_closedpath, t0=0., t1=1., tolerance=0.01):
     """ Find a parameter t0 and t1 of the given bezier path which
     bounds the intersecting points with a provided closed
     path(*inside_closedpath*). Search starts from *t0* and *t1* and it
     uses a simple bisecting algorithm therefore one of the end point
     must be inside the path while the orther doesn't. The search stop
-    when |t0-t1| gets smaller than the given tolerence.
+    when |t0-t1| gets smaller than the given tolerance.
     value for
 
     - bezier_point_at_t : a function which returns x, y coordinates at *t*
@@ -125,8 +124,8 @@ def find_bezier_t_intersecting_with_closedpath(bezier_point_at_t,
 
     while True:
 
-        # return if the distance is smaller than the tolerence
-        if np.hypot(start[0] - end[0], start[1] - end[1]) < tolerence:
+        # return if the distance is smaller than the tolerance
+        if np.hypot(start[0] - end[0], start[1] - end[1]) < tolerance:
             return t0, t1
 
         # calculate the middle point
@@ -177,9 +176,9 @@ class BezierSegment(object):
         return _x, _y
 
 
-def split_bezier_intersecting_with_closedpath(bezier,
-                                              inside_closedpath,
-                                              tolerence=0.01):
+@cbook._rename_parameter("3.1", "tolerence", "tolerance")
+def split_bezier_intersecting_with_closedpath(
+        bezier, inside_closedpath, tolerance=0.01):
 
     """
     bezier : control points of the bezier segment
@@ -190,17 +189,17 @@ def split_bezier_intersecting_with_closedpath(bezier,
     bz = BezierSegment(bezier)
     bezier_point_at_t = bz.point_at_t
 
-    t0, t1 = find_bezier_t_intersecting_with_closedpath(bezier_point_at_t,
-                                                        inside_closedpath,
-                                                        tolerence=tolerence)
+    t0, t1 = find_bezier_t_intersecting_with_closedpath(
+        bezier_point_at_t, inside_closedpath, tolerance=tolerance)
 
     _left, _right = split_de_casteljau(bezier, (t0 + t1) / 2.)
     return _left, _right
 
 
-def find_r_to_boundary_of_closedpath(inside_closedpath, xy,
-                                     cos_t, sin_t,
-                                     rmin=0., rmax=1., tolerence=0.01):
+@cbook.deprecated("3.1")
+@cbook._rename_parameter("3.1", "tolerence", "tolerance")
+def find_r_to_boundary_of_closedpath(
+        inside_closedpath, xy, cos_t, sin_t, rmin=0., rmax=1., tolerance=0.01):
     """
     Find a radius r (centered at *xy*) between *rmin* and *rmax* at
     which it intersect with the path.
@@ -216,14 +215,14 @@ def find_r_to_boundary_of_closedpath(inside_closedpath, xy,
     def _f(r):
         return cos_t * r + cx, sin_t * r + cy
 
-    find_bezier_t_intersecting_with_closedpath(_f, inside_closedpath,
-                                               t0=rmin, t1=rmax,
-                                               tolerence=tolerence)
+    find_bezier_t_intersecting_with_closedpath(
+        _f, inside_closedpath, t0=rmin, t1=rmax, tolerance=tolerance)
 
 # matplotlib specific
 
 
-def split_path_inout(path, inside, tolerence=0.01, reorder_inout=False):
+@cbook._rename_parameter("3.1", "tolerence", "tolerance")
+def split_path_inout(path, inside, tolerance=0.01, reorder_inout=False):
     """ divide a path into two segment at the point where inside(x, y)
     becomes False.
     """
@@ -252,7 +251,7 @@ def split_path_inout(path, inside, tolerence=0.01, reorder_inout=False):
 
     bp = bezier_path.reshape((-1, 2))
     left, right = split_bezier_intersecting_with_closedpath(
-        bp, inside, tolerence)
+        bp, inside, tolerance)
     if len(left) == 2:
         codes_left = [Path.LINETO]
         codes_right = [Path.MOVETO, Path.LINETO]
@@ -305,7 +304,8 @@ def get_cos_sin(x0, y0, x1, y1):
     return dx / d, dy / d
 
 
-def check_if_parallel(dx1, dy1, dx2, dy2, tolerence=1.e-5):
+@cbook._rename_parameter("3.1", "tolerence", "tolerance")
+def check_if_parallel(dx1, dy1, dx2, dy2, tolerance=1.e-5):
     """ returns
        * 1 if two lines are parralel in same direction
        * -1 if two lines are parralel in opposite direction
@@ -314,9 +314,9 @@ def check_if_parallel(dx1, dy1, dx2, dy2, tolerence=1.e-5):
     theta1 = np.arctan2(dx1, dy1)
     theta2 = np.arctan2(dx2, dy2)
     dtheta = np.abs(theta1 - theta2)
-    if dtheta < tolerence:
+    if dtheta < tolerance:
         return 1
-    elif np.abs(dtheta - np.pi) < tolerence:
+    elif np.abs(dtheta - np.pi) < tolerance:
         return -1
     else:
         return False

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2770,28 +2770,20 @@ class ConnectionStyle(_Style):
 
         def _shrink(self, path, shrinkA, shrinkB):
             """
-            Shrink the path by fixed size (in points) with shrinkA and shrinkB
+            Shrink the path by fixed size (in points) with shrinkA and shrinkB.
             """
             if shrinkA:
-                x, y = path.vertices[0]
-                insideA = inside_circle(x, y, shrinkA)
-
+                insideA = inside_circle(*path.vertices[0], shrinkA)
                 try:
-                    left, right = split_path_inout(path, insideA)
-                    path = right
+                    left, path = split_path_inout(path, insideA)
                 except ValueError:
                     pass
-
             if shrinkB:
-                x, y = path.vertices[-1]
-                insideB = inside_circle(x, y, shrinkB)
-
+                insideB = inside_circle(*path.vertices[-1], shrinkB)
                 try:
-                    left, right = split_path_inout(path, insideB)
-                    path = left
+                    path, right = split_path_inout(path, insideB)
                 except ValueError:
                     pass
-
             return path
 
         def __call__(self, posA, posB,
@@ -3720,9 +3712,8 @@ class ArrowStyle(_Style):
 
             try:
                 arrow_out, arrow_in = \
-                      split_bezier_intersecting_with_closedpath(arrow_path,
-                                                                in_f,
-                                                                tolerence=0.01)
+                    split_bezier_intersecting_with_closedpath(
+                        arrow_path, in_f, tolerance=0.01)
             except NonIntersectingPathException:
                 # if this happens, make a straight line of the head_length
                 # long.
@@ -3803,11 +3794,8 @@ class ArrowStyle(_Style):
             # path for head
             in_f = inside_circle(x2, y2, head_length)
             try:
-                path_out, path_in = \
-                          split_bezier_intersecting_with_closedpath(
-                                arrow_path,
-                                in_f,
-                                tolerence=0.01)
+                path_out, path_in = split_bezier_intersecting_with_closedpath(
+                    arrow_path, in_f, tolerance=0.01)
             except NonIntersectingPathException:
                 # if this happens, make a straight line of the head_length
                 # long.
@@ -3821,10 +3809,7 @@ class ArrowStyle(_Style):
             # path for head
             in_f = inside_circle(x2, y2, head_length * .8)
             path_out, path_in = split_bezier_intersecting_with_closedpath(
-                                        arrow_path,
-                                        in_f,
-                                        tolerence=0.01
-                                )
+                arrow_path, in_f, tolerance=0.01)
             path_tail = path_out
 
             # head
@@ -3842,10 +3827,7 @@ class ArrowStyle(_Style):
             # path for head
             in_f = inside_circle(x0, y0, tail_width * .3)
             path_in, path_out = split_bezier_intersecting_with_closedpath(
-                                    arrow_path,
-                                    in_f,
-                                    tolerence=0.01
-                                )
+                arrow_path, in_f, tolerance=0.01)
             tail_start = path_in[-1]
 
             head_right, head_left = head_r, head_l


### PR DESCRIPTION
- Rename `tolerence` parameter to `tolerance` (... as requested by a
  comment).
- Deprecate `find_r_to_boundary_of_closedpath` which is unused and
  always returned None anyways.
- Misc. small simplifications.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
