### PR TITLE
Deprecate dates.{str,bytes}pdate2num.

### DIFF
--- a/doc/api/next_api_changes/2018-01-31-AL.rst
+++ b/doc/api/next_api_changes/2018-01-31-AL.rst
@@ -1,0 +1,8 @@
+Deprecations
+````````````
+
+``dates.strpdate2num`` and ``dates.bytespdate2num`` are brittle in the
+presence of locale changes, and are deprecated.  Use standard datetime
+parsers such as `time.strptime` or `dateutil.parser.parse`, and additionally
+call `matplotlib.dates.date2num` if you insist on converting to Matplotlib's
+internal datetime representation; or use ``dates.datestr2num``.

--- a/examples/misc/load_converter.py
+++ b/examples/misc/load_converter.py
@@ -1,8 +1,10 @@
 """
 ==============
-Load Converter
+Load converter
 ==============
 
+This example demonstrates passing a custom converter to `numpy.genfromtxt` to
+extract dates from a CSV file.
 """
 
 import dateutil.parser
@@ -16,9 +18,9 @@ print('loading', datafile)
 
 data = np.genfromtxt(
     datafile, delimiter=',', names=True,
-    converters={0: lambda s: dates.date2num(dateutil.parser.parse(s))})
+    dtype=None, converters={0: dateutil.parser.parse})
 
 fig, ax = plt.subplots()
-ax.plot_date(data['Date'], data['High'], '-')
+ax.plot(data['Date'], data['High'], '-')
 fig.autofmt_xdate()
 plt.show()

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -317,6 +317,8 @@ def _from_ordinalf(x, tz=None):
 _from_ordinalf_np_vectorized = np.vectorize(_from_ordinalf)
 
 
+@cbook.deprecated(
+    "3.1", alternative="time.strptime or dateutil.parser.parse or datestr2num")
 class strpdate2num(object):
     """
     Use this class to parse date strings to matplotlib datenums when
@@ -333,6 +335,8 @@ class strpdate2num(object):
         return date2num(datetime.datetime(*time.strptime(s, self.fmt)[:6]))
 
 
+@cbook.deprecated(
+    "3.1", alternative="time.strptime or dateutil.parser.parse or datestr2num")
 class bytespdate2num(strpdate2num):
     """
     Use this class to parse date strings to matplotlib datenums when


### PR DESCRIPTION
They are brittle against locale changes (#13061) and there are replacements in
the stdlib (time.strpdate, also brittle against locale changes) or
elsewhere (dateutil.parser.parse, more robust), which also do not
convert to Matplotlib's internal date representation (as that's not
needed for plotting datetime data).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
