### PR TITLE
Kill some private, unused functions in dates.py.

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1868,24 +1868,6 @@ class MicrosecondLocator(DateLocator):
         return self._interval
 
 
-def _close_to_dt(d1, d2, epsilon=5):
-    """
-    Assert that datetimes *d1* and *d2* are within *epsilon* microseconds.
-    """
-    delta = d2 - d1
-    mus = abs(delta.total_seconds() * 1e6)
-    assert mus < epsilon
-
-
-def _close_to_num(o1, o2, epsilon=5):
-    """
-    Assert that float ordinals *o1* and *o2* are within *epsilon*
-    microseconds.
-    """
-    delta = abs((o2 - o1) * MUSECONDS_PER_DAY)
-    assert delta < epsilon
-
-
 def epoch2num(e):
     """
     Convert an epoch or sequence of epochs to the new date format,


### PR DESCRIPTION
_close_to_dt has been unused since 2012, _close_to_num has never been
used in the history of the repo.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
