### PR TITLE
In Py3, math.floor and math.ceil already return ints.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -498,7 +498,7 @@ class RendererPgf(RendererBase):
                 path.get_extents(transform).get_points()
             xmin, xmax = f * xmin, f * xmax
             ymin, ymax = f * ymin, f * ymax
-            repx, repy = int(math.ceil(xmax-xmin)), int(math.ceil(ymax-ymin))
+            repx, repy = math.ceil(xmax - xmin), math.ceil(ymax - ymin)
             writeln(self.fh,
                     r"\pgfsys@transformshift{%fin}{%fin}" % (xmin, ymin))
             for iy in range(repy):

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1943,14 +1943,13 @@ def date_ticker_factory(span, tz=None, numticks=5):
         locator = WeekdayLocator(tz=tz)
         fmt = '%a, %b %d'
     elif days > numticks:
-        locator = DayLocator(interval=int(math.ceil(days / numticks)), tz=tz)
+        locator = DayLocator(interval=math.ceil(days / numticks), tz=tz)
         fmt = '%b %d'
     elif hrs > numticks:
-        locator = HourLocator(interval=int(math.ceil(hrs / numticks)), tz=tz)
+        locator = HourLocator(interval=math.ceil(hrs / numticks), tz=tz)
         fmt = '%H:%M\n%b %d'
     elif mins > numticks:
-        locator = MinuteLocator(interval=int(math.ceil(mins / numticks)),
-                                tz=tz)
+        locator = MinuteLocator(interval=math.ceil(mins / numticks), tz=tz)
         fmt = '%H:%M:%S'
     else:
         locator = MinuteLocator(tz=tz)

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -77,7 +77,7 @@ class Epoch(object):
             self._jd = float(jd)
 
             # Resolve seconds down to [ 0, 86400)
-            deltaDays = int(math.floor(self._seconds / 86400.0))
+            deltaDays = math.floor(self._seconds / 86400)
             self._jd += deltaDays
             self._seconds -= deltaDays * 86400.0
 


### PR DESCRIPTION
Remove wrapping int() call.  Mostly to save a line in dates.py...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
