### PR TITLE
Move the call to Formatter.set_locs into Formatter.format_ticks.

### DIFF
--- a/doc/api/next_api_changes/2018-01-28-AL.rst
+++ b/doc/api/next_api_changes/2018-01-28-AL.rst
@@ -4,8 +4,13 @@ New `Formatter.format_ticks` method
 The `Formatter` class gained a new `~Formatter.format_ticks` method, which
 takes the list of all tick locations as a single argument and returns the list
 of all formatted values.  It is called by the axis tick handling code and, by
-default, repeatedly calls `~Formatter.__call__`.
+default, first calls `~Formatter.set_locs` with all locations, then repeatedly
+calls `~Formatter.__call__` for each location.
 
-It is intended to be overridden by `Formatter` subclasses for which
-the formatting of a tick value depends on other tick values, such as
-`ConciseDateFormatter`.
+Tick-handling code in the codebase that previously performed this sequence
+(`~Formatter.set_locs` followed by repeated `~Formatter.__call__`) have been
+updated to use `~Formatter.format_ticks`.
+
+`~Formatter.format_ticks` is intended to be overridden by `Formatter`
+subclasses for which the formatting of a tick value depends on other tick
+values, such as `ConciseDateFormatter`.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -934,12 +934,10 @@ class Axis(martist.Artist):
         """
         major_locs = self.major.locator()
         major_ticks = self.get_major_ticks(len(major_locs))
-        self.major.formatter.set_locs(major_locs)
         major_labels = self.major.formatter.format_ticks(major_locs)
 
         minor_locs = self.minor.locator()
         minor_ticks = self.get_minor_ticks(len(minor_locs))
-        self.minor.formatter.set_locs(minor_locs)
         minor_labels = self.minor.formatter.format_ticks(minor_locs)
 
         yield from zip(major_ticks, major_locs, major_labels)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -788,7 +788,6 @@ class ColorbarBase(cm.ScalarMappable):
             b = b[(b <= intv[1] + eps) & (b >= intv[0] - eps)]
         self._manual_tick_data_values = b
         ticks = self._locate(b)
-        formatter.set_locs(b)
         ticklabels = formatter.format_ticks(b)
         offset_string = formatter.get_offset()
         return ticks, ticklabels, offset_string

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -255,6 +255,7 @@ class Formatter(TickHelper):
 
     def format_ticks(self, values):
         """Return the tick labels for all the ticks at once."""
+        self.set_locs(values)
         return [self(value, i) for i, value in enumerate(values)]
 
     def format_data(self, value):

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -225,12 +225,10 @@ class AxisArtistHelperRectlinear(object):
 
             major = self.axis.major
             majorLocs = major.locator()
-            major.formatter.set_locs(majorLocs)
             majorLabels = major.formatter.format_ticks(majorLocs)
 
             minor = self.axis.minor
             minorLocs = minor.locator()
-            minor.formatter.set_locs(minorLocs)
             minorLabels = minor.formatter.format_ticks(minorLocs)
 
             trans_tick = self.get_tick_transform(axes)

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -291,11 +291,9 @@ class FormatterPrettyPrint(object):
     def __call__(self, direction, factor, values):
         if not self._ignore_factor:
             if factor is None:
-                factor = 1.
-            values = [v/factor for v in values]
-        #values = [v for v in values]
-        self._fmt.set_locs(values)
-        return [self._fmt(v) for v in values]
+                factor = 1
+            values = [v / factor for v in values]
+        return self._fmt.format_ticks(values)
 
 
 class DictFormatter(object):

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -135,9 +135,7 @@ class Axis(maxis.XAxis):
 
     def get_tick_positions(self):
         majorLocs = self.major.locator()
-        self.major.formatter.set_locs(majorLocs)
-        majorLabels = [self.major.formatter(val, i)
-                       for i, val in enumerate(majorLocs)]
+        majorLabels = self.major.formatter.format_ticks(majorLocs)
         return majorLabels, majorLocs
 
     def get_major_ticks(self, numticks=None):
@@ -236,11 +234,8 @@ class Axis(maxis.XAxis):
             locmin, locmax = locmax, locmin
 
         # Rudimentary clipping
-        majorLocs = [loc for loc in majorLocs if
-                     locmin <= loc <= locmax]
-        self.major.formatter.set_locs(majorLocs)
-        majorLabels = [self.major.formatter(val, i)
-                       for i, val in enumerate(majorLocs)]
+        majorLocs = [loc for loc in majorLocs if locmin <= loc <= locmax]
+        majorLabels = self.major.formatter.format_ticks(majorLocs)
 
         mins, maxs, centers, deltas, tc, highs = self._get_coord_info(renderer)
 


### PR DESCRIPTION
All calls to Formatter.set_locs occur before a call to
Formatter.format_ticks (or its predecessor, a list of calls to
`Formatter.__call__`); it was basically a bandaid around the fact that
all tick locations were needed to properly format an individual tick.

Move the call to set_locs into format_ticks, with the intention to later
deprecate set_locs.

Convert a few more places to use format_ticks.

Milestoning as 3.1 as format_ticks is a new API there so we can still change it before 3.1 is released...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
