### PR TITLE
Cleanup ScalarFormatter; preparatory to moving it to format_ticks.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -650,18 +650,13 @@ class ScalarFormatter(Formatter):
         """
         self.locs = locs
         if len(self.locs) > 0:
-            vmin, vmax = self.axis.get_view_interval()
-            d = abs(vmax - vmin)
             if self._useOffset:
                 self._compute_offset()
-            self._set_orderOfMagnitude(d)
-            self._set_format(vmin, vmax)
+            self._set_order_of_magnitude()
+            self._set_format()
 
     def _compute_offset(self):
         locs = self.locs
-        if locs is None or not len(locs):
-            self.offset = 0
-            return
         # Restrict to visible ticks.
         vmin, vmax = sorted(self.axis.get_view_interval())
         locs = np.asarray(locs)
@@ -699,7 +694,7 @@ class ScalarFormatter(Formatter):
                        if abs_max // 10 ** oom >= 10**n
                        else 0)
 
-    def _set_orderOfMagnitude(self, range):
+    def _set_order_of_magnitude(self):
         # if scientific notation is to be used, find the appropriate exponent
         # if using an numerical offset, find the exponent after applying the
         # offset. When lower power limit = upper <> 0, use provided exponent.
@@ -719,7 +714,7 @@ class ScalarFormatter(Formatter):
             self.orderOfMagnitude = 0
             return
         if self.offset:
-            oom = math.floor(math.log10(range))
+            oom = math.floor(math.log10(vmax - vmin))
         else:
             if locs[0] > locs[-1]:
                 val = locs[0]
@@ -736,11 +731,11 @@ class ScalarFormatter(Formatter):
         else:
             self.orderOfMagnitude = 0
 
-    def _set_format(self, vmin, vmax):
+    def _set_format(self):
         # set the format string to format all the ticklabels
         if len(self.locs) < 2:
             # Temporarily augment the locations with the axis end points.
-            _locs = [*self.locs, vmin, vmax]
+            _locs = [*self.locs, *self.axis.get_view_interval()]
         else:
             _locs = self.locs
         locs = (np.asarray(_locs) - self.offset) / 10. ** self.orderOfMagnitude


### PR DESCRIPTION
ScalarFormatter.set_locs calls a bunch of helper methods with arguments
that the helpers can reconstruct themselves based on
axis.get_view_interval(); in fact they *already* call
axis.get_view_interval() at certain places.  So get rid of these
arguments.

ScalarFormatter._compute_offset is only ever called by set_locs, and
only if len(locs) > 0, so the `locs is None or not len(locs)` condition
is never True.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
