### PR TITLE
Pin flake8<3.7 to mitigate issues with flake8-per-file-ignores

### DIFF
--- a/requirements/testing/travis_flake8.txt
+++ b/requirements/testing/travis_flake8.txt
@@ -1,4 +1,4 @@
 # Extra pip requirements for the travis flake8 build
 
-flake8
+flake8<3.7
 flake8-per-file-ignores


### PR DESCRIPTION
## PR Summary

Since flake8 3.7.0 (released today), flake8 has builtin functionality for per-file-ignores.
The plugin is not needed anymore. Also the plugin does not play well with flake8 since the argue about registering the command line parameter:
> optparse.OptionConflictError: option --per-file-ignores: conflicting option string(s): --per-file-ignores

which breaks our flake8 travis test.

**Update**
per-files-ignore has a bit of a rough start in flake8 v3.7. There have already been two patch releases and it's still not working for me. I suggest that we let flake8 settle down a bit and migrate to 3.7.x later.
