### PR TITLE
Add Axis.get_inverted and Axis.set_inverted.

### DIFF
--- a/doc/users/next_whats_new/2018-02-01-AL.rst
+++ b/doc/users/next_whats_new/2018-02-01-AL.rst
@@ -1,0 +1,11 @@
+Added `Axis.get_inverted` and `Axis.set_inverted`
+`````````````````````````````````````````````````
+
+The `Axis.get_inverted` and `Axis.set_inverted` methods query and set whether
+the axis uses "inverted" orientation (i.e. increasing to the left for the
+x-axis and to the bottom for the y-axis).
+
+They perform tasks similar to `Axes.xaxis_inverted`, `Axes.yaxis_inverted`,
+`Axes.invert_xaxis`, and `Axes.invert_yaxis`, with the specific difference that
+`.set_inverted` makes it easier to set the invertedness of an axis regardless
+of whether it had previously been inverted before.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2998,7 +2998,7 @@ class _AxesBase(martist.Artist):
         get_xlim, set_xlim
         get_xbound, set_xbound
         """
-        self.set_xlim(self.get_xlim()[::-1], auto=None)
+        self.xaxis.set_inverted(not self.xaxis.get_inverted())
 
     def xaxis_inverted(self):
         """
@@ -3012,8 +3012,7 @@ class _AxesBase(martist.Artist):
         get_xlim, set_xlim
         get_xbound, set_xbound
         """
-        left, right = self.get_xlim()
-        return right < left
+        return self.xaxis.get_inverted()
 
     def get_xbound(self):
         """
@@ -3404,7 +3403,7 @@ class _AxesBase(martist.Artist):
         get_ylim, set_ylim
         get_ybound, set_ybound
         """
-        self.set_ylim(self.get_ylim()[::-1], auto=None)
+        self.yaxis.set_inverted(not self.yaxis.get_inverted())
 
     def yaxis_inverted(self):
         """
@@ -3418,8 +3417,7 @@ class _AxesBase(martist.Artist):
         get_ylim, set_ylim
         get_ybound, set_ybound
         """
-        bottom, top = self.get_ylim()
-        return top < bottom
+        return self.yaxis.get_inverted()
 
     def get_ybound(self):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -909,6 +909,31 @@ class Axis(martist.Artist):
         '''set the axis data limits'''
         raise NotImplementedError('Derived must override')
 
+    def get_inverted(self):
+        """
+        Return whether the axis is oriented in the "inverse" direction.
+
+        The "normal" direction is increasing to the right for the x-axis and to
+        the top for the y-axis; the "inverse" direction is increasing to the
+        left for the x-axis and to the bottom for the y-axis.
+        """
+        low, high = self.get_view_interval()
+        return high < low
+
+    def set_inverted(self, inverted):
+        """
+        Set whether the axis is oriented in the "inverse" direction.
+
+        The "normal" direction is increasing to the right for the x-axis and to
+        the top for the y-axis; the "inverse" direction is increasing to the
+        left for the x-axis and to the bottom for the y-axis.
+        """
+        a, b = self.get_view_interval()
+        if inverted:
+            self.set_view_interval(max(a, b), min(a, b), ignore=True)
+        else:
+            self.set_view_interval(min(a, b), max(a, b), ignore=True)
+
     def set_default_intervals(self):
         '''set the default limits for the axis data and view interval if they
         are not mutated'''


### PR DESCRIPTION
See rationale in changelog note (basically, Axes.invert_xaxis is fine
for interactive use, but a bit of a pain for library-work).

Note that xaxis_inverted is now implemented in terms of get_inverted and
invert_xaxis in terms of set_inverted, so the new methods are properly
tested.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
