### PR TITLE
Try forcing font cache rebuild in flaky ttc test.

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -8,6 +8,7 @@ import warnings
 import numpy as np
 import pytest
 
+from matplotlib import font_manager as fm
 from matplotlib.font_manager import (
     findfont, findSystemFonts, FontProperties, fontManager, json_dump,
     json_load, get_font, get_fontconfig_fonts, is_opentype_cff_font,
@@ -114,12 +115,11 @@ def test_utf16m_sfnt():
                    reason="Font may be missing.")
 def test_find_ttc():
     fp = FontProperties(family=["WenQuanYi Zen Hei"])
-    font = findfont(fp)
-    if Path(font).name != "wqy-zenhei.ttc":
-        # This test appears to be flaky on Travis... investigate it.
-        print("system fonts:")
-        print(*findSystemFonts(), sep="\n")
-        pytest.fail("Failed to find wqy-zenhei.ttc")
+    if Path(findfont(fp)).name != "wqy-zenhei.ttc":
+        # Travis appears to fail to pick up the ttc file sometimes.  Try to
+        # rebuild the cache and try again.
+        fm._rebuild()
+        assert Path(findfont(fp)).name == "wqy-zenhei.ttc"
 
     fig, ax = plt.subplots()
     ax.text(.5, .5, "\N{KANGXI RADICAL DRAGON}", fontproperties=fp)


### PR DESCRIPTION
Looks like Travis is correctly installing the font (it is present as
/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc, https://github.com/matplotlib/matplotlib/pull/13072#issuecomment-459166919), but perhaps it is using
an outdated font cache?

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
