### PR TITLE
Fix possible leak of return of PySequence_GetItem.

### DIFF
--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -727,6 +727,7 @@ static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *
             return NULL;
         }
         codes[i] = PyBytes_AsString(item);
+        Py_DECREF(item);
         if (codes[i] == NULL) {
             return NULL;
         }

--- a/src/py_adaptors.h
+++ b/src/py_adaptors.h
@@ -240,6 +240,7 @@ class PathGenerator
             throw py::exception();
         }
         if (!convert_path(item, &path)) {
+            Py_DECREF(item);
             throw py::exception();
         }
         Py_DECREF(item);


### PR DESCRIPTION
## PR Summary

`PySequence_GetItem` returns a new reference, which we should decrement.

Note: Technically, the string (from `PyBytes_AsString`) requires the object to be ref'd, but we know it won't get GC'd because there's a ref by the containing object, and doing it early means we don't have to worry about error handling.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way