### PR TITLE
Update and factor out Axis.get_tick_positions.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1710,6 +1710,43 @@ class Axis(martist.Artist):
         # Must be overridden in the subclass
         raise NotImplementedError()
 
+    def _get_ticks_position(self):
+        """
+        Helper for `XAxis.get_ticks_position` and `YAxis.get_ticks_position`.
+
+        Check the visibility of tick1line, label1, tick2line, and label2 on
+        the first major and the first minor ticks, and return
+
+        - 1 if only tick1line and label1 are visible (which corresponds to
+          "bottom" for the x-axis and "left" for the y-axis);
+        - 2 if only tick2line and label2 are visible (which corresponds to
+          "top" for the x-axis and "right" for the y-axis);
+        - "default" if only tick1line, tick2line and label1 are visible;
+        - "unknown" otherwise.
+        """
+        major = self.majorTicks[0]
+        minor = self.minorTicks[0]
+        if all(tick.tick1line.get_visible()
+               and not tick.tick2line.get_visible()
+               and tick.label1.get_visible()
+               and not tick.label2.get_visible()
+               for tick in [major, minor]):
+            return 1
+        elif all(tick.tick2line.get_visible()
+                 and not tick.tick1line.get_visible()
+                 and tick.label2.get_visible()
+                 and not tick.label1.get_visible()
+                 for tick in [major, minor]):
+            return 2
+        elif all(tick.tick1line.get_visible()
+                 and tick.tick2line.get_visible()
+                 and tick.label1.get_visible()
+                 and not tick.label2.get_visible()
+                 for tick in [major, minor]):
+            return "default"
+        else:
+            return "unknown"
+
     def get_label_position(self):
         """
         Return the label position (top or bottom)
@@ -2002,30 +2039,11 @@ class XAxis(Axis):
 
     def get_ticks_position(self):
         """
-        Return the ticks position (top, bottom, default or unknown)
+        Return the ticks position ("top", "bottom", "default", or "unknown").
         """
-        major = self.majorTicks[0]
-        minor = self.minorTicks[0]
-        if all(tick.tick1line.get_visible()
-               and not tick.tick2line.get_visible()
-               and tick.label1.get_visible()
-               and not tick.label2.get_visible()
-               for tick in [major, minor]):
-            return "bottom"
-        elif all(tick.tick2line.get_visible()
-                 and not tick.tick1line.get_visible()
-                 and tick.label2.get_visible()
-                 and not tick.label1.get_visible()
-                 for tick in [major, minor]):
-            return "top"
-        elif all(tick.tick1line.get_visible()
-                 and tick.tick2line.get_visible()
-                 and tick.label1.get_visible()
-                 and not tick.label2.get_visible()
-                 for tick in [major, minor]):
-            return "default"
-        else:
-            return "unknown"
+        return {1: "bottom", 2: "top",
+                "default": "default", "unknown": "unknown"}[
+                    self._get_ticks_position()]
 
     def get_view_interval(self):
         'return the Interval instance for this axis view limits'
@@ -2383,33 +2401,11 @@ class YAxis(Axis):
 
     def get_ticks_position(self):
         """
-        Return the ticks position (left, right, both or unknown)
+        Return the ticks position ("left", "right", "default", or "unknown").
         """
-        majt = self.majorTicks[0]
-        mT = self.minorTicks[0]
-
-        majorRight = ((not majt.tick1On) and majt.tick2On and
-                      (not majt.label1On) and majt.label2On)
-        minorRight = ((not mT.tick1On) and mT.tick2On and
-                      (not mT.label1On) and mT.label2On)
-        if majorRight and minorRight:
-            return 'right'
-
-        majorLeft = (majt.tick1On and (not majt.tick2On) and
-                     majt.label1On and (not majt.label2On))
-        minorLeft = (mT.tick1On and (not mT.tick2On) and
-                     mT.label1On and (not mT.label2On))
-        if majorLeft and minorLeft:
-            return 'left'
-
-        majorDefault = (majt.tick1On and majt.tick2On and
-                        majt.label1On and (not majt.label2On))
-        minorDefault = (mT.tick1On and mT.tick2On and
-                        mT.label1On and (not mT.label2On))
-        if majorDefault and minorDefault:
-            return 'default'
-
-        return 'unknown'
+        return {1: "left", 2: "right",
+                "default": "default", "unknown": "unknown"}[
+                    self._get_ticks_position()]
 
     def get_view_interval(self):
         'return the Interval instance for this axis view limits'


### PR DESCRIPTION
YAxis.get_ticks_position had not been updated after the deprecation of
label1On (#10088).  Fix that by making it share its implementation with
XAxis.get_ticks_position.

Release critical as YAxis.get_ticks_position otherwise emits a DeprecationWarning.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
