### PR TITLE
Update imshow docs.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5406,21 +5406,25 @@ optional.
 
             - (M, N): an image with scalar data. The data is visualized
               using a colormap.
-            - (M, N, 3): an image with RGB values (float or uint8).
-            - (M, N, 4): an image with RGBA values (float or uint8), i.e.
-              including transparency.
+            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
+            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
+              i.e. including transparency.
 
             The first two dimensions (M, N) define the rows and columns of
             the image.
 
-            The RGB(A) values should be in the range [0 .. 1] for floats or
-            [0 .. 255] for integers.  Out-of-range values will be clipped to
-            these bounds.
+            Out-of-range RGB(A) values are clipped.
 
         cmap : str or `~matplotlib.colors.Colormap`, optional
-            A Colormap instance or registered colormap name. The colormap
-            maps scalar data to colors. It is ignored for RGB(A) data.
+            The Colormap instance or registered colormap name used to map
+            scalar data to colors. This parameter is ignored for RGB(A) data.
             Defaults to :rc:`image.cmap`.
+
+        norm : `~matplotlib.colors.Normalize`, optional
+            The `Normalize` instance used to scale scalar data to the [0, 1]
+            range before mapping to colors using *cmap*. By default, a linear
+            scaling mapping the lowest value to 0 and the highest to 1 is used.
+            This parameter is ignored for RGB(A) data.
 
         aspect : {'equal', 'auto'} or float, optional
             Controls the aspect ratio of the axes. The aspect is of particular
@@ -5462,22 +5466,15 @@ optional.
             which can be set by *filterrad*. Additionally, the antigrain image
             resize filter is controlled by the parameter *filternorm*.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            If scalar data are used, the Normalize instance scales the
-            data values to the canonical colormap range [0,1] for mapping
-            to colors. By default, the data range is mapped to the
-            colorbar range using linear scaling. This parameter is ignored for
-            RGB(A) data.
+        alpha : scalar, optional
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+            This parameter is ignored for RGBA input data.
 
         vmin, vmax : scalar, optional
             When using scalar data and no explicit *norm*, *vmin* and *vmax*
             define the data range that the colormap covers. By default,
             the colormap covers the complete value range of the supplied
             data. *vmin*, *vmax* are ignored if the *norm* parameter is used.
-
-        alpha : scalar, optional
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-            This parameter is ignored for RGBA input data.
 
         origin : {'upper', 'lower'}, optional
             Place the [0,0] index of the array in the upper left or lower left


### PR DESCRIPTION
- Reword a bit description of X argument.  Note that *any* integer
  data, even if not uint8, is interpreted as 0-255 uint8 (with clipping
  to that range).
- Move the doc for `norm` up to its position in the signature (right
  after `cmap`).  Reword the docs for `cmap` and `norm` to be phrased
  more similarly.
- Move the doc for `alpha` up to its position in the signature (before
  `vmin`, `vmax`).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
