### PR TITLE
MAINT pinning down the pytest-xdist version

### DIFF
--- a/requirements/testing/travis35.txt
+++ b/requirements/testing/travis35.txt
@@ -10,3 +10,4 @@ pytest-cov==2.3.1
 pytest-timeout==1.2.1  # Newer pytest-timeouts don't support pytest 3.4.
 pytest-rerunfailures<5  # newer versions require pytest3.6
 sphinx==1.3
+pytest-xdist==1.24.0 


### PR DESCRIPTION
Pinning down version pytest-xdist to fix tests.