### PR TITLE
Fix: Log Colorbar minorticks_off reverted if ticks set

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -579,6 +579,8 @@ class ColorbarBase(_ColorbarMappableDummy):
             # mid point is easier.
             self.ax.set_xscale('log')
             self.ax.set_yscale('log')
+
+            self.minorticks_on()
         else:
             self.ax.set_xscale('linear')
             self.ax.set_yscale('linear')
@@ -602,8 +604,6 @@ class ColorbarBase(_ColorbarMappableDummy):
             _log.debug('locator: %r', locator)
             long_axis.set_major_locator(locator)
             long_axis.set_major_formatter(formatter)
-            if type(self.norm) == colors.LogNorm:
-                self.minorticks_on()
         else:
             _log.debug('Using fixed locator on colorbar')
             ticks, ticklabels, offset_string = self._ticker(locator, formatter)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -325,6 +325,12 @@ def test_colorbar_minorticks_on_off():
     assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
                           default_minorticklocks)
 
+    # test issue #13339: minorticks for LogNorm should stay off
+    cbar.minorticks_off()
+    cbar.set_ticks([3, 5, 7, 9])
+    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
+                          np.array([]))
+
 
 def test_colorbar_autoticks():
     # Test new autotick modes. Needs to be classic because


### PR DESCRIPTION

## PR Summary

Closes #13339.

Fixes issue where colorbar lognorm minorticks are turned back on anytime ticks are updated.

## Before

Any time ``ColorbarBase.update_ticks`` is called, it forces minorticks on for LogNorm. Calling methods like ``set_ticks`` therefore reverts the action of minorticks_off. 

```python

fig, ax = plt.subplots()

data = np.clip(randn(250, 250)*1000, 0, 1000)

cax = ax.imshow(data, norm=mpl.colors.LogNorm(vmin=1, vmax=1000))
cbar = fig.colorbar(cax, format='%d')

cbar.minorticks_off()
cbar.set_ticks([5, 10, 100])

plt.show()
```

Produces,

![mpl3_lognorm_update_ticks_before](https://user-images.githubusercontent.com/15056721/52172623-81781980-2741-11e9-9129-7b08d574c3ba.png)

(Note minorticks come back on, after being explicitly turned off.)

## After

Minorticks stay off after being manually turned off.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
