### PR TITLE
ENH: add figure id to its __repr__

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -266,13 +266,9 @@ class Figure(Artist):
         return "Figure(%gx%g)" % tuple(self.bbox.size)
 
     def __repr__(self):
-        clsname=self.__class__.__name__
-        h = self.bbox.size[0]
-        w = self.bbox.size[1]
-        naxes=len(self.axes)
-        uniqueid=id(self)
-        return (f"<{clsname} size {h:g}x{w:g} with {naxes} Axes; "
-                f"0x{uniqueid:x}>")
+        return (f"<{self.__class__.__name__} size {self.bbox.size[0]:g}"
+                f"x{self.bbox.size[1]:g} with {len(self.axes)} Axes; "
+                f"0x{id(self):x}>")
 
     def __init__(self,
                  figsize=None,

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -266,11 +266,13 @@ class Figure(Artist):
         return "Figure(%gx%g)" % tuple(self.bbox.size)
 
     def __repr__(self):
-        return "<{clsname} size {h:g}x{w:g} with {naxes} Axes>".format(
-            clsname=self.__class__.__name__,
-            h=self.bbox.size[0], w=self.bbox.size[1],
-            naxes=len(self.axes),
-        )
+        clsname=self.__class__.__name__
+        h = self.bbox.size[0]
+        w = self.bbox.size[1]
+        naxes=len(self.axes)
+        uniqueid=id(self)
+        return (f"<{clsname} size {h:g}x{w:g} with {naxes} Axes; "
+                f"0x{uniqueid:x}>")
 
     def __init__(self,
                  figsize=None,

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -373,7 +373,7 @@ def test_savefig():
 
 def test_figure_repr():
     fig = plt.figure(figsize=(10, 20), dpi=10)
-    assert repr(fig) == "<Figure size 100x200 with 0 Axes>"
+    assert repr(fig)[:36] == "<Figure size 100x200 with 0 Axes; 0x"
 
 
 def test_warn_cl_plus_tl():


### PR DESCRIPTION
## PR Summary

Per #13344 I don't see any reason figure.__repr__ should *not* include the object id in it...
`print(fig.__repr__())` now returns:

```
<Figure size 1280x960 with 1 Axes; 0x109147cf8>
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->