### PR TITLE
Properly deprecate non-1D inputs to pie().

### DIFF
--- a/doc/api/next_api_changes/2018-02-03-AL.rst
+++ b/doc/api/next_api_changes/2018-02-03-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+Passing a non-1D (typically, (n, 1)-shaped) input to `Axes.pie` is deprecated.
+Pass a 1D array instead.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2809,11 +2809,19 @@ class Axes(_AxesBase):
         The axes aspect ratio can be controlled with `Axes.set_aspect`.
         """
         self.set_aspect('equal')
-        x = np.array(x, np.float32)
+        # The use of float32 is "historical", but can't be changed without
+        # regenerating the test baselines.
+        x = np.asarray(x, np.float32)
+        if x.ndim != 1 and x.squeeze().ndim <= 1:
+            cbook.warn_deprecated(
+                "3.1", message="Non-1D inputs to pie() are currently "
+                "squeeze()d, but this behavior is deprecated since %(since)s "
+                "and will be removed %(removal)s; pass a 1D array instead.")
+            x = np.atleast_1d(x.squeeze())
 
         sx = x.sum()
         if sx > 1:
-            x /= sx
+            x = x / sx
 
         if labels is None:
             labels = [''] * len(x)


### PR DESCRIPTION
This PR also restores (... for the duration of the deprecation) the
support for non-1D inputs that can be squeezed to a 1D array that was
broken with numpy 1.16.

Closes #13286, although someone *may* want to additionally backport the fix (without the deprecations) to 3.0.x.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
