### PR TITLE
DOC: fix note of what version hold was deprecated in (2.0 not 2.1)

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -42,7 +42,7 @@ API Changes for 3.0.1
 `.tight_layout.auto_adjust_subplotpars` can return ``None`` now if the new
 subplotparams will collapse axes to zero width or height.  This prevents
 ``tight_layout`` from being executed.  Similarly
-`.tight_layout.get_tight_layout_figure` will return None.  
+`.tight_layout.get_tight_layout_figure` will return None.
 
 API Changes for 3.0.0
 =====================
@@ -514,7 +514,7 @@ Removals
 Hold machinery
 ``````````````
 
-Setting or unsetting ``hold`` (deprecated in version 2.1) has now
+Setting or unsetting ``hold`` (:ref:`deprecated in version 2.0<v200_deprecate_hold>`) has now
 been completely removed. Matplotlib now always behaves as if ``hold=True``.
 To clear an axes you can manually use :meth:`~.axes.Axes.cla()`,
 or to clear an entire figure use :meth:`~.figure.Figure.clf()`.

--- a/doc/api/prev_api_changes/api_changes_2.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.0.0.rst
@@ -34,6 +34,8 @@ The TkAgg backend had its own implementation of the `round` function. This
 was unused internally and has been removed. Instead, use either the
 `round` builtin function or `numpy.round`.
 
+.. _v200_deprecate_hold:
+
 'hold' functionality deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The 'hold' keyword argument and all functions and methods related


### PR DESCRIPTION
Also add a link to initial deprecation.


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->