### PR TITLE
FIX: Fix shape of hist output when input is multidimensional empty list

### DIFF
--- a/doc/api/next_api_changes/2019-02-07-AH.rst
+++ b/doc/api/next_api_changes/2019-02-07-AH.rst
@@ -1,0 +1,6 @@
+Modify output of Axes.hist when input consists of multiple empty lists
+``````````````````````````````````````````````````````````````````````
+
+Input that consists of multiple empty lists will now return a list of histogram
+values for each one of the lists. For example, an input of ``[[],[]]`` will
+return 2 lists of histogram values. Previously, a single list was returned.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6625,10 +6625,7 @@ optional.
         # basic input validation
         input_empty = np.size(x) == 0
         # Massage 'x' for processing.
-        if input_empty:
-            x = [np.array([])]
-        else:
-            x = cbook._reshape_2D(x, 'x')
+        x = cbook._reshape_2D(x, 'x')
         nx = len(x)  # number of datasets
 
         # Process unit information

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1665,6 +1665,20 @@ def test_hist_datetime_datasets():
     ax.hist(data, stacked=False)
 
 
+@pytest.mark.parametrize('data, expected_number_of_hists',
+                         [([], 1),
+                          ([[]], 1),
+                          ([[], []], 2)])
+def test_hist_with_empty_input(data, expected_number_of_hists):
+    hists, _, _ = plt.hist(data)
+    hists = np.asarray(hists)
+
+    if hists.ndim == 1:
+        assert 1 == expected_number_of_hists
+    else:
+        assert hists.shape[0] == expected_number_of_hists
+
+
 def contour_dat():
     x = np.linspace(-3, 5, 150)
     y = np.linspace(-3, 5, 120)


### PR DESCRIPTION
## PR Summary
Fixes #13002.

Currently `plt.hist([np.array([])])` returns a single array of zeroes for the histogram values (`n` in the documentation). 
There is some pre-processing that converts any input for which `np.size(input) == 0` into `[np.array([])]`. 

In #13002 the code `plt.hist([[], []], color=["k", "r"])` produces an error because the input of `[[],[]]` is pre-processed into `[np.array([])]` and its length is no longer equal to the length of `color`.

The fact that an input of `[[],[]]` is pre-processed in this way means that its output is a single array of bin values. This seems to contradict the documentation for `n`:
> If input is a sequence of arrays ``[data1, data2,..]``, then this is a list of arrays with the values of the histograms for each of the arrays in the same order.

This PR modifies the treatment of multiple empty lists as input to follow the documentation. If the input contains multiple sets of data (even if they're empty), the output will contain the same number of histogram value sets. This also solves #13002.

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
