### PR TITLE
Deprecate axis3d.Axis.get_tick_positions.

### DIFF
--- a/doc/api/next_api_changes/2018-02-06-AL.rst
+++ b/doc/api/next_api_changes/2018-02-06-AL.rst
@@ -1,0 +1,7 @@
+Deprecations
+````````````
+
+``axis3d.Axis.get_tick_positions`` is deprecated.  It has never been used
+internally, no equivalent method exists on the 2D Axis classes, and, despite
+the similar name, it has a completely different behavior from the 2D Axis'
+`axis.Axis.get_ticks_position` method.

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -7,7 +7,8 @@ import copy
 import numpy as np
 
 from matplotlib import (
-    artist, lines as mlines, axis as maxis, patches as mpatches, rcParams)
+    artist, cbook, lines as mlines, axis as maxis, patches as mpatches,
+    rcParams)
 from . import art3d, proj3d
 
 
@@ -133,6 +134,7 @@ class Axis(maxis.XAxis):
         self.label._transform = self.axes.transData
         self.offsetText._transform = self.axes.transData
 
+    @cbook.deprecated("3.1")
     def get_tick_positions(self):
         majorLocs = self.major.locator()
         self.major.formatter.set_locs(majorLocs)


### PR DESCRIPTION
See changelog entry for rationale.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
