### PR TITLE
Improve Axes selection in Qt figure options.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -758,30 +758,31 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             return size
 
     def edit_parameters(self):
-        allaxes = self.canvas.figure.get_axes()
-        if not allaxes:
+        axes = self.canvas.figure.get_axes()
+        if not axes:
             QtWidgets.QMessageBox.warning(
                 self.parent, "Error", "There are no axes to edit.")
             return
-        elif len(allaxes) == 1:
-            axes, = allaxes
+        elif len(axes) == 1:
+            ax, = axes
         else:
-            titles = []
-            for axes in allaxes:
-                name = (axes.get_title() or
-                        " - ".join(filter(None, [axes.get_xlabel(),
-                                                 axes.get_ylabel()])) or
-                        "<anonymous {} (id: {:#x})>".format(
-                            type(axes).__name__, id(axes)))
-                titles.append(name)
+            titles = [
+                ax.get_label() or
+                ax.get_title() or
+                " - ".join(filter(None, [ax.get_xlabel(), ax.get_ylabel()])) or
+                f"<anonymous {type(ax).__name__}>"
+                for ax in axes]
+            duplicate_titles = [
+                title for title in titles if titles.count(title) > 1]
+            for i, ax in enumerate(axes):
+                if titles[i] in duplicate_titles:
+                    titles[i] += f" (id: {id(ax):#x})"  # Deduplicate titles.
             item, ok = QtWidgets.QInputDialog.getItem(
                 self.parent, 'Customize', 'Select axes:', titles, 0, False)
-            if ok:
-                axes = allaxes[titles.index(item)]
-            else:
+            if not ok:
                 return
-
-        figureoptions.figure_edit(axes, self)
+            ax = axes[titles.index(item)]
+        figureoptions.figure_edit(ax, self)
 
     def _update_buttons_checked(self):
         # sync button checkstates to match active mode

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1437,7 +1437,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         if parent_anchor is not False:
             ax.set_anchor(parent_anchor)
 
-    cax = fig.add_axes(pbcb)
+    cax = fig.add_axes(pbcb, label="<colorbar>")
 
     # OK, now make a layoutbox for the cb axis.  Later, we will use this
     # to make the colorbar fit nicely.
@@ -1551,7 +1551,7 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
     parent.set_anchor(panchor)
 
     fig = parent.get_figure()
-    cax = fig.add_subplot(gs2[1])
+    cax = fig.add_subplot(gs2[1], label="<colorbar>")
     cax.set_aspect(aspect, anchor=anchor, adjustable='box')
     return cax, kw
 


### PR DESCRIPTION
1. Make sure Axes "labels" in the input dialog are unique
   (QInputDialog.getItem returns the selected string, but we'll get the
   wrong index if two axes share e.g. the same title), by including the
   axes id() if necessary; conversely, don't include the id() in the
   user-facing UI unless necessary.

   For example, previously, after

       fig, axs = plt.subplots(2)
       axs[0].set(xlabel="foo"); axs[1].set(xlabel="foo")

   the input dialog would not allow selecting the second axes.

2. If the Axes artist has a "label" attached to it (per
   `Artist.set_label`), use it in priority for the input dialog.
   Normally, axes labels are not used (they are used for other artists
   for the legend, for example).  This change allows us to attach a
   "(colorbar)" label to colorbar axes, which makes it easier to select
   the right axes.

   After

        fig, axs = plt.subplots(2)
        axs[0].imshow([[0]]); fig.colorbar(axs[0].images[0])
        axs[1].imshow([[0]]); fig.colorbar(axs[1].images[0])

    previously the input dialog would have the entries

        <anonymous AxesSubplot (id: 0x...)>
        <anonymous AxesSubplot (id: 0x...)>
        <anonymous AxesSubplot (id: 0x...)>
        <anonymous AxesSubplot (id: 0x...)>

    but now it has the entries

        <anonymous AxesSubplot> (id: 0x...)
        <anonymous AxesSubplot> (id: 0x...)
        (colorbar) (id: 0x...)
        (colorbar) (id: 0x...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
