### PR TITLE
Add private helper to internally suppress deprecations.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -132,7 +132,6 @@ import shutil
 import subprocess
 import tempfile
 import urllib.request
-import warnings
 
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
@@ -760,8 +759,7 @@ class RcParams(MutableMapping, dict):
 
     def __iter__(self):
         """Yield sorted list of keys."""
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', MatplotlibDeprecationWarning)
+        with cbook._suppress_matplotlib_deprecation_warning():
             yield from sorted(dict.__iter__(self))
 
     def __len__(self):
@@ -917,8 +915,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
         return config_from_file
 
     iter_params = defaultParams.items()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+    with cbook._suppress_matplotlib_deprecation_warning():
         config = RcParams([(key, default) for key, (default, _) in iter_params
                            if key not in _all_deprecated])
     config.update(config_from_file)
@@ -958,8 +955,7 @@ if dict.__getitem__(rcParams, 'examples.directory'):
         rcParams['examples.directory'] = _fullpath
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+with cbook._suppress_matplotlib_deprecation_warning():
     rcParamsOrig = RcParams(rcParams.copy())
     rcParamsDefault = RcParams([(key, default) for key, (default, converter) in
                                 defaultParams.items()
@@ -1062,8 +1058,7 @@ def rcdefaults():
     """
     # Deprecation warnings were already handled when creating rcParamsDefault,
     # no need to reemit them here.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mplDeprecation)
+    with cbook._suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rcParams.clear()
         rcParams.update({k: v for k, v in rcParamsDefault.items()
@@ -1079,8 +1074,7 @@ def rc_file_defaults():
     """
     # Deprecation warnings were already handled when creating rcParamsOrig, no
     # need to reemit them here.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mplDeprecation)
+    with cbook._suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rcParams.update({k: rcParamsOrig[k] for k in rcParamsOrig
                          if k not in STYLE_BLACKLIST})
@@ -1106,8 +1100,7 @@ def rc_file(fname, *, use_default_template=True):
     """
     # Deprecation warnings were already handled in rc_params_from_file, no need
     # to reemit them here.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", mplDeprecation)
+    with cbook._suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rc_from_file = rc_params_from_file(
             fname, use_default_template=use_default_template)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -33,6 +33,7 @@ import numpy as np
 import matplotlib
 from .deprecation import (
     deprecated, warn_deprecated, _rename_parameter,
+    _suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning, mplDeprecation)
 
 

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -1,5 +1,7 @@
+import contextlib
 import functools
 import inspect
+import warnings
 
 
 class MatplotlibDeprecationWarning(UserWarning):
@@ -306,3 +308,10 @@ def _rename_parameter(since, old, new, func=None):
     # pyplot would explicitly pass both arguments to the Axes method.
 
     return wrapper
+
+
+@contextlib.contextmanager
+def _suppress_matplotlib_deprecation_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+        yield

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -25,7 +25,6 @@ from numbers import Number
 import re
 import sys
 import time
-import warnings
 
 from cycler import cycler
 import matplotlib
@@ -2262,9 +2261,7 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
 
     if plotfuncs is None:
         plotfuncs = {}
-    from matplotlib.cbook import MatplotlibDeprecationWarning
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', MatplotlibDeprecationWarning)
+    with cbook._suppress_matplotlib_deprecation_warning():
         r = mlab._csv2rec(fname, comments=comments, skiprows=skiprows,
                           checkrows=checkrows, delimiter=delimiter,
                           names=names)

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -19,7 +19,6 @@ import warnings
 
 import matplotlib as mpl
 from matplotlib import cbook, rc_params_from_file, rcParamsDefault
-from matplotlib.cbook import MatplotlibDeprecationWarning
 
 _log = logging.getLogger(__name__)
 
@@ -103,8 +102,7 @@ def use(style):
         elif style == 'default':
             # Deprecation warnings were already handled when creating
             # rcParamsDefault, no need to reemit them here.
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+            with cbook._suppress_matplotlib_deprecation_warning():
                 _apply_style(rcParamsDefault, warn=False)
         elif style in library:
             _apply_style(library[style])

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 
 import matplotlib as mpl
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib import cbook
 
 _log = logging.getLogger(__name__)
 
@@ -42,8 +42,7 @@ def setup():
 
     mpl.use('Agg', force=True, warn=False)  # use Agg backend for these tests
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+    with cbook._suppress_matplotlib_deprecation_warning():
         mpl.rcdefaults()  # Start with all defaults
 
     # These settings *must* be hardcoded for running the comparison tests and

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -1,10 +1,7 @@
-import warnings
-
 import pytest
 
 import matplotlib
 from matplotlib import cbook
-from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
 def pytest_configure(config):
@@ -53,8 +50,7 @@ def mpl_test_settings(request):
                                 .format(backend, exc))
                 else:
                     raise
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+        with cbook._suppress_matplotlib_deprecation_warning():
             matplotlib.style.use(style)
         try:
             yield

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5608,14 +5608,12 @@ def test_none_kwargs():
 
 
 def test_ls_ds_conflict():
-    with warnings.catch_warnings():
-        # Passing the drawstyle with the linestyle is deprecated since 3.1.
-        # We still need to test this until it's removed from the code.
-        # But we don't want to see the deprecation warning in the test.
-        warnings.filterwarnings('ignore',
-                                category=MatplotlibDeprecationWarning)
-        with pytest.raises(ValueError):
-            plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
+    # Passing the drawstyle with the linestyle is deprecated since 3.1.
+    # We still need to test this until it's removed from the code.
+    # But we don't want to see the deprecation warning in the test.
+    with matplotlib.cbook._suppress_matplotlib_deprecation_warning(), \
+         pytest.raises(ValueError):
+        plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
 
 
 def test_bar_uint8():


### PR DESCRIPTION
I think the warnings API is annoying enough to warrant a helper in
cbook (plus, one will "usually" save the an import of the warnings
module this way).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
