### PR TITLE
Avoid unneeded copies from flatten().

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -282,7 +282,7 @@ class BboxBase(TransformNode):
 
     def is_unit(self):
         """Return whether this is the unit box (from (0, 0) to (1, 1))."""
-        return list(self.get_points().flatten()) == [0., 0., 1., 1.]
+        return self.get_points().tolist() == [[0., 0.], [1., 1.]]
 
     @property
     def x0(self):
@@ -413,13 +413,13 @@ class BboxBase(TransformNode):
     @property
     def bounds(self):
         """Return (:attr:`x0`, :attr:`y0`, :attr:`width`, :attr:`height`)."""
-        x0, y0, x1, y1 = self.get_points().flatten()
+        (x0, y0), (x1, y1) = self.get_points()
         return (x0, y0, x1 - x0, y1 - y0)
 
     @property
     def extents(self):
         """Return (:attr:`x0`, :attr:`y0`, :attr:`x1`, :attr:`y1`)."""
-        return self.get_points().flatten().copy()
+        return self.get_points().flatten()  # flatten returns a copy.
 
     def get_points(self):
         raise NotImplementedError
@@ -1758,10 +1758,10 @@ class Affine2DBase(AffineBase):
 
     def to_values(self):
         """
-        Return the values of the matrix as a sequence (a,b,c,d,e,f)
+        Return the values of the matrix as an ``(a, b, c, d, e, f)`` tuple.
         """
         mtx = self.get_matrix()
-        return tuple(mtx[:2].swapaxes(0, 1).flatten())
+        return tuple(mtx[:2].swapaxes(0, 1).flat)
 
     @staticmethod
     def matrix_from_values(a, b, c, d, e, f):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -490,22 +490,16 @@ class Axes3D(Axes):
                                          scalez=scalez)
 
     def auto_scale_xyz(self, X, Y, Z=None, had_data=None):
-        x, y, z = map(np.asarray, (X, Y, Z))
-        try:
-            x, y = x.flatten(), y.flatten()
-            if Z is not None:
-                z = z.flatten()
-        except AttributeError:
-            raise
-
-        # This updates the bounding boxes as to keep a record as
-        # to what the minimum sized rectangular volume holds the
-        # data.
-        self.xy_dataLim.update_from_data_xy(np.array([x, y]).T, not had_data)
-        if z is not None:
+        # This updates the bounding boxes as to keep a record as to what the
+        # minimum sized rectangular volume holds the data.
+        X = np.reshape(X, -1)
+        Y = np.reshape(Y, -1)
+        self.xy_dataLim.update_from_data_xy(
+            np.column_stack([X, Y]), not had_data)
+        if Z is not None:
+            Z = np.reshape(Z, -1)
             self.zz_dataLim.update_from_data_xy(
-                np.array([z, z]).T, not had_data)
-
+                np.column_stack([Z, Z]), not had_data)
         # Let autoscale_view figure out how to use this data.
         self.autoscale_view()
 


### PR DESCRIPTION
flatten() always returns a new copy, but nearly all places that use
flatten() in the codebase don't need to pay that cost; the only place
that needed it did an additional copy.  Fix them.
(To be honest it's not clear this will make a measurable difference, but heh.)

As a replacement, there's ravel(), which only makes a copy if the input
is not C-contiguous to start with, and reshape(..., -1) which never
makes a copy (as long as the input is already an ndarray), so prefer the
latter.

Note that in the changed snippet in mplot3d, the AttributeError would
never be raised, as x/y/z are converted to arrays and thus always have a
flatten() method.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
