### PR TITLE
Replace np.take by normal indexing.

### DIFF
--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -93,7 +93,7 @@ def pick_simple():
             xdata = thisline.get_xdata()
             ydata = thisline.get_ydata()
             ind = event.ind
-            print('onpick1 line:', zip(np.take(xdata, ind), np.take(ydata, ind)))
+            print('onpick1 line:', np.column_stack([xdata[ind], ydata[ind]]))
         elif isinstance(event.artist, Rectangle):
             patch = event.artist
             print('onpick1 patch:', patch.get_path())
@@ -129,10 +129,10 @@ def pick_custom_hit():
         d = np.sqrt(
             (xdata - mouseevent.xdata)**2 + (ydata - mouseevent.ydata)**2)
 
-        ind = np.nonzero(np.less_equal(d, maxd))
+        ind, = np.nonzero(d <= maxd)
         if len(ind):
-            pickx = np.take(xdata, ind)
-            picky = np.take(ydata, ind)
+            pickx = xdata[ind]
+            picky = ydata[ind]
             props = dict(ind=ind, pickx=pickx, picky=picky)
             return True, props
         else:
@@ -154,7 +154,7 @@ def pick_scatter_plot():
 
     def onpick3(event):
         ind = event.ind
-        print('onpick3 scatter:', ind, np.take(x, ind), np.take(y, ind))
+        print('onpick3 scatter:', ind, x[ind], y[ind])
 
     fig, ax = plt.subplots()
     col = ax.scatter(x, y, 100*s, c, picker=True)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1063,7 +1063,7 @@ def delete_masked_points(*args):
         if len(igood) < nrecs:
             for i, x in enumerate(margs):
                 if seqlist[i]:
-                    margs[i] = x.take(igood, axis=0)
+                    margs[i] = x[igood]
     for i, x in enumerate(margs):
         if seqlist[i] and isinstance(x, np.ma.MaskedArray):
             margs[i] = x.filled()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -741,13 +741,11 @@ class ColorbarBase(_ColorbarMappableDummy):
         '''
         N = X.shape[0]
         ii = [0, 1, N - 2, N - 1, 2 * N - 1, 2 * N - 2, N + 1, N, 0]
-        x = np.take(np.ravel(np.transpose(X)), ii)
-        y = np.take(np.ravel(np.transpose(Y)), ii)
-        x = x.reshape((len(x), 1))
-        y = y.reshape((len(y), 1))
-        if self.orientation == 'horizontal':
-            return np.hstack((y, x))
-        return np.hstack((x, y))
+        x = X.T.reshape(-1)[ii]
+        y = Y.T.reshape(-1)[ii]
+        return (np.column_stack([y, x])
+                if self.orientation == 'horizontal' else
+                np.column_stack([x, y]))
 
     def _edges(self, X, Y):
         '''
@@ -1121,10 +1119,10 @@ class ColorbarBase(_ColorbarMappableDummy):
         i0[ibot] += 1
         ii[ibot] += 1
 
-        db = np.take(b, ii) - np.take(b, i0)
         y = self._y
-        dy = np.take(y, ii) - np.take(y, i0)
-        z = np.take(y, i0) + (xn - np.take(b, i0)) * dy / db
+        db = b[ii] - b[i0]
+        dy = y[ii] - y[i0]
+        z = y[i0] + (xn - b[i0]) * dy / db
         return z
 
     def set_alpha(self, alpha):

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -702,11 +702,11 @@ class Quiver(mcollections.PolyCollection):
                        minsh - self.headlength, minsh], np.float64)
         y0 = 0.5 * np.array([1, 1, self.headwidth, 0], np.float64)
         ii = [0, 1, 2, 3, 2, 1, 0, 0]
-        X = x.take(ii, 1)
-        Y = y.take(ii, 1)
+        X = x[:, ii]
+        Y = y[:, ii]
         Y[:, 3:-1] *= -1
-        X0 = x0.take(ii)
-        Y0 = y0.take(ii)
+        X0 = x0[ii]
+        Y0 = y0[ii]
         Y0[3:-1] *= -1
         shrink = length / minsh if minsh != 0. else 0.
         X0 = shrink * X0[np.newaxis, :]

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -47,23 +47,21 @@ class Test_delete_masked_points(object):
     def test_string_seq(self):
         actual = dmp(self.arr_s, self.arr1)
         ind = [0, 1, 2, 5]
-        expected = (self.arr_s2.take(ind), self.arr2.take(ind))
+        expected = (self.arr_s2[ind], self.arr2[ind])
         assert_array_equal(actual[0], expected[0])
         assert_array_equal(actual[1], expected[1])
 
     def test_datetime(self):
         actual = dmp(self.arr_dt, self.arr3)
-        ind = [0, 1,  5]
-        expected = (self.arr_dt2.take(ind),
-                    self.arr3.take(ind).compressed())
+        ind = [0, 1, 5]
+        expected = (self.arr_dt2[ind], self.arr3[ind].compressed())
         assert_array_equal(actual[0], expected[0])
         assert_array_equal(actual[1], expected[1])
 
     def test_rgba(self):
         actual = dmp(self.arr3, self.arr_rgba)
         ind = [0, 1, 5]
-        expected = (self.arr3.take(ind).compressed(),
-                    self.arr_rgba.take(ind, axis=0))
+        expected = (self.arr3[ind].compressed(), self.arr_rgba[ind])
         assert_array_equal(actual[0], expected[0])
         assert_array_equal(actual[1], expected[1])
 


### PR DESCRIPTION
`np.take(x, ind)` is equivalent to `x.ravel()[ind]` and `np.take(x, ind,
axis=0)` to `x[ind]` (except for some details about contiguity of the
output, not relevant to the changes here).  Straight indexing is more
legible, so use that.

In pick_event_demo, additionally replace zip() by column_stack(), as,
on Py3, printing a zip() object results in `<zip object at 0xdeadbeef>`
which is clearly not intended in the example.

In the same example, `np.nonzero()` always returns a 1-tuple (for 1d
inputs), so the `if len(ind)` test always returned True and the picker
would incorrectly fire even when clicking far away from the plotted
points.  Fix that by unpacking the 1-tuple.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
