### PR TITLE
Remove/rework uses of np.where where possible.

### DIFF
--- a/examples/images_contours_and_fields/barcode_demo.py
+++ b/examples/images_contours_and_fields/barcode_demo.py
@@ -11,12 +11,11 @@ import numpy as np
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-
 # the bar
-x = np.where(np.random.rand(500) > 0.7, 1.0, 0.0)
+x = np.random.rand(500) > 0.7
 
 axprops = dict(xticks=[], yticks=[])
-barprops = dict(aspect='auto', cmap=plt.cm.binary, interpolation='nearest')
+barprops = dict(aspect='auto', cmap='binary', interpolation='nearest')
 
 fig = plt.figure()
 
@@ -27,7 +26,6 @@ ax1.imshow(x.reshape((-1, 1)), **barprops)
 # a horizontal barcode
 ax2 = fig.add_axes([0.3, 0.1, 0.6, 0.1], **axprops)
 ax2.imshow(x.reshape((1, -1)), **barprops)
-
 
 plt.show()
 

--- a/examples/images_contours_and_fields/specgram_demo.py
+++ b/examples/images_contours_and_fields/specgram_demo.py
@@ -3,8 +3,7 @@
 Spectrogram Demo
 ================
 
-Demo of a spectrogram plot
-(:meth:`~.axes.Axes.specgram`).
+Demo of a spectrogram plot (`~.axes.Axes.specgram`).
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,8 +17,7 @@ s1 = np.sin(2 * np.pi * 100 * t)
 s2 = 2 * np.sin(2 * np.pi * 400 * t)
 
 # create a transient "chirp"
-mask = np.where(np.logical_and(t > 10, t < 12), 1.0, 0.0)
-s2 = s2 * mask
+s2[t <= 10] = s2[12 <= t] = 0
 
 # add some noise into the mix
 nse = 0.01 * np.random.random(size=len(t))

--- a/examples/mplot3d/trisurf3d_2.py
+++ b/examples/mplot3d/trisurf3d_2.py
@@ -1,4 +1,4 @@
-'''
+"""
 ===========================
 More triangular 3D surfaces
 ===========================
@@ -8,7 +8,7 @@ Two additional examples of plotting surfaces with triangular mesh.
 The first demonstrates use of plot_trisurf's triangles argument, and the
 second sets a Triangulation object's mask and passes the object directly
 to plot_trisurf.
-'''
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -71,7 +71,7 @@ triang = mtri.Triangulation(x, y)
 # Mask off unwanted triangles.
 xmid = x[triang.triangles].mean(axis=1)
 ymid = y[triang.triangles].mean(axis=1)
-mask = np.where(xmid**2 + ymid**2 < min_radius**2, 1, 0)
+mask = xmid**2 + ymid**2 < min_radius**2
 triang.set_mask(mask)
 
 # Plot the surface.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1775,28 +1775,19 @@ class LightSource(object):
         hsv = rgb_to_hsv(rgb[:, :, 0:3])
 
         # modify hsv values to simulate illumination.
-        hsv[:, :, 1] = np.where(np.logical_and(np.abs(hsv[:, :, 1]) > 1.e-10,
-                                               intensity > 0),
-                                ((1. - intensity) * hsv[:, :, 1] +
-                                 intensity * hsv_max_sat),
-                                hsv[:, :, 1])
-
-        hsv[:, :, 2] = np.where(intensity > 0,
-                                ((1. - intensity) * hsv[:, :, 2] +
-                                 intensity * hsv_max_val),
-                                hsv[:, :, 2])
-
-        hsv[:, :, 1] = np.where(np.logical_and(np.abs(hsv[:, :, 1]) > 1.e-10,
-                                               intensity < 0),
-                                ((1. + intensity) * hsv[:, :, 1] -
-                                 intensity * hsv_min_sat),
-                                hsv[:, :, 1])
-        hsv[:, :, 2] = np.where(intensity < 0,
-                                ((1. + intensity) * hsv[:, :, 2] -
-                                 intensity * hsv_min_val),
-                                hsv[:, :, 2])
-        hsv[:, :, 1:] = np.where(hsv[:, :, 1:] < 0., 0, hsv[:, :, 1:])
-        hsv[:, :, 1:] = np.where(hsv[:, :, 1:] > 1., 1, hsv[:, :, 1:])
+        np.putmask(hsv[:, :, 1],  # i.e. A[mask] = B[mask].
+                   (np.abs(hsv[:, :, 1]) > 1.e-10) & (intensity > 0),
+                   (1 - intensity) * hsv[:, :, 1] + intensity * hsv_max_sat)
+        np.putmask(hsv[:, :, 2],
+                   intensity > 0,
+                   (1 - intensity) * hsv[:, :, 2] + intensity * hsv_max_val)
+        np.putmask(hsv[:, :, 1],
+                   (np.abs(hsv[:, :, 1]) > 1.e-10) & (intensity < 0),
+                   (1 + intensity) * hsv[:, :, 1] - intensity * hsv_min_sat)
+        np.putmask(hsv[:, :, 2],
+                   intensity < 0,
+                   (1 + intensity) * hsv[:, :, 2] - intensity * hsv_min_val)
+        np.clip(hsv[:, :, 1:], 0, 1, out=hsv[:, :, 1:])
         # convert modified hsv back to rgb.
         return hsv_to_rgb(hsv)
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -44,27 +44,16 @@ class PolarTransform(mtransforms.Transform):
 
     def transform_non_affine(self, tr):
         # docstring inherited
-        xy = np.empty(tr.shape, float)
-
-        t = tr[:, 0:1]
-        r = tr[:, 1:2]
-        x = xy[:, 0:1]
-        y = xy[:, 1:2]
-
+        t, r = np.transpose(tr)
         # PolarAxes does not use the theta transforms here, but apply them for
         # backwards-compatibility if not being used by it.
         if self._apply_theta_transforms and self._axis is not None:
             t *= self._axis.get_theta_direction()
             t += self._axis.get_theta_offset()
-
         if self._use_rmin and self._axis is not None:
             r = (r - self._axis.get_rorigin()) * self._axis.get_rsign()
-
-        mask = r < 0
-        x[:] = np.where(mask, np.nan, r * np.cos(t))
-        y[:] = np.where(mask, np.nan, r * np.sin(t))
-
-        return xy
+        r = np.where(r >= 0, r, np.nan)
+        return np.column_stack([r * np.cos(t), r * np.sin(t)])
 
     def transform_path_non_affine(self, path):
         # docstring inherited

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -1341,7 +1341,7 @@ def _cg(A, b, x0=None, tol=1.e-10, maxiter=1000):
     # Jacobi pre-conditioner
     kvec = A.diag
     # For diag elem < 1e-6 we keep 1e-6.
-    kvec = np.where(kvec > 1.e-6, kvec, 1.e-6)
+    kvec = np.maximum(kvec, 1e-6)
 
     # Initial guess
     if x0 is None:


### PR DESCRIPTION
In a few places, np.where can be replaced by direct use of boolean
arrays, or other constructs.

In colors.py, the use of putmask may be slightly obscure (so I left a
comment explaining it), but avoids repeating the modified array twice,
so I think is more legible.

In polar.py, preallocating xy is just pointless given that we're
constructing intermediate arrays for x and y and filling them into xy
afterwards.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
