### PR TITLE
Replace use of np.<ufunc> by operators (</&/|).

### DIFF
--- a/examples/color/color_by_yvalue.py
+++ b/examples/color/color_by_yvalue.py
@@ -1,6 +1,6 @@
 """
 ================
-Color By y-value
+Color by y-value
 ================
 
 Use masked arrays to plot a line with different colors by y-value.
@@ -14,10 +14,9 @@ s = np.sin(2 * np.pi * t)
 upper = 0.77
 lower = -0.77
 
-
 supper = np.ma.masked_where(s < upper, s)
 slower = np.ma.masked_where(s > lower, s)
-smiddle = np.ma.masked_where(np.logical_or(s < lower, s > upper), s)
+smiddle = np.ma.masked_where((s < lower) | (s > upper), s)
 
 fig, ax = plt.subplots()
 ax.plot(t, smiddle, t, slower, t, supper)

--- a/examples/mplot3d/mixed_subplots.py
+++ b/examples/mplot3d/mixed_subplots.py
@@ -13,9 +13,7 @@ import numpy as np
 
 
 def f(t):
-    s1 = np.cos(2*np.pi*t)
-    e1 = np.exp(-t)
-    return np.multiply(s1, e1)
+    return np.cos(2*np.pi*t) * np.exp(-t)
 
 
 # Set up a figure twice as tall as it is wide

--- a/examples/showcase/mandelbrot.py
+++ b/examples/showcase/mandelbrot.py
@@ -20,7 +20,7 @@ def mandelbrot_set(xmin, xmax, ymin, ymax, xn, yn, maxiter, horizon=2.0):
     N = np.zeros_like(C, dtype=int)
     Z = np.zeros_like(C)
     for n in range(maxiter):
-        I = np.less(abs(Z), horizon)
+        I = abs(Z) < horizon
         N[I] = n
         Z[I] = Z[I]**2 + C[I]
     N[N == maxiter-1] = 0

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1000,7 +1000,7 @@ def test_qhull_triangle_orientation():
     # github issue 4437.
     xi = np.linspace(-2, 2, 100)
     x, y = map(np.ravel, np.meshgrid(xi, xi))
-    w = np.logical_and(x > y - 1, np.logical_and(x < -1.95, y > -1.2))
+    w = (x > y - 1) & (x < -1.95) & (y > -1.2)
     x, y = x[w], y[w]
     theta = np.radians(25)
     x1 = x*np.cos(theta) - y*np.sin(theta)

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -180,12 +180,11 @@ class TriAnalyzer(object):
         while nadd != 0:
             # The active wavefront is the triangles from the border (unmasked
             # but with a least 1 neighbor equal to -1
-            wavefront = ((np.min(valid_neighbors, axis=1) == -1)
-                         & ~current_mask)
+            wavefront = (np.min(valid_neighbors, axis=1) == -1) & ~current_mask
             # The element from the active wavefront will be masked if their
             # circle ratio is bad.
-            added_mask = np.logical_and(wavefront, mask_bad_ratio)
-            current_mask = (added_mask | current_mask)
+            added_mask = wavefront & mask_bad_ratio
+            current_mask = added_mask | current_mask
             nadd = np.sum(added_mask)
 
             # now we have to update the tables valid_neighbors

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -139,9 +139,7 @@ def test_lines3d():
                 pytest.param('svg', marks=pytest.mark.xfail(strict=False))])
 def test_mixedsubplots():
     def f(t):
-        s1 = np.cos(2*np.pi*t)
-        e1 = np.exp(-t)
-        return np.multiply(s1, e1)
+        return np.cos(2*np.pi*t) * np.exp(-t)
 
     t1 = np.arange(0.0, 5.0, 0.1)
     t2 = np.arange(0.0, 5.0, 0.02)


### PR DESCRIPTION
ufuncs are useful if you additionally want to handle both operands being
lists and convert them to arrays, but none of the places modified need
that (at least one input is already an array).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
