### PR TITLE
Deprecate Spine.is_frame_like.

### DIFF
--- a/doc/api/next_api_changes/2019-02-08-AL.rst
+++ b/doc/api/next_api_changes/2019-02-08-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``Spine.is_frame_like`` is deprecated.  It has never been used in the codebase
+since its addition in 2009.

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -177,6 +177,7 @@ class Spine(mpatches.Patch):
         if self.axis is not None:
             self.axis.cla()
 
+    @cbook.deprecated("3.1")
     def is_frame_like(self):
         """return True if directly on axes frame
 


### PR DESCRIPTION
It has never been used since its addition in the "smart bounds"
commit in 2009 (a5761e821) and the implementation just seems overly
complex (the `position == "center"` / `position == "zero"` checks have
effectively no effect on the return value).

If someone complains with a use case, we can always revisit...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
