### PR TITLE
Fix imshow()ing PIL-opened images.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -649,15 +649,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         ----------
         A : array-like
         """
-        # check if data is PIL Image without importing Image
-        if hasattr(A, 'getpixel'):
-            if A.mode == 'L':
-                # greyscale image, but our logic assumes rgba:
-                self._A = pil_to_array(A.convert('RGBA'))
-            else:
-                self._A = pil_to_array(A)
-        else:
-            self._A = cbook.safe_masked_invalid(A, copy=True)
+        self._A = cbook.safe_masked_invalid(A, copy=True)
 
         if (self._A.dtype != np.uint8 and
                 not np.can_cast(self._A.dtype, float, "same_kind")):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -18,7 +18,7 @@ from matplotlib import (
 from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
 
 import pytest
@@ -104,6 +104,15 @@ def test_image_python_io():
     fig.savefig(buffer)
     buffer.seek(0)
     plt.imread(buffer)
+
+
+@check_figures_equal()
+def test_imshow_pil(fig_test, fig_ref):
+    pytest.importorskip("PIL")
+    img = plt.imread(os.path.join(os.path.dirname(__file__),
+                     'baseline_images', 'test_image', 'uint16.tif'))
+    fig_test.subplots().imshow(img)
+    fig_ref.subplots().imshow(np.asarray(img))
 
 
 def test_imread_pil_uint16():


### PR DESCRIPTION
We actually handle grayscale images just fine, but they need to be
transformed into masked arrays like everyone else.

Closes #12140 (regression in 2.1.0), so maybe worth backporting to 2.2.x.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
