### PR TITLE
Simplify decade up- and down-rounding, and symmetrize expansion of degenerate log scales.

### DIFF
--- a/doc/api/next_api_changes/2019-02-13-AL.rst
+++ b/doc/api/next_api_changes/2019-02-13-AL.rst
@@ -1,0 +1,9 @@
+Deprecations
+````````````
+``ticker.decade_up`` and ``ticker.decade_down`` are deprecated.
+
+Autoscaling changes
+```````````````````
+On log-axes where a single value is plotted at a "full" decade (1, 10, 100,
+etc.), the autoscaling now expands the axis symmetrically around that point,
+instead of adding a decade only to the right.


### PR DESCRIPTION
Instead of `decade_up` and `decade_down`, use more explicit
`_decade_less`, `_decade_less_equal`, etc. which moreover also handle
negative values (used by the symlog scale).

Previously, `semilogx([.1, .1], [1, 2])` would autoscale the x-axis from
a bit less than 0.1 to a bit more than 1, because 0.1 == 10**-1 so
decade_down(0.1) would use `floor(-1) == -1` and return 0.1, while
decade_up(0.1) would return 1.

With this PR, `semilogx([.1, .1], [1, 2])` instead autoscales the x-axis
from a bit less than 0.01 to a bit more than 1 (i.e. one decade on each
side), which seems more logical.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
