### PR TITLE
FIX: secondary_axis resize

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -43,11 +43,12 @@ def _make_secondary_locator(rect, parent):
     *parent*.
     """
     _rect = mtransforms.Bbox.from_bounds(*rect)
-    bb = mtransforms.TransformedBbox(_rect, parent.transAxes)
-    tr = parent.figure.transFigure.inverted()
-    bb = mtransforms.TransformedBbox(bb, tr)
-
     def secondary_locator(ax, renderer):
+        # delay evaluating transform until draw time because the
+        # parent transform may have changed (i.e. if window reesized)
+        bb = mtransforms.TransformedBbox(_rect, parent.transAxes)
+        tr = parent.figure.transFigure.inverted()
+        bb = mtransforms.TransformedBbox(bb, tr)
         return bb
 
     return secondary_locator

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6106,3 +6106,16 @@ def test_secondary_fail():
         axsec = ax.secondary_xaxis('right')
     with pytest.raises(ValueError):
         axsec = ax.secondary_yaxis('bottom')
+
+
+def test_secondary_resize():
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(np.arange(2, 11), np.arange(2, 11))
+    def invert(x):
+        with np.errstate(divide='ignore'):
+            return 1 / x
+
+    axsec = ax.secondary_xaxis('top', functions=(invert, invert))
+    fig.canvas.draw()
+    fig.set_size_inches((7, 4))
+    assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])


### PR DESCRIPTION
## PR Summary

As pointed out by @ImportanceOfBeingErnest the new secondary_axis (#11859) didn't survive a resize.  This new version does.

Is there a good way to test resizing a canvas?  

closes: #13417




## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->