### PR TITLE
Deprecate Quiver.color in favor of Quiver.get_facecolor().

### DIFF
--- a/doc/api/next_api_changes/2019-02-14-AL.rst
+++ b/doc/api/next_api_changes/2019-02-14-AL.rst
@@ -1,0 +1,7 @@
+Deprecations
+````````````
+
+The ``.color`` attribute of `Quiver` objects is deprecated.  Instead, use (as
+for any `Collection`) the ``get_facecolor`` method.  Note that setting to the
+``.color`` attribute did not update the quiver artist, whereas calling
+``set_facecolor`` does.

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -455,7 +455,6 @@ class Quiver(mcollections.PolyCollection):
         self.scale_units = scale_units
         self.angles = angles
         self.width = width
-        self.color = color
 
         if pivot.lower() == 'mid':
             pivot = 'middle'
@@ -466,7 +465,7 @@ class Quiver(mcollections.PolyCollection):
                       keys=self._PIVOT_VALS, inp=pivot))
 
         self.transform = kw.pop('transform', ax.transData)
-        kw.setdefault('facecolors', self.color)
+        kw.setdefault('facecolors', color)
         kw.setdefault('linewidths', (0,))
         mcollections.PolyCollection.__init__(self, [], offsets=self.XY,
                                              transOffset=self.transform,
@@ -494,6 +493,11 @@ class Quiver(mcollections.PolyCollection):
 
         self._cid = self.ax.figure.callbacks.connect('dpi_changed',
                                                      on_dpi_change)
+
+    @cbook.deprecated("3.1", alternative="get_facecolor()")
+    @property
+    def color(self):
+        return self.get_facecolor()
 
     def remove(self):
         """


### PR DESCRIPTION
See changelog for rationale.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
