### PR TITLE
API: un-deprecate keyword only args to set_xlim, set_ylim

### DIFF
--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -154,8 +154,9 @@ Different exception types for undocumented options
   and ``right`` arguments.  :meth:`~matplotlib.axes.Axes.set_ylim` and the
   3D equivalents (e.g. :meth:`~mpl_toolkits.axes.Axes3D.set_zlim3d`) had a
   corresponding problem.
-  The ``_min`` and ``_max`` arguments are now deprecated, and a ``TypeError``
-  will be raised if they would override the earlier limit arguments.
+  A ``TypeError`` will be raised if they would override the earlier
+  limit arguments.  In 3.0 these were kwargs were deprecated, but in 3.1
+  the deprecation was undone.
 
 
 Improved call signature for ``Axes.margins``

--- a/doc/api/next_api_changes/2018-01-28_tac.rst
+++ b/doc/api/next_api_changes/2018-01-28_tac.rst
@@ -1,0 +1,5 @@
+De-deprecate xmin, xmax kwargs to set_xlim and ymin, ymax kwargs to set_ylim
+````````````````````````````````````````````````````````````````````````````
+
+These kwargs were deprecated in 3.0, but due to user feedback and the
+semantics of the new names are problematic for non-rectangular axes.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3145,8 +3145,7 @@ class _AxesBase(martist.Artist):
             False turns off (default action), None leaves unchanged.
 
         xmin, xmax : scalar, optional
-            These arguments are deprecated and will be removed in a future
-            version.  They are equivalent to left and right respectively,
+            They are equivalent to left and right respectively,
             and it is an error to pass both *xmin* and *left* or
             *xmax* and *right*.
 
@@ -3188,14 +3187,10 @@ class _AxesBase(martist.Artist):
         if right is None and np.iterable(left):
             left, right = left
         if xmin is not None:
-            cbook.warn_deprecated('3.0', name='`xmin`',
-                                  alternative='`left`', obj_type='argument')
             if left is not None:
                 raise TypeError('Cannot pass both `xmin` and `left`')
             left = xmin
         if xmax is not None:
-            cbook.warn_deprecated('3.0', name='`xmax`',
-                                  alternative='`right`', obj_type='argument')
             if right is not None:
                 raise TypeError('Cannot pass both `xmax` and `right`')
             right = xmax
@@ -3529,8 +3524,7 @@ class _AxesBase(martist.Artist):
             *False* turns off (default action), *None* leaves unchanged.
 
         ymin, ymax : scalar, optional
-            These arguments are deprecated and will be removed in a future
-            version.  They are equivalent to bottom and top respectively,
+            They are equivalent to bottom and top respectively,
             and it is an error to pass both *ymin* and *bottom* or
             *ymax* and *top*.
 
@@ -3571,14 +3565,10 @@ class _AxesBase(martist.Artist):
         if top is None and np.iterable(bottom):
             bottom, top = bottom
         if ymin is not None:
-            cbook.warn_deprecated('3.0', name='`ymin`',
-                                  alternative='`bottom`', obj_type='argument')
             if bottom is not None:
                 raise TypeError('Cannot pass both `ymin` and `bottom`')
             bottom = ymin
         if ymax is not None:
-            cbook.warn_deprecated('3.0', name='`ymax`',
-                                  alternative='`top`', obj_type='argument')
             if top is not None:
                 raise TypeError('Cannot pass both `ymax` and `top`')
             top = ymax


### PR DESCRIPTION
These were originally documented and deprecated in #11137 however
in later discussion we learned:

 - the 'left, right' / 'top, bottom' names don't make sense in the
   context of non-rectangular plots
 - we have at least one frustrated user

The original names were `xmin, xmax` but were changed to `left, right`
in 9ca5db03f692e73d155dbc7ca752413ccee01df6 (pre 1.0) and the kwarg
popping was added for back-compatibility.

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
