### PR TITLE
FIX: bbox_inches='tight' with only non-finite bounding boxes

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2366,11 +2366,14 @@ default: 'top'
                 except TypeError:
                     bbox = ax.get_tightbbox(renderer)
                 bb.append(bbox)
+        bb = [b for b in bb
+              if (np.isfinite(b.width) and np.isfinite(b.height)
+                  and (b.width != 0 or b.height != 0))]
 
         if len(bb) == 0:
             return self.bbox_inches
 
-        _bbox = Bbox.union([b for b in bb if b.width != 0 or b.height != 0])
+        _bbox = Bbox.union(bb)
 
         bbox_inches = TransformedBbox(_bbox,
                                       Affine2D().scale(1. / self.dpi))

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -1,4 +1,5 @@
 import numpy as np
+from io import BytesIO
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
@@ -86,3 +87,12 @@ def test_bbox_inches_tight_raster():
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.plot([1.0, 2.0], rasterized=True)
+
+
+def test_only_on_non_finite_bbox():
+
+    fig, ax = plt.subplots()
+    ax.annotate("", xy=(0, float('nan')))
+    ax.set_axis_off()
+    # we only need to test that it does not error out on save
+    fig.savefig(BytesIO(), bbox_inches='tight', format='png')


### PR DESCRIPTION
closes #13276


## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->