### PR TITLE
Simplify check for tight-bbox finiteness.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -232,6 +232,9 @@ class Artist(object):
     def get_window_extent(self, renderer):
         """
         Get the axes bounding box in display space.
+
+        The bounding box' width and height are nonnegative.
+
         Subclasses should override for inclusion in the bounding box
         "tight" calculation. Default is to return an empty bounding
         box at 0, 0.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4334,9 +4334,9 @@ class _AxesBase(martist.Artist):
 
         for a in bbox_artists:
             bbox = a.get_tightbbox(renderer)
-            if (bbox is not None and
-                    (bbox.width != 0 or bbox.height != 0) and
-                    np.isfinite(bbox.width) and np.isfinite(bbox.height)):
+            if (bbox is not None
+                    and 0 < bbox.width < np.inf
+                    and 0 < bbox.height < np.inf):
                 bb.append(bbox)
 
         _bbox = mtransforms.Bbox.union(

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1151,21 +1151,17 @@ class Axis(martist.Artist):
         self._update_offset_text_position(ticklabelBoxes, ticklabelBoxes2)
         self.offsetText.set_text(self.major.formatter.get_offset())
 
-        bb = []
-
-        for a in [self.label, self.offsetText]:
-            bbox = a.get_window_extent(renderer)
-            if (np.isfinite(bbox.width) and np.isfinite(bbox.height) and
-                    a.get_visible()):
-                bb.append(bbox)
-        bb.extend(ticklabelBoxes)
-        bb.extend(ticklabelBoxes2)
-        bb = [b for b in bb if ((b.width != 0 or b.height != 0) and
-                                np.isfinite(b.width) and
-                                np.isfinite(b.height))]
-        if bb:
-            _bbox = mtransforms.Bbox.union(bb)
-            return _bbox
+        bboxes = [
+            *(a.get_window_extent(renderer)
+              for a in [self.label, self.offsetText]
+              if a.get_visible()),
+            *ticklabelBoxes,
+            *ticklabelBoxes2,
+        ]
+        bboxes = [b for b in bboxes
+                  if 0 < b.width < np.inf and 0 < b.height < np.inf]
+        if bboxes:
+            return mtransforms.Bbox.union(bboxes)
         else:
             return None
 


### PR DESCRIPTION
`0 < bbox.width < np.inf` is as explicit as `bbox.width != 0 and
np.isfinite(bbox.width)`, shorter, and faster (not that it is a
bottleneck, though).  (It works because bboxes are oriented to have
nonnegative widths and heights.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
