### PR TITLE
Really fix ArtistInspector.get_aliases

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1209,7 +1209,7 @@ class ArtistInspector(object):
                 continue
             propname = re.search("`({}.*)`".format(name[:4]),  # get_.*/set_.*
                                  inspect.getdoc(func)).group(1)
-            aliases.setdefault(propname, set()).add(name[4:])
+            aliases.setdefault(propname[4:], set()).add(name[4:])
         return aliases
 
     _get_valid_values_regex = re.compile(

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -277,3 +277,10 @@ def test_artist_inspector_get_valid_values(accept_clause, expected):
     """ % accept_clause
     valid_values = martist.ArtistInspector(TestArtist).get_valid_values('f')
     assert valid_values == expected
+
+
+def test_artist_inspector_get_aliases():
+    # test the correct format and type of get_aliases method
+    ai = martist.ArtistInspector(mlines.Line2D)
+    aliases = ai.get_aliases()
+    assert aliases["linewidth"] == {"lw"}


### PR DESCRIPTION
## PR Summary

Fixes #13278. 

Either #9475 or #12037 broke `ArtistInspector.get_aliases` which would contrarily to the docstring produce a dictionary of the form

    'get_linestyle': {'ls'}, 'get_linewidth': {'lw'},

instead of 

     'linestyle': {'ls'}, 'linewidth': {'lw'},

This is detrimental to the documentation of the aliases, which would hence not appear in the docs any more.

**Previsouly**


![image](https://user-images.githubusercontent.com/23121882/52760136-b6705000-300e-11e9-9922-4752415d71ad.png)


**With this PR**

![image](https://user-images.githubusercontent.com/23121882/52760122-ac4e5180-300e-11e9-9e3b-12277aa474b9.png)

Adds a test as well, not to break it again.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
