### PR TITLE
Add get/set_in_layout to artist API docs.

### DIFF
--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -43,15 +43,6 @@ Interactive
    Artist.set_picker
    Artist.get_picker
 
-Margins and Autoscaling
------------------------
-
-.. autosummary::
-   :toctree: _as_gen
-   :nosignatures:
-
-   Artist.sticky_edges
-
 Clipping
 --------
 
@@ -171,13 +162,16 @@ Metadata
    Artist.set_url
    Artist.get_url
 
-Stale
------
+Miscellaneous
+-------------
 
 .. autosummary::
    :toctree: _as_gen
    :nosignatures:
 
+   Artist.sticky_edges
+   Artist.set_in_layout
+   Artist.get_in_layout
    Artist.stale
 
 Functions

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -998,7 +998,7 @@ class Artist(object):
     @property
     def sticky_edges(self):
         """
-        `x` and `y` sticky edge lists.
+        ``x`` and ``y`` sticky edge lists for autoscaling.
 
         When performing autoscaling, if a data limit coincides with a value in
         the corresponding sticky_edges list, then no margin will be added--the
@@ -1006,8 +1006,8 @@ class Artist(object):
         where one usually expects no margin on the bottom edge (0) of the
         histogram.
 
-        This attribute cannot be assigned to; however, the `x` and `y` lists
-        can be modified in place as needed.
+        This attribute cannot be assigned to; however, the ``x`` and ``y``
+        lists can be modified in place as needed.
 
         Examples
         --------


### PR DESCRIPTION
They don't seem to fit in any existing subsection and creating a section
just for them seems silly, so move them, together with other
single-entry subsections, to "misc.".

To compensate the loss of the "margins and autoscaling subsection", add
mention of autoscaling in the first line of the sticky_edges docstring,
to keep that term ctrl-f'able on the API docs page.

noticed while reviewing https://github.com/matplotlib/matplotlib/pull/13432.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
