### PR TITLE
Prevent reuse of certain Locators and Formatters over multiple Axises.

### DIFF
--- a/doc/api/next_api_changes/2018-02-15-AL.rst
+++ b/doc/api/next_api_changes/2018-02-15-AL.rst
@@ -1,0 +1,17 @@
+Axis-dependent Locators and Formatters explicitly error out when used over multiple Axis
+````````````````````````````````````````````````````````````````````````````````````````
+
+Certain Locators and Formatters (e.g. the default `AutoLocator` and
+`ScalarFormatter`) can only be used meaningfully on one Axis object at a time
+(i.e., attempting to use a single `AutoLocator` instance on the x and the y
+axis of an Axes, or the x axis of two different Axes, would result in
+nonsensical results).
+
+Such "double-use" is now detected and raises a RuntimeError *at canvas draw
+time*.  The exception is not raised when the second Axis is registered in order
+to avoid incorrectly raising exceptions for the Locators and Formatters that
+*can* be used on multiple Axis objects simultaneously (e.g. `NullLocator` and
+`FuncFormatter`).
+
+In case a Locator or a Formatter really needs to be reassigned from one axis to
+another, first set its axis to None to bypass this protection.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1589,11 +1589,19 @@ default: 'top'
             return axarr
 
     def _remove_ax(self, ax):
-        def _reset_loc_form(axis):
-            axis.set_major_formatter(axis.get_major_formatter())
-            axis.set_major_locator(axis.get_major_locator())
-            axis.set_minor_formatter(axis.get_minor_formatter())
-            axis.set_minor_locator(axis.get_minor_locator())
+        def _reset_tickers(axis):
+            major_formatter = axis.get_major_formatter()
+            major_formatter.set_axis(None)  # Bypass prevention of axis reset.
+            axis.set_major_formatter(major_formatter)
+            major_locator = axis.get_major_locator()
+            major_locator.set_axis(None)
+            axis.set_major_locator(major_locator)
+            minor_formatter = axis.get_minor_formatter()
+            minor_formatter.set_axis(None)
+            axis.set_minor_formatter(minor_formatter)
+            minor_locator = axis.get_minor_locator()
+            minor_locator.set_axis(None)
+            axis.set_minor_locator(minor_locator)
 
         def _break_share_link(ax, grouper):
             siblings = grouper.get_siblings(ax)
@@ -1607,11 +1615,11 @@ default: 'top'
         self.delaxes(ax)
         last_ax = _break_share_link(ax, ax._shared_y_axes)
         if last_ax is not None:
-            _reset_loc_form(last_ax.yaxis)
+            _reset_tickers(last_ax.yaxis)
 
         last_ax = _break_share_link(ax, ax._shared_x_axes)
         if last_ax is not None:
-            _reset_loc_form(last_ax.xaxis)
+            _reset_tickers(last_ax.xaxis)
 
     def clf(self, keep_observers=False):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -198,6 +198,14 @@ class _AxisWrapper(object):
     def __init__(self, axis):
         self._axis = axis
 
+    def __eq__(self, other):
+        # Needed so that assignment, as the locator.axis attribute, of another
+        # _AxisWrapper wrapping the same axis works.
+        return self._axis == other._axis
+
+    def __hash__(self):
+        return hash((type(self), *sorted(vars(self).items())))
+
     def get_view_interval(self):
         return np.rad2deg(self._axis.get_view_interval())
 
@@ -227,10 +235,11 @@ class ThetaLocator(mticker.Locator):
     """
     def __init__(self, base):
         self.base = base
-        self.axis = self.base.axis = _AxisWrapper(self.base.axis)
+        self.set_axis(self.base.axis)
 
     def set_axis(self, axis):
-        self.axis = _AxisWrapper(axis)
+        super().set_axis(_AxisWrapper(axis))
+        self.base.set_axis(None)  # Bypass prevention of axis resetting.
         self.base.set_axis(self.axis)
 
     def __call__(self):
@@ -383,7 +392,6 @@ class ThetaAxis(maxis.XAxis):
     def cla(self):
         super().cla()
         self.set_ticks_position('none')
-        self._wrap_locator_formatter()
 
     def _set_scale(self, value, **kwargs):
         super()._set_scale(value, **kwargs)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -897,3 +897,29 @@ def test_minorticks_rc():
     minorticksubplot(True, False, 2)
     minorticksubplot(False, True, 3)
     minorticksubplot(True, True, 4)
+
+
+def test_multiple_assignment():
+    fig = plt.figure()
+
+    ax = fig.subplots()
+    fmt = mticker.NullFormatter()
+    ax.xaxis.set_major_formatter(fmt)
+    ax.yaxis.set_major_formatter(fmt)
+    fig.canvas.draw()  # No error.
+    fig.clf()
+
+    ax = fig.subplots()
+    fmt = mticker.ScalarFormatter()
+    ax.xaxis.set_major_formatter(fmt)
+    ax.xaxis.set_minor_formatter(fmt)
+    fig.canvas.draw()  # No error.
+    fig.clf()
+
+    ax = fig.subplots()
+    fmt = mticker.ScalarFormatter()
+    ax.xaxis.set_major_formatter(fmt)
+    ax.yaxis.set_major_formatter(fmt)
+    with pytest.raises(RuntimeError):
+        fig.canvas.draw()
+    fig.clf()


### PR DESCRIPTION
## PR Summary

See discussion starting at https://github.com/matplotlib/matplotlib/pull/13323#issuecomment-459691080, and #13438.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
