### PR TITLE
Allow constructing boxplots over multiple calls.

### DIFF
--- a/doc/api/next_api_changes/2018-02-16-AL.rst
+++ b/doc/api/next_api_changes/2018-02-16-AL.rst
@@ -1,0 +1,11 @@
+API changes
+```````````
+
+The ``manage_xticks`` parameter of `~Axes.boxplot` and `~Axes.bxp` has been
+renamed (with a deprecation period) to ``manage_ticks``, to take into account
+the fact that it manages either x or y ticks depending on the ``vert``
+parameter.
+
+When ``manage_ticks`` is True (the default), these methods now attempt to take
+previously drawn boxplots into account when setting the axis limits, ticks, and
+tick labels.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2436,7 +2436,7 @@ def boxplot(
         meanline=None, showmeans=None, showcaps=None, showbox=None,
         showfliers=None, boxprops=None, labels=None, flierprops=None,
         medianprops=None, meanprops=None, capprops=None,
-        whiskerprops=None, manage_xticks=True, autorange=False,
+        whiskerprops=None, manage_ticks=True, autorange=False,
         zorder=None, *, data=None):
     return gca().boxplot(
         x, notch=notch, sym=sym, vert=vert, whis=whis,
@@ -2447,7 +2447,7 @@ def boxplot(
         showfliers=showfliers, boxprops=boxprops, labels=labels,
         flierprops=flierprops, medianprops=medianprops,
         meanprops=meanprops, capprops=capprops,
-        whiskerprops=whiskerprops, manage_xticks=manage_xticks,
+        whiskerprops=whiskerprops, manage_ticks=manage_ticks,
         autorange=autorange, zorder=zorder, **({"data": data} if data
         is not None else {}))
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2911,10 +2911,19 @@ def test_manage_xticks():
     np.random.seed(0)
     y1 = np.random.normal(10, 3, 20)
     y2 = np.random.normal(3, 1, 20)
-    ax.boxplot([y1, y2], positions=[1, 2],
-               manage_xticks=False)
+    ax.boxplot([y1, y2], positions=[1, 2], manage_ticks=False)
     new_xlim = ax.get_xlim()
     assert_array_equal(old_xlim, new_xlim)
+
+
+def test_boxplot_not_single():
+    fig, ax = plt.subplots()
+    ax.boxplot(np.random.rand(100), positions=[3])
+    ax.boxplot(np.random.rand(100), positions=[5])
+    fig.canvas.draw()
+    assert ax.get_xlim() == (2.5, 5.5)
+    assert list(ax.get_xticks()) == [3, 5]
+    assert [t.get_text() for t in ax.get_xticklabels()] == ["3", "5"]
 
 
 def test_tick_space_size_0():

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -335,8 +335,7 @@ class NullFormatter(Formatter):
 
 class FixedFormatter(Formatter):
     """
-    Return fixed strings for tick labels based only on position, not
-    value.
+    Return fixed strings for tick labels based only on position, not value.
     """
     def __init__(self, seq):
         """


### PR DESCRIPTION
Currently, calls to boxplot() set the axis limits, ticks, and ticklabels
assuming that nothing else, and in particular no other boxplot, will be
drawn on the axis; e.g., after

    boxplot(np.random.rand(100), positions=[3])
    boxplot(np.random.rand(100), positions=[5])

the xlims will be moved to hide the first boxplot, and even after
manually resetting the xlims, the tick at x=3 and its label will be gone
too.

Fix that to make boxplot a bit more cooperative with previous calls:
instead of forcefully setting the axis limits, just update the dataLim
and let autoscaling handle axis limits; also check whether the axis
already has a FixedLocator/FixedFormatter and if so, just append the new
tick locations and labels.

Also rename manage_xticks to manage_ticks (with deprecation), as the
direction it manages depends on the vert kwarg (discussed in https://github.com/matplotlib/matplotlib/issues/13435).

attn @phobson I guess.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
