### PR TITLE
Let boxplot() defer rcParams application to bxp()

### DIFF
--- a/doc/api/next_api_changes/2018-02-17-AL.rst
+++ b/doc/api/next_api_changes/2018-02-17-AL.rst
@@ -1,0 +1,8 @@
+`~Axes.bxp` now respects :rc:`boxplot.boxprops.linewidth` even when *patch_artist* is set
+`````````````````````````````````````````````````````````````````````````````````````````
+
+Previously, when the *patch_artist* parameter was set, `~Axes.bxp` would ignore
+:rc:`boxplot.boxprops.linewidth`.  This was an oversight -- in particular,
+`~Axes.boxplot` did not ignore it.
+
+This oversight is now fixed.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2111,7 +2111,7 @@ def test_stackplot_baseline():
 def _bxp_test_helper(
         stats_kwargs={}, transform_stats=lambda s: s, bxp_kwargs={}):
     np.random.seed(937)
-    logstats = matplotlib.cbook.boxplot_stats(
+    logstats = mpl.cbook.boxplot_stats(
         np.random.lognormal(mean=1.25, sigma=1., size=(37, 4)), **stats_kwargs)
     fig, ax = plt.subplots()
     if bxp_kwargs.get('vert', True):
@@ -2121,8 +2121,8 @@ def _bxp_test_helper(
     # Work around baseline images generate back when bxp did not respect the
     # boxplot.boxprops.linewidth rcParam when patch_artist is False.
     if not bxp_kwargs.get('patch_artist', False):
-        (bxp_kwargs.setdefault('boxprops', {})
-         .setdefault('linewidth', matplotlib.rcParams["lines.linewidth"]))
+        mpl.rcParams['boxplot.boxprops.linewidth'] = \
+            mpl.rcParams['lines.linewidth']
     ax.bxp(transform_stats(logstats), **bxp_kwargs)
 
 


### PR DESCRIPTION
instead of duplicating the defaults-applying code in both methods.

This caught an oversight in the application of the
boxplot.boxprops.linewidth rcParam in bxp (see changelog note);
because of that, the bxp testing code needed some update (to keep the
old behavior).

Preliminary work to having bxp() normalize properties passed in the
boxprops, meanprops, etc. kwargs as well (#13448).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
