### PR TITLE
Give `AnnotationBbox` an opinion about its extent

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1544,6 +1544,24 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         """Return the fontsize in points."""
         return self.prop.get_size_in_points()
 
+    def get_window_extent(self, renderer):
+        """
+        get the bounding box in display space.
+        """
+        bboxes = [child.get_window_extent(renderer)
+                  for child in self.get_children()]
+
+        return Bbox.union(bboxes)
+
+    def get_tightbbox(self, renderer):
+        """
+        get tight bounding box in display space.
+        """
+        bboxes = [child.get_tightbbox(renderer)
+                  for child in self.get_children()]
+
+        return Bbox.union(bboxes)
+
     def update_positions(self, renderer):
         """
         Update the pixel positions of the annotated point and the text.


### PR DESCRIPTION
## PR Summary

Fixes #12699.  

Give `AnnotationBbox` an opinion about its extent, i.e. add a `get_window_extent` and `get_tightbbox`.
This allows e.g. to `savefig` with the `bbox_inches='tight'` option and not have the annotations cropped.

**Before**

![annbbox_3 0 2](https://user-images.githubusercontent.com/23121882/52921796-5550c100-331b-11e9-9e36-9804e785a5fe.png)

**With this PR**

![annbbox_3 0 0 post1019 g3cc1af35a](https://user-images.githubusercontent.com/23121882/52921820-76b1ad00-331b-11e9-9736-7d40b85a6ce1.png)


<details>
 <summary>Code</summary>

```
import matplotlib
v = matplotlib.__version__
import matplotlib.pyplot as plt

import numpy as np

from matplotlib.patches import Circle
from matplotlib.offsetbox import (TextArea, DrawingArea, OffsetImage,
                                  AnnotationBbox, AnchoredOffsetbox)

fig, ax = plt.subplots(figsize=(4,3), constrained_layout=False)

xy = [.5, .5]
ax.plot(xy[0], xy[1], ".r")

for x0 in [-0.2, 1.1]:
    da = DrawingArea(20, 20, 0, 0, clip=x0<0)
    p = Circle((np.sign(x0)*20+10, 30), 32, fill=False, linewidth=3, edgecolor="crimson")
    da.add_artist(p)
    
    ab3 = AnnotationBbox(da, xy, xybox=(x0, 0.5), xycoords='data',
                        boxcoords="axes fraction", box_alignment=(0., .5),
                        arrowprops=dict(arrowstyle="->"))
    ax.add_artist(ab3)

im = OffsetImage(np.random.rand(30,30), zoom=1)
im.image.axes = ax
ab6 = AnnotationBbox(im, (0.5, -.3), xybox=(0.5, .2), xycoords='axes fraction',
                     boxcoords="axes fraction", pad=0.3,
                     arrowprops=dict(arrowstyle="->"))
ax.add_artist(ab6)

#plt.tight_layout()
plt.savefig(f'annbbox_{v}.png', bbox_inches='tight', facecolor="#e1f3ec")    
plt.show()
```


</details>


<hr>

It seems for static figures neither `tight_layout`, nor `constrained_layout` are affected by this. But using 

`constrained_layout=True` and resizing the figure on screen shows some really weird behaviour. 


![bboxannot](https://user-images.githubusercontent.com/23121882/52921975-30f5e400-331d-11e9-93e0-197040e77c8f.gif)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
