### PR TITLE
Deprecate Locator.autoscale.

### DIFF
--- a/doc/api/next_api_changes/2019-02-19-AL.rst
+++ b/doc/api/next_api_changes/2019-02-19-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The unused `Locator.autoscale()` method is deprecated (pass the axis limits to
+`Locator.view_limits()` instead).

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1196,6 +1196,7 @@ class RRuleLocator(DateLocator):
     def _get_interval(self):
         return self.rule._rrule._interval
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         """
         Set the view limits to include the data range.
@@ -1355,6 +1356,7 @@ class AutoDateLocator(DateLocator):
         else:
             return RRuleLocator.get_unit_generic(self._freq)
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         'Try to choose the view limits intelligently.'
         dmin, dmax = self.datalim_to_dt()
@@ -1531,6 +1533,7 @@ class YearLocator(DateLocator):
 
             ticks.append(dt)
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         """
         Set the view limits to include the data range.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -225,6 +225,7 @@ class ThetaLocator(mticker.Locator):
         else:
             return np.deg2rad(self.base())
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         return self.base.autoscale()
 
@@ -414,6 +415,7 @@ class RadialLocator(mticker.Locator):
         else:
             return [tick for tick in self.base() if tick > rorigin]
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         return self.base.autoscale()
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1531,6 +1531,7 @@ class Locator(TickHelper):
         """
         return mtransforms.nonsingular(vmin, vmax)
 
+    @cbook.deprecated("3.2")
     def autoscale(self):
         """Autoscale the view limits."""
         return self.view_limits(*self.axis.get_view_interval())


### PR DESCRIPTION
Note that this likely indicates that the dates Locators need new
implementations of view_limits, as they appear to never have been
updated to use the "new" (post-2008) API.

per https://github.com/matplotlib/matplotlib/issues/13292#issuecomment-464855904.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
