### PR TITLE
FIX: polar set_rlim allow bottom-only call

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1202,9 +1202,8 @@ class PolarAxes(Axes):
                                  'argument and kwarg "ymax"')
             else:
                 top = ymax
-        if top is None and len(bottom) == 2:
-            top = bottom[1]
-            bottom = bottom[0]
+        if top is None and np.iterable(bottom):
+            bottom, top = bottom[0], bottom[1]
 
         return super().set_ylim(bottom=bottom, top=top, emit=emit, auto=auto)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -794,6 +794,27 @@ def test_polar_theta_limits():
             ax.yaxis.set_tick_params(label2On=True, rotation='auto')
 
 
+@check_figures_equal(extensions=["png"])
+def test_polar_rlim(fig_test, fig_ref):
+    ax = fig_test.subplots(subplot_kw={'polar': True})
+    ax.set_rlim(top=10)
+    ax.set_rlim(bottom=.5)
+
+    ax = fig_ref.subplots(subplot_kw={'polar': True})
+    ax.set_rmax(10.)
+    ax.set_rmin(.5)
+
+
+@check_figures_equal(extensions=["png"])
+def test_polar_rlim_bottom(fig_test, fig_ref):
+    ax = fig_test.subplots(subplot_kw={'polar': True})
+    ax.set_rlim(bottom=[.5, 10])
+
+    ax = fig_ref.subplots(subplot_kw={'polar': True})
+    ax.set_rmax(10.)
+    ax.set_rmin(.5)
+
+
 @image_comparison(baseline_images=['axvspan_epoch'])
 def test_axvspan_epoch():
     from datetime import datetime


### PR DESCRIPTION
## PR Summary

closes #13464

Not sure this is the canonical way to do this.  Improvements welcome.  

~Should obviously get a test so this doesn't get missed again.~




## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->