### PR TITLE
Suppress chaining of cache lookup failure in color conversion.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -172,6 +172,8 @@ def to_rgba(c, alpha=None):
     try:
         rgba = _colors_full_map.cache[c, alpha]
     except (KeyError, TypeError):  # Not in cache, or unhashable.
+        rgba = None
+    if rgba is None:  # Suppress exception chaining of cache lookup failure.
         rgba = _to_rgba_no_colorcycle(c, alpha)
         try:
             _colors_full_map.cache[c, alpha] = rgba


### PR DESCRIPTION
Currently, something like
`scatter(range(4), range(4), c=np.arange(4).reshape((2, 2)))`
results in the following traceback:

```
Traceback (most recent call last):
  File "matplotlib/lib/matplotlib/colors.py", line 173, in to_rgba
    rgba = _colors_full_map.cache[c, alpha]
TypeError: unhashable type: 'numpy.ndarray'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "matplotlib/lib/matplotlib/axes/_axes.py", line 4289, in _parse_scatter_color_args
    colors = mcolors.to_rgba_array(c)
  File "matplotlib/lib/matplotlib/colors.py", line 284, in to_rgba_array
    result[i] = to_rgba(cc, alpha)
  File "matplotlib/lib/matplotlib/colors.py", line 175, in to_rgba
    rgba = _to_rgba_no_colorcycle(c, alpha)
  File "matplotlib/lib/matplotlib/colors.py", line 240, in _to_rgba_no_colorcycle
    raise ValueError("RGBA sequence should have length 3 or 4")
ValueError: RGBA sequence should have length 3 or 4

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "matplotlib/lib/matplotlib/pyplot.py", line 2826, in scatter
    None else {}), **kwargs)
  File "matplotlib/lib/matplotlib/__init__.py", line 1512, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "matplotlib/lib/matplotlib/axes/_axes.py", line 4458, in scatter
    get_next_color_func=self._get_patches_for_fill.get_next_color)
  File "matplotlib/lib/matplotlib/axes/_axes.py", line 4302, in _parse_scatter_color_args
    .format(nc=n_elem, xs=xsize, ys=ysize)
ValueError: 'c' argument has 2 elements, which is not acceptable for use with 'x' with size 4, 'y' with size 4.
```

At least the topmost failure, regarding cache lookup, is irrelevant to
the end user, so suppress it, which this commit does.

The middle traceback is mildly interesing, in case the user intended to
pass in RGBA but mis-shaped it; we may want to fold the message into the
scatter() error as well -- but that's not the object of this commit.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
