### PR TITLE
Raise NotImplementedError with equal aspect on 3D axes

### DIFF
--- a/doc/api/next_api_changes/2019-02-20-DS.rst
+++ b/doc/api/next_api_changes/2019-02-20-DS.rst
@@ -1,0 +1,7 @@
+Equal aspect axes for 3D plots disabled
+```````````````````````````````````````
+
+Setting the aspect on 3D axes previously returned non-sensical
+results (e.g. see https://github.com/matplotlib/matplotlib/issues/1077).
+Calling ``ax.set_aspect('equal')`` or ``ax.set_aspect(num)``
+on a 3D axes now raises a ``NotImplementedError``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1271,11 +1271,18 @@ class _AxesBase(martist.Artist):
         if not (cbook._str_equal(aspect, 'equal')
                 or cbook._str_equal(aspect, 'auto')):
             aspect = float(aspect)  # raise ValueError if necessary
+
+        if (not cbook._str_equal(aspect, 'auto')) and self.name == '3d':
+            raise NotImplementedError(
+                'It is not currently possible to manually set the aspect '
+                'on 3D axes')
+
         if share:
             axes = set(self._shared_x_axes.get_siblings(self)
                        + self._shared_y_axes.get_siblings(self))
         else:
             axes = [self]
+
         for ax in axes:
             ax._aspect = aspect
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -11,6 +11,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+def test_aspect_equal_error():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    with pytest.raises(NotImplementedError):
+        ax.set_aspect('equal')
+
+
 @image_comparison(baseline_images=['bar3d'], remove_text=True)
 def test_bar3d():
     fig = plt.figure()


### PR DESCRIPTION
See #1077. Until it is implemented properly, it seems reasonable to raise a `NotImplementedError` (and not a warning, because trying to set an equal aspect results in nonsense: https://github.com/matplotlib/matplotlib/issues/1077#issuecomment-14006279)