### PR TITLE
FIX: make EngFormatter respect axes.unicode_minus rcParam

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -694,38 +694,48 @@ class TestStrMethodFormatter(object):
 
 
 class TestEngFormatter(object):
-    # (input, expected) where ''expected'' corresponds to the outputs
-    # respectively returned when (places=None, places=0, places=2)
+    # (unicode_minus, input, expected) where ''expected'' corresponds to the
+    # outputs respectively returned when (places=None, places=0, places=2)
+    # unicode_minus is a boolean value for the rcParam['axes.unicode_minus']
     raw_format_data = [
-        (-1234.56789, ('\N{MINUS SIGN}1.23457 k', '\N{MINUS SIGN}1 k',
-                       '\N{MINUS SIGN}1.23 k')),
-        (-1.23456789, ('\N{MINUS SIGN}1.23457', '\N{MINUS SIGN}1',
-                       '\N{MINUS SIGN}1.23')),
-        (-0.123456789, ('\N{MINUS SIGN}123.457 m', '\N{MINUS SIGN}123 m',
-                        '\N{MINUS SIGN}123.46 m')),
-        (-0.00123456789, ('\N{MINUS SIGN}1.23457 m', '\N{MINUS SIGN}1 m',
-                          '\N{MINUS SIGN}1.23 m')),
-        (-0.0, ('0', '0', '0.00')),
-        (-0, ('0', '0', '0.00')),
-        (0, ('0', '0', '0.00')),
-        (1.23456789e-6, ('1.23457 µ', '1 µ', '1.23 µ')),
-        (0.123456789, ('123.457 m', '123 m', '123.46 m')),
-        (0.1, ('100 m', '100 m', '100.00 m')),
-        (1, ('1', '1', '1.00')),
-        (1.23456789, ('1.23457', '1', '1.23')),
-        (999.9, ('999.9', '1 k', '999.90')),  # places=0: corner-case rounding
-        (999.9999, ('1 k', '1 k', '1.00 k')),  # corner-case rounding for all
-        (-999.9999, ('\N{MINUS SIGN}1 k', '\N{MINUS SIGN}1 k',
-                     '\N{MINUS SIGN}1.00 k')),  # negative corner-case
-        (1000, ('1 k', '1 k', '1.00 k')),
-        (1001, ('1.001 k', '1 k', '1.00 k')),
-        (100001, ('100.001 k', '100 k', '100.00 k')),
-        (987654.321, ('987.654 k', '988 k', '987.65 k')),
-        (1.23e27, ('1230 Y', '1230 Y', '1230.00 Y'))  # OoR value (> 1000 Y)
+        (False, -1234.56789, ('-1.23457 k', '-1 k', '-1.23 k')),
+        (True, -1234.56789, ('\N{MINUS SIGN}1.23457 k', '\N{MINUS SIGN}1 k',
+                             '\N{MINUS SIGN}1.23 k')),
+        (False, -1.23456789, ('-1.23457', '-1', '-1.23')),
+        (True, -1.23456789, ('\N{MINUS SIGN}1.23457', '\N{MINUS SIGN}1',
+                             '\N{MINUS SIGN}1.23')),
+        (False, -0.123456789, ('-123.457 m', '-123 m', '-123.46 m')),
+        (True, -0.123456789, ('\N{MINUS SIGN}123.457 m', '\N{MINUS SIGN}123 m',
+                              '\N{MINUS SIGN}123.46 m')),
+        (False, -0.00123456789, ('-1.23457 m', '-1 m', '-1.23 m')),
+        (True, -0.00123456789, ('\N{MINUS SIGN}1.23457 m', '\N{MINUS SIGN}1 m',
+                                '\N{MINUS SIGN}1.23 m')),
+        (True, -0.0, ('0', '0', '0.00')),
+        (True, -0, ('0', '0', '0.00')),
+        (True, 0, ('0', '0', '0.00')),
+        (True, 1.23456789e-6, ('1.23457 µ', '1 µ', '1.23 µ')),
+        (True, 0.123456789, ('123.457 m', '123 m', '123.46 m')),
+        (True, 0.1, ('100 m', '100 m', '100.00 m')),
+        (True, 1, ('1', '1', '1.00')),
+        (True, 1.23456789, ('1.23457', '1', '1.23')),
+        # places=0: corner-case rounding
+        (True, 999.9, ('999.9', '1 k', '999.90')),
+        # corner-case rounding for all
+        (True, 999.9999, ('1 k', '1 k', '1.00 k')),
+        # negative corner-case
+        (False, -999.9999, ('-1 k', '-1 k', '-1.00 k')),
+        (True, -999.9999, ('\N{MINUS SIGN}1 k', '\N{MINUS SIGN}1 k',
+                           '\N{MINUS SIGN}1.00 k')),
+        (True, 1000, ('1 k', '1 k', '1.00 k')),
+        (True, 1001, ('1.001 k', '1 k', '1.00 k')),
+        (True, 100001, ('100.001 k', '100 k', '100.00 k')),
+        (True, 987654.321, ('987.654 k', '988 k', '987.65 k')),
+        # OoR value (> 1000 Y)
+        (True, 1.23e27, ('1230 Y', '1230 Y', '1230.00 Y'))
     ]
 
-    @pytest.mark.parametrize('input, expected', raw_format_data)
-    def test_params(self, input, expected):
+    @pytest.mark.parametrize('unicode_minus, input, expected', raw_format_data)
+    def test_params(self, unicode_minus, input, expected):
         """
         Test the formatting of EngFormatter for various values of the 'places'
         argument, in several cases:
@@ -738,7 +748,8 @@ class TestEngFormatter(object):
 
         UNIT = 's'  # seconds
         DIGITS = '0123456789'  # %timeit showed 10-20% faster search than set
-
+        plt.rcdefaults()
+        plt.rcParams['axes.unicode_minus'] = unicode_minus
         # Case 0: unit='' (default) and sep=' ' (default).
         # 'expected' already corresponds to this reference case.
         exp_outputs = expected

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -697,10 +697,14 @@ class TestEngFormatter(object):
     # (input, expected) where ''expected'' corresponds to the outputs
     # respectively returned when (places=None, places=0, places=2)
     raw_format_data = [
-        (-1234.56789, ('-1.23457 k', '-1 k', '-1.23 k')),
-        (-1.23456789, ('-1.23457', '-1', '-1.23')),
-        (-0.123456789, ('-123.457 m', '-123 m', '-123.46 m')),
-        (-0.00123456789, ('-1.23457 m', '-1 m', '-1.23 m')),
+        (-1234.56789, ('\N{MINUS SIGN}1.23457 k', '\N{MINUS SIGN}1 k',
+                       '\N{MINUS SIGN}1.23 k')),
+        (-1.23456789, ('\N{MINUS SIGN}1.23457', '\N{MINUS SIGN}1',
+                       '\N{MINUS SIGN}1.23')),
+        (-0.123456789, ('\N{MINUS SIGN}123.457 m', '\N{MINUS SIGN}123 m',
+                        '\N{MINUS SIGN}123.46 m')),
+        (-0.00123456789, ('\N{MINUS SIGN}1.23457 m', '\N{MINUS SIGN}1 m',
+                          '\N{MINUS SIGN}1.23 m')),
         (-0.0, ('0', '0', '0.00')),
         (-0, ('0', '0', '0.00')),
         (0, ('0', '0', '0.00')),
@@ -711,7 +715,8 @@ class TestEngFormatter(object):
         (1.23456789, ('1.23457', '1', '1.23')),
         (999.9, ('999.9', '1 k', '999.90')),  # places=0: corner-case rounding
         (999.9999, ('1 k', '1 k', '1.00 k')),  # corner-case rounding for all
-        (-999.9999, ('-1 k', '-1 k', '-1.00 k')),  # negative corner-case
+        (-999.9999, ('\N{MINUS SIGN}1 k', '\N{MINUS SIGN}1 k',
+                     '\N{MINUS SIGN}1.00 k')),  # negative corner-case
         (1000, ('1 k', '1 k', '1.00 k')),
         (1001, ('1.001 k', '1 k', '1.00 k')),
         (100001, ('100.001 k', '100 k', '100.00 k')),

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -746,10 +746,10 @@ class TestEngFormatter(object):
         Note that cases 2. and 3. are looped over several separator strings.
         """
 
+        plt.rcParams['axes.unicode_minus'] = unicode_minus
         UNIT = 's'  # seconds
         DIGITS = '0123456789'  # %timeit showed 10-20% faster search than set
-        plt.rcdefaults()
-        plt.rcParams['axes.unicode_minus'] = unicode_minus
+
         # Case 0: unit='' (default) and sep=' ' (default).
         # 'expected' already corresponds to this reference case.
         exp_outputs = expected

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1231,6 +1231,15 @@ class EngFormatter(Formatter):
         self.places = places
         self.sep = sep
 
+    def fix_minus(self, s):
+        """
+        Replace hyphens with a unicode minus.
+        """
+        if rcParams['axes.unicode_minus'] and not rcParams['text.usetex']:
+            return s.replace('-', '\N{MINUS SIGN}')
+        else:
+            return s
+
     def __call__(self, x, pos=None):
         s = "%s%s" % (self.format_eng(x), self.unit)
         # Remove the trailing separator when there is neither prefix nor unit

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1235,10 +1235,7 @@ class EngFormatter(Formatter):
         """
         Replace hyphens with a unicode minus.
         """
-        if rcParams['axes.unicode_minus'] and not rcParams['text.usetex']:
-            return s.replace('-', '\N{MINUS SIGN}')
-        else:
-            return s
+        return ScalarFormatter.fix_minus(self, s)
 
     def __call__(self, x, pos=None):
         s = "%s%s" % (self.format_eng(x), self.unit)


### PR DESCRIPTION
## PR Summary
`EngFormatter` was not respecting the `axes.unicode_minus` rcParam.

**Example (old behavior)**
```python
import matplotlib.pyplot as plt
from matplotlib.ticker import EngFormatter
plt.rc('font', size=14)
fig, ax = plt.subplots(figsize=(4.0, 2.5), constrained_layout=True)
ax.plot([-10000, -5000, 0, 5000, 10000], [-10000, -5000, 0, 5000, 10000], '*-')
formatter = EngFormatter()
ax.xaxis.set_major_formatter(formatter)
ax.yaxis.set_major_formatter(formatter)
fig.savefig('old_EngFormatter.png', dpi=200)
```
![test](https://user-images.githubusercontent.com/15175620/53141231-5bce7b00-355d-11e9-9369-4857944bfcef.png)


**Example (New behavior)**

![test_new](https://user-images.githubusercontent.com/15175620/53141283-83bdde80-355d-11e9-8a4f-ce68c709209e.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
