### PR TITLE
Animation:  interactive zoom/pan with blitting does not work

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1222,14 +1222,11 @@ class Animation(object):
         # axes
         self._blit_cache = dict()
         self._drawn_artists = []
-        def remove_from_cache(ax):
-            try:
-                del self._blit_cache[ax]
-            except KeyError:
-                pass
         for ax in self._fig.axes:
-            ax.callbacks.connect('xlim_changed', remove_from_cache)
-            ax.callbacks.connect('ylim_changed', remove_from_cache)
+            ax.callbacks.connect('xlim_changed',
+                                 lambda ax: self._blit_cache.pop(ax, None))
+            ax.callbacks.connect('ylim_changed',
+                                 lambda ax: self._blit_cache.pop(ax, None))
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
                                                        self._handle_resize)
         self._post_draw(None, self._blit)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1222,6 +1222,14 @@ class Animation(object):
         # axes
         self._blit_cache = dict()
         self._drawn_artists = []
+        def remove_from_cache(ax):
+            try:
+                del self._blit_cache[ax]
+            except KeyError:
+                pass
+        for ax in self._fig.axes:
+            ax.callbacks.connect('xlim_changed', remove_from_cache)
+            ax.callbacks.connect('ylim_changed', remove_from_cache)
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
                                                        self._handle_resize)
         self._post_draw(None, self._blit)


### PR DESCRIPTION
## PR Summary
In an animation using blitting that contains some static graphics elements, the static parts of the figure are not updated after an interactive zoom/pan event. However, they are correctly updated after an resize event (see issue #13478).

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
