### PR TITLE
Add colorbar annotation example plot to gallery

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -103,6 +103,7 @@ per-file-ignores =
     examples/images_contours_and_fields/affine_image.py: E402
     examples/images_contours_and_fields/barb_demo.py: E402
     examples/images_contours_and_fields/barcode_demo.py: E402
+    examples/images_contours_and_fields/colorbar_annotation_demo.py: E402
     examples/images_contours_and_fields/contour_corner_mask.py: E402
     examples/images_contours_and_fields/contour_demo.py: E402, E501
     examples/images_contours_and_fields/contour_image.py: E402

--- a/examples/images_contours_and_fields/colorbar_annotation_demo.py
+++ b/examples/images_contours_and_fields/colorbar_annotation_demo.py
@@ -1,0 +1,54 @@
+"""
+=========================
+Colorbar Annotation Demo
+=========================
+
+Demonstrates how one can annotate the colorbar without needing to also add
+lines to a contour plot. 
+
+Note that this is not a typical use case. The more common use case for 
+annotations is to add lines to both a contour plot *and* the corresponding
+location on the colorbar. In this more common use case, `~.colorbar.Colorbar.add_lines`
+can be used.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Create sample values to plot
+x = np.linspace(0,1,100)
+y = np.linspace(0,1,100)
+X,Y = np.meshgrid(x,y)
+Z = np.exp(-X**2 - Y**2)
+
+# Choose a value to annotate
+desired_cbar_yvalue = 0.90
+
+# Build filled contour plot
+surfplot=plt.contourf(X,Y,Z, cmap=plt.cm.binary_r)
+cbar=plt.colorbar(surfplot)
+
+# Find min and max values on colorbar
+cmin = np.float(cbar.ax.get_yticklabels()[0].get_text())
+cmax = np.float(cbar.ax.get_yticklabels()[-1].get_text())
+
+# Use min/max values to calculate annotation location
+loc = (desired_cbar_yvalue - cmin)/(cmax - cmin)
+
+# Annotate the colorbar
+cbar.ax.axhline(loc,color = 'r',linewidth=5)
+
+plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+import matplotlib
+matplotlib.colorbar

--- a/examples/images_contours_and_fields/colorbar_annotation_demo.py
+++ b/examples/images_contours_and_fields/colorbar_annotation_demo.py
@@ -52,4 +52,3 @@ plt.show()
 
 import matplotlib
 matplotlib.colorbar
-

--- a/examples/images_contours_and_fields/colorbar_annotation_demo.py
+++ b/examples/images_contours_and_fields/colorbar_annotation_demo.py
@@ -1,42 +1,42 @@
 """
-=========================
+========================
 Colorbar Annotation Demo
-=========================
+========================
 
 Demonstrates how one can annotate the colorbar without needing to also add
-lines to a contour plot. 
+lines to a contour plot.
 
-Note that this is not a typical use case. The more common use case for 
+Note that this is not a typical use case. The more common use case for
 annotations is to add lines to both a contour plot *and* the corresponding
-location on the colorbar. In this more common use case, `~.colorbar.Colorbar.add_lines`
-can be used.
+location on the colorbar. In this more common use case,
+`~matplotlib.colorbar.Colorbar.add_lines` can be used.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
 
 # Create sample values to plot
-x = np.linspace(0,1,100)
-y = np.linspace(0,1,100)
-X,Y = np.meshgrid(x,y)
+x = np.linspace(0, 1, 100)
+y = np.linspace(0, 1, 100)
+X, Y = np.meshgrid(x, y)
 Z = np.exp(-X**2 - Y**2)
 
 # Choose a value to annotate
 desired_cbar_yvalue = 0.90
 
 # Build filled contour plot
-surfplot=plt.contourf(X,Y,Z, cmap=plt.cm.binary_r)
-cbar=plt.colorbar(surfplot)
+surfplot = plt.contourf(X, Y, Z, cmap=plt.cm.binary_r)
+cbar = plt.colorbar(surfplot)
 
 # Find min and max values on colorbar
 cmin = np.float(cbar.ax.get_yticklabels()[0].get_text())
 cmax = np.float(cbar.ax.get_yticklabels()[-1].get_text())
 
 # Use min/max values to calculate annotation location
-loc = (desired_cbar_yvalue - cmin)/(cmax - cmin)
+loc = (desired_cbar_yvalue - cmin) / (cmax - cmin)
 
 # Annotate the colorbar
-cbar.ax.axhline(loc,color = 'r',linewidth=5)
+cbar.ax.axhline(loc, color='r', linewidth=5)
 
 plt.show()
 
@@ -52,3 +52,4 @@ plt.show()
 
 import matplotlib
 matplotlib.colorbar
+


### PR DESCRIPTION
## PR Summary

Add an example plot to gallery showing how to annotate a colorbar.  

While the `matplotlib.colorbar.Colorbar.add_lines` function cleanly allows the user to add annotations to both a contour plot and its associated colorbar, adding an annotation to the colorbar alone requires a few steps. This example plot illustrates how to annotate **just** the colorbar. Addresses issue #12462. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
