### PR TITLE
Change Locator MAXTICKS checking to emitting a log at WARNING level.

### DIFF
--- a/doc/api/next_api_changes/2019-02-25-AL.rst
+++ b/doc/api/next_api_changes/2019-02-25-AL.rst
@@ -1,0 +1,6 @@
+API changes
+```````````
+
+When more than `.Locator.MAXTICKS` ticks are generated, the behavior of
+`.Locator.raise_if_exceeds` changed from raising a RuntimeError to emitting a
+log at WARNING level.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1690,11 +1690,21 @@ class Locator(TickHelper):
         raise NotImplementedError('Derived must override')
 
     def raise_if_exceeds(self, locs):
-        """Raise a RuntimeError if ``len(locs) > self.MAXTICKS``."""
+        """
+        Log at WARNING level if *locs* is longer than `Locator.MAXTICKS`.
+
+        This is intended to be called immediately before returning *locs* from
+        ``__call__`` to inform users in case their Locator returns a huge
+        number of ticks, causing Matplotlib to run out of memory.
+
+        The "strange" name of this method dates back to when it would raise an
+        exception instead of emitting a log.
+        """
         if len(locs) >= self.MAXTICKS:
-            raise RuntimeError("Locator attempting to generate {} ticks from "
-                               "{} to {}: exceeds Locator.MAXTICKS".format(
-                                   len(locs), locs[0], locs[-1]))
+            _log.warning(
+                "Locator attempting to generate %s ticks ([%s, ..., %s]), "
+                "which exceeds Locator.MAXTICKS (%s).",
+                len(locs), locs[0], locs[-1], self.MAXTICKS)
         return locs
 
     def nonsingular(self, v0, v1):


### PR DESCRIPTION
I chose not to create a new helper method and instead change the
behavior of raise_if_exceeds, so that third-party locators also benefit
from the change.

Alternate for #8100 per https://github.com/matplotlib/matplotlib/pull/8100#issuecomment-466811624; closes #8089.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
