### PR TITLE
Cleanup docs for GraphicsContextBase.{get,set}_dashes.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -801,16 +801,14 @@ class GraphicsContextBase(object):
 
     def get_dashes(self):
         """
-        Return the dash information as an offset dashlist tuple.
+        Return the dash style as an (offset, dash-list) pair.
 
-        The dash list is a even size list that gives the ink on, ink
-        off in pixels.
+        The dash list is a even-length list that gives the ink on, ink off in
+        points.  See p. 107 of to PostScript `blue book`_ for more info.
 
-        See p107 of to PostScript `BLUEBOOK
-        <https://www-cdf.fnal.gov/offline/PostScript/BLUEBOOK.PDF>`_
-        for more info.
+        Default value is (None, None).
 
-        Default value is None
+        .. _blue book: https://www-cdf.fnal.gov/offline/PostScript/BLUEBOOK.PDF
         """
         return self._dashes
 
@@ -904,13 +902,18 @@ class GraphicsContextBase(object):
 
         Parameters
         ----------
-        dash_offset : float
-            is the offset (usually 0).
+        dash_offset : float or None
+            The offset (usually 0).
+        dash_list : array_like or None
+            The on-off sequence as points.
 
-        dash_list : array_like
-            specifies the on-off sequence as points.
-            ``(None, None)`` specifies a solid line
+        Notes
+        -----
+        ``(None, None)`` specifies a solid line.
 
+        See p. 107 of to PostScript `blue book`_ for more info.
+
+        .. _blue book: https://www-cdf.fnal.gov/offline/PostScript/BLUEBOOK.PDF
         """
         if dash_list is not None:
             dl = np.asarray(dash_list)


### PR DESCRIPTION
Note that the docs for get_dashes was wrong: the dash list is in points,
not in pixels; this is documented e.g. in the line_demo_dash_control
example; also the default dashstyle is (None, None).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
