### PR TITLE
DOC: fix Subplot calls

### DIFF
--- a/examples/subplots_axes_and_figures/gridspec_nested.py
+++ b/examples/subplots_axes_and_figures/gridspec_nested.py
@@ -28,8 +28,8 @@ ax1 = f.add_subplot(gs00[:-1, :])
 ax2 = f.add_subplot(gs00[-1, :-1])
 ax3 = f.add_subplot(gs00[-1, -1])
 
-
-gs01 = gridspec.GridSpecFromSubplotSpec(3, 3, subplot_spec=gs0[1])
+# the following syntax is the same as the GridSpecFromSubplotSpec call above:
+gs01 = gs0[1].subgridspec(3, 3)
 
 ax4 = f.add_subplot(gs01[:, :-1])
 ax5 = f.add_subplot(gs01[:-1, -1])

--- a/examples/subplots_axes_and_figures/gridspec_nested.py
+++ b/examples/subplots_axes_and_figures/gridspec_nested.py
@@ -28,7 +28,7 @@ ax1 = f.add_subplot(gs00[:-1, :])
 ax2 = f.add_subplot(gs00[-1, :-1])
 ax3 = f.add_subplot(gs00[-1, -1])
 
-# the following syntax is the same as the GridSpecFromSubplotSpec call above:
+# the following syntax does the same as the GridSpecFromSubplotSpec call above:
 gs01 = gs0[1].subgridspec(3, 3)
 
 ax4 = f.add_subplot(gs01[:, :-1])

--- a/examples/subplots_axes_and_figures/gridspec_nested.py
+++ b/examples/subplots_axes_and_figures/gridspec_nested.py
@@ -24,22 +24,16 @@ gs0 = gridspec.GridSpec(1, 2, figure=f)
 
 gs00 = gridspec.GridSpecFromSubplotSpec(3, 3, subplot_spec=gs0[0])
 
-ax1 = plt.Subplot(f, gs00[:-1, :])
-f.add_subplot(ax1)
-ax2 = plt.Subplot(f, gs00[-1, :-1])
-f.add_subplot(ax2)
-ax3 = plt.Subplot(f, gs00[-1, -1])
-f.add_subplot(ax3)
+ax1 = f.add_subplot(gs00[:-1, :])
+ax2 = f.add_subplot(gs00[-1, :-1])
+ax3 = f.add_subplot(gs00[-1, -1])
 
 
 gs01 = gridspec.GridSpecFromSubplotSpec(3, 3, subplot_spec=gs0[1])
 
-ax4 = plt.Subplot(f, gs01[:, :-1])
-f.add_subplot(ax4)
-ax5 = plt.Subplot(f, gs01[:-1, -1])
-f.add_subplot(ax5)
-ax6 = plt.Subplot(f, gs01[-1, -1])
-f.add_subplot(ax6)
+ax4 = f.add_subplot(gs01[:, :-1])
+ax5 = f.add_subplot(gs01[:-1, -1])
+ax6 = f.add_subplot(gs01[-1, -1])
 
 plt.suptitle("GridSpec Inside GridSpec")
 format_axes(f)

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -242,7 +242,7 @@ for i in range(16):
     inner_grid = outer_grid[i].subgridspec(3, 3, wspace=0.0, hspace=0.0)
     a, b = int(i/4)+1, i % 4+1
     for j, (c, d) in enumerate(product(range(1, 4), repeat=2)):
-        ax = plt.Subplot(fig11, inner_grid[j])
+        ax = fig11.add_subplot(inner_grid[j])
         ax.plot(*squiggle_xy(a, b, c, d))
         ax.set_xticks([])
         ax.set_yticks([])


### PR DESCRIPTION
## PR Summary

There were a few calls to `plt.Subplot` that confused the doc builds (and me!  See long discussion https://github.com/sphinx-gallery/sphinx-gallery/pull/448).  I don't even understand how those calls worked, since `pyplot` does not have anything defined as `Subplot`.  But basically they clobbered the `pyplot.subplot` gallery tracking.  Changed these instances to `add_subplot` and all seems to build fine.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->