### PR TITLE
Make SubplotSpec.num2 never None.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -245,8 +245,6 @@ def _make_ghost_gridspec_slots(fig, gs):
             axs += [ax]
     for ax in axs:
         ss0 = ax.get_subplotspec()
-        if ss0.num2 is None:
-            ss0.num2 = ss0.num1
         hassubplotspec[ss0.num1:(ss0.num2 + 1)] = True
     for nn, hss in enumerate(hassubplotspec):
         if not hss:
@@ -342,8 +340,6 @@ def _align_spines(fig, gs):
 
     for n, ax in enumerate(axs):
         ss0 = ax.get_subplotspec()
-        if ss0.num2 is None:
-            ss0.num2 = ss0.num1
         rownummin[n], colnummin[n] = divmod(ss0.num1, ncols)
         rownummax[n], colnummax[n] = divmod(ss0.num2, ncols)
         width[n] = np.sum(
@@ -483,16 +479,12 @@ def _arrange_subplotspecs(gs, hspace=0, wspace=0):
     for child0 in sschildren:
         ss0 = child0.artist
         nrows, ncols = ss0.get_gridspec().get_geometry()
-        if ss0.num2 is None:
-            ss0.num2 = ss0.num1
         rowNum0min, colNum0min = divmod(ss0.num1, ncols)
         rowNum0max, colNum0max = divmod(ss0.num2, ncols)
         sschildren = sschildren[1:]
         for childc in sschildren:
             ssc = childc.artist
             rowNumCmin, colNumCmin = divmod(ssc.num1, ncols)
-            if ssc.num2 is None:
-                ssc.num2 = ssc.num1
             rowNumCmax, colNumCmax = divmod(ssc.num2, ncols)
             # OK, this tells us the relative layout of ax
             # with axc

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -438,24 +438,13 @@ class LayoutBox(object):
         figLefts = [left + cellWs[2 * colNum] for colNum in range(ncols)]
         figRights = [left + cellWs[2 * colNum + 1] for colNum in range(ncols)]
 
-        rowNum, colNum = divmod(subspec.num1, ncols)
-        figBottom = figBottoms[rowNum]
-        figTop = figTops[rowNum]
-        figLeft = figLefts[colNum]
-        figRight = figRights[colNum]
+        rowNum1, colNum1 = divmod(subspec.num1, ncols)
+        rowNum2, colNum2 = divmod(subspec.num2, ncols)
+        figBottom = min(figBottoms[rowNum1], figBottoms[rowNum2])
+        figTop = max(figTops[rowNum1], figTops[rowNum2])
+        figLeft = min(figLefts[colNum1], figLefts[colNum2])
+        figRight = max(figRights[colNum1], figRights[colNum2])
 
-        if subspec.num2 is not None:
-
-            rowNum2, colNum2 = divmod(subspec.num2, ncols)
-            figBottom2 = figBottoms[rowNum2]
-            figTop2 = figTops[rowNum2]
-            figLeft2 = figLefts[colNum2]
-            figRight2 = figRights[colNum2]
-
-            figBottom = min(figBottom, figBottom2)
-            figLeft = min(figLeft, figLeft2)
-            figTop = max(figTop, figTop2)
-            figRight = max(figRight, figRight2)
         # These are numbers relative to 0,0,1,1.  Need to constrain
         # relative to parent.
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -410,7 +410,7 @@ class SubplotSpec(object):
         """
         The subplot will occupy the num1-th cell of the given
         gridspec.  If num2 is provided, the subplot will span between
-        num1-th cell and num2-th cell.
+        num1-th cell and num2-th cell *inclusive*.
 
         The index starts from 0.
         """
@@ -429,6 +429,17 @@ class SubplotSpec(object):
                     artist=self)
         else:
             self._layoutbox = None
+
+    # num2 is a property only to handle the case where it is None and someone
+    # mutates num1.
+
+    @property
+    def num2(self):
+        return self.num1 if self._num2 is None else self._num2
+
+    @num2.setter
+    def num2(self, value):
+        self._num2 = value
 
     def __getstate__(self):
         state = self.__dict__
@@ -464,11 +475,7 @@ class SubplotSpec(object):
         gridspec = self.get_gridspec()
         nrows, ncols = gridspec.get_geometry()
         row_start, col_start = divmod(self.num1, ncols)
-        if self.num2 is not None:
-            row_stop, col_stop = divmod(self.num2, ncols)
-        else:
-            row_stop = row_start
-            col_stop = col_start
+        row_stop, col_stop = divmod(self.num2, ncols)
         return nrows, ncols, row_start, row_stop, col_start, col_stop
 
     def get_position(self, figure, return_all=False):
@@ -476,9 +483,7 @@ class SubplotSpec(object):
         """
         gridspec = self.get_gridspec()
         nrows, ncols = gridspec.get_geometry()
-        rows, cols = np.unravel_index(
-            [self.num1] if self.num2 is None else [self.num1, self.num2],
-            (nrows, ncols))
+        rows, cols = np.unravel_index([self.num1, self.num2], (nrows, ncols))
         fig_bottoms, fig_tops, fig_lefts, fig_rights = \
             gridspec.get_grid_positions(figure)
 


### PR DESCRIPTION
SubplotSpec.num2 == None is handled as if num2 was set to num1 (a
subplot spanning a single entry of a GridSpec).  Instead of having a
bunch of checks everywhere for that, just hide None behind a property.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
