### PR TITLE
More followup to autoregistering 3d axes.

### DIFF
--- a/examples/animation/random_walk.py
+++ b/examples/animation/random_walk.py
@@ -7,31 +7,29 @@ Animated 3D random walk
 
 import numpy as np
 import matplotlib.pyplot as plt
-import mpl_toolkits.mplot3d.axes3d as p3
 import matplotlib.animation as animation
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
 
-def Gen_RandLine(length, dims=2):
+def gen_rand_line(length, dims=2):
     """
     Create a line using a random walk algorithm
 
     length is the number of points for the line.
     dims is the number of dimensions the line has.
     """
-    lineData = np.empty((dims, length))
-    lineData[:, 0] = np.random.rand(dims)
+    line_data = np.empty((dims, length))
+    line_data[:, 0] = np.random.rand(dims)
     for index in range(1, length):
         # scaling the random numbers by 0.1 so
         # movement is small compared to position.
         # subtraction by 0.5 is to change the range to [-0.5, 0.5]
         # to allow a line to move backwards.
-        step = ((np.random.rand(dims) - 0.5) * 0.1)
-        lineData[:, index] = lineData[:, index - 1] + step
-
-    return lineData
+        step = (np.random.rand(dims) - 0.5) * 0.1
+        line_data[:, index] = line_data[:, index - 1] + step
+    return line_data
 
 
 def update_lines(num, dataLines, lines):
@@ -41,12 +39,13 @@ def update_lines(num, dataLines, lines):
         line.set_3d_properties(data[2, :num])
     return lines
 
+
 # Attaching 3D axis to the figure
 fig = plt.figure()
-ax = p3.Axes3D(fig)
+ax = fig.add_subplot(projection="3d")
 
 # Fifty lines of random 3-D lines
-data = [Gen_RandLine(25, 3) for index in range(50)]
+data = [gen_rand_line(25, 3) for index in range(50)]
 
 # Creating fifty line objects.
 # NOTE: Can't pass empty arrays into 3d version of plot()
@@ -65,7 +64,7 @@ ax.set_zlabel('Z')
 ax.set_title('3D Test')
 
 # Creating the Animation object
-line_ani = animation.FuncAnimation(fig, update_lines, 25, fargs=(data, lines),
-                                   interval=50, blit=False)
+line_ani = animation.FuncAnimation(
+    fig, update_lines, 25, fargs=(data, lines), interval=50)
 
 plt.show()

--- a/tutorials/toolkits/mplot3d.py
+++ b/tutorials/toolkits/mplot3d.py
@@ -14,24 +14,21 @@ Generating 3D plots using the mplot3d toolkit.
 
 Getting started
 ---------------
-An Axes3D object is created just like any other axes using
-the projection='3d' keyword.
-Create a new :class:`matplotlib.figure.Figure` and
-add a new axes to it of type :class:`~mpl_toolkits.mplot3d.Axes3D`::
+3D Axes (of class `Axes3D`) are created by passing the ``projection="3d"``
+keyword argument to `Figure.add_subplot`::
 
    import matplotlib.pyplot as plt
-   from mpl_toolkits.mplot3d import Axes3D
    fig = plt.figure()
    ax = fig.add_subplot(111, projection='3d')
 
-.. versionadded:: 1.0.0
-   This approach is the preferred method of creating a 3D axes.
+.. versionchanged:: 1.0.0
+   Prior to Matplotlib 1.0.0, `Axes3D` needed to be directly instantiated with
+   ``from mpl_toolkits.mplot3d import Axes3D; ax = Axes3D(fig)``.
 
-.. note::
-   Prior to version 1.0.0, the method of creating a 3D axes was
-   different. For those using older versions of matplotlib, change
-   ``ax = fig.add_subplot(111, projection='3d')``
-   to ``ax = Axes3D(fig)``.
+.. versionchanged:: 3.2.0
+   Prior to Matplotlib 3.2.0, it was necessary to explicitly import the
+   :mod:`mpl_toolkits.mplot3d` module to make the '3d' projection to
+   `Figure.add_subplot`.
 
 See the :ref:`toolkit_mplot3d-faq` for more information about the mplot3d
 toolkit.


### PR DESCRIPTION
I split out these as a separate PR for simpler review.

followup to #13520.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
