### PR TITLE
Validate inputs to ScalarMappable constructor

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -167,21 +167,14 @@ class ScalarMappable:
         cmap : str or `~matplotlib.colors.Colormap`
             The colormap used to map normalized data values to RGBA colors.
         """
-
-        self.callbacksSM = cbook.CallbackRegistry()
-
-        if cmap is None:
-            cmap = get_cmap()
-        if norm is None:
-            norm = colors.Normalize()
-
         self._A = None
-        #: The Normalization instance of this ScalarMappable.
-        self.norm = norm
-        #: The Colormap instance of this ScalarMappable.
-        self.cmap = get_cmap(cmap)
+        self.norm = None  # So that the setter knows we're initializing.
+        self.set_norm(norm)  # The Normalize instance of this ScalarMappable.
+        self.cmap = None  # So that the setter knows we're initializing.
+        self.set_cmap(cmap)  # The Colormap instance of this ScalarMappable.
         #: The last colorbar associated with this ScalarMappable. May be None.
         self.colorbar = None
+        self.callbacksSM = cbook.CallbackRegistry()
         self.update_dict = {'array': False}
 
     def _scale_norm(self, norm, vmin, vmax):
@@ -336,35 +329,39 @@ class ScalarMappable:
 
     def set_cmap(self, cmap):
         """
-        set the colormap for luminance data
+        Set the colormap for luminance data.
 
         Parameters
         ----------
-        cmap : colormap or registered colormap name
+        cmap : `.Colormap` or str or None
         """
+        in_init = self.cmap is None
         cmap = get_cmap(cmap)
         self.cmap = cmap
-        self.changed()
+        if not in_init:
+            self.changed()  # Things are not set up properly yet.
 
     def set_norm(self, norm):
-        """Set the normalization instance.
+        """
+        Set the normalization instance.
 
         Parameters
         ----------
-        norm : `.Normalize`
+        norm : `.Normalize` or None
 
         Notes
         -----
         If there are any colorbars using the mappable for this norm, setting
         the norm of the mappable will reset the norm, locator, and formatters
         on the colorbar to default.
-
         """
         cbook._check_isinstance((colors.Normalize, None), norm=norm)
+        in_init = self.norm is None
         if norm is None:
             norm = colors.Normalize()
         self.norm = norm
-        self.changed()
+        if not in_init:
+            self.changed()  # Things are not set up properly yet.
 
     def autoscale(self):
         """


### PR DESCRIPTION
~~... by moving it to ScalarMappable.set_norm.~~

The original intent of this PR (deduplicating isinstance checks) was implemented in #14470, the only remaining point is to also perform checks in `__init__`.

Closes #14669.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
