### PR TITLE
Move {setup,install}_requires from setupext.py to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ mpl_packages = [
     setupext.Matplotlib(),
     setupext.Python(),
     setupext.Platform(),
-    setupext.Numpy(),
     setupext.LibAgg(),
     setupext.FreeType(),
     setupext.FT2Font(),
@@ -178,21 +177,13 @@ if __name__ == '__main__':
     packages = []
     namespace_packages = []
     py_modules = []
-    # Dummy extension to trigger build_ext, which will swap it out with real
-    # extensions that can depend on numpy for the build.
-    ext_modules = [Extension('', [])]
     package_data = {}
-    package_dir = {'': 'lib'}
-    install_requires = []
-    setup_requires = []
 
     # If the user just queries for information, don't bother figuring out which
     # packages to build or install.
-    if (any('--' + opt in sys.argv for opt in
-            Distribution.display_option_names + ['help']) or
-            'clean' in sys.argv):
-        setup_requires = []
-    else:
+    if not (any('--' + opt in sys.argv
+                for opt in [*Distribution.display_option_names, 'help'])
+            or 'clean' in sys.argv):
         # Go through all of the packages and figure out which ones we are
         # going to build/install.
         print_line()
@@ -245,8 +236,6 @@ if __name__ == '__main__':
             for key, val in data.items():
                 package_data.setdefault(key, [])
                 package_data[key] = list(set(val + package_data[key]))
-            install_requires.extend(package.get_install_requires())
-            setup_requires.extend(package.get_setup_requires())
 
         # Write the default matplotlibrc file
         with open('matplotlibrc.template') as fd:
@@ -268,6 +257,12 @@ if __name__ == '__main__':
         author="John D. Hunter, Michael Droettboom",
         author_email="matplotlib-users@python.org",
         url="https://matplotlib.org",
+        download_url="https://matplotlib.org/users/installing.html",
+        project_urls={
+            'Bug Tracker': 'https://github.com/matplotlib/matplotlib/issues',
+            'Documentation': 'https://matplotlib.org/contents.html',
+            'Source Code': 'https://github.com/matplotlib/matplotlib'
+        },
         long_description="""
         Matplotlib strives to produce publication quality 2D graphics
         for interactive graphing, scientific publishing, user interface
@@ -279,21 +274,24 @@ if __name__ == '__main__':
         namespace_packages=namespace_packages,
         platforms='any',
         py_modules=py_modules,
-        ext_modules=ext_modules,
-        package_dir=package_dir,
+        # Dummy extension to trigger build_ext, which will swap it out with
+        # real extensions that can depend on numpy for the build.
+        ext_modules=[Extension("", [])],
+        package_dir={"": "lib"},
         package_data=package_data,
         classifiers=classifiers,
-        download_url="https://matplotlib.org/users/installing.html",
-        project_urls={
-            'Bug Tracker': 'https://github.com/matplotlib/matplotlib/issues',
-            'Documentation': 'https://matplotlib.org/contents.html',
-            'Source Code': 'https://github.com/matplotlib/matplotlib'
-        },
 
         python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
-        # List third-party Python packages that we require
-        install_requires=install_requires,
-        setup_requires=setup_requires,
+        setup_requires=[
+            "numpy>=1.11",
+        ],
+        install_requires=[
+            "cycler>=0.10",
+            "kiwisolver>=1.0.1",
+            "numpy>=1.11",
+            "pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6",
+            "python-dateutil>=2.1",
+        ],
 
         # matplotlib has C/C++ extensions, so it's not zip safe.
         # Telling setuptools this prevents it from doing an automatic

--- a/setupext.py
+++ b/setupext.py
@@ -353,22 +353,6 @@ class SetupPackage(object):
         """
         return None
 
-    def get_install_requires(self):
-        """
-        Get a list of Python packages that we require.
-        pip/easy_install will attempt to download and install this
-        package if it is not installed.
-        """
-        return []
-
-    def get_setup_requires(self):
-        """
-        Get a list of Python packages that we require at build time.
-        pip/easy_install will attempt to download and install this
-        package if it is not installed.
-        """
-        return []
-
     def do_custom_build(self):
         """
         If a package needs to do extra custom things, such as building a
@@ -544,14 +528,6 @@ class Matplotlib(SetupPackage):
             ],
         }
 
-    def get_install_requires(self):
-        return [
-            "cycler>=0.10",
-            "kiwisolver>=1.0.1",
-            "pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6",
-            "python-dateutil>=2.1",
-        ]
-
 
 class SampleData(OptionalPackage):
     """
@@ -591,27 +567,18 @@ class Tests(OptionalPackage):
         }
 
 
-class Numpy(SetupPackage):
-    name = "numpy"
-
-    def add_flags(self, ext):
-        import numpy as np
-        ext.include_dirs.append(np.get_include())
-        ext.define_macros.extend([
-            # Ensure that PY_ARRAY_UNIQUE_SYMBOL is uniquely defined for each
-            # extension.
-            ('PY_ARRAY_UNIQUE_SYMBOL',
-             'MPL_' + ext.name.replace('.', '_') + '_ARRAY_API'),
-            ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
-            # Allow NumPy's printf format specifiers in C++.
-            ('__STDC_FORMAT_MACROS', 1),
-        ])
-
-    def get_setup_requires(self):
-        return ['numpy>=1.11']
-
-    def get_install_requires(self):
-        return ['numpy>=1.11']
+def add_numpy_flags(ext):
+    import numpy as np
+    ext.include_dirs.append(np.get_include())
+    ext.define_macros.extend([
+        # Ensure that PY_ARRAY_UNIQUE_SYMBOL is uniquely defined for each
+        # extension.
+        ('PY_ARRAY_UNIQUE_SYMBOL',
+         'MPL_' + ext.name.replace('.', '_') + '_ARRAY_API'),
+        ('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION'),
+        # Allow NumPy's printf format specifiers in C++.
+        ('__STDC_FORMAT_MACROS', 1),
+    ])
 
 
 class LibAgg(SetupPackage):
@@ -794,7 +761,7 @@ class FT2Font(SetupPackage):
             ]
         ext = Extension('matplotlib.ft2font', sources)
         FreeType().add_flags(ext)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext, add_sources=False)
         return ext
 
@@ -822,7 +789,7 @@ class Png(SetupPackage):
             atleast_version='1.2',
             alt_exec=['libpng-config', '--ldflags'],
             default_libraries=['png', 'z'])
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         return ext
 
 
@@ -850,7 +817,7 @@ class TTConv(SetupPackage):
             'extern/ttconv/ttutil.cpp'
             ]
         ext = Extension('matplotlib.ttconv', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         ext.include_dirs.insert(0, 'extern')
         return ext
 
@@ -863,9 +830,8 @@ class Path(SetupPackage):
             'src/py_converters.cpp',
             'src/_path_wrapper.cpp'
             ]
-
         ext = Extension('matplotlib._path', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext)
         return ext
 
@@ -881,7 +847,7 @@ class Image(SetupPackage):
             'src/py_converters.cpp'
             ]
         ext = Extension('matplotlib._image', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext)
 
         return ext
@@ -897,7 +863,7 @@ class Contour(SetupPackage):
             'src/py_converters.cpp',
             ]
         ext = Extension('matplotlib._contour', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext, add_sources=False)
         return ext
 
@@ -909,7 +875,7 @@ class QhullWrap(SetupPackage):
         sources = ['src/qhull_wrap.c']
         ext = Extension('matplotlib._qhull', sources,
                         define_macros=[('MPL_DEVNULL', os.devnull)])
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         Qhull().add_flags(ext)
         return ext
 
@@ -924,7 +890,7 @@ class Tri(SetupPackage):
             "src/mplutils.cpp"
             ]
         ext = Extension('matplotlib._tri', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         return ext
 
 
@@ -940,7 +906,7 @@ class BackendAgg(OptionalBackendPackage):
             "src/_backend_agg_wrapper.cpp"
             ]
         ext = Extension('matplotlib.backends._backend_agg', sources)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext)
         FreeType().add_flags(ext)
         return ext
@@ -961,7 +927,7 @@ class BackendTkAgg(OptionalBackendPackage):
 
         ext = Extension('matplotlib.backends._tkagg', sources)
         self.add_flags(ext)
-        Numpy().add_flags(ext)
+        add_numpy_flags(ext)
         LibAgg().add_flags(ext, add_sources=False)
         return ext
 
@@ -989,7 +955,6 @@ class BackendMacOSX(OptionalBackendPackage):
         sources = [
             'src/_macosx.m'
             ]
-
         ext = Extension('matplotlib.backends._macosx', sources)
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
         if platform.python_implementation().lower() == 'pypy':


### PR DESCRIPTION
The Numpy class in setupext.py serves two purposes: declare a
setup_requires and an install_requires on numpy, and provide a
add_flags() (effectively static) method to link extension modules to
numpy.

Instead, we can just merge the setup and install_requires together
with all other install_requires, and move all of them to setup.py
(deleting the machinery to grab setup_requires and install_requires
from multiple places), and make the add_flags() method a free function
(add_numpy_flags()).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
