### PR TITLE
 Modified docstring of the set_ylabel and set_xlabel

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -206,7 +206,8 @@ class Axes(_AxesBase):
             The label text.
 
         labelpad : scalar, optional, default: None
-            Spacing in points from the axes bounding box including ticks and tick labels.
+            Spacing in points from the axes bounding box including ticks
+            and tick labels.
 
         Other Parameters
         ----------------
@@ -238,7 +239,8 @@ class Axes(_AxesBase):
             The label text.
 
         labelpad : scalar, optional, default: None
-            Spacing in points from the axes bounding box including ticks and tick labels.
+            Spacing in points from the axes bounding box including ticks
+            and tick labels.
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -206,7 +206,7 @@ class Axes(_AxesBase):
             The label text.
 
         labelpad : scalar, optional, default: None
-            Spacing in points between the label and the x-axis.
+            Spacing in points from the axes bounding box including ticks and tick labels.
 
         Other Parameters
         ----------------
@@ -238,7 +238,7 @@ class Axes(_AxesBase):
             The label text.
 
         labelpad : scalar, optional, default: None
-            Spacing in points between the label and the y-axis.
+            Spacing in points from the axes bounding box including ticks and tick labels.
 
         Other Parameters
         ----------------


### PR DESCRIPTION
## PR Summary
Closes #13487
`labelpad` is a distance in points from the axes bounding box including ticks and tick labels. However presently documentation of `matplotlib.axes.Axes.set_ylabel` reads - 
"labelpad : Spacing in points between the label and the y-axis."

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
