### PR TITLE
Strip out Py2-compat in setupext.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ from distutils.dist import Distribution
 
 import setupext
 from setupext import (print_line, print_raw, print_message, print_status,
-                      download_or_cache, makedirs as _makedirs)
+                      download_or_cache)
 
 # Get the version from versioneer
 import versioneer
@@ -129,7 +129,7 @@ def _download_jquery_to(dest):
     url = "https://jqueryui.com/resources/download/jquery-ui-1.12.1.zip"
     sha = 'f8233674366ab36b2c34c577ec77a3d70cac75d2e387d8587f3836345c0f624d'
     if not os.path.exists(os.path.join(dest, "jquery-ui-1.12.1")):
-        _makedirs(dest, exist_ok=True)
+        os.makedirs(dest, exist_ok=True)
         try:
             buff = download_or_cache(url, sha)
         except Exception:


### PR DESCRIPTION
... that came in with the jquery-devendoring PR (#11246).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
