### PR TITLE
Cleanup warnings handling in tests.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5233,9 +5233,8 @@ def generate_errorbar_inputs():
 
 @pytest.mark.parametrize('kwargs', generate_errorbar_inputs())
 def test_errorbar_inputs_shotgun(kwargs):
-    with warnings.catch_warnings():
-        # (n, 1)-shaped error deprecation already tested by test_errorbar.
-        warnings.simplefilter("ignore", MatplotlibDeprecationWarning)
+    # (n, 1)-shaped error deprecation already tested by test_errorbar.
+    with mpl.cbook._suppress_matplotlib_deprecation_warning():
         ax = plt.gca()
         eb = ax.errorbar(**kwargs)
         eb.remove()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import platform
-import warnings
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -154,11 +153,9 @@ def test_gca():
 
     # the final request for a polar axes will end up creating one
     # with a spec of 111.
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter('always')
+    with pytest.warns(UserWarning):
         # Changing the projection will throw a warning
         assert fig.gca(polar=True) is not ax3
-        assert len(w) == 1
     assert fig.gca(polar=True) is not ax2
     assert fig.gca().get_geometry() == (1, 1, 1)
 
@@ -204,11 +201,9 @@ def test_alpha():
 
 
 def test_too_many_figures():
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+    with pytest.warns(RuntimeWarning):
         for i in range(rcParams['figure.max_open_warning'] + 1):
             plt.figure()
-        assert len(w) == 1
 
 
 def test_iterability_axes_argument():

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -894,9 +894,8 @@ def test_imshow_bignumbers_real():
      lambda: colors.PowerNorm(1)])
 def test_empty_imshow(make_norm):
     fig, ax = plt.subplots()
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "Attempting to set identical left==right")
+    with pytest.warns(UserWarning,
+                      match="Attempting to set identical left == right"):
         im = ax.imshow([[]], norm=make_norm())
     im.set_extent([-5, 5, -5, 5])
     fig.canvas.draw()

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -1,5 +1,4 @@
 import tempfile
-import warnings
 
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_equal, assert_array_almost_equal_nulp)
@@ -1859,13 +1858,9 @@ class TestSpectral(object):
         assert spec.shape[1] == self.t_specgram.shape[0]
 
     def test_specgram_warn_only1seg(self):
-        """Warning should be raised if len(x) <= NFFT. """
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always", category=UserWarning)
+        """Warning should be raised if len(x) <= NFFT."""
+        with pytest.warns(UserWarning, match="Only one segment is calculated"):
             mlab.specgram(x=self.y, NFFT=len(self.y), Fs=self.Fs)
-        assert len(w) == 1
-        assert issubclass(w[0].category, UserWarning)
-        assert str(w[0].message).startswith("Only one segment is calculated")
 
     def test_psd_csd_equal(self):
         freqs = self.freqs_density

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -2,13 +2,12 @@ from collections import OrderedDict
 import copy
 import os
 from unittest import mock
-import warnings
 
 from cycler import cycler, Cycler
 import pytest
 
 import matplotlib as mpl
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib import cbook
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np
@@ -91,22 +90,15 @@ def test_rcparams_update():
     rc = mpl.RcParams({'figure.figsize': (3.5, 42)})
     bad_dict = {'figure.figsize': (3.5, 42, 1)}
     # make sure validation happens on input
-    with pytest.raises(ValueError):
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore',
-                                message='.*(validate)',
-                                category=UserWarning)
-            rc.update(bad_dict)
+    with pytest.raises(ValueError), \
+         pytest.warns(UserWarning, match="validate"):
+        rc.update(bad_dict)
 
 
 def test_rcparams_init():
-    with pytest.raises(ValueError):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore',
-                                message='.*(validate)',
-                                category=UserWarning)
-            mpl.RcParams({'figure.figsize': (3.5, 42, 1)})
+    with pytest.raises(ValueError), \
+         pytest.warns(UserWarning, match="validate"):
+        mpl.RcParams({'figure.figsize': (3.5, 42, 1)})
 
 
 def test_Bug_2543():
@@ -117,9 +109,7 @@ def test_Bug_2543():
     # We filter warnings at this stage since a number of them are raised
     # for deprecated rcparams as they should. We don't want these in the
     # printed in the test suite.
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                category=MatplotlibDeprecationWarning)
+    with cbook._suppress_matplotlib_deprecation_warning():
         with mpl.rc_context():
             _copy = mpl.rcParams.copy()
             for key in _copy:

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 import gc
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import warnings
 
 import pytest
 
@@ -36,16 +35,13 @@ def temp_style(style_name, settings=None):
         style.reload_library()
 
 
-def test_invalid_rc_warning_includes_filename():
+def test_invalid_rc_warning_includes_filename(capsys):
     SETTINGS = {'foo': 'bar'}
     basename = 'basename'
-    with warnings.catch_warnings(record=True) as warns:
-        with temp_style(basename, SETTINGS):
-            # style.reload_library() in temp_style() triggers the warning
-            pass
-
-    for w in warns:
-        assert basename in str(w.message)
+    with temp_style(basename, SETTINGS):
+        # style.reload_library() in temp_style() triggers the warning
+        pass
+    assert basename in capsys.readouterr().err
 
 
 def test_available():

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -1,5 +1,4 @@
 import itertools
-import warnings
 
 import numpy
 import matplotlib.pyplot as plt
@@ -122,16 +121,15 @@ def test_exceptions():
         plt.subplots(2, 2, sharey='blah')
     # We filter warnings in this test which are genuine since
     # the point of this test is to ensure that this raises.
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore',
-                                message='.*sharex argument to subplots',
-                                category=UserWarning)
-        with pytest.raises(ValueError):
-            plt.subplots(2, 2, -1)
-        with pytest.raises(ValueError):
-            plt.subplots(2, 2, 0)
-        with pytest.raises(ValueError):
-            plt.subplots(2, 2, 5)
+    with pytest.warns(UserWarning, match='.*sharex argument to subplots'), \
+         pytest.raises(ValueError):
+        plt.subplots(2, 2, -1)
+    with pytest.warns(UserWarning, match='.*sharex argument to subplots'), \
+         pytest.raises(ValueError):
+        plt.subplots(2, 2, 0)
+    with pytest.warns(UserWarning, match='.*sharex argument to subplots'), \
+         pytest.raises(ValueError):
+        plt.subplots(2, 2, 5)
 
 
 @image_comparison(baseline_images=['subplots_offset_text'], remove_text=False)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -233,10 +233,8 @@ class TestNullLocator(object):
         Should not exception, and should raise a warning.
         """
         loc = mticker.NullLocator()
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(UserWarning):
             loc.set_params()
-            assert len(w) == 1
 
 
 class TestLogitLocator(object):

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -2,6 +2,7 @@ import warnings
 
 import numpy as np
 from numpy.testing import assert_array_equal
+import pytest
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
@@ -267,30 +268,18 @@ def test_tight_layout_offsetboxes():
 
 
 def test_empty_layout():
-    """Tests that tight layout doesn't cause an error when there are
-    no axes.
-    """
-
+    """Test that tight layout doesn't cause an error when there are no axes."""
     fig = plt.gcf()
     fig.tight_layout()
 
 
-def test_verybig_decorators_horizontal():
-    "Test that warning emitted when xlabel too big"
+@pytest.mark.parametrize("label", ["xlabel", "ylabel"])
+def test_verybig_decorators(label):
+    """Test that warning emitted when xlabel/ylabel too big."""
     fig, ax = plt.subplots(figsize=(3, 2))
-    ax.set_xlabel('a' * 100)
-    with warnings.catch_warnings(record=True) as w:
+    ax.set(**{label: 'a' * 100})
+    with pytest.warns(UserWarning):
         fig.tight_layout()
-        assert len(w) == 1
-
-
-def test_verybig_decorators_vertical():
-    "Test that warning emitted when xlabel too big"
-    fig, ax = plt.subplots(figsize=(3, 2))
-    ax.set_ylabel('a' * 100)
-    with warnings.catch_warnings(record=True) as w:
-        fig.tight_layout()
-        assert len(w) == 1
 
 
 def test_big_decorators_horizontal():
@@ -298,9 +287,8 @@ def test_big_decorators_horizontal():
     fig, axs = plt.subplots(1, 2, figsize=(3, 2))
     axs[0].set_xlabel('a' * 30)
     axs[1].set_xlabel('b' * 30)
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning):
         fig.tight_layout()
-        assert len(w) == 1
 
 
 def test_big_decorators_vertical():
@@ -308,9 +296,8 @@ def test_big_decorators_vertical():
     fig, axs = plt.subplots(2, 1, figsize=(3, 2))
     axs[0].set_ylabel('a' * 20)
     axs[1].set_ylabel('b' * 20)
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning):
         fig.tight_layout()
-        assert len(w) == 1
 
 
 def test_badsubplotgrid():
@@ -319,9 +306,8 @@ def test_badsubplotgrid():
     ax1 = plt.subplot2grid((4, 5), (0, 0))
     # this is the bad entry:
     ax5 = plt.subplot2grid((5, 5), (0, 3), colspan=3, rowspan=5)
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning):
         plt.tight_layout()
-        assert len(w) == 1
 
 
 def test_collapsed():
@@ -333,8 +319,7 @@ def test_collapsed():
 
     ax.annotate('BIG LONG STRING', xy=(1.25, 2), xytext=(10.5, 1.75),)
     p1 = ax.get_position()
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning):
         plt.tight_layout()
         p2 = ax.get_position()
         assert p1.width == p2.width
-        assert len(w) == 1


### PR DESCRIPTION
This caught two "incorrect" tests:

- in test_style.py::test_invalid_rc_warning_includes_filename, the
  `for w in warns: ...` assertion did nothing as no warning was
  emitted so `warns` was empty (instead, the message is just print()ed
  to stderr.
- in test_image.py::test_empty_imshow, the caught warning message was
  missing spaces around the equals.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
