### PR TITLE
FIX: inverted colorbar ticks

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -238,6 +238,9 @@ class _ColorbarAutoLocator(ticker.MaxNLocator):
         super().__init__(nbins=nbins, steps=steps)
 
     def tick_values(self, vmin, vmax):
+        # flip if needed:
+        if vmin > vmax:
+            vmin, vmax = vmax, vmin
         vmin = max(vmin, self._colorbar.norm.vmin)
         vmax = min(vmax, self._colorbar.norm.vmax)
         ticks = super().tick_values(vmin, vmax)
@@ -295,8 +298,10 @@ class _ColorbarLogLocator(ticker.LogLocator):
         super().__init__(*args, **kwargs)
 
     def tick_values(self, vmin, vmax):
-        vmin = self._colorbar.norm.vmin
-        vmax = self._colorbar.norm.vmax
+        if vmin > vmax:
+            vmin, vmax = vmax, vmin
+        vmin = max(vmin, self._colorbar.norm.vmin)
+        vmax = min(vmax, self._colorbar.norm.vmax)
         ticks = super().tick_values(vmin, vmax)
         rtol = (np.log10(vmax) - np.log10(vmin)) * 1e-10
         ticks = ticks[(np.log10(ticks) >= np.log10(vmin) - rtol) &

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -514,8 +514,28 @@ def test_colorbar_scale_reset():
 def test_colorbar_get_ticks():
     with rc_context({'_internal.classic_mode': False}):
 
-        fig, ax = plt. subplots()
+        fig, ax = plt.subplots()
         np.random.seed(19680801)
         pc = ax.pcolormesh(np.random.rand(30, 30))
         cb = fig.colorbar(pc)
         np.testing.assert_allclose(cb.get_ticks(), [0.2, 0.4, 0.6, 0.8])
+
+
+def test_colorbar_inverted_ticks():
+    fig, axs = plt.subplots(2)
+    ax = axs[0]
+    pc = ax.pcolormesh(10**np.arange(1, 5).reshape(2, 2), norm=LogNorm())
+    cbar = fig.colorbar(pc, ax=ax, extend='both')
+    ticks = cbar.get_ticks()
+    cbar.ax.invert_yaxis()
+    np.testing.assert_allclose(ticks, cbar.get_ticks())
+
+    ax = axs[1]
+    pc = ax.pcolormesh(np.arange(1, 5).reshape(2, 2))
+    cbar = fig.colorbar(pc, ax=ax, extend='both')
+    cbar.minorticks_on()
+    ticks = cbar.get_ticks()
+    minorticks = cbar.get_ticks(minor=True)
+    cbar.ax.invert_yaxis()
+    np.testing.assert_allclose(ticks, cbar.get_ticks())
+    np.testing.assert_allclose(minorticks, cbar.get_ticks(minor=True))


### PR DESCRIPTION


## PR Summary

Closes #13530

Before, if we inverted the colorbar the tick trimming logic was incorrect and we trimmed all the ticks!  This fixes that.

```python
import matplotlib.pyplot as plt
import numpy as np
import matplotlib.colors as mcolors

fig, axs = plt.subplots(2, 1)
axs = axs.flat
ax = axs[0]
pc = ax.pcolormesh(10**np.arange(1,5).reshape(2, 2), norm=mcolors.LogNorm())
cbar = fig.colorbar(pc, ax=ax, extend='both')
ticks = cbar.get_ticks()
cbar.ax.invert_yaxis()

ax = axs[1]
pc = ax.pcolormesh(np.arange(1,5).reshape(2, 2))
cbar = fig.colorbar(pc, ax=ax, extend='both')
ticks = cbar.get_ticks()
cbar.ax.invert_yaxis()
cbar.minorticks_on()
plt.show()
```

### Before:

<img width="588" alt="screen shot 2019-03-01 at 17 05 32" src="https://user-images.githubusercontent.com/1562854/53674648-3a981980-3c44-11e9-97ac-9d69b1888480.png">

Note this also gives an error and the figure can't be saved:

```
  File "/Users/jklymak/matplotlib/lib/matplotlib/axis.py", line 1312, in get_minorticklocs
    minor_locs = self.minor.locator()
  File "/Users/jklymak/matplotlib/lib/matplotlib/colorbar.py", line 272, in __call__
    return ticks[(ticks >= vmin - rtol) & (ticks <= vmax + rtol)]
TypeError: only integer scalar arrays can be converted to a scalar index
```

### After:

![figure_1](https://user-images.githubusercontent.com/1562854/53674571-b2b20f80-3c43-11e9-84ed-a91132d3aa96.png)

and no error....


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->