### PR TITLE
Add an option to log progress while saving animations

### DIFF
--- a/doc/users/next_whats_new/2019-03-18-SB.rst
+++ b/doc/users/next_whats_new/2019-03-18-SB.rst
@@ -1,0 +1,5 @@
+*progress_callback* argument to ani.save()
+-------------------------------------------------
+
+The method .FuncAnimation.save() gained an optional 
+*progress_callback* argument to notify the saving progress.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -957,7 +957,7 @@ class Animation(object):
 
     def save(self, filename, writer=None, fps=None, dpi=None, codec=None,
              bitrate=None, extra_args=None, metadata=None, extra_anim=None,
-             savefig_kwargs=None, progress_callback=None):
+             savefig_kwargs=None, *, progress_callback=None):
         """
         Save the animation as a movie file by drawing every frame.
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -957,7 +957,7 @@ class Animation(object):
 
     def save(self, filename, writer=None, fps=None, dpi=None, codec=None,
              bitrate=None, extra_args=None, metadata=None, extra_anim=None,
-             savefig_kwargs=None):
+             savefig_kwargs=None, progress_callback=None):
         """
         Save the animation as a movie file by drawing every frame.
 
@@ -1012,6 +1012,22 @@ class Animation(object):
            Is a dictionary containing keyword arguments to be passed
            on to the `savefig` command which is called repeatedly to
            save the individual frames.
+
+        progress_callback : function, optional
+            A callback function that will be called for every frame to notify
+            the saving progress. It must have the signature ::
+
+                def func(current_frame: int, total_frames: int) -> Any
+
+            where *current_frame* is the current frame number and
+            *total_frames* is the total number of frames to be saved.
+            *total_frames* is set to None, if the total number of frames can
+            not be determined. Return values may exist but are ignored.
+
+            Example code to write the progress to stdout::
+
+                progress_callback =\
+                    lambda i, n: print(f'Saving frame {i} of {n}')
 
         Notes
         -----
@@ -1111,10 +1127,19 @@ class Animation(object):
                 for anim in all_anim:
                     # Clear the initial frame
                     anim._init_draw()
+                frame_number = 0
+                save_count_list = [a.save_count for a in all_anim]
+                if None in save_count_list:
+                    total_frames = None
+                else:
+                    total_frames = sum(save_count_list)
                 for data in zip(*[a.new_saved_frame_seq() for a in all_anim]):
                     for anim, d in zip(all_anim, data):
                         # TODO: See if turning off blit is really necessary
                         anim._draw_next_frame(d, blit=False)
+                        if progress_callback is not None:
+                            progress_callback(frame_number, total_frames)
+                            frame_number += 1
                     writer.grab_frame(**savefig_kwargs)
 
         # Reconnect signal for first draw if necessary


### PR DESCRIPTION
## PR Summary

Closes #13561

Adds a parameter `log_progress ` to `anim.save(output_path, writer, log_progress=0)`

Parameter description:
        log_progress : int, optional
            Controls the frequency of progress information written
            during execution to the 'info' log. With log_progress=n
            the progress information is written every time n frames
            are processed. log_progress=0 disables this feature.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
