### PR TITLE
Deprecate MovieWriterRegistry cache-dirtyness system.

### DIFF
--- a/doc/api/next_api_changes/2019-03-03-AL.rst
+++ b/doc/api/next_api_changes/2019-03-03-AL.rst
@@ -1,0 +1,14 @@
+Deprecations
+````````````
+
+The following methods and attributes of the `MovieWriterRegistry` class are
+deprecated: ``set_dirty``, ``ensure_not_dirty``, ``reset_available_writers``,
+``avail``.
+
+The ``rcsetup.validate_animation_writer_path`` function is deprecated.
+
+`MovieWriterRegistry` now always checks the availability of the writer classes
+before returning them.  If one wishes, for example, to get the first available
+writer, without performing the availability check on subsequent writers, it is
+now possible to iterate over the registry, which will yield the names of the
+available classes.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -927,6 +927,7 @@ def validate_hist_bins(s):
                      " a sequence of floats".format(valid_strs))
 
 
+@cbook.deprecated("3.2")
 def validate_animation_writer_path(p):
     # Make sure it's a string and then figure out if the animations
     # are already loaded and reset the writers (which will validate
@@ -1454,15 +1455,15 @@ defaultParams = {
     # Additional arguments for HTML writer
     'animation.html_args':    [[], validate_stringlist],
     # Path to ffmpeg binary. If just binary name, subprocess uses $PATH.
-    'animation.ffmpeg_path':  ['ffmpeg', validate_animation_writer_path],
+    'animation.ffmpeg_path':  ['ffmpeg', validate_string],
     # Additional arguments for ffmpeg movie writer (using pipes)
     'animation.ffmpeg_args':   [[], validate_stringlist],
     # Path to AVConv binary. If just binary name, subprocess uses $PATH.
-    'animation.avconv_path':   ['avconv', validate_animation_writer_path],
+    'animation.avconv_path':   ['avconv', validate_string],
     # Additional arguments for avconv movie writer (using pipes)
     'animation.avconv_args':   [[], validate_stringlist],
      # Path to convert binary. If just binary name, subprocess uses $PATH.
-    'animation.convert_path':  ['convert', validate_animation_writer_path],
+    'animation.convert_path':  ['convert', validate_string],
      # Additional arguments for convert movie writer (using pipes)
     'animation.convert_args':  [[], validate_stringlist],
 


### PR DESCRIPTION
MovieWriterRegistry has a fairly extensive system to cache whether movie
writer classes are available or not.  Deprecate it and always perform
the check every time: for nearly all classes, the availability check is
either an import check (Pillow), or checking for whether an executable
is in the $PATH -- this is negligible compared to actually running the
executable to encode the movie.

The only exception is that ffmpeg actually checks whether it is
actually ffmpeg or ubuntu's broken libav.  In order to avoid performing
that check (... which should still be not so slow) when Pillow is
available (Pillow is registered first, so comes first :)), add
`MovieWriterRegistry.__iter__` which allows to get the first available
writer without checking the availability of the subsequent ones (this
behavior is consistent with `MovieWriterRegistry.__getitem__` and
`MovieWriterRegistry.list`).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
