### PR TITLE
Revert invalid change in Centered Ticklabels example

### DIFF
--- a/examples/ticks_and_spines/centered_ticklabels.py
+++ b/examples/ticks_and_spines/centered_ticklabels.py
@@ -7,7 +7,8 @@ sometimes it is nice to have ticklabels centered.  Matplotlib currently
 associates a label with a tick, and the label can be aligned
 'center', 'left', or 'right' using the horizontal alignment property::
 
-    ax.xaxis.set_tick_params(horizontalalignment='right')
+    for label in ax.xaxis.get_xticklabels():
+        label.set_horizontalalignment('right')
 
 but this doesn't help center the label between ticks.  One solution
 is to "fake it".  Use the minor ticks to place a tick centered


### PR DESCRIPTION
## PR Summary

This reverts a change in the example introduced by #8678. As #13400 states `ax.xaxis.set_tick_params(horizontalalignment='right')` does not work - it's not implemented.

This is a quick-fix to get the documentation correct for 3.1 again.

It's debatable if implementing `vertical/horizontalalignment` for `set_tick_params()` is reasonable. Essentally, verticalalignment will not give reasonable results for xticks and horizontalalignment will not give reasonable results for yticks. But that's for another PR.