### PR TITLE
FIX: fallback to viewlims if no data

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2439,6 +2439,16 @@ class _AxesBase(martist.Artist):
                 dl.extend(y_finite)
 
             bb = mtransforms.BboxBase.union(dl)
+            # fall back on the viewlimits if this is not finite:
+            vl = None
+            if not np.isfinite(bb.intervalx).all():
+                vl = mtransforms.BboxBase.union([ax.viewLim for ax in shared])
+                bb.intervalx = vl.intervalx
+            if not np.isfinite(bb.intervaly).all():
+                if vl is None:
+                    vl = mtransforms.BboxBase.union(
+                        [ax.viewLim for ax in shared])
+                bb.intervaly = vl.intervaly
             x0, x1 = getattr(bb, interval)
             locator = axis.get_major_locator()
             x0, x1 = locator.nonsingular(x0, x1)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6281,3 +6281,16 @@ def test_axis_bool_arguments(fig_test, fig_ref):
     ax.axis(False)
     ax.axis(True)
     fig_ref.add_subplot(212).axis("on")
+
+
+def test_datetime_masked():
+    # make sure that all-masked data falls back to the viewlim
+    # set in convert.axisinfo....
+    x = np.array([datetime.datetime(2017, 1, n) for n in range(1, 6)])
+    y = np.array([1, 2, 3, 4, 5])
+    m = np.ma.masked_greater(y, 0)
+
+    fig, ax = plt.subplots()
+    ax.plot(x, m)
+    # these are the default viewlim
+    assert ax.get_xlim() == (730120.0, 733773.0)


### PR DESCRIPTION
## PR Summary

Closes #11337

The following test would fail because the view limit was set from 0-1:

```python
    x = np.array([datetime.datetime(2017, 1, n) for n in range(1, 6)])
    y = np.array([1,2,3,4,5])
    m = np.ma.masked_greater(y, 0)

    fig = plt.figure()
    ax = fig.add_subplot(111)
    ax.plot(x, m)
    # these are the default viewlim
    assert ax.get_xlim() == (730120.0, 733773.0)
```

The issue was in `autoscale_view`, which never checked the axes.viewLim, even if the data lim came back undefined.  This PR checks the viewlim and uses that if the datalim is not finite.  

Note this issue is more generic than dates, but is most easily seen there because we can't have dates with ordinal values <1, and the default behaviour made it so such dates were the datalim.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->