### PR TITLE
Doc event loop requirements for Figure.show

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -411,6 +411,18 @@ class Figure(Artist):
         :class:`~matplotlib.backend_bases.FigureManagerBase`, and
         will raise an AttributeError.
 
+        .. warning::
+            This does not manage an GUI event loop. Consequently, the figure
+            may only be shown briefly or not shown at all if you or your
+            environment are not managing an event loop.
+
+            Proper use cases for `.Figure.show` include running this from a
+            GUI application or an IPython shell.
+
+            If you're running a pure python shell or executing a non-GUI
+            python script, you should use `matplotlib.pyplot.show` instead,
+            which takes care of managing the event loop for you.
+
         Parameters
         ----------
         warn : bool


### PR DESCRIPTION
## PR Summary

Trying to better document `Figure.show()` and how it's different from `plt.show()`.

Hopefully this is reasonably correct and understandable so that #13586 or #13101 do not happen anymore. Improvements welcome as this is hard to describe (see discussion in #13101).