### PR TITLE
DOC: Make canonical URLs point to versioned path.

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -162,7 +162,11 @@ parents[-1].link|e }}" />
     {%- endif %}
 {%- endblock %}
 {%- block extrahead %}
-  <link rel="canonical" href="https://matplotlib.org/{{pagename}}.html" />
+{%- if '+' in release %}
+    <link rel="canonical" href="https://matplotlib.org/devdocs/{{pagename}}.html" />
+{%- else %}
+    <link rel="canonical" href="https://matplotlib.org/{{version}}/{{pagename}}.html" />
+{%- endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
## PR Summary

Maybe this will help with #12374. We currently set the canonical URL to the unversioned path (matplotlib.org/page.html); this swaps it to the versioned one (matplotlib.org/3.1.0/page.html).

If this is a development version, it points to `/devdocs/` (not sure about this change; maybe it should point to stable?)

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way