### PR TITLE
Only autoscale_view() when needed, not after every plotting call.

### DIFF
--- a/doc/api/next_api_changes/2019-03-04-AL.rst
+++ b/doc/api/next_api_changes/2019-03-04-AL.rst
@@ -1,0 +1,20 @@
+Autoscaling changes
+```````````````````
+
+Matplotlib used to recompute autoscaled limits after every plotting
+(``plot()``, ``bar()``, etc.) call.  It now only does so when actually
+rendering the canvas, or when the user queries the Axes limits.  This is a
+major performance improvement for plots with a large number of artists.
+
+In particular, this means that artists added manually with `Axes.add_line`,
+`Axes.add_patch`, etc. will be taken into account by the autoscale, even
+without an explicit call to `Axes.autoscale_view`.
+
+In some cases, this can result in different limits being reported.  If this is
+an issue, consider triggering a draw with `fig.canvas.draw`.
+
+LogLocator.nonsingular now maintains the orders of its arguments
+````````````````````````````````````````````````````````````````
+
+It no longer reorders them in increasing order.  The new behavior is consistent
+with MaxNLocator.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -840,7 +840,7 @@ class Axes(_AxesBase):
         trans = self.get_yaxis_transform(which='grid')
         l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
         self.add_line(l)
-        self.autoscale_view(scalex=False, scaley=scaley)
+        self._request_autoscale_view(scalex=False, scaley=scaley)
         return l
 
     @docstring.dedent_interpd
@@ -909,7 +909,7 @@ class Axes(_AxesBase):
         trans = self.get_xaxis_transform(which='grid')
         l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
         self.add_line(l)
-        self.autoscale_view(scalex=scalex, scaley=False)
+        self._request_autoscale_view(scalex=scalex, scaley=False)
         return l
 
     @docstring.dedent_interpd
@@ -965,7 +965,7 @@ class Axes(_AxesBase):
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(trans)
         self.add_patch(p)
-        self.autoscale_view(scalex=False)
+        self._request_autoscale_view(scalex=False)
         return p
 
     def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
@@ -1030,7 +1030,7 @@ class Axes(_AxesBase):
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(trans)
         self.add_patch(p)
-        self.autoscale_view(scaley=False)
+        self._request_autoscale_view(scaley=False)
         return p
 
     @_preprocess_data(replace_names=["y", "xmin", "xmax", "colors"],
@@ -1105,7 +1105,7 @@ class Axes(_AxesBase):
             corners = (minx, miny), (maxx, maxy)
 
             self.update_datalim(corners)
-            self.autoscale_view()
+            self._request_autoscale_view()
 
         return lines
 
@@ -1182,7 +1182,7 @@ class Axes(_AxesBase):
 
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners)
-            self.autoscale_view()
+            self._request_autoscale_view()
 
         return lines
 
@@ -1398,7 +1398,7 @@ class Axes(_AxesBase):
                 else:  # "horizontal", None or "none" (see EventCollection)
                     corners = (minpos, minline), (maxpos, maxline)
                 self.update_datalim(corners)
-                self.autoscale_view()
+                self._request_autoscale_view()
 
         return colls
 
@@ -1642,7 +1642,7 @@ class Axes(_AxesBase):
         lines = [*self._get_lines(*args, data=data, **kwargs)]
         for line in lines:
             self.add_line(line)
-        self.autoscale_view(scalex=scalex, scaley=scaley)
+        self._request_autoscale_view(scalex=scalex, scaley=scaley)
         return lines
 
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
@@ -1718,7 +1718,7 @@ class Axes(_AxesBase):
 
         ret = self.plot(x, y, fmt, **kwargs)
 
-        self.autoscale_view()
+        self._request_autoscale_view()
 
         return ret
 
@@ -2422,7 +2422,7 @@ class Axes(_AxesBase):
                 ymin = ymin - np.max(yerr)
             ymin = max(ymin * 0.9, 1e-100)
             self.dataLim.intervaly = (ymin, ymax)
-        self.autoscale_view()
+        self._request_autoscale_view()
 
         bar_container = BarContainer(patches, errorbar, label=label)
         self.add_container(bar_container)
@@ -2623,7 +2623,7 @@ class Axes(_AxesBase):
 
         col = mcoll.BrokenBarHCollection(xranges_conv, yrange_conv, **kwargs)
         self.add_collection(col, autolim=True)
-        self.autoscale_view()
+        self._request_autoscale_view()
 
         return col
 
@@ -3429,7 +3429,7 @@ class Axes(_AxesBase):
         for l in caplines:
             self.add_line(l)
 
-        self.autoscale_view()
+        self._request_autoscale_view()
         errorbar_container = ErrorbarContainer((data_line, tuple(caplines),
                                                 tuple(barcols)),
                                                has_xerr=(xerr is not None),
@@ -4101,7 +4101,7 @@ class Axes(_AxesBase):
                 axis.set_major_formatter(formatter)
             formatter.seq = [*formatter.seq, *datalabels]
 
-            self.autoscale_view(
+            self._request_autoscale_view(
                 scalex=self._autoscaleXon, scaley=self._autoscaleYon)
 
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
@@ -4479,7 +4479,7 @@ optional.
                 self.set_ymargin(0.05)
 
         self.add_collection(collection)
-        self.autoscale_view()
+        self._request_autoscale_view()
 
         return collection
 
@@ -4832,9 +4832,7 @@ optional.
 
         corners = ((xmin, ymin), (xmax, ymax))
         self.update_datalim(corners)
-        collection.sticky_edges.x[:] = [xmin, xmax]
-        collection.sticky_edges.y[:] = [ymin, ymax]
-        self.autoscale_view(tight=True)
+        self._request_autoscale_view(tight=True)
 
         # add the collection last
         self.add_collection(collection, autolim=False)
@@ -5004,7 +5002,7 @@ optional.
         q = mquiver.Quiver(self, *args, **kw)
 
         self.add_collection(q, autolim=True)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return q
     quiver.__doc__ = mquiver.Quiver.quiver_doc
 
@@ -5020,7 +5018,7 @@ optional.
 
         b = mquiver.Barbs(self, *args, **kw)
         self.add_collection(b, autolim=True)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return b
 
     # Uses a custom implementation of data-kwarg handling in
@@ -5075,7 +5073,7 @@ optional.
         for poly in self._get_patches_for_fill(*args, data=data, **kwargs):
             self.add_patch(poly)
             patches.append(poly)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return patches
 
     @_preprocess_data(replace_names=["x", "y1", "y2", "where"])
@@ -5257,7 +5255,7 @@ optional.
         self.dataLim.update_from_data_xy(XY2, self.ignore_existing_data_limits,
                                          updatex=False, updatey=True)
         self.add_collection(collection, autolim=False)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return collection
 
     @_preprocess_data(replace_names=["y", "x1", "x2", "where"])
@@ -5438,7 +5436,7 @@ optional.
         self.dataLim.update_from_data_xy(X2Y, self.ignore_existing_data_limits,
                                          updatex=True, updatey=False)
         self.add_collection(collection, autolim=False)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return collection
 
     #### plotting z(x,y): imshow, pcolor and relatives, contour
@@ -5937,7 +5935,7 @@ optional.
         collection.sticky_edges.y[:] = [miny, maxy]
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return collection
 
     @_preprocess_data()
@@ -6150,7 +6148,7 @@ optional.
         collection.sticky_edges.y[:] = [miny, maxy]
         corners = (minx, miny), (maxx, maxy)
         self.update_datalim(corners)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return collection
 
     @_preprocess_data()
@@ -6320,14 +6318,14 @@ optional.
         ret.sticky_edges.x[:] = [xl, xr]
         ret.sticky_edges.y[:] = [yb, yt]
         self.update_datalim(np.array([[xl, yb], [xr, yt]]))
-        self.autoscale_view(tight=True)
+        self._request_autoscale_view(tight=True)
         return ret
 
     @_preprocess_data()
     def contour(self, *args, **kwargs):
         kwargs['filled'] = False
         contours = mcontour.QuadContourSet(self, *args, **kwargs)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return contours
     contour.__doc__ = mcontour.QuadContourSet._contour_doc
 
@@ -6335,7 +6333,7 @@ optional.
     def contourf(self, *args, **kwargs):
         kwargs['filled'] = True
         contours = mcontour.QuadContourSet(self, *args, **kwargs)
-        self.autoscale_view()
+        self._request_autoscale_view()
         return contours
     contourf.__doc__ = mcontour.QuadContourSet._contour_doc
 
@@ -6842,7 +6840,7 @@ optional.
 
         self.set_autoscalex_on(_saved_autoscalex)
         self.set_autoscaley_on(_saved_autoscaley)
-        self.autoscale_view()
+        self._request_autoscale_view()
 
         if label is None:
             labels = [None]

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -470,6 +470,8 @@ class _AxesBase(martist.Artist):
         self._aspect = 'auto'
         self._adjustable = 'box'
         self._anchor = 'C'
+        self._stale_viewlim_x = False
+        self._stale_viewlim_y = False
         self._sharex = sharex
         self._sharey = sharey
         if sharex is not None:
@@ -615,11 +617,40 @@ class _AxesBase(martist.Artist):
                                                 fig.transFigure)
         # these will be updated later as data is added
         self.dataLim = mtransforms.Bbox.null()
-        self.viewLim = mtransforms.Bbox.unit()
+        self._viewLim = mtransforms.Bbox.unit()
         self.transScale = mtransforms.TransformWrapper(
             mtransforms.IdentityTransform())
 
         self._set_lim_and_transforms()
+
+    def _unstale_viewLim(self):
+        # We should arrange to store this information once per share-group
+        # instead of on every axis.
+        scalex = any(ax._stale_viewlim_x
+                     for ax in self._shared_x_axes.get_siblings(self))
+        scaley = any(ax._stale_viewlim_y
+                     for ax in self._shared_y_axes.get_siblings(self))
+        if scalex or scaley:
+            for ax in self._shared_x_axes.get_siblings(self):
+                ax._stale_viewlim_x = False
+            for ax in self._shared_y_axes.get_siblings(self):
+                ax._stale_viewlim_y = False
+            self.autoscale_view(scalex=scalex, scaley=scaley)
+
+    @property
+    def viewLim(self):
+        self._unstale_viewLim()
+        return self._viewLim
+
+    # API could be better, right now this is just to match the old calls to
+    # autoscale_view() after each plotting method.
+    def _request_autoscale_view(self, tight=None, scalex=True, scaley=True):
+        if tight is not None:
+            self._tight = tight
+        if scalex:
+            self._stale_viewlim_x = True  # Else keep old state.
+        if scaley:
+            self._stale_viewlim_y = True
 
     def _set_lim_and_transforms(self):
         """
@@ -645,7 +676,7 @@ class _AxesBase(martist.Artist):
         # An affine transformation on the data, generally to limit the
         # range of the axes
         self.transLimits = mtransforms.BboxTransformFrom(
-            mtransforms.TransformedBbox(self.viewLim, self.transScale))
+            mtransforms.TransformedBbox(self._viewLim, self.transScale))
 
         # The parentheses are important for efficiency here -- they
         # group the last two (which are usually affines) separately
@@ -1862,6 +1893,9 @@ class _AxesBase(martist.Artist):
             collection.set_clip_path(self.patch)
 
         if autolim:
+            # Make sure viewLim is not stale (mostly to match
+            # pre-lazy-autoscale behavior, which is not really better).
+            self._unstale_viewLim()
             self.update_datalim(collection.get_datalim(self.transData))
 
         self.stale = True
@@ -2019,7 +2053,7 @@ class _AxesBase(martist.Artist):
         Currently forces updates of data limits and view limits.
         """
         self.relim()
-        self.autoscale_view(scalex=scalex, scaley=scaley)
+        self._request_autoscale_view(scalex=scalex, scaley=scaley)
 
     def relim(self, visible_only=False):
         """
@@ -2313,7 +2347,7 @@ class _AxesBase(martist.Artist):
         if y is not None:
             self.set_ymargin(y)
 
-        self.autoscale_view(
+        self._request_autoscale_view(
             tight=tight, scalex=(x is not None), scaley=(y is not None)
         )
 
@@ -2375,7 +2409,7 @@ class _AxesBase(martist.Artist):
             self._xmargin = 0
         if tight and scaley:
             self._ymargin = 0
-        self.autoscale_view(tight=tight, scalex=scalex, scaley=scaley)
+        self._request_autoscale_view(tight=tight, scalex=scalex, scaley=scaley)
 
     def autoscale_view(self, tight=None, scalex=True, scaley=True):
         """
@@ -2556,11 +2590,12 @@ class _AxesBase(martist.Artist):
         """Draw everything (plot lines, axes, labels)"""
         if renderer is None:
             renderer = self.figure._cachedRenderer
-
         if renderer is None:
             raise RuntimeError('No renderer defined')
         if not self.get_visible():
             return
+        self._unstale_viewLim()
+
         renderer.open_group('axes')
 
         # prevent triggering call backs during the draw process
@@ -2886,7 +2921,7 @@ class _AxesBase(martist.Artist):
             self.xaxis.get_major_locator().set_params(**kwargs)
         if _y:
             self.yaxis.get_major_locator().set_params(**kwargs)
-        self.autoscale_view(tight=tight, scalex=_x, scaley=_y)
+        self._request_autoscale_view(tight=tight, scalex=_x, scaley=_y)
 
     def tick_params(self, axis='both', **kwargs):
         """Change the appearance of ticks, tick labels, and gridlines.
@@ -3122,7 +3157,6 @@ class _AxesBase(martist.Artist):
         Returns
         -------
         The limit value after call to convert(), or None if limit is None.
-
         """
         if limit is not None:
             converted_limit = convert(limit)
@@ -3214,11 +3248,14 @@ class _AxesBase(martist.Artist):
         left = self._validate_converted_limits(left, self.convert_xunits)
         right = self._validate_converted_limits(right, self.convert_xunits)
 
-        old_left, old_right = self.get_xlim()
-        if left is None:
-            left = old_left
-        if right is None:
-            right = old_right
+        if left is None or right is None:
+            # Axes init calls set_xlim(0, 1) before get_xlim() can be called,
+            # so only grab the limits if we really need them.
+            old_left, old_right = self.get_xlim()
+            if left is None:
+                left = old_left
+            if right is None:
+                right = old_right
 
         if self.get_xscale() == 'log':
             if left <= 0:
@@ -3240,7 +3277,7 @@ class _AxesBase(martist.Artist):
         left, right = self.xaxis.get_major_locator().nonsingular(left, right)
         left, right = self.xaxis.limit_range_for_scale(left, right)
 
-        self.viewLim.intervalx = (left, right)
+        self._viewLim.intervalx = (left, right)
         if auto is not None:
             self._autoscaleXon = bool(auto)
 
@@ -3297,8 +3334,7 @@ class _AxesBase(martist.Artist):
             ax.xaxis._set_scale(value, **kwargs)
             ax._update_transScale()
             ax.stale = True
-
-        self.autoscale_view(scaley=False)
+        self._request_autoscale_view(scaley=False)
 
     def get_xticks(self, minor=False):
         """Return the x ticks as a list of locations"""
@@ -3592,12 +3628,14 @@ class _AxesBase(martist.Artist):
         bottom = self._validate_converted_limits(bottom, self.convert_yunits)
         top = self._validate_converted_limits(top, self.convert_yunits)
 
-        old_bottom, old_top = self.get_ylim()
-
-        if bottom is None:
-            bottom = old_bottom
-        if top is None:
-            top = old_top
+        if bottom is None or top is None:
+            # Axes init calls set_ylim(0, 1) before get_ylim() can be called,
+            # so only grab the limits if we really need them.
+            old_bottom, old_top = self.get_ylim()
+            if bottom is None:
+                bottom = old_bottom
+            if top is None:
+                top = old_top
 
         if self.get_yscale() == 'log':
             if bottom <= 0:
@@ -3620,7 +3658,7 @@ class _AxesBase(martist.Artist):
         bottom, top = self.yaxis.get_major_locator().nonsingular(bottom, top)
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
 
-        self.viewLim.intervaly = (bottom, top)
+        self._viewLim.intervaly = (bottom, top)
         if auto is not None:
             self._autoscaleYon = bool(auto)
 
@@ -3677,7 +3715,7 @@ class _AxesBase(martist.Artist):
             ax.yaxis._set_scale(value, **kwargs)
             ax._update_transScale()
             ax.stale = True
-        self.autoscale_view(scalex=False)
+        self._request_autoscale_view(scalex=False)
 
     def get_yticks(self, minor=False):
         """Return the y ticks as a list of locations"""

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -365,6 +365,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
                self._picker is not True  # the bool, not just nonzero or 1
             else self._pickradius)
 
+        if self.axes and self.get_offset_position() == "data":
+            self.axes._unstale_viewLim()
+
         transform, transOffset, offsets, paths = self._prepare_points()
 
         ind = _path.point_in_path_collection(

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -320,6 +320,7 @@ class Table(Artist):
         self._bbox = bbox
 
         # use axes coords
+        ax._unstale_viewLim()
         self.set_transform(ax.transAxes)
 
         self._texts = []

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -32,6 +32,7 @@ def test_bbox_inches_tight():
         yoff = yoff + data[row]
         cellText.append([''])
     plt.xticks([])
+    plt.xlim(0, 5)
     plt.legend([''] * 5, loc=(1.2, 0.2))
     # Add a table at the bottom of the axes
     cellText.reverse()

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -363,6 +363,9 @@ def test_multi_color_hatch():
         rect.set_edgecolor('C{}'.format(i))
         rect.set_hatch('/')
 
+    ax.autoscale_view()
+    ax.autoscale(False)
+
     for i in range(5):
         with mstyle.context({'hatch.color': 'C{}'.format(i)}):
             r = Rectangle((i - .8 / 2, 5), .8, 1, hatch='//', fc='none')

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -54,6 +54,8 @@ def test_noise():
     fig, ax = plt.subplots()
     p1 = ax.plot(x, solid_joinstyle='round', linewidth=2.0)
 
+    # Ensure that the path's transform takes the new axes limits into account.
+    fig.canvas.draw()
     path = p1[0].get_path()
     transform = p1[0].get_transform()
     path = transform.transform_path(path)
@@ -195,6 +197,8 @@ def test_sine_plus_noise():
     fig, ax = plt.subplots()
     p1 = ax.plot(x, solid_joinstyle='round', linewidth=2.0)
 
+    # Ensure that the path's transform takes the new axes limits into account.
+    fig.canvas.draw()
     path = p1[0].get_path()
     transform = p1[0].get_transform()
     path = transform.transform_path(path)
@@ -232,6 +236,8 @@ def test_fft_peaks():
     t = np.arange(65536)
     p1 = ax.plot(abs(np.fft.fft(np.sin(2*np.pi*.01*t)*np.blackman(len(t)))))
 
+    # Ensure that the path's transform takes the new axes limits into account.
+    fig.canvas.draw()
     path = p1[0].get_path()
     transform = p1[0].get_transform()
     path = transform.transform_path(path)


### PR DESCRIPTION
Closes the first half of #7413 (you may want to read that first).  Closes #12542.

This avoids quadratic complexity when accumulating sticky edges.

Mostly, this just replaces autoscale_view() calls with setting a flag
requesting that autoscale_view() be called the next time viewLim is
accessed.  Note that we cannot just do this in draw as this would break
common idioms like
```
ax.plot(...)
ax.set_xlim(0, None)  # keep top limit to what plot() set
```

The main nontrivial changes are
- Removal of sticky_edges from hexbin(): Previously, hexbin() actually
  did *not* respect the sticky_egdes settings for some reason (this can
  be checked visually); but with this patch it would respect them --
  breaking the baseline images.  So just don't set sticky_edges instead.
- Making LinearLocator.numticks a property: Previously, some code using
  LinearLocator would only work after the locator has been used once,
  so that tick_values properly set numticks to not-None; but with this
  patch, tick_values is no longer called early enough; making numticks
  a property fixes that.  Note that LinearLocator is likely extremely
  rarely used anyways...
- In test_bbox_inches_tight (which uses the old "round_numbers"
  autolimits mode), the autolimits change depending on whether
  autoscaling happens before the call to `xticks([])` (old behavior) or
  after (because there's no notion of "round numbers" anymore.  Here we
  can just force these limits.
- test_multi_color_hatch relied on ax.bar() triggering an autoscale but
  ax.add_patch *not* doing so.  Just disable autoscaling then.

This patch also prepares towards fixing collections autoscaling problems
when switching from linear to log scales (as that also needs to be
deferred to as late as possible, once the scale is actually known).
(i.e., work towards the second half of #7413, not that I have a complete
plan yet.)

-----

On the example in #12542, this version is ~35% faster than on 1.5.3 (which is the last version before quadratic behavior was introduced).  Obviously a lot of other things changed since then, though.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
