### PR TITLE
Add a make-parameter-keyword-only-with-deprecation decorator.

### DIFF
--- a/doc/api/next_api_changes/2019-03-07-AL.rst
+++ b/doc/api/next_api_changes/2019-03-07-AL.rst
@@ -1,0 +1,9 @@
+API changes
+```````````
+
+Passing the ``block`` argument of ``plt.show`` positionally is deprecated; it
+should be passed by keyword.
+
+When using the nbagg backend, ``plt.show`` used to silently accept and ignore
+all combinations of positional and keyword arguments.  This behavior is
+deprecated.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3216,8 +3216,10 @@ class _Backend(object):
                 cls.trigger_manager_draw(manager)
 
     @classmethod
+    @cbook._make_keyword_only("3.1", "block")
     def show(cls, block=None):
-        """Show all figures.
+        """
+        Show all figures.
 
         `show` blocks by calling `mainloop` if *block* is ``True``, or if it
         is ``None`` and we are neither in IPython's ``%pylab`` mode, nor in

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -17,7 +17,7 @@ except ImportError:
     # Jupyter/IPython 3.x or earlier
     from IPython.kernel.comm import Comm
 
-from matplotlib import is_interactive
+from matplotlib import cbook, is_interactive
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, NavigationToolbar2)
@@ -241,7 +241,13 @@ class _BackendNbAgg(_Backend):
         manager.show()
 
     @staticmethod
-    def show(*args, **kwargs):
+    def show(*args, block=None, **kwargs):
+        if args or kwargs:
+            cbook.warn_deprecated(
+                "3.1", message="Passing arguments to show(), other than "
+                "passing 'block' by keyword, is deprecated %(since)s, and "
+                "support for it will be removed %(removal)s.")
+
         ## TODO: something to do when keyword block==False ?
         from matplotlib._pylab_helpers import Gcf
 

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -173,7 +173,7 @@ def draw_if_interactive():
     """
 
 
-def show(block=None):
+def show(*, block=None):
     """
     For image backends - is not required.
     For GUI backends - show() is usually the last line of a pyplot script and

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -32,7 +32,8 @@ import numpy as np
 
 import matplotlib
 from .deprecation import (
-    deprecated, warn_deprecated, _rename_parameter, _delete_parameter,
+    deprecated, warn_deprecated,
+    _rename_parameter, _delete_parameter, _make_keyword_only,
     _suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning, mplDeprecation)
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -13,7 +13,8 @@ import pytest
 
 import matplotlib.cbook as cbook
 import matplotlib.colors as mcolors
-from matplotlib.cbook import delete_masked_points as dmp
+from matplotlib.cbook import (
+    MatplotlibDeprecationWarning, delete_masked_points as dmp)
 
 
 def test_is_hashable():
@@ -545,3 +546,17 @@ def test_safe_first_element_pandas_series(pd):
     s = pd.Series(range(5), index=range(10, 15))
     actual = cbook.safe_first_element(s)
     assert actual == 0
+
+
+def test_make_keyword_only(recwarn):
+    @cbook._make_keyword_only("3.0", "arg")
+    def func(pre, arg, post=None):
+        pass
+
+    func(1, arg=2)
+    assert len(recwarn) == 0
+
+    with pytest.warns(MatplotlibDeprecationWarning):
+        func(1, 2)
+    with pytest.warns(MatplotlibDeprecationWarning):
+        func(1, 2, 3)


### PR DESCRIPTION
(discussed in https://github.com/matplotlib/matplotlib/pull/13128#issuecomment-453868064)

... and use it to make the `block` argument of plt.show() keyword only
(with deprecation), with the idea of making the future signature
`plt.show(figures=None, *, block=True)` (discussed in https://github.com/matplotlib/matplotlib/pull/13590).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
