### PR TITLE
Deprecate cbook.is_hashable.

### DIFF
--- a/doc/api/next_api_changes/2019-03-06-AL.rst
+++ b/doc/api/next_api_changes/2019-03-06-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``cbook.is_hashable`` is deprecated (use
+``isinstance(..., collections.abc.Hashable)`` instead).

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -350,6 +350,7 @@ def iterable(obj):
     return True
 
 
+@deprecated("3.1", alternative="isinstance(..., collections.abc.Hashable)")
 def is_hashable(obj):
     """Returns true if *obj* can be hashed"""
     try:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -754,18 +754,15 @@ class Legend(Artist):
         method-resolution-order. If no matching key is found, it
         returns ``None``.
         """
-        if is_hashable(orig_handle):
-            try:
-                return legend_handler_map[orig_handle]
-            except KeyError:
-                pass
-
+        try:
+            return legend_handler_map[orig_handle]
+        except (TypeError, KeyError):  # TypeError if unhashable.
+            pass
         for handle_type in type(orig_handle).mro():
             try:
                 return legend_handler_map[handle_type]
             except KeyError:
                 pass
-
         return None
 
     def _init_legend_box(self, handles, labels, markerfirst=True):


### PR DESCRIPTION
It's used in a single place and doesn't buy much.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
