### PR TITLE
Warn on attempts at semi-transparent outputs in ps backend.

### DIFF
--- a/doc/api/next_api_changes/2019-03-05-AL.rst
+++ b/doc/api/next_api_changes/2019-03-05-AL.rst
@@ -1,0 +1,3 @@
+Deprecations
+````````````
+``GraphicsContextPS.shouldstroke`` is deprecated.


### PR DESCRIPTION
The postscript format does not support transparency at all; the
postscript backend currently silently ignores the alpha channel
(except if alpha = 0 in which case the artist is not drawn).

Log a warning when this happens so that the user knows what happened.

Small refactor of transparency handling in the backend.

See https://stackoverflow.com/questions/29321707/can-transparency-be-used-with-postscript-eps.
"Closes" https://github.com/matplotlib/matplotlib/issues/13604 by documenting the limitation.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
