### PR TITLE
Update centered ticklabels example

### DIFF
--- a/examples/ticks_and_spines/centered_ticklabels.py
+++ b/examples/ticks_and_spines/centered_ticklabels.py
@@ -35,6 +35,7 @@ fig, ax = plt.subplots()
 ax.plot(date, r.adj_close)
 
 ax.xaxis.set_major_locator(dates.MonthLocator())
+# 16 is a slight approximation since months differ in number of days.
 ax.xaxis.set_minor_locator(dates.MonthLocator(bymonthday=16))
 
 ax.xaxis.set_major_formatter(ticker.NullFormatter())

--- a/examples/ticks_and_spines/centered_ticklabels.py
+++ b/examples/ticks_and_spines/centered_ticklabels.py
@@ -1,19 +1,20 @@
 """
-===================
-Centered Ticklabels
-===================
+==============================
+Centering labels between ticks
+==============================
 
-sometimes it is nice to have ticklabels centered.  Matplotlib currently
-associates a label with a tick, and the label can be aligned
-'center', 'left', or 'right' using the horizontal alignment property::
+Ticklabels are aligned relative to their associated tick. The alignment
+'center', 'left', or 'right' can be controlled using the horizontal alignment
+property::
 
     for label in ax.xaxis.get_xticklabels():
         label.set_horizontalalignment('right')
 
-but this doesn't help center the label between ticks.  One solution
-is to "fake it".  Use the minor ticks to place a tick centered
-between the major ticks.  Here is an example that labels the months,
-centered between the ticks
+However there is no direct way to center the labels between ticks. To fake
+this behavior, one can place a label on the minor ticks in between the major
+ticks, and hide the major tick labels and minor ticks.
+
+Here is an example that labels the months, centered between the ticks.
 """
 
 import numpy as np
@@ -34,7 +35,7 @@ fig, ax = plt.subplots()
 ax.plot(date, r.adj_close)
 
 ax.xaxis.set_major_locator(dates.MonthLocator())
-ax.xaxis.set_minor_locator(dates.MonthLocator(bymonthday=15))
+ax.xaxis.set_minor_locator(dates.MonthLocator(bymonthday=16))
 
 ax.xaxis.set_major_formatter(ticker.NullFormatter())
 ax.xaxis.set_minor_formatter(dates.DateFormatter('%b'))


### PR DESCRIPTION
## PR Summary

- Actually centered the minor ticks (see comment).
- Rewrote the description.

[Old example](https://matplotlib.org/devdocs/gallery/ticks_and_spines/centered_ticklabels.html#sphx-glr-gallery-ticks-and-spines-centered-ticklabels-py)

[New example](https://19139-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/ticks_and_spines/centered_ticklabels.html#sphx-glr-gallery-ticks-and-spines-centered-ticklabels-py)