### PR TITLE
Fix text position in Fancytextbox demo

### DIFF
--- a/examples/text_labels_and_annotations/fancytextbox_demo.py
+++ b/examples/text_labels_and_annotations/fancytextbox_demo.py
@@ -6,7 +6,7 @@ Fancytextbox Demo
 """
 import matplotlib.pyplot as plt
 
-plt.text(0.6, 0.5, "test", size=50, rotation=30.,
+plt.text(0.6, 0.7, "eggs", size=50, rotation=30.,
          ha="center", va="center",
          bbox=dict(boxstyle="round",
                    ec=(1., 0.5, 0.5),
@@ -14,7 +14,7 @@ plt.text(0.6, 0.5, "test", size=50, rotation=30.,
                    )
          )
 
-plt.text(0.5, 0.4, "test", size=50, rotation=-30.,
+plt.text(0.55, 0.6, "spam", size=50, rotation=-25.,
          ha="right", va="top",
          bbox=dict(boxstyle="square",
                    ec=(1., 0.5, 0.5),


### PR DESCRIPTION
## PR Summary

Not sure how reasonable this demo is, but at least let's position the boxes so that they are within the axes (looks better) - and give them a better text :smile:.

Original layout was this: https://matplotlib.org/gallery/text_labels_and_annotations/fancytextbox_demo.html