### PR TITLE
Fix polar get window extent

### DIFF
--- a/examples/lines_bars_and_markers/markevery_demo.py
+++ b/examples/lines_bars_and_markers/markevery_demo.py
@@ -36,39 +36,39 @@ cases = [None,
 # define the figure size and grid layout properties
 figsize = (10, 8)
 cols = 3
-gs = gridspec.GridSpec(len(cases) // cols + 1, cols)
-gs.update(hspace=0.4)
+rows = len(cases) // cols + 1
 # define the data for cartesian plots
 delta = 0.11
 x = np.linspace(0, 10 - 2 * delta, 200) + delta
 y = np.sin(x) + 1.0 + delta
 
+
+def trim_axs(axs, N):
+    """little helper to massage the axs list to have correct length..."""
+    axs = axs.flat
+    for ax in axs[N:]:
+        ax.remove()
+    return axs[:N]
+
 ###############################################################################
 # Plot each markevery case for linear x and y scales
 
-fig1 = plt.figure(num=1, figsize=figsize)
-ax = []
-for i, case in enumerate(cases):
-    row = (i // cols)
-    col = i % cols
-    ax.append(fig1.add_subplot(gs[row, col]))
-    ax[-1].set_title('markevery=%s' % str(case))
-    ax[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
+fig1, axs = plt.subplots(rows, cols, figsize=figsize, constrained_layout=True)
+axs = trim_axs(axs, len(cases))
+for ax, case in zip(axs, cases):
+    ax.set_title('markevery=%s' % str(case))
+    ax.plot(x, y, 'o', ls='-', ms=4, markevery=case)
 
 ###############################################################################
 # Plot each markevery case for log x and y scales
 
-fig2 = plt.figure(num=2, figsize=figsize)
-axlog = []
-for i, case in enumerate(cases):
-    row = (i // cols)
-    col = i % cols
-    axlog.append(fig2.add_subplot(gs[row, col]))
-    axlog[-1].set_title('markevery=%s' % str(case))
-    axlog[-1].set_xscale('log')
-    axlog[-1].set_yscale('log')
-    axlog[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
-fig2.tight_layout()
+fig2, axs = plt.subplots(rows, cols, figsize=figsize, constrained_layout=True)
+axs = trim_axs(axs, len(cases))
+for ax, case in zip(axs, cases):
+    ax.set_title('markevery=%s' % str(case))
+    ax.set_xscale('log')
+    ax.set_yscale('log')
+    ax.plot(x, y, 'o', ls='-', ms=4, markevery=case)
 
 ###############################################################################
 # Plot each markevery case for linear x and y scales but zoomed in
@@ -76,17 +76,13 @@ fig2.tight_layout()
 # it is always interpreted with respect to the first data point which might be
 # different to the first visible data point.
 
-fig3 = plt.figure(num=3, figsize=figsize)
-axzoom = []
-for i, case in enumerate(cases):
-    row = (i // cols)
-    col = i % cols
-    axzoom.append(fig3.add_subplot(gs[row, col]))
-    axzoom[-1].set_title('markevery=%s' % str(case))
-    axzoom[-1].plot(x, y, 'o', ls='-', ms=4, markevery=case)
-    axzoom[-1].set_xlim((6, 6.7))
-    axzoom[-1].set_ylim((1.1, 1.7))
-fig3.tight_layout()
+fig3, axs = plt.subplots(rows, cols, figsize=figsize, constrained_layout=True)
+axs = trim_axs(axs, len(cases))
+for ax, case in zip(axs, cases):
+    ax.set_title('markevery=%s' % str(case))
+    ax.plot(x, y, 'o', ls='-', ms=4, markevery=case)
+    ax.set_xlim((6, 6.7))
+    ax.set_ylim((1.1, 1.7))
 
 # define data for polar plots
 r = np.linspace(0, 3.0, 200)
@@ -95,14 +91,11 @@ theta = 2 * np.pi * r
 ###############################################################################
 # Plot each markevery case for polar plots
 
-fig4 = plt.figure(num=4, figsize=figsize)
-axpolar = []
-for i, case in enumerate(cases):
-    row = (i // cols)
-    col = i % cols
-    axpolar.append(fig4.add_subplot(gs[row, col], projection='polar'))
-    axpolar[-1].set_title('markevery=%s' % str(case))
-    axpolar[-1].plot(theta, r, 'o', ls='-', ms=4, markevery=case)
-fig4.tight_layout()
+fig4, axs = plt.subplots(rows, cols, figsize=figsize,
+        subplot_kw={'projection': 'polar'}, constrained_layout=True)
+axs = trim_axs(axs, len(cases))
+for ax, case in zip(axs, cases):
+    ax.set_title('markevery=%s' % str(case))
+    ax.plot(theta, r, 'o', ls='-', ms=4, markevery=case)
 
 plt.show()

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -159,6 +159,8 @@ class Spine(mpatches.Patch):
         # correct:
         self._adjust_location()
         bb = super().get_window_extent(renderer=renderer)
+        if self.axis is None:
+            return bb
         bboxes = [bb]
         tickstocheck = [self.axis.majorTicks[0]]
         if len(self.axis.minorTicks) > 1:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6271,6 +6271,14 @@ def test_minor_accountedfor():
                            atol=1e-2)
 
 
+def test_get_tightbbox_polar():
+    fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    fig.canvas.draw()
+    bb = ax.get_tightbbox(fig.canvas.get_renderer())
+    assert_allclose(bb.extents,
+        [107.7778,  29.2778, 539.7847, 450.7222], rtol=1e-03)
+
+
 @check_figures_equal(extensions=["png"])
 def test_axis_bool_arguments(fig_test, fig_ref):
     # Test if False and "off" give the same


### PR DESCRIPTION
## PR Summary

This PR does 2 things.  First, cleans up `markerevery_demo` to use modern semantics; Second, catches an error in `spines.get_window_extent` that can happen if the spine has no axis.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->