### PR TITLE
Remove `asfileobj=False` from a bunch of examples loading sample_data.

### DIFF
--- a/examples/frontpage/3D.py
+++ b/examples/frontpage/3D.py
@@ -4,7 +4,6 @@ Frontpage 3D example
 ====================
 
 This example reproduces the frontpage 3D example.
-
 """
 
 from matplotlib import cbook
@@ -13,8 +12,8 @@ from matplotlib.colors import LightSource
 import matplotlib.pyplot as plt
 import numpy as np
 
-filename = cbook.get_sample_data('jacksboro_fault_dem.npz', asfileobj=False)
-with np.load(filename) as dem:
+with cbook.get_sample_data('jacksboro_fault_dem.npz') as file, \
+     np.load(file) as dem:
     z = dem['elevation']
     nrows, ncols = z.shape
     x = np.linspace(dem['xmin'], dem['xmax'], ncols)

--- a/examples/images_contours_and_fields/image_demo.py
+++ b/examples/images_contours_and_fields/image_demo.py
@@ -51,7 +51,7 @@ ax.axis('off')  # clear x-axis and y-axis
 
 w, h = 512, 512
 
-with cbook.get_sample_data('ct.raw.gz', asfileobj=True) as datafile:
+with cbook.get_sample_data('ct.raw.gz') as datafile:
     s = datafile.read()
 A = np.frombuffer(s, np.uint16).astype(float).reshape((w, h))
 A /= A.max()

--- a/examples/images_contours_and_fields/shading_example.py
+++ b/examples/images_contours_and_fields/shading_example.py
@@ -1,18 +1,19 @@
 """
 ===============
-Shading Example
+Shading example
 ===============
 
-Example showing how to make shaded relief plots
-like Mathematica
-(http://reference.wolfram.com/mathematica/ref/ReliefPlot.html)
-or Generic Mapping Tools
-(https://gmt.soest.hawaii.edu/)
+Example showing how to make shaded relief plots like Mathematica_ or
+`Generic Mapping Tools`_.
+
+.. _Mathematica: http://reference.wolfram.com/mathematica/ref/ReliefPlot.html
+.. _Generic Mapping Tools: https://gmt.soest.hawaii.edu/
 """
+
 import numpy as np
+from matplotlib import cbook
 import matplotlib.pyplot as plt
 from matplotlib.colors import LightSource
-from matplotlib.cbook import get_sample_data
 
 
 def main():
@@ -20,8 +21,8 @@ def main():
     x, y = np.mgrid[-5:5:0.05, -5:5:0.05]
     z = 5 * (np.sqrt(x**2 + y**2) + np.sin(x**2 + y**2))
 
-    filename = get_sample_data('jacksboro_fault_dem.npz', asfileobj=False)
-    with np.load(filename) as dem:
+    with cbook.get_sample_data('jacksboro_fault_dem.npz') as file, \
+         np.load(file) as dem:
         elev = dem['elevation']
 
     fig = compare(z, plt.cm.copper)

--- a/examples/images_contours_and_fields/watermark_image.py
+++ b/examples/images_contours_and_fields/watermark_image.py
@@ -5,25 +5,21 @@ Watermark image
 
 Using a PNG file as a watermark.
 """
+
 import numpy as np
 import matplotlib.cbook as cbook
 import matplotlib.image as image
 import matplotlib.pyplot as plt
 
-# Fixing random state for reproducibility
-np.random.seed(19680801)
 
-
-datafile = cbook.get_sample_data('logo2.png', asfileobj=False)
-print('loading %s' % datafile)
-im = image.imread(datafile)
-im[:, :, -1] = 0.5  # set the alpha channel
+with cbook.get_sample_data('logo2.png') as file:
+    im = image.imread(file)
 
 fig, ax = plt.subplots()
 
-ax.plot(np.random.rand(20), '-o', ms=20, lw=2, alpha=0.7, mfc='orange')
+ax.plot(np.sin(10 * np.linspace(0, 1)), '-o', ms=20, alpha=0.7, mfc='orange')
 ax.grid()
-fig.figimage(im, 10, 10, zorder=3)
+fig.figimage(im, 10, 10, zorder=3, alpha=.5)
 
 plt.show()
 

--- a/examples/mplot3d/custom_shaded_3d_surface.py
+++ b/examples/mplot3d/custom_shaded_3d_surface.py
@@ -13,8 +13,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Load and format data
-filename = cbook.get_sample_data('jacksboro_fault_dem.npz', asfileobj=False)
-with np.load(filename) as dem:
+with cbook.get_sample_data('jacksboro_fault_dem.npz') as file, \
+     np.load(file) as dem:
     z = dem['elevation']
     nrows, ncols = z.shape
     x = np.linspace(dem['xmin'], dem['xmax'], ncols)

--- a/examples/text_labels_and_annotations/demo_annotation_box.py
+++ b/examples/text_labels_and_annotations/demo_annotation_box.py
@@ -77,8 +77,8 @@ ab = AnnotationBbox(im, xy,
 ax.add_artist(ab)
 
 # Annotate the 2nd position with another image (a Grace Hopper portrait)
-fn = get_sample_data("grace_hopper.png", asfileobj=False)
-arr_img = plt.imread(fn, format='png')
+with get_sample_data("grace_hopper.png") as file:
+    arr_img = plt.imread(file, format='png')
 
 imagebox = OffsetImage(arr_img, zoom=0.2)
 imagebox.image.axes = ax

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -391,15 +391,14 @@ def test_colors_no_float():
                   extensions=['png'])
 def test_light_source_topo_surface():
     """Shades a DEM using different v.e.'s and blend modes."""
-    fname = cbook.get_sample_data('jacksboro_fault_dem.npz', asfileobj=False)
-    dem = np.load(fname)
-    elev = dem['elevation']
-    # Get the true cellsize in meters for accurate vertical exaggeration
-    #   Convert from decimal degrees to meters
-    dx, dy = dem['dx'], dem['dy']
-    dx = 111320.0 * dx * np.cos(dem['ymin'])
-    dy = 111320.0 * dy
-    dem.close()
+    with cbook.get_sample_data('jacksboro_fault_dem.npz') as file, \
+         np.load(file) as dem:
+        elev = dem['elevation']
+        dx, dy = dem['dx'], dem['dy']
+        # Get the true cellsize in meters for accurate vertical exaggeration
+        # Convert from decimal degrees to meters
+        dx = 111320.0 * dx * np.cos(dem['ymin'])
+        dy = 111320.0 * dy
 
     ls = mcolors.LightSource(315, 45)
     cmap = cm.gist_earth


### PR DESCRIPTION
Using a file object works just fine.

There are some more examples that use genfromtxt, but their conversion
    effectively needs numpy>=1.14 per
    https://github.com/numpy/numpy/blob/master/doc/release/1.14.0-notes.rst#encoding-argument-for-text-io-functions

There are some more examples that load bivariate_normal.npy, but they
have a bunch of duplicated code that could use some more refactor.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
