### PR TITLE
Backport PR #13603 on branch v3.1.x

### DIFF
--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -338,3 +338,5 @@ def test_collapsed():
         p2 = ax.get_position()
         assert p1.width == p2.width
         assert len(w) == 1
+    # test that passing a rect doesn't crash...
+    plt.tight_layout(rect=[0, 0, 0.8, 0.8])

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -361,7 +361,8 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
                                      ax_bbox_list=ax_bbox_list,
                                      pad=pad, h_pad=h_pad, w_pad=w_pad)
 
-    if rect is not None:
+    # kwargs can be none if tight_layout fails...
+    if rect is not None and kwargs is not None:
         # if rect is given, the whole subplots area (including
         # labels) will fit into the rect instead of the
         # figure. Note that the rect argument of


### PR DESCRIPTION
FIX: continue to bail tight layout if rect supplied