### PR TITLE
plot_directive: Avoid warning if plot_formats doesn't contain 'png'

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -419,11 +419,13 @@ TEMPLATE = """
 {{ only_texinfo }}
 
    {% for img in images %}
+   {% if 'png' in img.formats -%}
    .. image:: {{ build_dir }}/{{ img.basename }}.png
       {% for option in options -%}
       {{ option }}
       {% endfor %}
 
+   {% endif -%}
    {% endfor %}
 
 """


### PR DESCRIPTION
## PR Summary

When using `matplotlib.sphinxext.plot_directive` in Sphinx and for example using this setting:

    plot_formats = ['svg', 'pdf']

... or anything without `'png'` for that matter, I get a warning for each plot:

    WARNING: image file not readable: _build/plot_directive/index-1.png

This is caused by the `texinfo` section in the template, which seems to expect a `.png` file no matter what.

This PR includes the PNG image only if PNG is among the chosen formats.

This is the same fix as #3530 did to fix issue #2800 for the PDF case.

## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way