### PR TITLE
Fix empty FancyArrow crash

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1269,7 +1269,7 @@ class FancyArrow(Polygon):
         else:
             length = distance + head_length
         if not length:
-            verts = []  # display nothing if empty
+            verts = np.empty([0, 2])  # display nothing if empty
         else:
             # start by drawing horizontal arrow, point at (0,0)
             hw, hl, hs, lw = head_width, head_length, overhang, width

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -379,6 +379,12 @@ def test_arrow_simple():
                  head_length=theta / 10)
 
 
+def test_arrow_empty():
+    _, ax = plt.subplots()
+    # Create an empty FancyArrow
+    ax.arrow(0, 0, 0, 0, head_length=0)
+
+
 def test_annotate_default_arrow():
     # Check that we can make an annotation arrow with only default properties.
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary
If `dx`, `dy`, and `head_length` are 0, then creating a FancyArrow will crash(`ValueError`).
This is due to setting `verts = []`.
This gets passed into Path which expects verts to be a `Nx2` numpy array.

The fix is to set verts to be an empty `0x2` numpy array.

Also added a simple test for this.

This PR fixes #11217 
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way