### PR TITLE
Fix passing iterator as frames to FuncAnimation

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -186,6 +186,13 @@ def test_no_length_frames():
      .save('unused.null', writer=NullMovieWriter()))
 
 
+def test_generator_expression_repeat():
+    """A generator expression cannot be used for frames if repeat=True"""
+    with pytest.raises(ValueError) as e:
+        make_animation(frames=(i for i in range(5)), repeat=True)
+    assert 'frames must be iterable multiple times' in str(e)
+
+
 def test_movie_writer_registry():
     ffmpeg_path = mpl.rcParams['animation.ffmpeg_path']
     # Not sure about the first state as there could be some writer


### PR DESCRIPTION
## PR Summary

Fixes #13676.

The problem  occurs in `FuncAnimation` when using `repeat=True` (the default) and passing an iterator as `frames`. Internally, we use a `iter(frames)` for each cycle, however, since`i = iter(iterable); iter(i) is i`, the iterator values are used up after the first animation cycle.

**Updated:**

Fix: Ensure to use a new iterator for each cycle. This can be achieved in two ways:
- either `iter(frames)` does already yield a new iterator (`iter(frames) is not frames`)
- or we copy frames.

If neither of both is possible error out with a reasonable error message.