### PR TITLE
Update seaborn style

### DIFF
--- a/doc/api/next_api_changes/2019-03-17-TH-seaborn-style.rst
+++ b/doc/api/next_api_changes/2019-03-17-TH-seaborn-style.rst
@@ -1,0 +1,8 @@
+API changes
+```````````
+
+The the style changes introduced in seaborn 0.9 have been included in the
+Matplotlib seaborn styles.
+Most notably, the color palettes have been extended from 6 to 10 colors.
+The former 6-color palettes are still available via a '6' suffix in the
+style name, e.g. ``plt.style.use('seaborn-bright6')``.

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-bright.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-bright.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn bright palette
-axes.prop_cycle: cycler('color', ['003FFF', '03ED3A', 'E8000B', '8A2BE2', 'FFC400', '00D7FF'])
-patch.facecolor: 003FFF
+# seaborn bright palette
+axes.prop_cycle: cycler('color', ['023EFF', 'FF7C00', '1AC938', 'E8000B', '8B2BE2', '9F4800', 'F14CC1', 'A3A3A3', 'FFC400', '00D7FF'])
+patch.facecolor: 023EFF

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-bright6.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-bright6.mplstyle
@@ -1,0 +1,3 @@
+# seaborn bright6 palette
+axes.prop_cycle: cycler('color', ['023EFF', '1AC938', 'E8000B', '8B2BE2', 'FFC400', '00D7FF'])
+patch.facecolor: 023EFF

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-colorblind.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-colorblind.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn colorblind palette
-axes.prop_cycle: cycler('color', ['0072B2', '009E73', 'D55E00', 'CC79A7', 'F0E442', '56B4E9'])
-patch.facecolor: 0072B2
+# seaborn colorblind palette
+axes.prop_cycle: cycler('color', ['0173B2', 'DE8F05', '029E73', 'D55E00', 'CC78BC', 'CA9161', 'FBAFE4', '949494', 'ECE133', '56B4E9'])
+patch.facecolor: 0173B2

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-colorblind6.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-colorblind6.mplstyle
@@ -1,0 +1,3 @@
+# seaborn colorblind6 palette
+axes.prop_cycle: cycler('color', ['0173B2', '029E73', 'D55E00', 'CC78BC', 'ECE133', '56B4E9'])
+patch.facecolor: 0173B2

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-dark-palette.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-dark-palette.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn dark palette
-axes.prop_cycle: cycler('color', ['001C7F', '017517', '8C0900', '7600A1', 'B8860B', '006374'])
+# seaborn dark palette
+axes.prop_cycle: cycler('color', ['001C7F', 'B1400D', '12711C', '8C0800', '591E71', '592F0D', 'A23582', '3C3C3C', 'B8850A', '006374'])
 patch.facecolor: 001C7F

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-dark.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-dark.mplstyle
@@ -1,30 +1,41 @@
-# Seaborn common parameters
-# .15 = dark_gray
-# .8 = light_gray
+# seaborn dark style
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
 figure.facecolor: white
-text.color: .15
 axes.labelcolor: .15
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
+
 xtick.direction: out
 ytick.direction: out
 xtick.color: .15
 ytick.color: .15
-axes.axisbelow: True
-image.cmap: Greys
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-grid.linestyle: -
-lines.solid_capstyle: round
 
-# Seaborn dark parameters
+axes.axisbelow: True
+grid.linestyle: -
+
+text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
+
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
+
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# dark parameters
 axes.grid: False
 axes.facecolor: EAEAF2
 axes.edgecolor: white
-axes.linewidth: 0
 grid.color: white
-xtick.major.size: 0
-ytick.major.size: 0
-xtick.minor.size: 0
-ytick.minor.size: 0
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: False
+ytick.left: False

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-dark6-palette.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-dark6-palette.mplstyle
@@ -1,0 +1,3 @@
+# seaborn dark6 palette
+axes.prop_cycle: cycler('color', ['001C7F', '12711C', '8C0800', '591E71', 'B8850A', '006374'])
+patch.facecolor: 001C7F

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-darkgrid.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-darkgrid.mplstyle
@@ -1,30 +1,41 @@
-# Seaborn common parameters
-# .15 = dark_gray
-# .8 = light_gray
+# seaborn darkgrid style
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
 figure.facecolor: white
-text.color: .15
 axes.labelcolor: .15
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
+
 xtick.direction: out
 ytick.direction: out
 xtick.color: .15
 ytick.color: .15
-axes.axisbelow: True
-image.cmap: Greys
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-grid.linestyle: -
-lines.solid_capstyle: round
 
-# Seaborn darkgrid parameters
+axes.axisbelow: True
+grid.linestyle: -
+
+text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
+
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
+
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# darkgrid parameters
 axes.grid: True
 axes.facecolor: EAEAF2
 axes.edgecolor: white
-axes.linewidth: 0
 grid.color: white
-xtick.major.size: 0
-ytick.major.size: 0
-xtick.minor.size: 0
-ytick.minor.size: 0
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: False
+ytick.left: False

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-deep.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-deep.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn deep palette
-axes.prop_cycle: cycler('color', ['4C72B0', '55A868', 'C44E52', '8172B2', 'CCB974', '64B5CD'])
+# seaborn deep palette
+axes.prop_cycle: cycler('color', ['4C72B0', 'DD8452', '55A868', 'C44E52', '8172B3', '937860', 'DA8BC3', '8C8C8C', 'CCB974', '64B5CD'])
 patch.facecolor: 4C72B0

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-deep6.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-deep6.mplstyle
@@ -1,0 +1,3 @@
+# seaborn deep6 palette
+axes.prop_cycle: cycler('color', ['4C72B0', '55A868', 'C44E52', '8172B3', 'CCB974', '64B5CD'])
+patch.facecolor: 4C72B0

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-muted.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-muted.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn muted palette
-axes.prop_cycle: cycler('color', ['4878CF', '6ACC65', 'D65F5F', 'B47CC7', 'C4AD66', '77BEDB'])
-patch.facecolor: 4878CF
+# seaborn muted palette
+axes.prop_cycle: cycler('color', ['4878D0', 'EE854A', '6ACC64', 'D65F5F', '956CB4', '8C613C', 'DC7EC0', '797979', 'D5BB67', '82C6E2'])
+patch.facecolor: 4878D0

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-muted6.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-muted6.mplstyle
@@ -1,0 +1,3 @@
+# seaborn muted6 palette
+axes.prop_cycle: cycler('color', ['4878D0', '6ACC64', 'D65F5F', '956CB4', 'D5BB67', '82C6E2'])
+patch.facecolor: 4878D0

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-notebook.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-notebook.mplstyle
@@ -1,21 +1,24 @@
-# Seaborn notebook context
-figure.figsize: 8.0, 5.5
-axes.labelsize: 11
+# seaborn notebook context
+# see seaborn.rcmod.plotting_context()
+font.size: 12
+axes.labelsize: 12
 axes.titlesize: 12
-xtick.labelsize: 10
-ytick.labelsize: 10
-legend.fontsize: 10
+xtick.labelsize: 11
+ytick.labelsize: 11
+legend.fontsize: 11
 
+axes.linewidth: 1.25
 grid.linewidth: 1
-lines.linewidth: 1.75
-patch.linewidth: .3
-lines.markersize: 7
-lines.markeredgewidth: 0
+lines.linewidth: 1.5
+lines.markersize: 6
+patch.linewidth: 1
 
-xtick.major.width: 1
-ytick.major.width: 1
-xtick.minor.width: .5
-ytick.minor.width: .5
+xtick.major.width: 1.25
+ytick.major.width: 1.25
+xtick.minor.width: 1
+ytick.minor.width: 1
 
-xtick.major.pad: 7
-ytick.major.pad: 7
+xtick.major.size: 6
+ytick.major.size: 6
+xtick.minor.size: 4
+ytick.minor.size: 4

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-paper.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-paper.mplstyle
@@ -1,21 +1,24 @@
-# Seaborn paper context
-figure.figsize: 6.4, 4.4
-axes.labelsize: 8.8
+# seaborn paper context
+# see seaborn.rcmod.plotting_context()
+font.size: 9.6
+axes.labelsize: 9.6
 axes.titlesize: 9.6
-xtick.labelsize: 8
-ytick.labelsize: 8
-legend.fontsize: 8
+xtick.labelsize: 8.8
+ytick.labelsize: 8.8
+legend.fontsize: 8.8
 
+axes.linewidth: 1
 grid.linewidth: 0.8
-lines.linewidth: 1.4
-patch.linewidth: 0.24
-lines.markersize: 5.6
-lines.markeredgewidth: 0
+lines.linewidth: 1.2
+lines.markersize: 4.8
+patch.linewidth: 0.8
 
-xtick.major.width: 0.8
-ytick.major.width: 0.8
-xtick.minor.width: 0.4
-ytick.minor.width: 0.4
+xtick.major.width: 1
+ytick.major.width: 1
+xtick.minor.width: 0.8
+ytick.minor.width: 0.8
 
-xtick.major.pad: 5.6
-ytick.major.pad: 5.6
+xtick.major.size: 4.8
+ytick.major.size: 4.8
+xtick.minor.size: 3.2
+ytick.minor.size: 3.2

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-pastel.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-pastel.mplstyle
@@ -1,3 +1,3 @@
-# Seaborn pastel palette
-axes.prop_cycle: cycler('color', ['92C6FF', '97F0AA', 'FF9F9A', 'D0BBFF', 'FFFEA3', 'B0E0E6'])
-patch.facecolor: 92C6FF
+# seaborn pastel palette
+axes.prop_cycle: cycler('color', ['A1C9F4', 'FFB482', '8DE5A1', 'FF9F9B', 'D0BBFF', 'DEBB9B', 'FAB0E4', 'CFCFCF', 'FFFEA3', 'B9F2F0'])
+patch.facecolor: A1C9F4

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-pastel6.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-pastel6.mplstyle
@@ -1,0 +1,3 @@
+# seaborn pastel6 palette
+axes.prop_cycle: cycler('color', ['A1C9F4', '8DE5A1', 'FF9F9B', 'D0BBFF', 'FFFEA3', 'B9F2F0'])
+patch.facecolor: A1C9F4

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-poster.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-poster.mplstyle
@@ -1,21 +1,24 @@
-# Seaborn poster context
-figure.figsize: 12.8, 8.8
-axes.labelsize: 17.6
-axes.titlesize: 19.2
-xtick.labelsize: 16
-ytick.labelsize: 16
-legend.fontsize: 16
+# seaborn poster context
+# see seaborn.rcmod.plotting_context()
+font.size: 24
+axes.labelsize: 24
+axes.titlesize: 24
+xtick.labelsize: 22
+ytick.labelsize: 22
+legend.fontsize: 22
 
-grid.linewidth: 1.6
-lines.linewidth: 2.8
-patch.linewidth: 0.48
-lines.markersize: 11.2
-lines.markeredgewidth: 0
+axes.linewidth: 2.5
+grid.linewidth: 2
+lines.linewidth: 3
+lines.markersize: 12
+patch.linewidth: 2
 
-xtick.major.width: 1.6
-ytick.major.width: 1.6
-xtick.minor.width: 0.8
-ytick.minor.width: 0.8
+xtick.major.width: 2.5
+ytick.major.width: 2.5
+xtick.minor.width: 2
+ytick.minor.width: 2
 
-xtick.major.pad: 11.2
-ytick.major.pad: 11.2
+xtick.major.size: 12
+ytick.major.size: 12
+xtick.minor.size: 8
+ytick.minor.size: 8

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-talk.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-talk.mplstyle
@@ -1,21 +1,24 @@
-# Seaborn talk context
-figure.figsize: 10.4, 7.15
-axes.labelsize: 14.3
-axes.titlesize: 15.6
-xtick.labelsize: 13
-ytick.labelsize: 13
-legend.fontsize: 13
+# seaborn talk context
+# see seaborn.rcmod.plotting_context()
+font.size: 18
+axes.labelsize: 18
+axes.titlesize: 18
+xtick.labelsize: 16.5
+ytick.labelsize: 16.5
+legend.fontsize: 16.5
 
-grid.linewidth: 1.3
-lines.linewidth: 2.275
-patch.linewidth: 0.39
-lines.markersize: 9.1
-lines.markeredgewidth: 0
+axes.linewidth: 1.875
+grid.linewidth: 1.5
+lines.linewidth: 2.25
+lines.markersize: 9
+patch.linewidth: 1.5
 
-xtick.major.width: 1.3
-ytick.major.width: 1.3
-xtick.minor.width: 0.65
-ytick.minor.width: 0.65
+xtick.major.width: 1.875
+ytick.major.width: 1.875
+xtick.minor.width: 1.5
+ytick.minor.width: 1.5
 
-xtick.major.pad: 9.1
-ytick.major.pad: 9.1
+xtick.major.size: 9
+ytick.major.size: 9
+xtick.minor.size: 6
+ytick.minor.size: 6

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-ticks.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-ticks.mplstyle
@@ -1,30 +1,41 @@
-# Seaborn common parameters
-# .15 = dark_gray
-# .8 = light_gray
+# seaborn ticks style
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
 figure.facecolor: white
-text.color: .15
 axes.labelcolor: .15
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
+
 xtick.direction: out
 ytick.direction: out
 xtick.color: .15
 ytick.color: .15
-axes.axisbelow: True
-image.cmap: Greys
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-grid.linestyle: -
-lines.solid_capstyle: round
 
-# Seaborn white parameters
+axes.axisbelow: True
+grid.linestyle: -
+
+text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
+
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
+
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# white parameters
 axes.grid: False
 axes.facecolor: white
 axes.edgecolor: .15
-axes.linewidth: 1.25
 grid.color: .8
-xtick.major.size: 6
-ytick.major.size: 6
-xtick.minor.size: 3
-ytick.minor.size: 3
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: True
+ytick.left: True

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-white.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-white.mplstyle
@@ -1,30 +1,41 @@
-# Seaborn common parameters
-# .15 = dark_gray
-# .8 = light_gray
+# seaborn white style
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
 figure.facecolor: white
-text.color: .15
 axes.labelcolor: .15
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
+
 xtick.direction: out
 ytick.direction: out
 xtick.color: .15
 ytick.color: .15
-axes.axisbelow: True
-image.cmap: Greys
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-grid.linestyle: -
-lines.solid_capstyle: round
 
-# Seaborn white parameters
+axes.axisbelow: True
+grid.linestyle: -
+
+text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
+
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
+
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# white parameters
 axes.grid: False
 axes.facecolor: white
 axes.edgecolor: .15
-axes.linewidth: 1.25
 grid.color: .8
-xtick.major.size: 0
-ytick.major.size: 0
-xtick.minor.size: 0
-ytick.minor.size: 0
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: False
+ytick.left: False

--- a/lib/matplotlib/mpl-data/stylelib/seaborn-whitegrid.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn-whitegrid.mplstyle
@@ -1,30 +1,41 @@
-# Seaborn common parameters
-# .15 = dark_gray
-# .8 = light_gray
+# seaborn whitegrid style
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
 figure.facecolor: white
-text.color: .15
 axes.labelcolor: .15
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
+
 xtick.direction: out
 ytick.direction: out
 xtick.color: .15
 ytick.color: .15
-axes.axisbelow: True
-image.cmap: Greys
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-grid.linestyle: -
-lines.solid_capstyle: round
 
-# Seaborn whitegrid parameters
+axes.axisbelow: True
+grid.linestyle: -
+
+text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
+
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
+
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# whitegrid parameters
 axes.grid: True
 axes.facecolor: white
 axes.edgecolor: .8
-axes.linewidth: 1
 grid.color: .8
-xtick.major.size: 0
-ytick.major.size: 0
-xtick.minor.size: 0
-ytick.minor.size: 0
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: False
+ytick.left: False

--- a/lib/matplotlib/mpl-data/stylelib/seaborn.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/seaborn.mplstyle
@@ -1,57 +1,76 @@
-# default seaborn aesthetic
-# darkgrid + deep palette + notebook context
+# default seaborn aesthetic based on seaborn 0.9:
+#   style="darkgrid"
+#   context="notebook"
+#   palette="deep"
+
+
+# common parameters (see style_dict in seaborn.rcmod.axes_style()):
+figure.facecolor: white
+axes.labelcolor: 0.15
+
+xtick.direction: out
+ytick.direction: out
+xtick.color: .15
+ytick.color: .15
 
 axes.axisbelow: True
-axes.edgecolor: white
-axes.facecolor: EAEAF2
-axes.grid: True
-axes.labelcolor: .15
-axes.labelsize: 11
-axes.linewidth: 0
-axes.prop_cycle: cycler('color', ['4C72B0', '55A868', 'C44E52', '8172B2', 'CCB974', '64B5CD'])
-axes.titlesize: 12
-
-figure.facecolor: white
-figure.figsize: 8.0, 5.5
-
-font.family: sans-serif
-font.sans-serif: Arial, Liberation Sans, DejaVu Sans, Bitstream Vera Sans, sans-serif
-
-grid.color: white
 grid.linestyle: -
-grid.linewidth: 1
-
-image.cmap: Greys
-
-legend.fontsize: 10
-legend.frameon: False
-legend.numpoints: 1
-legend.scatterpoints: 1
-
-lines.linewidth: 1.75
-lines.markeredgewidth: 0
-lines.markersize: 7
-lines.solid_capstyle: round
-
-patch.facecolor: 4C72B0
-patch.linewidth: .3
 
 text.color: .15
+font.family: sans-serif
+font.sans-serif: Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 
-xtick.color: .15
-xtick.direction: out
-xtick.labelsize: 10
-xtick.major.pad: 7
-xtick.major.size: 0
-xtick.major.width: 1
-xtick.minor.size: 0
-xtick.minor.width: .5
+lines.solid_capstyle: round
+patch.edgecolor: w
+patch.force_edgecolor: True
 
-ytick.color: .15
-ytick.direction: out
-ytick.labelsize: 10
-ytick.major.pad: 7
-ytick.major.size: 0
-ytick.major.width: 1
-ytick.minor.size: 0
-ytick.minor.width: .5
+# seaborn image.cmap is "rocket", but we do not have that
+image.cmap: Greys
+
+xtick.top: False
+ytick.right: False
+
+
+# darkgrid parameters
+axes.grid: True
+axes.facecolor: EAEAF2
+axes.edgecolor: white
+grid.color: white
+axes.spines.left: True
+axes.spines.bottom: True
+axes.spines.right: True
+axes.spines.top: True
+
+xtick.bottom: False
+ytick.left: False
+
+
+# plotting_context (see seaborn.rcmod.plotting_context()):
+# notebook context = base context (scale=1)
+font.size: 12
+axes.labelsize: 12
+axes.titlesize: 12
+xtick.labelsize: 11
+ytick.labelsize: 11
+legend.fontsize: 11
+
+axes.linewidth: 1.25
+grid.linewidth: 1
+lines.linewidth: 1.5
+lines.markersize: 6
+patch.linewidth: 1
+
+xtick.major.width: 1.25
+ytick.major.width: 1.25
+xtick.minor.width: 1
+ytick.minor.width: 1
+
+xtick.major.size: 6
+ytick.major.size: 6
+xtick.minor.size: 4
+ytick.minor.size: 4
+
+
+# palette "deep"
+axes.prop_cycle: cycler('color', ['4C72B0', 'DD8452', '55A868', 'C44E52', '8172B3', '937860', 'DA8BC3', '8C8C8C', 'CCB974', '64B5CD'])
+patch.facecolor: 4C72B0

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 import pytest
 
 import matplotlib
@@ -92,3 +94,11 @@ def pd():
     except ImportError:
         pass
     return pd
+
+
+@pytest.fixture
+def seaborn():
+    seaborn = pytest.importorskip('seaborn')
+    if LooseVersion(seaborn.__version__) < LooseVersion('0.9'):
+        pytest.skip('seaborn style comparisons need at least seaborn 0.9')
+    return seaborn

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -1,4 +1,4 @@
 from matplotlib.testing.conftest import (mpl_test_settings,
                                          mpl_image_comparison_parameters,
                                          pytest_configure, pytest_unconfigure,
-                                         pd)
+                                         pd, seaborn)

--- a/requirements/testing/travis36.txt
+++ b/requirements/testing/travis36.txt
@@ -4,3 +4,4 @@ ipykernel
 nbconvert[execute]
 pandas
 pytz
+seaborn>0.9


### PR DESCRIPTION
## PR Summary

Following up on https://github.com/matplotlib/matplotlib/issues/13022#issuecomment-471179200

seaborn has implemented some [style changes](https://seaborn.pydata.org/whatsnew.html#updates-to-themes-and-palettes) in v0.9.0. This tries to get matplotlib styles back in sync with seaborn.

Current status: Done

- [x] update seaborn.mplstyle
- [x] update seaborn-[palette].mplstyle styles
- [x] update seaborn-[context].mplstyle styles
- [x] update other seaborn-[style].mplstyle styles
- [x] add a test for the styles
- [x] add a changelog entry

## Review proposal
For review, I suggest to focus on the tests. They should make sure that the contents of the .mplstyle file matches the definitions in seaborn. I don't think it's feasible to cross-check every single parameter by hand.