### PR TITLE
Remove axes border for examples that list styles

### DIFF
--- a/examples/lines_bars_and_markers/joinstyle.py
+++ b/examples/lines_bars_and_markers/joinstyle.py
@@ -47,8 +47,7 @@ ax.text(1, 4.7, '(default)')
 
 ax.set_xlim(-1.5, 2.75)
 ax.set_ylim(-.5, 5.5)
-ax.xaxis.set_visible(False)
-ax.yaxis.set_visible(False)
+ax.set_axis_off()
 plt.show()
 
 
@@ -66,17 +65,16 @@ fig, ax = plt.subplots(figsize=(8, 2))
 ax.set_title('Cap style')
 
 for x, style in enumerate(['butt', 'round', 'projecting']):
-    ax.text(x, 1, style)
+    ax.text(x+0.25, 1, style, ha='center')
     xx = [x, x+0.5]
     yy = [0, 0]
     ax.plot(xx, yy, lw=12, color='tab:blue', solid_capstyle=style)
     ax.plot(xx, yy, lw=1, color='black')
     ax.plot(xx, yy, 'o', color='tab:red', markersize=3)
-ax.text(2, 0.7, '(default)')
+ax.text(2.25, 0.7, '(default)', ha='center')
 
 ax.set_ylim(-.5, 1.5)
-ax.xaxis.set_visible(False)
-ax.yaxis.set_visible(False)
+ax.set_axis_off()
 
 
 #############################################################################

--- a/examples/lines_bars_and_markers/linestyles.py
+++ b/examples/lines_bars_and_markers/linestyles.py
@@ -41,7 +41,7 @@ linestyle_tuple = [
      ('densely dashdotdotted', (0, (3, 1, 1, 1, 1, 1)))]
 
 
-def plot_linestyles(ax, linestyles):
+def plot_linestyles(ax, linestyles, title):
     X, Y = np.linspace(0, 100, 10), np.zeros(10)
     yticklabels = []
 
@@ -49,8 +49,13 @@ def plot_linestyles(ax, linestyles):
         ax.plot(X, Y+i, linestyle=linestyle, linewidth=1.5, color='black')
         yticklabels.append(name)
 
-    ax.set(xticks=[], ylim=(-0.5, len(linestyles)-0.5),
-           yticks=np.arange(len(linestyles)), yticklabels=yticklabels)
+    ax.set_title(title)
+    ax.set(ylim=(-0.5, len(linestyles)-0.5),
+           yticks=np.arange(len(linestyles)),
+           yticklabels=yticklabels)
+    ax.tick_params(left=False, bottom=False, labelbottom=False)
+    for spine in ax.spines.values():
+        spine.set_visible(False)
 
     # For each line style, add a text annotation with a small offset from
     # the reference point (0 in Axes coords, y tick value in Data coords).
@@ -64,8 +69,8 @@ def plot_linestyles(ax, linestyles):
 fig, (ax0, ax1) = plt.subplots(2, 1, gridspec_kw={'height_ratios': [1, 3]},
                                figsize=(10, 8))
 
-plot_linestyles(ax0, linestyle_str[::-1])
-plot_linestyles(ax1, linestyle_tuple[::-1])
+plot_linestyles(ax0, linestyle_str[::-1], title='Named linestyles')
+plot_linestyles(ax1, linestyle_tuple[::-1], title='Parametrized linestyles')
 
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
## PR Summary

This removes the axes border from the linestyle and joinstyle examples.

This brings these examples visually closer to other examples that list the possible values of a parameter e.g.
https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/marker_fillstyle_reference.html
https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/marker_reference.html
https://matplotlib.org/devdocs/gallery/text_labels_and_annotations/fancyarrow_demo.html
https://matplotlib.org/devdocs/gallery/text_labels_and_annotations/usetex_fonteffects.html
https://matplotlib.org/devdocs/gallery/color/named_colors.html

Having no border is a nice visual hint that these examples are not primarily an example plot.


