### PR TITLE
Use format_data_short to format image cursor data.

### DIFF
--- a/doc/users/next_whats_new/2018-10-10-AL.rst
+++ b/doc/users/next_whats_new/2018-10-10-AL.rst
@@ -4,6 +4,5 @@ Improved formatting of image values under cursor when a colorbar is present
 When a colorbar is present, its formatter is now used to format the image
 values under the mouse cursor in the status bar.  For example, for an image
 displaying the values 10,000 and 10,001, the statusbar will now (using default
-settings) display the values as ``0.0+1e4`` and ``1.0+1e4`` (or ``10000.0``
-and ``10001.0`` if the offset-text is disabled on the colorbar), whereas both
-values were previously displayed as ``1e+04``.
+settings) display the values as ``10000`` and ``10001``), whereas both values
+were previously displayed as ``1e+04``.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -934,10 +934,11 @@ class AxesImage(_ImageBase):
 
     def format_cursor_data(self, data):
         if self.colorbar:
-            return ("["
-                    + cbook.strip_math(self.colorbar.formatter(data))
-                    + cbook.strip_math(self.colorbar.formatter.get_offset())
-                    + "]")
+            return (
+                "["
+                + cbook.strip_math(
+                    self.colorbar.formatter.format_data_short(data)).strip()
+                + "]")
         else:
             return super().format_cursor_data(data)
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -291,22 +291,29 @@ def test_cursor_data():
     assert im.get_cursor_data(event) is None
 
 
-def test_format_cursor_data():
+@pytest.mark.parametrize(
+    "data, text_without_colorbar, text_with_colorbar", [
+        ([[10001, 10000]], "[1e+04]", "[10001]"),
+        ([[.123, .987]], "[0.123]", "[0.123]"),
+])
+def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
     from matplotlib.backend_bases import MouseEvent
 
     fig, ax = plt.subplots()
-    im = ax.imshow([[10000, 10001]])
+    im = ax.imshow(data)
 
     xdisp, ydisp = ax.transData.transform_point([0, 0])
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    assert im.get_cursor_data(event) == 10000
-    assert im.format_cursor_data(im.get_cursor_data(event)) == "[1e+04]"
+    assert im.get_cursor_data(event) == data[0][0]
+    assert im.format_cursor_data(im.get_cursor_data(event)) \
+        == text_without_colorbar
 
     fig.colorbar(im)
     fig.canvas.draw()  # This is necessary to set up the colorbar formatter.
 
-    assert im.get_cursor_data(event) == 10000
-    assert im.format_cursor_data(im.get_cursor_data(event)) == "[0.0+1e4]"
+    assert im.get_cursor_data(event) == data[0][0]
+    assert im.format_cursor_data(im.get_cursor_data(event)) \
+        == text_with_colorbar
 
 
 @image_comparison(baseline_images=['image_clip'], style='mpl20')


### PR DESCRIPTION
Despite its name, format_data_short is actually used to format the x/y
cursor data; it makes sense to also use it for image data.  By doing so,
e.g. for `imshow([[.123, .987]])`, one gets the more accurate `.123`
string when the mouse is over the first pixel instead of `.1` that
`__call__` returns (which would have been intended as a tick label).

Release critical as an improvement over #12459.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
