### PR TITLE
Deduplicate methods shared between Container and Artist.

### DIFF
--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -1,5 +1,5 @@
+from matplotlib.artist import Artist
 import matplotlib.cbook as cbook
-import matplotlib.artist as martist
 
 
 class Container(tuple):
@@ -18,83 +18,29 @@ class Container(tuple):
         return tuple.__new__(cls, args[0])
 
     def __init__(self, kl, label=None):
-
         self.eventson = False  # fire events only if eventson
         self._oid = 0  # an observer id
         self._propobservers = {}  # a dict from oids to funcs
-
         self._remove_method = None
-
         self.set_label(label)
 
     def remove(self):
         for c in cbook.flatten(
-                self, scalarp=lambda x: isinstance(x, martist.Artist)):
+                self, scalarp=lambda x: isinstance(x, Artist)):
             if c is not None:
                 c.remove()
 
         if self._remove_method:
             self._remove_method(self)
 
-    def get_label(self):
-        """
-        Get the label used for this artist in the legend.
-        """
-        return self._label
-
-    def set_label(self, s):
-        """
-        Set the label to *s* for auto legend.
-
-        Parameters
-        ----------
-        s : object
-            Any object other than None gets converted to its `str`.
-        """
-        if s is not None:
-            self._label = str(s)
-        else:
-            self._label = None
-        self.pchanged()
-
-    def add_callback(self, func):
-        """
-        Adds a callback function that will be called whenever one of
-        the :class:`Artist`'s properties changes.
-
-        Returns an *id* that is useful for removing the callback with
-        :meth:`remove_callback` later.
-        """
-        oid = self._oid
-        self._propobservers[oid] = func
-        self._oid += 1
-        return oid
-
-    def remove_callback(self, oid):
-        """
-        Remove a callback based on its *id*.
-
-        .. seealso::
-
-            :meth:`add_callback`
-               For adding callbacks
-
-        """
-        try:
-            del self._propobservers[oid]
-        except KeyError:
-            pass
-
-    def pchanged(self):
-        """
-        Fire an event when property changed, calling all of the
-        registered callbacks.
-        """
-        for oid, func in list(self._propobservers.items()):
-            func(self)
-
     def get_children(self):
         return [child for child in cbook.flatten(self) if child is not None]
+
+    get_label = Artist.get_label
+    set_label = Artist.set_label
+    add_callback = Artist.add_callback
+    remove_callback = Artist.remove_callback
+    pchanged = Artist.pchanged
 
 
 class BarContainer(Container):


### PR DESCRIPTION
Container does not inherit from Artist, but still shares some of its
methods.  Instead of duplicating the implementation, just directly use
the Artist methods.

We could also move these shared methods to a mixin that both Artist and
Container inherit, but that would just confuse the matters IMO.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
