### PR TITLE
Annotation.contains shouldn't consider the text+arrow's joint bbox.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -200,7 +200,10 @@ class Text(Artist):
         if not self.get_visible() or self._renderer is None:
             return False, {}
 
-        l, b, w, h = self.get_window_extent().bounds
+        # Explicitly use Text.get_window_extent(self) and not
+        # self.get_window_extent() so that Annotation.contains does not
+        # accidentally cover the entire annotation bounding box.
+        l, b, w, h = Text.get_window_extent(self).bounds
         r, t = l + w, b + h
 
         x, y = mouseevent.x, mouseevent.y
@@ -2187,11 +2190,12 @@ class Annotation(Text, _AnnotationBase):
             self.arrow_patch = None
 
     def contains(self, event):
+        if self._contains is not None:
+            return self._contains(self, event)
         contains, tinfo = Text.contains(self, event)
         if self.arrow_patch is not None:
             in_patch, _ = self.arrow_patch.contains(event)
             contains = contains or in_patch
-
         return contains, tinfo
 
     @property


### PR DESCRIPTION
Previously, when deferring to Text.contains, self.get_window_extent
would incorrectly use Annotation.get_window_extent.  Just force it to
use Text.get_window_extent instead.

Also make Annotation obey the optional `._contains` attribute.

Also renamed the parameter to Annotation.contains to mouseevent, which is consistent with Text.contains and most other contains() methods.  I decided to skip the deprecation on that...

Closes #10875.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
