### PR TITLE
TST: only test agg_filter extensions with baseline images

### DIFF
--- a/lib/matplotlib/tests/test_agg_filter.py
+++ b/lib/matplotlib/tests/test_agg_filter.py
@@ -4,7 +4,8 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-@image_comparison(baseline_images=['agg_filter_alpha'])
+@image_comparison(baseline_images=['agg_filter_alpha'],
+                  extensions=['png', 'pdf'])
 def test_agg_filter_alpha():
     ax = plt.axes()
     x, y = np.mgrid[0:7, 0:8]


### PR DESCRIPTION
Follow up to https://github.com/matplotlib/matplotlib/pull/13021

This will not backport and should be manually added to https://github.com/matplotlib/matplotlib/pull/13704