### PR TITLE
Deprecate NavigationToolbar2Tk.set_active.

### DIFF
--- a/doc/api/next_api_changes/2019-03-19-AL.rst
+++ b/doc/api/next_api_changes/2019-03-19-AL.rst
@@ -1,0 +1,4 @@
+Deprecations
+````````````
+``NavigationToolbar2Tk.set_active`` is deprecated, as it has no (observable)
+effect.

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -12,9 +12,9 @@ https://docs.python.org/3/license.html
 This is yet another example of using matplotlib with wx.  Hopefully
 this is pretty full-featured:
 
-  - both matplotlib toolbar and WX buttons manipulate plot
-  - full wxApp framework, including widget interaction
-  - XRC (XML wxWidgets resource) file to create GUI (made with XRCed)
+- both matplotlib toolbar and WX buttons manipulate plot
+- full wxApp framework, including widget interaction
+- XRC (XML wxWidgets resource) file to create GUI (made with XRCed)
 
 This was derived from embedding_in_wx and dynamic_image_wxagg.
 
@@ -46,7 +46,6 @@ class PlotPanel(wx.Panel):
         self.canvas = FigureCanvas(self, -1, self.fig)
         self.toolbar = NavigationToolbar(self.canvas)  # matplotlib toolbar
         self.toolbar.Realize()
-        # self.toolbar.set_active([0,1])
 
         # Now put all into a sizer
         sizer = wx.BoxSizer(wx.VERTICAL)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -705,6 +705,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         except Exception as e:
             tkinter.messagebox.showerror("Error saving file", str(e))
 
+    @cbook.deprecated("3.1")
     def set_active(self, ind):
         self._ind = ind
         self._active = [self._axes[i] for i in self._ind]


### PR DESCRIPTION
It appears to be some vestige of the NavigationToolbar(1) code, with
some traces also in the wx examples and currently being deprecated in
backend_wx.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
