### PR TITLE
ENH: anti-alias down-sampled images

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -94,6 +94,7 @@ per-file-ignores =
     examples/images_contours_and_fields/contourf_hatching.py: E402
     examples/images_contours_and_fields/contourf_log.py: E402
     examples/images_contours_and_fields/demo_bboximage.py: E402
+    examples/images_contours_and_fields/image_antialiasing.py: E402
     examples/images_contours_and_fields/image_clip_path.py: E402
     examples/images_contours_and_fields/image_demo.py: E402
     examples/images_contours_and_fields/image_masked.py: E402

--- a/doc/api/next_api_changes/2019-07-17-JMK.rst
+++ b/doc/api/next_api_changes/2019-07-17-JMK.rst
@@ -1,0 +1,22 @@
+Default interpolation for `image` is new "antialiased" option
+-------------------------------------------------------------
+
+Images displayed in Matplotlib previously used nearest-neighbor
+interpolation, leading to aliasing effects for downscaling and non-integer
+upscaling.  
+
+New default for :rc:`image.interpolation` is the new option "antialiased".
+`imshow(A, interpolation='antialiased')` will apply a Hanning filter when
+resampling the data in A for display (or saving to file) *if* the upsample
+rate is less than a factor of three, and not an integer; downsampled data is
+always smoothed at resampling.
+
+To get the old behavior, set :rc:`interpolation` to the old default "nearest"
+(or specify the ``interpolation`` kwarg of `.Axes.imshow`)
+
+To always get the anti-aliasing behavior, no matter what the up/down sample
+rate, set :rc:`interpolation` to "hanning" (or one of the other filters
+available.
+
+Note that the "hanning" filter was chosen because it has only a modest
+performance penalty.  Anti-aliasing can be improved with other filters.

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -1,0 +1,81 @@
+"""
+==================
+Image Antialiasing
+==================
+
+Images are represented by discrete pixels, either on the screen or in an
+image file.  When data that makes up the image has a different resolution
+than its representation on the screen we will see aliasing effects.
+
+The default image interpolation in Matplotlib is 'antialiased'.  This uses a
+hanning interpolation for reduced aliasing in most situations. Only when there
+is upsampling by a factor of 1, 2 or >=3 is 'nearest' neighbor interpolation
+used.
+
+Other anti-aliasing filters can be specified in `.Axes.imshow` using the
+*interpolation* kwarg.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+###############################################################################
+# First we generate an image with varying frequency content:
+x = np.arange(500) / 500 - 0.5
+y = np.arange(500) / 500 - 0.5
+
+X, Y = np.meshgrid(x, y)
+R = np.sqrt(X**2 + Y**2)
+f0 = 10
+k = 250
+a = np.sin(np.pi * 2 * (f0 * R + k * R**2 / 2))
+
+
+###############################################################################
+# The following images are subsampled from 1000 data pixels to 604 rendered
+# pixels. The Moire patterns in the "nearest" interpolation are caused by the
+# high-frequency data being subsampled.  The "antialiased" image
+# still has some Moire patterns as well, but they are greatly reduced.
+fig, axs = plt.subplots(1, 2, figsize=(7, 4), constrained_layout=True)
+for n, interp in enumerate(['nearest', 'antialiased']):
+    im = axs[n].imshow(a, interpolation=interp, cmap='gray')
+    axs[n].set_title(interp)
+plt.show()
+
+###############################################################################
+# Even up-sampling an image will lead to Moire patterns unless the upsample
+# is an integer number of pixels.
+fig, ax = plt.subplots(1, 1, figsize=(5.3, 5.3))
+ax.set_position([0, 0, 1, 1])
+im = ax.imshow(a, interpolation='nearest', cmap='gray')
+plt.show()
+
+###############################################################################
+# The patterns aren't as bad, but still benefit from anti-aliasing
+fig, ax = plt.subplots(1, 1, figsize=(5.3, 5.3))
+ax.set_position([0, 0, 1, 1])
+im = ax.imshow(a, interpolation='antialiased', cmap='gray')
+plt.show()
+
+###############################################################################
+# If the small Moire patterns in the default "hanning" antialiasing are
+# still undesireable, then we can use other filters.
+fig, axs = plt.subplots(1, 2, figsize=(7, 4), constrained_layout=True)
+for n, interp in enumerate(['hanning', 'lanczos']):
+    im = axs[n].imshow(a, interpolation=interp, cmap='gray')
+    axs[n].set_title(interp)
+plt.show()
+
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown
+# in this example:
+
+import matplotlib
+matplotlib.axes.Axes.imshow

--- a/examples/images_contours_and_fields/interpolation_methods.py
+++ b/examples/images_contours_and_fields/interpolation_methods.py
@@ -9,11 +9,14 @@ This example displays the difference between interpolation methods for
 If `interpolation` is None, it defaults to the :rc:`image.interpolation`
 (default: ``'nearest'``). If the interpolation is ``'none'``, then no
 interpolation is performed for the Agg, ps and pdf backends. Other backends
-will default to ``'nearest'``.
+will default to ``'antialiased'``.
 
 For the Agg, ps and pdf backends, ``interpolation = 'none'`` works well when a
 big image is scaled down, while ``interpolation = 'nearest'`` works well when
 a small image is scaled up.
+
+See :doc:`/gallery/images_contours_and_fields/image_antialiasing` for a
+discussion on the default `interpolation="antialiased"` option.
 """
 
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5488,10 +5488,10 @@ optional.
             The interpolation method used. If *None*
             :rc:`image.interpolation` is used, which defaults to 'nearest'.
 
-            Supported values are 'none', 'nearest', 'bilinear', 'bicubic',
-            'spline16', 'spline36', 'hanning', 'hamming', 'hermite', 'kaiser',
-            'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell', 'sinc',
-            'lanczos'.
+            Supported values are 'none', 'antialiased', 'nearest', 'bilinear',
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
+            'sinc', 'lanczos'.
 
             If *interpolation* is 'none', then no interpolation is performed
             on the Agg, ps, pdf and svg backends. Other backends will fall back
@@ -5499,9 +5499,19 @@ optional.
             rendering and that the default interpolation method they implement
             may differ.
 
+            If *interpolation* is the default 'antialiased', then 'nearest'
+            interpolation is used if the image is upsampled by more than a
+            factor of three (i.e. the number of display pixels is at least
+            three times the size of the data array).  If the upsampling rate is
+            smaller than 3, or the image is downsampled, then 'hanning'
+            interpolation is used to act as an anti-aliasing filter, unless the
+            image happens to be upsampled by exactly a factor of two or one.
+
             See
             :doc:`/gallery/images_contours_and_fields/interpolation_methods`
-            for an overview of the supported interpolation methods.
+            for an overview of the supported interpolation methods, and
+            :doc:`/gallery/images_contours_and_fields/image_antialiasing` for
+            a discussion of image antialiasing.
 
             Some interpolation methods require an additional radius parameter,
             which can be set by *filterrad*. Additionally, the antigrain image

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1100,7 +1100,7 @@ defaultParams = {
     'mathtext.fallback_to_cm': [True, validate_bool],
 
     'image.aspect':        ['equal', validate_aspect],  # equal, auto, a number
-    'image.interpolation': ['nearest', validate_string],
+    'image.interpolation': ['antialiased', validate_string],
     'image.cmap':          ['viridis', validate_string],  # gray, jet, etc.
     'image.lut':           [256, validate_int],  # lookup table
     'image.origin':        ['upper',

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -915,6 +915,8 @@ def test_nonfinite_limits():
 
 @image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')
 def test_imshow():
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
     # Create a NxN image
     N = 100
     (x, y) = np.indices((N, N))
@@ -936,6 +938,8 @@ def test_imshow():
 @image_comparison(['imshow_clip'], style='mpl20')
 def test_imshow_clip():
     # As originally reported by Gellule Xg <gellule.xg@free.fr>
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
 
     # Create a NxN image
     N = 100
@@ -3732,6 +3736,10 @@ def test_subplot_key_hash():
                   remove_text=True, tol=0.07, style='default')
 def test_specgram_freqs():
     '''test axes.specgram in default (psd) mode with sinusoidal stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     n = 1000
     Fs = 10.
 
@@ -3784,6 +3792,10 @@ def test_specgram_freqs():
                   remove_text=True, tol=0.01, style='default')
 def test_specgram_noise():
     '''test axes.specgram in default (psd) mode with noise stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     np.random.seed(0)
 
     n = 1000
@@ -3831,6 +3843,10 @@ def test_specgram_noise():
                   remove_text=True, tol=0.07, style='default')
 def test_specgram_magnitude_freqs():
     '''test axes.specgram in magnitude mode with sinusoidal stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     n = 1000
     Fs = 10.
 
@@ -3886,6 +3902,10 @@ def test_specgram_magnitude_freqs():
                   remove_text=True, style='default')
 def test_specgram_magnitude_noise():
     '''test axes.specgram in magnitude mode with noise stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     np.random.seed(0)
 
     n = 1000
@@ -3932,6 +3952,10 @@ def test_specgram_magnitude_noise():
                   remove_text=True, tol=0.007, style='default')
 def test_specgram_angle_freqs():
     '''test axes.specgram in angle mode with sinusoidal stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     n = 1000
     Fs = 10.
 
@@ -3986,6 +4010,10 @@ def test_specgram_angle_freqs():
                   remove_text=True, style='default')
 def test_specgram_noise_angle():
     '''test axes.specgram in angle mode with noise stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     np.random.seed(0)
 
     n = 1000
@@ -4032,6 +4060,9 @@ def test_specgram_noise_angle():
                   remove_text=True, style='default')
 def test_specgram_freqs_phase():
     '''test axes.specgram in phase mode with sinusoidal stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
     n = 1000
     Fs = 10.
 
@@ -4086,6 +4117,9 @@ def test_specgram_freqs_phase():
                   remove_text=True, style='default')
 def test_specgram_noise_phase():
     '''test axes.specgram in phase mode with noise stimuli'''
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
     np.random.seed(0)
 
     n = 1000

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -29,7 +29,7 @@ def test_patheffect2():
 
     ax2 = plt.subplot(111)
     arr = np.arange(25).reshape((5, 5))
-    ax2.imshow(arr)
+    ax2.imshow(arr, interpolation='nearest')
     cntr = ax2.contour(arr, colors="k")
 
     plt.setp(cntr.collections,

--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -1,4 +1,5 @@
 
+import matplotlib
 from matplotlib.testing.decorators import image_comparison
 from mpl_toolkits.axes_grid1 import ImageGrid
 import numpy as np
@@ -7,6 +8,8 @@ import matplotlib.pyplot as plt
 
 @image_comparison(['imagegrid_cbar_mode.png'], remove_text=True, style='mpl20')
 def test_imagegrid_cbar_mode_edge():
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
     X, Y = np.meshgrid(np.linspace(0, 6, 30), np.linspace(0, 6, 30))
     arr = np.sin(X) * np.cos(Y) + 1j*(np.sin(3*Y) * np.cos(Y/2.))
 

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -355,7 +355,7 @@ def test_zooming_with_inverted_axes():
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
-    ax.imshow(np.zeros((10, 10)))
+    ax.imshow(np.zeros((10, 10)), interpolation='nearest')
 
     simple_arrow = AnchoredDirectionArrows(ax.transAxes, 'X', 'Y')
     ax.add_artist(simple_arrow)
@@ -394,7 +394,7 @@ def test_image_grid():
     grid = ImageGrid(fig, 111, nrows_ncols=(2, 2), axes_pad=0.1)
 
     for i in range(4):
-        grid[i].imshow(im)
+        grid[i].imshow(im, interpolation='nearest')
         grid[i].set_title('test {0}{0}'.format(i))
 
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -559,7 +559,7 @@
 ## * IMAGES                                                                  *
 ## ***************************************************************************
 #image.aspect : equal            ## {equal, auto} or a number
-#image.interpolation  : nearest  ## see help(imshow) for options
+#image.interpolation  : antialiased  ## see help(imshow) for options
 #image.cmap   : viridis          ## A colormap name, gray etc...
 #image.lut    : 256              ## the size of the colormap lookup table
 #image.origin : upper            ## {lower, upper}


### PR DESCRIPTION
## PR Summary

Closes #5602   

See new example documenting the change: https://23268-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/images_contours_and_fields/image_antialiasing.html


### UPDATED: 16 April 2019

The API is now 

```
ax.imshow(A, interpolation='antialiased')
```
with `'antialiased'` as the default, and `'nearest'` giving the old behaviour.  This API was discussed on the early-April development call, and strongly suggested by @efiring .

Q: a) should this be the default? and b) should the 12 or so failing tests be changed to non-default so the images don't have to change?

### OLD: UPDATED:

Below is the logic for turning on hanning-window smoothing:  
 - only do it if the interpolation is already "nearest"  The other interpolation schemes will 
anti-alias
 - only do if up-sampling less than a factor of three (and for all down-sampling) so long as the up-sample isn't an integer.

```python
                interpolation = self.get_interpolation()
                if interpolation == 'nearest' and self.get_antialiased():
                    # do antialiasing....
                    # compare the number of displayed pixels to the number of
                    # the data pixels.
                    samplerate = t.transform([A.shape[1], 0])[0] / A.shape[1]
                    if samplerate <= 3:
                        # don't auto-alias if a sample rate is 1 or 2...
                        if (np.abs(int(samplerate) - (samplerate)) > 0.0001):
                            # do anti-aliasing
                            interpolation = 'hanning'
```

```python
import matplotlib.pyplot as plt
import numpy as np
import scipy.signal as signal
import timeit

# a = plt.imread('rings_sm_orig.gif')
x = np.arange(2000) / 2000 - 0.5
y = np.arange(2000) / 2000 - 0.5

X, Y = np.meshgrid(x, y)
R = np.sqrt(X**2 + Y**2)
f0 = 10
k = 1000
a = np.sin(np.pi * 2 * (f0 * R + k * R**2 / 2))

for filt in ['hanning', 'gaussian', 'lanczos', 'sinc']:
   # approx 10x subsample and 20x subsample, un-even #....
    for dpi in [210, 95]:
        fig, axs = plt.subplots(1, 2, figsize=(4, 2), num=1)
        ax = axs[0]
        ax.imshow(a, cmap='gray', antialiased=False)
        ax.set_position([0, 0, 0.5, 1])
        ax = axs[1]
        ax.imshow(a, cmap='gray', antialiased=False,
                  interpolation=filt, filterrad=1000 / dpi / 2)
        ax.set_position([0.5, 0, 0.5, 1])
        ax.axis('off')
        t0 = timeit.default_timer()
        fig.savefig(f'{filt}dpi{dpi}.png', dpi=dpi)
        print('filt', filt, 'dpi', dpi, 'time', '%1.3f'%(timeit.default_timer() - t0))
```

## No anti-aliasing:

  - filt nearest dpi 210 time 0.241
  - filt nearest dpi 95 time 0.382

## Hanning:

  - filt hanning dpi 210 time 0.415
  - filt  hanning dpi 95 time 0.578

![hanningdpi95](https://user-images.githubusercontent.com/1562854/54829411-94a06380-4c73-11e9-86b7-39d2766dfc5e.png)
![hanningdpi210](https://user-images.githubusercontent.com/1562854/54829425-9d913500-4c73-11e9-855c-9c1fb8ca4ead.png)

## Gaussian

  - filt gaussian dpi 210 time 1.340
  - filt gaussian dpi 95 time 1.884

![gaussiandpi95](https://user-images.githubusercontent.com/1562854/54829481-ba2d6d00-4c73-11e9-9a3f-6c8df5f6a6e7.png)
![gaussiandpi210](https://user-images.githubusercontent.com/1562854/54829482-ba2d6d00-4c73-11e9-8ca3-982e9e4da127.png)

## Lanczos 

  - filt lanczos dpi 210 time 3.236
  - filt lanczos dpi 95 time 7.577 

![lanczosdpi95](https://user-images.githubusercontent.com/1562854/54829510-d0d3c400-4c73-11e9-8e4d-ce8e810468ae.png)
![lanczosdpi210](https://user-images.githubusercontent.com/1562854/54829511-d0d3c400-4c73-11e9-8762-a1b950f19f1a.png)

## Sinc 

  - filt sinc dpi 210 time 8.894
  - filt sinc dpi 95 time 13.192

![sincdpi95](https://user-images.githubusercontent.com/1562854/54829552-e2b56700-4c73-11e9-8678-ec960158d95a.png)
![sincdpi210](https://user-images.githubusercontent.com/1562854/54829553-e2b56700-4c73-11e9-939f-f6be67d465fc.png)

## Importance of anti-aliasing even if not "downsampling":

Note that we really need the anti-aliasing filter unless we upsample by more than a factor of two, so this PR proposes doing that:

```python
import matplotlib.pyplot as plt
import numpy as np
import scipy.signal as signal
import timeit

a = plt.imread('rings_sm_orig.gif')
print(np.shape(a))

for dpi in [30, 60, 90, 100, 150, 175, 210]:
    fig, axs = plt.subplots(1, 2, figsize=(4, 2), num=1)
    ax = axs[0]
    ax.imshow(a, cmap='gray', antialiased=True)
    ax.set_position([0, 0, 0.5, 1])
    ax = axs[1]
    ax.imshow(a, cmap='gray', antialiased=False)
    ax.set_position([0.5, 0, 0.5, 1])
    ax.axis('off')
    ax.set_title(dpi)
    t0 = timeit.default_timer()
    fig.savefig(f'filtdpi{dpi}.png', dpi=dpi)
```

![filtdpi175](https://user-images.githubusercontent.com/1562854/54831067-e72f4f00-4c76-11e9-89f5-3f52658f64f3.png)
![filtdpi150](https://user-images.githubusercontent.com/1562854/54831068-e7c7e580-4c76-11e9-8f20-94ab00d46978.png)
![filtdpi110](https://user-images.githubusercontent.com/1562854/54831164-15ad2a00-4c77-11e9-8b76-993ef03260c3.png)
![filtdpi100](https://user-images.githubusercontent.com/1562854/54831069-e7c7e580-4c76-11e9-923a-54a961ec9436.png)
![filtdpi90](https://user-images.githubusercontent.com/1562854/54831070-e7c7e580-4c76-11e9-86e4-23f544f9623a.png)
![filtdpi60](https://user-images.githubusercontent.com/1562854/54831071-e7c7e580-4c76-11e9-89fd-d984f2eccbc9.png)
![filtdpi30](https://user-images.githubusercontent.com/1562854/54831072-e7c7e580-4c76-11e9-9533-107a9309ad2b.png)