### PR TITLE
Include FreeType error codes in FreeType exception messages.

### DIFF
--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -119,7 +119,6 @@ class FT2Font
     FT_Face face;
     FT_Matrix matrix; /* transformation matrix */
     FT_Vector pen;    /* untransformed origin  */
-    FT_Error error;
     std::vector<FT_Glyph> glyphs;
     std::vector<FT_Vector> pos;
     FT_BBox bbox;


### PR DESCRIPTION
... to help with interpreting bug reports, e.g. #13723.

Actually in the case of #13723 the error reported is always 0x14 ("invalid outline") which is a bit mysterious, but at least now we have the info.  (My guess is that even with multiprocessing we end up with some shared state (interestingly that bug is reproducible even with mp.set_start_method("spawn"), so it's not due solely to forking), but I haven't investigated more.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
