### PR TITLE
Fix pressing tab breaks keymap in CanvasTk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -175,6 +175,7 @@ class FigureCanvasTk(FigureCanvasBase):
                65455: '/',
                65439: 'dec',
                65421: 'enter',
+               65289: 'tab',
                }
 
     _keycode_lookup = {
@@ -204,6 +205,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self._resize_callback = resize_callback
         self._tkcanvas.bind("<Configure>", self.resize)
         self._tkcanvas.bind("<Key>", self.key_press)
+        self._tkcanvas.bind("<Tab>", self.tab_event)
         self._tkcanvas.bind("<Motion>", self.motion_notify_event)
         self._tkcanvas.bind("<Enter>", self.enter_notify_event)
         self._tkcanvas.bind("<Leave>", self.leave_notify_event)
@@ -452,6 +454,11 @@ class FigureCanvasTk(FigureCanvasBase):
                     key = '{0}+{1}'.format(prefix, key)
 
         return key
+
+    def tab_event(self, event):
+        self._tkcanvas.focus_set()
+        self.key_press(event)
+        return 'break'
 
     def key_press(self, event):
         key = self._get_key(event)


### PR DESCRIPTION
Hi, I'm opening this as part of coursework from University of Toronto Scarborough's CSCD01 taught by Dr. Anya Tafliovich @atafliovich. (https://www.utsc.utoronto.ca/~atafliovich/cscd01/index.html)

### PR Summary
Closes #13484 - Matplotlib keymap stop working after pressing tab

### Bug Analysis and Technical Commentary:
When using figureCanvas and NavigationToolBar embedded in Tkinter, Matplotlib has some key mappings to NavigationToolBar actions. However, if tab is pressed, none of the key mappings works and clicking in the figure/plot does not help. The methods to bring the key mappings back are to use either alt+tab or pressing tab for a few times.

The problem is with the default Tkinter tab action, it will move the focus around on different objects in the Tinkter canvas, in this case, buttons in the NavigationToolBar. The key mapping functions are set on figureCanvas so they work only when the focus in on the figure.

The fix is to add a tab_event to handle the case where tab is pressed on the Tkinter Canvas. The tab_event will set focus to the figureCanvas and call ```key_press``` from ```FigureCanvasTk```, and uses return 'break' to disable the default Tkinter tab action. By binding the Tkinter tab pressed event "\<tab\>" to my customized tab_event fixes the misbehaviour when tab is pressed. I also added a default tab key recognition to the ```FigureCanvasTk``` class since None was returned before when tab is pressed.

### Acceptance Test:
- create FigureCanvasTkAgg and NavigationToolbar2Tk based on a Tkinter root
- pressing tab does not move the focus and disable any key mappings
### Result:
pressing tab behaves as expected

### Example code:
see [matplotlib embedded in tk example](https://matplotlib.org/gallery/user_interfaces/embedding_in_tk_sgskip.html#sphx-glr-gallery-user-interfaces-embedding-in-tk-sgskip-py)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
