### PR TITLE
FIX: make title move above ticklabels

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2535,8 +2535,9 @@ class _AxesBase(martist.Artist):
             top = 0
             for ax in axs:
                 try:
-                    if (ax.xaxis.get_label_position() != 'bottom'
-                            or ax.xaxis.get_ticks_position() != 'bottom'):
+                    choices = ['top', 'unknown']
+                    if (ax.xaxis.get_label_position() == 'top' or
+                            ax.xaxis.get_ticks_position() in choices):
                         bb = ax.xaxis.get_tightbbox(renderer)
                     else:
                         bb = ax.get_window_extent(renderer)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2535,8 +2535,8 @@ class _AxesBase(martist.Artist):
             top = 0
             for ax in axs:
                 try:
-                    if (ax.xaxis.get_label_position() == 'top'
-                            or ax.xaxis.get_ticks_position() == 'top'):
+                    if (ax.xaxis.get_label_position() != 'bottom'
+                            or ax.xaxis.get_ticks_position() != 'bottom'):
                         bb = ax.xaxis.get_tightbbox(renderer)
                     else:
                         bb = ax.get_window_extent(renderer)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5723,6 +5723,16 @@ def test_title_xticks_top():
     assert ax.title.get_position()[1] > 1.04
 
 
+def test_title_xticks_top_both():
+    # Test that title moves if xticks on top of axes.
+    fig, ax = plt.subplots()
+    ax.tick_params(axis="x", bottom=True, top=True,
+                             labelbottom=True, labeltop=True)
+    ax.set_title('xlabel top')
+    fig.canvas.draw()
+    assert ax.title.get_position()[1] > 1.04
+
+
 def test_offset_label_color():
     # Tests issue 6440
     fig = plt.figure()


### PR DESCRIPTION
## PR Summary

Titles are supposed to avoid tick labels as of #9498.   However, if ticks are labeled at the top and bottom of a plot, `ax.xaxis.get_ticks_position()` returns "unknown" instead of "top", so old logic didn't move title above tick labels on the top of the axes for that case.

Closes #13735

```python 
import pandas as pd
import numpy as np
import string
import matplotlib.pyplot as plt

n = 10
names = ['Long Name ' + suffix for suffix in string.ascii_uppercase[:n]]

fig = plt.figure(constrained_layout=True)
ax = plt.gca()

ax.set_xticks(np.arange(n))
ax.set_xticklabels(names)
ax.set_yticks(np.arange(n))
ax.set_yticklabels(names)

# Set ticks on both sides of axes on
ax.tick_params(axis="x", bottom=True, top=True, labelbottom=True, labeltop=True)
# Rotate and align bottom ticklabels
plt.setp([tick.label1 for tick in ax.xaxis.get_major_ticks()], rotation=45,
         ha="right", va="center", rotation_mode="anchor")
# Rotate and align top ticklabels
plt.setp([tick.label2 for tick in ax.xaxis.get_major_ticks()], rotation=45,
         ha="left", va="center",rotation_mode="anchor")

ax.set_title("Name Co-Occurrences")
plt.show()
```

### Before

![titleissold](https://user-images.githubusercontent.com/1562854/54857710-09988b00-4cbe-11e9-96df-4f88545e7c83.png)

### After

![titleissnew](https://user-images.githubusercontent.com/1562854/54857719-11f0c600-4cbe-11e9-87a1-7636a234258f.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->