### PR TITLE
Arrow head color fix to match arrow body

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2729,8 +2729,9 @@ pivot='tail', normalize=False, **kwargs)
             # transpose to get a list of lines
             heads = heads.swapaxes(0, 1)
 
-            #create seperate lists for lines, left arrow head lines, and right arrow head lines
-            #from the computed lines and heads to be used for generating gradients
+            # create seperate lists for lines, left arrow head lines,
+            # and right arrow head lines from the computed lines and
+            # heads to be used for generating gradients
             lines = shafts
             arrows1 = []
             arrows2 = []
@@ -2744,7 +2745,8 @@ pivot='tail', normalize=False, **kwargs)
             arrows2 = []
             lines = []
 
-        #generate 3D lines with gradient for body, left arrow head lines, and right arrow head lines
+        # generate 3D lines with gradient for body, left arrow head lines,
+        # and right arrow head lines
         linec = art3d.Line3DCollection(lines, *args[argi:], **kwargs)
         arrow1c = art3d.Line3DCollection(arrows1, *args[argi:], **kwargs)
         arrow2c = art3d.Line3DCollection(arrows2, *args[argi:], **kwargs)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2729,12 +2729,28 @@ pivot='tail', normalize=False, **kwargs)
             # transpose to get a list of lines
             heads = heads.swapaxes(0, 1)
 
-            lines = [*shafts, *heads]
+            #create seperate lists for lines, left arrow head lines, and right arrow head lines
+            #from the computed lines and heads to be used for generating gradients
+            lines = shafts
+            arrows1 = []
+            arrows2 = []
+            for a in range(len(heads)):
+                if a % 2 == 0:
+                    arrows1.append(heads[a])
+                else:
+                    arrows2.append(heads[a])
         else:
+            arrows1 = []
+            arrows2 = []
             lines = []
 
+        #generate 3D lines with gradient for body, left arrow head lines, and right arrow head lines
         linec = art3d.Line3DCollection(lines, *args[argi:], **kwargs)
+        arrow1c = art3d.Line3DCollection(arrows1, *args[argi:], **kwargs)
+        arrow2c = art3d.Line3DCollection(arrows2, *args[argi:], **kwargs)
         self.add_collection(linec)
+        self.add_collection(arrow1c)
+        self.add_collection(arrow2c)
 
         self.auto_scale_xyz(XYZ[:, 0], XYZ[:, 1], XYZ[:, 2], had_data)
 


### PR DESCRIPTION
## PR Summary
Tried to fix this issue by separating arrow head bodies and arrow heads to be used for generating gradient lines separately. This PR is part of coursework for CSCD01 at UTSC.

Closes #11759

## Bug Description
Currently when plotting arrows using the quiver method with a gradient correctly shows a gradient for arrow bodies but not for arrow heads. Within the `quiver` method inside class `Axes3D` in `mpl_toolkits/mplot3d/axes3d.py` each arrow head is actually created as two lines that are at a different angle to the body of the arrow. Originally the main body lines and the lines used to generate the arrow heads are being passed together to create a single `Line3DCollection` object:

```
lines = [*shafts, *heads]
.
.
.
linec = art3d.Line3DCollection(lines, *args[argi:], **kwargs)
```

This resulted in the arrow heads to have an inconsistent gradient for the plot. The fix was to create separate `Line3DCollection` for each collection of lines. Instead of one single `Line3DCollection` object to be plotted containing the body lines and then the arrow head lines, I now split it into a `Line3DCollection` object for the body lines, a `Line3DCollection` object for one side of the arrow heads, and a `Line3DCollection` object for the other side of the arrow
heads. 

## Example code to test
```
import numpy as np
import matplotlib.pyplot as plt
from mpl_toolkits.mplot3d import Axes3D

x = np.zeros(10)
y = np.zeros(10)
z = np.arange(10.)
dx = np.zeros(10)
dy = np.arange(10.)
dz = np.zeros(10)

fig = plt.figure()
ax = fig.gca(projection='3d')

arrow_color = plt.cm.Reds(dy/dy.max())

ax.quiver(x, y, z, dx, dy, dz, colors=arrow_color)
ax.set_ylim(0,10)
plt.show()
```

## Before
![before](https://user-images.githubusercontent.com/13884538/54862392-6755c300-4d10-11e9-9a40-b7d6f8e5cb0a.png)

## After
![arrowheads](https://user-images.githubusercontent.com/13884538/54862395-70469480-4d10-11e9-9133-e482cb4be869.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
