### PR TITLE
Reorder the logic of _update_title_position.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2514,10 +2514,8 @@ class _AxesBase(martist.Artist):
                     return
             self._autotitlepos = True
 
-        ymax = -10
         for title in titles:
-            x, y0 = title.get_position()
-            y = 1
+            x, _ = title.get_position()
             # need to start again in case of window resizing
             title.set_position((x, 1.0))
             # need to check all our twins too...
@@ -2534,20 +2532,15 @@ class _AxesBase(martist.Artist):
                     axs = axs + [ax]
             top = 0
             for ax in axs:
-                try:
-                    choices = ['top', 'unknown']
-                    if (ax.xaxis.get_label_position() == 'top' or
-                            ax.xaxis.get_ticks_position() in choices):
-                        bb = ax.xaxis.get_tightbbox(renderer)
-                    else:
-                        bb = ax.get_window_extent(renderer)
+                if (ax.xaxis.get_ticks_position() in ['top', 'unknown']
+                        or ax.xaxis.get_label_position() == 'top'):
+                    bb = ax.xaxis.get_tightbbox(renderer)
+                else:
+                    bb = ax.get_window_extent(renderer)
+                if bb is not None:
                     top = max(top, bb.ymax)
-                except AttributeError:
-                    # this happens for an empty bb
-                    y = 1
             if title.get_window_extent(renderer).ymin < top:
-                y = self.transAxes.inverted().transform(
-                        (0., top))[1]
+                _, y = self.transAxes.inverted().transform((0, top))
                 title.set_position((x, y))
                 # empirically, this doesn't always get the min to top,
                 # so we need to adjust again.
@@ -2555,10 +2548,11 @@ class _AxesBase(martist.Artist):
                     _, y = self.transAxes.inverted().transform(
                         (0., 2 * top - title.get_window_extent(renderer).ymin))
                     title.set_position((x, y))
-            ymax = max(y, ymax)
+
+        ymax = max(title.get_position()[1] for title in titles)
         for title in titles:
             # now line up all the titles at the highest baseline.
-            x, y0 = title.get_position()
+            x, _ = title.get_position()
             title.set_position((x, ymax))
 
     # Drawing


### PR DESCRIPTION
- Replace try... except by explicit check for None (which is the only
  case triggering an exception).
- Move ymax computation out of the loop.
- Remove some unused variables (`y0`) and inline `choices`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
