### PR TITLE
broken_barh docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2566,7 +2566,7 @@ class Axes(_AxesBase):
             The x-positions and extends of the rectangles. For each tuple
             (*xmin*, *xwidth*) a rectangle is drawn from *xmin* to *xmin* +
             *xwidth*.
-        yranges : (*ymin*, *ymax*)
+        yranges : (*ymin*, *ywidth*)
             The y-position and extend for all the rectangles.
 
         Other Parameters

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2566,7 +2566,7 @@ class Axes(_AxesBase):
             The x-positions and extends of the rectangles. For each tuple
             (*xmin*, *xwidth*) a rectangle is drawn from *xmin* to *xmin* +
             *xwidth*.
-        yranges : (*ymin*, *ywidth*)
+        yranges : (*ymin*, *yheight*)
             The y-position and extend for all the rectangles.
 
         Other Parameters

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2566,7 +2566,7 @@ class Axes(_AxesBase):
             The x-positions and extends of the rectangles. For each tuple
             (*xmin*, *xwidth*) a rectangle is drawn from *xmin* to *xmin* +
             *xwidth*.
-        yranges : (*ymin*, *yheight*)
+        yrange : (*ymin*, *yheight*)
             The y-position and extend for all the rectangles.
 
         Other Parameters


### PR DESCRIPTION
## PR Summary
Fixing the incorrect information in the broken_barh docstring, which was discussed in issue #13768. 
**Error**
```
yranges : (*ymin*, *ymax*)
The y-position and extend for all the rectangles.
```
The text of the explanation is correct, however, the *ymax* should have been *yheight*, as it is the extend of the height of the bar. A user might be confused with *ymax*.

## PR Checklist

Following checklist are not applicable in this case. 
- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
