### PR TITLE
GUI: add font widget for title with Qt

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -44,7 +44,8 @@ def figure_edit(axes, parent=None):
     xmin, xmax = map(float, axes.get_xlim())
     ymin, ymax = map(float, axes.get_ylim())
     general = [('Title', axes.get_title()),
-               ('Size', axes.title.get_size()),
+               ('Font', (axes.title.get_fontname(), int(axes.title.get_size()),
+                         False, False)),
                sep,
                (None, "<b>X-Axis</b>"),
                ('Left', xmin), ('Right', xmax),
@@ -188,7 +189,7 @@ def figure_edit(axes, parent=None):
             raise ValueError("Unexpected field")
 
         # Set / General
-        (title, titleSize, xmin, xmax, xlabel, xscale, ymin, ymax, ylabel,
+        (title, titlefont, xmin, xmax, xlabel, xscale, ymin, ymax, ylabel,
          yscale, generate_legend) = general
 
         if axes.get_xscale() != xscale:
@@ -196,7 +197,12 @@ def figure_edit(axes, parent=None):
         if axes.get_yscale() != yscale:
             axes.set_yscale(yscale)
 
-        axes.set_title(title, size=titleSize)
+        axes.set_title(title, fontdict=dict(
+            fontname=titlefont[0], size=titlefont[1],
+            fontstyle="italic" if titlefont[2] else "normal",
+            fontweight="bold" if titlefont[3] else "medium",
+            )
+        )
         axes.set_xlim(xmin, xmax)
         axes.set_xlabel(xlabel)
         axes.set_ylim(ymin, ymax)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -44,6 +44,7 @@ def figure_edit(axes, parent=None):
     xmin, xmax = map(float, axes.get_xlim())
     ymin, ymax = map(float, axes.get_ylim())
     general = [('Title', axes.get_title()),
+               ('Size', axes.title().get_size()),
                sep,
                (None, "<b>X-Axis</b>"),
                ('Left', xmin), ('Right', xmax),
@@ -187,15 +188,15 @@ def figure_edit(axes, parent=None):
             raise ValueError("Unexpected field")
 
         # Set / General
-        (title, xmin, xmax, xlabel, xscale, ymin, ymax, ylabel, yscale,
-         generate_legend) = general
+        (title, titleSize, xmin, xmax, xlabel, xscale, ymin, ymax, ylabel,
+         yscale, generate_legend) = general
 
         if axes.get_xscale() != xscale:
             axes.set_xscale(xscale)
         if axes.get_yscale() != yscale:
             axes.set_yscale(yscale)
 
-        axes.set_title(title)
+        axes.set_title(title, size=titleSize)
         axes.set_xlim(xmin, xmax)
         axes.set_xlabel(xlabel)
         axes.set_ylim(ymin, ymax)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -44,7 +44,7 @@ def figure_edit(axes, parent=None):
     xmin, xmax = map(float, axes.get_xlim())
     ymin, ymax = map(float, axes.get_ylim())
     general = [('Title', axes.get_title()),
-               ('Size', axes.title().get_size()),
+               ('Size', axes.title.get_size()),
                sep,
                (None, "<b>X-Axis</b>"),
                ('Left', xmin), ('Right', xmax),


### PR DESCRIPTION
## PR Summary

This is just a simple PR playing with Qt backend because I wanted to change the font size of an ax title without going through the interpreter.

I did not find anything related to guideline concerning the GUI, so I started this PR.

Please let me know if some GUI development are welcome, if so, I may continue.

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way