### PR TITLE
Use class-based directive for mathmpl sphinxext.

### DIFF
--- a/doc/api/next_api_changes/2019-01-09-deprecations.rst
+++ b/doc/api/next_api_changes/2019-01-09-deprecations.rst
@@ -1,8 +1,10 @@
 Deprecations
 ````````````
 
-The ``matplotlib.sphinxext.plot_directive`` interface has changed from
-the (Sphinx-)deprecated function-based interface to a class-based interface.
-This should not affect end users, but the
-``matplotlib.sphinxext.plot_directive.plot_directive`` function is now
+The ``matplotlib.sphinxext.mathmpl`` and
+``matplotlib.sphinxext.plot_directive`` interfaces have changed from the
+(Sphinx-)deprecated function-based interface to a class-based interface.  This
+should not affect end users, but the
+``matplotlib.sphinxext.mathmpl.math_directive`` and
+``matplotlib.sphinxext.plot_directive.plot_directive`` functions are now
 deprecated.


### PR DESCRIPTION
## PR Summary

This was done in #13138 for the plot directive, but not the math one.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way