### PR TITLE
Don't access internet during tests.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ environment:
   global:
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
-                 --cov-report= --cov=lib -m "not network" --log-level=DEBUG
+                 --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:
     # theoretically the CONDA_INSTALL_LOCN could be only two: one for 32bit,

--- a/doc/api/next_api_changes/2019-04-01-AL.rst
+++ b/doc/api/next_api_changes/2019-04-01-AL.rst
@@ -1,0 +1,7 @@
+API changes
+```````````
+
+The ``--no-network`` flag to ``tests.py`` has been removed (no test requires
+internet access anymore).  If it is desired to disable internet access both for
+old and new versions of Matplotlib, use ``tests.py -m 'not network'`` (which is
+now a no-op).

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -54,7 +54,6 @@ commands, such as:
 
 ========================  ===========
 ``--pep8``                Perform pep8 checks (requires pytest-pep8_)
-``-m "not network"``      Disable tests that require network access
 ========================  ===========
 
 Additional arguments are passed on to pytest. See the pytest documentation for

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -867,7 +867,7 @@ def rc_params(fail_on_error=False):
     return rc_params_from_file(matplotlib_fname(), fail_on_error)
 
 
-URL_REGEX = re.compile(r'http://|https://|ftp://|file://|file:\\')
+URL_REGEX = re.compile(r'^http://|^https://|^ftp://|^file:')
 
 
 def is_url(filename):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1379,12 +1379,20 @@ def imread(fname, format=None):
     if format is None:
         if isinstance(fname, str):
             parsed = urllib.parse.urlparse(fname)
-            # If the string is a URL, assume png
+            # If the string is a URL (Windows paths appear as if they have a
+            # length-1 scheme), assume png.
             if len(parsed.scheme) > 1:
                 ext = 'png'
             else:
                 basename, ext = os.path.splitext(fname)
                 ext = ext.lower()[1:]
+        elif hasattr(fname, 'geturl'):  # Returned by urlopen().
+            # We could try to parse the url's path and use the extension, but
+            # returning png is consistent with the block above.  Note that this
+            # if clause has to come before checking for fname.name as
+            # urlopen("file:///...") also has a name attribute (with the fixed
+            # value "<urllib response>").
+            ext = 'png'
         elif hasattr(fname, 'name'):
             basename, ext = os.path.splitext(fname.name)
             ext = ext.lower()[1:]

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -5,6 +5,7 @@ import os
 import sys
 from pathlib import Path
 import platform
+import sys
 import urllib.request
 import warnings
 
@@ -657,9 +658,11 @@ def test_minimized_rasterized():
                 assert False
 
 
-@pytest.mark.network
 def test_load_from_url():
-    url = "http://matplotlib.org/_static/logo_sidebar_horiz.png"
+    path = Path(__file__).parent / "baseline_images/test_image/imshow.png"
+    url = ('file:'
+           + ('///' if sys.platform == 'win32' else '')
+           + path.resolve().as_posix())
     plt.imread(url)
     plt.imread(urllib.request.urlopen(url))
 

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 import gc
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import sys
 
 import pytest
 
@@ -56,10 +57,14 @@ def test_use():
             assert mpl.rcParams[PARAM] == VALUE
 
 
-@pytest.mark.network
-def test_use_url():
+def test_use_url(tmpdir):
+    path = Path(tmpdir, 'file')
+    path.write_text('axes.facecolor: adeade')
     with temp_style('test', DUMMY_SETTINGS):
-        with style.context('https://gist.github.com/adrn/6590261/raw'):
+        url = ('file:'
+               + ('///' if sys.platform == 'win32' else '')
+               + path.resolve().as_posix())
+        with style.context(url):
             assert mpl.rcParams['axes.facecolor'] == "#adeade"
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,4 @@ python_files = test_*.py
 
 markers =
     backend: Set alternate Matplotlib backend temporarily.
-    network: Mark a test that uses the network.
     style: Set alternate Matplotlib style temporarily.

--- a/tests.py
+++ b/tests.py
@@ -39,16 +39,9 @@ if __name__ == '__main__':
     from matplotlib import test
 
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('--no-network', action='store_true',
-                        help='Run tests without network connection')
     parser.add_argument('--recursionlimit', type=int, default=0,
                         help='Specify recursionlimit for test run')
     args, extra_args = parser.parse_known_args()
-
-    if args.no_network:
-        from matplotlib.testing import disable_internet
-        disable_internet.turn_off_internet()
-        extra_args.extend(['-m', 'not network'])
 
     print('Python byte-compilation optimization level:', sys.flags.optimize)
 


### PR DESCRIPTION
The tests that style.use() and imread() support urls can just use local
urls (`file://`); this avoids failing the tests when downloading the
gist fails due to a flaky connection.

Since RFC8089 file: urls don't necessarily start with two slashes
anymore (https://tools.ietf.org/html/rfc8089#appendix-A).

(If we really want to test https we could use http.server to spin up a local server but that seems overkill.)


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
