### PR TITLE
Make _warn_external correctly report warnings arising from tests.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2041,7 +2041,7 @@ def _warn_external(message, category=None):
         if frame is None:
             # when called in embedded context may hit frame is None
             break
-        if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.)",
+        if not re.match(r"\A(matplotlib|mpl_toolkits)(\Z|\.(?!tests\.))",
                         # Work around sphinx-gallery not setting __name__.
                         frame.f_globals.get("__name__", "")):
             break

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -560,3 +560,9 @@ def test_make_keyword_only(recwarn):
         func(1, 2)
     with pytest.warns(MatplotlibDeprecationWarning):
         func(1, 2, 3)
+
+
+def test_warn_external(recwarn):
+    cbook._warn_external("oops")
+    assert len(recwarn) == 1
+    assert recwarn[0].filename == __file__


### PR DESCRIPTION
Before the PR:
```
$ pytest lib/matplotlib/tests/test_cbook.py::test_is_hashable
<elided>
lib/matplotlib/tests/test_cbook.py::test_is_hashable
  .../site-packages/_pytest/python.py:166: MatplotlibDeprecationWarning:
  The is_hashable function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use isinstance(..., collections.abc.Hashable) instead.
    testfunction(**testargs)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```
After
```
$ pytest lib/matplotlib/tests/test_cbook.py::test_is_hashable
<elided>
lib/matplotlib/tests/test_cbook.py::test_is_hashable
  .../lib/matplotlib/tests/test_cbook.py:22: MatplotlibDeprecationWarning:
  The is_hashable function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use isinstance(..., collections.abc.Hashable) instead.
    assert cbook.is_hashable(s)

lib/matplotlib/tests/test_cbook.py::test_is_hashable
  .../lib/matplotlib/tests/test_cbook.py:25: MatplotlibDeprecationWarning:
  The is_hashable function was deprecated in Matplotlib 3.1 and will be removed in 3.3. Use isinstance(..., collections.abc.Hashable) instead.
    assert not cbook.is_hashable(lst)
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
