### PR TITLE
Pin Sphinx to 1.x

### DIFF
--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.8.1
+sphinx>=1.8.1,<2.0.0
 colorspacious
 ipython
 ipywidgets


### PR DESCRIPTION
## PR Summary

As reported in #13591 the matplotlib style is not rendered correctly with sphinx 2.0.
See also e.g. https://matplotlib.org/devdocs/api/axes_api.html.

As a temporary containment (and in the prospect that 3.1 might be released soon), this pins sphinx to <2.0 to keep the docs correctly rendered.

In the long run, we need to adapt the matplotlib style.