### PR TITLE
Remove borders from barcode example

### DIFF
--- a/examples/images_contours_and_fields/barcode_demo.py
+++ b/examples/images_contours_and_fields/barcode_demo.py
@@ -14,17 +14,18 @@ np.random.seed(19680801)
 # the bar
 x = np.random.rand(500) > 0.7
 
-axprops = dict(xticks=[], yticks=[])
 barprops = dict(aspect='auto', cmap='binary', interpolation='nearest')
 
 fig = plt.figure()
 
 # a vertical barcode
-ax1 = fig.add_axes([0.1, 0.3, 0.1, 0.6], **axprops)
+ax1 = fig.add_axes([0.1, 0.1, 0.1, 0.8])
+ax1.set_axis_off()
 ax1.imshow(x.reshape((-1, 1)), **barprops)
 
 # a horizontal barcode
-ax2 = fig.add_axes([0.3, 0.1, 0.6, 0.1], **axprops)
+ax2 = fig.add_axes([0.3, 0.4, 0.6, 0.2])
+ax2.set_axis_off()
 ax2.imshow(x.reshape((1, -1)), **barprops)
 
 plt.show()


### PR DESCRIPTION
## PR Summary

While it's still not a realistic bar code, lets remove the axes borders so that it looks a bit more like a bar code. Also change the positioning so that the barcodes are not awkwardly squeezed to the side with a lot of empty space in the center.

Previously: https://matplotlib.org/gallery/images_contours_and_fields/barcode_demo.html

Now:
![image](https://user-images.githubusercontent.com/2836374/55288341-5c58fd80-53b6-11e9-99c1-401818488edf.png)

