### PR TITLE
incorrect error bar colors when NaN values are present

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3211,6 +3211,19 @@ class Axes(_AxesBase):
 
         if not np.iterable(y):
             y = [y]
+        # The actual errorbar function works even if lengths of x and y
+        # dont matches with "ecolor" inorder to retain the same behavior
+        # the new change will only effect if lengths matches
+        if iterable(ecolor) and len(ecolor) == len(x) and len(ecolor) == len(y):
+            # To get np.nan indices in both x and y lists
+            nan_indices = list(np.where(np.isnan(x))[
+                               0]) + list(np.where(np.isnan(y))[0])
+            # To remove duplicates
+            nan_indices = list(set(nan_indices))
+            ecolor = np.array(ecolor)
+            # To delete colors corrresonding to np.nan in  x and y
+            ecolor = np.delete(ecolor, nan_indices)
+            ecolor = list(ecolor)
 
         if xerr is not None:
             if not np.iterable(xerr):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3214,7 +3214,7 @@ class Axes(_AxesBase):
         # The actual errorbar function works even if lengths of x and y
         # dont matches with "ecolor" inorder to retain the same behavior
         # the new change will only effect if lengths matches
-        if iterable(ecolor) and len(ecolor) == len(x) and len(ecolor) == len(y):
+        if np.iterable(ecolor) and len(ecolor) == len(x) and len(ecolor) == len(y):
             # To get np.nan indices in both x and y lists
             nan_indices = list(np.where(np.isnan(x))[
                                0]) + list(np.where(np.isnan(y))[0])


### PR DESCRIPTION
BUG:13799


## PR Summary
incorrect error bar colors when NaN values are present
https://github.com/matplotlib/matplotlib/issues/13799

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
