### PR TITLE
Enh optional tick deconflict

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1326,10 +1326,11 @@ class Axis(martist.Artist):
         # Use the transformed view limits as scale.  1e-5 is the default rtol
         # for np.isclose.
         tol = (hi - lo) * 1e-5
-        minor_locs = [
-            loc for loc, tr_loc in zip(minor_locs, tr_minor_locs)
-            if (not remove_overlaps or
-                not np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any())]
+        if remove_overlaps:
+            minor_locs = [
+                loc for loc, tr_loc in zip(minor_locs, tr_minor_locs)
+                if ~(np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any())
+            ]
         return minor_locs
 
     def get_ticklocs(self, minor=False):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1064,19 +1064,18 @@ class Axis(martist.Artist):
         Update ticks (position and labels) using the current data interval of
         the axes.  Return the list of ticks that will be drawn.
         """
-
-        major_locs = self.major.locator()
+        major_locs = self.get_majorticklocs()
+        major_labels = self.major.formatter.format_ticks(major_locs)
         major_ticks = self.get_major_ticks(len(major_locs))
         self.major.formatter.set_locs(major_locs)
-        major_labels = self.major.formatter.format_ticks(major_locs)
         for tick, loc, label in zip(major_ticks, major_locs, major_labels):
             tick.update_position(loc)
             tick.set_label1(label)
             tick.set_label2(label)
-        minor_locs = self.minor.locator()
+        minor_locs = self.get_minorticklocs()
+        minor_labels = self.minor.formatter.format_ticks(minor_locs)
         minor_ticks = self.get_minor_ticks(len(minor_locs))
         self.minor.formatter.set_locs(minor_locs)
-        minor_labels = self.minor.formatter.format_ticks(minor_locs)
         for tick, loc, label in zip(minor_ticks, minor_locs, minor_labels):
             tick.update_position(loc)
             tick.set_label1(label)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1316,6 +1316,9 @@ class Axis(martist.Artist):
         # Remove minor ticks duplicating major ticks.
         major_locs = self.major.locator()
         minor_locs = self.minor.locator()
+        # we do check when we set the attribute that this is a Locator
+        # subclass, use getattr out of an over abundance of caution
+        remove_overlaps = getattr(self.minor.locator, 'remove_overlaps', True)
         transform = self._scale.get_transform()
         tr_minor_locs = transform.transform(minor_locs)
         tr_major_locs = transform.transform(major_locs)
@@ -1325,7 +1328,8 @@ class Axis(martist.Artist):
         tol = (hi - lo) * 1e-5
         minor_locs = [
             loc for loc, tr_loc in zip(minor_locs, tr_minor_locs)
-            if not np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any()]
+            if (not remove_overlaps or
+                not np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any())]
         return minor_locs
 
     def get_ticklocs(self, minor=False):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1469,6 +1469,11 @@ class Locator(TickHelper):
     # many ticks are generated.
     MAXTICKS = 1000
 
+    # Default to requsting minor locators have overlapping ticks with the
+    # major locator removed.  If you want to have overlapping ticks, set
+    # this to False on the Locator instance.
+    remove_overlaps = True
+
     def tick_values(self, vmin, vmax):
         """
         Return the values of the located ticks given **vmin** and **vmax**.


### PR DESCRIPTION
The name is up for debate as is threading it through all of the `__init__` methods.

Docs and tests will follow if we agree on this approach and settle on some names.

This now works as expected:

```python


import numpy as np
import matplotlib.dates as mdates
import matplotlib.pyplot as plt

t = np.arange("2018-11-03", "2018-11-06", dtype="datetime64")
x = np.random.rand(len(t))

fig, ax = plt.subplots()
ax.plot(t,x)

ax.xaxis.set_major_locator(mdates.DayLocator())
ax.xaxis.set_major_formatter(mdates.DateFormatter('\n%a'))

ax.xaxis.set_minor_locator(mdates.HourLocator((0,6,12,18),
                                              enable_deconflict=False))
ax.xaxis.set_minor_formatter(mdates.DateFormatter('%H:%M'))
plt.show()
```
