### PR TITLE
Better MovieWriter init error message

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -235,8 +235,9 @@ class AbstractMovieWriter(abc.ABC):
 class MovieWriter(AbstractMovieWriter):
     '''Base class for writing movies.
 
-    This class is set up to provide for writing movie frame data to a pipe.
-    See examples for how to use these classes.
+    This is a base class for MovieWriter subclasses that write a movie frame
+    data to a pipe. You cannot instantiate this class directly.
+    See examples for how to use its subclasses.
 
     Attributes
     ----------
@@ -274,6 +275,15 @@ class MovieWriter(AbstractMovieWriter):
             output file. Some keys that may be of use include:
             title, artist, genre, subject, copyright, srcform, comment.
         '''
+        if self.__class__ is MovieWriter:
+            # TODO MovieWriter is still an abstract class and needs to be
+            #      extended with a mixin. This should be clearer in naming
+            #      and description. For now, just give a reasonable error
+            #      message to users.
+            raise TypeError(
+                'MovieWriter cannot be instantiated directly. Please use one '
+                'of its subclasses.')
+
         self.fps = fps
         self.frame_format = 'rgba'
 

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -77,8 +77,11 @@ def test_null_movie_writer():
 
 
 def test_movie_writer_dpi_default():
-    # Test setting up movie writer with figure.dpi default.
+    class DummyMovieWriter(animation.MovieWriter):
+        def _run(self):
+            pass
 
+    # Test setting up movie writer with figure.dpi default.
     fig = plt.figure()
 
     filename = "unused.null"
@@ -87,11 +90,7 @@ def test_movie_writer_dpi_default():
     bitrate = 1
     extra_args = ["unused"]
 
-    def run():
-        pass
-
-    writer = animation.MovieWriter(fps, codec, bitrate, extra_args)
-    writer._run = run
+    writer = DummyMovieWriter(fps, codec, bitrate, extra_args)
     writer.setup(fig, filename)
     assert writer.dpi == fig.dpi
 


### PR DESCRIPTION
## PR Summary

From https://github.com/matplotlib/matplotlib/issues/5403#issuecomment-478428564. Calling `MovieWriter(fps=25)` results in a not quite helpful error message `'MovieWriter' object has no attribute 'args_key'`. 

This is just a quick fix to give a reasonable error message, and get that improved user experience in with 3.1.

A full solution should add a description on the mixin mechanism, and maybe even join AbstractMovieWriter and MovieWriter classes. But that's beyond the scope of this PR.