### PR TITLE
MNT: account for cpython deprecations

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Cocoa/Cocoa.h>
 #include <ApplicationServices/ApplicationServices.h>
 #include <sys/socket.h>

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -9,7 +9,7 @@
    Undefining _POSIX_C_SOURCE and _XOPEN_SOURCE stops a couple
    of harmless warnings.
 */
-
+#define PY_SSIZE_T_CLEAN
 
 extern "C" {
 #   include <png.h>

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -7,7 +7,7 @@
  * See LICENSE/LICENSE.PIL for details.
  *
  */
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <cstdlib>
 #include <cstdio>

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -5,7 +5,7 @@
 
   Python wrapper for TrueType conversion library in ../ttconv.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include "mplutils.h"
 
 #include <Python.h>

--- a/src/file_compat.h
+++ b/src/file_compat.h
@@ -1,6 +1,6 @@
 #ifndef MPL_FILE_COMPAT_H
 #define MPL_FILE_COMPAT_H
-
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdio.h>
 #include "numpy/npy_common.h"

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -4,6 +4,7 @@
 
 #ifndef MPLUTILS_H
 #define MPLUTILS_H
+#define PY_SSIZE_T_CLEAN
 
 #include <stdint.h>
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -2,7 +2,7 @@
 
 #ifndef MPL_NUMPY_CPP_H
 #define MPL_NUMPY_CPP_H
-
+#define PY_SSIZE_T_CLEAN
 /***************************************************************************
  * This file is based on original work by Mark Wiebe, available at:
  *

--- a/src/py_adaptors.h
+++ b/src/py_adaptors.h
@@ -2,7 +2,7 @@
 
 #ifndef MPL_PY_ADAPTORS_H
 #define MPL_PY_ADAPTORS_H
-
+#define PY_SSIZE_T_CLEAN
 /***************************************************************************
  * This module contains a number of C++ classes that adapt Python data
  * structures to C++ and Agg-friendly interfaces.

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -1,5 +1,5 @@
 #define NO_IMPORT_ARRAY
-
+#define PY_SSIZE_T_CLEAN
 #include "py_converters.h"
 #include "numpy_cpp.h"
 

--- a/src/qhull_wrap.c
+++ b/src/qhull_wrap.c
@@ -5,6 +5,7 @@
  * triangulation, construct an instance of the matplotlib.tri.Triangulation
  * class without specifying a triangles array.
  */
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "numpy/ndarrayobject.h"
 #include "libqhull/qhull_a.h"


### PR DESCRIPTION
The # variants the PyArg formats will raise deprecation warnings in
py38.

https://bugs.python.org/issue8677
https://bugs.python.org/issue36381
https://github.com/python/cpython/pull/12473
https://github.com/python/cpython/commit/d3c72a223a5f771f964fc34557c55eb5bfa0f5a0

We should have done this a while ago :man_shrugging: .