### PR TITLE
Fix some broken documentation links

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -615,7 +615,7 @@ for it in the :ref:`users-guide-index`.  And so on...  I think you get the
 idea.
 
 Matplotlib is documented using the `sphinx
-<http://www.sphinx-doc.org/index.html>`_ extensions to restructured text
+<http://www.sphinx-doc.org/en/stable/>`_ extensions to restructured text
 `(ReST) <http://docutils.sourceforge.net/rst.html>`_.  sphinx is an
 extensible python framework for documentation projects which generates
 HTML and PDF, and is pretty easy to write; you can see the source for this

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -62,9 +62,9 @@ plotnine
 ========
 
 `plotnine <https://plotnine.readthedocs.io/en/stable/>`_ implements a grammar
-of graphics, similar to R's `ggplot2 <http://ggplot2.org/>`_. The grammar allows
-users to compose plots by explicitly mapping data to the visual objects that
-make up the plot.
+of graphics, similar to R's `ggplot2 <https://ggplot2.tidyverse.org/>`_.
+The grammar allows users to compose plots by explicitly mapping data to the
+visual objects that make up the plot.
 
 .. image:: /_static/plotnine.png
 

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -180,6 +180,6 @@ plt.plot(data)
 # .. literalinclude:: ../../../matplotlibrc.template
 #
 #
-# .. _ggplot: http://ggplot2.org/
+# .. _ggplot: https://ggplot2.tidyverse.org/
 # .. _R: https://www.r-project.org/
 # .. _provided by Matplotlib: https://github.com/matplotlib/matplotlib/tree/master/lib/matplotlib/mpl-data/stylelib


### PR DESCRIPTION
Don't have time to fix them all at the moment, but here's a few so they don't get lost...