### PR TITLE
Deprecate setting Axis.major.locator to non-Locator; idem for Formatters

### DIFF
--- a/doc/api/next_api_changes/2019-04-02-AL.rst
+++ b/doc/api/next_api_changes/2019-04-02-AL.rst
@@ -1,0 +1,8 @@
+Deprecations
+````````````
+
+Setting ``Axis.major.locator``, ``Axis.minor.locator``, ``Axis.major.formatter``
+or ``Axis.minor.formatter`` to an object that is not a subclass of `Locator` or
+`Formatter` (respectively) is deprecated.  Note that these attributes should
+usually be set using `Axis.set_major_locator`, `Axis.set_minor_locator`, etc.
+which already raise an exception when an object of the wrong class is passed.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -640,8 +640,36 @@ class Ticker(object):
     formatter : `matplotlib.ticker.Formatter` subclass
         Determines the format of the tick labels.
     """
-    locator = None
-    formatter = None
+
+    def __init__(self):
+        self._locator = None
+        self._formatter = None
+
+    @property
+    def locator(self):
+        return self._locator
+
+    @locator.setter
+    def locator(self, locator):
+        if not isinstance(locator, mticker.Locator):
+            cbook.warn_deprecated(
+                "3.2", message="Support for locators that do not subclass "
+                "matplotlib.ticker.Locator is deprecated since %(since)s and "
+                "support for them will be removed %(removal)s.")
+        self._locator = locator
+
+    @property
+    def formatter(self):
+        return self._formatter
+
+    @formatter.setter
+    def formatter(self, formatter):
+        if not isinstance(formatter, mticker.Formatter):
+            cbook.warn_deprecated(
+                "3.2", message="Support for formatters that do not subclass "
+                "matplotlib.ticker.Formatter is deprecated since %(since)s "
+                "and support for them will be removed %(removal)s.")
+        self._formatter = formatter
 
 
 class _LazyTickList(object):


### PR DESCRIPTION
See changelog.

This is so that we can actually add new APIs to the base class (e.g.
format_ticks; tick_deconflict (however that one ends up being named)
and actually benefit from it in the rest of the codebase without
worrying that third-party locators/formatters do not inherit from the
base class (note that inheriting from the base class does not preclude
third-party locators/formatters from completely redefining all methods,
so this does not limit them).

(e.g. https://github.com/matplotlib/matplotlib/pull/13826/files#diff-52127080e2783464f529df684d82d476R1319)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
