### PR TITLE
Cleanup contour.py.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1542,33 +1542,27 @@ class Transform(TransformNode):
         # Must be 2D
         if self.input_dims != 2 or self.output_dims != 2:
             raise NotImplementedError('Only defined in 2D')
-
-        if pts.shape[1] != 2:
-            raise ValueError("'pts' must be array with 2 columns for x,y")
-
+        angles = np.asarray(angles)
+        pts = np.asarray(pts)
         if angles.ndim != 1 or angles.shape[0] != pts.shape[0]:
             raise ValueError("'angles' must be a column vector and have same "
                              "number of rows as 'pts'")
-
+        if pts.shape[1] != 2:
+            raise ValueError("'pts' must be array with 2 columns for x,y")
         # Convert to radians if desired
         if not radians:
-            angles = angles / 180.0 * np.pi
-
+            angles = np.deg2rad(angles)
         # Move a short distance away
         pts2 = pts + pushoff * np.c_[np.cos(angles), np.sin(angles)]
-
         # Transform both sets of points
         tpts = self.transform(pts)
         tpts2 = self.transform(pts2)
-
         # Calculate transformed angles
         d = tpts2 - tpts
         a = np.arctan2(d[:, 1], d[:, 0])
-
         # Convert back to degrees if desired
         if not radians:
             a = np.rad2deg(a)
-
         return a
 
     def inverted(self):


### PR DESCRIPTION
- Replace `*args`-parsing in clabel by standard parameters; clarify the
  method's docstring (the `cs` parameter is actually `self`).
- TexManager is a singleton so no need to cache it explicitly.
- Some f-stringification (in helpful cases).
- `a and b or c` -> ternary.
- Simplify `ClabelText.get_rotation` by making `transform_angles` accept
  array-likes instead of just arrays.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
