### PR TITLE
Ensure figsize is positive finite

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -345,9 +345,9 @@ class Figure(Artist):
         if frameon is None:
             frameon = rcParams['figure.frameon']
 
-        if not np.isfinite(figsize).all():
-            raise ValueError('figure size must be finite not '
-                             '{}'.format(figsize))
+        if not np.isfinite(figsize).all() or (np.array(figsize) <= 0).any():
+            raise ValueError('figure size must be positive finite not '
+                             f'{figsize}')
         self.bbox_inches = Bbox.from_bounds(0, 0, *figsize)
 
         self.dpi_scale_trans = Affine2D().scale(dpi, dpi)
@@ -895,9 +895,9 @@ default: 'top'
         # argument, so unpack them
         if h is None:
             w, h = w
-        if not all(np.isfinite(_) for _ in (w, h)):
-            raise ValueError('figure size must be finite not '
-                             '({}, {})'.format(w, h))
+        size = w, h
+        if not np.isfinite(size).all() or (np.array(size) <= 0).any():
+            raise ValueError(f'figure size must be positive finite not {size}')
         self.bbox_inches.p1 = w, h
 
         if forward:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -325,14 +325,23 @@ def test_change_dpi():
     assert fig.canvas.renderer.width == 200
 
 
-def test_invalid_figure_size():
+@pytest.mark.parametrize('width, height', [
+    (1, np.nan),
+    (0, 1),
+    (-1, 1),
+    (np.inf, 1)
+])
+def test_invalid_figure_size(width, height):
     with pytest.raises(ValueError):
-        plt.figure(figsize=(1, np.nan))
+        plt.figure(figsize=(width, height))
 
     fig = plt.figure()
     with pytest.raises(ValueError):
-        fig.set_size_inches(1, np.nan)
+        fig.set_size_inches(width, height)
 
+
+def test_invalid_figure_add_axes():
+    fig = plt.figure()
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
 


### PR DESCRIPTION
## PR Summary

Fixes #13857. We were only checking for finite figsize. Changed that to positive finite.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant