### PR TITLE
Deprecate {Locator,Formatter}.set_{{view,data}_interval,bounds}.

### DIFF
--- a/doc/api/next_api_changes/deprecations/13860-AL.rst
+++ b/doc/api/next_api_changes/deprecations/13860-AL.rst
@@ -1,0 +1,6 @@
+Locator and Formatter wrapper methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``set_view_interval``, ``set_data_interval`` and ``set_bounds`` methods of
+`.Locator`\s and `.Formatter`\s (and their common base class, TickHelper) are
+deprecated.  Directly manipulate the view and data intervals on the underlying
+axis instead.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1128,7 +1128,9 @@ class PathCollection(_CollectionWithSizes):
             raise ValueError("Valid values for `prop` are 'colors' or "
                              f"'sizes'. You supplied '{prop}' instead.")
 
-        fmt.set_bounds(func(u).min(), func(u).max())
+        fu = func(u)
+        fmt.axis.set_view_interval(fu.min(), fu.max())
+        fmt.axis.set_data_interval(fu.min(), fu.max())
         if num == "auto":
             num = 9
             if len(u) <= num:

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -869,11 +869,9 @@ class ColorbarBase:
         else:
             intv = self.vmin, self.vmax
         locator.create_dummy_axis(minpos=intv[0])
-        formatter.create_dummy_axis(minpos=intv[0])
-        locator.set_view_interval(*intv)
-        locator.set_data_interval(*intv)
-        formatter.set_view_interval(*intv)
-        formatter.set_data_interval(*intv)
+        locator.axis.set_view_interval(*intv)
+        locator.axis.set_data_interval(*intv)
+        formatter.set_axis(locator.axis)
 
         b = np.array(locator())
         if isinstance(locator, ticker.LogLocator):

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1480,10 +1480,6 @@ class AutoDateLocator(DateLocator):
                     'epoch.')
 
         locator.set_axis(self.axis)
-
-        if self.axis is not None:
-            locator.set_view_interval(*self.axis.get_view_interval())
-            locator.set_data_interval(*self.axis.get_data_interval())
         return locator
 
 
@@ -1727,10 +1723,12 @@ class MicrosecondLocator(DateLocator):
         self._wrapped_locator.set_axis(axis)
         return super().set_axis(axis)
 
+    @_api.deprecated("3.5", alternative=".axis.set_view_interval")
     def set_view_interval(self, vmin, vmax):
         self._wrapped_locator.set_view_interval(vmin, vmax)
         return super().set_view_interval(vmin, vmax)
 
+    @_api.deprecated("3.5", alternative=".axis.set_data_interval")
     def set_data_interval(self, vmin, vmax):
         self._wrapped_locator.set_data_interval(vmin, vmax)
         return super().set_data_interval(vmin, vmax)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -280,7 +280,7 @@ def test_date_formatter_usetex(delta, expected):
 
     locator = mdates.AutoDateLocator(interval_multiples=False)
     locator.create_dummy_axis()
-    locator.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
+    locator.axis.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
 
     formatter = mdates.AutoDateFormatter(locator, usetex=True)
     assert [formatter(loc) for loc in locator()] == expected
@@ -319,8 +319,7 @@ def test_auto_date_locator():
     def _create_auto_date_locator(date1, date2):
         locator = mdates.AutoDateLocator(interval_multiples=False)
         locator.create_dummy_axis()
-        locator.set_view_interval(mdates.date2num(date1),
-                                  mdates.date2num(date2))
+        locator.axis.set_view_interval(*mdates.date2num([date1, date2]))
         return locator
 
     d1 = datetime.datetime(1990, 1, 1)
@@ -391,8 +390,7 @@ def test_auto_date_locator_intmult():
     def _create_auto_date_locator(date1, date2):
         locator = mdates.AutoDateLocator(interval_multiples=True)
         locator.create_dummy_axis()
-        locator.set_view_interval(mdates.date2num(date1),
-                                  mdates.date2num(date2))
+        locator.axis.set_view_interval(*mdates.date2num([date1, date2]))
         return locator
 
     results = ([datetime.timedelta(weeks=52 * 200),
@@ -574,7 +572,7 @@ def test_concise_formatter_usetex(t_delta, expected):
 
     locator = mdates.AutoDateLocator(interval_multiples=True)
     locator.create_dummy_axis()
-    locator.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
+    locator.axis.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
 
     formatter = mdates.ConciseDateFormatter(locator, usetex=True)
     assert formatter.format_ticks(locator()) == expected
@@ -732,8 +730,7 @@ def test_auto_date_locator_intmult_tz():
     def _create_auto_date_locator(date1, date2, tz):
         locator = mdates.AutoDateLocator(interval_multiples=True, tz=tz)
         locator.create_dummy_axis()
-        locator.set_view_interval(mdates.date2num(date1),
-                                  mdates.date2num(date2))
+        locator.axis.set_view_interval(*mdates.date2num([date1, date2]))
         return locator
 
     results = ([datetime.timedelta(weeks=52*200),
@@ -951,8 +948,8 @@ def test_yearlocator_pytz():
          + datetime.timedelta(i) for i in range(2000)]
     locator = mdates.AutoDateLocator(interval_multiples=True, tz=tz)
     locator.create_dummy_axis()
-    locator.set_view_interval(mdates.date2num(x[0])-1.0,
-                              mdates.date2num(x[-1])+1.0)
+    locator.axis.set_view_interval(mdates.date2num(x[0])-1.0,
+                                   mdates.date2num(x[-1])+1.0)
     t = np.array([733408.208333, 733773.208333, 734138.208333,
                   734503.208333, 734869.208333, 735234.208333, 735599.208333])
     # convert to new epoch from old...
@@ -1035,8 +1032,8 @@ def test_warn_notintervals():
     locator = mdates.AutoDateLocator(interval_multiples=False)
     locator.intervald[3] = [2]
     locator.create_dummy_axis()
-    locator.set_view_interval(mdates.date2num(dates[0]),
-                              mdates.date2num(dates[-1]))
+    locator.axis.set_view_interval(mdates.date2num(dates[0]),
+                                   mdates.date2num(dates[-1]))
     with pytest.warns(UserWarning, match="AutoDateLocator was unable") as rec:
         locs = locator()
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -558,7 +558,7 @@ class TestScalarFormatter:
             assert tmp_form.get_useLocale()
 
             tmp_form.create_dummy_axis()
-            tmp_form.set_bounds(0, 10)
+            tmp_form.axis.set_data_interval(0, 10)
             tmp_form.set_locs([1, 2, 3])
             assert sep in tmp_form(1e9)
 
@@ -589,7 +589,7 @@ class TestScalarFormatter:
         # Issue #17624
         sf = mticker.ScalarFormatter()
         sf.create_dummy_axis()
-        sf.set_bounds(0, 10)
+        sf.axis.set_view_interval(0, 10)
         fmt = sf.format_data_short
         assert fmt(data) == expected
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -231,12 +231,17 @@ class TickHelper:
         if self.axis is None:
             self.axis = _DummyAxis(**kwargs)
 
+    @_api.deprecated("3.5", alternative=".axis.set_view_interval")
     def set_view_interval(self, vmin, vmax):
         self.axis.set_view_interval(vmin, vmax)
 
+    @_api.deprecated("3.5", alternative=".axis.set_data_interval")
     def set_data_interval(self, vmin, vmax):
         self.axis.set_data_interval(vmin, vmax)
 
+    @_api.deprecated(
+        "3.5",
+        alternative=".axis.set_view_interval and .axis.set_data_interval")
     def set_bounds(self, vmin, vmax):
         self.set_view_interval(vmin, vmax)
         self.set_data_interval(vmin, vmax)

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -222,8 +222,7 @@ class MaxNLocator(mticker.MaxNLocator):
         self._factor = 1
 
     def __call__(self, v1, v2):
-        self.set_bounds(v1 * self._factor, v2 * self._factor)
-        locs = super().__call__()
+        locs = super().tick_values(v1 * self._factor, v2 * self._factor)
         return np.array(locs), len(locs), self._factor
 
     @_api.deprecated("3.3")


### PR DESCRIPTION
Directly manipulating the underlying axis' view and data intervals is
clearer (see e.g. the changes in dates.py which ultimately just deletes
code that sets `self.axis`'s view and data intervals to themselves).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
