### PR TITLE
Switch PyArg_ParseTupleAndKeywords from "es" to "s".

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -812,10 +812,10 @@ static PyObject*
 FigureManager_set_window_title(FigureManager* self,
                                PyObject *args, PyObject *kwds)
 {
-    char* title;
-    if(!PyArg_ParseTuple(args, "es", "UTF-8", &title))
+    const char* title;
+    if (!PyArg_ParseTuple(args, "s", &title)) {
         return NULL;
-
+    }
     Window* window = self->window;
     if(window)
     {
@@ -826,7 +826,6 @@ FigureManager_set_window_title(FigureManager* self,
         [window setTitle: ns_title];
         [pool release];
     }
-    PyMem_Free(title);
     Py_RETURN_NONE;
 }
 
@@ -1369,10 +1368,10 @@ choose_save_file(PyObject* unused, PyObject* args)
 {
     int result;
     const char* title;
-    char* default_filename;
-    if(!PyArg_ParseTuple(args, "ses", &title, "UTF-8", &default_filename))
+    const char* default_filename;
+    if (!PyArg_ParseTuple(args, "ss", &title, &default_filename)) {
         return NULL;
-
+    }
     NSSavePanel* panel = [NSSavePanel savePanel];
     [panel setTitle: [NSString stringWithCString: title
                                         encoding: NSASCIIStringEncoding]];
@@ -1380,7 +1379,6 @@ choose_save_file(PyObject* unused, PyObject* args)
         [[NSString alloc]
          initWithCString: default_filename
          encoding: NSUTF8StringEncoding];
-    PyMem_Free(default_filename);
 #ifdef COMPILING_FOR_10_6
     [panel setNameFieldStringValue: ns_default_filename];
     result = [panel runModal];

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1066,15 +1066,10 @@ static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args, PyObj
 {
     char *glyphname;
     long name_index;
-
-    if (!PyArg_ParseTuple(args, "es:get_name_index", "ascii", &glyphname)) {
+    if (!PyArg_ParseTuple(args, "s:get_name_index", &glyphname)) {
         return NULL;
     }
-
     CALL_CPP("get_name_index", name_index = self->x->get_name_index(glyphname));
-
-    PyMem_Free(glyphname);
-
     return PyLong_FromLong(name_index);
 }
 
@@ -1114,8 +1109,7 @@ const char *PyFT2Font_get_sfnt_table__doc__ =
 static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
     char *tagname;
-
-    if (!PyArg_ParseTuple(args, "es:get_sfnt_table", "ascii", &tagname)) {
+    if (!PyArg_ParseTuple(args, "s:get_sfnt_table", &tagname)) {
         return NULL;
     }
 
@@ -1127,8 +1121,6 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObj
             break;
         }
     }
-
-    PyMem_Free(tagname);
 
     void *table = FT_Get_Sfnt_Table(self->x->get_face(), (FT_Sfnt_Tag)tag);
     if (!table) {


### PR DESCRIPTION
This avoids having to call PyMem_Free ourselves.

Note that all call sites either already use utf-8 (which "s" does), or
use ascii but then match the string against some ascii-only strings (or
glyph names), so the change is fine encoding-wise.

Perhaps this will fix #13865? (which fails with a MemoryError in get_sfnt_table)

edit: well no, this segfaults the doc build.
edit: duh, should be fixed now.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
