### PR TITLE
Rename "docs" to "contents" in navigation bar

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -41,7 +41,7 @@ endif %}>
         <li><a href="{{ pathto('gallery/index') }}">examples</a>|&nbsp;</li>
         <li><a href="{{ pathto('tutorials/index') }}">tutorials</a>|&nbsp;</li>
         <li><a href="{{ pathto('api/api_overview') }}">API</a>|&nbsp;</li>
-        <li><a href="{{ pathto('contents') }}">docs</a> &raquo;</li>
+        <li><a href="{{ pathto('contents') }}">contents</a> &raquo;</li>
 
         {%- for parent in parents %}
           <li><a href="{{ parent.link|e }}" {% if loop.last %}{{


### PR DESCRIPTION
"docs" doesn't make much sense to me (isn't the whole website docs?), so change to contents which I think describes the page much better.