### PR TITLE
Remove redundant call to Formatter.set_locs() before .format_ticks().

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1067,7 +1067,6 @@ class Axis(martist.Artist):
 
         major_locs = self.major.locator()
         major_ticks = self.get_major_ticks(len(major_locs))
-        self.major.formatter.set_locs(major_locs)
         major_labels = self.major.formatter.format_ticks(major_locs)
         for tick, loc, label in zip(major_ticks, major_locs, major_labels):
             tick.update_position(loc)
@@ -1075,7 +1074,6 @@ class Axis(martist.Artist):
             tick.set_label2(label)
         minor_locs = self.minor.locator()
         minor_ticks = self.get_minor_ticks(len(minor_locs))
-        self.minor.formatter.set_locs(minor_locs)
         minor_labels = self.minor.formatter.format_ticks(minor_locs)
         for tick, loc, label in zip(minor_ticks, minor_locs, minor_labels):
             tick.update_position(loc)

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -318,12 +318,10 @@ class AxisArtistHelperRectlinear(object):
 
             major = self.axis.major
             majorLocs = major.locator()
-            major.formatter.set_locs(majorLocs)
             majorLabels = major.formatter.format_ticks(majorLocs)
 
             minor = self.axis.minor
             minorLocs = minor.locator()
-            minor.formatter.set_locs(minorLocs)
             minorLabels = minor.formatter.format_ticks(minorLocs)
 
             tr2ax = axes.transData + axes.transAxes.inverted()


### PR DESCRIPTION
Just some occurrences missed in da55037 (#13323); milestoning as 3.1 to match
that PR.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
