### PR TITLE
Deprecate factor=None in axisartist.

### DIFF
--- a/doc/api/next_api_changes/2019-04-16-AL.rst
+++ b/doc/api/next_api_changes/2019-04-16-AL.rst
@@ -1,0 +1,7 @@
+Deprecations
+````````````
+
+Returning a factor equal to None from axisartist Locators (which are **not**
+the same as "standard" tick Locators), or passing a factor equal to None
+to axisartist Formatters (which are **not** the same as "standard" tick
+Formatters) is deprecated.  Pass a factor equal to 1 instead.

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -9,7 +9,7 @@ from matplotlib.path import Path
 from matplotlib.transforms import Affine2D, IdentityTransform
 from .axislines import AxisArtistHelper, GridHelperBase
 from .axis_artist import AxisArtist
-from .grid_finder import GridFinder
+from .grid_finder import GridFinder, _deprecate_factor_none
 
 
 class FixedAxisArtistHelper(AxisArtistHelper.Fixed):
@@ -132,12 +132,12 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         self.grid_info = {
             "extremes": extremes,
-            "lon_info": (lon_levs, lon_n, lon_factor),
-            "lat_info": (lat_levs, lat_n, lat_factor),
+            "lon_info": (lon_levs, lon_n, _deprecate_factor_none(lon_factor)),
+            "lat_info": (lat_levs, lat_n, _deprecate_factor_none(lat_factor)),
             "lon_labels": grid_finder.tick_formatter1(
-                "bottom", lon_factor, lon_levs),
+                "bottom", _deprecate_factor_none(lon_factor), lon_levs),
             "lat_labels": grid_finder.tick_formatter2(
-                "bottom", lat_factor, lat_levs),
+                "bottom", _deprecate_factor_none(lat_factor), lat_levs),
             "line_xy": (xx, yy),
         }
 
@@ -183,21 +183,13 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         lat_levs, lat_n, lat_factor = self.grid_info["lat_info"]
         lat_levs = np.asarray(lat_levs)
-        if lat_factor is not None:
-            yy0 = lat_levs / lat_factor
-            dy = 0.01 / lat_factor
-        else:
-            yy0 = lat_levs
-            dy = 0.01
+        yy0 = lat_levs / _deprecate_factor_none(lat_factor)
+        dy = 0.01 / _deprecate_factor_none(lat_factor)
 
         lon_levs, lon_n, lon_factor = self.grid_info["lon_info"]
         lon_levs = np.asarray(lon_levs)
-        if lon_factor is not None:
-            xx0 = lon_levs / lon_factor
-            dx = 0.01 / lon_factor
-        else:
-            xx0 = lon_levs
-            dx = 0.01
+        xx0 = lon_levs / _deprecate_factor_none(lon_factor)
+        dx = 0.01 / _deprecate_factor_none(lon_factor)
 
         if None in self._extremes:
             e0, e1 = self._extremes


### PR DESCRIPTION
mpl_toolkits.axisartist has its own notion of Locators and Formatters
(which have a different API from standard Locators and Formatters); in
particular, they have a notion of "factor" -- either a numeric value, or
None, which is treated equivalently to 1.

Simplify a bit axisartist by deprecating support for None (as 1 is
synonym and is handled by the more general code).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
