### PR TITLE
FIX: if the user calls `matplotlib.use` disable backend fallback

### DIFF
--- a/doc/api/api_changes/2019-02_tac.rst
+++ b/doc/api/api_changes/2019-02_tac.rst
@@ -1,0 +1,14 @@
+Do not use backend fallback if backend in explicitly set
+````````````````````````````````````````````````````````
+
+If the backend is selected via ``mpl.use``,  setting the
+``MPLBACKEND`` env, or directly setting ``rcParams['backend']`` prior
+to importing pyplot, do not attempt to fallback to a backend compatible
+with the currently running event loop.  If the backend in set via a
+configuration file, it will respect the value of ``'backend_fallback'``
+in the file (and continues to default to True).
+
+This is mostly relevant on headless servers.  Having a configuration
+file with an interactive backend will correctly fallback to a
+non-interactive backend but code that calls ``matplotlib.use`` will
+fail on pyplot import.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -867,8 +867,9 @@ class RcParams(MutableMapping, dict):
         return {k: dict.__getitem__(self, k) for k in self}
 
     def update(self, *args, **kwargs):
-        inp_backend_fallback = dict(*args, **kwargs).get('backend_fallback')
-        super().update(*args, **kwargs)
+        inp = dict(*args, **kwargs)
+        inp_backend_fallback = inp.get('backend_fallback')
+        super().update(inp)
         if inp_backend_fallback is not None:
             self['backend_fallback'] = inp_backend_fallback
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -932,15 +932,15 @@ def _rc_params_in_file(fname, fail_on_error=False):
 
     for key, (val, line, cnt) in rc_temp.items():
         if key in defaultParams:
-            if fail_on_error:
-                config[key] = val  # try to convert to proper type or raise
-            else:
-                try:
-                    config[key] = val  # try to convert to proper type or skip
-                except Exception as msg:
+            try:
+                config[key] = val  # try to convert to proper type
+            except Exception as msg:
+                if not fail_on_error:
                     error_details = _error_details_fmt % (cnt, line, fname)
                     _log.warning('Bad val %r on %s\n\t%s',
                                  val, error_details, msg)
+                else:
+                    raise
         elif key in _deprecated_ignore_map:
             version, alt_key = _deprecated_ignore_map[key]
             cbook.warn_deprecated(

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -480,11 +480,11 @@ def test_if_rctemplate_would_be_valid(tmpdir):
                                 use_default_template=False)
         assert len(record) == 0
 
-
+# mark with backend so we are sure it will get re-set!
+@pytest.mark.backend('agg')
 @pytest.mark.parametrize('target', ('agg', 'svg'))
 def test_use_no_fallback(target):
     import matplotlib as mpl
-    mpl.use('agg')
     mpl.rcParams['backend_fallback'] = True
     mpl.use(target)
     assert mpl.rcParams['backend_fallback'] == False

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -487,7 +487,7 @@ def test_use_no_fallback(target):
     import matplotlib as mpl
     mpl.rcParams['backend_fallback'] = True
     mpl.use(target)
-    assert mpl.rcParams['backend_fallback'] == False
+    assert not mpl.rcParams['backend_fallback']
 
 
 _backend_fallaback_test_data = (
@@ -503,11 +503,11 @@ def test_backend_fallback_init(inp):
     from matplotlib import RcParams
 
     rc = RcParams(**inp)
-    assert (rc.get('backend_fallback', True) \
+    assert (rc.get('backend_fallback', True)
             == inp.get('backend_fallback', True))
 
     rc['backend_fallback'] = inp.get('backend_fallback', True)
-
+    rc['backend'] = inp['backend']
     rc['backend'] = 'agg'
     assert not rc['backend_fallback']
 
@@ -522,7 +522,7 @@ def test_backend_fallback_update(inp):
 
     rc = RcParams()
     rc.update(inp)
-    assert (rc.get('backend_fallback', True) \
+    assert (rc.get('backend_fallback', True)
             == inp.get('backend_fallback', True))
 
 

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -316,18 +316,36 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # "interactive backends") and hardcopy backends to make image files
 # (PNG, SVG, PDF, PS; also referred to as "non-interactive backends").
 #
-# There are four ways to configure your backend. If they conflict each other,
-# the method mentioned last in the following list will be used, e.g. calling
-# :func:`~matplotlib.use()` will override the setting in your ``matplotlibrc``.
+#
+# There are three ways to configure your backend. If they conflict each
+# other, the method mentioned last in the following list will be used,
+# e.g. calling :func:`~matplotlib.use()` will override the setting in
+# your ``matplotlibrc``.
 #
 #
 # #. The ``backend`` parameter in your ``matplotlibrc`` file (see
 #    :doc:`/tutorials/introductory/customizing`)::
 #
-#        backend : WXAgg   # use wxpython with antigrain (agg) rendering
+#        backend : Qt5Agg   # use pyqt5 with antigrain (agg) rendering
 #
-# #. Setting the :envvar:`MPLBACKEND` environment variable, either for your
-#    current shell or for a single script.  On Unix::
+#    If you do not want to explicitly set the backend in your
+#    ``matplotlibrc`` file the default value is to detect a usable
+#    backend based event loop is currently running on your system and
+#    what is available on your system.
+#
+#    if :rc:`'backend_fallback` is True, then on import of
+#    `~matplotlib.pyplot` if your selected backend is interactive (aka,
+#    a GUI backend), and there is a running interactive framework, then
+#    Matplotlib will ignore the value of :rc:`'backend']` and
+#    instead fall back to a backend that is compatible with your current
+#    process.
+#
+#    On linux if there if the :envvar:`DISPLAY` is not set, we identify
+#    the running backend as ``"headless"``, thus on servers will
+#    auto-magically fall back to a non-interactive backend.
+#
+# #. Setting the :envvar:`MPLBACKEND` environment variable, either for
+#    your current shell or for a single script.  On Unix::
 #
 #         > export MPLBACKEND=module://my_backend
 #         > python simple_plot.py
@@ -339,11 +357,14 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #         > set MPLBACKEND=module://my_backend
 #         > python simple_plot.py
 #
-#    Setting this environment variable will override the ``backend`` parameter
-#    in *any* ``matplotlibrc``, even if there is a ``matplotlibrc`` in your
-#    current working directory. Therefore setting :envvar:`MPLBACKEND`
-#    globally, e.g. in your ``.bashrc`` or ``.profile``, is discouraged as it
-#    might lead to counter-intuitive behavior.
+#    Setting this environment variable will override the :rc:`backend`
+#    parameter in *any* ``matplotlibrc``, even if there is a
+#    ``matplotlibrc`` in your current working directory. Therefore
+#    setting :envvar:`MPLBACKEND` globally, e.g. in your ``.bashrc`` or
+#    ``.profile``, is discouraged as it might lead to counter-intuitive
+#    behavior.
+#
+#    If this is set, then :rc:`backend_fallback` is set to `False`.
 #
 # #. If your script depends on a specific backend you can use the
 #    :func:`~matplotlib.use` function::
@@ -351,23 +372,24 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #       import matplotlib
 #       matplotlib.use('PS')   # generate postscript output by default
 #
-#    If you use the :func:`~matplotlib.use` function, this must be done before
-#    importing :mod:`matplotlib.pyplot`. Calling :func:`~matplotlib.use` after
-#    pyplot has been imported will have no effect.  Using
-#    :func:`~matplotlib.use` will require changes in your code if users want to
-#    use a different backend.  Therefore, you should avoid explicitly calling
-#    :func:`~matplotlib.use` unless absolutely necessary.
+#    If you use the :func:`~matplotlib.use` function, this must be done
+#    before importing :mod:`matplotlib.pyplot`. Calling
+#    :func:`~matplotlib.use` after pyplot has been imported will attempt
+#    to change the backend.  If this is not possible,
+#    :func:`~matplotlib.use` will raise.
 #
-# .. note::
-#    Backend name specifications are not case-sensitive; e.g., 'GTK3Agg'
-#    and 'gtk3agg' are equivalent.
+#    Using :func:`~matplotlib.use` will require changes in your code if
+#    users want to use a different backend.  Therefore, you should avoid
+#    explicitly calling :func:`~matplotlib.use` unless absolutely
+#    necessary.
+#
+#    If this is set, then :rc:`backend_fallback` is set to `False`.
 #
 # With a typical installation of matplotlib, such as from a
 # binary installer or a linux distribution package, a good default
 # backend will already be set, allowing both interactive work and
 # plotting from scripts, with output to the screen and/or to
-# a file, so at least initially you will not need to use any of the
-# methods given above.
+# a file.
 #
 # If, however, you want to write graphical user interfaces, or a web
 # application server (:ref:`howto-webapp`), or need a better


### PR DESCRIPTION
If `rcParmas['backend_fallback'] == True` and we find the user has
requested an inconsistent backend with the currently running event
loop we resest `rcParams['backend']` to the auto backend selection
sentinel.  Immediately afterwards we call `switch_backend`.

In the case where we are on a headless linux machine we always detect
the running event loop as 'headless'.  This means that if any
interactive backend was selected (via an rcparams file, directly
setting `rcParams['backend']` or using `mpl.use`) on import of
`pyplot` we would, by default, run through the fallback logic and
select 'agg' as the backend.

This change records the user's intent to select a backend via `use` or
via setting an environmental variable by setting
`rcParam['backend_fallback'] = False` to prevent this fallback in the
case where the user has explicitly selected a backend in their code.
If the backend is selected an rcparam file, or directly setting the
value in the rcParam dict we will fallback.

closes #13883

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
