### PR TITLE
Enh control tick deconflict2

### DIFF
--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -60,7 +60,7 @@ Formatters and Locators
    Axis.set_major_locator
    Axis.set_minor_formatter
    Axis.set_minor_locator
-
+   Axis.remove_overlapping_locs
 
 Axis Label
 ----------

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1405,7 +1405,7 @@ class Axis(martist.Artist):
     def get_major_ticks(self, numticks=None):
         'Get the tick instances; grow as necessary.'
         if numticks is None:
-            numticks = len(self.get_major_locator()())
+            numticks = len(self.get_majorticklocs())
 
         while len(self.majorTicks) < numticks:
             # Update the new tick label properties from the old.
@@ -1419,7 +1419,7 @@ class Axis(martist.Artist):
     def get_minor_ticks(self, numticks=None):
         'Get the minor tick instances; grow as necessary.'
         if numticks is None:
-            numticks = len(self.get_minor_locator()())
+            numticks = len(self.get_minorticklocs())
 
         while len(self.minorTicks) < numticks:
             # Update the new tick label properties from the old.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1095,6 +1095,11 @@ class Axis(martist.Artist):
             tick.set_label2(label)
         ticks = [*major_ticks, *minor_ticks]
 
+        # mark the ticks that we will not be using as not visible
+        for t in (self.minorTicks[len(minor_locs):] +
+                  self.majorTicks[len(major_locs):]):
+            t.set_visible(False)
+
         view_low, view_high = self.get_view_interval()
         if view_low > view_high:
             view_low, view_high = view_high, view_low

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1064,17 +1064,18 @@ class Axis(martist.Artist):
         Update ticks (position and labels) using the current data interval of
         the axes.  Return the list of ticks that will be drawn.
         """
-
-        major_locs = self.major.locator()
-        major_ticks = self.get_major_ticks(len(major_locs))
+        major_locs = self.get_majorticklocs()
         major_labels = self.major.formatter.format_ticks(major_locs)
+        major_ticks = self.get_major_ticks(len(major_locs))
+        self.major.formatter.set_locs(major_locs)
         for tick, loc, label in zip(major_ticks, major_locs, major_labels):
             tick.update_position(loc)
             tick.set_label1(label)
             tick.set_label2(label)
-        minor_locs = self.minor.locator()
-        minor_ticks = self.get_minor_ticks(len(minor_locs))
+        minor_locs = self.get_minorticklocs()
         minor_labels = self.minor.formatter.format_ticks(minor_locs)
+        minor_ticks = self.get_minor_ticks(len(minor_locs))
+        self.minor.formatter.set_locs(minor_locs)
         for tick, loc, label in zip(minor_ticks, minor_locs, minor_labels):
             tick.update_position(loc)
             tick.set_label1(label)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -923,3 +923,24 @@ def test_minorticks_rc():
     minorticksubplot(True, False, 2)
     minorticksubplot(False, True, 3)
     minorticksubplot(True, True, 4)
+
+
+def test_remove_overlap():
+    import numpy as np
+    import matplotlib.dates as mdates
+
+    t = np.arange("2018-11-03", "2018-11-06", dtype="datetime64")
+    x = np.ones(len(t))
+
+    fig, ax = plt.subplots()
+    ax.plot(t, x)
+
+    ax.xaxis.set_major_locator(mdates.DayLocator())
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('\n%a'))
+
+    ax.xaxis.set_minor_locator(mdates.HourLocator((0, 6, 12, 18)))
+    ax.xaxis.set_minor_formatter(mdates.DateFormatter('%H:%M'))
+
+    assert len(ax.xaxis.get_minorticklocs()) == 6
+    ax.xaxis.remove_overlapping_locs = False
+    assert len(ax.xaxis.get_minorticklocs()) == 9


### PR DESCRIPTION
This is an alternative to #13826 that puts the knob on the `Axis` rather than the locator.

I have a memory of talking about doing this and deciding not to, but do not remember _why_.

attn @efiring 