### PR TITLE
Fix joinstyles example

### DIFF
--- a/examples/lines_bars_and_markers/joinstyle.py
+++ b/examples/lines_bars_and_markers/joinstyle.py
@@ -9,17 +9,15 @@ Both are used in `.Line2D` and various ``Collections`` from
 `matplotlib.collections` as well as some functions that create these, e.g.
 `~matplotlib.pyplot.plot`.
 
-"""
 
-#############################################################################
-#
-# Join styles
-# """""""""""
-#
-# Join styles define how the connection between two line segments is drawn.
-#
-# See the respective ``solid_joinstyle``, ``dash_joinstyle`` or ``joinstyle``
-# parameters.
+Join styles
+===========
+
+Join styles define how the connection between two line segments is drawn.
+
+See the respective ``solid_joinstyle``, ``dash_joinstyle`` or ``joinstyle``
+parameters.
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -54,7 +52,7 @@ plt.show()
 #############################################################################
 #
 # Cap styles
-# """"""""""
+# ==========
 #
 # Cap styles define how the the end of a line is drawn.
 #


### PR DESCRIPTION
## PR Summary

Fixes a formatting issue with the heading. Original rendered docs:

![grafik](https://user-images.githubusercontent.com/2836374/55838028-6059ed80-5b23-11e9-863c-16fd0d8a0a06.png)

### Cause:

Having a file-level """-docstring immediately followed by a sphinx-gallery comment section is problematic. Each part is stripped when generating the .rst file. In the present case, this results in no blank line before the heading (https://matplotlib.org/devdocs/_sources/gallery/lines_bars_and_markers/joinstyle.rst.txt), which is invalid ReST markup.

Note: Also changed the heading marker to not conflict with triple-quotes.

