### PR TITLE
Faster categorical tick formatter.

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -148,11 +148,11 @@ class StrCategoryFormatter(ticker.Formatter):
         self._units = units_mapping
 
     def __call__(self, x, pos=None):
-        if pos is None:
-            return ""
-        r_mapping = {v: StrCategoryFormatter._text(k)
-                     for k, v in self._units.items()}
-        return r_mapping.get(int(np.round(x)), '')
+        return '' if pos is None else self.format_ticks([x])[0]
+
+    def format_ticks(self, values):
+        r_mapping = {v: self._text(k) for k, v in self._units.items()}
+        return [r_mapping.get(round(val), '') for val in values]
 
     @staticmethod
     def _text(value):


### PR DESCRIPTION
Having thousands of categories is most likely a sign that the user
forgot to convert strings to floats or dates, but we may as well not
take forever to generate the incorrect plot so that they can observe the
failure faster (cf "slow beyond belief" comment in #13910).

Right now StrCategoryFormatter constructs the value-to-label dict at
every call to `__call__` which leads to quadratic complexity when
iterating over the ticks.  Instead, just do this once in `format_ticks`
(and let `__call__` use that implementation too), for linear complexity.

This speeds up

    from pylab import *
    cats = [str(x) for x in np.random.rand(4000)]  # Bunch of labels.
    plt.plot(cats)
    plt.gcf().canvas.draw()

from ~25s to ~11s (and the difference gets bigger for more ticks as
we're comparing O(n^2) to O(n) (modulo dict lookup terms in log(n),
probably)).

The other option was to make UnitData maintain both a forward and a
backward mapping in sync but this would require passing the UnitData
instance rather than the mapping to the StrCategoryFormatter constructor
and the API break is just not worth it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
