### PR TITLE
Make matplotlib.testing assume pytest by default, not nose.

### DIFF
--- a/doc/api/next_api_changes/2019-04-09-AL.rst
+++ b/doc/api/next_api_changes/2019-04-09-AL.rst
@@ -1,0 +1,19 @@
+Deprecations
+````````````
+
+Support in `matplotlib.testing` for nose-based tests is deprecated (a
+deprecation is emitted if using e.g. the decorators from that module while
+both 1) matplotlib's conftests have not been called and 2) nose is in
+``sys.modules``).
+
+``testing.is_called_from_pytest`` is deprecated.
+
+During the deprecation period, to force the generation of nose base tests,
+import nose first.
+
+API changes
+```````````
+
+The default value of the "obj_type" parameter to ``cbook.warn_deprecated`` has
+been changed from "attribute" (a default that was never used internally) to the
+empty string.

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -22,8 +22,8 @@ mplDeprecation = MatplotlibDeprecationWarning
 
 
 def _generate_deprecation_warning(
-        since, message='', name='', alternative='', pending=False,
-        obj_type='attribute', addendum='', *, removal=''):
+        since, message='', name='', alternative='', pending=False, obj_type='',
+        addendum='', *, removal=''):
     if pending:
         if removal:
             raise ValueError(
@@ -55,7 +55,7 @@ def _generate_deprecation_warning(
 
 def warn_deprecated(
         since, *, message='', name='', alternative='', pending=False,
-        obj_type='attribute', addendum='', removal=''):
+        obj_type='', addendum='', removal=''):
     """
     Used to display deprecation in a standard way.
 

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -3,6 +3,7 @@ Helper functions for testing.
 """
 import locale
 import logging
+import sys
 import warnings
 
 import matplotlib as mpl
@@ -11,9 +12,18 @@ from matplotlib import cbook
 _log = logging.getLogger(__name__)
 
 
+@cbook.deprecated("3.2")
 def is_called_from_pytest():
     """Whether we are in a pytest run."""
     return getattr(mpl, '_called_from_pytest', False)
+
+
+def _wants_nose():
+    wants_nose = (not getattr(mpl, '_called_from_pytest', False)
+                  and 'nose' in sys.modules)
+    if wants_nose:
+        cbook.warn_deprecated("3.2", name="support for nose-based tests")
+    return wants_nose
 
 
 def set_font_settings_for_testing():

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -311,13 +311,12 @@ def convert(filename, cache):
     base, extension = filename.rsplit('.', 1)
     if extension not in converter:
         reason = "Don't know how to convert %s files to png" % extension
-        from . import is_called_from_pytest
-        if is_called_from_pytest():
-            import pytest
-            pytest.skip(reason)
-        else:
+        if mpl.testing._wants_nose():
             from nose import SkipTest
             raise SkipTest(reason)
+        else:
+            import pytest
+            pytest.skip(reason)
     newname = base + '_' + extension + '.png'
     if not os.path.exists(filename):
         raise IOError("'%s' does not exist" % filename)

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -403,16 +403,16 @@ def image_comparison(baseline_images, extensions=None, tol=0,
         #default no kwargs to savefig
         savefig_kwarg = dict()
 
-    if is_called_from_pytest():
-        return _pytest_image_comparison(
-            baseline_images=baseline_images, extensions=extensions, tol=tol,
-            freetype_version=freetype_version, remove_text=remove_text,
-            savefig_kwargs=savefig_kwarg, style=style)
-    else:
+    if mpl.testing._wants_nose():
         if baseline_images is None:
             raise ValueError('baseline_images must be specified')
 
         return ImageComparisonTest(
+            baseline_images=baseline_images, extensions=extensions, tol=tol,
+            freetype_version=freetype_version, remove_text=remove_text,
+            savefig_kwargs=savefig_kwarg, style=style)
+    else:
+        return _pytest_image_comparison(
             baseline_images=baseline_images, extensions=extensions, tol=tol,
             freetype_version=freetype_version, remove_text=remove_text,
             savefig_kwargs=savefig_kwarg, style=style)


### PR DESCRIPTION
Currently, matplotlib.testing generates nose-based tests (through the
deprecated ImageComparisonTest class and nose.SkipTest), unless one is
actually running tests with pytest (so that matplotlib.testing.conftest
has been run).

This means that e.g. importing `matplotlib.tests.test_foo` will fail if
nose is not installed (because we'll try to import nose.tools).

Given that both support for nose in Matplotlib and nose itself are
deprecated, invert the logic to generate pytest-base tests unless
both matplotlib.testing.conftest has *not* been run by pytest, and
"nose" is already in sys.modules.

Also change the default value of the "obj_type" parameter from
"attribute" to cbook.warn_deprecated to the empty string (the previous
default was never used, and the empty string as default is practical
e.g. in the case in this PR).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
