### PR TITLE
Correctly handle invalid PNG metadata.

### DIFF
--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -300,7 +300,11 @@ static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 
 #ifdef PNG_TEXT_SUPPORTED
     // Save the metadata
-    if (metadata != NULL) {
+    if (metadata != NULL && metadata != Py_None) {
+        if (!PyDict_Check(metadata)) {
+            PyErr_SetString(PyExc_TypeError, "metadata must be a dict or None");
+            goto exit;
+        }
         meta_size = PyDict_Size(metadata);
         text = new png_text[meta_size];
 


### PR DESCRIPTION
## PR Summary

Fix the crash in #13902 due to invalid metadata. Not sure if I should bother with a test since #13902 will exercise it.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way