### PR TITLE
Followup to deprecation of usetex parameter in get_text_path.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -564,13 +564,7 @@ class RendererBase(object):
 
         text2path = self._text2path
         fontsize = self.points_to_pixels(prop.get_size_in_points())
-
-        if ismath == "TeX":
-            verts, codes = text2path.get_text_path(prop, s, ismath=False,
-                                                   usetex=True)
-        else:
-            verts, codes = text2path.get_text_path(prop, s, ismath=ismath,
-                                                   usetex=False)
+        verts, codes = text2path.get_text_path(prop, s, ismath=ismath)
 
         path = Path(verts, codes)
         angle = np.deg2rad(angle)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -463,12 +463,8 @@ class TextPath(Path):
 
         self._cached_vertices = None
         s, ismath = Text(usetex=usetex)._preprocess_math(s)
-        if ismath == "TeX":
-            self._vertices, self._codes = text_to_path.get_text_path(
-                prop, s, usetex=True)
-        else:
-            self._vertices, self._codes = text_to_path.get_text_path(
-                prop, s, ismath=ismath)
+        self._vertices, self._codes = text_to_path.get_text_path(
+            prop, s, ismath=ismath)
         self._should_simplify = False
         self._simplify_threshold = rcParams['path.simplify_threshold']
         self._interpolation_steps = _interpolation_steps


### PR DESCRIPTION
followup to #13180.

This is in particular necessary to avoid triggering a (spurious) deprecation
warning in test_backend_ps::test_patheffects.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
