### PR TITLE
Fix passing Path to ps backend when text.usetex rc is True.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1119,12 +1119,14 @@ class FigureCanvasPS(FigureCanvasBase):
         the key 'Creator' is used.
         """
         isEPSF = format == 'eps'
-        if isinstance(outfile, str):
-            title = outfile
-        elif is_writable_file_like(outfile):
+        if is_writable_file_like(outfile):
             title = None
         else:
-            raise ValueError("outfile must be a path or a file-like object")
+            try:
+                title = os.fspath(outfile)
+            except TypeError:
+                raise ValueError(
+                    "outfile must be a path or a file-like object")
 
         self.figure.dpi = 72  # ignore the dpi kwarg
         width, height = self.figure.get_size_inches()

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -71,13 +71,12 @@ def test_savefig_to_stringio(format, use_log, rcParams):
 
 
 def test_patheffects():
-    with mpl.rc_context():
-        mpl.rcParams['path.effects'] = [
-            patheffects.withStroke(linewidth=4, foreground='w')]
-        fig, ax = plt.subplots()
-        ax.plot([1, 2, 3])
-        with io.BytesIO() as ps:
-            fig.savefig(ps, format='ps')
+    mpl.rcParams['path.effects'] = [
+        patheffects.withStroke(linewidth=4, foreground='w')]
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3])
+    with io.BytesIO() as ps:
+        fig.savefig(ps, format='ps')
 
 
 @needs_usetex
@@ -86,18 +85,17 @@ def test_tilde_in_tempfilename(tmpdir):
     # Tilde ~ in the tempdir path (e.g. TMPDIR, TMP or TEMP on windows
     # when the username is very long and windows uses a short name) breaks
     # latex before https://github.com/matplotlib/matplotlib/pull/5928
-    base_tempdir = Path(str(tmpdir), "short-1")
+    base_tempdir = Path(tmpdir, "short-1")
     base_tempdir.mkdir()
     # Change the path for new tempdirs, which is used internally by the ps
     # backend to write a file.
     with cbook._setattr_cm(tempfile, tempdir=str(base_tempdir)):
         # usetex results in the latex call, which does not like the ~
-        plt.rc('text', usetex=True)
+        mpl.rcParams['text.usetex'] = True
         plt.plot([1, 2, 3, 4])
         plt.xlabel(r'\textbf{time} (s)')
-        output_eps = os.path.join(str(base_tempdir), 'tex_demo.eps')
         # use the PS backend to write the file...
-        plt.savefig(output_eps, format="ps")
+        plt.savefig(base_tempdir / 'tex_demo.eps', format="ps")
 
 
 def test_source_date_epoch():
@@ -133,11 +131,8 @@ def test_transparency():
 @needs_usetex
 def test_failing_latex(tmpdir):
     """Test failing latex subprocess call"""
-    path = str(tmpdir.join("tmpoutput.ps"))
-
     mpl.rcParams['text.usetex'] = True
-
     # This fails with "Double subscript"
     plt.xlabel("$22_2_2$")
     with pytest.raises(RuntimeError):
-        plt.savefig(path)
+        plt.savefig(Path(tmpdir, "tmpoutput.ps"))


### PR DESCRIPTION
... and misc. cleanups to test_backend_ps (more pathlib + remove an
unnecessary rc_context() as tests always reset the rcs at exit).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
