### PR TITLE
Suppress warnings in tests.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3091,10 +3091,10 @@ def test_stem_args():
     y = list(range(10))
 
     # Test the call signatures
-    ax.stem(y)
-    ax.stem(x, y)
-    ax.stem(x, y, 'r--')
-    ax.stem(x, y, 'r--', basefmt='b--')
+    ax.stem(y, use_line_collection=True)
+    ax.stem(x, y, use_line_collection=True)
+    ax.stem(x, y, 'r--', use_line_collection=True)
+    ax.stem(x, y, 'r--', basefmt='b--', use_line_collection=True)
 
 
 def test_stem_dates():
@@ -3106,7 +3106,7 @@ def test_stem_dates():
     x1 = parser.parse("2013-9-28 12:00:00")
     y1 = 200
 
-    ax.stem([x, x1], [y, y1], "*-")
+    ax.stem([x, x1], [y, y1], "*-", use_line_collection=True)
 
 
 @image_comparison(baseline_images=['hist_stacked_stepfilled_alpha'])

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -1,9 +1,9 @@
 import builtins
 import subprocess
 import sys
+import textwrap
 
 import matplotlib
-from matplotlib.cbook import dedent
 
 
 def test_simple():
@@ -36,7 +36,7 @@ def test_override_builtins():
 
 
 def test_lazy_imports():
-    source = dedent("""
+    source = textwrap.dedent("""
     import sys
 
     import matplotlib.figure

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -18,11 +18,11 @@ from matplotlib.cbook import (
 
 
 def test_is_hashable():
-    s = 'string'
-    assert cbook.is_hashable(s)
-
-    lst = ['list', 'of', 'stings']
-    assert not cbook.is_hashable(lst)
+    with pytest.warns(MatplotlibDeprecationWarning):
+        s = 'string'
+        assert cbook.is_hashable(s)
+        lst = ['list', 'of', 'stings']
+        assert not cbook.is_hashable(lst)
 
 
 class Test_delete_masked_points(object):

--- a/lib/matplotlib/tests/test_container.py
+++ b/lib/matplotlib/tests/test_container.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 def test_stem_remove():
     ax = plt.gca()
-    st = ax.stem([1, 2], [1, 2])
+    st = ax.stem([1, 2], [1, 2], use_line_collection=True)
     st.remove()
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -943,13 +943,10 @@ def test_imshow_bool():
 
 
 def test_full_invalid():
-    x = np.ones((10, 10))
-    x[:] = np.nan
-
-    f, ax = plt.subplots()
-    ax.imshow(x)
-
-    f.canvas.draw()
+    fig, ax = plt.subplots()
+    ax.imshow(np.full((10, 10), np.nan))
+    with pytest.warns(UserWarning):
+        fig.canvas.draw()
 
 
 @pytest.mark.parametrize("fmt,counted",

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -908,7 +908,8 @@ class TestDetrend(object):
 
     def test_demean_1D_d1_ValueError(self):
         input = self.sig_slope
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), \
+             pytest.warns(MatplotlibDeprecationWarning):
             mlab.demean(input, axis=1)
 
     def test_detrend_mean_2D_d2_ValueError(self):
@@ -923,7 +924,8 @@ class TestDetrend(object):
 
     def test_demean_2D_d2_ValueError(self):
         input = self.sig_slope[np.newaxis]
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError), \
+             pytest.warns(MatplotlibDeprecationWarning):
             mlab.demean(input, axis=2)
 
     def test_detrend_linear_0D_zeros(self):

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -324,4 +324,5 @@ def test_collapsed():
         p2 = ax.get_position()
         assert p1.width == p2.width
     # test that passing a rect doesn't crash...
-    plt.tight_layout(rect=[0, 0, 0.8, 0.8])
+    with pytest.warns(UserWarning):
+        plt.tight_layout(rect=[0, 0, 0.8, 0.8])

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -186,8 +186,8 @@ def test_clipping_of_log():
     path = Path(points, codes)
 
     # something like this happens in plotting logarithmic histograms
-    trans = mtransforms.BlendedGenericTransform(mtransforms.Affine2D(),
-                                            LogScale.Log10Transform('clip'))
+    trans = mtransforms.BlendedGenericTransform(
+        mtransforms.Affine2D(), LogScale.LogTransform(10, 'clip'))
     tpath = trans.transform_path_non_affine(path)
     result = tpath.iter_segments(trans.get_affine(),
                                  clip=(0, 0, 100, 100),

--- a/lib/matplotlib/tests/test_ttconv.py
+++ b/lib/matplotlib/tests/test_ttconv.py
@@ -1,16 +1,18 @@
+from pathlib import Path
+
 import matplotlib
 from matplotlib.font_manager import FontProperties
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
-import os.path
 
 
 @image_comparison(baseline_images=["truetype-conversion"],
                   extensions=["pdf"])
-def test_truetype_conversion():
-    fontname = os.path.join(os.path.dirname(__file__), 'mpltest.ttf')
-    fontname = os.path.abspath(fontname)
-    fontprop = FontProperties(fname=fontname, size=80)
+# mpltest.ttf does not have "l"/"p" glyphs so we get a warning when trying to
+# get the font extents.
+def test_truetype_conversion(recwarn):
+    fontprop = FontProperties(
+        fname=str(Path(__file__).with_name('mpltest.ttf').resolve()), size=80)
     matplotlib.rcParams['pdf.fonttype'] = 3
     fig, ax = plt.subplots()
     ax.text(0, 0, "ABCDE", fontproperties=fontprop)


### PR DESCRIPTION
Handles
- stem(..., use_line_collection=True).
- deprecation of cbook.dedent, cbook.is_hashable, mlab.demean,
  transforms.Log10Transform.

Explicitly check for numpy's warning when imshow()ing an image with only
nans.

Catch an "expected" warning in test_ttconv (the warning is only emitted
when the figure is being saved, so we can't actually assert it).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
