### PR TITLE
Added cursor widget with coordinate text

### DIFF
--- a/doc/users/next_whats_new/cursor_widget_with_coordinate_text.rst
+++ b/doc/users/next_whats_new/cursor_widget_with_coordinate_text.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+New cursor widget with coordinate text: `~matplotlib.widgets.TextCursor`
+------------------------------------------------------------------------
+Added a new widget, which is a sub class of the Cursor widget, but displays a text field right next
+to the cursor showing a tuple of the current mouse x position and the function value y at that x
+coordinate or vice versa. See :doc:`/gallery/widgets/text_cursor` for an example.

--- a/examples/widgets/text_cursor.py
+++ b/examples/widgets/text_cursor.py
@@ -1,29 +1,40 @@
 """
-======
+==========
 Textcursor
-======
+==========
 
 """
 from matplotlib.widgets import TextCursor
 import numpy as np
 import matplotlib.pyplot as plt
 
-
-# Fixing random state for reproducibility
-np.random.seed(19680801)
-
 fig = plt.figure(figsize=(8, 6))
 ax = fig.add_subplot(111, facecolor='#FFFFCC')
 
-#x, y = 4*(np.random.rand(2, 100) - .5)
-x = np.linspace(-2, 2, 1000)
-#y = 2*np.sin(x*np.pi)
-y=(x**2)-2
-lin = ax.plot(x, y)
-ax.set_xlim(-2, 2)
-ax.set_ylim(-2, 2)
+#A linearly growing x vector.
+x = np.linspace(-5, 5, 1000)
+#A non biunique function. dataaxis='y' will cause trouble.
+y=(x**2)
 
-# Set useblit=True on most backends for enhanced performance.
+lin = ax.plot(x, y)
+ax.set_xlim(-5, 5)
+ax.set_ylim(0, 25)
+
+#A minimum call
+#Set useblit=True on most backends for enhanced performance and pass the ax parameter
+#to the Cursor base class.
+#cursor = TextCursor(line=lin[0], ax=ax, useblit=True)
+
+#A more advanced call. Properties for text and lines are passed.
+#See the color if you are confused which parameter is passed where.
+#The dataaxis parameter is still the default.
 cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='x', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
+
+#A call demonstrating problems with the dataaxis=y parameter.
+#The text now looks up the matching x value for the current cursor y position instead of vice versa.
+#Hover you cursor to y=4. There are two x values producing this y value: -2 and 2.
+#The function is only unique, but not biunique.
+#Only one value is shown at the text.
+#cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='y', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
 
 plt.show()

--- a/examples/widgets/text_cursor.py
+++ b/examples/widgets/text_cursor.py
@@ -14,7 +14,7 @@ ax = fig.add_subplot(111, facecolor='#FFFFCC')
 #A linearly growing x vector.
 x = np.linspace(-5, 5, 1000)
 #A non biunique function. dataaxis='y' will cause trouble.
-y=(x ** 2)
+y = (x ** 2)
 
 lin = ax.plot(x, y)
 ax.set_xlim(-5, 5)
@@ -28,9 +28,9 @@ ax.set_ylim(0, 25)
 #A more advanced call. Properties for text and lines are passed.
 #See the color if you are confused which parameter is passed where.
 #The dataaxis parameter is still the default.
-cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
-    dataaxis='x', offset=[10, 10], \
-    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True, \
+cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}",
+    dataaxis='x', offset=[10, 10],
+    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True,
     color='red', linewidth=2)
 
 #A call demonstrating problems with the dataaxis=y parameter.
@@ -38,9 +38,9 @@ cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
 #instead of vice versa. Hover you cursor to y=4. There are two x values
 #producing this y value: -2 and 2. The function is only unique,
 #but not biunique. Only one value is shown in the text.
-#cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
-#    dataaxis='y', offset=[10, 10], \
-#    textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, \
+#cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}",
+#    dataaxis='y', offset=[10, 10],
+#    textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True,
 #    color='red', linewidth=2)
 
 #In the gallery picture, we cannot see the cursor.
@@ -55,7 +55,7 @@ cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
 #from matplotlib.backend_bases import MouseEvent
 #location = np.array([0, 10])
 #location = ax.transData.transform(location)
-#event = MouseEvent(name='motion_notify_event', button=None, key=None, \
+#event = MouseEvent(name='motion_notify_event', button=None, key=None,
 #    x=location[0], y=location[1], canvas=ax.figure.canvas)
 #ax.figure.canvas.draw()
 #cursor.onmove(event)

--- a/examples/widgets/text_cursor.py
+++ b/examples/widgets/text_cursor.py
@@ -1,0 +1,29 @@
+"""
+======
+Textcursor
+======
+
+"""
+from matplotlib.widgets import TextCursor
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
+fig = plt.figure(figsize=(8, 6))
+ax = fig.add_subplot(111, facecolor='#FFFFCC')
+
+#x, y = 4*(np.random.rand(2, 100) - .5)
+x = np.linspace(-2, 2, 1000)
+#y = 2*np.sin(x*np.pi)
+y=(x**2)-2
+lin = ax.plot(x, y)
+ax.set_xlim(-2, 2)
+ax.set_ylim(-2, 2)
+
+# Set useblit=True on most backends for enhanced performance.
+cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='x', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
+
+plt.show()

--- a/examples/widgets/text_cursor.py
+++ b/examples/widgets/text_cursor.py
@@ -34,7 +34,23 @@ cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='x', 
 #The text now looks up the matching x value for the current cursor y position instead of vice versa.
 #Hover you cursor to y=4. There are two x values producing this y value: -2 and 2.
 #The function is only unique, but not biunique.
-#Only one value is shown at the text.
+#Only one value is shown in the text.
 #cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='y', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
+
+#In the gallery picture, we cannot see the cursor.
+#The cursor is displayed after the first mouse move event. There is no mouse move when
+#using automatic scripts for generating the documentation.
+#The onmove event needs to occur after the plt.show() command, because this one creates a fresh
+#and clean canvas. Without the cursor or its text. And after the plt.show(), we cannot execute
+#more instructions. The following code draws the figure (without showing it) and calls the mouse
+#event manually. The resulting figure is saved to a file. But it cannot be shown, because this
+#first clears the canvas and therefore removes the cursor.
+#from matplotlib.backend_bases import MouseEvent
+#location = np.array([0, 10])
+#location = ax.transData.transform(location)
+#event = MouseEvent(name='motion_notify_event', button=None, key=None, x=location[0], y=location[1], canvas=ax.figure.canvas)
+#ax.figure.canvas.draw()
+#cursor.onmove(event)
+#fig.savefig('text_cursor.png')
 
 plt.show()

--- a/examples/widgets/text_cursor.py
+++ b/examples/widgets/text_cursor.py
@@ -14,41 +14,49 @@ ax = fig.add_subplot(111, facecolor='#FFFFCC')
 #A linearly growing x vector.
 x = np.linspace(-5, 5, 1000)
 #A non biunique function. dataaxis='y' will cause trouble.
-y=(x**2)
+y=(x ** 2)
 
 lin = ax.plot(x, y)
 ax.set_xlim(-5, 5)
 ax.set_ylim(0, 25)
 
 #A minimum call
-#Set useblit=True on most backends for enhanced performance and pass the ax parameter
-#to the Cursor base class.
+#Set useblit=True on most backends for enhanced performance
+#and pass the ax parameter to the Cursor base class.
 #cursor = TextCursor(line=lin[0], ax=ax, useblit=True)
 
 #A more advanced call. Properties for text and lines are passed.
 #See the color if you are confused which parameter is passed where.
 #The dataaxis parameter is still the default.
-cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='x', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
+cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
+    dataaxis='x', offset=[10, 10], \
+    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True, \
+    color='red', linewidth=2)
 
 #A call demonstrating problems with the dataaxis=y parameter.
-#The text now looks up the matching x value for the current cursor y position instead of vice versa.
-#Hover you cursor to y=4. There are two x values producing this y value: -2 and 2.
-#The function is only unique, but not biunique.
-#Only one value is shown in the text.
-#cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", dataaxis='y', offset=[10, 10], textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, color='red', linewidth=2)
+#The text now looks up the matching x value for the current cursor y position
+#instead of vice versa. Hover you cursor to y=4. There are two x values
+#producing this y value: -2 and 2. The function is only unique,
+#but not biunique. Only one value is shown in the text.
+#cursor = TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
+#    dataaxis='y', offset=[10, 10], \
+#    textprops={'color':'blue', 'fontweight':'bold'}, ax=ax, useblit=True, \
+#    color='red', linewidth=2)
 
 #In the gallery picture, we cannot see the cursor.
-#The cursor is displayed after the first mouse move event. There is no mouse move when
-#using automatic scripts for generating the documentation.
-#The onmove event needs to occur after the plt.show() command, because this one creates a fresh
-#and clean canvas. Without the cursor or its text. And after the plt.show(), we cannot execute
-#more instructions. The following code draws the figure (without showing it) and calls the mouse
-#event manually. The resulting figure is saved to a file. But it cannot be shown, because this
-#first clears the canvas and therefore removes the cursor.
+#The cursor is displayed after the first mouse move event.
+#There is no mouse move when using automatic scripts forgenerating the
+#documentation. The onmove event needs to occur after the plt.show() command,
+#because this one creates a fresh and clean canvas. Without the cursor or
+#its text. And after the plt.show(), we cannot execute more instructions.
+#The following code draws the figure (without showing it) and calls the mouse
+#event manually. The resulting figure is saved to a file. But it cannot be
+#shown, because this first clears the canvas and therefore removes the cursor.
 #from matplotlib.backend_bases import MouseEvent
 #location = np.array([0, 10])
 #location = ax.transData.transform(location)
-#event = MouseEvent(name='motion_notify_event', button=None, key=None, x=location[0], y=location[1], canvas=ax.figure.canvas)
+#event = MouseEvent(name='motion_notify_event', button=None, key=None, \
+#    x=location[0], y=location[1], canvas=ax.figure.canvas)
 #ax.figure.canvas.draw()
 #cursor.onmove(event)
 #fig.savefig('text_cursor.png')

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -474,14 +474,15 @@ def test_polygon_selector():
                       + polygon_place_vertex(50, 50))
     check_polygon_selector(event_sequence, expected_result, 1)
 
+
 def test_text_cursor():
     ax = get_ax()
     #Draw horizontal line
     lin = ax.plot([1, 1], [1, 1])
     ax.figure.canvas.draw()
-    tool = widgets.TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
-    dataaxis='x', offset=[10, 10], \
-    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True, \
+    tool = widgets.TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}",
+    dataaxis='x', offset=[10, 10],
+    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True,
     color='red', linewidth=2)
 
     #Check that setpos returns None for invalid event region
@@ -491,4 +492,4 @@ def test_text_cursor():
     #the numpy searchsorted method will return an out of bound index.
     #The text needs to become invisible.
     do_event(tool, 'onmove', xdata=-1, ydata=1)
-    assert tool.text.get_visible() == False
+    assert tool.text.get_visible() is False

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -473,3 +473,22 @@ def test_polygon_selector():
                       + polygon_place_vertex(50, 150)
                       + polygon_place_vertex(50, 50))
     check_polygon_selector(event_sequence, expected_result, 1)
+
+def test_text_cursor():
+    ax = get_ax()
+    #Draw horizontal line
+    lin = ax.plot([1, 1], [1, 1])
+    ax.figure.canvas.draw()
+    tool = widgets.TextCursor(line=lin[0], numberformat="{0:.2f}\n{1:.2f}", \
+    dataaxis='x', offset=[10, 10], \
+    textprops={'color': 'blue', 'fontweight': 'bold'}, ax=ax, useblit=True, \
+    color='red', linewidth=2)
+
+    #Check that setpos returns None for invalid event region
+    assert tool.setpos(xpos=None, ypos=1) is None
+
+    #For mouse event out of the current data,
+    #the numpy searchsorted method will return an out of bound index.
+    #The text needs to become invisible.
+    do_event(tool, 'onmove', xdata=-1, ydata=1)
+    assert tool.text.get_visible() == False

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1345,33 +1345,40 @@ class Cursor(AxesWidget):
             self.canvas.draw_idle()
         return False
 
+
 class TextCursor(Cursor):
     """
-    A crosshair cursor like `~matplotlib.widgets.Cursor` with a text showing the current coordinates.
+    A crosshair cursor like `~matplotlib.widgets.Cursor` with a text showing \
+    the current coordinates.
 
     For the cursor to remain responsive you must keep a reference to it.
-    The data of the axis specified as *dataaxis* needs to be constantly growing.
-    Otherwise, the `numpy.searchsorted` call might fail and the text disappears.
-    You can satisfy the requirement by sorting the data you plot. Usually the data is already
-    sorted (if it was created e.g. using `numpy.linspace`), but e.g. scatter plots might cause this problem.
+    The data of the axis specified as *dataaxis* needs to be constantly
+    growing. Otherwise, the `numpy.searchsorted` call might fail and the text
+    disappears. You can satisfy the requirement by sorting the data you plot.
+    Usually the data is already sorted (if it was created e.g. using
+    `numpy.linspace`), but e.g. scatter plots might cause this problem.
 
     Parameters
     ----------
     line : `matplotlib.lines.Line2D`
         The plot line from which the data coordinates are displayed.
 
-    numberformat : `python format string <https://docs.python.org/3/library/string.html#formatstrings>`_, optional, default: "{0:.4g};{1:.4g}"
-        The displayed text is created by calling *format()* on this string with the two coordinates.
+    numberformat : `python format string <https://docs.python.org/3/\
+    library/string.html#formatstrings>`_, optional, default: "{0:.4g};{1:.4g}"
+        The displayed text is created by calling *format()* on this string
+        with the two coordinates.
 
     offset : 2D array-like, optional, default: [5, 5]
-        The offset in display (pixel) coordinates of the text position relative to the cross hair.
+        The offset in display (pixel) coordinates of the text position
+        relative to the cross hair.
 
     dataaxis : {"x", "y"}, optional, default: "x"
-        If "x" is specified, the nearest x value for the current cursor position is found and
-        the y value at that x value is the other displayed cooridnate. If "y" is specified,
-        the nearest y coordinate is found, but there might be many x values matching this y value.
-        The left one in the x data set is displayed. If you use "y", please ensure that your
-        plot is biunique.
+        If "x" is specified, the nearest x value for the current cursor
+        position is found and the y value at that x value is the other
+        displayed cooridnate. If "y" is specified, the nearest y coordinate is
+        found, but there might be many x values matching this y value.
+        The left one in the x data set is displayed. If you use "y",
+        please ensure that your plot is biunique.
 
     Other Parameters
     ----------------
@@ -1380,15 +1387,16 @@ class TextCursor(Cursor):
 
     **cursorargs : `matplotlib.widgets.Cursor` properties
         Arguments passed to the internal `~matplotlib.widgets.Cursor` instance.
-        The `matplotlib.axes.Axes` argument is mandatory! The parameter *useblit* can be set to
-        *True* in order to achieve faster rendering.
+        The `matplotlib.axes.Axes` argument is mandatory! The parameter
+        *useblit* can be set to *True* in order to achieve faster rendering.
 
     Examples
     --------
     See :doc:`/gallery/widgets/text_cursor`.
     """
 
-    def __init__(self, line, numberformat="{0:.4g};{1:.4g}", offset=[5, 5], dataaxis='x', textprops={}, **cursorargs):
+    def __init__(self, line, numberformat="{0:.4g};{1:.4g}", offset=[5, 5], \
+        dataaxis='x', textprops={}, **cursorargs):
         #The line object, for which the coordinates are displayed
         self.line = line
         #The format string, on which .format() is called for creating the text
@@ -1408,10 +1416,13 @@ class TextCursor(Cursor):
         #Default value for position of text.
         self.setpos(self.line.get_xdata()[0], self.line.get_ydata()[0])
         #Create invisible animated text
-        self.text = self.ax.text(self.ax.get_xbound()[0], self.ax.get_ybound()[0], "0, 0", animated=bool(self.useblit), visible=False, **textprops)
+        self.text = self.ax.text(self.ax.get_xbound()[0], \
+            self.ax.get_ybound()[0], "0, 0", animated=bool(self.useblit), \
+            visible=False, **textprops)
 
     def onmove(self, event):
-        """Overwritten draw callback for cursor. Called when moving the mouse."""
+        """Overwritten draw callback for cursor. \
+        Called when moving the mouse."""
 
         #Leave method under the same conditions as in overwritten method
         if self.ignore(event):
@@ -1420,7 +1431,8 @@ class TextCursor(Cursor):
             return
 
         #If the mouse left drawable area, we now make the text invisible.
-        #Baseclass will redraw complete canvas after, which makes both text and cursor disappear.
+        #Baseclass will redraw complete canvas after, which makes both text
+        #and cursor disappear.
         if event.inaxes != self.ax:
             self.text.set_visible(False)
             super().onmove(event)
@@ -1438,21 +1450,21 @@ class TextCursor(Cursor):
             return
 
         #Draw the widget, if event coordinates are valid
-        if (event.xdata != None) and (event.ydata != None):
+        if (event.xdata is not None) and (event.ydata is not None):
             #Get plot point related to current x position.
             #These coordinates are displayed in text.
             plotpoint = self.setpos(event.xdata, event.ydata)
             #If plotpoint is valid (not None)
-            if plotpoint != None:
+            if plotpoint is not None:
                 #Update position and displayed text.
                 #Position: Where the event occured.
                 #Text: Determined by setpos() method earlier
                 #Position is transformed to pixel coordinates,
                 #an offset is added there and this is transformed back.
-                temp=[event.xdata, event.ydata]
-                temp=self.ax.transData.transform(temp)
-                temp=temp+self.offset
-                temp=self.ax.transData.inverted().transform(temp)
+                temp = [event.xdata, event.ydata]
+                temp = self.ax.transData.transform(temp)
+                temp = temp + self.offset
+                temp = self.ax.transData.inverted().transform(temp)
                 self.text.set_position(temp)
                 self.text.set_text(self.numberformat.format(*plotpoint))
                 self.text.set_visible(self.visible)
@@ -1467,20 +1479,22 @@ class TextCursor(Cursor):
                 self.ax.draw_artist(self.text)
                 self.canvas.blit(self.ax.bbox)
             else:
-                #If blitting is deactivated, the overwritten _update call made by the base class
-                #immedeately returned. We still have to draw the changes.
+                #If blitting is deactivated, the overwritten _update call made
+                #by the base class immedeately returned.
+                #We still have to draw the changes.
                 self.canvas.draw_idle()
 
             #Tell base class, that we drawed something.
-            #Baseclass needs to know, that it needs to restore a clean backround
-            #if the cursor leaves our figure context.
+            #Baseclass needs to know, that it needs to restore a clean
+            #backround, if the cursor leaves our figure context.
             self.needclear = True
 
     def setpos(self, xpos, ypos):
         """
         Finds the coordinates, which have to be shown in text.
 
-        The behaviour depends on the *dataaxis* attribute.
+        The behaviour depends on the *dataaxis* attribute. Function looks
+        up the matching plot coordinate for the given mouse position.
 
         Parameters
         ----------
@@ -1493,7 +1507,7 @@ class TextCursor(Cursor):
 
         Returns
         -------
-        ret : {2D array-like, None} The coordinates, which should appear in the text.
+        ret : {2D array-like, None} The coordinates which should be displayed.
             *None* is the fallback value.
         """
 
@@ -1501,27 +1515,31 @@ class TextCursor(Cursor):
         xdata = self.line.get_xdata()
         ydata = self.line.get_ydata()
 
-        #The dataaxis attribute decides, in which axis we look up which cursor coordinate.
+        #The dataaxis attribute decides, in which axis we look up which cursor
+        #coordinate.
         if self.dataaxis == 'x':
-            pos=xpos
-            data=xdata
-            lim=self.ax.get_xlim()
+            pos = xpos
+            data = xdata
+            lim = self.ax.get_xlim()
         elif self.dataaxis == 'y':
-            pos=ypos
-            data=ydata
-            lim=self.ax.get_ylim()
+            pos = ypos
+            data = ydata
+            lim = self.ax.get_ylim()
         else:
-            raise ValueError("The data axis specifier {} should be a string holding 'x' or 'y'".format(self.dataaxis))
+            raise ValueError(\
+                "The data axis specifier {} should be 'x' or 'y'"\
+                .format(self.dataaxis))
 
         #If position is valid
-        if pos != None:
+        if pos is not None:
             #And in valid plot data range
             if pos >= lim[0] and pos <= lim[-1]:
                 #Convert given positon to numpy array,
                 #so numpy function can be used.
                 findme = np.array([pos])
                 #Find closest x value in sorted x vector.
-                #This is the code line, which requires the plotted data to be sorted.
+                #This is the code line,
+                #which requires the plotted data to be sorted.
                 index = np.searchsorted(data, findme)
                 #Return none, if this index is out of range.
                 if (index < 0) or (index >= len(data)):
@@ -1533,10 +1551,12 @@ class TextCursor(Cursor):
         return None
 
     def clear(self, event):
-        """Overwirtten clear callback for cursor. Called right before displaying the figure."""
+        """Overwirtten clear callback for cursor. Called right before \
+        displaying the figure."""
 
         #The base class saves the clean background for blitting.
-        #Text and cursor are invisible, until the first mouse move event occurs.
+        #Text and cursor are invisible,
+        #until the first mouse move event occurs.
         super().clear(event)
         if self.ignore(event):
             return
@@ -1546,9 +1566,11 @@ class TextCursor(Cursor):
         """
         Overwritten method for eather blitting or drawing the widget canvas.
 
-        Passes call to base class if blitting is activated, only. In other cases, one draw_idle
-        call is enough, which is placed explicitly in this class (see `~matplotlib.widgets.TextCursor.onmove`.
-        In that case, `~matplotlib.widgets.Cursor` is not supposed to draw something using this method.
+        Passes call to base class if blitting is activated, only.
+        In other cases, one draw_idle call is enough, which is placed
+        explicitly in this class (see `~matplotlib.widgets.TextCursor.onmove`.
+        In that case, `~matplotlib.widgets.Cursor` is not supposed to draw
+        something using this method.
         """
 
         if self.useblit:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1352,29 +1352,32 @@ class TextCursor(Cursor):
     For the cursor to remain responsive you must keep a reference to it.
     The data of the axis specified as *dataaxis* needs to be constantly growing.
     Otherwise, the `numpy.searchsorted` call might fail and the text disappears.
-    You can satisfy the requirement by sorting the data you plot and usually the data is already
-    sorted, but e.g. scatter plots might cause this problem.
+    You can satisfy the requirement by sorting the data you plot. Usually the data is already
+    sorted (if it was created e.g. using `numpy.linspace`), but e.g. scatter plots might cause this problem.
 
     Parameters
     ----------
     line : `matplotlib.lines.Line2D`
         The plot line from which the data coordinates are displayed.
-    numberformat : `python.string.format` compatible format string, default: '{0:.4g}\n{1:.4g}'
-        The displayed text is created by calling *format()* on this string with the two coordinates.
-    offset : 2D array-like, default: [5, 5]
-        The offset in display (pixel) coordinates of the text position relative to the cross hair.
-    dataaxis : {'x', 'y'}, default: 'x'
-        If 'x' is specified, the nearest x value for the current cursor position is found and
-        the y value at that x value is the other displayed cooridnate. If 'y' is specified,
-        the nearest y coordinate is found, but there might be many x values matching this y value.
-        The left one in the x data set is displayed. If you use 'y', please ensure that your
-        data is biunique.
 
+    numberformat : `python format string <https://docs.python.org/3/library/string.html#formatstrings>`_, optional, default: "{0:.4g};{1:.4g}"
+        The displayed text is created by calling *format()* on this string with the two coordinates.
+
+    offset : 2D array-like, optional, default: [5, 5]
+        The offset in display (pixel) coordinates of the text position relative to the cross hair.
+
+    dataaxis : {"x", "y"}, optional, default: "x"
+        If "x" is specified, the nearest x value for the current cursor position is found and
+        the y value at that x value is the other displayed cooridnate. If "y" is specified,
+        the nearest y coordinate is found, but there might be many x values matching this y value.
+        The left one in the x data set is displayed. If you use "y", please ensure that your
+        plot is biunique.
 
     Other Parameters
     ----------------
     textprops : `matplotlib.text` properties as dictionay
         Specifies the appearance of the rendered text object.
+
     **cursorargs : `matplotlib.widgets.Cursor` properties
         Arguments passed to the internal `~matplotlib.widgets.Cursor` instance.
         The `matplotlib.axes.Axes` argument is mandatory! The parameter *useblit* can be set to
@@ -1383,16 +1386,9 @@ class TextCursor(Cursor):
     Examples
     --------
     See :doc:`/gallery/widgets/text_cursor`.
-
-
-    See also
-    --------
-    matplotlib.widgets.Cursor : the base class for this class
     """
 
-    def __init__(self, line, numberformat="{0:.4g}\n{1:.4g}", offset=[5, 5], dataaxis='x', textprops={}, **cursorargs):
-        """Create text object and attributes. Forward call to base class."""
-
+    def __init__(self, line, numberformat="{0:.4g};{1:.4g}", offset=[5, 5], dataaxis='x', textprops={}, **cursorargs):
         #The line object, for which the coordinates are displayed
         self.line = line
         #The format string, on which .format() is called for creating the text
@@ -1415,7 +1411,7 @@ class TextCursor(Cursor):
         self.text = self.ax.text(self.ax.get_xbound()[0], self.ax.get_ybound()[0], "0, 0", animated=bool(self.useblit), visible=False, **textprops)
 
     def onmove(self, event):
-        """Overwirtten draw callback for cursor. Called when moving the mouse."""
+        """Overwritten draw callback for cursor. Called when moving the mouse."""
 
         #Leave method under the same conditions as in overwritten method
         if self.ignore(event):
@@ -1497,7 +1493,7 @@ class TextCursor(Cursor):
 
         Returns
         -------
-         : {2D array-like, None} The coordinates, which should appear in the text.
+        ret : {2D array-like, None} The coordinates, which should appear in the text.
             *None* is the fallback value.
         """
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1399,7 +1399,7 @@ class TextCursor(Cursor):
     See :doc:`/gallery/widgets/text_cursor`.
     """
 
-    def __init__(self, line, numberformat="{0:.4g};{1:.4g}", offset=[5, 5], \
+    def __init__(self, line, numberformat="{0:.4g};{1:.4g}", offset=[5, 5],
         dataaxis='x', textprops={}, **cursorargs):
         #The line object, for which the coordinates are displayed
         self.line = line
@@ -1420,8 +1420,8 @@ class TextCursor(Cursor):
         #Default value for position of text.
         self.setpos(self.line.get_xdata()[0], self.line.get_ydata()[0])
         #Create invisible animated text
-        self.text = self.ax.text(self.ax.get_xbound()[0], \
-            self.ax.get_ybound()[0], "0, 0", animated=bool(self.useblit), \
+        self.text = self.ax.text(self.ax.get_xbound()[0],
+            self.ax.get_ybound()[0], "0, 0", animated=bool(self.useblit),
             visible=False, **textprops)
 
     def onmove(self, event):
@@ -1540,8 +1540,8 @@ class TextCursor(Cursor):
             data = ydata
             lim = self.ax.get_ylim()
         else:
-            raise ValueError(\
-                "The data axis specifier {} should be 'x' or 'y'"\
+            raise ValueError(
+                "The data axis specifier {} should be 'x' or 'y'"
                 .format(self.dataaxis))
 
         #If position is valid

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1374,15 +1374,15 @@ class TextCursor(Cursor):
         relative to the cross hair.
 
     dataaxis : {"x", "y"}, optional, default: "x"
-		If "x" is specified, the vertical cursor line sticks to the mouse
-		pointer. The horizontal cursor line sticks to the plotted line
-		at that x value. The text shows the data coordinates of the plotted
-		line at the pointed x value. If you specify "y", it works vice-versa.
-		But: For the "y" value, where the mouse points to, there might be
-		multiple matching x values, if the plotted function is not biunique.
-		Cursor and text coordinate will always refer to only one x value.
-		So if you use the parameter value "y", ensure that your function is
-		biunique.
+        If "x" is specified, the vertical cursor line sticks to the mouse
+        pointer. The horizontal cursor line sticks to the plotted line
+        at that x value. The text shows the data coordinates of the plotted
+        line at the pointed x value. If you specify "y", it works vice-versa.
+        But: For the "y" value, where the mouse points to, there might be
+        multiple matching x values, if the plotted function is not biunique.
+        Cursor and text coordinate will always refer to only one x value.
+        So if you use the parameter value "y", ensure that your function is
+        biunique.
 
     Other Parameters
     ----------------


### PR DESCRIPTION
Added a new widget, which is a sub class of the Cursor widget, but displays a text field right next to the cursor showing a tuple of the current mouse x position and the function value y at that x coordinate or vice versa.

An entry in the whats new section and an example was added. There is no unittest yet (the Cursor instance also does not have one).

The behaviour of the cursor class is adapted. The new methods, which overwrite the base class always also call the method of the base class.

Please have a look on especially these two things:
-In widgets.py [1327] the Cursor method onmove() returns, if the cursor is supposedto be invisible. But line 1332 and 1333 therefore will not be reached and cannot make the cursor invisible?
-In the gallery, the cursor is not visible in the picture, because the picture is exported without creating a mouse move event. The example I commit hereby describes the problem with a code example. Does somebody have suggestions?

Please be patient with me ;D