### PR TITLE
Deprecate the useless switch_backend_warn parameter to matplotlib.test.

### DIFF
--- a/doc/api/next_api_changes/2019-04-12-AL.rst
+++ b/doc/api/next_api_changes/2019-04-12-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The ``switch_backend_warn`` parameter to ``matplotlib.test`` has no effect and
+is deprecated.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1262,7 +1262,6 @@ def use(backend, warn=False, force=True):
         If True and not *force*, warn that the call will have no effect if
         this is called after pyplot has been imported and a backend is set up.
 
-
     force : bool, optional, default: True
         If True, attempt to switch the backend.   An ImportError is raised if
         an interactive backend is selected, but another interactive
@@ -1281,20 +1280,17 @@ def use(backend, warn=False, force=True):
     elif 'matplotlib.pyplot' in sys.modules:
         # pyplot has already been imported (which triggered backend selection)
         # and the requested backend is different from the current one.
-
-        # If we are going to force the switch, never warn, else, if warn
-        # is True, then direct users to `plt.switch_backend`
-        if (not force) and warn:
+        if force:
+            # if we are going to force switching the backend, pull in
+            # `switch_backend` from pyplot (which is already imported).
+            from matplotlib.pyplot import switch_backend
+            switch_backend(name)
+        elif warn:
+            # Only if we are not going to force the switch *and* warn is True,
+            # then direct users to `plt.switch_backend`.
             cbook._warn_external(
                 "matplotlib.pyplot has already been imported, "
                 "this call will have no effect.")
-
-        # if we are going to force switching the backend, pull in
-        # `switch_backend` from pyplot.  This will only happen if
-        # pyplot is already imported.
-        if force:
-            from matplotlib.pyplot import switch_backend
-            switch_backend(name)
     else:
         # Finally if pyplot is not imported update both rcParams and
         # rcDefaults so restoring the defaults later with rcdefaults
@@ -1385,6 +1381,7 @@ def _init_tests():
         raise
 
 
+@cbook._delete_parameter("3.2", "switch_backend_warn")
 def test(verbosity=None, coverage=False, switch_backend_warn=True,
          recursionlimit=0, **kwargs):
     """Run the matplotlib test suite."""
@@ -1426,7 +1423,7 @@ def test(verbosity=None, coverage=False, switch_backend_warn=True,
         retcode = pytest.main(args, **kwargs)
     finally:
         if old_backend.lower() != 'agg':
-            use(old_backend, warn=switch_backend_warn)
+            use(old_backend)
         if recursionlimit:
             sys.setrecursionlimit(old_recursionlimit)
 

--- a/tests.py
+++ b/tests.py
@@ -45,6 +45,5 @@ if __name__ == '__main__':
 
     print('Python byte-compilation optimization level:', sys.flags.optimize)
 
-    retcode = test(argv=extra_args, switch_backend_warn=False,
-                   recursionlimit=args.recursionlimit)
+    retcode = test(argv=extra_args, recursionlimit=args.recursionlimit)
     sys.exit(retcode)


### PR DESCRIPTION
`matplotlib.test` always calls `matplotlib.use()` with `force` set to its
default value of True, which means that the `warn` parameter has no
effect.  So just don't bother passing it.

Also slightly reorder the logic in `use()` to make this more apparent (I
think?).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
