### PR TITLE
Don't crash on str(figimage(...)).

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -177,9 +177,6 @@ def _rgb_to_rgba(A):
 class _ImageBase(martist.Artist, cm.ScalarMappable):
     zorder = 0
 
-    def __str__(self):
-        return "AxesImage(%g,%g;%gx%g)" % tuple(self.axes.bbox.bounds)
-
     def __init__(self, ax,
                  cmap=None,
                  norm=None,


### PR DESCRIPTION
`im = figimage(np.random.rand(100, 100), xo=100, yo=100); print(im)`

Previously:
```
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "/usr/lib/python3.7/site-packages/matplotlib/image.py", line 184, in __str__
    return "AxesImage(%g,%g;%gx%g)" % tuple(self.axes.bbox.bounds)
AttributeError: 'NoneType' object has no attribute 'bbox'
```

now:
```
<matplotlib.image.FigureImage object at 0x7fa97be63860>
```

Note that `AxesImage` actually already has the same `__str__` defined in
its own body (which this PR leaves untouched).

Defining a proper `__str__` for `FigureImage` (and other `_ImageBase`
subclasses) is not the object of this PR.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
