### PR TITLE
DOC: Add documentation to Text.set_fontfamily

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -976,7 +976,7 @@ class Text(Artist):
         strings in decreasing priority.  Each string may be either a real font
         name or a generic font class name.  If the latter, the specific font
         names will be looked up in the corresponding rcParams.
-        Defaults to `matplotlib.rcParams['font.family']`.
+
         If a `Text` instance is constructed with `fontfamily=None`, then the
         font is set to `matplotlib.rcParams['font.family']`, and the
         same is done when `set_fontfamily()` is called on an existing

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -976,6 +976,11 @@ class Text(Artist):
         strings in decreasing priority.  Each string may be either a real font
         name or a generic font class name.  If the latter, the specific font
         names will be looked up in the corresponding rcParams.
+        Defaults to `matplotlib.rcParams['font.family']`.
+        If a `Text` instance is constructed with `fontfamily=None`, then the
+        font is set to `matplotlib.rcParams['font.family']`, and the
+        same is done when `set_fontfamily()` is called on an existing
+        `Text` instance.
 
         Parameters
         ----------

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -977,8 +977,8 @@ class Text(Artist):
         name or a generic font class name.  If the latter, the specific font
         names will be looked up in the corresponding rcParams.
 
-        If a `Text` instance is constructed with `fontfamily=None`, then the
-        font is set to `matplotlib.rcParams['font.family']`, and the
+        If a `Text` instance is constructed with ``fontfamily=None``, then the
+        font is set to :rc:`font.family`, and the
         same is done when `set_fontfamily()` is called on an existing
         `Text` instance.
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests (Not needed; doc change)
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there) (Not a major new feature)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way (Not backward incompatible)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

Fix #13880 by adding documentation to `Text.set_fontfamily()`
