### PR TITLE
confidence_ellipse_markup

### DIFF
--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -17,6 +17,12 @@ pearson correlation coefficients and ones) is particularly easy to handle.
 """
 
 
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Ellipse
+import matplotlib.transforms as transforms
+
+
 #############################################################################
 #
 # The plotting function itself
@@ -30,12 +36,6 @@ pearson correlation coefficients and ones) is particularly easy to handle.
 # of standard deviations. The default value is 3 which makes the ellipse
 # enclose 99.7% of the points (given the data is normally distributed
 # like in these examples).
-
-
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.patches import Ellipse
-import matplotlib.transforms as transforms
 
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -16,6 +16,7 @@ and makes use of the fact that a normalized covariance matrix (composed of
 pearson correlation coefficients and ones) is particularly easy to handle.
 """
 
+
 #############################################################################
 #
 # The plotting function itself


### PR DESCRIPTION
The line "The plotting function itself" should be a heading.

## PR Summary
The line "The plotting function itself" should be a heading.
Probably inserting another linefeed above that line will make it render as such.
I hope that this minuscule change will fix it!
Kind regards, Carsten.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
