### PR TITLE
Cleanup animation tests.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -209,10 +209,12 @@ def test_movie_writer_registry():
     mpl.rcParams['animation.ffmpeg_path'] = ffmpeg_path
 
 
-@pytest.mark.skipif(
-    not animation.writers.is_available(mpl.rcParams["animation.writer"]),
-    reason="animation writer not installed")
-@pytest.mark.parametrize("method_name", ["to_html5_video", "to_jshtml"])
+@pytest.mark.parametrize(
+    "method_name",
+    [pytest.param("to_html5_video", marks=pytest.mark.skipif(
+        not animation.writers.is_available(mpl.rcParams["animation.writer"]),
+        reason="animation writer not installed")),
+     "to_jshtml"])
 def test_embed_limit(method_name, caplog, tmpdir):
     caplog.set_level("WARNING")
     with tmpdir.as_cwd():
@@ -224,14 +226,12 @@ def test_embed_limit(method_name, caplog, tmpdir):
             and record.levelname == "WARNING")
 
 
-@pytest.mark.skipif(
-    not animation.writers.is_available(mpl.rcParams["animation.writer"]),
-    reason="animation writer not installed")
 @pytest.mark.parametrize(
     "method_name",
-    ["to_html5_video",
-     pytest.param("to_jshtml",
-                  marks=pytest.mark.xfail)])
+    [pytest.param("to_html5_video", marks=pytest.mark.skipif(
+        not animation.writers.is_available(mpl.rcParams["animation.writer"]),
+        reason="animation writer not installed")),
+     "to_jshtml"])
 def test_cleanup_temporaries(method_name, tmpdir):
     with tmpdir.as_cwd():
         getattr(make_animation(frames=1), method_name)()


### PR DESCRIPTION
- unxfail test_cleanup_temporaries[to_jshtml] which was fixed a while
  ago (as a side effect of #12368, apparently).
- move the check for available writers to only control to_html5_video
  as to_jshtml doesn't require any external writers.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
