### PR TITLE
Unxfail a now fixed test in test_category.

### DIFF
--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -255,19 +255,16 @@ class TestPlotTypes(object):
 
     fids, fvalues = zip(*failing_test_cases)
 
-    PLOT_BROKEN_LIST = [Axes.scatter,
-                        pytest.param(Axes.plot, marks=pytest.mark.xfail),
-                        pytest.param(Axes.bar, marks=pytest.mark.xfail)]
+    plotters = [Axes.scatter, Axes.bar,
+                pytest.param(Axes.plot, marks=pytest.mark.xfail)]
 
-    PLOT_BROKEN_IDS = ["scatter", "plot", "bar"]
-
-    @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
+    @pytest.mark.parametrize("plotter", plotters)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_exception(self, ax, plotter, xdata):
         with pytest.raises(TypeError):
             plotter(ax, xdata, [1, 2])
 
-    @pytest.mark.parametrize("plotter", PLOT_BROKEN_LIST, ids=PLOT_BROKEN_IDS)
+    @pytest.mark.parametrize("plotter", plotters)
     @pytest.mark.parametrize("xdata", fvalues, ids=fids)
     def test_mixed_type_update_exception(self, ax, plotter, xdata):
         with pytest.raises(TypeError):


### PR DESCRIPTION
test_mixed_type{,_update}_exception no longer fails with Axes.bar, so
unxfail it.

We also don't need to provide ids explicitly as pytest now gets them
from the method names directly.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
