### PR TITLE
Remove many unused variables in tests.

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -7,7 +7,6 @@ import pytest
 from matplotlib import (
     collections, path, pyplot as plt, transforms as mtransforms, rcParams)
 from matplotlib.image import imread
-from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.testing.decorators import image_comparison
 
@@ -17,7 +16,6 @@ def test_repeated_save_with_alpha():
     # alpha of 0.25.
 
     fig = Figure([1, 0.4])
-    canvas = FigureCanvas(fig)
     fig.set_facecolor((0, 1, 0.4))
     fig.patch.set_alpha(0.25)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -104,31 +104,26 @@ def test_formatter_ticker():
     ydata1 = [(1.5*y - 0.5)*units.km for y in range(10)]
     ydata2 = [(1.75*y - 1.0)*units.km for y in range(10)]
 
-    fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.figure().subplots()
     ax.set_xlabel("x-label 001")
 
-    fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.figure().subplots()
     ax.set_xlabel("x-label 001")
     ax.plot(xdata, ydata1, color='blue', xunits="sec")
 
-    fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.figure().subplots()
     ax.set_xlabel("x-label 001")
     ax.plot(xdata, ydata1, color='blue', xunits="sec")
     ax.set_xlabel("x-label 003")
 
-    fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.figure().subplots()
     ax.plot(xdata, ydata1, color='blue', xunits="sec")
     ax.plot(xdata, ydata2, color='green', xunits="hour")
     ax.set_xlabel("x-label 004")
 
     # See SF bug 2846058
     # https://sourceforge.net/tracker/?func=detail&aid=2846058&group_id=80706&atid=560720
-    fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.figure().subplots()
     ax.plot(xdata, ydata1, color='blue', xunits="sec")
     ax.plot(xdata, ydata2, color='green', xunits="hour")
     ax.set_xlabel("x-label 005")
@@ -156,8 +151,8 @@ def test_twin_axis_locators_formatters():
     ax1.xaxis.set_minor_locator(plt.FixedLocator([15, 35, 55, 75]))
     ax1.xaxis.set_major_formatter(plt.FormatStrFormatter('%05.2lf'))
     ax1.xaxis.set_minor_formatter(plt.FixedFormatter(['c', '3', 'p', 'o']))
-    ax2 = ax1.twiny()
-    ax3 = ax1.twinx()
+    ax1.twiny()
+    ax1.twinx()
 
 
 def test_twinx_cla():
@@ -463,34 +458,26 @@ def test_polar_coord_annotations():
 
 @image_comparison(baseline_images=['polar_alignment'], extensions=['png'])
 def test_polar_alignment():
-    '''
+    """
     Test that changing the vertical/horizontal alignment of a polar graph
-    works as expected '''
-    ranges = [(0, 5), (0, 5)]
-
+    works as expected.
+    """
     angles = np.arange(0, 360, 90)
-
-    levels = 5
+    grid_values = [0, 0.2, 0.4, 0.6, 0.8, 1]
 
     fig = plt.figure()
+    rect = [0.1, 0.1, 0.8, 0.8]
 
-    figureSize = [0.1, 0.1, 0.8, 0.8]
-
-    horizontal = fig.add_axes(figureSize, polar=True, label='horizontal')
-    vertical = fig.add_axes(figureSize, polar=True, label='vertical')
-
-    axes = [horizontal, vertical]
-
+    horizontal = fig.add_axes(rect, polar=True, label='horizontal')
     horizontal.set_thetagrids(angles)
 
+    vertical = fig.add_axes(rect, polar=True, label='vertical')
     vertical.patch.set_visible(False)
 
     for i in range(2):
-        grid = np.linspace(*ranges[i], num=levels)
-        gridValues = [0, 0.2, 0.4, 0.6, 0.8, 1]
-        axes[i].set_rgrids(gridValues, angle=angles[i],
-                           horizontalalignment='left',
-                           verticalalignment='top')
+        fig.axes[i].set_rgrids(
+            grid_values, angle=angles[i],
+            horizontalalignment='left', verticalalignment='top')
 
 
 @image_comparison(baseline_images=['fill_units'], extensions=['png'],
@@ -542,7 +529,7 @@ def test_single_point():
     matplotlib.rcParams['lines.marker'] = 'o'
     matplotlib.rcParams['axes.grid'] = True
 
-    fig = plt.figure()
+    plt.figure()
     plt.subplot(211)
     plt.plot([0], [0], 'o')
 
@@ -552,7 +539,7 @@ def test_single_point():
     # Reuse testcase from above for a labeled data test
     data = {'a': [0], 'b': [1]}
 
-    fig = plt.figure()
+    plt.figure()
     plt.subplot(211)
     plt.plot('a', 'a', 'o', data=data)
 
@@ -561,12 +548,11 @@ def test_single_point():
 
 
 @image_comparison(baseline_images=['single_date'], extensions=['png'],
-        style='mpl20')
+                  style='mpl20')
 def test_single_date():
     time1 = [721964.0]
     data1 = [-65.54]
 
-    fig = plt.figure()
     plt.subplot(211)
     plt.plot_date(time1, data1, 'o', color='r')
 
@@ -610,7 +596,6 @@ def test_shaped_data():
     y1 = np.arange(10).reshape((1, -1))
     y2 = np.arange(10).reshape((-1, 1))
 
-    fig = plt.figure()
     plt.subplot(411)
     plt.plot(y1)
     plt.subplot(412)
@@ -629,15 +614,13 @@ def test_structured_data():
     pts = np.array([(1, 1), (2, 2)], dtype=[("ones", float), ("twos", float)])
 
     # this should not read second name as a format and raise ValueError
-    fig, ax = plt.subplots(2)
-    ax[0].plot("ones", "twos", data=pts)
-    ax[1].plot("ones", "twos", "r", data=pts)
+    axs = plt.figure().subplots(2)
+    axs[0].plot("ones", "twos", data=pts)
+    axs[1].plot("ones", "twos", "r", data=pts)
 
 
 @image_comparison(baseline_images=['const_xy'])
 def test_const_xy():
-    fig = plt.figure()
-
     plt.subplot(311)
     plt.plot(np.arange(10), np.ones(10))
 
@@ -672,28 +655,19 @@ def test_polar_units():
     import matplotlib.testing.jpl_units as units
     units.register()
 
-    pi = np.pi
     deg = units.deg
     km = units.km
 
-    x1 = [pi/6.0, pi/4.0, pi/3.0, pi/2.0]
-    x2 = [30.0*deg, 45.0*deg, 60.0*deg, 90.0*deg]
+    xs = [30.0*deg, 45.0*deg, 60.0*deg, 90.0*deg]
+    ys = [1.0, 2.0, 3.0, 4.0]
 
-    y1 = [1.0, 2.0, 3.0, 4.0]
-    y2 = [4.0, 3.0, 2.0, 1.0]
+    plt.figure()
+    plt.polar(xs, ys, color="blue")
 
-    fig = plt.figure()
-
-    plt.polar(x2, y1, color="blue")
-
-    # polar(x2, y1, color = "red", xunits="rad")
-    # polar(x2, y2, color = "green")
-
-    fig = plt.figure()
-
+    plt.figure()
     # make sure runits and theta units work
-    y1 = [y*km for y in y1]
-    plt.polar(x2, y1, color="blue", thetaunits="rad", runits="km")
+    ykm = [y*km for y in ys]
+    plt.polar(xs, ykm, color="blue", thetaunits="rad", runits="km")
     assert isinstance(plt.gca().get_xaxis().get_major_formatter(),
                       units.UnitDblFormatter)
 
@@ -833,14 +807,10 @@ def test_axvspan_epoch():
     # generate some data
     t0 = units.Epoch("ET", dt=datetime(2009, 1, 20))
     tf = units.Epoch("ET", dt=datetime(2009, 1, 21))
-
     dt = units.Duration("ET", units.day.convert("sec"))
 
-    fig = plt.figure()
-
-    plt.axvspan(t0, tf, facecolor="blue", alpha=0.25)
-
     ax = plt.gca()
+    plt.axvspan(t0, tf, facecolor="blue", alpha=0.25)
     ax.set_xlim(t0 - 5.0*dt, tf + 5.0*dt)
 
 
@@ -853,14 +823,10 @@ def test_axhspan_epoch():
     # generate some data
     t0 = units.Epoch("ET", dt=datetime(2009, 1, 20))
     tf = units.Epoch("ET", dt=datetime(2009, 1, 21))
-
     dt = units.Duration("ET", units.day.convert("sec"))
 
-    fig = plt.figure()
-
-    plt.axhspan(t0, tf, facecolor="blue", alpha=0.25)
-
     ax = plt.gca()
+    ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
     ax.set_ylim(t0 - 5.0*dt, tf + 5.0*dt)
 
 
@@ -1621,18 +1587,12 @@ def test_hist_steplog():
     data_big = data_pos + 30
     weights = np.ones_like(data) * 1.e-5
 
-    ax = plt.subplot(4, 1, 1)
-    plt.hist(data, 100, histtype='stepfilled', log=True)
-
-    ax = plt.subplot(4, 1, 2)
-    plt.hist(data_pos, 100, histtype='stepfilled', log=True)
-
-    ax = plt.subplot(4, 1, 3)
-    plt.hist(data, 100, weights=weights, histtype='stepfilled', log=True)
-
-    ax = plt.subplot(4, 1, 4)
-    plt.hist(data_big, 100, histtype='stepfilled', log=True,
-             orientation='horizontal')
+    axs = plt.figure().subplots(4)
+    axs[0].hist(data, 100, histtype='stepfilled', log=True)
+    axs[1].hist(data_pos, 100, histtype='stepfilled', log=True)
+    axs[2].hist(data, 100, weights=weights, histtype='stepfilled', log=True)
+    axs[3].hist(data_big, 100, histtype='stepfilled', log=True,
+                orientation='horizontal')
 
 
 @image_comparison(baseline_images=['hist_step_filled'], remove_text=True,
@@ -1732,12 +1692,11 @@ def contour_dat():
                   remove_text=True, style='mpl20')
 def test_contour_hatching():
     x, y, z = contour_dat()
-
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    cs = ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
-                     cmap=plt.get_cmap('gray'),
-                     extend='both', alpha=0.5)
+    ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
+                cmap=plt.get_cmap('gray'),
+                extend='both', alpha=0.5)
 
 
 @image_comparison(baseline_images=['contour_colorbar'],
@@ -3379,7 +3338,7 @@ def test_eventplot_defaults():
 
     fig = plt.figure()
     axobj = fig.add_subplot(111)
-    colls = axobj.eventplot(data)
+    axobj.eventplot(data)
 
 
 @pytest.mark.parametrize(('colors'), [
@@ -3429,13 +3388,13 @@ def test_eventplot_problem_kwargs():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        colls = axobj.eventplot(data,
-                                colors=['r', 'b'],
-                                color=['c', 'm'],
-                                linewidths=[2, 1],
-                                linewidth=[1, 2],
-                                linestyles=['solid', 'dashed'],
-                                linestyle=['dashdot', 'dotted'])
+        axobj.eventplot(data,
+                        colors=['r', 'b'],
+                        color=['c', 'm'],
+                        linewidths=[2, 1],
+                        linewidth=[1, 2],
+                        linestyles=['solid', 'dashed'],
+                        linestyle=['dashdot', 'dotted'])
 
         # check that three IgnoredKeywordWarnings were raised
         assert len(w) == 3
@@ -3645,8 +3604,6 @@ def test_mixed_collection():
     from matplotlib import patches
     from matplotlib import collections
 
-    x = list(range(10))
-
     # First illustrate basic pyplot interface, using defaults where possible.
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -3714,22 +3671,22 @@ def test_specgram_freqs():
     ax22 = fig2.add_subplot(3, 1, 2)
     ax23 = fig2.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided')
 
-    spec21 = ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec22 = ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec23 = ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
+    ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
 
 
 @image_comparison(baseline_images=['specgram_noise',
@@ -3762,22 +3719,22 @@ def test_specgram_noise():
     ax22 = fig2.add_subplot(3, 1, 2)
     ax23 = fig2.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided')
 
-    spec21 = ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec22 = ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec23 = ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
+    ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
 
 
 @image_comparison(baseline_images=['specgram_magnitude_freqs',
@@ -3818,22 +3775,22 @@ def test_specgram_magnitude_freqs():
     ax22 = fig2.add_subplot(3, 1, 2)
     ax23 = fig2.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='magnitude')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='magnitude')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='magnitude')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='magnitude')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='magnitude')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='magnitude')
 
-    spec21 = ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec22 = ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec23 = ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
+    ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
 
 
 @image_comparison(baseline_images=['specgram_magnitude_noise',
@@ -3866,22 +3823,22 @@ def test_specgram_magnitude_noise():
     ax22 = fig2.add_subplot(3, 1, 2)
     ax23 = fig2.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='magnitude')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='magnitude')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='magnitude')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='magnitude')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='magnitude')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='magnitude')
 
-    spec21 = ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec22 = ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
-    spec23 = ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='magnitude',
-                           scale='linear', norm=matplotlib.colors.LogNorm())
+    ax21.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax22.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
+    ax23.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='magnitude',
+                  scale='linear', norm=matplotlib.colors.LogNorm())
 
 
 @image_comparison(baseline_images=['specgram_angle_freqs'],
@@ -3916,12 +3873,12 @@ def test_specgram_angle_freqs():
     ax12 = fig1.add_subplot(3, 1, 2)
     ax13 = fig1.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='angle')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='angle')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='angle')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='angle')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='angle')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='angle')
 
     with pytest.raises(ValueError):
         ax11.specgram(y, NFFT=NFFT, Fs=Fs,
@@ -3963,12 +3920,12 @@ def test_specgram_noise_angle():
     ax12 = fig1.add_subplot(3, 1, 2)
     ax13 = fig1.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='angle')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='angle')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='angle')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='angle')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='angle')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='angle')
 
     with pytest.raises(ValueError):
         ax11.specgram(y, NFFT=NFFT, Fs=Fs,
@@ -4018,12 +3975,12 @@ def test_specgram_freqs_phase():
     ax12 = fig1.add_subplot(3, 1, 2)
     ax13 = fig1.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default', mode='phase')
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided', mode='phase')
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided', mode='phase')
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='phase')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='phase')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='phase')
 
     with pytest.raises(ValueError):
         ax11.specgram(y, NFFT=NFFT, Fs=Fs,
@@ -4065,15 +4022,12 @@ def test_specgram_noise_phase():
     ax12 = fig1.add_subplot(3, 1, 2)
     ax13 = fig1.add_subplot(3, 1, 3)
 
-    spec11 = ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='default',
-                           mode='phase', )
-    spec12 = ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='onesided',
-                           mode='phase', )
-    spec13 = ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                           pad_to=pad_to, sides='twosided',
-                           mode='phase', )
+    ax11.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='default', mode='phase')
+    ax12.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='onesided', mode='phase')
+    ax13.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                  pad_to=pad_to, sides='twosided', mode='phase')
 
     with pytest.raises(ValueError):
         ax11.specgram(y, NFFT=NFFT, Fs=Fs,
@@ -4755,8 +4709,8 @@ def test_pie_default():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
     fig1, ax1 = plt.subplots(figsize=(8, 6))
-    pie1 = ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
-                autopct='%1.1f%%', shadow=True, startangle=90)
+    ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90)
 
 
 @image_comparison(baseline_images=['pie_linewidth_0', 'pie_linewidth_0',
@@ -5303,7 +5257,6 @@ def test_title_location_roundtrip():
     fig, ax = plt.subplots()
     # set default title location
     plt.rcParams['axes.titlelocation'] = 'center'
-
     ax.set_title('aardvark')
     ax.set_title('left', loc='left')
     ax.set_title('right', loc='right')
@@ -5594,7 +5547,7 @@ def test_axes_tick_params_xlabelside():
 
 
 def test_none_kwargs():
-    fig, ax = plt.subplots()
+    ax = plt.figure().subplots()
     ln, = ax.plot(range(32), linestyle=None)
     assert ln.get_linestyle() == '-'
 
@@ -5623,7 +5576,7 @@ def test_date_timezone_x():
                   for x in range(3)]
 
     # Same Timezone
-    fig = plt.figure(figsize=(20, 12))
+    plt.figure(figsize=(20, 12))
     plt.subplot(2, 1, 1)
     plt.plot_date(time_index, [3] * 3, tz='Canada/Eastern')
 
@@ -5641,7 +5594,7 @@ def test_date_timezone_y():
                   for x in range(3)]
 
     # Same Timezone
-    fig = plt.figure(figsize=(20, 12))
+    plt.figure(figsize=(20, 12))
     plt.subplot(2, 1, 1)
     plt.plot_date([3] * 3,
                   time_index, tz='Canada/Eastern', xdate=False, ydate=True)
@@ -5660,7 +5613,7 @@ def test_date_timezone_x_and_y():
                   for x in range(3)]
 
     # Same Timezone
-    fig = plt.figure(figsize=(20, 12))
+    plt.figure(figsize=(20, 12))
     plt.subplot(2, 1, 1)
     plt.plot_date(time_index, time_index, tz='UTC', ydate=True)
 
@@ -5675,7 +5628,7 @@ def test_axisbelow():
     # Test 'line' setting added in 6287.
     # Show only grids, not frame or ticks, to make this test
     # independent of future change to drawing order of those elements.
-    fig, axs = plt.subplots(ncols=3, sharex=True, sharey=True)
+    axs = plt.figure().subplots(ncols=3, sharex=True, sharey=True)
     settings = (False, 'line', True)
 
     for ax, setting in zip(axs, settings):
@@ -6032,7 +5985,7 @@ def test_cartopy_backcompat():
 def test_gettightbbox_ignoreNaN():
     fig, ax = plt.subplots()
     remove_ticks_and_titles(fig)
-    t = ax.text(np.NaN, 1, 'Boo')
+    ax.text(np.NaN, 1, 'Boo')
     renderer = fig.canvas.get_renderer()
     np.testing.assert_allclose(ax.get_tightbbox(renderer).width, 496)
 
@@ -6093,21 +6046,21 @@ def test_secondary_xy():
         else:
             secax = ax.secondary_yaxis
 
-        axsec = secax(0.2, functions=(invert, invert))
-        axsec = secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
-        axsec = secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
-        axsec = secax(0.8)
+        secax(0.2, functions=(invert, invert))
+        secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
+        secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
+        secax(0.8)
 
 
 def test_secondary_fail():
     fig, ax = plt.subplots()
     ax.plot(np.arange(2, 11), np.arange(2, 11))
     with pytest.raises(ValueError):
-        axsec = ax.secondary_xaxis(0.2, functions=(lambda x: 1 / x))
+        ax.secondary_xaxis(0.2, functions=(lambda x: 1 / x))
     with pytest.raises(ValueError):
-        axsec = ax.secondary_xaxis('right')
+        ax.secondary_xaxis('right')
     with pytest.raises(ValueError):
-        axsec = ax.secondary_yaxis('bottom')
+        ax.secondary_yaxis('bottom')
 
 
 def test_secondary_resize():
@@ -6117,7 +6070,7 @@ def test_secondary_resize():
         with np.errstate(divide='ignore'):
             return 1 / x
 
-    axsec = ax.secondary_xaxis('top', functions=(invert, invert))
+    ax.secondary_xaxis('top', functions=(invert, invert))
     fig.canvas.draw()
     fig.set_size_inches((7, 4))
     assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -117,7 +117,7 @@ def test_fig_close(backend):
 @pytest.mark.backend('Qt5Agg')
 def test_fig_signals(qt_module):
     # Create a figure
-    fig = plt.figure()
+    plt.figure()
 
     # Access QtCore
     QtCore = qt_module[0]

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -35,9 +35,8 @@ def test_bbox_inches_tight():
     plt.legend([''] * 5, loc=(1.2, 0.2))
     # Add a table at the bottom of the axes
     cellText.reverse()
-    the_table = plt.table(cellText=cellText,
-                          rowLabels=rowLabels,
-                          colLabels=colLabels, loc='bottom')
+    plt.table(cellText=cellText, rowLabels=rowLabels, colLabels=colLabels,
+              loc='bottom')
 
 
 @image_comparison(baseline_images=['bbox_inches_tight_suptile_legend'],

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -172,12 +172,12 @@ class Test_boxplot_stats(object):
     def test_label_error(self):
         labels = [1, 2]
         with pytest.raises(ValueError):
-            results = cbook.boxplot_stats(self.data, labels=labels)
+            cbook.boxplot_stats(self.data, labels=labels)
 
     def test_bad_dims(self):
         data = np.random.normal(size=(34, 34, 34))
         with pytest.raises(ValueError):
-            results = cbook.boxplot_stats(data)
+            cbook.boxplot_stats(data)
 
     def test_boxplot_stats_autorange_false(self):
         x = np.zeros(shape=140)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -50,10 +50,10 @@ def _colorbar_extension_shape(spacing):
         # Create a subplot.
         cax = fig.add_subplot(4, 1, i + 1)
         # Generate the colorbar.
-        cb = ColorbarBase(cax, cmap=cmap, norm=norm,
-                boundaries=boundaries, values=values,
-                extend=extension_type, extendrect=True,
-                orientation='horizontal', spacing=spacing)
+        ColorbarBase(cax, cmap=cmap, norm=norm,
+                     boundaries=boundaries, values=values,
+                     extend=extension_type, extendrect=True,
+                     orientation='horizontal', spacing=spacing)
         # Turn off text and ticks.
         cax.tick_params(left=False, labelleft=False,
                         bottom=False, labelbottom=False)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -252,7 +252,7 @@ def test_DivergingNorm_scale():
 def test_DivergingNorm_scaleout_center():
     # test the vmin never goes above vcenter
     norm = mcolors.DivergingNorm(vcenter=0)
-    x = norm([1, 2, 3, 5])
+    norm([1, 2, 3, 5])
     assert norm.vmin == 0
     assert norm.vmax == 5
 
@@ -260,7 +260,7 @@ def test_DivergingNorm_scaleout_center():
 def test_DivergingNorm_scaleout_center_max():
     # test the vmax never goes below vcenter
     norm = mcolors.DivergingNorm(vcenter=0)
-    x = norm([-1, -2, -3, -5])
+    norm([-1, -2, -3, -5])
     assert norm.vmax == 0
     assert norm.vmin == -5
 
@@ -281,28 +281,27 @@ def test_DivergingNorm_Odd():
 
 def test_DivergingNorm_VminEqualsVcenter():
     with pytest.raises(ValueError):
-        norm = mcolors.DivergingNorm(vmin=-2, vcenter=-2, vmax=2)
+        mcolors.DivergingNorm(vmin=-2, vcenter=-2, vmax=2)
 
 
 def test_DivergingNorm_VmaxEqualsVcenter():
     with pytest.raises(ValueError):
-        norm = mcolors.DivergingNorm(vmin=-2, vcenter=2, vmax=2)
+        mcolors.DivergingNorm(vmin=-2, vcenter=2, vmax=2)
 
 
 def test_DivergingNorm_VminGTVcenter():
     with pytest.raises(ValueError):
-        norm = mcolors.DivergingNorm(vmin=10, vcenter=0, vmax=20)
+        mcolors.DivergingNorm(vmin=10, vcenter=0, vmax=20)
 
 
 def test_DivergingNorm_DivergingNorm_VminGTVmax():
     with pytest.raises(ValueError):
-        norm = mcolors.DivergingNorm(vmin=10, vcenter=0, vmax=5)
+        mcolors.DivergingNorm(vmin=10, vcenter=0, vmax=5)
 
 
 def test_DivergingNorm_VcenterGTVmax():
-    vals = np.arange(50)
     with pytest.raises(ValueError):
-        norm = mcolors.DivergingNorm(vmin=10, vcenter=25, vmax=20)
+        mcolors.DivergingNorm(vmin=10, vcenter=25, vmax=20)
 
 
 def test_DivergingNorm_premature_scaling():
@@ -336,7 +335,7 @@ def test_SymLogNorm_colorbar():
     """
     norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1)
     fig = plt.figure()
-    cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
+    mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
     plt.close(fig)
 
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -122,9 +122,8 @@ def test_constrained_layout7():
         gs = gridspec.GridSpec(1, 2)
         gsl = gridspec.GridSpecFromSubplotSpec(2, 2, gs[0])
         gsr = gridspec.GridSpecFromSubplotSpec(1, 2, gs[1])
-        axsl = []
         for gs in gsl:
-            ax = fig.add_subplot(gs)
+            fig.add_subplot(gs)
         # need to trigger a draw to get warning
         fig.draw(fig.canvas.get_renderer())
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -295,7 +295,7 @@ def test_corner_mask():
     z = np.ma.array(z, mask=mask)
 
     for corner_mask in [False, True]:
-        fig = plt.figure()
+        plt.figure()
         plt.contourf(z, corner_mask=corner_mask)
 
 

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -162,7 +162,6 @@ def test_valid_input_forms():
     ax.set_prop_cycle(lw=np.array([1, 2]),
                       color=np.array(['k', 'w']),
                       ls=np.array(['-', '--']))
-    assert True
 
 
 def test_cycle_reset():

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -404,7 +404,7 @@ def test_add_artist(fig_test, fig_ref):
     fig_test.set_dpi(100)
     fig_ref.set_dpi(100)
 
-    ax = fig_test.subplots()
+    fig_test.subplots()
     l1 = plt.Line2D([.2, .7], [.7, .7], gid='l1')
     l2 = plt.Line2D([.2, .7], [.8, .8], gid='l2')
     r1 = plt.Circle((20, 20), 100, transform=None, gid='C1')

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -299,9 +299,8 @@ class TestLegendFunction(object):
         p2, = par.plot([0, 1, 2], [0, 3, 2], label="Temperature")
 
         with mock.patch('matplotlib.legend.Legend') as Legend:
-            leg = plt.legend()
-        Legend.assert_called_with(host, [p1, p2],
-                ['Density', 'Temperature'])
+            plt.legend()
+        Legend.assert_called_with(host, [p1, p2], ['Density', 'Temperature'])
 
 
 class TestLegendFigureFunction(object):
@@ -412,13 +411,13 @@ def test_legend_repeatcheckok():
     fig, ax = plt.subplots()
     ax.scatter(0.0, 1.0, color='k', marker='o', label='test')
     ax.scatter(0.5, 0.0, color='r', marker='v', label='test')
-    hl = ax.legend()
+    ax.legend()
     hand, lab = mlegend._get_legend_handles_labels([ax])
     assert len(lab) == 2
     fig, ax = plt.subplots()
     ax.scatter(0.0, 1.0, color='k', marker='o', label='test')
     ax.scatter(0.5, 0.0, color='k', marker='v', label='test')
-    hl = ax.legend()
+    ax.legend()
     hand, lab = mlegend._get_legend_handles_labels([ax])
     assert len(lab) == 2
 
@@ -561,7 +560,7 @@ def test_warn_big_data_best_loc():
     ax.plot(np.arange(200001), label='Is this big data?')
     with pytest.warns(UserWarning) as records:
         with rc_context({'legend.loc': 'best'}):
-            l = ax.legend()
+            ax.legend()
         fig.canvas.draw()
     # The _find_best_position method of Legend is called twice, duplicating
     # the warning message.
@@ -576,6 +575,6 @@ def test_no_warn_big_data_when_loc_specified():
     fig, ax = plt.subplots()
     ax.plot(np.arange(200001), label='Is this big data?')
     with pytest.warns(None) as records:
-        l = ax.legend('best')
+        ax.legend('best')
         fig.canvas.draw()
     assert len(records) == 0

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -64,13 +64,10 @@ def test_invisible_Line_rendering():
 def test_set_line_coll_dash():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
-
     np.random.seed(0)
     # Testing setting linestyles for line collections.
     # This should not produce an error.
-    cs = ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
-
-    assert True
+    ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 
 
 @image_comparison(baseline_images=['line_dashes'], remove_text=True)
@@ -90,7 +87,6 @@ def test_line_colors():
     ax.plot(range(10), color=(1, 0, 0, 1))
     ax.plot(range(10), color=(1, 0, 0))
     fig.canvas.draw()
-    assert True
 
 
 def test_linestyle_variants():
@@ -99,9 +95,7 @@ def test_linestyle_variants():
     for ls in ["-", "solid", "--", "dashed",
                "-.", "dashdot", ":", "dotted"]:
         ax.plot(range(10), linestyle=ls)
-
     fig.canvas.draw()
-    assert True
 
 
 def test_valid_linestyles():
@@ -148,9 +142,8 @@ def test_set_drawstyle():
 def test_set_line_coll_dash_image():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
-
     np.random.seed(0)
-    cs = ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
+    ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 
 
 @image_comparison(baseline_images=['marker_fill_styles'], remove_text=True,

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -464,31 +464,31 @@ class TestDetrend(object):
     def test_detrend_none_0D_zeros(self):
         input = 0.
         targ = input
-        res = mlab.detrend_none(input)
+        mlab.detrend_none(input)
         assert input == targ
 
     def test_detrend_none_0D_zeros_axis1(self):
         input = 0.
         targ = input
-        res = mlab.detrend_none(input, axis=1)
+        mlab.detrend_none(input, axis=1)
         assert input == targ
 
     def test_detrend_str_none_0D_zeros(self):
         input = 0.
         targ = input
-        res = mlab.detrend(input, key='none')
+        mlab.detrend(input, key='none')
         assert input == targ
 
     def test_detrend_detrend_none_0D_zeros(self):
         input = 0.
         targ = input
-        res = mlab.detrend(input, key=mlab.detrend_none)
+        mlab.detrend(input, key=mlab.detrend_none)
         assert input == targ
 
     def test_detrend_none_0D_off(self):
         input = 5.5
         targ = input
-        res = mlab.detrend_none(input)
+        mlab.detrend_none(input)
         assert input == targ
 
     def test_detrend_none_1D_off(self):
@@ -1122,7 +1122,7 @@ class TestSpectral(object):
             NFFT_spectrum_real = NFFT_spectrum = pad_to_spectrum_real
         else:
             NFFT_spectrum_real = NFFT_spectrum = len(x)
-        nover_spectrum_real = nover_spectrum = 0
+        nover_spectrum = 0
 
         NFFT_specgram = NFFT_density
         nover_specgram = nover_density
@@ -1399,7 +1399,6 @@ class TestSpectral(object):
     def test_psd_detrend_mean_func_offset(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.zeros(self.NFFT_density)
         ydata1 = ydata+5
         ydata2 = ydata+3.3
@@ -1435,7 +1434,6 @@ class TestSpectral(object):
     def test_psd_detrend_mean_str_offset(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.zeros(self.NFFT_density)
         ydata1 = ydata+5
         ydata2 = ydata+3.3
@@ -1471,7 +1469,6 @@ class TestSpectral(object):
     def test_psd_detrend_linear_func_trend(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.arange(self.NFFT_density)
         ydata1 = ydata+5
         ydata2 = ydata+3.3
@@ -1507,7 +1504,6 @@ class TestSpectral(object):
     def test_psd_detrend_linear_str_trend(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.arange(self.NFFT_density)
         ydata1 = ydata+5
         ydata2 = ydata+3.3
@@ -1543,7 +1539,6 @@ class TestSpectral(object):
     def test_psd_window_hanning(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.arange(self.NFFT_density)
         ydata1 = ydata+5
         ydata2 = ydata+3.3
@@ -1587,7 +1582,6 @@ class TestSpectral(object):
     def test_psd_window_hanning_detrend_linear(self):
         if self.NFFT_density is None:
             return
-        freqs = self.freqs_density
         ydata = np.arange(self.NFFT_density)
         ycontrol = np.zeros(self.NFFT_density)
         ydata1 = ydata+5
@@ -1646,7 +1640,6 @@ class TestSpectral(object):
         assert spec.shape == freqs.shape
 
     def test_psd_windowarray_scale_by_freq(self):
-        freqs = self.freqs_density
         win = mlab.window_hanning(np.ones(self.NFFT_density_real))
 
         spec, fsp = mlab.psd(x=self.y,
@@ -1835,7 +1828,6 @@ class TestSpectral(object):
                                      pad_to=self.pad_to_specgram,
                                      sides=self.sides,
                                      mode='angle')
-        specm = np.mean(spec, axis=1)
         assert_allclose(fsp, freqs, atol=1e-06)
         assert_allclose(t, self.t_specgram, atol=1e-06)
 
@@ -1851,8 +1843,6 @@ class TestSpectral(object):
                                      pad_to=self.pad_to_specgram,
                                      sides=self.sides,
                                      mode='phase')
-        specm = np.mean(spec, axis=1)
-
         assert_allclose(fsp, freqs, atol=1e-06)
         assert_allclose(t, self.t_specgram, atol=1e-06)
 
@@ -1865,7 +1855,6 @@ class TestSpectral(object):
             mlab.specgram(x=self.y, NFFT=len(self.y), Fs=self.Fs)
 
     def test_psd_csd_equal(self):
-        freqs = self.freqs_density
         Pxx, freqsxx = mlab.psd(x=self.y,
                                 NFFT=self.NFFT_density,
                                 Fs=self.Fs,
@@ -1884,7 +1873,6 @@ class TestSpectral(object):
     def test_specgram_auto_default_equal(self):
         '''test that mlab.specgram without mode and with mode 'default' and
         'psd' are all the same'''
-        freqs = self.freqs_specgram
         speca, freqspeca, ta = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -1905,7 +1893,6 @@ class TestSpectral(object):
     def test_specgram_auto_psd_equal(self):
         '''test that mlab.specgram without mode and with mode 'default' and
         'psd' are all the same'''
-        freqs = self.freqs_specgram
         speca, freqspeca, ta = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -1924,7 +1911,6 @@ class TestSpectral(object):
         assert_array_equal(ta, tc)
 
     def test_specgram_complex_mag_equivalent(self):
-        freqs = self.freqs_specgram
         specc, freqspecc, tc = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -1945,7 +1931,6 @@ class TestSpectral(object):
         assert_allclose(np.abs(specc), specm, atol=1e-06)
 
     def test_specgram_complex_angle_equivalent(self):
-        freqs = self.freqs_specgram
         specc, freqspecc, tc = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -1966,7 +1951,6 @@ class TestSpectral(object):
         assert_allclose(np.angle(specc), speca, atol=1e-06)
 
     def test_specgram_complex_phase_equivalent(self):
-        freqs = self.freqs_specgram
         specc, freqspecc, tc = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -1988,7 +1972,6 @@ class TestSpectral(object):
                         atol=1e-06)
 
     def test_specgram_angle_phase_equivalent(self):
-        freqs = self.freqs_specgram
         speca, freqspeca, ta = mlab.specgram(x=self.y,
                                              NFFT=self.NFFT_specgram,
                                              Fs=self.Fs,
@@ -2010,7 +1993,6 @@ class TestSpectral(object):
                         atol=1e-06)
 
     def test_psd_windowarray_equal(self):
-        freqs = self.freqs_density
         win = mlab.window_hanning(np.ones(self.NFFT_density_real))
         speca, fspa = mlab.psd(x=self.y,
                                NFFT=self.NFFT_density,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -240,7 +240,6 @@ def test_patch_linestyle_accents():
     ax.set_xlim([-1, i + 1])
     ax.set_ylim([-1, i + 1])
     fig.canvas.draw()
-    assert True
 
 
 def test_wedge_movement():

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -139,7 +139,7 @@ def test_image():
 
 
 def test_polar():
-    ax = plt.subplot(111, polar=True)
+    plt.subplot(111, polar=True)
     fig = plt.gcf()
     pf = pickle.dumps(fig)
     pickle.loads(pf)

--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -20,7 +20,7 @@ def test_pngsuite():
         'pngsuite')
     files = sorted(glob.iglob(os.path.join(dirname, 'basn*.png')))
 
-    fig = plt.figure(figsize=(len(files), 2))
+    plt.figure(figsize=(len(files), 2))
 
     for i, fname in enumerate(files):
         data = plt.imread(fname)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -71,12 +71,9 @@ def test_zero_headlength():
 def test_quiver_animate():
     # Tests fix for #2616
     fig, ax = plt.subplots()
-
     Q = draw_quiver(ax, animated=True)
-
-    qk = ax.quiverkey(Q, 0.5, 0.92, 2, r'$2 \frac{m}{s}$',
-                      labelpos='W',
-                      fontproperties={'weight': 'bold'})
+    ax.quiverkey(Q, 0.5, 0.92, 2, r'$2 \frac{m}{s}$',
+                 labelpos='W', fontproperties={'weight': 'bold'})
 
 
 @image_comparison(baseline_images=['quiver_with_key_test_image'],
@@ -84,16 +81,13 @@ def test_quiver_animate():
 def test_quiver_with_key():
     fig, ax = plt.subplots()
     ax.margins(0.1)
-
     Q = draw_quiver(ax)
-
-    qk = ax.quiverkey(Q, 0.5, 0.95, 2,
-                      r'$2\, \mathrm{m}\, \mathrm{s}^{-1}$',
-                      angle=-10,
-                      coordinates='figure',
-                      labelpos='W',
-                      fontproperties={'weight': 'bold',
-                                      'size': 'large'})
+    ax.quiverkey(Q, 0.5, 0.95, 2,
+                 r'$2\, \mathrm{m}\, \mathrm{s}^{-1}$',
+                 angle=-10,
+                 coordinates='figure',
+                 labelpos='W',
+                 fontproperties={'weight': 'bold', 'size': 'large'})
 
 
 @image_comparison(baseline_images=['quiver_single_test_image'],
@@ -101,7 +95,6 @@ def test_quiver_with_key():
 def test_quiver_single():
     fig, ax = plt.subplots()
     ax.margins(0.1)
-
     ax.quiver([1], [1], [2], [2])
 
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -115,7 +115,7 @@ def test_Bug_2543():
             for key in _copy:
                 mpl.rcParams[key] = _copy[key]
         with mpl.rc_context():
-            _deep_copy = copy.deepcopy(mpl.rcParams)
+            copy.deepcopy(mpl.rcParams)
         # real test is that this does not raise
         assert validate_bool_maybe_none(None) is None
         assert validate_bool_maybe_none("none") is None

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -97,14 +97,13 @@ def test_logscale_invert_transform():
 
 
 def test_logscale_transform_repr():
-    # check that repr of log transform succeeds
     fig, ax = plt.subplots()
     ax.set_yscale('log')
-    s = repr(ax.transData)
+    repr(ax.transData)  # check that repr of log transform succeeds
 
     # check that repr of log transform succeeds
     with pytest.warns(MatplotlibDeprecationWarning):
-        s = repr(Log10Transform(nonpos='clip'))
+        repr(Log10Transform(nonpos='clip'))
 
 
 @image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -40,17 +40,12 @@ def test_tight_layout2():
 @image_comparison(baseline_images=['tight_layout3'])
 def test_tight_layout3():
     'Test tight_layout for multiple subplots'
-
-    fig = plt.figure()
-
     ax1 = plt.subplot(221)
     ax2 = plt.subplot(223)
     ax3 = plt.subplot(122)
-
     example_plot(ax1)
     example_plot(ax2)
     example_plot(ax3)
-
     plt.tight_layout()
 
 
@@ -58,32 +53,23 @@ def test_tight_layout3():
                   freetype_version=('2.5.5', '2.6.1'))
 def test_tight_layout4():
     'Test tight_layout for subplot2grid'
-
-    fig = plt.figure()
-
     ax1 = plt.subplot2grid((3, 3), (0, 0))
     ax2 = plt.subplot2grid((3, 3), (0, 1), colspan=2)
     ax3 = plt.subplot2grid((3, 3), (1, 0), colspan=2, rowspan=2)
     ax4 = plt.subplot2grid((3, 3), (1, 2), rowspan=2)
-
     example_plot(ax1)
     example_plot(ax2)
     example_plot(ax3)
     example_plot(ax4)
-
     plt.tight_layout()
 
 
 @image_comparison(baseline_images=['tight_layout5'])
 def test_tight_layout5():
     'Test tight_layout for image'
-
-    fig = plt.figure()
-
     ax = plt.subplot(111)
     arr = np.arange(100).reshape((10, 10))
     ax.imshow(arr, interpolation="none")
-
     plt.tight_layout()
 
 
@@ -301,11 +287,10 @@ def test_big_decorators_vertical():
 
 
 def test_badsubplotgrid():
-    # test that we get warning for mismatched subplot grids rather
-    # than an error
-    ax1 = plt.subplot2grid((4, 5), (0, 0))
+    # test that we get warning for mismatched subplot grids, not than an error
+    plt.subplot2grid((4, 5), (0, 0))
     # this is the bad entry:
-    ax5 = plt.subplot2grid((5, 5), (0, 3), colspan=3, rowspan=5)
+    plt.subplot2grid((5, 5), (0, 3), colspan=3, rowspan=5)
     with pytest.warns(UserWarning):
         plt.tight_layout()
 

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -86,7 +86,7 @@ def test_delaunay_points_in_line():
     # Add an extra point not on the line and the triangulation is OK.
     x = np.append(x, 2.0)
     y = np.append(y, 8.0)
-    triang = mtri.Triangulation(x, y)
+    mtri.Triangulation(x, y)
 
 
 @pytest.mark.parametrize('x, y', [
@@ -187,8 +187,7 @@ def test_no_modify():
     points = np.array([(0, 0), (0, 1.1), (1, 0), (1, 1)])
 
     old_triangles = triangles.copy()
-    tri = mtri.Triangulation(points[:, 0], points[:, 1], triangles)
-    edges = tri.edges
+    mtri.Triangulation(points[:, 0], points[:, 1], triangles).edges
     assert_array_equal(old_triangles, triangles)
 
 
@@ -1029,7 +1028,7 @@ def test_trianalyzer_mismatched_indices():
     analyser = mtri.TriAnalyzer(triang)
     # numpy >= 1.10 raises a VisibleDeprecationWarning in the following line
     # prior to the fix.
-    triang2 = analyser._get_compressed_triangulation()
+    analyser._get_compressed_triangulation()
 
 
 def test_tricontourf_decreasing_levels():

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -39,7 +39,6 @@ def test_custom_transform():
         transform_non_affine = transform
 
         def transform_path(self, path):
-            vertices = path.vertices
             ipath = path.interpolated(self._resolution)
             return Path(self.transform(ipath.vertices), ipath.codes)
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -77,9 +77,9 @@ def test_contour3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    cset = ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
-    cset = ax.contour(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
-    cset = ax.contour(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
+    ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
+    ax.contour(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
+    ax.contour(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
     ax.set_xlim(-40, 40)
     ax.set_ylim(-40, 40)
     ax.set_zlim(-100, 100)
@@ -90,9 +90,9 @@ def test_contourf3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    cset = ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
-    cset = ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
-    cset = ax.contourf(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
     ax.set_xlim(-40, 40)
     ax.set_ylim(-40, 40)
     ax.set_zlim(-100, 100)
@@ -107,7 +107,7 @@ def test_contourf3d_fill():
     # This produces holes in the z=0 surface that causes rendering errors if
     # the Poly3DCollection is not aware of path code information (issue #4784)
     Z[::5, ::5] = 0.1
-    cset = ax.contourf(X, Y, Z, offset=0, levels=[-0.1, 0], cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, offset=0, levels=[-0.1, 0], cmap=cm.coolwarm)
     ax.set_xlim(-2, 2)
     ax.set_ylim(-2, 2)
     ax.set_zlim(-1, 1)
@@ -155,8 +155,7 @@ def test_mixedsubplots():
 
     fig = plt.figure(figsize=plt.figaspect(2.))
     ax = fig.add_subplot(2, 1, 1)
-    l = ax.plot(t1, f(t1), 'bo',
-                t2, f(t2), 'k--', markerfacecolor='green')
+    ax.plot(t1, f(t1), 'bo', t2, f(t2), 'k--', markerfacecolor='green')
     ax.grid(True)
 
     ax = fig.add_subplot(2, 1, 2, projection='3d')
@@ -164,8 +163,8 @@ def test_mixedsubplots():
     R = np.hypot(X, Y)
     Z = np.sin(R)
 
-    surf = ax.plot_surface(X, Y, Z, rcount=40, ccount=40,
-                           linewidth=0, antialiased=False)
+    ax.plot_surface(X, Y, Z, rcount=40, ccount=40,
+                    linewidth=0, antialiased=False)
 
     ax.set_zlim3d(-1, 1)
 
@@ -240,8 +239,8 @@ def test_surface3d_shaded():
     X, Y = np.meshgrid(X, Y)
     R = np.sqrt(X ** 2 + Y ** 2)
     Z = np.sin(R)
-    surf = ax.plot_surface(X, Y, Z, rstride=5, cstride=5,
-                           color=[0.25, 1, 0.25], lw=1, antialiased=False)
+    ax.plot_surface(X, Y, Z, rstride=5, cstride=5,
+                    color=[0.25, 1, 0.25], lw=1, antialiased=False)
     ax.set_zlim(-1.01, 1.01)
 
 


### PR DESCRIPTION
... as detected by enabling F841 in flake8.

A lot of these are instantiations of figures which are not used because
the test then uses the pyplot interface anyways; the figure doesn't need
to be explicitly instantiated as tests always run with no preexisting
figure (via an autouse fixture).

Split out from #13932 for reviewability.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
