### PR TITLE
BUG: Ensure docstrings are not accessed with -OO

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -741,8 +741,10 @@ def scale_factory(scale, axis, **kwargs):
     if scale not in _scale_mapping:
         raise ValueError("Unknown scale type '%s'" % scale)
     return _scale_mapping[scale](axis, **kwargs)
-scale_factory.__doc__ = scale_factory.__doc__ % {
-    "names": ", ".join(get_scale_names())}
+
+if scale_factory.__doc__:
+    scale_factory.__doc__ = scale_factory.__doc__ % {
+        "names": ", ".join(get_scale_names())}
 
 
 def register_scale(scale_class):


### PR DESCRIPTION
## PR Summary

Python when run as `python -OO` omits docstrings for optimization.
Previously, importing pyplot accessed the `__doc__` of one function, resulting in improper formatting on `None`.

This simply introduces a quick check which prevents calling on `__doc__` if it is not defined.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->