### PR TITLE
Always import pyplot when calling matplotlib.use().

### DIFF
--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -316,15 +316,22 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # "interactive backends") and hardcopy backends to make image files
 # (PNG, SVG, PDF, PS; also referred to as "non-interactive backends").
 #
-# There are four ways to configure your backend. If they conflict each other,
+# There are three ways to configure your backend. If they conflict each other,
 # the method mentioned last in the following list will be used, e.g. calling
 # :func:`~matplotlib.use()` will override the setting in your ``matplotlibrc``.
 #
-#
-# #. The ``backend`` parameter in your ``matplotlibrc`` file (see
+# #. The :rc:`backend` parameter in your ``matplotlibrc`` file (see
 #    :doc:`/tutorials/introductory/customizing`)::
 #
-#        backend : WXAgg   # use wxpython with antigrain (agg) rendering
+#        backend : qt5agg   # use pyqt5 with antigrain (agg) rendering
+#
+#    If no backend is explicitly set in the ``matplotlibrc`` file, Matplotlib
+#    automatically detects a usable backend based on what is available on your
+#    system and on whether a GUI event loop is already running.
+#
+#    On Linux, if the environment variable :envvar:`DISPLAY` is unset, the
+#    "event loop" is identified as "headless", which causes a fallback to a
+#    noninteractive backend (agg).
 #
 # #. Setting the :envvar:`MPLBACKEND` environment variable, either for your
 #    current shell or for a single script.  On Unix::
@@ -351,12 +358,13 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #       import matplotlib
 #       matplotlib.use('PS')   # generate postscript output by default
 #
-#    If you use the :func:`~matplotlib.use` function, this must be done before
-#    importing :mod:`matplotlib.pyplot`. Calling :func:`~matplotlib.use` after
-#    pyplot has been imported will have no effect.  Using
-#    :func:`~matplotlib.use` will require changes in your code if users want to
+#    If you use the `~matplotlib.use` function, this should be done before
+#    importing :mod:`matplotlib.pyplot`. Calling `~matplotlib.use` after pyplot
+#    has been imported may fail to switch the backend and raise an ImportError.
+#
+#    Using `~matplotlib.use` will require changes in your code if users want to
 #    use a different backend.  Therefore, you should avoid explicitly calling
-#    :func:`~matplotlib.use` unless absolutely necessary.
+#    `~matplotlib.use` unless absolutely necessary.
 #
 # .. note::
 #    Backend name specifications are not case-sensitive; e.g., 'GTK3Agg'


### PR DESCRIPTION
This avoids having to reason about various delayed backend resolution
strategies.

Simpler (IMO) alternative to #13892.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
