### PR TITLE
Don't let margins expand polar plots to negative radii by default.

### DIFF
--- a/doc/api/next_api_changes/2019-04-17-AL.rst
+++ b/doc/api/next_api_changes/2019-04-17-AL.rst
@@ -1,0 +1,24 @@
+Change in the application of ``Artist.sticky_edges``
+````````````````````````````````````````````````````
+
+Previously, the ``sticky_edges`` attribute of artists was a list of values such
+that if an axis limit coincides with a sticky edge, it would not be expanded by
+the axes margins (this is the mechanism that e.g. prevents margins from being
+added around images).
+
+``sticky_edges`` now have an additional effect on margins application: even if
+an axis limit did not coincide with a sticky edge, it cannot *cross* a sticky
+edge through margin application -- instead, the margins will only expand the
+axis limit until it bumps against the sticky edge.
+
+This change improves the margins of axes displaying a `~Axes.streamplot`:
+
+- if the streamplot goes all the way to the edges of the vector field, then the
+  axis limits are set to match exactly the vector field limits (whereas they
+  would be sometimes be off by a small floating point error previously).
+- if the streamplot does not reach the edges of the vector field (e.g., due to
+  the use of ``start_points`` and ``maxlength``), then margins expansion will
+  not cross the the vector field limits anymore.
+
+This change is also used internally to ensure that polar plots don't display
+negative *r* values unless the user really passes in a negative value.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -797,6 +797,12 @@ def test_polar_rlim_bottom(fig_test, fig_ref):
     ax.set_rmin(.5)
 
 
+def test_polar_rlim_zero():
+    ax = plt.figure().add_subplot(projection='polar')
+    ax.plot(np.arange(10), np.arange(10) + .01)
+    assert ax.get_ylim()[0] == 0
+
+
 @image_comparison(baseline_images=['axvspan_epoch'])
 def test_axvspan_epoch():
     from datetime import datetime

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -55,9 +55,13 @@ def test_linewidth():
     X, Y, U, V = velocity_field()
     speed = np.hypot(U, V)
     lw = 5 * speed / speed.max()
-    df = 25 / 30   # Compatibility factor for old test image
-    plt.streamplot(X, Y, U, V, density=[0.5 * df, 1. * df], color='k',
-                   linewidth=lw)
+    # Compatibility for old test image
+    df = 25 / 30
+    ax = plt.figure().subplots()
+    ax.set(xlim=(-3.0, 2.9999999999999947),
+           ylim=(-3.0000000000000004, 2.9999999999999947))
+    ax.streamplot(X, Y, U, V, density=[0.5 * df, 1. * df], color='k',
+                  linewidth=lw)
 
 
 @image_comparison(baseline_images=['streamplot_masks_and_nans'],
@@ -69,16 +73,24 @@ def test_masks_and_nans():
     mask[40:60, 40:60] = 1
     U[:20, :20] = np.nan
     U = np.ma.array(U, mask=mask)
+    # Compatibility for old test image
+    ax = plt.figure().subplots()
+    ax.set(xlim=(-3.0, 2.9999999999999947),
+           ylim=(-3.0000000000000004, 2.9999999999999947))
     with np.errstate(invalid='ignore'):
-        plt.streamplot(X, Y, U, V, color=U, cmap=plt.cm.Blues)
+        ax.streamplot(X, Y, U, V, color=U, cmap=plt.cm.Blues)
 
 
 @image_comparison(baseline_images=['streamplot_maxlength'],
                   extensions=['png'], remove_text=True, style='mpl20')
 def test_maxlength():
     x, y, U, V = swirl_velocity_field()
-    plt.streamplot(x, y, U, V, maxlength=10., start_points=[[0., 1.5]],
-                   linewidth=2, density=2)
+    ax = plt.figure().subplots()
+    ax.streamplot(x, y, U, V, maxlength=10., start_points=[[0., 1.5]],
+                  linewidth=2, density=2)
+    assert ax.get_xlim()[-1] == ax.get_ylim()[-1] == 3
+    # Compatibility for old test image
+    ax.set(xlim=(None, 3.2555988021882305), ylim=(None, 3.078326760195413))
 
 
 @image_comparison(baseline_images=['streamplot_direction'],


### PR DESCRIPTION
This is implemented by altering the semantics of sticky edges as
documented in the changelog.  As it turns out, this change also improves
consistency for streamplot():

- in test_streamplot.py::test_{linewidth,mask_and_nans}, the small bump
  in tolerance is necessary because the axes limits are now (-3, 3)
  (matching the vector field limits), whereas they were previously
  xlim=(-3.0, 2.9999999999999947), ylim=(-3.0000000000000004, 2.9999999999999947)
  (they can be inspected with
  `plt.gcf().canvas.draw(); print(plt.gca().get_xlim(), plt.gca().get_ylim())`).

- in test_streamplot.py::test_maxlength, note that the previous version
  expanded the axes limits *beyond* (-3, 3), whereas the current doesn't
  do so anymore.  It doesn't actually make much sense if the vector
  field limits are applied if the streamplot goes all the way to the
  edges, but are ignored otherwise.

Closes #13292.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
