### PR TITLE
Fix locator/formatter setting when removing shared Axes

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1616,7 +1616,7 @@ class Axis(martist.Artist):
         """
         if not isinstance(formatter, mticker.Formatter):
             raise TypeError("formatter argument should be instance of "
-                    "matplotlib.ticker.Formatter")
+                            "matplotlib.ticker.Formatter")
         self.isDefault_majfmt = False
         self.major.formatter = formatter
         formatter.set_axis(self)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1592,10 +1592,24 @@ default: 'top'
 
     def _remove_ax(self, ax):
         def _reset_loc_form(axis):
-            axis.set_major_formatter(axis.get_major_formatter())
-            axis.set_major_locator(axis.get_major_locator())
-            axis.set_minor_formatter(axis.get_minor_formatter())
-            axis.set_minor_locator(axis.get_minor_locator())
+            # Set the formatters and locators to be associated with axis
+            # (where previously they may have been associated with another
+            # Axis isntance)
+            majfmt = axis.get_major_formatter()
+            if not majfmt.axis.isDefault_majfmt:
+                axis.set_major_formatter(majfmt)
+
+            majloc = axis.get_major_locator()
+            if not majloc.axis.isDefault_majloc:
+                axis.set_major_locator(majloc)
+
+            minfmt = axis.get_minor_formatter()
+            if not minfmt.axis.isDefault_minfmt:
+                axis.set_minor_formatter(minfmt)
+
+            minloc = axis.get_minor_locator()
+            if not minfmt.axis.isDefault_minloc:
+                axis.set_minor_locator(minloc)
 
         def _break_share_link(ax, grouper):
             siblings = grouper.get_siblings(ax)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from pathlib import Path
 import platform
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
-from matplotlib.ticker import AutoMinorLocator, FixedFormatter
+from matplotlib.ticker import AutoMinorLocator, FixedFormatter, ScalarFormatter
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import matplotlib.gridspec as gridspec
@@ -461,3 +462,21 @@ def test_tightbbox():
     # test bbox_extra_artists method...
     assert abs(ax.get_tightbbox(renderer, bbox_extra_artists=[]).x1
                - x1Nom * fig.dpi) < 2
+
+
+def test_axes_removal():
+    # Check that units can set the formatter after an Axes removal
+    fig, axs = plt.subplots(1, 2, sharex=True)
+    axs[1].remove()
+    axs[0].plot([datetime(2000, 1, 1), datetime(2000, 2, 1)], [0, 1])
+    assert isinstance(axs[0].xaxis.get_major_formatter(),
+                      mdates.AutoDateFormatter)
+
+    # Check that manually setting the formatter, then removing Axes keeps
+    # the set formatter.
+    fig, axs = plt.subplots(1, 2, sharex=True)
+    axs[1].xaxis.set_major_formatter(ScalarFormatter())
+    axs[1].remove()
+    axs[0].plot([datetime(2000, 1, 1), datetime(2000, 2, 1)], [0, 1])
+    assert isinstance(axs[0].xaxis.get_major_formatter(),
+                      ScalarFormatter)


### PR DESCRIPTION
When a shared Axes was removed from a plot, any other Axes it was shared with had their Axis locators/formatters set to the locator/formatter on the removed Axes. This PR makes sure that setting only happens if the locator/formatter has previously been manually set. This allows the locator/formatter to be automatically set in the future by e.g. units being plotted.


Fixes  #12853