### PR TITLE
FIX: undeprecate MaxNLocator default_params

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -750,9 +750,6 @@ The following signature related behaviours are deprecated:
 - Passing ``shade=None`` to `~.axes3d.Axes3D.plot_surface` is deprecated. This
   was an unintended implementation detail with the same semantics as
   ``shade=False``. Please use the latter code instead.
-- `matplotlib.ticker.MaxNLocator` and its *set_params* method will issue
-  a warning on unknown keyword arguments instead of silently ignoring them.
-  Future versions will raise an error.
 
 Changes in parameter names
 --------------------------
@@ -937,10 +934,6 @@ classes, whose constructors take a *base* argument.
 
 Locators / Formatters
 ~~~~~~~~~~~~~~~~~~~~~
-
-- `matplotlib.ticker.MaxNLocator.default_params` class variable
-
-The defaults are not supposed to be user-configurable.
 
 - ``OldScalarFormatter.pprint_val``
 - ``ScalarFormatter.pprint_val``

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -750,6 +750,9 @@ The following signature related behaviours are deprecated:
 - Passing ``shade=None`` to `~.axes3d.Axes3D.plot_surface` is deprecated. This
   was an unintended implementation detail with the same semantics as
   ``shade=False``. Please use the latter code instead.
+- `matplotlib.ticker.MaxNLocator` and its *set_params* method will issue
+  a warning on unknown keyword arguments instead of silently ignoring them.
+  Future versions will raise an error.
 
 Changes in parameter names
 --------------------------

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1883,12 +1883,12 @@ class MaxNLocator(Locator):
     """
     Select no more than N intervals at nice locations.
     """
-    _default_params = dict(nbins=10,
-                           steps=None,
-                           integer=False,
-                           symmetric=False,
-                           prune=None,
-                           min_n_ticks=2)
+    default_params = dict(nbins=10,
+                          steps=None,
+                          integer=False,
+                          symmetric=False,
+                          prune=None,
+                          min_n_ticks=2)
 
     def __init__(self, *args, **kwargs):
         """
@@ -1940,7 +1940,7 @@ class MaxNLocator(Locator):
             if len(args) > 1:
                 raise ValueError(
                     "Keywords are required for all arguments except 'nbins'")
-        self.set_params(**{**self._default_params, **kwargs})
+        self.set_params(**{**self.default_params, **kwargs})
 
     @staticmethod
     def _validate_steps(steps):
@@ -1956,16 +1956,6 @@ class MaxNLocator(Locator):
         if steps[-1] != 10:
             steps = np.hstack((steps, 10))
         return steps
-
-    @cbook.deprecated("3.1")
-    @property
-    def default_params(self):
-        return self._default_params
-
-    @cbook.deprecated("3.1")
-    @default_params.setter
-    def default_params(self, params):
-        self._default_params = params
 
     @staticmethod
     def _staircase(steps):


### PR DESCRIPTION
## PR Summary

Closes #13991 

As pointed out in #13991 the deprecation (in #12998) of the global `default_params` will break Cartopy, and cartopy seems to do the right thing for the current way `MaxNLocator` is set up, so this breakage seems undesirable...

Cartopy's problem can be tested as:

```python
import matplotlib.ticker as mticker

class FancyLocator(mticker.MaxNLocator):
    default_params = mticker.MaxNLocator.default_params.copy()
    default_params.update(nbins=8, dms=False)

loc0 = mticker.MaxNLocator()
loc1 = FancyLocator()
```

Which gives the error:

```
Traceback (most recent call last):
  File "testLocator.py", line 3, in <module>
    class FancyLocator(mticker.MaxNLocator):
  File "testLocator.py", line 4, in FancyLocator
    default_params = mticker.MaxNLocator.default_params.copy()
AttributeError: '_deprecated_property' object has no attribute 'copy'
```


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->