### PR TITLE
Allow pandas DataFrames through norms

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -895,7 +895,7 @@ class Normalize(object):
         # ensure data passed in as an ndarray subclass are interpreted as
         # an ndarray. See issue #6622.
         mask = np.ma.getmask(value)
-        data = np.asarray(np.ma.getdata(value))
+        data = np.asarray(value)
         result = np.ma.array(data, mask=mask, dtype=dtype, copy=True)
         return result, is_scalar
 


### PR DESCRIPTION
Fixes #10909, and allows `Norm` objects to be called with Pandas DataFrames. I think the change still works fine with other types of array subclasses, will see if the tests pass. If they do I will add a pandas test.