### PR TITLE
DOC: pin numpydoc to less than 0.9

### DIFF
--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -11,7 +11,7 @@ sphinx>=1.8.1,<2.0.0
 colorspacious
 ipython
 ipywidgets
-numpydoc>=0.8
+numpydoc>=0.8,<0.9
 pillow>=3.4,!=5.4.0
 sphinx-gallery>=0.2
 sphinx-copybutton


### PR DESCRIPTION
Some of our docstring manipulation does not play well with it.

This is a stop-gap for a real fix, see #14003