### PR TITLE
Deprecate get_home()

### DIFF
--- a/doc/api/next_api_changes/2019-04-22-AL.rst
+++ b/doc/api/next_api_changes/2019-04-22-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``matplotlib.get_home`` is deprecated (use e.g. ``os.path.expanduser("~")``)
+instead.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -497,6 +497,7 @@ def checkdep_usetex(s):
     return True
 
 
+@cbook.deprecated("3.2", alternative="os.path.expanduser('~')")
 @_logged_cached('$HOME=%s')
 def get_home():
     """
@@ -526,10 +527,7 @@ def _get_xdg_config_dir():
     base directory spec
     <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
     """
-    return (os.environ.get('XDG_CONFIG_HOME')
-            or (str(Path(get_home(), ".config"))
-                if get_home()
-                else None))
+    return os.environ.get('XDG_CONFIG_HOME') or str(Path.home() / ".config")
 
 
 def _get_xdg_cache_dir():
@@ -538,10 +536,7 @@ def _get_xdg_cache_dir():
     base directory spec
     <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
     """
-    return (os.environ.get('XDG_CACHE_HOME')
-            or (str(Path(get_home(), ".cache"))
-                if get_home()
-                else None))
+    return os.environ.get('XDG_CACHE_HOME') or str(Path.home() / ".cache")
 
 
 def _get_config_or_cache_dir(xdg_base):
@@ -550,20 +545,15 @@ def _get_config_or_cache_dir(xdg_base):
         configdir = Path(configdir).resolve()
     elif sys.platform.startswith(('linux', 'freebsd')) and xdg_base:
         configdir = Path(xdg_base, "matplotlib")
-    elif get_home():
-        configdir = Path(get_home(), ".matplotlib")
     else:
-        configdir = None
-
-    if configdir:
-        try:
-            configdir.mkdir(parents=True, exist_ok=True)
-        except OSError:
-            pass
-        else:
-            if os.access(str(configdir), os.W_OK) and configdir.is_dir():
-                return str(configdir)
-
+        configdir = Path.home() / ".matplotlib"
+    try:
+        configdir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    else:
+        if os.access(str(configdir), os.W_OK) and configdir.is_dir():
+            return str(configdir)
     return _create_tmp_config_or_cache_dir()
 
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -94,15 +94,13 @@ font_family_aliases = {
 #  OS Font paths
 MSFolders = \
     r'Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
-
 MSFontDirectories = [
     r'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts',
     r'SOFTWARE\Microsoft\Windows\CurrentVersion\Fonts']
-
 MSUserFontDirectories = [
-    os.path.join(str(Path.home()), r'AppData\Local\Microsoft\Windows\Fonts'),
-    os.path.join(str(Path.home()), r'AppData\Roaming\Microsoft\Windows\Fonts')]
-
+    str(Path.home() / 'AppData/Local/Microsoft/Windows/Fonts'),
+    str(Path.home() / 'AppData/Roaming/Microsoft/Windows/Fonts'),
+]
 X11FontDirectories = [
     # an old standard installation point
     "/usr/X11R6/lib/X11/fonts/TTF/",
@@ -118,7 +116,6 @@ X11FontDirectories = [
                             Path.home() / ".local/share")) / "fonts"),
     str(Path.home() / ".fonts"),
 ]
-
 OSXFontDirectories = [
     "/Library/Fonts/",
     "/Network/Library/Fonts/",


### PR DESCRIPTION
font_manager.py has been using Path.home() without any checks for a
while, so the lack of crash reports indicate that Path.home() returns
without crashing in any system that uses Matplotlib, so get_home() and
its error handling can just be replaced by Path.home().

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
