### PR TITLE
Disallow figure argument for pyplot.subplot() and Figure.add_subplot()

### DIFF
--- a/doc/api/next_api_changes/2019-04-23-TH.rst
+++ b/doc/api/next_api_changes/2019-04-23-TH.rst
@@ -1,0 +1,6 @@
+API changes
+```````````
+
+`.Figure.add_subplot()` and `.pyplot.subplot()` do not accept a `figure`
+keyword argument anymore. It only used to work anyway if the passed figure
+was ``self`` or the current figure, respectively.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1301,9 +1301,9 @@ default: 'top'
         Other Parameters
         ----------------
         **kwargs
-            This method also takes the keyword arguments for
-            the returned axes base class. The keyword arguments for the
-            rectilinear base class `~.axes.Axes` can be found in
+            This method also takes the keyword arguments for the returned axes
+            base class; except for the *figure* argument. The keyword arguments
+            for the rectilinear base class `~.axes.Axes` can be found in
             the following table but there might also be other keyword
             arguments if another projection is used.
             %(Axes)s
@@ -1375,6 +1375,12 @@ default: 'top'
                 raise ValueError("Integer subplot specification must be a "
                                  "three-digit number, not {}".format(args[0]))
             args = tuple(map(int, str(args[0])))
+
+        if 'figure' in kwargs:
+            # Axes itself allows for a 'figure' kwarg, but since we want to
+            # bind the created Axes to self, it is not allowed here.
+            raise TypeError(
+                "add_subplot() got an unexpected keyword argument 'figure'")
 
         if isinstance(args[0], SubplotBase):
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -912,9 +912,9 @@ def subplot(*args, **kwargs):
     Other Parameters
     ----------------
     **kwargs
-        This method also takes the keyword arguments for
-        the returned axes base class. The keyword arguments for the
-        rectilinear base class `~.axes.Axes` can be found in
+        This method also takes the keyword arguments for the returned axes
+        base class; except for the *figure* argument. The keyword arguments
+        for the rectilinear base class `~.axes.Axes` can be found in
         the following table but there might also be other keyword
         arguments if another projection is used.
         %(Axes)s


### PR DESCRIPTION
## PR Summary

Closes #14011.

`Figure.add_subplot()` and `pyplot.subplot()` have technically accepted a `figure` keyword argument by allowing all keywords from the `Axes` constructor.

In this context, supplying a figure does not make sense since the axes should be bound to `self` or the current figure respecively.

I'm daring to go without a deprecation since this anyway did only work so far if the user supplied the same figure that would have been used without the parameter. Please let me know if that's too bold and we should deprecate this first.