### PR TITLE
Better error message when trying to use Gtk3Agg backend without cairo

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 from .. import cbook
-from . import backend_agg, backend_cairo, backend_gtk3
+try:
+    from . import backend_cairo
+except ImportError as e:
+    raise ImportError('backend Gtk3Agg requires cairo') from e
+from . import backend_agg, backend_gtk3
 from .backend_cairo import cairo
 from .backend_gtk3 import Gtk, _BackendGTK3
 from matplotlib import transforms


### PR DESCRIPTION


## PR Summary

Fixes #14007.
It's not obvious that Gtk3Agg depends on cairo. Stating this explicitly in the ImportError message makes it clear that this is not a bug in Matplotlib but an intended dependency.

