### PR TITLE
Fix bug in plot_directive that caused links to plots in different formats to be missing

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -568,10 +568,14 @@ def render_figures(code, code_path, output_dir, output_base, context,
     # Look for single-figure output files first
     all_exists = True
     img = ImageFile(output_base, output_dir)
-    if not any(out_of_date(code_path, img.filename(fmt))
-               for fmt, dpi in formats):
+    for format, dpi in formats:
+        if out_of_date(code_path, img.filename(format)):
+            all_exists = False
+            break
+        img.formats.append(format)
+
+    if all_exists:
         return [(code, [img])]
-    img.formats.extend(fmt for fmt, dpi in formats)
 
     # Then look for multi-figure output files
     results = []


### PR DESCRIPTION
## PR Summary

https://github.com/matplotlib/matplotlib/commit/441a6bc2d0aa677c2db0ad0f3387eb4602ad85a0 introduced some style changes that unfortunately also broke the display of available formats in the plot directive. I've reverted the relevant code to its original form.

Before this fix:

<img width="712" alt="Screenshot 2019-04-24 at 10 58 08" src="https://user-images.githubusercontent.com/314716/56651142-53d7a800-6680-11e9-8576-befc6ecc7368.png">

After this fix:

<img width="707" alt="Screenshot 2019-04-24 at 10 58 51" src="https://user-images.githubusercontent.com/314716/56651157-5afeb600-6680-11e9-9d16-f768a86ff91a.png">

cc @anntzer as the author of 441a6bc2d0aa677c2db0ad0f3387eb4602ad85a0

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way