### PR TITLE
Fix doc building with numpydoc 0.9

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1450,6 +1450,12 @@ def _label_from_arg(y, default_name):
     return None
 
 
+_DATA_DOC_TITLE = """
+
+Notes
+-----
+"""
+
 _DATA_DOC_APPENDIX = """
 
 .. note::
@@ -1487,7 +1493,10 @@ def _add_data_doc(docstring, replace_names):
             if len(replace_names) == 0 else
             "* All arguments with the following names: {}.".format(
                 ", ".join(map(repr, sorted(replace_names)))))
-    return docstring + _DATA_DOC_APPENDIX.format(replaced=repl)
+    addendum = _DATA_DOC_APPENDIX.format(replaced=repl)
+    if _DATA_DOC_TITLE not in docstring:
+        addendum = _DATA_DOC_TITLE + addendum
+    return docstring + addendum
 
 
 def _preprocess_data(func=None, *, replace_names=None, label_namer=None):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2615,11 +2615,6 @@ class Axes(_AxesBase):
         Returns
         -------
         collection : A :class:`~.collections.BrokenBarHCollection`
-
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
-
         """
         # process the unit information
         if len(xranges):
@@ -3183,10 +3178,6 @@ class Axes(_AxesBase):
 
         %(_Line2D_docstr)s
 
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
-
         """
         kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
         # anything that comes in as 'None', drop so the default thing
@@ -3640,10 +3631,6 @@ class Axes(_AxesBase):
             the whiskers (fliers).
 
           - ``means``: points or lines representing the means.
-
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
 
         """
 
@@ -6579,10 +6566,6 @@ optional.
         --------
         hist2d : 2D histograms
 
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
-
         """
         # Avoid shadowing the builtin.
         bin_range = range
@@ -7299,10 +7282,6 @@ optional.
             :func:`specgram` can plot the magnitude spectrum of segments within
             the signal in a colormap.
 
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
-
         """
         if Fc is None:
             Fc = 0
@@ -7388,10 +7367,6 @@ optional.
             :func:`specgram` can plot the angle spectrum of segments within the
             signal in a colormap.
 
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
-
         """
         if Fc is None:
             Fc = 0
@@ -7463,10 +7438,6 @@ optional.
         :func:`specgram`
             :func:`specgram` can plot the phase spectrum of segments within the
             signal in a colormap.
-
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
 
         """
         if Fc is None:
@@ -7965,10 +7936,6 @@ optional.
 
           - ``cmedians``: A `~.collections.LineCollection` instance that
             marks the median values of each of the violin's distribution.
-
-        Notes
-        -----
-        .. [Notes section required for data comment. See #10189.]
 
         """
 

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -250,9 +250,9 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
 
         message = message.strip()
         # Add "Deprecated" to top of docstring
-        new_doc = '[*Deprecated*] {old_doc}\n\n'.format(old_doc=old_doc)
+        new_doc = '[*Deprecated*] {old_doc}\n'.format(old_doc=old_doc)
         # Add a notes section if one isn't already present
-        note_section = 'Notes\n-----'
+        note_section = '\nNotes\n-----'
         if note_section not in new_doc:
             new_doc += note_section
         # Add deprecated message

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -248,16 +248,12 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
 
         old_doc = inspect.cleandoc(old_doc or '').strip('\n')
 
-        message = message.strip()
-        # Add "Deprecated" to top of docstring
-        new_doc = '[*Deprecated*] {old_doc}\n'.format(old_doc=old_doc)
-        # Add a notes section if one isn't already present
-        note_section = '\nNotes\n-----'
-        if note_section not in new_doc:
-            new_doc += note_section
-        # Add deprecated message
-        new_doc += ('\n.. deprecated:: {since}\n'
-                    '   {message}'.format(since=since, message=message))
+        notes_header = '\nNotes\n-----'
+        new_doc = (f"[*Deprecated*] {old_doc}\n"
+                   f"{notes_header if notes_header not in old_doc else ''}\n"
+                   f".. deprecated:: {since}\n"
+                   f"   {message.strip()}")
+
         if not old_doc:
             # This is to prevent a spurious 'unexpected unindent' warning from
             # docutils when the original docstring was blank.

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -249,11 +249,15 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
         old_doc = inspect.cleandoc(old_doc or '').strip('\n')
 
         message = message.strip()
-        new_doc = ('[*Deprecated*] {old_doc}\n'
-                   '\n'
-                   '.. deprecated:: {since}\n'
-                   '   {message}'
-                   .format(since=since, message=message, old_doc=old_doc))
+        # Add "Deprecated" to top of docstring
+        new_doc = '[*Deprecated*] {old_doc}\n\n'.format(old_doc=old_doc)
+        # Add a notes section if one isn't already present
+        note_section = 'Notes\n-----'
+        if note_section not in new_doc:
+            new_doc += note_section
+        # Add deprecated message
+        new_doc += ('\n.. deprecated:: {since}\n'
+                    '   {message}'.format(since=since, message=message))
         if not old_doc:
             # This is to prevent a spurious 'unexpected unindent' warning from
             # docutils when the original docstring was blank.

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -11,7 +11,7 @@ sphinx>=1.8.1,<2.0.0
 colorspacious
 ipython
 ipywidgets
-numpydoc>=0.8,<0.9
+numpydoc>=0.8
 pillow>=3.4,!=5.4.0
 sphinx-gallery>=0.2
 sphinx-copybutton


### PR DESCRIPTION
Fixes #14003 

The issue is that adding a `.. note` or `.. deprecated` after some numpydoc sections throws an error. This PR inserts a `Notes` section if one isn't already present at the bottom of the docstring, which should always be the last section (see https://numpydoc.readthedocs.io/en/latest/format.html), so inserting it at the end of the docstring is fine.