### PR TITLE
Gracefully handle non-finite z in tricontour (issue #10167)

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1124,18 +1124,17 @@ def test_tricontour_non_finite_z():
     triang = mtri.Triangulation(x, y)
     plt.figure()
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
+                                         'values'):
         plt.tricontourf(triang, [0, 1, 2, np.inf])
-    excinfo.match(r'z array cannot contain non-finite values')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
+                                         'values'):
         plt.tricontourf(triang, [0, 1, 2, -np.inf])
-    excinfo.match(r'z array cannot contain non-finite values')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
+                                         'values'):
         plt.tricontourf(triang, [0, 1, 2, np.nan])
-    excinfo.match(r'z array cannot contain non-finite values')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='z cannot be a masked array'):
         plt.tricontourf(triang, np.ma.array([0, 1, 2, 3], mask=[1, 0, 0, 0]))
-    excinfo.match(r'z cannot be a masked array')

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1124,17 +1124,18 @@ def test_tricontour_non_finite_z():
     triang = mtri.Triangulation(x, y)
     plt.figure()
 
-    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
-                                         'values'):
+    with pytest.raises(ValueError, match='z array must not contain non-finite '
+                                         'values within the triangulation'):
         plt.tricontourf(triang, [0, 1, 2, np.inf])
 
-    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
-                                         'values'):
+    with pytest.raises(ValueError, match='z array must not contain non-finite '
+                                         'values within the triangulation'):
         plt.tricontourf(triang, [0, 1, 2, -np.inf])
 
-    with pytest.raises(ValueError, match='z array cannot contain non-finite ' +
-                                         'values'):
+    with pytest.raises(ValueError, match='z array must not contain non-finite '
+                                         'values within the triangulation'):
         plt.tricontourf(triang, [0, 1, 2, np.nan])
 
-    with pytest.raises(ValueError, match='z cannot be a masked array'):
+    with pytest.raises(ValueError, match='z must not contain masked points '
+                                         'within the triangulation'):
         plt.tricontourf(triang, np.ma.array([0, 1, 2, 3], mask=[1, 0, 0, 0]))

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1115,3 +1115,27 @@ def test_qhull_large_offset():
     triang = mtri.Triangulation(x, y)
     triang_offset = mtri.Triangulation(x + offset, y + offset)
     assert len(triang.triangles) == len(triang_offset.triangles)
+
+
+def test_tricontour_non_finite_z():
+    # github issue 10167.
+    x = [0, 1, 0, 1]
+    y = [0, 0, 1, 1]
+    triang = mtri.Triangulation(x, y)
+    plt.figure()
+
+    with pytest.raises(ValueError) as excinfo:
+        plt.tricontourf(triang, [0, 1, 2, np.inf])
+    excinfo.match(r'z array cannot contain non-finite values')
+
+    with pytest.raises(ValueError) as excinfo:
+        plt.tricontourf(triang, [0, 1, 2, -np.inf])
+    excinfo.match(r'z array cannot contain non-finite values')
+
+    with pytest.raises(ValueError) as excinfo:
+        plt.tricontourf(triang, [0, 1, 2, np.nan])
+    excinfo.match(r'z array cannot contain non-finite values')
+
+    with pytest.raises(ValueError) as excinfo:
+        plt.tricontourf(triang, np.ma.array([0, 1, 2, 3], mask=[1, 0, 0, 0]))
+    excinfo.match(r'z cannot be a masked array')

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -91,8 +91,8 @@ class TriContourSet(ContourSet):
             raise ValueError('z must not contain masked points within the '
                              'triangulation')
         if not np.isfinite(z_check).all():
-            raise ValueError('z array must not contain non-finite values within'
-                             ' the triangulation')
+            raise ValueError('z array must not contain non-finite values '
+                             'within the triangulation')
 
         z = np.ma.masked_invalid(z, copy=False)
         self.zmax = float(z_check.max())

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -93,8 +93,8 @@ class TriContourSet(ContourSet):
             raise ValueError('z array cannot contain non-finite values')
 
         z = np.ma.masked_invalid(z, copy=False)
-        self.zmax = float(z.max())
-        self.zmin = float(z.min())
+        self.zmax = float(z_check.max())
+        self.zmin = float(z_check.min())
         if self.logscale and self.zmin <= 0:
             raise ValueError('Cannot %s log of negative values.' % fn)
         self._contour_level_args(z, args[1:])

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -79,12 +79,22 @@ class TriContourSet(ContourSet):
             fn = 'contour'
         tri, args, kwargs = Triangulation.get_from_args_and_kwargs(*args,
                                                                    **kwargs)
-        z = np.asarray(args[0])
+        z = np.ma.asarray(args[0])
         if z.shape != tri.x.shape:
             raise ValueError('z array must have same length as triangulation x'
                              ' and y arrays')
-        self.zmax = z.max()
-        self.zmin = z.min()
+
+        # z values must be finite, only need to check points that are included
+        # in the triangulation.
+        z_check = z[np.unique(tri.get_masked_triangles())]
+        if np.ma.is_masked(z_check):
+            raise ValueError('z cannot be a masked array')
+        if not np.isfinite(z_check).all():
+            raise ValueError('z array cannot contain non-finite values')
+
+        z = np.ma.masked_invalid(z, copy=False)
+        self.zmax = float(z.max())
+        self.zmin = float(z.min())
         if self.logscale and self.zmin <= 0:
             raise ValueError('Cannot %s log of negative values.' % fn)
         self._contour_level_args(z, args[1:])

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -88,9 +88,11 @@ class TriContourSet(ContourSet):
         # in the triangulation.
         z_check = z[np.unique(tri.get_masked_triangles())]
         if np.ma.is_masked(z_check):
-            raise ValueError('z cannot be a masked array')
+            raise ValueError('z must not contain masked points within the '
+                             'triangulation')
         if not np.isfinite(z_check).all():
-            raise ValueError('z array cannot contain non-finite values')
+            raise ValueError('z array must not contain non-finite values within'
+                             ' the triangulation')
 
         z = np.ma.masked_invalid(z, copy=False)
         self.zmax = float(z_check.max())


### PR DESCRIPTION
`tricontour` and `tricontourf` expect a `z` array containing finite values, so no `np.nan`, `np.inf` or masked values. Up until now this has not been checked and a non-finite value causes a segmentation fault in the underlying C++ code.

This bug was reported in issue #10167.

The fix is to explicitly check for non-finite values and raise an exception. The only complexity is that a triangulation may not include all the specified points and so we only need to check those points that are included in the triangulation.

Fix includes tests for `np.inf`, `-np.inf`, `np.nan` and `np.ma`masked values.