### PR TITLE
Pretty-format subprocess logs.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -354,7 +354,8 @@ class MovieWriter(AbstractMovieWriter):
         # movie file.  *args* returns the sequence of command line arguments
         # from a few configuration options.
         command = self._args()
-        _log.info('MovieWriter.run: running command: %s', command)
+        _log.info('MovieWriter._run: running command: %s',
+                  cbook._pformat_subprocess(command))
         PIPE = subprocess.PIPE
         self._proc = subprocess.Popen(
             command, stdin=PIPE, stdout=PIPE, stderr=PIPE,

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -19,6 +19,7 @@ import operator
 import os
 from pathlib import Path
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -2119,6 +2120,12 @@ def _unmultiplied_rgba8888_to_premultiplied_argb32(rgba8888):
     return argb32
 
 
+def _pformat_subprocess(command):
+    """Pretty-format a subprocess command for printing/logging purposes."""
+    return (command if isinstance(command, str)
+            else " ".join(shlex.quote(os.fspath(arg)) for arg in command))
+
+
 def _check_and_log_subprocess(command, logger, **kwargs):
     """
     Run *command* using `subprocess.check_output`.  If it succeeds, return the
@@ -2126,7 +2133,7 @@ def _check_and_log_subprocess(command, logger, **kwargs):
     the failed command and captured output.  Both the command and the output
     are logged at DEBUG level on *logger*.
     """
-    logger.debug(command)
+    logger.debug('%s', _pformat_subprocess(command))
     try:
         report = subprocess.check_output(
             command, stderr=subprocess.STDOUT, **kwargs)
@@ -2136,7 +2143,7 @@ def _check_and_log_subprocess(command, logger, **kwargs):
             '    {}\n'
             'failed and generated the following output:\n'
             '{}'
-            .format(command, exc.output.decode('utf-8')))
+            .format(_pformat_subprocess(command), exc.output.decode('utf-8')))
     logger.debug(report)
     return report
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -297,7 +297,7 @@ class TexManager(object):
         return texfile
 
     def _run_checked_subprocess(self, command, tex):
-        _log.debug(command)
+        _log.debug(cbook._pformat_subprocess(command))
         try:
             report = subprocess.check_output(command,
                                              cwd=self.texcache,


### PR DESCRIPTION
e.g. subprocess spawned by the animation machinery are now logged as
```
MovieWriter._run: running command: ffmpeg -f rawvideo -vcodec rawvideo -s 640x480 -pix_fmt rgba -r 20.0 -i pipe: -vcodec h264 -pix_fmt yuv420p -y movie.mp4
```
instead of
```
MovieWriter.run: running command: ['ffmpeg', '-f', 'rawvideo', '-vcodec', 'rawvideo', '-s', '640x480', '-pix_fmt', 'rgba', '-r', '20.0', '-i', 'pipe:', '-vcodec', 'h264', '-pix_fmt', 'yuv420p', '-y', 'movie.mp4']
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
