### PR TITLE
Ensure errorbars are always drawn on top of bars in ax.bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2297,7 +2297,7 @@ class Axes(_AxesBase):
             if ezorder is not None:
                 # If using the bar zorder, increment slightly to make sure
                 # errorbars are drawn on top of bars
-                ezorder += 0.1
+                ezorder += 0.01
         error_kw.setdefault('zorder', ezorder)
         ecolor = kwargs.pop('ecolor', 'k')
         capsize = kwargs.pop('capsize', rcParams["errorbar.capsize"])

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2291,6 +2291,14 @@ class Axes(_AxesBase):
         xerr = kwargs.pop('xerr', None)
         yerr = kwargs.pop('yerr', None)
         error_kw = kwargs.pop('error_kw', {})
+        ezorder = error_kw.pop('zorder', None)
+        if ezorder is None:
+            ezorder = kwargs.pop('zorder', None)
+            if ezorder is not None:
+                # If using the bar zorder, increment slightly to make sure
+                # errorbars are drawn on top of bars
+                ezorder += 0.1
+        error_kw['zorder'] = ezorder
         ecolor = kwargs.pop('ecolor', 'k')
         capsize = kwargs.pop('capsize', rcParams["errorbar.capsize"])
         error_kw.setdefault('ecolor', ecolor)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2293,12 +2293,12 @@ class Axes(_AxesBase):
         error_kw = kwargs.pop('error_kw', {})
         ezorder = error_kw.pop('zorder', None)
         if ezorder is None:
-            ezorder = kwargs.pop('zorder', None)
+            ezorder = kwargs.get('zorder', None)
             if ezorder is not None:
                 # If using the bar zorder, increment slightly to make sure
                 # errorbars are drawn on top of bars
                 ezorder += 0.1
-        error_kw['zorder'] = ezorder
+        error_kw.setdefault('zorder', ezorder)
         ecolor = kwargs.pop('ecolor', 'k')
         capsize = kwargs.pop('capsize', rcParams["errorbar.capsize"])
         error_kw.setdefault('ecolor', ecolor)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6314,3 +6314,18 @@ def test_hist_range_and_density():
                           range=(0, 1), density=True)
     assert bins[0] == 0
     assert bins[-1] == 1
+
+
+def test_bar_errbar_zorder():
+    # Check that the zorder of errorbars is always greater than the bar they
+    # are plotted on
+    fig, ax = plt.subplots()
+    x = [1, 2, 3]
+    barcont = ax.bar(x=x, height=x, yerr=x, capsize=5, zorder=3)
+
+    data_line, caplines, barlinecols = barcont.errorbar.lines
+    for bar in barcont.patches:
+        for capline in caplines:
+            assert capline.zorder > bar.zorder
+        for barlinecol in barlinecols:
+            assert barlinecol.zorder > bar.zorder


### PR DESCRIPTION
Fixes  #14039 by ensuring the zorder of errorbars is always slightly larger than that of bars. Comments/questions:

- If anyone has a neater way to write the code, suggestions welcome
- This still allows the errorbar zorder to be set independently by passing `error_kw`
- Does this need an API change or anything extra in the docs?