### PR TITLE
Remove font preamble caching in TexManager.

### DIFF
--- a/doc/api/next_api_changes/2019-04-25-AL.rst
+++ b/doc/api/next_api_changes/2019-04-25-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The ``TexManager.serif``, ``TexManager.sans_serif``, ``TexManager.cursive`` and
+``TexManager.monospace`` attributes are deprecated.


### PR DESCRIPTION
TexManager has a complex caching machinery (... among other caching
layers) to map font-related rcParams to a tex preamble (see `_rc_cache`,
`_rc_cache_keys`, `_reinit`) but that's just a matter of a few dict
lookups which are negligible compared to invoking the subprocess; so
just strip out that caching and always regenerate the font-related
preamble.

That caching also set some attributes (`texmanager.serif`, etc.) as a
side-effect via `setattr`/`getattr`, which are used nowhere else (and
it's hard to know they even exist other than figuring out the relevant
`setattr` calls); just deprecate them.

(I have some followup cleanups on that...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
