### PR TITLE
Remove references to "Draws" in matplotlib.patches

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -658,7 +658,7 @@ class Shadow(Patch):
 
 class Rectangle(Patch):
     """
-    Draw a rectangle with lower left at *xy* = (*x*, *y*) with
+    A rectangle with lower left at *xy* = (*x*, *y*) with
     specified *width*, *height* and rotation *angle*.
     """
 
@@ -1048,7 +1048,7 @@ class Wedge(Patch):
     @docstring.dedent_interpd
     def __init__(self, center, r, theta1, theta2, width=None, **kwargs):
         """
-        Draw a wedge centered at *x*, *y* center with radius *r* that
+        A wedge centered at *x*, *y* center with radius *r* that
         sweeps *theta1* to *theta2* (in degrees).  If *width* is given,
         then a partial wedge is drawn from inner radius *r* - *width*
         to outer radius *r*.
@@ -2437,7 +2437,7 @@ docstring.interpd.update(
 
 class FancyBboxPatch(Patch):
     """
-    Draw a fancy box around a rectangle with lower left at *xy*=(*x*,
+    A fancy box around a rectangle with lower left at *xy*=(*x*,
     *y*) with specified width and height.
 
     :class:`FancyBboxPatch` class is similar to :class:`Rectangle`


### PR DESCRIPTION
Creating a `Patch` doesn't actually draw anything, so remove a few bits of docstring that erroneously say this.