### PR TITLE
Fix Animation.save

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1134,7 +1134,10 @@ class Animation(object):
                     # Clear the initial frame
                     anim._init_draw()
                 frame_number = 0
-                save_count_list = [a.save_count for a in all_anim]
+                # TODO: Currently only FuncAnimation has a save_count
+                #       attribute. Can we generalize this to all Animations?
+                save_count_list = [getattr(a, 'save_count', None)
+                                   for a in all_anim]
                 if None in save_count_list:
                     total_frames = None
                 else:


### PR DESCRIPTION
## PR Summary

Fixes #14042.

This is a minimal fix to unbreak 3.1. In the long run, we should check if we can make the number of frames available for all (Timed)Animations, so that they can be used in the progress callback.
