### PR TITLE
Check axes identity in image.contains.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -625,6 +625,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         if self._contains is not None:
             return self._contains(self, mouseevent)
+        # 1) This doesn't work for figimage; but figimage also needs a fix
+        #    below (as the check cannot use x/ydata and extents).
+        # 2) As long as the check below uses x/ydata, we need to test axes
+        #    identity instead of `self.axes.contains(event)` because even if
+        #    axes overlap, x/ydata is only valid for event.inaxes anyways.
+        if self.axes is not mouseevent.inaxes:
+            return False, {}
         # TODO: make sure this is consistent with patch and patch
         # collection on nonlinear transformed coordinates.
         # TODO: consider returning image coordinates (shouldn't


### PR DESCRIPTION
Otherwise, image.contains(event) will incorrectly return True for a
click in *another* axes, somewhere else, that happens to be at the same
x/ydata.  Try e.g.
```
from pylab import *
axs = gcf().subplots(2)
im0 = axs[0].imshow([[0, 1], [2, 3]])
im1 = axs[1].imshow([[0, 1], [2, 3]])
gcf().canvas.mpl_connect(
    "button_press_event",
    lambda event: print(im0.contains(event), im1.contains(event)))
show()
```

Probably a test would be nice, sure.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
