### PR TITLE
FIX: do not try to manage the visibility of un-drawn ticks

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1123,11 +1123,6 @@ class Axis(martist.Artist):
             tick.set_label2(label)
         ticks = [*major_ticks, *minor_ticks]
 
-        # mark the ticks that we will not be using as not visible
-        for t in (self.minorTicks[len(minor_locs):] +
-                  self.majorTicks[len(major_locs):]):
-            t.set_visible(False)
-
         view_low, view_high = self.get_view_interval()
         if view_low > view_high:
             view_low, view_high = view_high, view_low

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -963,9 +963,3 @@ def test_remove_overlap(remove_overlapping_locs, expected_num):
     assert len(ax.xaxis.get_minor_ticks()) == expected_num
     assert len(ax.xaxis.get_minorticklabels()) == expected_num
     assert len(ax.xaxis.get_minorticklines()) == expected_num*2
-
-    # force a draw to call _update_ticks under the hood
-    fig.canvas.draw()
-    # check that the correct number of ticks report them selves as
-    # visible
-    assert sum(t.get_visible() for t in ax.xaxis.minorTicks) == expected_num


### PR DESCRIPTION
This reverts part of the changes from #13908 (in particular commit
e908efe37131da0697bd8e9c62444d37b4940ad3 ) that tried to manage the
visibility if the ticks that are not used.  However, there was a bug
in this that nothing would ever set ticks to be visible
again.  Because we currently cache / recycle ticks this meant that
panning / zooming or resizing the figure would eventually lose ticks
if the number of ticks ever went down and then back up.

We could fix this by adding a `tick.set_visible(True)` for the drawn
ticks, however this would break the (brittle) use case where users are
reaching in and manually setting the visibility of individual ticks to
False to hide them.

Instead, we revert the consistency code altogether and accept that
there will be `Tick` objects in `Axis.majorTicks` and
`Axis.minorTicks` that are marked as visible, but are not
drawn (because they are filtered by `_update_ticks`).

Closes #14054


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->