### PR TITLE
Improve Scatter hist example

### DIFF
--- a/examples/lines_bars_and_markers/scatter_hist.py
+++ b/examples/lines_bars_and_markers/scatter_hist.py
@@ -1,62 +1,54 @@
 """
-============
-Scatter Hist
-============
+============================
+Scatter plot with histograms
+============================
 
-Creates histogram from scatter plot
-and adds them to the sides of the plot.
-
+Create a scatter plot with histograms to its sides.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.ticker import NullFormatter
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
-
 
 # the random data
 x = np.random.randn(1000)
 y = np.random.randn(1000)
 
-nullfmt = NullFormatter()         # no labels
-
 # definitions for the axes
 left, width = 0.1, 0.65
 bottom, height = 0.1, 0.65
-bottom_h = left_h = left + width + 0.02
+spacing = 0.005
+
 
 rect_scatter = [left, bottom, width, height]
-rect_histx = [left, bottom_h, width, 0.2]
-rect_histy = [left_h, bottom, 0.2, height]
+rect_histx = [left, bottom + height + spacing, width, 0.2]
+rect_histy = [left + width + spacing, bottom, 0.2, height]
 
 # start with a rectangular Figure
 plt.figure(figsize=(8, 8))
 
-axScatter = plt.axes(rect_scatter)
-axHistx = plt.axes(rect_histx)
-axHisty = plt.axes(rect_histy)
-
-# no labels
-axHistx.xaxis.set_major_formatter(nullfmt)
-axHisty.yaxis.set_major_formatter(nullfmt)
+ax_scatter = plt.axes(rect_scatter)
+ax_scatter.tick_params(direction='in', top=True, right=True)
+ax_histx = plt.axes(rect_histx)
+ax_histx.tick_params(direction='in', labelbottom=False)
+ax_histy = plt.axes(rect_histy)
+ax_histy.tick_params(direction='in', labelleft=False)
 
 # the scatter plot:
-axScatter.scatter(x, y)
+ax_scatter.scatter(x, y)
 
 # now determine nice limits by hand:
 binwidth = 0.25
-xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))
-lim = (int(xymax/binwidth) + 1) * binwidth
-
-axScatter.set_xlim((-lim, lim))
-axScatter.set_ylim((-lim, lim))
+lim = np.ceil(np.abs([x, y]).max() / binwidth) * binwidth
+ax_scatter.set_xlim((-lim, lim))
+ax_scatter.set_ylim((-lim, lim))
 
 bins = np.arange(-lim, lim + binwidth, binwidth)
-axHistx.hist(x, bins=bins)
-axHisty.hist(y, bins=bins, orientation='horizontal')
+ax_histx.hist(x, bins=bins)
+ax_histy.hist(y, bins=bins, orientation='horizontal')
 
-axHistx.set_xlim(axScatter.get_xlim())
-axHisty.set_ylim(axScatter.get_ylim())
+ax_histx.set_xlim(ax_scatter.get_xlim())
+ax_histy.set_ylim(ax_scatter.get_ylim())
 
 plt.show()


### PR DESCRIPTION
## PR Summary

- move ticks to the inside. This gives a better visual impression for axes that are laid out close to each other.
- Use `tick_params()` instead of setting a `NullFormatter`. This is the more high-level approach and IMHO more suited here.
- some general cleanup.

[link to doc build](https://20627-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/lines_bars_and_markers/scatter_hist.html#sphx-glr-gallery-lines-bars-and-markers-scatter-hist-py)