### PR TITLE
Improve advanced quiver example

### DIFF
--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -1,16 +1,17 @@
 """
-========================================================
-Demonstration of advanced quiver and quiverkey functions
-========================================================
+=======================================
+Advanced quiver and quiverkey functions
+=======================================
 
 Demonstrates some more advanced options for `~.axes.Axes.quiver`.  For a simple
 example refer to :doc:`/gallery/images_contours_and_fields/quiver_simple_demo`.
 
-Known problem: the plot autoscaling does not take into account the arrows, so
-those on the boundaries are often out of the picture.  This is *not* an easy
-problem to solve in a perfectly general way.  The workaround is to manually
-expand the Axes objects.
+Note: The plot autoscaling does not take into account the arrows, so
+those on the boundaries may reach out of the picture.  This is not an easy
+problem to solve in a perfectly general way.  The recommended workaround is to
+manually set the Axes limits in such a case.
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -38,6 +39,8 @@ ax2.scatter(X[::3, ::3], Y[::3, ::3], color='r', s=5)
 
 ###############################################################################
 
+# sphinx_gallery_thumbnail_number = 3
+
 fig3, ax3 = plt.subplots()
 ax3.set_title("pivot='tip'; scales with x view")
 M = np.hypot(U, V)
@@ -45,7 +48,7 @@ Q = ax3.quiver(X, Y, U, V, M, units='x', pivot='tip', width=0.022,
                scale=1 / 0.15)
 qk = ax3.quiverkey(Q, 0.9, 0.9, 1, r'$1 \frac{m}{s}$', labelpos='E',
                    coordinates='figure')
-ax3.scatter(X, Y, color='k', s=5)
+ax3.scatter(X, Y, color='0.5', s=1)
 
 plt.show()
 


### PR DESCRIPTION
## PR Summary

- Make the third example the thumbnail. Looks a bit nicer since it's colored.
- Minor style changes in the third example to make the scatter points less prominent compared to the arrows.
- Changed the note on autoscaling a bit to make it less strong. I assume that it's still valid, however due to the default margins around data, it's less prominent. In particular, it does not occur in this example.
