### PR TITLE
Alternative fix for passing iterator as frames to FuncAnimation

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1658,7 +1658,14 @@ class FuncAnimation(TimedAnimation):
         elif callable(frames):
             self._iter_gen = frames
         elif np.iterable(frames):
-            self._iter_gen = lambda: iter(frames)
+            if kwargs.get('repeat', True):
+                def iter_frames(frames=frames):
+                    while True:
+                        this, frames = itertools.tee(frames, 2)
+                        yield from this
+                self._iter_gen = iter_frames
+            else:
+                self._iter_gen = lambda: iter(frames)
             if hasattr(frames, '__len__'):
                 self.save_count = len(frames)
         else:


### PR DESCRIPTION
## PR Summary

Fixes #13676. Replaces #13679.

This was proposed in https://github.com/matplotlib/matplotlib/pull/13679#issuecomment-478905310 it's clearly the better approach as it's simpler and can handle generators. Thanks @anntzer.

I do not really know how to add a test for this. Can't have an infinite loop in a unittest :smile:. Works fine as a standalone test with the following code

~~~
import matplotlib.pyplot as plt
import numpy as np
from matplotlib.animation import FuncAnimation

fig, ax = plt.subplots()
s = ax.set_title('0')
plt.plot([1,2,3],[2,4,3])
def update(frame):
    print(frame)
    s.set_text(str(frame))
    return []
animation = FuncAnimation(fig, update, frames=(i for i in range(5)), blit=True, interval=100)
plt.show()
~~~
