### PR TITLE
Don't try to use the colorbar formatter to format RGBA data.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -930,7 +930,7 @@ class AxesImage(_ImageBase):
             return arr[i, j]
 
     def format_cursor_data(self, data):
-        if self.colorbar:
+        if np.ndim(data) == 0 and self.colorbar:
             return (
                 "["
                 + cbook.strip_math(


### PR DESCRIPTION
A colorbar doesn't make much sense for RGBA data, but matplotlib does
allow one to be constructed; when formatting the cursor data for a RGBA
image we must be careful to not use the colorbar formatter.

Otherwise, after `plt.imshow(np.random.rand(5, 5, 3)); plt.colorbar()`,
when moving the mouse cursor over the image, we get
```
<elided>
  File "/usr/lib/python3.7/site-packages/matplotlib/ticker.py", line 604, in format_data_short
    return '%-12g' % value
  File "/usr/lib/python3.7/site-packages/numpy/ma/core.py", line 4296, in __float__
    raise TypeError("Only length-1 arrays can be converted "
TypeError: Only length-1 arrays can be converted to Python scalars
```

release critical as a regression from #12459.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
