### PR TITLE
Minor fix in multiple subplots example

### DIFF
--- a/examples/subplots_axes_and_figures/subplots_demo.py
+++ b/examples/subplots_axes_and_figures/subplots_demo.py
@@ -104,7 +104,7 @@ ax2.plot(x, y**2, 'tab:orange')
 ax3.plot(x, -y, 'tab:green')
 ax4.plot(x, -y**2, 'tab:red')
 
-for ax in axs.flat:
+for ax in fig.get_axes():
     ax.label_outer()
 
 ###############################################################################


### PR DESCRIPTION
## PR Summary

`axs` is not part of that example section. We need to get the axes from the figure.