### PR TITLE
 Consistently use axs to refer to a set of Axes

### DIFF
--- a/examples/color/colormap_reference.py
+++ b/examples/color/colormap_reference.py
@@ -48,18 +48,18 @@ def plot_color_gradients(cmap_category, cmap_list):
     # Create figure and adjust figure height to number of colormaps
     nrows = len(cmap_list)
     figh = 0.35 + 0.15 + (nrows + (nrows-1)*0.1)*0.22
-    fig, axes = plt.subplots(nrows=nrows, figsize=(6.4, figh))
+    fig, axs = plt.subplots(nrows=nrows, figsize=(6.4, figh))
     fig.subplots_adjust(top=1-.35/figh, bottom=.15/figh, left=0.2, right=0.99)
 
-    axes[0].set_title(cmap_category + ' colormaps', fontsize=14)
+    axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
 
-    for ax, name in zip(axes, cmap_list):
+    for ax, name in zip(axs, cmap_list):
         ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
         ax.text(-.01, .5, name, va='center', ha='right', fontsize=10,
                 transform=ax.transAxes)
 
     # Turn off *all* ticks & spines, not just the ones with colormaps.
-    for ax in axes:
+    for ax in axs:
         ax.set_axis_off()
 
 

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -39,14 +39,14 @@ def split_list(a_list):
 #
 # Plot all un-filled markers
 
-fig, axes = plt.subplots(ncols=2)
+fig, axs = plt.subplots(ncols=2)
 fig.suptitle('un-filled markers', fontsize=14)
 
 # Filter out filled markers and marker settings that do nothing.
 unfilled_markers = [m for m, func in Line2D.markers.items()
                     if func != 'nothing' and m not in Line2D.filled_markers]
 
-for ax, markers in zip(axes, split_list(unfilled_markers)):
+for ax, markers in zip(axs, split_list(unfilled_markers)):
     for y, marker in enumerate(markers):
         ax.text(-0.5, y, repr(marker), **text_style)
         ax.plot(y * points, marker=marker, **marker_style)
@@ -58,8 +58,8 @@ plt.show()
 ###############################################################################
 # Plot all filled markers.
 
-fig, axes = plt.subplots(ncols=2)
-for ax, markers in zip(axes, split_list(Line2D.filled_markers)):
+fig, axs = plt.subplots(ncols=2)
+for ax, markers in zip(axs, split_list(Line2D.filled_markers)):
     for y, marker in enumerate(markers):
         ax.text(-0.5, y, repr(marker), **text_style)
         ax.plot(y * points, marker=marker, **marker_style)

--- a/examples/lines_bars_and_markers/spectrum_demo.py
+++ b/examples/lines_bars_and_markers/spectrum_demo.py
@@ -25,28 +25,28 @@ cnse = cnse[:len(t)]
 
 s = 0.1 * np.sin(4 * np.pi * t) + cnse  # the signal
 
-fig, axes = plt.subplots(nrows=3, ncols=2, figsize=(7, 7))
+fig, axs = plt.subplots(nrows=3, ncols=2, figsize=(7, 7))
 
 # plot time signal:
-axes[0, 0].set_title("Signal")
-axes[0, 0].plot(t, s, color='C0')
-axes[0, 0].set_xlabel("Time")
-axes[0, 0].set_ylabel("Amplitude")
+axs[0, 0].set_title("Signal")
+axs[0, 0].plot(t, s, color='C0')
+axs[0, 0].set_xlabel("Time")
+axs[0, 0].set_ylabel("Amplitude")
 
 # plot different spectrum types:
-axes[1, 0].set_title("Magnitude Spectrum")
-axes[1, 0].magnitude_spectrum(s, Fs=Fs, color='C1')
+axs[1, 0].set_title("Magnitude Spectrum")
+axs[1, 0].magnitude_spectrum(s, Fs=Fs, color='C1')
 
-axes[1, 1].set_title("Log. Magnitude Spectrum")
-axes[1, 1].magnitude_spectrum(s, Fs=Fs, scale='dB', color='C1')
+axs[1, 1].set_title("Log. Magnitude Spectrum")
+axs[1, 1].magnitude_spectrum(s, Fs=Fs, scale='dB', color='C1')
 
-axes[2, 0].set_title("Phase Spectrum ")
-axes[2, 0].phase_spectrum(s, Fs=Fs, color='C2')
+axs[2, 0].set_title("Phase Spectrum ")
+axs[2, 0].phase_spectrum(s, Fs=Fs, color='C2')
 
-axes[2, 1].set_title("Angle Spectrum")
-axes[2, 1].angle_spectrum(s, Fs=Fs, color='C2')
+axs[2, 1].set_title("Angle Spectrum")
+axs[2, 1].angle_spectrum(s, Fs=Fs, color='C2')
 
-axes[0, 1].remove()  # don't display empty ax
+axs[0, 1].remove()  # don't display empty ax
 
 fig.tight_layout()
 plt.show()

--- a/examples/scales/power_norm.py
+++ b/examples/scales/power_norm.py
@@ -19,15 +19,14 @@ data = np.vstack([
 
 gammas = [0.8, 0.5, 0.3]
 
-fig, axes = plt.subplots(nrows=2, ncols=2)
+fig, axs = plt.subplots(nrows=2, ncols=2)
 
-axes[0, 0].set_title('Linear normalization')
-axes[0, 0].hist2d(data[:, 0], data[:, 1], bins=100)
+axs[0, 0].set_title('Linear normalization')
+axs[0, 0].hist2d(data[:, 0], data[:, 1], bins=100)
 
-for ax, gamma in zip(axes.flat[1:], gammas):
+for ax, gamma in zip(axs.flat[1:], gammas):
     ax.set_title(r'Power law $(\gamma=%1.1f)$' % gamma)
-    ax.hist2d(data[:, 0], data[:, 1],
-              bins=100, norm=mcolors.PowerNorm(gamma))
+    ax.hist2d(data[:, 0], data[:, 1], bins=100, norm=mcolors.PowerNorm(gamma))
 
 fig.tight_layout()
 

--- a/examples/shapes_and_collections/collections.py
+++ b/examples/shapes_and_collections/collections.py
@@ -43,10 +43,9 @@ xyo = rs.randn(npts, 2)
 colors = [colors.to_rgba(c)
           for c in plt.rcParams['axes.prop_cycle'].by_key()['color']]
 
-fig, axes = plt.subplots(2, 2)
+fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
 fig.subplots_adjust(top=0.92, left=0.07, right=0.97,
                     hspace=0.3, wspace=0.3)
-((ax1, ax2), (ax3, ax4)) = axes  # unpack the axes
 
 
 col = collections.LineCollection([spiral], offsets=xyo,

--- a/examples/specialty_plots/radar_chart.py
+++ b/examples/specialty_plots/radar_chart.py
@@ -162,13 +162,13 @@ if __name__ == '__main__':
     data = example_data()
     spoke_labels = data.pop(0)
 
-    fig, axes = plt.subplots(figsize=(9, 9), nrows=2, ncols=2,
-                             subplot_kw=dict(projection='radar'))
+    fig, axs = plt.subplots(figsize=(9, 9), nrows=2, ncols=2,
+                            subplot_kw=dict(projection='radar'))
     fig.subplots_adjust(wspace=0.25, hspace=0.20, top=0.85, bottom=0.05)
 
     colors = ['b', 'r', 'g', 'm', 'y']
     # Plot the four cases from the example data on separate axes
-    for ax, (title, case_data) in zip(axes.flat, data):
+    for ax, (title, case_data) in zip(axs.flat, data):
         ax.set_rgrids([0.2, 0.4, 0.6, 0.8])
         ax.set_title(title, weight='bold', size='medium', position=(0.5, 1.1),
                      horizontalalignment='center', verticalalignment='center')
@@ -178,10 +178,9 @@ if __name__ == '__main__':
         ax.set_varlabels(spoke_labels)
 
     # add legend relative to top-left plot
-    ax = axes[0, 0]
     labels = ('Factor 1', 'Factor 2', 'Factor 3', 'Factor 4', 'Factor 5')
-    legend = ax.legend(labels, loc=(0.9, .95),
-                       labelspacing=0.1, fontsize='small')
+    legend = axs[0, 0].legend(labels, loc=(0.9, .95),
+                              labelspacing=0.1, fontsize='small')
 
     fig.text(0.5, 0.965, '5-Factor Solution Profiles Across Four Scenarios',
              horizontalalignment='center', color='black', weight='bold',

--- a/examples/specialty_plots/topographic_hillshading.py
+++ b/examples/specialty_plots/topographic_hillshading.py
@@ -44,11 +44,11 @@ with np.load(get_sample_data('jacksboro_fault_dem.npz')) as dem:
 ls = LightSource(azdeg=315, altdeg=45)
 cmap = plt.cm.gist_earth
 
-fig, axes = plt.subplots(nrows=4, ncols=3, figsize=(8, 9))
-plt.setp(axes.flat, xticks=[], yticks=[])
+fig, axs = plt.subplots(nrows=4, ncols=3, figsize=(8, 9))
+plt.setp(axs.flat, xticks=[], yticks=[])
 
 # Vary vertical exaggeration and blend mode and plot all combinations
-for col, ve in zip(axes.T, [0.1, 1, 10]):
+for col, ve in zip(axs.T, [0.1, 1, 10]):
     # Show the hillshade intensity image in the first row
     col[0].imshow(ls.hillshade(z, vert_exag=ve, dx=dx, dy=dy), cmap='gray')
 
@@ -59,18 +59,18 @@ for col, ve in zip(axes.T, [0.1, 1, 10]):
         ax.imshow(rgb)
 
 # Label rows and columns
-for ax, ve in zip(axes[0], [0.1, 1, 10]):
+for ax, ve in zip(axs[0], [0.1, 1, 10]):
     ax.set_title('{0}'.format(ve), size=18)
-for ax, mode in zip(axes[:, 0], ['Hillshade', 'hsv', 'overlay', 'soft']):
+for ax, mode in zip(axs[:, 0], ['Hillshade', 'hsv', 'overlay', 'soft']):
     ax.set_ylabel(mode, size=18)
 
 # Group labels...
-axes[0, 1].annotate('Vertical Exaggeration', (0.5, 1), xytext=(0, 30),
-                    textcoords='offset points', xycoords='axes fraction',
-                    ha='center', va='bottom', size=20)
-axes[2, 0].annotate('Blend Mode', (0, 0.5), xytext=(-30, 0),
-                    textcoords='offset points', xycoords='axes fraction',
-                    ha='right', va='center', size=20, rotation=90)
+axs[0, 1].annotate('Vertical Exaggeration', (0.5, 1), xytext=(0, 30),
+                   textcoords='offset points', xycoords='axes fraction',
+                   ha='center', va='bottom', size=20)
+axs[2, 0].annotate('Blend Mode', (0, 0.5), xytext=(-30, 0),
+                   textcoords='offset points', xycoords='axes fraction',
+                   ha='right', va='center', size=20, rotation=90)
 fig.subplots_adjust(bottom=0.05, right=0.95)
 
 plt.show()

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -28,27 +28,27 @@ fs = 10  # fontsize
 ###############################################################################
 # Demonstrate how to toggle the display of different elements:
 
-fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
-axes[0, 0].boxplot(data, labels=labels)
-axes[0, 0].set_title('Default', fontsize=fs)
+fig, axs = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
+axs[0, 0].boxplot(data, labels=labels)
+axs[0, 0].set_title('Default', fontsize=fs)
 
-axes[0, 1].boxplot(data, labels=labels, showmeans=True)
-axes[0, 1].set_title('showmeans=True', fontsize=fs)
+axs[0, 1].boxplot(data, labels=labels, showmeans=True)
+axs[0, 1].set_title('showmeans=True', fontsize=fs)
 
-axes[0, 2].boxplot(data, labels=labels, showmeans=True, meanline=True)
-axes[0, 2].set_title('showmeans=True,\nmeanline=True', fontsize=fs)
+axs[0, 2].boxplot(data, labels=labels, showmeans=True, meanline=True)
+axs[0, 2].set_title('showmeans=True,\nmeanline=True', fontsize=fs)
 
-axes[1, 0].boxplot(data, labels=labels, showbox=False, showcaps=False)
+axs[1, 0].boxplot(data, labels=labels, showbox=False, showcaps=False)
 tufte_title = 'Tufte Style \n(showbox=False,\nshowcaps=False)'
-axes[1, 0].set_title(tufte_title, fontsize=fs)
+axs[1, 0].set_title(tufte_title, fontsize=fs)
 
-axes[1, 1].boxplot(data, labels=labels, notch=True, bootstrap=10000)
-axes[1, 1].set_title('notch=True,\nbootstrap=10000', fontsize=fs)
+axs[1, 1].boxplot(data, labels=labels, notch=True, bootstrap=10000)
+axs[1, 1].set_title('notch=True,\nbootstrap=10000', fontsize=fs)
 
-axes[1, 2].boxplot(data, labels=labels, showfliers=False)
-axes[1, 2].set_title('showfliers=False', fontsize=fs)
+axs[1, 2].boxplot(data, labels=labels, showfliers=False)
+axs[1, 2].set_title('showfliers=False', fontsize=fs)
 
-for ax in axes.flat:
+for ax in axs.flat:
     ax.set_yscale('log')
     ax.set_yticklabels([])
 
@@ -67,28 +67,28 @@ meanpointprops = dict(marker='D', markeredgecolor='black',
                       markerfacecolor='firebrick')
 meanlineprops = dict(linestyle='--', linewidth=2.5, color='purple')
 
-fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
-axes[0, 0].boxplot(data, boxprops=boxprops)
-axes[0, 0].set_title('Custom boxprops', fontsize=fs)
+fig, axs = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
+axs[0, 0].boxplot(data, boxprops=boxprops)
+axs[0, 0].set_title('Custom boxprops', fontsize=fs)
 
-axes[0, 1].boxplot(data, flierprops=flierprops, medianprops=medianprops)
-axes[0, 1].set_title('Custom medianprops\nand flierprops', fontsize=fs)
+axs[0, 1].boxplot(data, flierprops=flierprops, medianprops=medianprops)
+axs[0, 1].set_title('Custom medianprops\nand flierprops', fontsize=fs)
 
-axes[0, 2].boxplot(data, whis='range')
-axes[0, 2].set_title('whis="range"', fontsize=fs)
+axs[0, 2].boxplot(data, whis='range')
+axs[0, 2].set_title('whis="range"', fontsize=fs)
 
-axes[1, 0].boxplot(data, meanprops=meanpointprops, meanline=False,
-                   showmeans=True)
-axes[1, 0].set_title('Custom mean\nas point', fontsize=fs)
+axs[1, 0].boxplot(data, meanprops=meanpointprops, meanline=False,
+                  showmeans=True)
+axs[1, 0].set_title('Custom mean\nas point', fontsize=fs)
 
-axes[1, 1].boxplot(data, meanprops=meanlineprops, meanline=True,
-                   showmeans=True)
-axes[1, 1].set_title('Custom mean\nas line', fontsize=fs)
+axs[1, 1].boxplot(data, meanprops=meanlineprops, meanline=True,
+                  showmeans=True)
+axs[1, 1].set_title('Custom mean\nas line', fontsize=fs)
 
-axes[1, 2].boxplot(data, whis=[15, 85])
-axes[1, 2].set_title('whis=[15, 85]\n#percentiles', fontsize=fs)
+axs[1, 2].boxplot(data, whis=[15, 85])
+axs[1, 2].set_title('whis=[15, 85]\n#percentiles', fontsize=fs)
 
-for ax in axes.flat:
+for ax in axs.flat:
     ax.set_yscale('log')
     ax.set_yticklabels([])
 

--- a/examples/statistics/boxplot_color.py
+++ b/examples/statistics/boxplot_color.py
@@ -21,22 +21,22 @@ np.random.seed(19680801)
 all_data = [np.random.normal(0, std, size=100) for std in range(1, 4)]
 labels = ['x1', 'x2', 'x3']
 
-fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(9, 4))
+fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(9, 4))
 
 # rectangular box plot
-bplot1 = axes[0].boxplot(all_data,
-                         vert=True,  # vertical box alignment
-                         patch_artist=True,  # fill with color
-                         labels=labels)  # will be used to label x-ticks
-axes[0].set_title('Rectangular box plot')
+bplot1 = ax1.boxplot(all_data,
+                     vert=True,  # vertical box alignment
+                     patch_artist=True,  # fill with color
+                     labels=labels)  # will be used to label x-ticks
+ax1.set_title('Rectangular box plot')
 
 # notch shape box plot
-bplot2 = axes[1].boxplot(all_data,
-                         notch=True,  # notch shape
-                         vert=True,  # vertical box alignment
-                         patch_artist=True,  # fill with color
-                         labels=labels)  # will be used to label x-ticks
-axes[1].set_title('Notched box plot')
+bplot2 = ax2.boxplot(all_data,
+                     notch=True,  # notch shape
+                     vert=True,  # vertical box alignment
+                     patch_artist=True,  # fill with color
+                     labels=labels)  # will be used to label x-ticks
+ax2.set_title('Notched box plot')
 
 # fill with colors
 colors = ['pink', 'lightblue', 'lightgreen']
@@ -45,7 +45,7 @@ for bplot in (bplot1, bplot2):
         patch.set_facecolor(color)
 
 # adding horizontal grid lines
-for ax in axes:
+for ax in [ax1, ax2]:
     ax.yaxis.grid(True)
     ax.set_xlabel('Three separate samples')
     ax.set_ylabel('Observed values')

--- a/examples/statistics/boxplot_vs_violin.py
+++ b/examples/statistics/boxplot_vs_violin.py
@@ -23,7 +23,7 @@ section: http://scikit-learn.org/stable/modules/density.html
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(9, 4))
+fig, axs = plt.subplots(nrows=1, ncols=2, figsize=(9, 4))
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -33,23 +33,23 @@ np.random.seed(19680801)
 all_data = [np.random.normal(0, std, 100) for std in range(6, 10)]
 
 # plot violin plot
-axes[0].violinplot(all_data,
-                   showmeans=False,
-                   showmedians=True)
-axes[0].set_title('Violin plot')
+axs[0].violinplot(all_data,
+                  showmeans=False,
+                  showmedians=True)
+axs[0].set_title('Violin plot')
 
 # plot box plot
-axes[1].boxplot(all_data)
-axes[1].set_title('Box plot')
+axs[1].boxplot(all_data)
+axs[1].set_title('Box plot')
 
 # adding horizontal grid lines
-for ax in axes:
+for ax in axs:
     ax.yaxis.grid(True)
     ax.set_xticks([y + 1 for y in range(len(all_data))])
     ax.set_xlabel('Four separate samples')
     ax.set_ylabel('Observed values')
 
 # add x-tick labels
-plt.setp(axes, xticks=[y + 1 for y in range(len(all_data))],
+plt.setp(axs, xticks=[y + 1 for y in range(len(all_data))],
          xticklabels=['x1', 'x2', 'x3', 'x4'])
 plt.show()

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -42,27 +42,27 @@ fs = 10  # fontsize
 ###############################################################################
 # Demonstrate how to toggle the display of different elements:
 
-fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
-axes[0, 0].bxp(stats)
-axes[0, 0].set_title('Default', fontsize=fs)
+fig, axs = plt.subplots(nrows=2, ncols=3, figsize=(6, 6), sharey=True)
+axs[0, 0].bxp(stats)
+axs[0, 0].set_title('Default', fontsize=fs)
 
-axes[0, 1].bxp(stats, showmeans=True)
-axes[0, 1].set_title('showmeans=True', fontsize=fs)
+axs[0, 1].bxp(stats, showmeans=True)
+axs[0, 1].set_title('showmeans=True', fontsize=fs)
 
-axes[0, 2].bxp(stats, showmeans=True, meanline=True)
-axes[0, 2].set_title('showmeans=True,\nmeanline=True', fontsize=fs)
+axs[0, 2].bxp(stats, showmeans=True, meanline=True)
+axs[0, 2].set_title('showmeans=True,\nmeanline=True', fontsize=fs)
 
-axes[1, 0].bxp(stats, showbox=False, showcaps=False)
+axs[1, 0].bxp(stats, showbox=False, showcaps=False)
 tufte_title = 'Tufte Style\n(showbox=False,\nshowcaps=False)'
-axes[1, 0].set_title(tufte_title, fontsize=fs)
+axs[1, 0].set_title(tufte_title, fontsize=fs)
 
-axes[1, 1].bxp(stats, shownotches=True)
-axes[1, 1].set_title('notch=True', fontsize=fs)
+axs[1, 1].bxp(stats, shownotches=True)
+axs[1, 1].set_title('notch=True', fontsize=fs)
 
-axes[1, 2].bxp(stats, showfliers=False)
-axes[1, 2].set_title('showfliers=False', fontsize=fs)
+axs[1, 2].bxp(stats, showfliers=False)
+axs[1, 2].set_title('showfliers=False', fontsize=fs)
 
-for ax in axes.flat:
+for ax in axs.flat:
     ax.set_yscale('log')
     ax.set_yticklabels([])
 
@@ -80,22 +80,22 @@ meanpointprops = dict(marker='D', markeredgecolor='black',
                       markerfacecolor='firebrick')
 meanlineprops = dict(linestyle='--', linewidth=2.5, color='purple')
 
-fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(6, 6), sharey=True)
-axes[0, 0].bxp(stats, boxprops=boxprops)
-axes[0, 0].set_title('Custom boxprops', fontsize=fs)
+fig, axs = plt.subplots(nrows=2, ncols=2, figsize=(6, 6), sharey=True)
+axs[0, 0].bxp(stats, boxprops=boxprops)
+axs[0, 0].set_title('Custom boxprops', fontsize=fs)
 
-axes[0, 1].bxp(stats, flierprops=flierprops, medianprops=medianprops)
-axes[0, 1].set_title('Custom medianprops\nand flierprops', fontsize=fs)
+axs[0, 1].bxp(stats, flierprops=flierprops, medianprops=medianprops)
+axs[0, 1].set_title('Custom medianprops\nand flierprops', fontsize=fs)
 
-axes[1, 0].bxp(stats, meanprops=meanpointprops, meanline=False,
-               showmeans=True)
-axes[1, 0].set_title('Custom mean\nas point', fontsize=fs)
+axs[1, 0].bxp(stats, meanprops=meanpointprops, meanline=False,
+              showmeans=True)
+axs[1, 0].set_title('Custom mean\nas point', fontsize=fs)
 
-axes[1, 1].bxp(stats, meanprops=meanlineprops, meanline=True,
-               showmeans=True)
-axes[1, 1].set_title('Custom mean\nas line', fontsize=fs)
+axs[1, 1].bxp(stats, meanprops=meanlineprops, meanline=True,
+              showmeans=True)
+axs[1, 1].set_title('Custom mean\nas line', fontsize=fs)
 
-for ax in axes.flat:
+for ax in axs.flat:
     ax.set_yscale('log')
     ax.set_yticklabels([])
 

--- a/examples/statistics/histogram_multihist.py
+++ b/examples/statistics/histogram_multihist.py
@@ -24,8 +24,7 @@ np.random.seed(19680801)
 n_bins = 10
 x = np.random.randn(1000, 3)
 
-fig, axes = plt.subplots(nrows=2, ncols=2)
-ax0, ax1, ax2, ax3 = axes.flatten()
+fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2)
 
 colors = ['red', 'tan', 'lime']
 ax0.hist(x, n_bins, density=True, histtype='bar', color=colors, label=colors)

--- a/examples/statistics/violinplot.py
+++ b/examples/statistics/violinplot.py
@@ -28,59 +28,58 @@ fs = 10  # fontsize
 pos = [1, 2, 4, 5, 7, 8]
 data = [np.random.normal(0, std, size=100) for std in pos]
 
-fig, axes = plt.subplots(nrows=2, ncols=5, figsize=(10, 6))
+fig, axs = plt.subplots(nrows=2, ncols=5, figsize=(10, 6))
 
-axes[0, 0].violinplot(data, pos, points=20, widths=0.3,
-                      showmeans=True, showextrema=True, showmedians=True)
-axes[0, 0].set_title('Custom violinplot 1', fontsize=fs)
+axs[0, 0].violinplot(data, pos, points=20, widths=0.3,
+                     showmeans=True, showextrema=True, showmedians=True)
+axs[0, 0].set_title('Custom violinplot 1', fontsize=fs)
 
-axes[0, 1].violinplot(data, pos, points=40, widths=0.5,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      bw_method='silverman')
-axes[0, 1].set_title('Custom violinplot 2', fontsize=fs)
+axs[0, 1].violinplot(data, pos, points=40, widths=0.5,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     bw_method='silverman')
+axs[0, 1].set_title('Custom violinplot 2', fontsize=fs)
 
-axes[0, 2].violinplot(data, pos, points=60, widths=0.7, showmeans=True,
-                      showextrema=True, showmedians=True, bw_method=0.5)
-axes[0, 2].set_title('Custom violinplot 3', fontsize=fs)
+axs[0, 2].violinplot(data, pos, points=60, widths=0.7, showmeans=True,
+                     showextrema=True, showmedians=True, bw_method=0.5)
+axs[0, 2].set_title('Custom violinplot 3', fontsize=fs)
 
-axes[0, 3].violinplot(data, pos, points=60, widths=0.7, showmeans=True,
-                      showextrema=True, showmedians=True, bw_method=0.5,
-                      quantiles=[[0.1], [], [], [0.175, 0.954], [0.75],
-                                 [0.25]])
-axes[0, 3].set_title('Custom violinplot 4', fontsize=fs)
+axs[0, 3].violinplot(data, pos, points=60, widths=0.7, showmeans=True,
+                     showextrema=True, showmedians=True, bw_method=0.5,
+                     quantiles=[[0.1], [], [], [0.175, 0.954], [0.75], [0.25]])
+axs[0, 3].set_title('Custom violinplot 4', fontsize=fs)
 
-axes[0, 4].violinplot(data[-1:], pos[-1:], points=60, widths=0.7,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      quantiles=[0.05, 0.1, 0.8, 0.9], bw_method=0.5)
-axes[0, 4].set_title('Custom violinplot 5', fontsize=fs)
+axs[0, 4].violinplot(data[-1:], pos[-1:], points=60, widths=0.7,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     quantiles=[0.05, 0.1, 0.8, 0.9], bw_method=0.5)
+axs[0, 4].set_title('Custom violinplot 5', fontsize=fs)
 
-axes[1, 0].violinplot(data, pos, points=80, vert=False, widths=0.7,
-                      showmeans=True, showextrema=True, showmedians=True)
-axes[1, 0].set_title('Custom violinplot 6', fontsize=fs)
+axs[1, 0].violinplot(data, pos, points=80, vert=False, widths=0.7,
+                     showmeans=True, showextrema=True, showmedians=True)
+axs[1, 0].set_title('Custom violinplot 6', fontsize=fs)
 
-axes[1, 1].violinplot(data, pos, points=100, vert=False, widths=0.9,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      bw_method='silverman')
-axes[1, 1].set_title('Custom violinplot 7', fontsize=fs)
+axs[1, 1].violinplot(data, pos, points=100, vert=False, widths=0.9,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     bw_method='silverman')
+axs[1, 1].set_title('Custom violinplot 7', fontsize=fs)
 
-axes[1, 2].violinplot(data, pos, points=200, vert=False, widths=1.1,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      bw_method=0.5)
-axes[1, 2].set_title('Custom violinplot 8', fontsize=fs)
+axs[1, 2].violinplot(data, pos, points=200, vert=False, widths=1.1,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     bw_method=0.5)
+axs[1, 2].set_title('Custom violinplot 8', fontsize=fs)
 
-axes[1, 3].violinplot(data, pos, points=200, vert=False, widths=1.1,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      quantiles=[[0.1], [], [], [0.175, 0.954], [0.75],
-                                 [0.25]],
-                      bw_method=0.5)
-axes[1, 3].set_title('Custom violinplot 9', fontsize=fs)
+axs[1, 3].violinplot(data, pos, points=200, vert=False, widths=1.1,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     quantiles=[[0.1], [], [], [0.175, 0.954], [0.75], [0.25]],
+                     bw_method=0.5)
+axs[1, 3].set_title('Custom violinplot 9', fontsize=fs)
 
-axes[1, 4].violinplot(data[-1:], pos[-1:], points=200, vert=False, widths=1.1,
-                      showmeans=True, showextrema=True, showmedians=True,
-                      quantiles=[0.05, 0.1, 0.8, 0.9], bw_method=0.5)
-axes[1, 4].set_title('Custom violinplot 10', fontsize=fs)
+axs[1, 4].violinplot(data[-1:], pos[-1:], points=200, vert=False, widths=1.1,
+                     showmeans=True, showextrema=True, showmedians=True,
+                     quantiles=[0.05, 0.1, 0.8, 0.9], bw_method=0.5)
+axs[1, 4].set_title('Custom violinplot 10', fontsize=fs)
 
-for ax in axes.flat:
+
+for ax in axs.flat:
     ax.set_yticklabels([])
 
 fig.suptitle("Violin Plotting Examples")

--- a/examples/style_sheets/ggplot.py
+++ b/examples/style_sheets/ggplot.py
@@ -22,8 +22,8 @@ plt.style.use('ggplot')
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-fig, axes = plt.subplots(ncols=2, nrows=2)
-ax1, ax2, ax3, ax4 = axes.ravel()
+fig, axs = plt.subplots(ncols=2, nrows=2)
+ax1, ax2, ax3, ax4 = axs.ravel()
 
 # scatter plot (Note: `plt.scatter` doesn't use default colors)
 x, y = np.random.normal(size=(2, 200))

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -115,16 +115,16 @@ def plot_figure(style_label=""):
     (fig_width, fig_height) = plt.rcParams['figure.figsize']
     fig_size = [fig_width * 2, fig_height / 2]
 
-    fig, axes = plt.subplots(ncols=6, nrows=1, num=style_label,
-                             figsize=fig_size, squeeze=True)
-    axes[0].set_ylabel(style_label)
+    fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
+                            figsize=fig_size, squeeze=True)
+    axs[0].set_ylabel(style_label)
 
-    plot_scatter(axes[0], prng)
-    plot_image_and_patch(axes[1], prng)
-    plot_bar_graphs(axes[2], prng)
-    plot_colored_circles(axes[3], prng)
-    plot_colored_sinusoidal_lines(axes[4])
-    plot_histograms(axes[5], prng)
+    plot_scatter(axs[0], prng)
+    plot_image_and_patch(axs[1], prng)
+    plot_bar_graphs(axs[2], prng)
+    plot_colored_circles(axs[3], prng)
+    plot_colored_sinusoidal_lines(axs[4])
+    plot_histograms(axs[5], prng)
 
     fig.tight_layout()
 

--- a/examples/subplots_axes_and_figures/demo_tight_layout.py
+++ b/examples/subplots_axes_and_figures/demo_tight_layout.py
@@ -58,10 +58,9 @@ plt.tight_layout()
 
 ###############################################################################
 
-fig, axes = plt.subplots(nrows=3, ncols=3)
-for row in axes:
-    for ax in row:
-        example_plot(ax)
+fig, axs = plt.subplots(nrows=3, ncols=3)
+for ax in axs.flat:
+    example_plot(ax)
 plt.tight_layout()
 
 ###############################################################################

--- a/examples/text_labels_and_annotations/date_index_formatter.py
+++ b/examples/text_labels_and_annotations/date_index_formatter.py
@@ -23,10 +23,9 @@ r = r[-30:]  # get the last 30 days
 date = r.date.astype('O')
 
 # first we'll do it the default way, with gaps on weekends
-fig, axes = plt.subplots(ncols=2, figsize=(8, 4))
-ax = axes[0]
-ax.plot(date, r.adj_close, 'o-')
-ax.set_title("Default")
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
+ax1.plot(date, r.adj_close, 'o-')
+ax1.set_title("Default")
 fig.autofmt_xdate()
 
 # next we'll write a custom formatter
@@ -38,10 +37,10 @@ def format_date(x, pos=None):
     thisind = np.clip(int(x + 0.5), 0, N - 1)
     return date[thisind].strftime('%Y-%m-%d')
 
-ax = axes[1]
-ax.plot(ind, r.adj_close, 'o-')
-ax.xaxis.set_major_formatter(ticker.FuncFormatter(format_date))
-ax.set_title("Custom tick formatter")
+
+ax2.plot(ind, r.adj_close, 'o-')
+ax2.xaxis.set_major_formatter(ticker.FuncFormatter(format_date))
+ax2.set_title("Custom tick formatter")
 fig.autofmt_xdate()
 
 plt.show()

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1099,6 +1099,22 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         dimensions of the resulting array can be controlled with the squeeze
         keyword, see above.
 
+        Typical idioms for handling the return value are::
+
+            # using the variable ax for single a Axes
+            fig, ax = plt.subplots()
+
+            # using the variable axs for multiple Axes
+            fig, axs = plt.subplots(2, 2)
+
+            # using tuple unpacking for multiple Axes
+            fig, (ax1, ax2) = plt.subplot(1, 2)
+            fig, ((ax1, ax2), (ax3, ax4)) = plt.subplot(2, 2)
+
+        The names ``ax`` and pluralized ``axs`` are preferred over ``axes``
+        because for the latter it's not clear if it refers to a single
+        `~.axes.Axes` instance or a collection of these.
+
     Examples
     --------
     ::
@@ -1119,9 +1135,9 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         ax2.scatter(x, y)
 
         # Creates four polar axes, and accesses them through the returned array
-        fig, axes = plt.subplots(2, 2, subplot_kw=dict(polar=True))
-        axes[0, 0].plot(x, y)
-        axes[1, 1].scatter(x, y)
+        fig, axs = plt.subplots(2, 2, subplot_kw=dict(polar=True))
+        axs[0, 0].plot(x, y)
+        axs[1, 1].scatter(x, y)
 
         # Share a X axis with each column of subplots
         plt.subplots(2, 2, sharex='col')
@@ -1137,7 +1153,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
 
         # Creates figure number 10 with a single subplot
         # and clears it if it already exists.
-        fig, ax=plt.subplots(num=10, clear=True)
+        fig, ax = plt.subplots(num=10, clear=True)
 
     See Also
     --------

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -17,13 +17,13 @@ def test_fancyarrow():
     r = [0.4, 0.3, 0.2, 0.1, 0]
     t = ["fancy", "simple", mpatches.ArrowStyle.Fancy()]
 
-    fig, axes = plt.subplots(len(t), len(r), squeeze=False,
-                             subplot_kw=dict(aspect=True),
-                             figsize=(8, 4.5))
+    fig, axs = plt.subplots(len(t), len(r), squeeze=False,
+                            subplot_kw=dict(aspect=True),
+                            figsize=(8, 4.5))
 
     for i_r, r1 in enumerate(r):
         for i_t, t1 in enumerate(t):
-            ax = axes[i_t, i_r]
+            ax = axs[i_t, i_r]
             draw_arrow(ax, t1, r1)
             ax.tick_params(labelleft=False, labelbottom=False)
 

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -234,11 +234,11 @@ def test_setp():
     plt.setp([[]])
 
     # Check arbitrary iterables
-    fig, axes = plt.subplots()
-    lines1 = axes.plot(range(3))
-    lines2 = axes.plot(range(3))
+    fig, ax = plt.subplots()
+    lines1 = ax.plot(range(3))
+    lines2 = ax.plot(range(3))
     martist.setp(chain(lines1, lines2), 'lw', 5)
-    plt.setp(axes.spines.values(), color='green')
+    plt.setp(ax.spines.values(), color='green')
 
     # Check `file` argument
     sio = io.StringIO()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -754,13 +754,13 @@ def test_polar_theta_limits():
     theta_maxs = np.arange(50.0, 361.0, 90.0)
     DIRECTIONS = ('out', 'in', 'inout')
 
-    fig, axes = plt.subplots(len(theta_mins), len(theta_maxs),
-                             subplot_kw={'polar': True},
-                             figsize=(8, 6))
+    fig, axs = plt.subplots(len(theta_mins), len(theta_maxs),
+                            subplot_kw={'polar': True},
+                            figsize=(8, 6))
 
     for i, start in enumerate(theta_mins):
         for j, end in enumerate(theta_maxs):
-            ax = axes[i, j]
+            ax = axs[i, j]
             ax.plot(theta, r)
             if start < end:
                 ax.set_thetamin(start)
@@ -1609,15 +1609,14 @@ def test_hist_step_filled():
 
     kwargs = [{'fill': True}, {'fill': False}, {'fill': None}, {}]*2
     types = ['step']*4+['stepfilled']*4
-    fig, axes = plt.subplots(nrows=2, ncols=4)
-    axes = axes.flatten()
+    fig, axs = plt.subplots(nrows=2, ncols=4)
 
-    for kg, _type, ax in zip(kwargs, types, axes):
+    for kg, _type, ax in zip(kwargs, types, axs.flat):
         ax.hist(x, n_bins, histtype=_type, stacked=True, **kg)
         ax.set_title('%s/%s' % (kg, _type))
         ax.set_ylim(bottom=-50)
 
-    patches = axes[0].patches
+    patches = axs[0, 0].patches
     assert all(p.get_facecolor() == p.get_edgecolor() for p in patches)
 
 
@@ -4691,10 +4690,10 @@ def test_vline_limit():
 
 def test_empty_shared_subplots():
     # empty plots with shared axes inherit limits from populated plots
-    fig, axes = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)
-    axes[0].plot([1, 2, 3], [2, 4, 6])
-    x0, x1 = axes[1].get_xlim()
-    y0, y1 = axes[1].get_ylim()
+    fig, axs = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)
+    axs[0].plot([1, 2, 3], [2, 4, 6])
+    x0, x1 = axs[1].get_xlim()
+    y0, y1 = axs[1].get_ylim()
     assert x0 <= 1
     assert x1 >= 3
     assert y0 <= 2
@@ -4704,40 +4703,40 @@ def test_empty_shared_subplots():
 def test_shared_with_aspect_1():
     # allow sharing one axis
     for adjustable in ['box', 'datalim']:
-        fig, axes = plt.subplots(nrows=2, sharex=True)
-        axes[0].set_aspect(2, adjustable=adjustable, share=True)
-        assert axes[1].get_aspect() == 2
-        assert axes[1].get_adjustable() == adjustable
+        fig, axs = plt.subplots(nrows=2, sharex=True)
+        axs[0].set_aspect(2, adjustable=adjustable, share=True)
+        assert axs[1].get_aspect() == 2
+        assert axs[1].get_adjustable() == adjustable
 
-        fig, axes = plt.subplots(nrows=2, sharex=True)
-        axes[0].set_aspect(2, adjustable=adjustable)
-        assert axes[1].get_aspect() == 'auto'
+        fig, axs = plt.subplots(nrows=2, sharex=True)
+        axs[0].set_aspect(2, adjustable=adjustable)
+        assert axs[1].get_aspect() == 'auto'
 
 
 def test_shared_with_aspect_2():
     # Share 2 axes only with 'box':
-    fig, axes = plt.subplots(nrows=2, sharex=True, sharey=True)
-    axes[0].set_aspect(2, share=True)
-    axes[0].plot([1, 2], [3, 4])
-    axes[1].plot([3, 4], [1, 2])
+    fig, axs = plt.subplots(nrows=2, sharex=True, sharey=True)
+    axs[0].set_aspect(2, share=True)
+    axs[0].plot([1, 2], [3, 4])
+    axs[1].plot([3, 4], [1, 2])
     plt.draw()  # Trigger apply_aspect().
-    assert axes[0].get_xlim() == axes[1].get_xlim()
-    assert axes[0].get_ylim() == axes[1].get_ylim()
+    assert axs[0].get_xlim() == axs[1].get_xlim()
+    assert axs[0].get_ylim() == axs[1].get_ylim()
 
 
 def test_shared_with_aspect_3():
     # Different aspect ratios:
     for adjustable in ['box', 'datalim']:
-        fig, axes = plt.subplots(nrows=2, sharey=True)
-        axes[0].set_aspect(2, adjustable=adjustable)
-        axes[1].set_aspect(0.5, adjustable=adjustable)
-        axes[0].plot([1, 2], [3, 4])
-        axes[1].plot([3, 4], [1, 2])
+        fig, axs = plt.subplots(nrows=2, sharey=True)
+        axs[0].set_aspect(2, adjustable=adjustable)
+        axs[1].set_aspect(0.5, adjustable=adjustable)
+        axs[0].plot([1, 2], [3, 4])
+        axs[1].plot([3, 4], [1, 2])
         plt.draw()  # Trigger apply_aspect().
-        assert axes[0].get_xlim() != axes[1].get_xlim()
-        assert axes[0].get_ylim() == axes[1].get_ylim()
+        assert axs[0].get_xlim() != axs[1].get_xlim()
+        assert axs[0].get_ylim() == axs[1].get_ylim()
         fig_aspect = fig.bbox_inches.height / fig.bbox_inches.width
-        for ax in axes:
+        for ax in axs:
             p = ax.get_position()
             box_aspect = p.height / p.width
             lim_aspect = ax.viewLim.height / ax.viewLim.width
@@ -5492,7 +5491,7 @@ def test_adjust_numtick_aspect():
                   extensions=['png'])
 def test_auto_numticks():
     # Make tiny, empty subplots, verify that there are only 3 ticks.
-    fig, axes = plt.subplots(4, 4)
+    fig, axs = plt.subplots(4, 4)
 
 
 @image_comparison(baseline_images=["auto_numticks_log"], style='default',
@@ -5549,8 +5548,8 @@ def test_pandas_errorbar_indexing(pd):
 def test_pandas_indexing_hist(pd):
     ser_1 = pd.Series(data=[1, 2, 2, 3, 3, 4, 4, 4, 4, 5])
     ser_2 = ser_1.iloc[1:]
-    fig, axes = plt.subplots()
-    axes.hist(ser_2)
+    fig, ax = plt.subplots()
+    ax.hist(ser_2)
 
 
 def test_pandas_bar_align_center(pd):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -496,8 +496,8 @@ def test_light_source_topo_surface():
     ls = mcolors.LightSource(315, 45)
     cmap = cm.gist_earth
 
-    fig, axes = plt.subplots(nrows=3, ncols=3)
-    for row, mode in zip(axes, ['hsv', 'overlay', 'soft']):
+    fig, axs = plt.subplots(nrows=3, ncols=3)
+    for row, mode in zip(axs, ['hsv', 'overlay', 'soft']):
         for ax, ve in zip(row, [0.1, 1, 10]):
             rgb = ls.shade(elev, cmap, vert_exag=ve, dx=dx, dy=dy,
                            blend_mode=mode)

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -199,14 +199,14 @@ def test_contour_labels_size_color():
 @image_comparison(baseline_images=['contour_manual_colors_and_levels'],
                   extensions=['png'], remove_text=True)
 def test_given_colors_levels_and_extends():
-    _, axes = plt.subplots(2, 4)
+    _, axs = plt.subplots(2, 4)
 
     data = np.arange(12).reshape(3, 4)
 
     colors = ['red', 'yellow', 'pink', 'blue', 'black']
     levels = [2, 4, 8, 10]
 
-    for i, ax in enumerate(axes.flat):
+    for i, ax in enumerate(axs.flat):
         filled = i % 2 == 0.
         extend = ['neither', 'min', 'max', 'both'][i // 2]
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -128,13 +128,13 @@ def test_figure():
 
 @image_comparison(baseline_images=['figure_legend'])
 def test_figure_legend():
-    fig, axes = plt.subplots(2)
-    axes[0].plot([0, 1], [1, 0], label='x', color='g')
-    axes[0].plot([0, 1], [0, 1], label='y', color='r')
-    axes[0].plot([0, 1], [0.5, 0.5], label='y', color='k')
+    fig, axs = plt.subplots(2)
+    axs[0].plot([0, 1], [1, 0], label='x', color='g')
+    axs[0].plot([0, 1], [0, 1], label='y', color='r')
+    axs[0].plot([0, 1], [0.5, 0.5], label='y', color='k')
 
-    axes[1].plot([0, 1], [1, 0], label='_y', color='r')
-    axes[1].plot([0, 1], [0, 1], label='z', color='b')
+    axs[1].plot([0, 1], [1, 0], label='_y', color='r')
+    axs[1].plot([0, 1], [0, 1], label='z', color='b')
     fig.legend()
 
 
@@ -271,11 +271,11 @@ def test_set_fig_size():
 
 
 def test_axes_remove():
-    fig, axes = plt.subplots(2, 2)
-    axes[-1, -1].remove()
-    for ax in axes.ravel()[:-1]:
+    fig, axs = plt.subplots(2, 2)
+    axs[-1, -1].remove()
+    for ax in axs.ravel()[:-1]:
         assert ax in fig.axes
-    assert axes[-1, -1] not in fig.axes
+    assert axs[-1, -1] not in fig.axes
     assert len(fig.axes) == 3
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -472,19 +472,19 @@ def test_rasterize_dpi():
     # image_comparison.
     img = np.asarray([[1, 2], [3, 4]])
 
-    fig, axes = plt.subplots(1, 3, figsize=(3, 1))
+    fig, axs = plt.subplots(1, 3, figsize=(3, 1))
 
-    axes[0].imshow(img)
+    axs[0].imshow(img)
 
-    axes[1].plot([0, 1], [0, 1], linewidth=20., rasterized=True)
-    axes[1].set(xlim=(0, 1), ylim=(-1, 2))
+    axs[1].plot([0, 1], [0, 1], linewidth=20., rasterized=True)
+    axs[1].set(xlim=(0, 1), ylim=(-1, 2))
 
-    axes[2].plot([0, 1], [0, 1], linewidth=20.)
-    axes[2].set(xlim=(0, 1), ylim=(-1, 2))
+    axs[2].plot([0, 1], [0, 1], linewidth=20.)
+    axs[2].set(xlim=(0, 1), ylim=(-1, 2))
 
     # Low-dpi PDF rasterization errors prevent proper image comparison tests.
     # Hide detailed structures like the axes spines.
-    for ax in axes:
+    for ax in axs:
         ax.set_xticks([])
         ax.set_yticks([])
         for spine in ax.spines.values():

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -136,11 +136,11 @@ def test_exceptions():
 def test_subplots_offsettext():
     x = numpy.arange(0, 1e10, 1e9)
     y = numpy.arange(0, 100, 10)+1e4
-    fig, axes = plt.subplots(2, 2, sharex='col', sharey='all')
-    axes[0, 0].plot(x, x)
-    axes[1, 0].plot(x, x)
-    axes[0, 1].plot(y, x)
-    axes[1, 1].plot(y, x)
+    fig, axs = plt.subplots(2, 2, sharex='col', sharey='all')
+    axs[0, 0].plot(x, x)
+    axs[1, 0].plot(x, x)
+    axs[0, 1].plot(y, x)
+    axs[1, 1].plot(y, x)
 
 
 def test_get_gridspec():

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -92,8 +92,8 @@ def test_diff_cell_table():
     cellText = [['1'] * len(cells)] * 2
     colWidths = [0.1] * len(cells)
 
-    _, axes = plt.subplots(nrows=len(cells), figsize=(4, len(cells)+1))
-    for ax, cell in zip(axes, cells):
+    _, axs = plt.subplots(nrows=len(cells), figsize=(4, len(cells)+1))
+    for ax, cell in zip(axs, cells):
         ax.table(
                 colWidths=colWidths,
                 cellText=cellText,


### PR DESCRIPTION
## PR Summary

<s>Builds on top of #14079. You may wait with review until the above is in and I've rebased so that the changes are a bit smaller.</s> Is merged.

The intention of this PR is described in the addition to `pyplot.subplots()` docstring:

~~~
Typical idioms for handling the return value are::

    # using the variable ax for single a Axes
    fig, ax = plt.subplots()

    # using the variable axs for multiple Axes
    fig, axs = plt.subplots(2, 2)

    # using tuple unpacking for multiple Axes
    fig, (ax1, ax2) = plt.subplot(1, 2)
    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplot(2, 2)

The names ``ax`` and pluralized ``axs`` are preferred over ``axes``
because for the latter it's not clear if it refers to a single
`~.axes.Axes` instance or a collection of these.
~~~

Everything else in the commit is only applying this to examples and tests.

