### PR TITLE
Improve docstring of axes_zoom_effect example.

### DIFF
--- a/examples/subplots_axes_and_figures/axes_zoom_effect.py
+++ b/examples/subplots_axes_and_figures/axes_zoom_effect.py
@@ -4,9 +4,9 @@ Axes Zoom Effect
 ================
 
 """
+
 from matplotlib.transforms import (
     Bbox, TransformedBbox, blended_transform_factory)
-
 from mpl_toolkits.axes_grid1.inset_locator import (
     BboxPatch, BboxConnector, BboxConnectorPatch)
 
@@ -39,14 +39,19 @@ def connect_bbox(bbox1, bbox2,
 
 def zoom_effect01(ax1, ax2, xmin, xmax, **kwargs):
     """
-    ax1 : the main axes
-    ax1 : the zoomed axes
-    (xmin,xmax) : the limits of the colored area in both plot axes.
+    Connect *ax1* and *ax2*. The *xmin*-to-*xmax* range in both axes will
+    be marked.
 
-    connect ax1 & ax2. The x-range of (xmin, xmax) in both axes will
-    be marked.  The keywords parameters will be used ti create
-    patches.
-
+    Parameters
+    ----------
+    ax1
+        The main axes.
+    ax2
+        The zoomed axes.
+    xmin, xmax
+        The limits of the colored area in both plot axes.
+    **kwargs
+        Arguments passed to the patch constructor.
     """
 
     trans1 = blended_transform_factory(ax1.transData, ax1.transAxes)


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
