### PR TITLE
Fix API contents display for sphinx 2

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1117,3 +1117,9 @@ div.viewcode-block:target {
 .sidebar-announcement p {
     margin: 0.4em 0.4em 0.6em 0.4em;
 }
+
+.classifier:before {
+    font-style: normal;
+    margin: 0.2em;
+    content: ":";
+}

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -632,7 +632,7 @@ table.docutils {
     border: 0px;
 }
 
-table.docutils th {
+dl.field-list dt.field-odd {
     border-width: 1px 0px;
     border-color: #888;
     background-color: #f0f0f0;
@@ -700,27 +700,27 @@ dl.class table.property-table {
 }
 
 /* tables inside parameter descriptions */
-td.field-body table.property-table {
+dd.field-odd table.property-table {
     width: 100%;
     border-spacing: 2px;
     border-collapse: collapse;
     border: 0px;
 }
 
-td.field-body table.property-table th {
+dd.field-odd table.property-table th {
     padding: 2px 10px;
     border-width: 1px 0px;
     border-color: #888;
     background-color: #f0f0f0;
 }
 
-td.field-body table.property-table td {
+dd.field-odd table.property-table td {
     padding: 2px 10px;
     border-width: 1px 0px;
     border-color: #ccc;
 }
 
-td.field-body table.property-table tr:last-of-type td {
+dd.field-odd table.property-table tr:last-of-type td {
     border-bottom-color: #888;
 }
 
@@ -811,16 +811,16 @@ table.docutils.field-list {
     vertical-align: top;
     width: 125px;
 }
-.docutils.field-list td.field-body {
+.docutils.field-list dd.field-odd {
     padding: 10px 10px 10px 20px;
     text-align: left;
     vertical-align: top;
 }
-.docutils.field-list td.field-body blockquote p {
+.docutils.field-list dd.field-odd blockquote p {
     font-size: 13px;
     line-height: 18px;
 }
-.docutils.field-list td.field-body blockquote p ul li{
+.docutils.field-list dd.field-odd blockquote p ul li{
     font-size: 13px;
 }
 

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -187,6 +187,11 @@ div.related ul {
     padding-left: 10px;
 }
 
+li p {
+  margin: unset;
+  display: inline;
+}
+
 div.related ul li {
     margin: 0;
     padding: 0;

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -632,6 +632,9 @@ table.docutils {
     border: 0px;
 }
 
+table.docutils p{
+    margin: inherit;
+}
 dl.field-list dt.field-odd {
     border-width: 1px 0px;
     border-color: #888;

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -187,11 +187,6 @@ div.related ul {
     padding-left: 10px;
 }
 
-li p {
-  margin: unset;
-  display: inline;
-}
-
 div.related ul li {
     margin: 0;
     padding: 0;
@@ -510,10 +505,11 @@ p.topic-title {
     padding-right: .3em;
 }
 
-.contents > ul > li > a {
+.contents > ul > li  p {
     font-size: 1.0em;
+    margin: unset;
+    display: inline;
 }
-
 
 
 div.versioninfo {

--- a/doc/_static/mpl_sphinx1.css
+++ b/doc/_static/mpl_sphinx1.css
@@ -1,0 +1,1115 @@
+/*
+ * Alternate Sphinx design
+ * Originally created by Armin Ronacher for Werkzeug, adapted by Georg Brandl.
+ */
+
+body {
+    font-family: "Helvetica Neue", Helvetica, 'Lucida Grande', 'Lucida Sans Unicode', 'Geneva', 'Verdana', sans-serif;
+    font-size: 14px;
+    line-height: 150%;
+    text-align: center;
+    background-color: #BFD1D4;
+    color: black;
+    padding: 0;
+    border: 1px solid #aaa;
+    color: #333;
+    margin: auto;
+    min-width: 740px;
+    max-width: 1200px;
+}
+
+a {
+    color: #CA7900;
+    text-decoration: none;
+}
+
+a:hover {
+    color: #2491CF;
+}
+
+div.highlight-python a {
+    color: #CA7900;
+}
+
+div.highlight-python a:hover {
+    color: #2491CF;
+}
+
+strong {
+  font-weight: strong;
+}
+
+pre {
+    font-family:  Monaco, Menlo, Consolas, 'Courier New', monospace;
+    font-size: 0.90em;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    letter-spacing: 0.015em;
+    padding: 1em;
+    border: 1px solid #ccc;
+    background-color: #f8f8f8;
+    line-height: 140%;
+    overflow-x: auto;
+}
+
+td.linenos pre {
+    padding: 0.5em 0;
+    border: 0;
+    background-color: transparent;
+    color: #aaa;
+}
+
+table.highlighttable {
+    margin-left: 0.5em;
+}
+
+table.highlighttable td {
+    padding: 0 0.5em 0 0.5em;
+}
+
+cite, code, tt {
+    font-family: 'Consolas', 'Deja Vu Sans Mono', 'Bitstream Vera Sans Mono', monospace;
+    font-size: 0.95em;
+    letter-spacing: 0.01em;
+}
+
+hr {
+    border: 1px solid #abc;
+    margin: 2em;
+}
+
+tt {
+    background-color: #f2f2f2;
+    border-bottom: 1px solid #ddd;
+    color: #333;
+}
+
+tt.descname {
+    background-color: transparent;
+    font-weight: bold;
+    font-size: 1.2em;
+    border: 0;
+}
+
+tt.descclassname {
+    background-color: transparent;
+    border: 0;
+}
+
+tt.xref {
+    background-color: transparent;
+    font-weight: bold;
+    border: 0;
+}
+
+a tt {
+    background-color: transparent;
+    font-weight: bold;
+    border: 0;
+    color: #CA7900;
+}
+
+a tt:hover {
+    color: #2491CF;
+}
+
+dl {
+    margin-bottom: 15px;
+}
+
+dd p {
+    margin-top: 1px;
+}
+
+dd ul, dd table {
+    margin-bottom: 10px;
+}
+
+dd {
+    margin-top: 3px;
+    margin-bottom: 10px;
+    margin-left: 30px;
+}
+
+.refcount {
+    color: #060;
+}
+
+dt:target,
+.highlight {
+    background-color: #ffffee;
+}
+
+dl.glossary dt {
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+pre a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.first {
+    margin-top: 0 !important;
+}
+
+div.document {
+    background-color: white;
+    text-align: left;
+    background-image: url(contents.png);
+    background-repeat: repeat-x;
+}
+
+/*
+div.documentwrapper {
+    width: 100%;
+}
+*/
+
+div.clearer {
+    clear: both;
+}
+
+div.related h3 {
+    display: none;
+}
+
+div.related ul {
+    background-image: url(navigation.png);
+    height: 2em;
+    list-style: none;
+    border-top: 1px solid #ddd;
+    border-bottom: 1px solid #ddd;
+    margin: 0;
+    padding-left: 10px;
+}
+
+div.related ul li {
+    margin: 0;
+    padding: 0;
+    height: 2em;
+    float: left;
+}
+
+div.related ul li.right {
+    float: right;
+    margin-right: 5px;
+}
+
+div.related ul li a {
+    margin: 0;
+    padding: 0 5px 0 5px;
+    line-height: 1.75em;
+    color: #EE9816;
+}
+
+div.related ul li a:hover {
+    color: #3CA8E7;
+}
+
+div.body {
+    margin: 0;
+    padding: 0.5em 20px 20px 20px;
+}
+
+div.bodywrapper {
+    margin: 0 240px 0 0;
+    border-right: 1px solid #ccc;
+}
+
+div.sphinxsidebar {
+    margin: 0;
+    padding: 0.5em 15px 15px 0;
+    width: 210px;
+    float: right;
+    text-align: left;
+/*    margin-left: -100%; */
+}
+
+div.sphinxsidebar h4, div.sphinxsidebar h3 {
+    margin: 1em 0 0.5em 0;
+    font-size: 0.9em;
+    padding: 0.1em 0 0.1em 0.5em;
+    color: white;
+    border: 1px solid #86989B;
+    background-color: #AFC1C4;
+}
+
+div.sphinxsidebar h3 a {
+    /* workaround for table of contents heading, which is a link */
+    color: white !important;
+}
+
+div.sphinxsidebar ul {
+    padding-left: 1.5em;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    list-style: none;
+    padding: 0;
+    line-height: 130%;
+}
+
+div.sphinxsidebar ul ul {
+    list-style: square;
+    margin-top: 6px;
+    margin-bottom: 6px;
+    margin-left: 16px;
+}
+
+div.sphinxsidebar #searchbox input {
+    border: 1px solid #aaa;
+    padding: 0.25em;
+    box-sizing: border-box;
+}
+
+div.sphinxsidebar #searchbox form {
+    display: inline-block;
+    width: 100%
+}
+
+div.sphinxsidebar #searchbox input[type="text"] {
+    float: left;
+    width: 80%;
+}
+
+div.sphinxsidebar #searchbox input[type="submit"] {
+    float: left;
+    width: 20%;
+    border-left: none;
+}
+
+div.sphinxsidebar #searchbox input[type="submit"]:hover {
+    background: #ddd;
+}
+
+div.sphinxsidebar .searchformwrapper {
+    display: block;
+}
+
+p {
+    margin: 0.8em 0 0.8em 0;
+}
+
+h1 {
+    margin: 0.5em 0em;
+    padding-top: 0.5em;
+    font-size: 2em;
+    color: #11557C;
+}
+
+h2 {
+    margin: 0.5em 0 0.2em 0;
+    padding-top: 0.5em;
+    font-size: 1.7em;
+}
+
+h3 {
+    margin: 0.2em 0 0.1em 0;
+    padding-top: 0.5em;
+    font-size: 1.2em;
+}
+
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+    color: black!important;
+}
+
+h1 a.anchor, h2 a.anchor, h3 a.anchor, h4 a.anchor, h5 a.anchor, h6 a.anchor {
+    display: none;
+    margin: 0 0 0 0.3em;
+    padding: 0 0.2em 0 0.2em;
+    color: #aaa!important;
+}
+
+h1:hover a.anchor, h2:hover a.anchor, h3:hover a.anchor, h4:hover a.anchor,
+h5:hover a.anchor, h6:hover a.anchor {
+    display: inline;
+}
+
+h1 a.anchor:hover, h2 a.anchor:hover, h3 a.anchor:hover, h4 a.anchor:hover,
+h5 a.anchor:hover, h6 a.anchor:hover {
+    color: #777;
+    background-color: #eee;
+}
+
+table {
+    border-collapse: collapse;
+    margin: 0 -0.5em 0 -0.5em;
+}
+
+table td, table th {
+    padding: 0.2em 0.5em 0.2em 0.5em;
+}
+
+div.footer {
+    background-color: #E3EFF1;
+    color: #86989B;
+    padding: 3px 8px 3px 0;
+    clear: both;
+    font-size: 0.8em;
+    text-align: right;
+}
+
+div.footer a {
+    color: #86989B;
+    text-decoration: underline;
+}
+
+div.pagination {
+    margin-top: 2em;
+    padding-top: 0.5em;
+    border-top: 1px solid black;
+    text-align: center;
+}
+
+div.sphinxsidebar ul.toc {
+    margin: 1em 0 1em 0;
+    padding: 0 0 0 0.5em;
+    list-style: none;
+}
+
+div.sphinxsidebar ul.toc li {
+    margin: 0.5em 0 0.5em 0;
+    font-size: 0.9em;
+    line-height: 130%;
+}
+
+div.sphinxsidebar ul.toc li p {
+    margin: 0;
+    padding: 0;
+}
+
+div.sphinxsidebar ul.toc ul {
+    margin: 0.2em 0 0.2em 0;
+    padding: 0 0 0 1.8em;
+}
+
+div.sphinxsidebar ul.toc ul li {
+    padding: 0;
+}
+
+/* admonitions */
+
+div.admonition, div.deprecated {
+    margin: 10px 0px;
+    padding: 0.7em 1.4em;
+    border-left: 5px solid;
+  }
+
+div.note {
+    background-color: #eee;
+    border-color: #ccc;
+}
+
+div.seealso {
+    background-color: #EAF1F7;
+    border-color: #8EADCC;
+    color: #3F5E7F;
+  }
+
+div.warning, div.important {
+    background-color: #F3E5E5;
+    border-color: #CC8E8E;
+    color: #7F1919;
+}
+
+div.deprecated {
+    background-color: #f0f0f0;
+    border-color: #404040;
+    color: #606060;
+}
+
+span.versionmodified {
+    font-style: italic;
+}
+
+div.deprecated span.versionmodified {
+    font-weight: bold;
+    font-style: normal;
+}
+
+div.green, div.hint {
+    background-color: #E1F2DA;
+    border-color: #A1CC8E;
+    color: #3F7F3F;
+}
+
+div.admonition p.admonition-title {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+div.admonition p, div.deprecated p {
+    margin: 0.6em 0;
+    padding: 0;
+}
+
+div.admonition pre {
+    margin: 0.6em 0;
+}
+
+div.admonition ul, div.admonition ol {
+    margin: 0.1em 0.5em 0.5em 2em;
+    padding: 0;
+}
+
+div.topic {
+    background-color: #f4f4f4;
+    border: 2px solid #ccc;
+    border-left: 0px;
+    border-right: 0px;
+    margin: 10px 0px;
+    padding-left: 1em;
+}
+
+p.topic-title {
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+.contents ul {
+    list-style-type: none;
+    padding-left: 2em;
+}
+
+/* first level */
+.contents > ul {
+    padding-left: 0;
+}
+
+.multicol-toc > ul {
+    column-width: 250px;
+    column-gap: 60px;
+    -webkit-column-width: 250px;
+    -moz-column-width: 250px;
+    column-rule: 1px solid #ccc;
+}
+
+.multicol-toc > li {
+       /* break inside is not yet broadly supported, but we just try */
+    break-inside: avoid-column;
+    -moz-break-inside: avoid-column;
+    -webkit-break-inside: avoid-column;
+}
+
+.contents > ul > li {
+    padding-top: 0.3em;
+    padding-bottom: 0.3em;
+}
+
+.contents ul > li::before {
+    content: "\25FE";
+    color: #bbb;
+    padding-right: .3em;
+}
+
+.contents > ul > li > a {
+    font-size: 1.0em;
+}
+
+
+
+div.versioninfo {
+    margin: 1em 0 0 0;
+    border: 1px solid #ccc;
+    background-color: #DDEAF0;
+    padding: 8px;
+    line-height: 1.3em;
+    font-size: 0.9em;
+}
+
+a.headerlink {
+    color: #c60f0f!important;
+    font-size: 1em;
+    margin-left: 6px;
+    padding: 0 4px 0 4px;
+    text-decoration: none!important;
+    visibility: hidden;
+}
+
+h1:hover > a.headerlink,
+h2:hover > a.headerlink,
+h3:hover > a.headerlink,
+h4:hover > a.headerlink,
+h5:hover > a.headerlink,
+h6:hover > a.headerlink,
+dt:hover > a.headerlink {
+    visibility: visible;
+}
+
+a.headerlink:hover {
+    background-color: #ccc;
+    color: white!important;
+}
+
+table.indextable td {
+    text-align: left;
+    vertical-align: top;
+}
+
+table.indextable dl, table.indextable dd {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+table.indextable tr.pcap {
+    height: 10px;
+}
+
+table.indextable tr.cap {
+    margin-top: 10px;
+    background-color: #f2f2f2;
+}
+
+img.toggler {
+    margin-right: 3px;
+    margin-top: 3px;
+    cursor: pointer;
+}
+
+img.inheritance {
+    border: 0px
+}
+
+form.pfform {
+    margin: 10px 0 20px 0;
+}
+
+table.contentstable {
+    width: 90%;
+}
+
+table.contentstable p.biglink {
+    line-height: 150%;
+}
+
+a.biglink {
+    font-size: 1.3em;
+}
+
+span.linkdescr {
+    font-style: italic;
+    padding-top: 5px;
+    font-size: 90%;
+}
+
+.highlight span.c1 span.highlighted {
+    background-color: #fce5a6;
+}
+
+ul.search {
+    margin: 10px 0 0 20px;
+    padding: 0;
+}
+
+ul.search li {
+    padding: 5px 0 5px 20px;
+    background-image: url(file.png);
+    background-repeat: no-repeat;
+    background-position: 0 7px;
+}
+
+ul.search li a {
+    font-weight: bold;
+}
+
+ul.search li div.context {
+    color: #888;
+    margin: 2px 0 0 30px;
+    text-align: left;
+}
+
+ul.keywordmatches li.goodmatch a {
+    font-weight: bold;
+}
+
+table.docutils {
+    border-spacing: 2px;
+    border-collapse: collapse;
+    border: 0px;
+}
+
+table.docutils th {
+    border-width: 1px 0px;
+    border-color: #888;
+    background-color: #f0f0f0;
+    width: 100px;
+}
+
+table.docutils td {
+    border-width: 1px 0px;
+    border-color: #ccc;
+}
+
+table.docutils tr:last-of-type td {
+    border-bottom-color: #888;
+}
+
+table.docutils tr:first-of-type td {
+    border-top-color: #888;
+}
+
+/* Section titles within classes */
+dl.class p.rubric {
+    font-size: 16px;
+}
+
+/* Attribute tables */
+dl.class p.rubric + table.docutils {
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-bottom: 1.5em;
+    border-top: 1px solid #888;
+    border-bottom: 1px solid #888;
+}
+
+dl.class p.rubric + table.docutils td {
+    padding-left: 0px;
+    border-color: #ccc;
+}
+
+dl.class p.rubric + table.docutils td:first-of-type > strong {
+    font-family: monospace;
+    font-size: 14px;
+    font-weight: normal;
+}
+
+
+/* module summary table */
+.longtable.docutils {
+    font-size: 12px;
+    margin-bottom: 30px;
+}
+.longtable.docutils, .longtable.docutils td {
+    border-color: #ccc;
+}
+
+.longtable.docutils tr.row-even{
+    background-color: #eff3f4;
+}
+
+/* tables inside class descriptions */
+dl.class table.property-table {
+    width: 85%;
+    border-spacing: 2px;
+    border-collapse: collapse;
+    border: 0px;
+}
+
+/* tables inside parameter descriptions */
+td.field-body table.property-table {
+    width: 100%;
+    border-spacing: 2px;
+    border-collapse: collapse;
+    border: 0px;
+}
+
+td.field-body table.property-table th {
+    padding: 2px 10px;
+    border-width: 1px 0px;
+    border-color: #888;
+    background-color: #f0f0f0;
+}
+
+td.field-body table.property-table td {
+    padding: 2px 10px;
+    border-width: 1px 0px;
+    border-color: #ccc;
+}
+
+td.field-body table.property-table tr:last-of-type td {
+    border-bottom-color: #888;
+}
+
+
+/* function and class description */
+.descclassname {
+    color: #aaa;
+    font-weight: normal;
+    font-family: monospace;
+}
+.descname {
+    font-family: monospace;
+}
+
+/*** function and class description ***/
+/* top-level definitions */
+dl.class, dl.function, dl.data, dl.exception {
+    border-top: 1px solid #888;
+    padding-top: 0px;
+    margin-top: 20px;
+}
+
+dl.method, dl.classmethod, dl.staticmethod, dl.attribute {
+    border-top: 1px solid #ccc;
+    padding-top: 0px;
+}
+
+
+dl.class > dt, dl.classmethod > dt, dl.method > dt, dl.function > dt,
+dl.attribute > dt, dl.staticmethod > dt, dl.data > dt, dl.exception > dt {
+    background-color: #eff3f4;
+    padding-left: 6px;
+    padding-right: 6px;
+    padding-top: 2px;
+    padding-bottom: 1px;
+}
+
+em.property {
+    margin-right: 4px;
+}
+
+.sig-paren {
+    font-size: 14px;
+}
+
+.sig-paren ~ em {
+    font-weight: normal;
+    font-family: monospace;
+    font-size: 14px;
+}
+
+dl.class big, dl.function big {
+    font-weight: normal;
+    font-family: monospace;
+}
+
+dl.class dd, dl.function dd, dl.data dd {
+    padding: 10px;
+}
+
+dl.class > dd {
+    padding: 10px;
+    padding-left: 35px;
+    margin-left: 0px;
+    border-left: 5px solid #f8f8f8;
+}
+
+.descclassname {
+    color: #aaa;
+    font-weight: normal;
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.descname {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+/* parameter section table */
+table.docutils.field-list {
+    width: 100%;
+}
+.docutils.field-list th.field-name {
+    background-color: #eee;
+    padding: 10px;
+    text-align: left;
+    vertical-align: top;
+    width: 125px;
+}
+.docutils.field-list td.field-body {
+    padding: 10px 10px 10px 20px;
+    text-align: left;
+    vertical-align: top;
+}
+.docutils.field-list td.field-body blockquote p {
+    font-size: 13px;
+    line-height: 18px;
+}
+.docutils.field-list td.field-body blockquote p ul li{
+    font-size: 13px;
+}
+
+p.rubric {
+    font-weight: bold;
+    font-size: 19px;
+    margin: 15px 0 10px 0;
+}
+
+#matplotlib-examples ul li{
+  font-size: large;
+}
+
+#matplotlib-examples ul li ul{
+  margin-bottom:20px;
+  overflow:hidden;
+  border-top:1px solid #ccc;
+}
+
+#matplotlib-examples ul li ul li {
+  font-size: small;
+  line-height:1.75em;
+  display:inline;
+  float: left;
+  width: 22em;
+}
+
+#overview ul li ul{
+  margin-bottom:20px;
+  overflow:hidden;
+  border-top:1px solid #ccc;
+}
+
+#overview ul li ul li {
+  display:inline;
+  float: left;
+  width: 30em;
+}
+
+figure {
+  margin: 1em;
+  display: inline-block;
+}
+
+figure img {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+figcaption {
+  text-align: center;
+}
+
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}
+
+/* Fork me on GitHub "button" */
+#forkongithub a{
+  background:#FF7F0E;
+  color:#fff !important;
+  text-decoration:none;
+  text-align:center;
+  font-weight:bold;
+  padding:5px 40px;
+  line-height:1.5rem;
+  position:relative;
+  transition:background .25s ease;
+}
+#forkongithub a:hover{
+  background:#CA7900;
+}
+#forkongithub a::before,#forkongithub a::after{
+  content:"";
+  width:100%;
+  display:block;
+  position:absolute;
+  top:1px;
+  left:0;
+  height:1px;
+  background:#fff;
+}
+#forkongithub a::after{
+  bottom:1px;
+  top:auto;
+}
+@media screen and (min-width:700px){
+  #forkongithub{
+    position:absolute;
+    top:0;
+    right:0;
+    width:150px;
+    overflow:hidden;
+    height:150px;
+    z-index:9999;
+  }
+  #forkongithub a{
+    width:150px;
+    position:absolute;
+    top:40px;
+    right:-60px;
+    transform:rotate(45deg);
+    -webkit-transform:rotate(45deg);
+    -ms-transform:rotate(45deg);
+    -moz-transform:rotate(45deg);
+    -o-transform:rotate(45deg);
+    box-shadow:4px 4px 10px rgba(0,0,0,0.8);
+  }
+}
+
+#sidebar-donations {
+    margin-top: 40px;
+}
+
+.donate_button {
+    background:#11557C;
+    font-weight:normal;
+    clear: both;
+    display: block;
+    width:200px;
+    line-height:2.8;
+    font-size: 16px;
+    text-align: center;
+    cursor:pointer;
+    color:#fff;
+    text-decoration: none;
+    margin: 30px auto 0;
+    border-radius: 6px;
+    z-index:1;
+    transition: background .25s ease;
+}
+
+.donate_button:last-of-type {
+    margin: 15px auto 30px;
+
+
+}
+
+.donate_button:hover, .donate_button:active, .donate_button:focus {
+    background: #003c63;
+    outline-color: #003c63;
+}
+
+
+div.responsive_screenshots {
+    /* Horizontally centered */
+    display: block;
+    margin: auto;
+
+    /* Do not go beyond 1:1 scale (and ensure a 1x4 tight layout) */
+    max-width: 640px;  /* at most 4 x 1:1 subfig width  */
+    max-height: 120px; /* at most 1 x 1:1 subfig height */
+}
+
+/* To avoid subfigure parts outside of the responsive_screenshots  */
+/* element (see: https://stackoverflow.com/questions/2062258/      */
+/* floating-stuff-within-a-div-floats-outside-of-div-why)          */
+span.clear_screenshots { clear: left; display: block; }
+
+div.responsive_subfig{
+    float: left;
+    width: 25%;  /* we want 4 subfigs in a row */
+
+    /* Include content, padding and border in width. This should */
+    /* avoid having to use tricks like "width: 24.9999%"         */
+    box-sizing: border-box;
+}
+
+div.responsive_subfig img {
+    /* Horizontally centered */
+    display: block;
+    margin: auto;
+
+    /* Possible downscaling */
+    max-width: 162px;  /* at most 1 x 1:1 subfig width  */
+    max-height: 139px; /* at most 1 x 1:1 subfig height */
+
+    width: 100%;
+}
+
+@media only screen and (max-width: 1000px){
+    /* The value of 1000px was handcrafted to provide a more or less */
+    /* smooth transition between the 1x4 and the 2x2 layouts. It is  */
+    /* NB: it is slightly below 1024px: so one should still have a   */
+    /* row in a 1024x768 window                                      */
+
+    div.responsive_screenshots {
+        /* Do not go beyond 1:1 scale (and ensure a 2x2 tight layout) */
+        max-width: 324px;  /* at most 2 x 1:1 subfig width  */
+        max-height: 278px; /* at most 2 x 1:1 subfig height */
+    }
+
+    div.responsive_subfig {
+        width: 50%;  /* we want 2 subfigs in a row */
+    }
+}
+
+/* Sphinx gallery display */
+
+div.align-center {
+    margin: auto;
+    text-align: center;
+}
+
+p.caption {
+    font-weight: bold;
+}
+
+div#gallery.section, div#tutorials.section {
+    overflow: hidden;
+}
+
+.sphx-glr-multi-img{
+    max-width: 99% !important;
+}
+
+.sphx-glr-thumbcontainer {
+    border: solid #d6d6d6 1px !important;
+    text-align: center !important;
+    font-size: 1.2em !important;
+}
+
+div.sphx-glr-download {
+    width: auto !important;
+}
+
+div.sphx-glr-download a {
+   background-color: #d9edf7 !important;
+   border: 1px solid #bce8f1 !important;
+   background-image: none !important;
+}
+
+p.sphx-glr-signature {
+   display: none !important;
+}
+
+div.sphx-glr-download-link-note {
+   display: none !important;
+}
+
+.sphx-glr-thumbcontainer a.internal {
+    font-weight: 400;
+}
+
+.viewcode-link {
+    float: right;
+}
+
+.viewcode-back {
+    float: right;
+    font-family: "Helvetica Neue", Helvetica, 'Lucida Grande', 'Lucida Sans Unicode', 'Geneva', 'Verdana', sans-serif;
+}
+
+div.viewcode-block:target {
+    margin: -1px -13px;
+    padding: 0 10px;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    background-color: #f4debf;
+
+}
+
+.sidebar-announcement {
+    border: 1px solid #11557C;
+    background: #eff9ff;
+    padding: 2px;
+    margin-top: 40px;
+}
+
+.sidebar-announcement p {
+    margin: 0.4em 0.4em 0.6em 0.4em;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -226,8 +226,10 @@ github_project_url = "https://github.com/matplotlib/matplotlib/"
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-#html_style = 'matplotlib.css'
-html_style = 'mpl.css'
+if sphinx.version_info < (2, 0):
+    html_style = 'mpl_sphinx1.css'
+else:
+    html_style = 'mpl.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.8.1,<2.0.0
+sphinx>=1.8.1
 colorspacious
 ipython
 ipywidgets

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.8.1
+sphinx>=1.8.1,!=2.0.0
 colorspacious
 ipython
 ipywidgets


### PR DESCRIPTION
Fixes https://github.com/matplotlib/matplotlib/issues/13591#issuecomment-478263720 . The problem is that sphinx wraps list elements in a `<p>` tag as of sphinx 2.0, so the elements were inheriting properties from `p`. I've defined `li p` to have the required properties for the lists.

Not sure if this is the right approach, or if this is just a bug that needs reporting upstream to sphinx instead of fixing here, maybe someone with more CSS/HTML knowledge than me will know.