### PR TITLE
Allow SVG Text-as-Text to Use Data Coordinates

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1040,7 +1040,7 @@ class RendererSVG(RendererBase):
 
                 # Get anchor coordinates.
                 transform = mtext.get_transform()
-                ax, ay = transform.transform_point(mtext.get_position())
+                ax, ay = transform.transform_point(mtext.get_unitless_position())
                 ay = self.height - ay
 
                 # Don't do vertical anchor alignment. Most applications do not

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1040,7 +1040,8 @@ class RendererSVG(RendererBase):
 
                 # Get anchor coordinates.
                 transform = mtext.get_transform()
-                ax, ay = transform.transform_point(mtext.get_unitless_position())
+                ax, ay = transform.transform_point(
+                    mtext.get_unitless_position())
                 ay = self.height - ay
 
                 # Don't do vertical anchor alignment. Most applications do not

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -200,17 +200,16 @@ def test_unicode_won():
 
 def test_svgnone_with_data_coordinates():
     plt.rcParams['svg.fonttype'] = 'none'
-    expected = 'TEXT'
+    expected = 'Unlikely to appear by chance'
 
     fig, ax = plt.subplots()
     ax.text(np.datetime64('2019-06-30'), 1, expected)
     ax.set_xlim(np.datetime64('2019-01-01'), np.datetime64('2019-12-31'))
     ax.set_ylim(0, 2)
 
-    fd = BytesIO()
-    fig.savefig(fd, format='svg')
-    fd.seek(0)
-    buf = fd.read().decode()
-    fd.close()
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        fd.seek(0)
+        buf = fd.read().decode()
 
     assert expected in buf

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -196,3 +196,21 @@ def test_unicode_won():
     won_id = 'Computer_Modern_Sans_Serif-142'
     assert re.search(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id), buf)
     assert re.search(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id), buf)
+
+
+def test_svgnone_with_data_coordinates():
+    plt.rcParams['svg.fonttype'] = 'none'
+    expected = 'TEXT'
+
+    fig, ax = plt.subplots()
+    ax.text(np.datetime64('2019-06-30'), 1, expected)
+    ax.set_xlim(np.datetime64('2019-01-01'), np.datetime64('2019-12-31'))
+    ax.set_ylim(0, 2)
+
+    fd = BytesIO()
+    fig.savefig(fd, format='svg')
+    fd.seek(0)
+    buf = fd.read().decode()
+    fd.close()
+
+    assert expected in buf


### PR DESCRIPTION
## PR Summary

Drawing SVG text as text (svg.fonttype is "none") should allow locations in data-coordinates. The included test case fails on master as the x-value (a np.datetime64) is expected to be a float (see stacktrace before fix below).

````
____________________________________________________ test_svgnone_with_data_coordinates ____________________________________________________

    def test_svgnone_with_data_coordinates():
        plt.rcParams['svg.fonttype'] = 'none'
        expected = 'TEXT'
    
        fig, ax = plt.subplots()
        ax.text(np.datetime64('2019-06-30'), 1, expected)
        ax.set_xlim(np.datetime64('2019-01-01'), np.datetime64('2019-12-31'))
        ax.set_ylim(0, 2)
    
        fd = BytesIO()
>       fig.savefig(fd, format='svg')

lib/matplotlib/tests/test_backend_svg.py:211: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
lib/matplotlib/figure.py:2186: in savefig
    self.canvas.print_figure(fname, **kwargs)
lib/matplotlib/backend_bases.py:2079: in print_figure
    **kwargs)
lib/matplotlib/backends/backend_svg.py:1199: in print_svg
    result = self._print_svg(filename, fh, **kwargs)
lib/matplotlib/backends/backend_svg.py:1224: in _print_svg
    self.figure.draw(renderer)
lib/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
lib/matplotlib/figure.py:1716: in draw
    renderer, self, artists, self.suppressComposite)
lib/matplotlib/image.py:135: in _draw_list_compositing_images
    a.draw(renderer)
lib/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
lib/matplotlib/axes/_base.py:2630: in draw
    mimage._draw_list_compositing_images(renderer, self, artists)
lib/matplotlib/image.py:135: in _draw_list_compositing_images
    a.draw(renderer)
lib/matplotlib/artist.py:38: in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
lib/matplotlib/text.py:718: in draw
    ismath=ismath, mtext=mtext)
lib/matplotlib/backends/backend_svg.py:1159: in draw_text
    self._draw_text_as_text(gc, x, y, s, prop, angle, ismath, mtext)
lib/matplotlib/backends/backend_svg.py:1043: in _draw_text_as_text
    ax, ay = transform.transform_point(mtext.get_position())
lib/matplotlib/transforms.py:1468: in transform_point
    return self.transform(np.asarray([point]))[0]
lib/matplotlib/transforms.py:1381: in transform
    res = self.transform_affine(self.transform_non_affine(values))
lib/matplotlib/transforms.py:2348: in transform_affine
    return self.get_affine().transform(points)
lib/matplotlib/transforms.py:1679: in transform
    return self.transform_affine(values)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <matplotlib.transforms.Affine2D object at 0x7f76ef2b02e8>, points = array([[numpy.datetime64('2019-06-30'), 1]], dtype=object)

    def transform_affine(self, points):
        mtx = self.get_matrix()
        if isinstance(points, np.ma.MaskedArray):
            tpoints = affine_transform(points.data, mtx)
            return np.ma.MaskedArray(tpoints, mask=np.ma.getmask(points))
>       return affine_transform(points, mtx)
E       TypeError: Cannot cast array data from dtype('O') to dtype('float64') according to the rule 'safe'

lib/matplotlib/transforms.py:1761: TypeError

````