### PR TITLE
Remove mention of $QT_API in matplotlibrc example.

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -41,11 +41,6 @@
 ## 'module://my_backend'.
 #backend      : Agg
 
-## Note that this can be overridden by the environment variable
-## QT_API used by Enthought Tool Suite (ETS); valid values are
-## "pyqt" and "pyside".  The "pyqt" setting has the side effect of
-## forcing the use of Version 2 API for QString and QVariant.
-
 ## The port to use for the web server in the WebAgg backend.
 #webagg.port : 8988
 


### PR DESCRIPTION
This was relevant back when the `backend.qt{4,5}` rcParams still existed
(QT_API would override them), but not anymore.  (Right now it reads like
it override the `backend` rcParam, which is plain wrong.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
