### PR TITLE
Remove extra keyword from pytest.skip call.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -56,7 +56,7 @@ def qt_module(request):
             py_qt_ver = QtCore.__version_info__[0]
 
         if py_qt_ver != 4:
-            pytest.skip(reason='Qt4 is not available')
+            pytest.skip('Qt4 is not available')
 
         from matplotlib.backends.backend_qt4 import (
             MODIFIER_KEYS, SUPER, ALT, CTRL, SHIFT)


### PR DESCRIPTION
## PR Summary

There is no `reason` keyword argument to the top-level `pytest.skip` function.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way