### PR TITLE
Simplify grouped bar chart example

### DIFF
--- a/examples/lines_bars_and_markers/barchart.py
+++ b/examples/lines_bars_and_markers/barchart.py
@@ -3,9 +3,8 @@
 Grouped bar chart with labels
 =============================
 
-Bar charts are useful for visualizing counts, or summary statistics
-with error bars. This example shows a ways to create a grouped bar chart
-with Matplotlib and also how to annotate bars with labels.
+This example shows a how to create a grouped bar chart and how to annotate
+bars with labels.
 """
 
 import matplotlib
@@ -13,53 +12,42 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-men_means, men_std = (20, 35, 30, 35, 27), (2, 3, 4, 1, 2)
-women_means, women_std = (25, 32, 34, 20, 25), (3, 5, 2, 3, 3)
+labels = ['G1', 'G2', 'G3', 'G4', 'G5']
+men_means = [20, 34, 30, 35, 27]
+women_means = [25, 32, 34, 20, 25]
 
-ind = np.arange(len(men_means))  # the x locations for the groups
+x = np.arange(len(labels))  # the label locations
 width = 0.35  # the width of the bars
 
 fig, ax = plt.subplots()
-rects1 = ax.bar(ind - width/2, men_means, width, yerr=men_std,
-                label='Men')
-rects2 = ax.bar(ind + width/2, women_means, width, yerr=women_std,
-                label='Women')
+rects1 = ax.bar(x - width/2, men_means, width, label='Men')
+rects2 = ax.bar(x + width/2, women_means, width, label='Women')
 
 # Add some text for labels, title and custom x-axis tick labels, etc.
 ax.set_ylabel('Scores')
 ax.set_title('Scores by group and gender')
-ax.set_xticks(ind)
-ax.set_xticklabels(('G1', 'G2', 'G3', 'G4', 'G5'))
+ax.set_xticks(x)
+ax.set_xticklabels(labels)
 ax.legend()
 
 
-def autolabel(rects, xpos='center'):
-    """
-    Attach a text label above each bar in *rects*, displaying its height.
-
-    *xpos* indicates which side to place the text w.r.t. the center of
-    the bar. It can be one of the following {'center', 'right', 'left'}.
-    """
-
-    ha = {'center': 'center', 'right': 'left', 'left': 'right'}
-    offset = {'center': 0, 'right': 1, 'left': -1}
-
+def autolabel(rects):
+    """Attach a text label above each bar in *rects*, displaying its height."""
     for rect in rects:
         height = rect.get_height()
         ax.annotate('{}'.format(height),
                     xy=(rect.get_x() + rect.get_width() / 2, height),
-                    xytext=(offset[xpos]*3, 3),  # use 3 points offset
-                    textcoords="offset points",  # in both directions
-                    ha=ha[xpos], va='bottom')
+                    xytext=(0, 3),  # 3 points vertical offset
+                    textcoords="offset points",
+                    ha='center', va='bottom')
 
 
-autolabel(rects1, "left")
-autolabel(rects2, "right")
+autolabel(rects1)
+autolabel(rects2)
 
 fig.tight_layout()
 
 plt.show()
-
 
 #############################################################################
 #


### PR DESCRIPTION
## PR Summary

IMHO the [Grouped bar chart example](https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/barchart.html) is trying to show too much. Illustrating grouping of bars and annotating with values is more than enough.

I've removed the error bars. The error bars made the example more complex and thus harder to understand. While error bars are useful depending on the context, they are rather rarely used with bar charts (c.f. google image search "bar chart"); and we have other examples for error bars with bar charts.

Bonus question: Can I tell matplotlib to include the texts in the ylim calculation?