### PR TITLE
Make test suite fail on warnings.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6079,7 +6079,8 @@ def test_secondary_xy():
 
         secax(0.2, functions=(invert, invert))
         secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
-        secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
+        with pytest.warns(RuntimeWarning):  # Needs to be fixed.
+            secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
         secax(0.8)
 
 
@@ -6101,7 +6102,8 @@ def test_secondary_resize():
         with np.errstate(divide='ignore'):
             return 1 / x
 
-    ax.secondary_xaxis('top', functions=(invert, invert))
+    with pytest.warns(RuntimeWarning):  # May need to be fixed.
+        ax.secondary_xaxis('top', functions=(invert, invert))
     fig.canvas.draw()
     fig.set_size_inches((7, 4))
     assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -353,10 +353,8 @@ def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm):
 def test_warn_external_frame_embedded_python():
     with patch.object(cbook, "sys") as mock_sys:
         mock_sys._getframe = Mock(return_value=None)
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns(UserWarning, match=r"\Adummy\Z"):
             cbook._warn_external("dummy")
-    assert len(w) == 1
-    assert str(w[0].message) == "dummy"
 
 
 def test_to_prestep():

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -121,12 +121,12 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
                   grid_finder.grid_locator2(lat_min, lat_max)
 
         if self.nth_coord == 0:
-            xx0 = np.full(self._line_num_points, self.value)
+            xx0 = np.full(self._line_num_points, self.value, type(self.value))
             yy0 = np.linspace(lat_min, lat_max, self._line_num_points)
             xx, yy = grid_finder.transform_xy(xx0, yy0)
         elif self.nth_coord == 1:
             xx0 = np.linspace(lon_min, lon_max, self._line_num_points)
-            yy0 = np.full(self._line_num_points, self.value)
+            yy0 = np.full(self._line_num_points, self.value, type(self.value))
             xx, yy = grid_finder.transform_xy(xx0, yy0)
 
         self.grid_info = {

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,6 @@ python_files = test_*.py
 markers =
     backend: Set alternate Matplotlib backend temporarily.
     style: Set alternate Matplotlib style temporarily.
+
+filterwarnings =
+    error


### PR DESCRIPTION
## PR Summary

There are a few remaining warnings with secondary_axes, which should be handled by #13593 (which, as a side effect, delays applyings margins to the secondary axes until the axes have "valid" limits).

Edits:
- Looks like test_warn_external_frame_embedded_python had to be slightly adjusted (although it does something nasty by patching sys, so it probably can't really be considered a pytest bug...); done.
- And some warning with old numpys, also fixed.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
