### PR TITLE
Deprecate the dryrun parameter to print_foo().

### DIFF
--- a/doc/api/next_api_changes/2019-05-05-AL.rst
+++ b/doc/api/next_api_changes/2019-05-05-AL.rst
@@ -1,0 +1,4 @@
+Deprecations
+````````````
+
+The ``dryrun`` parameter to the various ``FigureCanvasFoo.print_foo`` methods is deprecated.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1528,6 +1528,27 @@ class KeyEvent(LocationEvent):
         self.key = key
 
 
+def _get_renderer(figure, print_method):
+    """
+    Get the renderer that would be used to save a `~.Figure`, and cache it on
+    the figure.
+    """
+    # This is implemented by triggering a draw, then immediately jumping out of
+    # Figure.draw() by raising an exception.
+
+    class Done(Exception):
+        pass
+
+    def _draw(renderer): raise Done(renderer)
+
+    with cbook._setattr_cm(figure, draw=_draw):
+        try:
+            print_method(io.BytesIO())
+        except Done as exc:
+            figure._cachedRenderer, = exc.args
+            return figure._cachedRenderer
+
+
 class FigureCanvasBase(object):
     """
     The canvas the figure renders into.
@@ -2038,20 +2059,11 @@ class FigureCanvasBase(object):
                 bbox_inches = rcParams['savefig.bbox']
 
             if bbox_inches:
-                # call adjust_bbox to save only the given area
                 if bbox_inches == "tight":
-                    # When bbox_inches == "tight", it saves the figure twice.
-                    # The first save command (to a BytesIO) is just to estimate
-                    # the bounding box of the figure.
-                    result = print_method(
-                        io.BytesIO(),
-                        dpi=dpi,
-                        facecolor=facecolor,
-                        edgecolor=edgecolor,
-                        orientation=orientation,
-                        dryrun=True,
-                        **kwargs)
-                    renderer = self.figure._cachedRenderer
+                    renderer = _get_renderer(
+                        self.figure,
+                        functools.partial(
+                            print_method, dpi=dpi, orientation=orientation))
                     bbox_artists = kwargs.pop("bbox_extra_artists", None)
                     bbox_inches = self.figure.get_tightbbox(renderer,
                             bbox_extra_artists=bbox_artists)
@@ -2061,6 +2073,7 @@ class FigureCanvasBase(object):
 
                     bbox_inches = bbox_inches.padded(pad)
 
+                # call adjust_bbox to save only the given area
                 restore_bbox = tight_bbox.adjust_bbox(self.figure, bbox_inches,
                                                       canvas.fixed_dpi)
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -544,6 +544,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         # print_figure(), and the latter ensures that `self.figure.dpi` already
         # matches the dpi kwarg (if any).
 
+        @cbook._delete_parameter("3.2", "dryrun")
         def print_jpg(self, filename_or_obj, *args, dryrun=False,
                       pil_kwargs=None, **kwargs):
             """
@@ -598,6 +599,7 @@ class FigureCanvasAgg(FigureCanvasBase):
 
         print_jpeg = print_jpg
 
+        @cbook._delete_parameter("3.2", "dryrun")
         def print_tif(self, filename_or_obj, *args, dryrun=False,
                       pil_kwargs=None, **kwargs):
             buf, size = self.print_to_buffer()

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -775,6 +775,7 @@ class FigureCanvasPgf(FigureCanvasBase):
     def get_default_filetype(self):
         return 'pdf'
 
+    @cbook._delete_parameter("3.2", "dryrun")
     def _print_pgf_to_fh(self, fh, *args,
                          dryrun=False, bbox_inches_restore=None, **kwargs):
         if dryrun:

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -870,6 +870,7 @@ class FigureCanvasPS(FigureCanvasBase):
                                orientation, isLandscape, papertype,
                                **kwargs)
 
+    @cbook._delete_parameter("3.2", "dryrun")
     def _print_figure(
             self, outfile, format, dpi=72, facecolor='w', edgecolor='w',
             orientation='portrait', isLandscape=False, papertype=None,

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -458,6 +458,7 @@ class Table(Artist):
 
     def get_window_extent(self, renderer):
         """Return the bounding box of the table in window coords."""
+        self._update_positions(renderer)
         boxes = [cell.get_window_extent(renderer)
                  for cell in self._cells.values()]
         return Bbox.union(boxes)


### PR DESCRIPTION
The print_foo() methods of all backends (that implement saving to a
given format -- print_svg saves to svg, etc.) all have an undocumented
`dryrun` parameter that effectively means "don't actually do the
drawing; just set the _cachedRenderer attribute on the figure" with the
intent of using that renderer object to determine the figure tight bbox
for saving with bbox_inches="tight".

- This behavior is not actually implemented for the pdf backend, so
  saving to pdf with bbox_inches="tight" will currently fully walk the
  artist tree twice.
- This is a parameter that needs to be reimplemented again and again for
  all third-party backends (cough cough, mplcairo).

Instead, we can extract that renderer object by fiddling with
Figure.draw (see implementation of _get_renderer), which may not be the
most elegant, but avoids having to reimplement the same functionality
across each backend.

This patch also found that Table's window_extent is incorrect until a
draw() is performed.  Fix that problem by correctly setting the table's
text positions in get_window_extent().

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
