### PR TITLE
MNT: inspect.getfullargspec will be deprecated in py3.8

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1270,7 +1270,8 @@ class ArtistInspector(object):
             func = getattr(self.o, name)
             if not callable(func):
                 continue
-            nargs = len(inspect.signature(func).parameters)
+            nargs = len([p for p in inspect.signature(func).parameters.values()
+                         if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD])
             if nargs < 2 or self.is_alias(func):
                 continue
             source_class = self.o.__module__ + "." + self.o.__name__

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1270,7 +1270,7 @@ class ArtistInspector(object):
             func = getattr(self.o, name)
             if not callable(func):
                 continue
-            nargs = len(inspect.getfullargspec(func).args)
+            nargs = len(inspect.signature(func).parameters)
             if nargs < 2 or self.is_alias(func):
                 continue
             source_class = self.o.__module__ + "." + self.o.__name__

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1863,12 +1863,11 @@ def _pprint_styles(_styles):
     _table = [["Class", "Name", "Attrs"]]
 
     for name, cls in sorted(_styles.items()):
-        spec = inspect.getfullargspec(cls.__init__)
-        if spec.defaults:
-            argstr = ", ".join(map(
-                "{}={}".format, spec.args[-len(spec.defaults):], spec.defaults
-            ))
-        else:
+        sig = inspect.signature(cls.__init__)
+        argstr = ", ".join(
+            f"{p.name}={p.default}"
+            for p in sig.parameters.values() if p.default is not p.empty)
+        if not argstr:
             argstr = 'None'
         # adding ``quotes`` since - and | have special meaning in reST
         _table.append([cls.__name__, "``%s``" % name, argstr])


### PR DESCRIPTION
Switch to using inspect.signature

Still need to verify that the replacement is equivalent (which is why I marked it as draft), but pushing this out early so I don't forget I did this.