### PR TITLE
Deprecate the 'warn' parameter to matplotlib.use().

### DIFF
--- a/doc/api/next_api_changes/2019-05-06-AL.rst
+++ b/doc/api/next_api_changes/2019-05-06-AL.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+The ``warn`` parameter to `matplotlib.use()` is deprecated (catch the
+`ImportError` emitted on backend switch failure and reemit a warning yourself
+if so desired).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1226,6 +1226,7 @@ class rc_context:
 
 
 @cbook._rename_parameter("3.1", "arg", "backend")
+@cbook._delete_parameter("3.1", "warn")
 def use(backend, warn=False, force=True):
     """
     Select the backend used for rendering and GUI integration.
@@ -1248,7 +1249,7 @@ def use(backend, warn=False, force=True):
 
     warn : bool, optional, default: False
         If True and not *force*, emit a warning if a failure-to-switch
-        `ImportError` has been suppressed.
+        `ImportError` has been suppressed.  This parameter is deprecated.
 
     force : bool, optional, default: True
         If True (the default), raise an `ImportError` if the backend cannot be

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -50,7 +50,7 @@ def setup():
                 "Could not set locale to English/United States. "
                 "Some date-related tests may fail.")
 
-    mpl.use('Agg', force=True, warn=False)  # use Agg backend for these tests
+    mpl.use('Agg')
 
     with cbook._suppress_matplotlib_deprecation_warning():
         mpl.rcdefaults()  # Start with all defaults


### PR DESCRIPTION
Right now, the only case where the 'warn' parameter to use() has an
observable effect is if the user calls
`use(some_backend, warn=True, force=False)` (the default is
`warn=False, force=True`) and `some_backend` cannot be switched to.

If they really want a warning in that case and not an exception (why?),
they can just do
```
try: use(some_backend)
except ImportError: warnings.warn(...)
```
instead.

Given the non-obvious interaction between `warn` and `force`, just
deprecate `warn`.

We could even deprecate `force` and tell user to catch ImportErrors if
they know a switch can fail and that they want to silently ignore the
switch failure, but I guess someone will complain that
`use(some_backend, force=False)` is so much shorter to write than
```
try: use(some_backend)
except ImportError: pass
```
...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
