### PR TITLE
Remove warnings handling for fixed bugs.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6079,8 +6079,7 @@ def test_secondary_xy():
 
         secax(0.2, functions=(invert, invert))
         secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
-        with pytest.warns(RuntimeWarning):  # Needs to be fixed.
-            secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
+        secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
         secax(0.8)
 
 
@@ -6102,8 +6101,7 @@ def test_secondary_resize():
         with np.errstate(divide='ignore'):
             return 1 / x
 
-    with pytest.warns(RuntimeWarning):  # May need to be fixed.
-        ax.secondary_xaxis('top', functions=(invert, invert))
+    ax.secondary_xaxis('top', functions=(invert, invert))
     fig.canvas.draw()
     fig.set_size_inches((7, 4))
     assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])


### PR DESCRIPTION
## PR Summary

Unbreak the build breakage due to #13593 and #14131 being merged nearly at the same time (the contextmanagers were added in #14131 because #13593 had not been merged yet at that point).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
