### PR TITLE
Clarify error with usetex when cm-super is not installed.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -86,10 +86,13 @@ class TexManager(object):
         'helvetica': ('phv', r'\usepackage{helvet}'),
         'avant garde': ('pag', r'\usepackage{avant}'),
         'courier': ('pcr', r'\usepackage{courier}'),
-        'monospace': ('cmtt', ''),
-        'computer modern roman': ('cmr', ''),
-        'computer modern sans serif': ('cmss', ''),
-        'computer modern typewriter': ('cmtt', '')}
+        # Loading the type1ec package ensures that cm-super is installed, which
+        # is necessary for unicode computer modern.  (It also allows the use of
+        # computer modern at arbitrary sizes, but that's just a side effect.)
+        'monospace': ('cmtt', r'\usepackage{type1ec}'),
+        'computer modern roman': ('cmr', r'\usepackage{type1ec}'),
+        'computer modern sans serif': ('cmss', r'\usepackage{type1ec}'),
+        'computer modern typewriter': ('cmtt', r'\usepackage{type1ec}')}
 
     _rc_cache = None
     _rc_cache_keys = (


### PR DESCRIPTION
This PR makes the error when cm-super is not installed (and
rcParams["text.latex.unicode"] = True, which is now the default) be
```
! LaTeX Error: File `type1ec.sty' not found.

Type X to quit or <RETURN> to proceed,
or enter new name. (Default extension: sty)

Enter file name:
! Emergency stop.
<read *>

l.5 \usepackage
               {type1ec}^^M
No pages of output.
```
(or, if using miktex, miktex will prompt for installing cm-super).

Closes #14146, I think.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
