### PR TITLE
Fix glyph loading in textpath.

### DIFF
--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -312,18 +312,10 @@ class TextToPath(object):
                 font.set_size(self.FONT_SCALE, self.DPI)
                 # See comments in _get_ps_font_and_encoding.
                 if enc is not None:
-                    if glyph not in enc:
-                        _log.warning(
-                            "The glyph %d of font %s cannot be converted with "
-                            "the encoding; glyph may be wrong.",
-                            glyph, font.fname)
-                        font.load_char(glyph, flags=LOAD_TARGET_LIGHT)
-                    else:
-                        index = font.get_name_index(enc[glyph])
-                        font.load_glyph(index, flags=LOAD_TARGET_LIGHT)
+                    index = font.get_name_index(enc[glyph])
+                    font.load_glyph(index, flags=LOAD_TARGET_LIGHT)
                 else:
-                    index = glyph
-                    font.load_char(index, flags=LOAD_TARGET_LIGHT)
+                    font.load_char(glyph, flags=LOAD_TARGET_LIGHT)
                 glyph_map_new[char_id] = font.get_path()
 
             glyph_ids.append(char_id)


### PR DESCRIPTION
I missed the fact that `enc` is now a list, not a mapping anymore (and
`glyph` is still an index), so the `glyph in enc` check does not make
sense anymore.

(Edit: looks like this was an incorrect last-minute partial revert after a review: https://github.com/matplotlib/matplotlib/pull/12928#discussion_r271213867.)

This fixes test_backend_svg::test_unicode_won, which previously failed
*if run by itself* but curiously would not fail when run with the rest
of the test suite.

followup to #12928; I'm going to mark this as release critical as #12928 is basically wrong without this but feel free to untag.

there's a test in the followup PR, #14159.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
