### PR TITLE
Isolate nbagg test from user ipython profile.

### DIFF
--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -1,6 +1,7 @@
+import os
 from pathlib import Path
 import subprocess
-import tempfile
+from tempfile import TemporaryDirectory
 
 import pytest
 
@@ -9,25 +10,20 @@ nbformat = pytest.importorskip('nbformat')
 # From https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
 
 
-def _notebook_run(nb_file):
-    """Execute a notebook via nbconvert and collect output.
-       :returns (parsed nb object, execution errors)
-    """
-    with tempfile.NamedTemporaryFile(suffix=".ipynb", mode='w+t') as fout:
-        subprocess.check_call([
-            "jupyter", "nbconvert", "--to", "notebook",
-            "--execute", "--ExecutePreprocessor.timeout=500",
-            "--output", fout.name, nb_file,
-        ])
-        fout.seek(0)
-        nb = nbformat.read(fout, nbformat.current_nbformat)
+def test_ipynb():
+    nb_path = Path(__file__).parent / 'test_nbagg_01.ipynb'
+
+    with TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir, "out.ipynb")
+        subprocess.check_call(
+            ["jupyter", "nbconvert", "--to", "notebook",
+             "--execute", "--ExecutePreprocessor.timeout=500",
+             "--output", str(out_path), str(nb_path)],
+            env={**os.environ, "IPYTHONDIR": tmpdir})
+        with out_path.open() as out:
+            nb = nbformat.read(out, nbformat.current_nbformat)
 
     errors = [output for cell in nb.cells if "outputs" in cell
                      for output in cell["outputs"]
                      if output.output_type == "error"]
-    return nb, errors
-
-
-def test_ipynb():
-    nb, errors = _notebook_run(Path(__file__).parent / 'test_nbagg_01.ipynb')
-    assert errors == []
+    assert not errors


### PR DESCRIPTION
My ~/.ipython profile causes test_backend_nbagg to fail (but is
otherwise valid for my own use).  To fix that, point the ipython
directory to a temporary directory when running that test (per
https://ipython.readthedocs.io/en/stable/config/intro.html#the-ipython-directory).

While we're at it, also create the temporary output file in that
directory -- that's quite likely to be necessary for the test to
actually work on Windows, anyways (due to vagaries with writing from
multiple processes to a NamedTemporaryFile).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
