### PR TITLE
Fix test_lazy_imports in presence of $MPLBACKEND or matplotlibrc.

### DIFF
--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -1,4 +1,5 @@
 import builtins
+import os
 import subprocess
 import sys
 import textwrap
@@ -50,8 +51,6 @@ def test_lazy_imports():
     assert 'urllib.request' not in sys.modules
     """)
 
-    subprocess.check_call([
-        sys.executable,
-        '-c',
-        source
-    ])
+    subprocess.check_call(
+        [sys.executable, '-c', source],
+        env={**os.environ, "MPLBACKEND": "", "MATPLOTLIBRC": os.devnull})


### PR DESCRIPTION
$MPLBACKEND or the matplotlibrc can make matplotlib load a nondefault
backend (cough cough, mplcairo) by default which then makes the test
fail.  Overwrite these in the test.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
