### PR TITLE
Fix glyph sizing in textpath.

### DIFF
--- a/lib/matplotlib/tests/baseline_images/test_backend_svg/unicode_usetex.svg
+++ b/lib/matplotlib/tests/baseline_images/test_backend_svg/unicode_usetex.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Created with matplotlib (https://matplotlib.org/) -->
+<svg height="345.6pt" version="1.1" viewBox="0 0 460.8 345.6" width="460.8pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">
+*{stroke-linecap:butt;stroke-linejoin:round;white-space:pre;}
+  </style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+z
+" style="fill:#ffffff;"/>
+  </g>
+  <g id="text_1">
+   <!-- \textdegree -->
+   <defs>
+    <path d="M 13.90625 68 
+C 8.5 67.296875 5.09375 62.75 5.09375 58 
+C 5.09375 52.953125 9 48 15 48 
+L 15.90625 48 
+C 21.203125 48.703125 24.796875 53.25 24.796875 58 
+C 24.796875 63.15625 20.5 68 14.796875 68 
+z
+M 8.203125 57.390625 
+L 8.203125 58 
+C 8.203125 61.546875 11.296875 64.671875 14.796875 64.671875 
+C 18.40625 64.671875 20.90625 61.875 21.59375 58.609375 
+L 21.59375 57.984375 
+C 21.59375 54.40625 18.5 51.21875 15 51.21875 
+C 11.40625 51.21875 8.90625 54.0625 8.203125 57.390625 
+z
+" id="Computer_Modern_Sans_Serif-176"/>
+   </defs>
+   <g transform="translate(230.4 172.8)scale(0.1 -0.1)">
+    <use xlink:href="#Computer_Modern_Sans_Serif-176"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -182,20 +182,12 @@ def test_missing_psfont(monkeypatch):
         fig.savefig(tmpfile, format='svg')
 
 
-# Use Computer Modern Sans Serif, not Helvetica (which has no \textwon).
-@pytest.mark.style('default')
 @needs_usetex
-def test_unicode_won():
-    fig = Figure()
-    fig.text(.5, .5, r'\textwon', usetex=True)
-
-    with BytesIO() as fd:
-        fig.savefig(fd, format='svg')
-        buf = fd.getvalue().decode('ascii')
-
-    won_id = 'Computer_Modern_Sans_Serif-142'
-    assert re.search(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id), buf)
-    assert re.search(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id), buf)
+@image_comparison(baseline_images=['unicode_usetex'], extensions=['svg'])
+def test_unicode_usetex():
+    mpl.rcParams['svg.fonttype'] = 'none'
+    mpl.style.use('default')
+    plt.figtext(.5, .5, r'\textdegree', usetex=True)
 
 
 def test_svgnone_with_data_coordinates():

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -321,7 +321,7 @@ class TextToPath(object):
             glyph_ids.append(char_id)
             xpositions.append(x1)
             ypositions.append(y1)
-            sizes.append(dvifont.size / self.FONT_SCALE)
+            sizes.append(1)
 
         myrects = []
 


### PR DESCRIPTION
## PR Summary

Scaling by dvifont.size / self.FONT_SCALE resulted in way to small
glyphs for many fonts.

Closes the "bad size" part of #12928 / https://github.com/matplotlib/matplotlib/issues/14146#issuecomment-490119850.
This goes on top of #14156 even though they are technically independent as both are needed to fix (I think) #14156.

Setting the later scaling of 1 should be equivalent (modulo hinting, which is likely better?) to the solution in https://github.com/matplotlib/matplotlib/pull/12928#issuecomment-445072209, which increased the font size to compensate for the later scaling.

Closes #8068.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
