### PR TITLE
Fix regexp for dvipng version detection

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -331,7 +331,7 @@ def _get_executable_info(name):
                 f"{' '.join(args)}, which output {output}")
 
     if name == "dvipng":
-        return impl(["dvipng", "-version"], "(?m)^dvipng .* (.+)", "1.6")
+        return impl(["dvipng", "-version"], "(?m)^dvipng(?: .*)? (.+)", "1.6")
     elif name == "gs":
         execs = (["gswin32c", "gswin64c", "mgs", "gs"]  # "mgs" for miktex.
                  if sys.platform == "win32" else


### PR DESCRIPTION
## PR Summary

`dvipng --verision` outputs in some recent version

~~~
This is dvipng 1.15 Copyright 2002-2015 Jan-Ake Larsson
dvipng 1.15
kpathsea version 6.2.3
Compiled with Freetype 2.8.1
Using libft 2.8.1
Copyright (C) 2002-2015 Jan-Ake Larsson.
There is NO warranty.  You may redistribute this software
under the terms of the GNU Lesser General Public License
version 3, see the COPYING file in the dvipng distribution
or <http://www.gnu.org/licenses/>.
~~~

This was not captured by the regexp. It probably assumed `dvipng version 1.15` or similar. The changed regexp still accepts all the previous strings plus one with only a single space between `dvipng` and the version number.

This bug made `@needs_usetex` skip tests, claiming a missing TeX installation. Noticed from #14156.
