### PR TITLE
Shorten usage of `@image_comparison`.

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -366,6 +366,10 @@ def image_comparison(baseline_images, extensions=None, tol=0,
 
         If *None*, defaults to all supported extensions: png, pdf, and svg.
 
+        When testing a single extension, it can be directly included in the
+        names passed to *baseline_images*.  In that case, *extensions* must not
+        be set.
+
         In order to keep the size of the test suite from ballooning, we only
         include the ``svg`` or ``pdf`` outputs if the test is explicitly
         exercising a feature dependent on that backend (see also the
@@ -393,10 +397,26 @@ def image_comparison(baseline_images, extensions=None, tol=0,
         Optional name for the base style to apply to the image test. The test
         itself can also apply additional styles if desired. Defaults to the
         '_classic_test' style.
-
     """
+
+    if baseline_images is not None:
+        # List of non-empty filename extensions.
+        baseline_exts = [*filter(None, {Path(baseline).suffix[1:]
+                                        for baseline in baseline_images})]
+        if baseline_exts:
+            if extensions is not None:
+                raise ValueError(
+                    "When including extensions directly in 'baseline_images', "
+                    "'extensions' cannot be set as well")
+            if len(baseline_exts) > 1:
+                raise ValueError(
+                    "When including extensions directly in 'baseline_images', "
+                    "all baselines must share the same suffix")
+            extensions = baseline_exts
+            baseline_images = [  # Chop suffix out from baseline_images.
+                Path(baseline).stem for baseline in baseline_images]
     if extensions is None:
-        # default extensions to test
+        # Default extensions to test, if not set via baseline_images.
         extensions = ['png', 'pdf', 'svg']
 
     if savefig_kwarg is None:

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -78,8 +78,7 @@ def test_long_path():
     fig.savefig(buff, format='png')
 
 
-@image_comparison(baseline_images=['agg_filter'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['agg_filter.png'], remove_text=True)
 def test_agg_filter():
     def smooth1d(x, window_len):
         s = np.r_[2*x[0] - x[window_len:1:-1],

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -11,7 +11,7 @@ def draw_arrow(ax, t, r):
                                 fc="b", ec='k'))
 
 
-@image_comparison(baseline_images=['fancyarrow_test_image'])
+@image_comparison(['fancyarrow_test_image'])
 def test_fancyarrow():
     # Added 0 to test division by zero error described in issue 3930
     r = [0.4, 0.3, 0.2, 0.1, 0]
@@ -28,7 +28,7 @@ def test_fancyarrow():
             ax.tick_params(labelleft=False, labelbottom=False)
 
 
-@image_comparison(baseline_images=['boxarrow_test_image'], extensions=['png'])
+@image_comparison(['boxarrow_test_image.png'])
 def test_boxarrow():
 
     styles = mpatches.BoxStyle.get_styles()
@@ -67,8 +67,7 @@ def __prepare_fancyarrow_dpi_cor_test():
     return fig2
 
 
-@image_comparison(baseline_images=['fancyarrow_dpi_cor_100dpi'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['fancyarrow_dpi_cor_100dpi.png'], remove_text=True,
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=100))
 def test_fancyarrow_dpi_cor_100dpi():
@@ -83,8 +82,7 @@ def test_fancyarrow_dpi_cor_100dpi():
     __prepare_fancyarrow_dpi_cor_test()
 
 
-@image_comparison(baseline_images=['fancyarrow_dpi_cor_200dpi'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['fancyarrow_dpi_cor_200dpi.png'], remove_text=True,
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   savefig_kwarg=dict(dpi=200))
 def test_fancyarrow_dpi_cor_200dpi():
@@ -96,9 +94,7 @@ def test_fancyarrow_dpi_cor_200dpi():
     __prepare_fancyarrow_dpi_cor_test()
 
 
-@image_comparison(baseline_images=['fancyarrow_dash'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['fancyarrow_dash.png'], remove_text=True, style='default')
 def test_fancyarrow_dash():
     from matplotlib.patches import FancyArrowPatch
     fig, ax = plt.subplots()
@@ -122,8 +118,7 @@ def test_fancyarrow_dash():
     ax.add_patch(e2)
 
 
-@image_comparison(baseline_images=['arrow_styles'], extensions=['png'],
-                  style='mpl20', remove_text=True)
+@image_comparison(['arrow_styles.png'], style='mpl20', remove_text=True)
 def test_arrow_styles():
     styles = mpatches.ArrowStyle.get_styles()
 
@@ -139,8 +134,7 @@ def test_arrow_styles():
         ax.add_patch(patch)
 
 
-@image_comparison(baseline_images=['connection_styles'], extensions=['png'],
-                  style='mpl20', remove_text=True)
+@image_comparison(['connection_styles.png'], style='mpl20', remove_text=True)
 def test_connection_styles():
     styles = mpatches.ConnectionStyle.get_styles()
 

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -94,7 +94,7 @@ def test_collection_transform_of_none():
     assert isinstance(c._transOffset, mtransforms.IdentityTransform)
 
 
-@image_comparison(baseline_images=["clip_path_clipping"], remove_text=True)
+@image_comparison(["clip_path_clipping"], remove_text=True)
 def test_clipping():
     exterior = mpath.Path.unit_rectangle().deepcopy()
     exterior.vertices *= 4
@@ -142,8 +142,7 @@ def test_cull_markers():
     assert len(svg.getvalue()) < 20000
 
 
-@image_comparison(baseline_images=['hatching'], remove_text=True,
-                  style='default')
+@image_comparison(['hatching'], remove_text=True, style='default')
 def test_hatching():
     fig, ax = plt.subplots(1, 1)
 
@@ -200,8 +199,7 @@ def test_remove():
     assert ax.stale
 
 
-@image_comparison(baseline_images=["default_edges"], remove_text=True,
-                  extensions=['png'], style='default')
+@image_comparison(["default_edges.png"], remove_text=True, style='default')
 def test_default_edges():
     fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -45,7 +45,7 @@ def test_get_labels():
     assert ax.get_ylabel() == 'y label'
 
 
-@image_comparison(baseline_images=['acorr'], extensions=['png'], style='mpl20')
+@image_comparison(['acorr.png'], style='mpl20')
 def test_acorr():
     np.random.seed(19680801)
     n = 512
@@ -56,7 +56,7 @@ def test_acorr():
     ax.legend()
 
 
-@image_comparison(baseline_images=['spy'], extensions=['png'], style='mpl20')
+@image_comparison(['spy.png'], style='mpl20')
 def test_spy():
     np.random.seed(19680801)
     a = np.ones(32 * 32)
@@ -76,8 +76,7 @@ def test_spy_invalid_kwargs():
             ax.spy(np.eye(3, 3), **unsupported_kw)
 
 
-@image_comparison(baseline_images=['matshow'],
-                  extensions=['png'], style='mpl20')
+@image_comparison(['matshow.png'], style='mpl20')
 def test_matshow():
     np.random.seed(19680801)
     a = np.random.rand(32, 32)
@@ -86,12 +85,12 @@ def test_matshow():
     ax.matshow(a)
 
 
-@image_comparison(baseline_images=['formatter_ticker_001',
-                                   'formatter_ticker_002',
-                                   'formatter_ticker_003',
-                                   'formatter_ticker_004',
-                                   'formatter_ticker_005',
-                                   ])
+@image_comparison(['formatter_ticker_001',
+                   'formatter_ticker_002',
+                   'formatter_ticker_003',
+                   'formatter_ticker_004',
+                   'formatter_ticker_005',
+                   ])
 def test_formatter_ticker():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -131,7 +130,7 @@ def test_formatter_ticker():
     ax.autoscale_view()
 
 
-@image_comparison(baseline_images=["twin_axis_locators_formatters"])
+@image_comparison(["twin_axis_locators_formatters"])
 def test_twin_axis_locators_formatters():
     vals = np.linspace(0, 1, num=5, endpoint=True)
     locs = np.sin(np.pi * vals / 2.0)
@@ -179,7 +178,7 @@ def test_twinx_cla():
     assert ax.yaxis.get_visible()
 
 
-@image_comparison(baseline_images=['twin_autoscale'], extensions=['png'])
+@image_comparison(['twin_autoscale.png'])
 def test_twinx_axis_scales():
     x = np.array([0, 0.5, 1])
     y = 0.5 * x
@@ -273,7 +272,7 @@ def test_minorticks_on_rcParams_both(fig_test, fig_ref):
     ax_ref.minorticks_on()
 
 
-@image_comparison(baseline_images=["autoscale_tiny_range"], remove_text=True)
+@image_comparison(["autoscale_tiny_range"], remove_text=True)
 def test_autoscale_tiny_range():
     # github pull #904
     fig, axs = plt.subplots(2, 2)
@@ -329,8 +328,7 @@ def test_use_sticky_edges():
     assert_allclose(ax.get_ylim(), (-0.5, 1.5))
 
 
-@image_comparison(baseline_images=['offset_points'],
-                  remove_text=True)
+@image_comparison(['offset_points'], remove_text=True)
 def test_basic_annotate():
     # Setup some data
     t = np.arange(0.0, 5.0, 0.01)
@@ -346,8 +344,7 @@ def test_basic_annotate():
                 xytext=(3, 3), textcoords='offset points')
 
 
-@image_comparison(baseline_images=['arrow_simple'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['arrow_simple.png'], remove_text=True)
 def test_arrow_simple():
     # Simple image test for ax.arrow
     # kwargs that take discrete values
@@ -389,7 +386,7 @@ def test_annotate_default_arrow():
     assert ann.arrow_patch is not None
 
 
-@image_comparison(baseline_images=['polar_axes'], style='default')
+@image_comparison(['polar_axes'], style='default')
 def test_polar_annotations():
     # you can specify the xypoint and the xytext in different
     # positions and coordinate systems, and optionally turn on a
@@ -425,8 +422,7 @@ def test_polar_annotations():
     ax.tick_params(axis='x', tick1On=True, tick2On=True, direction='out')
 
 
-@image_comparison(baseline_images=['polar_coords'], style='default',
-                  remove_text=True)
+@image_comparison(['polar_coords'], style='default', remove_text=True)
 def test_polar_coord_annotations():
     # You can also use polar notation on a cartesian axes.  Here the
     # native coordinate system ('data') is cartesian, so you need to
@@ -456,7 +452,7 @@ def test_polar_coord_annotations():
     ax.set_ylim(-20, 20)
 
 
-@image_comparison(baseline_images=['polar_alignment'], extensions=['png'])
+@image_comparison(['polar_alignment.png'])
 def test_polar_alignment():
     """
     Test that changing the vertical/horizontal alignment of a polar graph
@@ -480,8 +476,7 @@ def test_polar_alignment():
             horizontalalignment='left', verticalalignment='top')
 
 
-@image_comparison(baseline_images=['fill_units'], extensions=['png'],
-                  savefig_kwarg={'dpi': 60})
+@image_comparison(['fill_units.png'], savefig_kwarg={'dpi': 60})
 def test_fill_units():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
@@ -523,7 +518,7 @@ def test_fill_units():
     fig.autofmt_xdate()
 
 
-@image_comparison(baseline_images=['single_point', 'single_point'])
+@image_comparison(['single_point', 'single_point'])
 def test_single_point():
     # Issue #1796: don't let lines.marker affect the grid
     matplotlib.rcParams['lines.marker'] = 'o'
@@ -547,8 +542,7 @@ def test_single_point():
     plt.plot('b', 'b', 'o', data=data)
 
 
-@image_comparison(baseline_images=['single_date'], extensions=['png'],
-                  style='mpl20')
+@image_comparison(['single_date.png'], style='mpl20')
 def test_single_date():
     time1 = [721964.0]
     data1 = [-65.54]
@@ -560,7 +554,7 @@ def test_single_date():
     plt.plot(time1, data1, 'o', color='r')
 
 
-@image_comparison(baseline_images=['shaped_data'])
+@image_comparison(['shaped_data'])
 def test_shaped_data():
     xdata = np.array([[0.53295185, 0.23052951, 0.19057629, 0.66724975,
                        0.96577916, 0.73136095, 0.60823287, 0.01792100,
@@ -619,7 +613,7 @@ def test_structured_data():
     axs[1].plot("ones", "twos", "r", data=pts)
 
 
-@image_comparison(baseline_images=['const_xy'])
+@image_comparison(['const_xy'])
 def test_const_xy():
     plt.subplot(311)
     plt.plot(np.arange(10), np.ones(10))
@@ -631,8 +625,7 @@ def test_const_xy():
     plt.plot(np.ones(10), np.ones(10), 'o')
 
 
-@image_comparison(baseline_images=['polar_wrap_180', 'polar_wrap_360'],
-                  style='default')
+@image_comparison(['polar_wrap_180', 'polar_wrap_360'], style='default')
 def test_polar_wrap():
     fig = plt.figure()
     plt.subplot(111, polar=True)
@@ -649,8 +642,7 @@ def test_polar_wrap():
     plt.rgrids([0.05, 0.1, 0.15, 0.2, 0.25, 0.3])
 
 
-@image_comparison(baseline_images=['polar_units', 'polar_units_2'],
-                  style='default')
+@image_comparison(['polar_units', 'polar_units_2'], style='default')
 def test_polar_units():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -672,7 +664,7 @@ def test_polar_units():
                       units.UnitDblFormatter)
 
 
-@image_comparison(baseline_images=['polar_rmin'], style='default')
+@image_comparison(['polar_rmin'], style='default')
 def test_polar_rmin():
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r
@@ -684,7 +676,7 @@ def test_polar_rmin():
     ax.set_rmin(0.5)
 
 
-@image_comparison(baseline_images=['polar_negative_rmin'], style='default')
+@image_comparison(['polar_negative_rmin'], style='default')
 def test_polar_negative_rmin():
     r = np.arange(-3.0, 0.0, 0.01)
     theta = 2*np.pi*r
@@ -696,7 +688,7 @@ def test_polar_negative_rmin():
     ax.set_rmin(-3.0)
 
 
-@image_comparison(baseline_images=['polar_rorigin'], style='default')
+@image_comparison(['polar_rorigin'], style='default')
 def test_polar_rorigin():
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r
@@ -709,16 +701,14 @@ def test_polar_rorigin():
     ax.set_rorigin(0.0)
 
 
-@image_comparison(baseline_images=['polar_invertedylim'], style='default',
-                   extensions=['png'])
+@image_comparison(['polar_invertedylim.png'], style='default')
 def test_polar_invertedylim():
     fig = plt.figure()
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], polar=True)
     ax.set_ylim(2, 0)
 
 
-@image_comparison(baseline_images=['polar_invertedylim_rorigin'],
-                  style='default', extensions=['png'])
+@image_comparison(['polar_invertedylim_rorigin.png'], style='default')
 def test_polar_invertedylim_rorigin():
     fig = plt.figure()
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], polar=True)
@@ -726,7 +716,7 @@ def test_polar_invertedylim_rorigin():
     ax.set_rorigin(3)
 
 
-@image_comparison(baseline_images=['polar_theta_position'], style='default')
+@image_comparison(['polar_theta_position'], style='default')
 def test_polar_theta_position():
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r
@@ -738,7 +728,7 @@ def test_polar_theta_position():
     ax.set_theta_direction('clockwise')
 
 
-@image_comparison(baseline_images=['polar_rlabel_position'], style='default')
+@image_comparison(['polar_rlabel_position'], style='default')
 def test_polar_rlabel_position():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='polar')
@@ -746,7 +736,7 @@ def test_polar_rlabel_position():
     ax.tick_params(rotation='auto')
 
 
-@image_comparison(baseline_images=['polar_theta_wedge'], style='default')
+@image_comparison(['polar_theta_wedge'], style='default')
 def test_polar_theta_limits():
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r
@@ -804,7 +794,7 @@ def test_polar_rlim_zero():
     assert ax.get_ylim()[0] == 0
 
 
-@image_comparison(baseline_images=['axvspan_epoch'])
+@image_comparison(['axvspan_epoch'])
 def test_axvspan_epoch():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
@@ -820,7 +810,7 @@ def test_axvspan_epoch():
     ax.set_xlim(t0 - 5.0*dt, tf + 5.0*dt)
 
 
-@image_comparison(baseline_images=['axhspan_epoch'])
+@image_comparison(['axhspan_epoch'])
 def test_axhspan_epoch():
     from datetime import datetime
     import matplotlib.testing.jpl_units as units
@@ -836,8 +826,7 @@ def test_axhspan_epoch():
     ax.set_ylim(t0 - 5.0*dt, tf + 5.0*dt)
 
 
-@image_comparison(baseline_images=['hexbin_extent', 'hexbin_extent'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['hexbin_extent.png', 'hexbin_extent.png'], remove_text=True)
 def test_hexbin_extent():
     # this test exposes sf bug 2856228
     fig, ax = plt.subplots()
@@ -853,8 +842,7 @@ def test_hexbin_extent():
     ax.hexbin("x", "y", extent=[.1, .3, .6, .7], data=data)
 
 
-@image_comparison(baseline_images=['hexbin_empty'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['hexbin_empty.png'], remove_text=True)
 def test_hexbin_empty():
     # From #3886: creating hexbin from empty dataset raises ValueError
     ax = plt.gca()
@@ -876,8 +864,7 @@ def test_hexbin_pickable():
     assert hb.contains(FauxMouseEvent(400, 300))[0]
 
 
-@image_comparison(baseline_images=['hexbin_log'],
-                  extensions=['png'], style='mpl20')
+@image_comparison(['hexbin_log.png'], style='mpl20')
 def test_hexbin_log():
     # Issue #1636 (and also test log scaled colorbar)
     np.random.seed(19680801)
@@ -912,7 +899,7 @@ def test_inverted_limits():
     plt.close()
 
 
-@image_comparison(baseline_images=['nonfinite_limits'])
+@image_comparison(['nonfinite_limits'])
 def test_nonfinite_limits():
     x = np.arange(0., np.e, 0.01)
     # silence divide by zero warning from log(0)
@@ -923,8 +910,7 @@ def test_nonfinite_limits():
     ax.plot(x, y)
 
 
-@image_comparison(baseline_images=['imshow', 'imshow'],
-                  remove_text=True, style='mpl20')
+@image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')
 def test_imshow():
     # Create a NxN image
     N = 100
@@ -944,7 +930,7 @@ def test_imshow():
     ax.imshow("r", data=data)
 
 
-@image_comparison(baseline_images=['imshow_clip'], style='mpl20')
+@image_comparison(['imshow_clip'], style='mpl20')
 def test_imshow_clip():
     # As originally reported by Gellule Xg <gellule.xg@free.fr>
 
@@ -970,8 +956,7 @@ def test_imshow_clip():
     ax.imshow(r, clip_path=clip_path)
 
 
-@image_comparison(baseline_images=['polycollection_joinstyle'],
-                  remove_text=True)
+@image_comparison(['polycollection_joinstyle'], remove_text=True)
 def test_polycollection_joinstyle():
     # Bug #2890979 reported by Matthew West
 
@@ -1019,8 +1004,7 @@ def test_fill_betweenx_input(y, x1, x2):
         ax.fill_betweenx(y, x1, x2)
 
 
-@image_comparison(baseline_images=['fill_between_interpolate'],
-                  remove_text=True)
+@image_comparison(['fill_between_interpolate'], remove_text=True)
 def test_fill_between_interpolate():
     x = np.arange(0.0, 2, 0.02)
     y1 = np.sin(2*np.pi*x)
@@ -1044,7 +1028,7 @@ def test_fill_between_interpolate():
                      interpolate=True)
 
 
-@image_comparison(baseline_images=['fill_between_interpolate_decreasing'],
+@image_comparison(['fill_between_interpolate_decreasing'],
                   style='mpl20', remove_text=True)
 def test_fill_between_interpolate_decreasing():
     p = np.array([724.3, 700, 655])
@@ -1068,7 +1052,7 @@ def test_fill_between_interpolate_decreasing():
 # test_symlog and test_symlog2 used to have baseline images in all three
 # formats, but the png and svg baselines got invalidated by the removal of
 # minor tick overstriking.
-@image_comparison(baseline_images=['symlog'], extensions=['pdf'])
+@image_comparison(['symlog.pdf'])
 def test_symlog():
     x = np.array([0, 1, 2, 4, 6, 9, 12, 24])
     y = np.array([1000000, 500000, 100000, 100, 5, 0, 0, 0])
@@ -1080,8 +1064,7 @@ def test_symlog():
     ax.set_ylim(-1, 10000000)
 
 
-@image_comparison(baseline_images=['symlog2'], extensions=['pdf'],
-                  remove_text=True)
+@image_comparison(['symlog2.pdf'], remove_text=True)
 def test_symlog2():
     # Numbers from -50 to 50, with 0.1 as step
     x = np.arange(-50, 50, 0.001)
@@ -1108,7 +1091,7 @@ def test_pcolorargs_5205():
     plt.pcolor(X, Y, list(Z))
 
 
-@image_comparison(baseline_images=['pcolormesh'], remove_text=True)
+@image_comparison(['pcolormesh'], remove_text=True)
 def test_pcolormesh():
     n = 12
     x = np.linspace(-1.5, 1.5, n)
@@ -1129,8 +1112,8 @@ def test_pcolormesh():
     ax3.pcolormesh(Qx, Qz, Z, shading="gouraud")
 
 
-@image_comparison(baseline_images=['pcolormesh_datetime_axis'],
-                  extensions=['png'], remove_text=False, style='mpl20')
+@image_comparison(['pcolormesh_datetime_axis.png'],
+                  remove_text=False, style='mpl20')
 def test_pcolormesh_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -1155,8 +1138,8 @@ def test_pcolormesh_datetime_axis():
             label.set_rotation(30)
 
 
-@image_comparison(baseline_images=['pcolor_datetime_axis'],
-                  extensions=['png'], remove_text=False, style='mpl20')
+@image_comparison(['pcolor_datetime_axis.png'],
+                  remove_text=False, style='mpl20')
 def test_pcolor_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -1206,14 +1189,13 @@ def test_pcolorargs():
         ax.pcolormesh(x, y, Z[:-1, :-1])
 
 
-@image_comparison(baseline_images=['canonical'])
+@image_comparison(['canonical'])
 def test_canonical():
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3])
 
 
-@image_comparison(baseline_images=['arc_angles'], remove_text=True,
-                  style='default', extensions=['png'])
+@image_comparison(['arc_angles.png'], remove_text=True, style='default')
 def test_arc_angles():
     from matplotlib import patches
     # Ellipse parameters
@@ -1248,8 +1230,7 @@ def test_arc_angles():
         scale *= 10
 
 
-@image_comparison(baseline_images=['arc_ellipse'],
-                  remove_text=True)
+@image_comparison(['arc_ellipse'], remove_text=True)
 def test_arc_ellipse():
     from matplotlib import patches
     xcenter, ycenter = 0.38, 0.52
@@ -1287,8 +1268,7 @@ def test_arc_ellipse():
     ax.add_patch(e2)
 
 
-@image_comparison(baseline_images=['markevery'],
-                  remove_text=True)
+@image_comparison(['markevery'], remove_text=True)
 def test_markevery():
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * np.sqrt(x/10 + 0.5)
@@ -1303,8 +1283,7 @@ def test_markevery():
     ax.legend()
 
 
-@image_comparison(baseline_images=['markevery_line'],
-                  remove_text=True)
+@image_comparison(['markevery_line'], remove_text=True)
 def test_markevery_line():
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * np.sqrt(x/10 + 0.5)
@@ -1319,8 +1298,7 @@ def test_markevery_line():
     ax.legend()
 
 
-@image_comparison(baseline_images=['markevery_linear_scales'],
-                  remove_text=True)
+@image_comparison(['markevery_linear_scales'], remove_text=True)
 def test_markevery_linear_scales():
     cases = [None,
              8,
@@ -1345,8 +1323,7 @@ def test_markevery_linear_scales():
         plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
 
 
-@image_comparison(baseline_images=['markevery_linear_scales_zoomed'],
-                  remove_text=True)
+@image_comparison(['markevery_linear_scales_zoomed'], remove_text=True)
 def test_markevery_linear_scales_zoomed():
     cases = [None,
              8,
@@ -1373,8 +1350,7 @@ def test_markevery_linear_scales_zoomed():
         plt.ylim((1.1, 1.7))
 
 
-@image_comparison(baseline_images=['markevery_log_scales'],
-                  remove_text=True)
+@image_comparison(['markevery_log_scales'], remove_text=True)
 def test_markevery_log_scales():
     cases = [None,
              8,
@@ -1401,8 +1377,7 @@ def test_markevery_log_scales():
         plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
 
 
-@image_comparison(baseline_images=['markevery_polar'], style='default',
-                  remove_text=True)
+@image_comparison(['markevery_polar'], style='default', remove_text=True)
 def test_markevery_polar():
     cases = [None,
              8,
@@ -1426,8 +1401,7 @@ def test_markevery_polar():
         plt.plot(theta, r, 'o', ls='-', ms=4,  markevery=case)
 
 
-@image_comparison(baseline_images=['marker_edges'],
-                  remove_text=True)
+@image_comparison(['marker_edges'], remove_text=True)
 def test_marker_edges():
     x = np.linspace(0, 1, 10)
     fig = plt.figure()
@@ -1437,9 +1411,7 @@ def test_marker_edges():
     ax.plot(x+0.2, np.sin(x), 'y.', ms=30.0, mew=2, mec='b')
 
 
-@image_comparison(baseline_images=['bar_tick_label_single',
-                                   'bar_tick_label_single'],
-                  extensions=['png'])
+@image_comparison(['bar_tick_label_single.png', 'bar_tick_label_single.png'])
 def test_bar_tick_label_single():
     # From 2516: plot bar with array of string labels for x axis
     ax = plt.gca()
@@ -1458,8 +1430,7 @@ def test_bar_ticklabel_fail():
     ax.bar([], [])
 
 
-@image_comparison(baseline_images=['bar_tick_label_multiple'],
-                  extensions=['png'])
+@image_comparison(['bar_tick_label_multiple.png'])
 def test_bar_tick_label_multiple():
     # From 2516: plot bar with array of string labels for x axis
     ax = plt.gca()
@@ -1467,9 +1438,7 @@ def test_bar_tick_label_multiple():
            align='center')
 
 
-@image_comparison(
-    baseline_images=['bar_tick_label_multiple_old_label_alignment'],
-    extensions=['png'])
+@image_comparison(['bar_tick_label_multiple_old_label_alignment.png'])
 def test_bar_tick_label_multiple_old_alignment():
     # Test that the alignment for class is backward compatible
     matplotlib.rcParams["ytick.alignment"] = "center"
@@ -1550,8 +1519,7 @@ def test_bar_edgecolor_none_alpha():
         assert rect.get_edgecolor() == (0, 0, 0, 0)
 
 
-@image_comparison(baseline_images=['barh_tick_label'],
-                  extensions=['png'])
+@image_comparison(['barh_tick_label.png'])
 def test_barh_tick_label():
     # From 2516: plot barh with array of string labels for y axis
     ax = plt.gca()
@@ -1614,8 +1582,7 @@ def test_bar_pandas(pd):
     ax.plot(dates, baseline, color='orange', lw=4)
 
 
-@image_comparison(baseline_images=['hist_log'],
-                  remove_text=True)
+@image_comparison(['hist_log'], remove_text=True)
 def test_hist_log():
     data0 = np.linspace(0, 1, 200)**3
     data = np.r_[1-data0, 1+data0]
@@ -1624,23 +1591,21 @@ def test_hist_log():
     ax.hist(data, fill=False, log=True)
 
 
-@image_comparison(baseline_images=['hist_bar_empty'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['hist_bar_empty.png'], remove_text=True)
 def test_hist_bar_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
     ax.hist([], histtype='bar')
 
 
-@image_comparison(baseline_images=['hist_step_empty'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['hist_step_empty.png'], remove_text=True)
 def test_hist_step_empty():
     # From #3886: creating hist from empty dataset raises ValueError
     ax = plt.gca()
     ax.hist([], histtype='step')
 
 
-@image_comparison(baseline_images=['hist_steplog'], remove_text=True, tol=0.1)
+@image_comparison(['hist_steplog'], remove_text=True, tol=0.1)
 def test_hist_steplog():
     np.random.seed(0)
     data = np.random.standard_normal(2000)
@@ -1657,8 +1622,7 @@ def test_hist_steplog():
                 orientation='horizontal')
 
 
-@image_comparison(baseline_images=['hist_step_filled'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['hist_step_filled.png'], remove_text=True)
 def test_hist_step_filled():
     np.random.seed(0)
     x = np.random.randn(1000, 3)
@@ -1677,7 +1641,7 @@ def test_hist_step_filled():
     assert all(p.get_facecolor() == p.get_edgecolor() for p in patches)
 
 
-@image_comparison(baseline_images=['hist_density'], extensions=['png'])
+@image_comparison(['hist_density.png'])
 def test_hist_density():
     np.random.seed(19680801)
     data = np.random.standard_normal(2000)
@@ -1685,8 +1649,7 @@ def test_hist_density():
     ax.hist(data, density=True)
 
 
-@image_comparison(baseline_images=['hist_step_log_bottom'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['hist_step_log_bottom.png'], remove_text=True)
 def test_hist_step_log_bottom():
     # check that bottom doesn't get overwritten by the 'minimum' on a
     # log scale histogram (https://github.com/matplotlib/matplotlib/pull/4608)
@@ -1749,8 +1712,7 @@ def contour_dat():
     return x, y, z
 
 
-@image_comparison(baseline_images=['contour_hatching'],
-                  remove_text=True, style='mpl20')
+@image_comparison(['contour_hatching'], remove_text=True, style='mpl20')
 def test_contour_hatching():
     x, y, z = contour_dat()
     fig = plt.figure()
@@ -1760,8 +1722,7 @@ def test_contour_hatching():
                 extend='both', alpha=0.5)
 
 
-@image_comparison(baseline_images=['contour_colorbar'],
-                  style='mpl20')
+@image_comparison(['contour_colorbar'], style='mpl20')
 def test_contour_colorbar():
     x, y, z = contour_dat()
 
@@ -1784,8 +1745,7 @@ def test_contour_colorbar():
     cbar.add_lines(cs2, erase=False)
 
 
-@image_comparison(baseline_images=['hist2d', 'hist2d'],
-        remove_text=True, style='mpl20')
+@image_comparison(['hist2d', 'hist2d'], remove_text=True, style='mpl20')
 def test_hist2d():
     np.random.seed(0)
     # make it not symmetric in case we switch x and y axis
@@ -1802,8 +1762,7 @@ def test_hist2d():
     ax.hist2d("x", "y", bins=10, data=data, rasterized=True)
 
 
-@image_comparison(baseline_images=['hist2d_transpose'],
-        remove_text=True, style='mpl20')
+@image_comparison(['hist2d_transpose'], remove_text=True, style='mpl20')
 def test_hist2d_transpose():
     np.random.seed(0)
     # make sure the output from np.histogram is transposed before
@@ -1827,8 +1786,7 @@ def test_hist2d_density_normed():
 
 
 class TestScatter(object):
-    @image_comparison(baseline_images=['scatter'],
-                      style='mpl20', remove_text=True)
+    @image_comparison(['scatter'], style='mpl20', remove_text=True)
     def test_scatter_plot(self):
         data = {"x": np.array([3, 4, 2, 6]), "y": np.array([2, 5, 2, 3]),
                 "c": ['r', 'y', 'b', 'lime'], "s": [24, 15, 19, 29],
@@ -1839,8 +1797,7 @@ class TestScatter(object):
         ax.scatter(data["x"] + 1., data["y"] + 1., c=data["c2"], s=data["s"])
         ax.scatter("x", "y", c="c", s="s", data=data)
 
-    @image_comparison(baseline_images=['scatter_marker'], remove_text=True,
-                      extensions=['png'])
+    @image_comparison(['scatter_marker.png'], remove_text=True)
     def test_scatter_marker(self):
         fig, (ax0, ax1, ax2) = plt.subplots(ncols=3)
         ax0.scatter([3, 4, 2, 6], [2, 5, 2, 3],
@@ -1865,8 +1822,7 @@ class TestScatter(object):
                     edgecolors=['k', 'r', 'g', 'b'],
                     marker=verts)
 
-    @image_comparison(baseline_images=['scatter_2D'], remove_text=True,
-                      extensions=['png'])
+    @image_comparison(['scatter_2D'], remove_text=True, extensions=['png'])
     def test_scatter_2D(self):
         x = np.arange(3)
         y = np.arange(2)
@@ -2144,7 +2100,7 @@ def test_pyplot_axes():
     plt.close(fig2)
 
 
-@image_comparison(baseline_images=['log_scales'])
+@image_comparison(['log_scales'])
 def test_log_scales():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -2154,8 +2110,7 @@ def test_log_scales():
     ax.set_xscale('log', basex=9.0)
 
 
-@image_comparison(baseline_images=['stackplot_test_image',
-                                   'stackplot_test_image'])
+@image_comparison(['stackplot_test_image', 'stackplot_test_image'])
 def test_stackplot():
     fig = plt.figure()
     x = np.linspace(0, 10, 10)
@@ -2176,8 +2131,7 @@ def test_stackplot():
     ax.set_ylim((0, 70))
 
 
-@image_comparison(baseline_images=['stackplot_test_baseline'],
-                  remove_text=True)
+@image_comparison(['stackplot_test_baseline'], remove_text=True)
 def test_stackplot_baseline():
     np.random.seed(0)
 
@@ -2220,32 +2174,28 @@ def _bxp_test_helper(
     ax.bxp(transform_stats(logstats), **bxp_kwargs)
 
 
-@image_comparison(baseline_images=['bxp_baseline'],
-                  extensions=['png'],
+@image_comparison(['bxp_baseline.png'],
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_baseline():
     _bxp_test_helper()
 
 
-@image_comparison(baseline_images=['bxp_rangewhis'],
-                  extensions=['png'],
+@image_comparison(['bxp_rangewhis.png'],
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_rangewhis():
     _bxp_test_helper(stats_kwargs=dict(whis='range'))
 
 
-@image_comparison(baseline_images=['bxp_precentilewhis'],
-                  extensions=['png'],
+@image_comparison(['bxp_precentilewhis.png'],
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_precentilewhis():
     _bxp_test_helper(stats_kwargs=dict(whis=[5, 95]))
 
 
-@image_comparison(baseline_images=['bxp_with_xlabels'],
-                  extensions=['png'],
+@image_comparison(['bxp_with_xlabels.png'],
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_with_xlabels():
@@ -2257,8 +2207,8 @@ def test_bxp_with_xlabels():
     _bxp_test_helper(transform_stats=transform)
 
 
-@image_comparison(baseline_images=['bxp_horizontal'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_horizontal.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default',
                   tol=0.1)
@@ -2266,11 +2216,10 @@ def test_bxp_horizontal():
     _bxp_test_helper(bxp_kwargs=dict(vert=False))
 
 
-@image_comparison(baseline_images=['bxp_with_ylabels'],
-                  extensions=['png'],
+@image_comparison(['bxp_with_ylabels.png'],
                   savefig_kwarg={'dpi': 40},
                   style='default',
-                  tol=0.1,)
+                  tol=0.1)
 def test_bxp_with_ylabels():
     def transform(stats):
         for s, label in zip(stats, list('ABCD')):
@@ -2280,16 +2229,16 @@ def test_bxp_with_ylabels():
     _bxp_test_helper(transform_stats=transform, bxp_kwargs=dict(vert=False))
 
 
-@image_comparison(baseline_images=['bxp_patchartist'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_patchartist.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_patchartist():
     _bxp_test_helper(bxp_kwargs=dict(patch_artist=True))
 
 
-@image_comparison(baseline_images=['bxp_custompatchartist'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_custompatchartist.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 100},
                   style='default')
 def test_bxp_custompatchartist():
@@ -2298,8 +2247,8 @@ def test_bxp_custompatchartist():
         boxprops=dict(facecolor='yellow', edgecolor='green', linestyle=':')))
 
 
-@image_comparison(baseline_images=['bxp_customoutlier'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_customoutlier.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_customoutlier():
@@ -2307,8 +2256,8 @@ def test_bxp_customoutlier():
         flierprops=dict(linestyle='none', marker='d', markerfacecolor='g')))
 
 
-@image_comparison(baseline_images=['bxp_withmean_custompoint'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_withmean_custompoint.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_showcustommean():
@@ -2318,8 +2267,8 @@ def test_bxp_showcustommean():
     ))
 
 
-@image_comparison(baseline_images=['bxp_custombox'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_custombox.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_custombox():
@@ -2327,8 +2276,8 @@ def test_bxp_custombox():
         boxprops=dict(linestyle='--', color='b', linewidth=3)))
 
 
-@image_comparison(baseline_images=['bxp_custommedian'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_custommedian.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_custommedian():
@@ -2336,8 +2285,8 @@ def test_bxp_custommedian():
         medianprops=dict(linestyle='--', color='b', linewidth=3)))
 
 
-@image_comparison(baseline_images=['bxp_customcap'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_customcap.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_customcap():
@@ -2345,8 +2294,8 @@ def test_bxp_customcap():
         capprops=dict(linestyle='--', color='g', linewidth=3)))
 
 
-@image_comparison(baseline_images=['bxp_customwhisker'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_customwhisker.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_customwhisker():
@@ -2354,32 +2303,32 @@ def test_bxp_customwhisker():
         whiskerprops=dict(linestyle='-', color='m', linewidth=3)))
 
 
-@image_comparison(baseline_images=['bxp_withnotch'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_withnotch.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_shownotches():
     _bxp_test_helper(bxp_kwargs=dict(shownotches=True))
 
 
-@image_comparison(baseline_images=['bxp_nocaps'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_nocaps.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_nocaps():
     _bxp_test_helper(bxp_kwargs=dict(showcaps=False))
 
 
-@image_comparison(baseline_images=['bxp_nobox'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_nobox.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_nobox():
     _bxp_test_helper(bxp_kwargs=dict(showbox=False))
 
 
-@image_comparison(baseline_images=['bxp_no_flier_stats'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_no_flier_stats.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_no_flier_stats():
@@ -2392,40 +2341,40 @@ def test_bxp_no_flier_stats():
                      bxp_kwargs=dict(showfliers=False))
 
 
-@image_comparison(baseline_images=['bxp_withmean_point'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_withmean_point.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_showmean():
     _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=False))
 
 
-@image_comparison(baseline_images=['bxp_withmean_line'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_withmean_line.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_showmeanasline():
     _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=True))
 
 
-@image_comparison(baseline_images=['bxp_scalarwidth'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_scalarwidth.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_scalarwidth():
     _bxp_test_helper(bxp_kwargs=dict(widths=.25))
 
 
-@image_comparison(baseline_images=['bxp_customwidths'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_customwidths.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_customwidths():
     _bxp_test_helper(bxp_kwargs=dict(widths=[0.10, 0.25, 0.65, 0.85]))
 
 
-@image_comparison(baseline_images=['bxp_custompositions'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['bxp_custompositions.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_custompositions():
@@ -2442,9 +2391,7 @@ def test_bxp_bad_positions():
         _bxp_test_helper(bxp_kwargs=dict(positions=[2, 3]))
 
 
-@image_comparison(baseline_images=['boxplot', 'boxplot'],
-                  tol=1.28,
-                  style='default')
+@image_comparison(['boxplot', 'boxplot'], tol=1.28, style='default')
 def test_boxplot():
     # Randomness used for bootstrapping.
     np.random.seed(937)
@@ -2463,9 +2410,7 @@ def test_boxplot():
     ax.set_ylim((-30, 30))
 
 
-@image_comparison(baseline_images=['boxplot_sym2'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['boxplot_sym2.png'], remove_text=True, style='default')
 def test_boxplot_sym2():
     # Randomness used for bootstrapping.
     np.random.seed(937)
@@ -2481,8 +2426,8 @@ def test_boxplot_sym2():
     ax2.set_ylim((-30, 30))
 
 
-@image_comparison(baseline_images=['boxplot_sym'],
-                  remove_text=True, extensions=['png'],
+@image_comparison(['boxplot_sym.png'],
+                  remove_text=True,
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_boxplot_sym():
@@ -2494,12 +2439,9 @@ def test_boxplot_sym():
     ax.set_ylim((-30, 30))
 
 
-@image_comparison(
-    baseline_images=['boxplot_autorange_false_whiskers',
-                     'boxplot_autorange_true_whiskers'],
-    extensions=['png'],
-    style='default'
-)
+@image_comparison(['boxplot_autorange_false_whiskers.png',
+                   'boxplot_autorange_true_whiskers.png'],
+                  style='default')
 def test_boxplot_autorange_whiskers():
     # Randomness used for bootstrapping.
     np.random.seed(937)
@@ -2524,7 +2466,7 @@ def _rc_test_bxp_helper(ax, rc_dict):
     return ax
 
 
-@image_comparison(baseline_images=['boxplot_rc_parameters'],
+@image_comparison(['boxplot_rc_parameters'],
                   savefig_kwarg={'dpi': 100}, remove_text=True,
                   tol=1, style='default')
 def test_boxplot_rc_parameters():
@@ -2589,9 +2531,8 @@ def test_boxplot_rc_parameters():
             [type(t) for t in ax[1].get_children()])
 
 
-@image_comparison(baseline_images=['boxplot_with_CIarray'],
-                  remove_text=True, extensions=['png'],
-                  savefig_kwarg={'dpi': 40}, style='default')
+@image_comparison(['boxplot_with_CIarray.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
 def test_boxplot_with_CIarray():
     # Randomness used for bootstrapping.
     np.random.seed(937)
@@ -2608,9 +2549,8 @@ def test_boxplot_with_CIarray():
     ax.set_ylim((-30, 30))
 
 
-@image_comparison(baseline_images=['boxplot_no_inverted_whisker'],
-                  remove_text=True, extensions=['png'],
-                  savefig_kwarg={'dpi': 40}, style='default')
+@image_comparison(['boxplot_no_inverted_whisker.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
 def test_boxplot_no_weird_whisker():
     x = np.array([3, 9000, 150, 88, 350, 200000, 1400, 960],
                  dtype=np.float64)
@@ -2660,9 +2600,8 @@ def test_boxplot_bad_ci_2():
         ax.boxplot([x, x], conf_intervals=[[1, 2], [1]])
 
 
-@image_comparison(baseline_images=['boxplot_mod_artists_after_plotting'],
-                  remove_text=True, extensions=['png'],
-                  savefig_kwarg={'dpi': 40}, style='default')
+@image_comparison(['boxplot_mod_artists_after_plotting.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
 def test_boxplot_mod_artist_after_plotting():
     x = [0.15, 0.11, 0.06, 0.06, 0.12, 0.56, -0.56]
     fig, ax = plt.subplots()
@@ -2672,9 +2611,8 @@ def test_boxplot_mod_artist_after_plotting():
             obj.set_color('green')
 
 
-@image_comparison(baseline_images=['violinplot_vert_baseline',
-                                   'violinplot_vert_baseline'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_baseline.png',
+                   'violinplot_vert_baseline.png'])
 def test_vert_violinplot_baseline():
     # First 9 digits of frac(sqrt(2))
     np.random.seed(414213562)
@@ -2691,8 +2629,7 @@ def test_vert_violinplot_baseline():
                   showmedians=0, data=data)
 
 
-@image_comparison(baseline_images=['violinplot_vert_showmeans'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_showmeans.png'])
 def test_vert_violinplot_showmeans():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(3))
@@ -2702,8 +2639,7 @@ def test_vert_violinplot_showmeans():
                   showmedians=0)
 
 
-@image_comparison(baseline_images=['violinplot_vert_showextrema'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_showextrema.png'])
 def test_vert_violinplot_showextrema():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(5))
@@ -2713,8 +2649,7 @@ def test_vert_violinplot_showextrema():
                   showmedians=0)
 
 
-@image_comparison(baseline_images=['violinplot_vert_showmedians'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_showmedians.png'])
 def test_vert_violinplot_showmedians():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(7))
@@ -2724,8 +2659,7 @@ def test_vert_violinplot_showmedians():
                   showmedians=1)
 
 
-@image_comparison(baseline_images=['violinplot_vert_showall'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_showall.png'])
 def test_vert_violinplot_showall():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(11))
@@ -2736,8 +2670,7 @@ def test_vert_violinplot_showall():
                   quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
 
 
-@image_comparison(baseline_images=['violinplot_vert_custompoints_10'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_custompoints_10.png'])
 def test_vert_violinplot_custompoints_10():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(13))
@@ -2747,8 +2680,7 @@ def test_vert_violinplot_custompoints_10():
                   showmedians=0, points=10)
 
 
-@image_comparison(baseline_images=['violinplot_vert_custompoints_200'],
-                  extensions=['png'])
+@image_comparison(['violinplot_vert_custompoints_200.png'])
 def test_vert_violinplot_custompoints_200():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(17))
@@ -2758,8 +2690,7 @@ def test_vert_violinplot_custompoints_200():
                   showmedians=0, points=200)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_baseline'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_baseline.png'])
 def test_horiz_violinplot_baseline():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(19))
@@ -2769,8 +2700,7 @@ def test_horiz_violinplot_baseline():
                   showextrema=0, showmedians=0)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_showmedians'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_showmedians.png'])
 def test_horiz_violinplot_showmedians():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(23))
@@ -2780,8 +2710,7 @@ def test_horiz_violinplot_showmedians():
                   showextrema=0, showmedians=1)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_showmeans'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_showmeans.png'])
 def test_horiz_violinplot_showmeans():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(29))
@@ -2791,8 +2720,7 @@ def test_horiz_violinplot_showmeans():
                   showextrema=0, showmedians=0)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_showextrema'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_showextrema.png'])
 def test_horiz_violinplot_showextrema():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(31))
@@ -2802,8 +2730,7 @@ def test_horiz_violinplot_showextrema():
                   showextrema=1, showmedians=0)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_showall'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_showall.png'])
 def test_horiz_violinplot_showall():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(37))
@@ -2814,8 +2741,7 @@ def test_horiz_violinplot_showall():
                   quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
 
 
-@image_comparison(baseline_images=['violinplot_horiz_custompoints_10'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_custompoints_10.png'])
 def test_horiz_violinplot_custompoints_10():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(41))
@@ -2825,8 +2751,7 @@ def test_horiz_violinplot_custompoints_10():
                   showextrema=0, showmedians=0, points=10)
 
 
-@image_comparison(baseline_images=['violinplot_horiz_custompoints_200'],
-                  extensions=['png'])
+@image_comparison(['violinplot_horiz_custompoints_200.png'])
 def test_horiz_violinplot_custompoints_200():
     ax = plt.axes()
     # First 9 digits of frac(sqrt(43))
@@ -2927,8 +2852,7 @@ def test_tick_space_size_0():
     plt.savefig(b, dpi=80, format='raw')
 
 
-@image_comparison(baseline_images=['errorbar_basic', 'errorbar_mixed',
-                                   'errorbar_basic'])
+@image_comparison(['errorbar_basic', 'errorbar_mixed', 'errorbar_basic'])
 def test_errorbar():
     x = np.arange(0.1, 4, 0.5)
     y = np.exp(-x)
@@ -3014,7 +2938,7 @@ def test_errorbar_shape():
         ax.errorbar(x, y, yerr=yerr, xerr=xerr, fmt='o')
 
 
-@image_comparison(baseline_images=['errorbar_limits'])
+@image_comparison(['errorbar_limits'])
 def test_errorbar_limits():
     x = np.arange(0.5, 5.5, 0.5)
     y = np.exp(-x)
@@ -3073,8 +2997,8 @@ def test_errobar_nonefmt():
         assert np.all(errbar.get_color() == mcolors.to_rgba('C0'))
 
 
-@image_comparison(baseline_images=['errorbar_with_prop_cycle'],
-                  extensions=['png'], style='mpl20', remove_text=True)
+@image_comparison(['errorbar_with_prop_cycle.png'],
+                  style='mpl20', remove_text=True)
 def test_errorbar_with_prop_cycle():
     _cycle = cycler(ls=['--', ':'], marker=['s', 's'], mfc=['k', 'w'])
     plt.rc("axes", prop_cycle=_cycle)
@@ -3106,8 +3030,7 @@ def test_errorbar_offsets(fig_test, fig_ref):
                         capsize=4, c=color, fmt='none')
 
 
-@image_comparison(baseline_images=['hist_stacked_stepfilled',
-                                   'hist_stacked_stepfilled'])
+@image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])
 def test_hist_stacked_stepfilled():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3123,7 +3046,7 @@ def test_hist_stacked_stepfilled():
     ax.hist("x", histtype="stepfilled", stacked=True, data=data)
 
 
-@image_comparison(baseline_images=['hist_offset'])
+@image_comparison(['hist_offset'])
 def test_hist_offset():
     # make some data
     d1 = np.linspace(0, 10, 50)
@@ -3134,8 +3057,7 @@ def test_hist_offset():
     ax.hist(d2, bottom=15)
 
 
-@image_comparison(baseline_images=['hist_step'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['hist_step.png'], remove_text=True)
 def test_hist_step():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3146,7 +3068,7 @@ def test_hist_step():
     ax.set_xlim(-1, 5)
 
 
-@image_comparison(baseline_images=['hist_step_horiz'], extensions=['png'])
+@image_comparison(['hist_step_horiz.png'])
 def test_hist_step_horiz():
     # make some data
     d1 = np.linspace(0, 10, 50)
@@ -3156,7 +3078,7 @@ def test_hist_step_horiz():
     ax.hist((d1, d2), histtype="step", orientation="horizontal")
 
 
-@image_comparison(baseline_images=['hist_stacked_weights'])
+@image_comparison(['hist_stacked_weights'])
 def test_hist_stacked_weighted():
     # make some data
     d1 = np.linspace(0, 10, 50)
@@ -3170,8 +3092,7 @@ def test_hist_stacked_weighted():
 
 @pytest.mark.parametrize("use_line_collection", [True, False],
                          ids=['w/ line collection', 'w/o line collection'])
-@image_comparison(baseline_images=['stem'], extensions=['png'], style='mpl20',
-                  remove_text=True)
+@image_comparison(['stem.png'], style='mpl20', remove_text=True)
 def test_stem(use_line_collection):
     x = np.linspace(0.1, 2 * np.pi, 100)
     args = (x, np.cos(x))
@@ -3229,7 +3150,7 @@ def test_stem_dates():
     ax.stem([x, x1], [y, y1], "*-", use_line_collection=True)
 
 
-@image_comparison(baseline_images=['hist_stacked_stepfilled_alpha'])
+@image_comparison(['hist_stacked_stepfilled_alpha'])
 def test_hist_stacked_stepfilled_alpha():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3239,7 +3160,7 @@ def test_hist_stacked_stepfilled_alpha():
     ax.hist((d1, d2), histtype="stepfilled", stacked=True, alpha=0.5)
 
 
-@image_comparison(baseline_images=['hist_stacked_step'])
+@image_comparison(['hist_stacked_step'])
 def test_hist_stacked_step():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3249,8 +3170,7 @@ def test_hist_stacked_step():
     ax.hist((d1, d2), histtype="step", stacked=True)
 
 
-@image_comparison(baseline_images=['hist_stacked_normed',
-                                   'hist_stacked_normed'])
+@image_comparison(['hist_stacked_normed', 'hist_stacked_normed'])
 def test_hist_stacked_density():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3277,8 +3197,7 @@ def test_hist_normed_density(normed, density):
         ax.hist((d1, d2), stacked=True, normed=normed, density=density)
 
 
-@image_comparison(baseline_images=['hist_step_bottom'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['hist_step_bottom.png'], remove_text=True)
 def test_hist_step_bottom():
     # make some data
     d1 = np.linspace(1, 3, 20)
@@ -3287,7 +3206,7 @@ def test_hist_step_bottom():
     ax.hist(d1, bottom=np.arange(10), histtype="stepfilled")
 
 
-@image_comparison(baseline_images=['hist_stacked_bar'])
+@image_comparison(['hist_stacked_bar'])
 def test_hist_stacked_bar():
     # make some data
     d = [[100, 100, 100, 100, 200, 320, 450, 80, 20, 600, 310, 800],
@@ -3327,7 +3246,7 @@ def test_hist_labels():
     assert l[2][0].get_label() == '00'
 
 
-@image_comparison(baseline_images=['transparent_markers'], remove_text=True)
+@image_comparison(['transparent_markers'], remove_text=True)
 def test_transparent_markers():
     np.random.seed(0)
     data = np.random.random(50)
@@ -3337,7 +3256,7 @@ def test_transparent_markers():
     ax.plot(data, 'D', mfc='none', markersize=100)
 
 
-@image_comparison(baseline_images=['rgba_markers'], remove_text=True)
+@image_comparison(['rgba_markers'], remove_text=True)
 def test_rgba_markers():
     fig, axs = plt.subplots(ncols=2)
     rcolors = [(1, 0, 0, 1), (1, 0, 0, 0.5)]
@@ -3354,7 +3273,7 @@ def test_rgba_markers():
         ax.axis([-1, 4, 0, 5])
 
 
-@image_comparison(baseline_images=['mollweide_grid'], remove_text=True)
+@image_comparison(['mollweide_grid'], remove_text=True)
 def test_mollweide_grid():
     # test that both horizontal and vertical gridlines appear on the Mollweide
     # projection
@@ -3406,7 +3325,7 @@ def test_mollweide_inverse_forward_closure():
     np.testing.assert_array_almost_equal(xy, xy2, 3)
 
 
-@image_comparison(baseline_images=['test_alpha'], remove_text=True)
+@image_comparison(['test_alpha'], remove_text=True)
 def test_alpha():
     np.random.seed(0)
     data = np.random.random(50)
@@ -3437,7 +3356,7 @@ def test_alpha():
             markersize=20, lw=10)
 
 
-@image_comparison(baseline_images=['eventplot', 'eventplot'], remove_text=True)
+@image_comparison(['eventplot', 'eventplot'], remove_text=True)
 def test_eventplot():
     '''
     test that eventplot produces the correct output
@@ -3484,8 +3403,7 @@ def test_eventplot():
     assert num_collections == num_datasets
 
 
-@image_comparison(baseline_images=['test_eventplot_defaults'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['test_eventplot_defaults.png'], remove_text=True)
 def test_eventplot_defaults():
     '''
     test that eventplot produces the correct output given the default params
@@ -3530,8 +3448,7 @@ def test_eventplot_colors(colors):
         assert_allclose(coll.get_color(), color)
 
 
-@image_comparison(baseline_images=['test_eventplot_problem_kwargs'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['test_eventplot_problem_kwargs.png'], remove_text=True)
 def test_eventplot_problem_kwargs():
     '''
     test that 'singular' versions of LineCollection props raise an
@@ -3579,8 +3496,7 @@ def test_eventplot_orientation(data, orientation):
     plt.draw()
 
 
-@image_comparison(baseline_images=['marker_styles'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['marker_styles.png'], remove_text=True)
 def test_marker_styles():
     fig = plt.figure()
     ax = fig.add_subplot(111)
@@ -3590,7 +3506,7 @@ def test_marker_styles():
                 marker=marker, markersize=10+y/5, label=marker)
 
 
-@image_comparison(baseline_images=['rc_markerfill'], extensions=['png'])
+@image_comparison(['rc_markerfill.png'])
 def test_markers_fillstyle_rcparams():
     fig, ax = plt.subplots()
     x = np.arange(7)
@@ -3600,8 +3516,7 @@ def test_markers_fillstyle_rcparams():
         ax.plot(x+idx, marker=marker)
 
 
-@image_comparison(baseline_images=['vertex_markers'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['vertex_markers.png'], remove_text=True)
 def test_vertex_markers():
     data = list(range(10))
     marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
@@ -3614,8 +3529,7 @@ def test_vertex_markers():
     ax.set_ylim([-1, 10])
 
 
-@image_comparison(baseline_images=['vline_hline_zorder',
-                                   'errorbar_zorder'],
+@image_comparison(['vline_hline_zorder', 'errorbar_zorder'],
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_eb_line_zorder():
     x = list(range(10))
@@ -3645,10 +3559,8 @@ def test_eb_line_zorder():
     ax.set_title("errorbar zorder test")
 
 
-@image_comparison(
-    baseline_images=['vlines_basic', 'vlines_with_nan', 'vlines_masked'],
-    extensions=['png']
-)
+@image_comparison(['vlines_basic', 'vlines_with_nan', 'vlines_masked'],
+                  extensions=['png'])
 def test_vlines():
     # normal
     x1 = [2, 3, 4, 5, 7]
@@ -3687,10 +3599,8 @@ def test_vlines():
     ax5.set_xlim(0, 15)
 
 
-@image_comparison(
-    baseline_images=['hlines_basic', 'hlines_with_nan', 'hlines_masked'],
-    extensions=['png']
-)
+@image_comparison(['hlines_basic', 'hlines_with_nan', 'hlines_masked'],
+                  extensions=['png'])
 def test_hlines():
     # normal
     y1 = [2, 3, 4, 5, 7]
@@ -3729,8 +3639,7 @@ def test_hlines():
     ax5.set_ylim(0, 15)
 
 
-@image_comparison(baseline_images=['step_linestyle', 'step_linestyle'],
-                  remove_text=True)
+@image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True)
 def test_step_linestyle():
     x = y = np.arange(10)
 
@@ -3760,7 +3669,7 @@ def test_step_linestyle():
         ax.set_ylim([-1, 7])
 
 
-@image_comparison(baseline_images=['mixed_collection'], remove_text=True)
+@image_comparison(['mixed_collection'], remove_text=True)
 def test_mixed_collection():
     from matplotlib import patches
     from matplotlib import collections
@@ -3796,10 +3705,8 @@ def test_subplot_key_hash():
     assert ax.get_subplotspec().get_geometry() == (5, 1, 0, 0)
 
 
-@image_comparison(baseline_images=['specgram_freqs',
-                                   'specgram_freqs_linear'],
-                  remove_text=True, extensions=['png'], tol=0.07,
-                  style='default')
+@image_comparison(['specgram_freqs.png', 'specgram_freqs_linear.png'],
+                  remove_text=True, tol=0.07, style='default')
 def test_specgram_freqs():
     '''test axes.specgram in default (psd) mode with sinusoidal stimuli'''
     n = 1000
@@ -3850,10 +3757,8 @@ def test_specgram_freqs():
                   scale='linear', norm=matplotlib.colors.LogNorm())
 
 
-@image_comparison(baseline_images=['specgram_noise',
-                                   'specgram_noise_linear'],
-                  remove_text=True, extensions=['png'], tol=0.01,
-                  style='default')
+@image_comparison(['specgram_noise.png', 'specgram_noise_linear.png'],
+                  remove_text=True, tol=0.01, style='default')
 def test_specgram_noise():
     '''test axes.specgram in default (psd) mode with noise stimuli'''
     np.random.seed(0)
@@ -3898,10 +3803,9 @@ def test_specgram_noise():
                   scale='linear', norm=matplotlib.colors.LogNorm())
 
 
-@image_comparison(baseline_images=['specgram_magnitude_freqs',
-                                   'specgram_magnitude_freqs_linear'],
-                  remove_text=True, extensions=['png'], tol=0.07,
-                  style='default')
+@image_comparison(['specgram_magnitude_freqs.png',
+                   'specgram_magnitude_freqs_linear.png'],
+                  remove_text=True, tol=0.07, style='default')
 def test_specgram_magnitude_freqs():
     '''test axes.specgram in magnitude mode with sinusoidal stimuli'''
     n = 1000
@@ -3954,10 +3858,9 @@ def test_specgram_magnitude_freqs():
                   scale='linear', norm=matplotlib.colors.LogNorm())
 
 
-@image_comparison(baseline_images=['specgram_magnitude_noise',
-                                   'specgram_magnitude_noise_linear'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['specgram_magnitude_noise.png',
+                   'specgram_magnitude_noise_linear.png'],
+                  remove_text=True, style='default')
 def test_specgram_magnitude_noise():
     '''test axes.specgram in magnitude mode with noise stimuli'''
     np.random.seed(0)
@@ -4002,9 +3905,8 @@ def test_specgram_magnitude_noise():
                   scale='linear', norm=matplotlib.colors.LogNorm())
 
 
-@image_comparison(baseline_images=['specgram_angle_freqs'],
-                  remove_text=True, extensions=['png'], tol=0.007,
-                  style='default')
+@image_comparison(['specgram_angle_freqs.png'],
+                  remove_text=True, tol=0.007, style='default')
 def test_specgram_angle_freqs():
     '''test axes.specgram in angle mode with sinusoidal stimuli'''
     n = 1000
@@ -4057,9 +3959,8 @@ def test_specgram_angle_freqs():
                       mode='phase', scale='dB')
 
 
-@image_comparison(baseline_images=['specgram_angle_noise'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['specgram_angle_noise.png'],
+                  remove_text=True, style='default')
 def test_specgram_noise_angle():
     '''test axes.specgram in angle mode with noise stimuli'''
     np.random.seed(0)
@@ -4104,9 +4005,8 @@ def test_specgram_noise_angle():
                       mode='phase', scale='dB')
 
 
-@image_comparison(baseline_images=['specgram_phase_freqs'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['specgram_phase_freqs.png'],
+                  remove_text=True, style='default')
 def test_specgram_freqs_phase():
     '''test axes.specgram in phase mode with sinusoidal stimuli'''
     n = 1000
@@ -4159,9 +4059,8 @@ def test_specgram_freqs_phase():
                       mode='phase', scale='dB')
 
 
-@image_comparison(baseline_images=['specgram_phase_noise'],
-                  remove_text=True, extensions=['png'],
-                  style='default')
+@image_comparison(['specgram_phase_noise.png'],
+                  remove_text=True, style='default')
 def test_specgram_noise_phase():
     '''test axes.specgram in phase mode with noise stimuli'''
     np.random.seed(0)
@@ -4206,8 +4105,7 @@ def test_specgram_noise_phase():
                       mode='phase', scale='dB')
 
 
-@image_comparison(baseline_images=['psd_freqs'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['psd_freqs.png'], remove_text=True)
 def test_psd_freqs():
     '''test axes.psd with sinusoidal stimuli'''
     n = 10000
@@ -4251,8 +4149,7 @@ def test_psd_freqs():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['psd_noise'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['psd_noise.png'], remove_text=True)
 def test_psd_noise():
     '''test axes.psd with noise stimuli'''
     np.random.seed(0)
@@ -4290,8 +4187,7 @@ def test_psd_noise():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['csd_freqs'], remove_text=True,
-                  extensions=['png'], tol=0.002)
+@image_comparison(['csd_freqs.png'], remove_text=True, tol=0.002)
 def test_csd_freqs():
     '''test axes.csd with sinusoidal stimuli'''
     n = 10000
@@ -4334,8 +4230,7 @@ def test_csd_freqs():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['csd_noise'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['csd_noise.png'], remove_text=True)
 def test_csd_noise():
     '''test axes.csd with noise stimuli'''
     np.random.seed(0)
@@ -4372,10 +4267,9 @@ def test_csd_noise():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['magnitude_spectrum_freqs_linear',
-                                   'magnitude_spectrum_freqs_dB'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['magnitude_spectrum_freqs_linear.png',
+                   'magnitude_spectrum_freqs_dB.png'],
+                  remove_text=True)
 def test_magnitude_spectrum_freqs():
     '''test axes.magnitude_spectrum with sinusoidal stimuli'''
     n = 10000
@@ -4436,10 +4330,9 @@ def test_magnitude_spectrum_freqs():
     ax23.set_ylabel('')
 
 
-@image_comparison(baseline_images=['magnitude_spectrum_noise_linear',
-                                   'magnitude_spectrum_noise_dB'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['magnitude_spectrum_noise_linear.png',
+                   'magnitude_spectrum_noise_dB.png'],
+                  remove_text=True)
 def test_magnitude_spectrum_noise():
     '''test axes.magnitude_spectrum with noise stimuli'''
     np.random.seed(0)
@@ -4497,9 +4390,7 @@ def test_magnitude_spectrum_noise():
     ax23.set_ylabel('')
 
 
-@image_comparison(baseline_images=['angle_spectrum_freqs'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['angle_spectrum_freqs.png'], remove_text=True)
 def test_angle_spectrum_freqs():
     '''test axes.angle_spectrum with sinusoidal stimuli'''
     n = 10000
@@ -4537,9 +4428,7 @@ def test_angle_spectrum_freqs():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['angle_spectrum_noise'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['angle_spectrum_noise.png'], remove_text=True)
 def test_angle_spectrum_noise():
     '''test axes.angle_spectrum with noise stimuli'''
     np.random.seed(0)
@@ -4574,9 +4463,7 @@ def test_angle_spectrum_noise():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['phase_spectrum_freqs'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['phase_spectrum_freqs.png'], remove_text=True)
 def test_phase_spectrum_freqs():
     '''test axes.phase_spectrum with sinusoidal stimuli'''
     n = 10000
@@ -4614,9 +4501,7 @@ def test_phase_spectrum_freqs():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['phase_spectrum_noise'],
-                  remove_text=True,
-                  extensions=['png'])
+@image_comparison(['phase_spectrum_noise.png'], remove_text=True)
 def test_phase_spectrum_noise():
     '''test axes.phase_spectrum with noise stimuli'''
     np.random.seed(0)
@@ -4651,8 +4536,7 @@ def test_phase_spectrum_noise():
     ax3.set_ylabel('')
 
 
-@image_comparison(baseline_images=['twin_spines'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['twin_spines.png'], remove_text=True)
 def test_twin_spines():
 
     def make_patch_spines_invisible(ax):
@@ -4698,8 +4582,8 @@ def test_twin_spines():
     host.tick_params(axis='x', **tkw)
 
 
-@image_comparison(baseline_images=['twin_spines_on_top', 'twin_spines_on_top'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['twin_spines_on_top.png', 'twin_spines_on_top.png'],
+                  remove_text=True)
 def test_twin_spines_on_top():
     matplotlib.rcParams['axes.linewidth'] = 48.0
     matplotlib.rcParams['lines.linewidth'] = 48.0
@@ -4862,7 +4746,7 @@ def test_text_labelsize():
     ax.tick_params(direction='out')
 
 
-@image_comparison(baseline_images=['pie_default'], extensions=['png'])
+@image_comparison(['pie_default.png'])
 def test_pie_default():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -4874,8 +4758,7 @@ def test_pie_default():
             autopct='%1.1f%%', shadow=True, startangle=90)
 
 
-@image_comparison(baseline_images=['pie_linewidth_0', 'pie_linewidth_0',
-                                   'pie_linewidth_0'],
+@image_comparison(['pie_linewidth_0', 'pie_linewidth_0', 'pie_linewidth_0'],
                   extensions=['png'])
 def test_pie_linewidth_0():
     # The slices will be ordered and plotted counter-clockwise.
@@ -4908,7 +4791,7 @@ def test_pie_linewidth_0():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_center_radius'], extensions=['png'])
+@image_comparison(['pie_center_radius.png'])
 def test_pie_center_radius():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -4927,7 +4810,7 @@ def test_pie_center_radius():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_linewidth_2'], extensions=['png'])
+@image_comparison(['pie_linewidth_2.png'])
 def test_pie_linewidth_2():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -4942,7 +4825,7 @@ def test_pie_linewidth_2():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_ccw_true'], extensions=['png'])
+@image_comparison(['pie_ccw_true.png'])
 def test_pie_ccw_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -4957,7 +4840,7 @@ def test_pie_ccw_true():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_frame_grid'], extensions=['png'])
+@image_comparison(['pie_frame_grid.png'])
 def test_pie_frame_grid():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -4984,8 +4867,7 @@ def test_pie_frame_grid():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_rotatelabels_true'],
-                  extensions=['png'])
+@image_comparison(['pie_rotatelabels_true.png'])
 def test_pie_rotatelabels_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
@@ -5000,7 +4882,7 @@ def test_pie_rotatelabels_true():
     plt.axis('equal')
 
 
-@image_comparison(baseline_images=['pie_no_label'], extensions=['png'])
+@image_comparison(['pie_no_label.png'])
 def test_pie_nolabel_but_legend():
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
     sizes = [15, 30, 45, 10]
@@ -5036,7 +4918,7 @@ def test_pie_textprops():
             assert tx.get_color() == textprops["color"]
 
 
-@image_comparison(baseline_images=['set_get_ticklabels'], extensions=['png'])
+@image_comparison(['set_get_ticklabels.png'])
 def test_set_get_ticklabels():
     # test issue 2246
     fig, ax = plt.subplots(2)
@@ -5058,10 +4940,7 @@ def test_set_get_ticklabels():
     ax[1].set_yticklabels(ax[0].get_yticklabels())
 
 
-@image_comparison(
-    baseline_images=['retain_tick_visibility'],
-    extensions=['png'],
-)
+@image_comparison(['retain_tick_visibility.png'])
 def test_retain_tick_visibility():
     fig, ax = plt.subplots()
     plt.plot([0, 1, 2], [0, -1, 4])
@@ -5088,8 +4967,7 @@ def test_tick_label_update():
     assert tick_texts == ["", "", "unit value", "", ""]
 
 
-@image_comparison(baseline_images=['o_marker_path_snap'], extensions=['png'],
-                  savefig_kwarg={'dpi': 72})
+@image_comparison(['o_marker_path_snap.png'], savefig_kwarg={'dpi': 72})
 def test_o_marker_path_snap():
     fig, ax = plt.subplots()
     ax.margins(.1)
@@ -5196,8 +5074,7 @@ def test_move_offsetlabel():
     assert (1, 0.5) == ax.yaxis.offsetText.get_position()
 
 
-@image_comparison(baseline_images=['rc_spines'], extensions=['png'],
-                  savefig_kwarg={'dpi': 40})
+@image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})
 def test_rc_spines():
     rc_dict = {
         'axes.spines.left': False,
@@ -5208,8 +5085,7 @@ def test_rc_spines():
         fig, ax = plt.subplots()
 
 
-@image_comparison(baseline_images=['rc_grid'], extensions=['png'],
-                  savefig_kwarg={'dpi': 40})
+@image_comparison(['rc_grid.png'], savefig_kwarg={'dpi': 40})
 def test_rc_grid():
     fig = plt.figure()
     rc_dict0 = {
@@ -5374,7 +5250,7 @@ def test_errorbar_inputs_shotgun(kwargs):
         eb.remove()
 
 
-@image_comparison(baseline_images=["dash_offset"], remove_text=True)
+@image_comparison(["dash_offset"], remove_text=True)
 def test_dash_offset():
     fig, ax = plt.subplots()
     x = np.linspace(0, 10)
@@ -5417,8 +5293,7 @@ def test_title_location_roundtrip():
         ax.set_title('fail', loc='foo')
 
 
-@image_comparison(baseline_images=["loglog"], remove_text=True,
-                  extensions=['png'], tol=0.02)
+@image_comparison(["loglog.png"], remove_text=True, tol=0.02)
 def test_loglog():
     fig, ax = plt.subplots()
     x = np.arange(1, 11)
@@ -5427,8 +5302,7 @@ def test_loglog():
     ax.tick_params(length=15, width=2, which='minor')
 
 
-@image_comparison(baseline_images=["test_loglog_nonpos"],
-                  remove_text=True, extensions=['png'], style='mpl20')
+@image_comparison(["test_loglog_nonpos.png"], remove_text=True, style='mpl20')
 def test_loglog_nonpos():
     fig, ax = plt.subplots(3, 3)
     x = np.arange(1, 11)
@@ -5559,15 +5433,13 @@ def test_adjust_numtick_aspect():
     assert len(ax.yaxis.get_major_locator()()) > 2
 
 
-@image_comparison(baseline_images=["auto_numticks"], style='default',
-                  extensions=['png'])
+@image_comparison(["auto_numticks.png"], style='default')
 def test_auto_numticks():
     # Make tiny, empty subplots, verify that there are only 3 ticks.
     fig, axs = plt.subplots(4, 4)
 
 
-@image_comparison(baseline_images=["auto_numticks_log"], style='default',
-                  extensions=['png'])
+@image_comparison(["auto_numticks_log.png"], style='default')
 def test_auto_numticks_log():
     # Verify that there are not too many ticks with a large log range.
     fig, ax = plt.subplots()
@@ -5714,7 +5586,7 @@ def test_bar_uint8():
         assert patch.xy[0] == x
 
 
-@image_comparison(baseline_images=['date_timezone_x'], extensions=['png'])
+@image_comparison(['date_timezone_x.png'])
 def test_date_timezone_x():
     # Tests issue 5575
     time_index = [datetime.datetime(2016, 2, 22, hour=x,
@@ -5731,8 +5603,7 @@ def test_date_timezone_x():
     plt.plot_date(time_index, [3] * 3, tz='UTC')
 
 
-@image_comparison(baseline_images=['date_timezone_y'],
-                  extensions=['png'])
+@image_comparison(['date_timezone_y.png'])
 def test_date_timezone_y():
     # Tests issue 5575
     time_index = [datetime.datetime(2016, 2, 22, hour=x,
@@ -5750,8 +5621,7 @@ def test_date_timezone_y():
     plt.plot_date([3] * 3, time_index, tz='UTC', xdate=False, ydate=True)
 
 
-@image_comparison(baseline_images=['date_timezone_x_and_y'],
-                  extensions=['png'])
+@image_comparison(['date_timezone_x_and_y.png'])
 def test_date_timezone_x_and_y():
     # Tests issue 5575
     UTC = datetime.timezone.utc
@@ -5768,8 +5638,7 @@ def test_date_timezone_x_and_y():
     plt.plot_date(time_index, time_index, tz='US/Eastern', ydate=True)
 
 
-@image_comparison(baseline_images=['axisbelow'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['axisbelow.png'], remove_text=True)
 def test_axisbelow():
     # Test 'line' setting added in 6287.
     # Show only grids, not frame or ticks, to make this test
@@ -5789,8 +5658,7 @@ def test_axisbelow():
         ax.set_axisbelow(setting)
 
 
-@image_comparison(baseline_images=['titletwiny'], style='mpl20',
-        extensions=['png'])
+@image_comparison(['titletwiny.png'], style='mpl20')
 def test_titletwiny():
     # Test that title is put above xlabel if xlabel at top
     fig, ax = plt.subplots()
@@ -6163,8 +6031,8 @@ def test_scatter_empty_data():
     plt.scatter([], [], s=[], c=[])
 
 
-@image_comparison(baseline_images=['annotate_across_transforms'],
-        style='mpl20', extensions=['png'], remove_text=True)
+@image_comparison(['annotate_across_transforms.png'],
+                  style='mpl20', remove_text=True)
 def test_annotate_across_transforms():
     x = np.linspace(0, 10, 200)
     y = np.exp(-x) * np.sin(x)
@@ -6188,8 +6056,7 @@ def test_deprecated_uppercase_colors():
         fig.canvas.draw()
 
 
-@image_comparison(baseline_images=['secondary_xy'], style='mpl20',
-        extensions=['png'])
+@image_comparison(['secondary_xy.png'], style='mpl20')
 def test_secondary_xy():
     fig, axs = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -23,8 +23,7 @@ with warnings.catch_warnings():
         reason="This test needs a TeX installation")
 
 
-@image_comparison(baseline_images=['pdf_use14corefonts'],
-                  extensions=['pdf'])
+@image_comparison(['pdf_use14corefonts.pdf'])
 def test_use14corefonts():
     rcParams['pdf.use14corefonts'] = True
     rcParams['font.family'] = 'sans-serif'
@@ -168,8 +167,7 @@ def test_determinism_all():
     _determinism_check(format="pdf")
 
 
-@image_comparison(baseline_images=['hatching_legend'],
-                  extensions=['pdf'])
+@image_comparison(['hatching_legend.pdf'])
 def test_hatching_legend():
     """Test for correct hatching on patches in legend"""
     fig = plt.figure(figsize=(1, 2))
@@ -180,8 +178,7 @@ def test_hatching_legend():
     fig.legend([a, b, a, b], ["", "", "", ""])
 
 
-@image_comparison(baseline_images=['grayscale_alpha'],
-                  extensions=['pdf'])
+@image_comparison(['grayscale_alpha.pdf'])
 def test_grayscale_alpha():
     """Masking images with NaN did not work for grayscale images"""
     x, y = np.ogrid[-2:2:.1, -2:2:.1]

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -84,8 +84,7 @@ def create_figure():
 # test compiling a figure to pdf with xelatex
 @needs_xelatex
 @pytest.mark.backend('pgf')
-@image_comparison(baseline_images=['pgf_xelatex'], extensions=['pdf'],
-                  style='default')
+@image_comparison(['pgf_xelatex.pdf'], style='default')
 def test_xelatex():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}
@@ -96,8 +95,7 @@ def test_xelatex():
 # test compiling a figure to pdf with pdflatex
 @needs_pdflatex
 @pytest.mark.backend('pgf')
-@image_comparison(baseline_images=['pgf_pdflatex'], extensions=['pdf'],
-                  style='default')
+@image_comparison(['pgf_pdflatex.pdf'], style='default')
 def test_pdflatex():
     if os.environ.get('APPVEYOR', False):
         pytest.xfail("pdflatex test does not work on appveyor due to missing "
@@ -160,8 +158,7 @@ def test_pathclip():
 # test mixed mode rendering
 @needs_xelatex
 @pytest.mark.backend('pgf')
-@image_comparison(baseline_images=['pgf_mixedmode'], extensions=['pdf'],
-                  style='default')
+@image_comparison(['pgf_mixedmode.pdf'], style='default')
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -120,7 +120,7 @@ def test_determinism_all_tex():
     _determinism_check(format="ps", usetex=True)
 
 
-@image_comparison(baseline_images=["empty"], extensions=["eps"])
+@image_comparison(["empty.eps"])
 def test_transparency():
     fig, ax = plt.subplots()
     ax.set_axis_off()

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -44,15 +44,14 @@ def test_visibility():
     parser.Parse(buf)  # this will raise ExpatError if the svg is invalid
 
 
-@image_comparison(baseline_images=['fill_black_with_alpha'], remove_text=True,
-                  extensions=['svg'])
+@image_comparison(['fill_black_with_alpha.svg'], remove_text=True)
 def test_fill_black_with_alpha():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
     ax.scatter(x=[0, 0.1, 1], y=[0, 0, 0], c='k', alpha=0.1, s=10000)
 
 
-@image_comparison(baseline_images=['noscale'], remove_text=True)
+@image_comparison(['noscale'], remove_text=True)
 def test_noscale():
     X, Y = np.meshgrid(np.arange(-5, 5, 1), np.arange(-5, 5, 1))
     Z = np.sin(Y ** 2)
@@ -78,14 +77,14 @@ def test_text_urls():
     assert expected in buf
 
 
-@image_comparison(baseline_images=['white_space_pre'], extensions=['svg'])
+@image_comparison(['white_space_pre.svg'])
 def test_white_space_pre():
     plt.rcParams["svg.fonttype"] = "none"
     fig = plt.figure()
     fig.text(.5, .5, "a b   c")
 
 
-@image_comparison(baseline_images=['bold_font_output'], extensions=['svg'])
+@image_comparison(['bold_font_output.svg'])
 def test_bold_font_output():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -95,8 +94,7 @@ def test_bold_font_output():
     ax.set_title('bold-title', fontweight='bold')
 
 
-@image_comparison(baseline_images=['bold_font_output_with_none_fonttype'],
-                  extensions=['svg'])
+@image_comparison(['bold_font_output_with_none_fonttype.svg'])
 def test_bold_font_output_with_none_fonttype():
     plt.rcParams['svg.fonttype'] = 'none'
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -8,7 +8,7 @@ import matplotlib.patches as mpatches
 from matplotlib.ticker import FuncFormatter
 
 
-@image_comparison(baseline_images=['bbox_inches_tight'], remove_text=True,
+@image_comparison(['bbox_inches_tight'], remove_text=True,
                   savefig_kwarg=dict(bbox_inches='tight'))
 def test_bbox_inches_tight():
     #: Test that a figure saved using bbox_inches='tight' is clipped correctly
@@ -40,7 +40,7 @@ def test_bbox_inches_tight():
               loc='bottom')
 
 
-@image_comparison(baseline_images=['bbox_inches_tight_suptile_legend'],
+@image_comparison(['bbox_inches_tight_suptile_legend'],
                   remove_text=False, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_suptile_legend():
     plt.plot(np.arange(10), label='a straight line')
@@ -59,7 +59,7 @@ def test_bbox_inches_tight_suptile_legend():
     plt.xlabel('X axis')
 
 
-@image_comparison(baseline_images=['bbox_inches_tight_clipping'],
+@image_comparison(['bbox_inches_tight_clipping'],
                   remove_text=True, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_clipping():
     # tests bbox clipping on scatter points, and path clipping on a patch
@@ -80,7 +80,7 @@ def test_bbox_inches_tight_clipping():
     plt.gcf().artists.append(patch)
 
 
-@image_comparison(baseline_images=['bbox_inches_tight_raster'],
+@image_comparison(['bbox_inches_tight_raster'],
                   remove_text=True, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_raster():
     """Test rasterization with tight_layout"""

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -58,7 +58,7 @@ def generate_EventCollection_plot():
     return splt, coll, props
 
 
-@image_comparison(baseline_images=['EventCollection_plot__default'])
+@image_comparison(['EventCollection_plot__default'])
 def test__EventCollection__get_segments():
     '''
     check to make sure the default segments have the correct coordinates
@@ -130,7 +130,7 @@ def test__EventCollection__get_color():
     check_allprop_array(coll.get_colors(), props['color'])
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_positions'])
+@image_comparison(['EventCollection_plot__set_positions'])
 def test__EventCollection__set_positions():
     '''
     check to make sure set_positions works properly
@@ -147,7 +147,7 @@ def test__EventCollection__set_positions():
     splt.set_xlim(-1, 90)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__add_positions'])
+@image_comparison(['EventCollection_plot__add_positions'])
 def test__EventCollection__add_positions():
     '''
     check to make sure add_positions works properly
@@ -166,7 +166,7 @@ def test__EventCollection__add_positions():
     splt.set_xlim(-1, 35)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__append_positions'])
+@image_comparison(['EventCollection_plot__append_positions'])
 def test__EventCollection__append_positions():
     '''
     check to make sure append_positions works properly
@@ -185,7 +185,7 @@ def test__EventCollection__append_positions():
     splt.set_xlim(-1, 90)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__extend_positions'])
+@image_comparison(['EventCollection_plot__extend_positions'])
 def test__EventCollection__extend_positions():
     '''
     check to make sure extend_positions works properly
@@ -204,7 +204,7 @@ def test__EventCollection__extend_positions():
     splt.set_xlim(-1, 90)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__switch_orientation'])
+@image_comparison(['EventCollection_plot__switch_orientation'])
 def test__EventCollection__switch_orientation():
     '''
     check to make sure switch_orientation works properly
@@ -224,8 +224,7 @@ def test__EventCollection__switch_orientation():
     splt.set_xlim(0, 2)
 
 
-@image_comparison(
-    baseline_images=['EventCollection_plot__switch_orientation__2x'])
+@image_comparison(['EventCollection_plot__switch_orientation__2x'])
 def test__EventCollection__switch_orientation_2x():
     '''
     check to make sure calling switch_orientation twice sets the
@@ -246,7 +245,7 @@ def test__EventCollection__switch_orientation_2x():
     splt.set_title('EventCollection: switch_orientation 2x')
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_orientation'])
+@image_comparison(['EventCollection_plot__set_orientation'])
 def test__EventCollection__set_orientation():
     '''
     check to make sure set_orientation works properly
@@ -266,7 +265,7 @@ def test__EventCollection__set_orientation():
     splt.set_xlim(0, 2)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_linelength'])
+@image_comparison(['EventCollection_plot__set_linelength'])
 def test__EventCollection__set_linelength():
     '''
     check to make sure set_linelength works properly
@@ -284,7 +283,7 @@ def test__EventCollection__set_linelength():
     splt.set_ylim(-20, 20)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_lineoffset'])
+@image_comparison(['EventCollection_plot__set_lineoffset'])
 def test__EventCollection__set_lineoffset():
     '''
     check to make sure set_lineoffset works properly
@@ -302,7 +301,7 @@ def test__EventCollection__set_lineoffset():
     splt.set_ylim(-6, -4)
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_linestyle'])
+@image_comparison(['EventCollection_plot__set_linestyle'])
 def test__EventCollection__set_linestyle():
     '''
     check to make sure set_linestyle works properly
@@ -314,8 +313,7 @@ def test__EventCollection__set_linestyle():
     splt.set_title('EventCollection: set_linestyle')
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_ls_dash'],
-                  remove_text=True)
+@image_comparison(['EventCollection_plot__set_ls_dash'], remove_text=True)
 def test__EventCollection__set_linestyle_single_dash():
     '''
     check to make sure set_linestyle accepts a single dash pattern
@@ -327,7 +325,7 @@ def test__EventCollection__set_linestyle_single_dash():
     splt.set_title('EventCollection: set_linestyle')
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_linewidth'])
+@image_comparison(['EventCollection_plot__set_linewidth'])
 def test__EventCollection__set_linewidth():
     '''
     check to make sure set_linestyle works properly
@@ -339,7 +337,7 @@ def test__EventCollection__set_linewidth():
     splt.set_title('EventCollection: set_linewidth')
 
 
-@image_comparison(baseline_images=['EventCollection_plot__set_color'])
+@image_comparison(['EventCollection_plot__set_color'])
 def test__EventCollection__set_color():
     '''
     check to make sure set_color works properly
@@ -440,10 +438,8 @@ def test_barb_limits():
                               decimal=1)
 
 
-@image_comparison(baseline_images=['EllipseCollection_test_image'],
-                  extensions=['png'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  remove_text=True)
+@image_comparison(['EllipseCollection_test_image.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_EllipseCollection():
     # Test basic functionality
     fig, ax = plt.subplots()
@@ -465,8 +461,7 @@ def test_EllipseCollection():
     ax.autoscale_view()
 
 
-@image_comparison(baseline_images=['polycollection_close'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['polycollection_close.png'], remove_text=True)
 def test_polycollection_close():
     from mpl_toolkits.mplot3d import Axes3D
 
@@ -503,8 +498,7 @@ def test_polycollection_close():
     ax.set_ylim3d(0, 4)
 
 
-@image_comparison(baseline_images=['regularpolycollection_rotate'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['regularpolycollection_rotate.png'], remove_text=True)
 def test_regularpolycollection_rotate():
     xx, yy = np.mgrid[:10, :10]
     xy_points = np.transpose([xx.flatten(), yy.flatten()])
@@ -519,8 +513,7 @@ def test_regularpolycollection_rotate():
     ax.autoscale_view()
 
 
-@image_comparison(baseline_images=['regularpolycollection_scale'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['regularpolycollection_scale.png'], remove_text=True)
 def test_regularpolycollection_scale():
     # See issue #3860
 
@@ -571,8 +564,7 @@ def test_linestyle_single_dashes():
     plt.draw()
 
 
-@image_comparison(baseline_images=['size_in_xy'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['size_in_xy.png'], remove_text=True)
 def test_size_in_xy():
     fig, ax = plt.subplots()
 
@@ -638,8 +630,7 @@ def test_joinstyle():
     assert col.get_joinstyle() == 'miter'
 
 
-@image_comparison(baseline_images=['cap_and_joinstyle'],
-                  extensions=['png'])
+@image_comparison(['cap_and_joinstyle.png'])
 def test_cap_and_joinstyle_image():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -660,9 +651,8 @@ def test_cap_and_joinstyle_image():
     ax.set_title('Line collection with customized caps and joinstyle')
 
 
-@image_comparison(baseline_images=['scatter_post_alpha'],
-                  extensions=['png'], remove_text=True,
-                  style='default')
+@image_comparison(['scatter_post_alpha.png'],
+                  remove_text=True, style='default')
 def test_scatter_post_alpha():
     fig, ax = plt.subplots()
     sc = ax.scatter(range(5), range(5), c=range(5))

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -94,10 +94,8 @@ def _colorbar_extension_length(spacing):
     return fig
 
 
-@image_comparison(
-        baseline_images=['colorbar_extensions_shape_uniform',
-                         'colorbar_extensions_shape_proportional'],
-        extensions=['png'])
+@image_comparison(['colorbar_extensions_shape_uniform.png',
+                   'colorbar_extensions_shape_proportional.png'])
 def test_colorbar_extension_shape():
     '''Test rectangular colorbar extensions.'''
     # Create figures for uniform and proportionally spaced colorbars.
@@ -105,9 +103,8 @@ def test_colorbar_extension_shape():
     _colorbar_extension_shape('proportional')
 
 
-@image_comparison(baseline_images=['colorbar_extensions_uniform',
-                                   'colorbar_extensions_proportional'],
-                  extensions=['png'])
+@image_comparison(['colorbar_extensions_uniform.png',
+                   'colorbar_extensions_proportional.png'])
 def test_colorbar_extension_length():
     '''Test variable length colorbar extensions.'''
     # Create figures for uniform and proportionally spaced colorbars.
@@ -115,11 +112,11 @@ def test_colorbar_extension_length():
     _colorbar_extension_length('proportional')
 
 
-@image_comparison(baseline_images=['cbar_with_orientation',
-                                   'cbar_locationing',
-                                   'double_cbar',
-                                   'cbar_sharing',
-                                   ],
+@image_comparison(['cbar_with_orientation',
+                   'cbar_locationing',
+                   'double_cbar',
+                   'cbar_sharing',
+                   ],
                   extensions=['png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_colorbar_positioning():
@@ -173,8 +170,7 @@ def test_colorbar_positioning():
                  anchor=(0.8, 0.5), shrink=0.6, use_gridspec=False)
 
 
-@image_comparison(baseline_images=['cbar_with_subplots_adjust'],
-                  extensions=['png'], remove_text=True,
+@image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_gridspec_make_colorbar():
     plt.figure()
@@ -192,8 +188,7 @@ def test_gridspec_make_colorbar():
     plt.subplots_adjust(top=0.95, right=0.95, bottom=0.2, hspace=0.25)
 
 
-@image_comparison(baseline_images=['colorbar_single_scatter'],
-                  extensions=['png'], remove_text=True,
+@image_comparison(['colorbar_single_scatter.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_colorbar_single_scatter():
     # Issue #2642: if a path collection has only one entry,
@@ -231,9 +226,7 @@ def test_colorbarbase():
     ColorbarBase(ax, plt.cm.bone)
 
 
-@image_comparison(
-    baseline_images=['colorbar_closed_patch'],
-    remove_text=True)
+@image_comparison(['colorbar_closed_patch'], remove_text=True)
 def test_colorbar_closed_patch():
     fig = plt.figure(figsize=(8, 6))
     ax1 = fig.add_axes([0.05, 0.85, 0.9, 0.1])

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -386,8 +386,7 @@ def _mask_tester(norm_instance, vals):
     assert_array_equal(masked_array.mask, norm_instance(masked_array).mask)
 
 
-@image_comparison(baseline_images=['levels_and_colors'],
-                  extensions=['png'])
+@image_comparison(['levels_and_colors.png'])
 def test_cmap_and_norm_from_levels_and_colors():
     data = np.linspace(-2, 4, 49).reshape(7, 7)
     levels = [-1, 2, 2.5, 3]
@@ -480,8 +479,7 @@ def test_autoscale_masked():
     plt.draw()
 
 
-@image_comparison(baseline_images=['light_source_shading_topo'],
-                  extensions=['png'])
+@image_comparison(['light_source_shading_topo.png'])
 def test_light_source_topo_surface():
     """Shades a DEM using different v.e.'s and blend modes."""
     with cbook.get_sample_data('jacksboro_fault_dem.npz') as file, \

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -33,8 +33,7 @@ def example_pcolor(ax, fontsize=12):
     return pcm
 
 
-@image_comparison(baseline_images=['constrained_layout1'],
-        extensions=['png'])
+@image_comparison(['constrained_layout1.png'])
 def test_constrained_layout1():
     'Test constrained_layout for a single subplot'
     fig = plt.figure(constrained_layout=True)
@@ -42,8 +41,7 @@ def test_constrained_layout1():
     example_plot(ax, fontsize=24)
 
 
-@image_comparison(baseline_images=['constrained_layout2'],
-        extensions=['png'])
+@image_comparison(['constrained_layout2.png'])
 def test_constrained_layout2():
     'Test constrained_layout for 2x2 subplots'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -51,8 +49,7 @@ def test_constrained_layout2():
         example_plot(ax, fontsize=24)
 
 
-@image_comparison(baseline_images=['constrained_layout3'],
-        extensions=['png'])
+@image_comparison(['constrained_layout3.png'])
 def test_constrained_layout3():
     'Test constrained_layout for colorbars with subplots'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -65,7 +62,7 @@ def test_constrained_layout3():
         fig.colorbar(pcm, ax=ax, pad=pad)
 
 
-@image_comparison(baseline_images=['constrained_layout4'])
+@image_comparison(['constrained_layout4'])
 def test_constrained_layout4():
     'Test constrained_layout for a single colorbar with subplots'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -74,8 +71,7 @@ def test_constrained_layout4():
     fig.colorbar(pcm, ax=axs, pad=0.01, shrink=0.6)
 
 
-@image_comparison(baseline_images=['constrained_layout5'],
-                  tol=5.e-2, extensions=['png'])
+@image_comparison(['constrained_layout5.png'], tol=5.e-2)
 def test_constrained_layout5():
     '''
     Test constrained_layout for a single colorbar with subplots,
@@ -89,8 +85,7 @@ def test_constrained_layout5():
                  location='bottom')
 
 
-@image_comparison(baseline_images=['constrained_layout6'],
-        extensions=['png'])
+@image_comparison(['constrained_layout6.png'])
 def test_constrained_layout6():
     'Test constrained_layout for nested gridspecs'
     fig = plt.figure(constrained_layout=True)
@@ -128,8 +123,7 @@ def test_constrained_layout7():
         fig.draw(fig.canvas.get_renderer())
 
 
-@image_comparison(baseline_images=['constrained_layout8'],
-        extensions=['png'])
+@image_comparison(['constrained_layout8.png'])
 def test_constrained_layout8():
     'Test for gridspecs that are not completely full'
     fig = plt.figure(figsize=(10, 5), constrained_layout=True)
@@ -156,8 +150,7 @@ def test_constrained_layout8():
     fig.colorbar(pcm, ax=axs, pad=0.01, shrink=0.6)
 
 
-@image_comparison(baseline_images=['constrained_layout9'],
-        extensions=['png'])
+@image_comparison(['constrained_layout9.png'])
 def test_constrained_layout9():
     'Test for handling suptitle and for sharex and sharey'
     fig, axs = plt.subplots(2, 2, constrained_layout=True,
@@ -171,8 +164,7 @@ def test_constrained_layout9():
     fig.suptitle('Test Suptitle', fontsize=28)
 
 
-@image_comparison(baseline_images=['constrained_layout10'],
-        extensions=['png'])
+@image_comparison(['constrained_layout10.png'])
 def test_constrained_layout10():
     'Test for handling legend outside axis'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -181,8 +173,7 @@ def test_constrained_layout10():
     ax.legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
 
 
-@image_comparison(baseline_images=['constrained_layout11'],
-        extensions=['png'])
+@image_comparison(['constrained_layout11.png'])
 def test_constrained_layout11():
     'Test for multiple nested gridspecs'
     fig = plt.figure(constrained_layout=True, figsize=(10, 3))
@@ -201,8 +192,7 @@ def test_constrained_layout11():
     example_plot(ax, fontsize=9)
 
 
-@image_comparison(baseline_images=['constrained_layout11rat'],
-        extensions=['png'])
+@image_comparison(['constrained_layout11rat.png'])
 def test_constrained_layout11rat():
     'Test for multiple nested gridspecs with width_ratios'
     fig = plt.figure(constrained_layout=True, figsize=(10, 3))
@@ -222,8 +212,7 @@ def test_constrained_layout11rat():
     example_plot(ax, fontsize=9)
 
 
-@image_comparison(baseline_images=['constrained_layout12'],
-        extensions=['png'])
+@image_comparison(['constrained_layout12.png'])
 def test_constrained_layout12():
     'Test that very unbalanced labeling still works.'
     fig = plt.figure(constrained_layout=True)
@@ -245,8 +234,7 @@ def test_constrained_layout12():
     ax.set_xlabel('x-label')
 
 
-@image_comparison(baseline_images=['constrained_layout13'], tol=2.e-2,
-        extensions=['png'])
+@image_comparison(['constrained_layout13.png'], tol=2.e-2)
 def test_constrained_layout13():
     'Test that padding works.'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -256,8 +244,7 @@ def test_constrained_layout13():
     fig.set_constrained_layout_pads(w_pad=24./72., h_pad=24./72.)
 
 
-@image_comparison(baseline_images=['constrained_layout14'],
-        extensions=['png'])
+@image_comparison(['constrained_layout14.png'])
 def test_constrained_layout14():
     'Test that padding works.'
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
@@ -269,8 +256,7 @@ def test_constrained_layout14():
             hspace=0.2, wspace=0.2)
 
 
-@image_comparison(baseline_images=['constrained_layout15'],
-        extensions=['png'])
+@image_comparison(['constrained_layout15.png'])
 def test_constrained_layout15():
     'Test that rcparams work.'
     rcParams['figure.constrained_layout.use'] = True
@@ -279,8 +265,7 @@ def test_constrained_layout15():
         example_plot(ax, fontsize=12)
 
 
-@image_comparison(baseline_images=['constrained_layout16'],
-        extensions=['png'])
+@image_comparison(['constrained_layout16.png'])
 def test_constrained_layout16():
     'Test ax.set_position.'
     fig, ax = plt.subplots(constrained_layout=True)
@@ -288,8 +273,7 @@ def test_constrained_layout16():
     ax2 = fig.add_axes([0.2, 0.2, 0.4, 0.4])
 
 
-@image_comparison(baseline_images=['constrained_layout17'],
-        extensions=['png'])
+@image_comparison(['constrained_layout17.png'])
 def test_constrained_layout17():
     'Test uneven gridspecs'
     fig = plt.figure(constrained_layout=True)
@@ -384,8 +368,8 @@ def test_constrained_layout23():
 # optimize.  Would be nice if this were more deterministic...
 @pytest.mark.timeout(30)
 @pytest.mark.flaky(reruns=3)
-@image_comparison(baseline_images=['test_colorbar_location'],
-        extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['test_colorbar_location.png'],
+                  remove_text=True, style='mpl20')
 def test_colorbar_location():
     """
     Test that colorbar handling is as expected for various complicated

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -170,8 +170,8 @@ def test_contour_uniform_z():
     assert len(record) == 1
 
 
-@image_comparison(baseline_images=['contour_manual_labels'],
-    savefig_kwarg={'dpi': 200}, remove_text=True, style='mpl20')
+@image_comparison(['contour_manual_labels'],
+                  savefig_kwarg={'dpi': 200}, remove_text=True, style='mpl20')
 def test_contour_manual_labels():
 
     x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
@@ -183,8 +183,8 @@ def test_contour_manual_labels():
     plt.clabel(cs, manual=pts)
 
 
-@image_comparison(baseline_images=['contour_labels_size_color'],
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['contour_labels_size_color.png'],
+                  remove_text=True, style='mpl20')
 def test_contour_labels_size_color():
 
     x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
@@ -196,8 +196,7 @@ def test_contour_labels_size_color():
     plt.clabel(cs, manual=pts, fontsize='small', colors=('r', 'g'))
 
 
-@image_comparison(baseline_images=['contour_manual_colors_and_levels'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['contour_manual_colors_and_levels.png'], remove_text=True)
 def test_given_colors_levels_and_extends():
     _, axs = plt.subplots(2, 4)
 
@@ -225,8 +224,8 @@ def test_given_colors_levels_and_extends():
         plt.colorbar(c, ax=ax)
 
 
-@image_comparison(baseline_images=['contour_datetime_axis'],
-                  extensions=['png'], remove_text=False, style='mpl20')
+@image_comparison(['contour_datetime_axis.png'],
+                  remove_text=False, style='mpl20')
 def test_contour_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -251,8 +250,8 @@ def test_contour_datetime_axis():
             label.set_rotation(30)
 
 
-@image_comparison(baseline_images=['contour_test_label_transforms'],
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['contour_test_label_transforms.png'],
+                  remove_text=True, style='mpl20')
 def test_labels():
     # Adapted from pylab_examples example code: contour_demo.py
     # see issues #2475, #2843, and #2818 for explanation
@@ -281,9 +280,9 @@ def test_labels():
         CS.add_label_near(x, y, inline=True, transform=False)
 
 
-@image_comparison(baseline_images=['contour_corner_mask_False',
-                                   'contour_corner_mask_True'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['contour_corner_mask_False.png',
+                   'contour_corner_mask_True.png'],
+                  remove_text=True)
 def test_corner_mask():
     n = 60
     mask_level = 0.95
@@ -370,8 +369,8 @@ def test_circular_contour_warning():
     assert len(record) == 0
 
 
-@image_comparison(baseline_images=['contour_log_extension'],
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['contour_log_extension.png'],
+                  remove_text=True, style='mpl20')
 def test_contourf_log_extension():
     # Test that contourf with lognorm is extended correctly
     fig = plt.figure(figsize=(10, 5))
@@ -403,9 +402,8 @@ def test_contourf_log_extension():
     plt.colorbar(c3, ax=ax3)
 
 
-@image_comparison(baseline_images=['contour_addlines'],
-                  extensions=['png'], remove_text=True, style='mpl20',
-                  tol=0.03)
+@image_comparison(['contour_addlines.png'],
+                  remove_text=True, style='mpl20', tol=0.03)
 # tolerance is because image changed minutely when tick finding on
 # colorbars was cleaned up...
 def test_contour_addlines():

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -8,9 +8,8 @@ import pytest
 from cycler import cycler
 
 
-@image_comparison(baseline_images=['color_cycle_basic'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'])
+@image_comparison(['color_cycle_basic.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_colorcycle_basic():
     fig, ax = plt.subplots()
     ax.set_prop_cycle(cycler('color', ['r', 'g', 'y']))
@@ -26,9 +25,8 @@ def test_colorcycle_basic():
     ax.legend(loc='upper left')
 
 
-@image_comparison(baseline_images=['marker_cycle', 'marker_cycle'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  remove_text=True, extensions=['png'])
+@image_comparison(['marker_cycle.png', 'marker_cycle.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_marker_cycle():
     fig, ax = plt.subplots()
     ax.set_prop_cycle(cycler('c', ['r', 'g', 'y']) +
@@ -60,9 +58,8 @@ def test_marker_cycle():
     ax.legend(loc='upper left')
 
 
-@image_comparison(baseline_images=['lineprop_cycle_basic'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'])
+@image_comparison(['lineprop_cycle_basic.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_linestylecycle_basic():
     fig, ax = plt.subplots()
     ax.set_prop_cycle(cycler('ls', ['-', '--', ':']))
@@ -78,8 +75,7 @@ def test_linestylecycle_basic():
     ax.legend(loc='upper left')
 
 
-@image_comparison(baseline_images=['fill_cycle_basic'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['fill_cycle_basic.png'], remove_text=True)
 def test_fillcycle_basic():
     fig, ax = plt.subplots()
     ax.set_prop_cycle(cycler('c',  ['r', 'g', 'y']) +
@@ -97,8 +93,7 @@ def test_fillcycle_basic():
     ax.legend(loc='upper left')
 
 
-@image_comparison(baseline_images=['fill_cycle_ignore'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['fill_cycle_ignore.png'], remove_text=True)
 def test_fillcycle_ignore():
     fig, ax = plt.subplots()
     ax.set_prop_cycle(cycler('color',  ['r', 'g', 'y']) +
@@ -120,8 +115,7 @@ def test_fillcycle_ignore():
     ax.legend(loc='upper left')
 
 
-@image_comparison(baseline_images=['property_collision_plot'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['property_collision_plot.png'], remove_text=True)
 def test_property_collision_plot():
     fig, ax = plt.subplots()
     ax.set_prop_cycle('linewidth', [2, 4])
@@ -131,8 +125,7 @@ def test_property_collision_plot():
     ax.plot(np.arange(10), 5 * np.arange(10), color='k')
 
 
-@image_comparison(baseline_images=['property_collision_fill'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['property_collision_fill.png'], remove_text=True)
 def test_property_collision_fill():
     fig, ax = plt.subplots()
     xs = np.arange(10)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -79,7 +79,7 @@ def test_date2num_NaT_scalar(units):
     assert np.isnan(tmpl)
 
 
-@image_comparison(baseline_images=['date_empty'], extensions=['png'])
+@image_comparison(['date_empty.png'])
 def test_date_empty():
     # make sure mpl does the right thing when told to plot dates even
     # if no date data has been presented, cf
@@ -89,7 +89,7 @@ def test_date_empty():
     ax.xaxis_date()
 
 
-@image_comparison(baseline_images=['date_axhspan'], extensions=['png'])
+@image_comparison(['date_axhspan.png'])
 def test_date_axhspan():
     # test ax hspan with date inputs
     t0 = datetime.datetime(2009, 1, 20)
@@ -102,7 +102,7 @@ def test_date_axhspan():
     fig.subplots_adjust(left=0.25)
 
 
-@image_comparison(baseline_images=['date_axvspan'], extensions=['png'])
+@image_comparison(['date_axvspan.png'])
 def test_date_axvspan():
     # test ax hspan with date inputs
     t0 = datetime.datetime(2000, 1, 20)
@@ -115,8 +115,7 @@ def test_date_axvspan():
     fig.autofmt_xdate()
 
 
-@image_comparison(baseline_images=['date_axhline'],
-                  extensions=['png'])
+@image_comparison(['date_axhline.png'])
 def test_date_axhline():
     # test ax hline with date inputs
     t0 = datetime.datetime(2009, 1, 20)
@@ -129,8 +128,7 @@ def test_date_axhline():
     fig.subplots_adjust(left=0.25)
 
 
-@image_comparison(baseline_images=['date_axvline'],
-                  extensions=['png'])
+@image_comparison(['date_axvline.png'])
 def test_date_axvline():
     # test ax hline with date inputs
     t0 = datetime.datetime(2000, 1, 20)
@@ -164,7 +162,7 @@ def test_too_many_date_ticks():
         fig.savefig('junk.png')
 
 
-@image_comparison(baseline_images=['RRuleLocator_bounds'], extensions=['png'])
+@image_comparison(['RRuleLocator_bounds.png'])
 def test_RRuleLocator():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -197,8 +195,7 @@ def test_RRuleLocator_dayrange():
     # On success, no overflow error shall be thrown
 
 
-@image_comparison(baseline_images=['DateFormatter_fractionalSeconds'],
-                  extensions=['png'])
+@image_comparison(['DateFormatter_fractionalSeconds.png'])
 def test_DateFormatter():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -630,8 +627,7 @@ def test_auto_date_locator_intmult_tz():
             assert st == expected
 
 
-@image_comparison(baseline_images=['date_inverted_limit'],
-                  extensions=['png'])
+@image_comparison(['date_inverted_limit.png'])
 def test_date_inverted_limit():
     # test ax hline with date inputs
     t0 = datetime.datetime(2009, 1, 20)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 
-@image_comparison(baseline_images=['figure_align_labels'],
+@image_comparison(['figure_align_labels'],
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_align_labels():
     # Check the figure.align_labels() command
@@ -111,7 +111,7 @@ def test_clf_keyword():
     assert [t.get_text() for t in fig2.texts] == []
 
 
-@image_comparison(baseline_images=['figure_today'])
+@image_comparison(['figure_today'])
 def test_figure():
     # named figure support
     fig = plt.figure('today')
@@ -126,7 +126,7 @@ def test_figure():
     plt.close('tomorrow')
 
 
-@image_comparison(baseline_images=['figure_legend'])
+@image_comparison(['figure_legend'])
 def test_figure_legend():
     fig, axs = plt.subplots(2)
     axs[0].plot([0, 1], [1, 0], label='x', color='g')
@@ -177,7 +177,7 @@ def test_add_subplot_invalid():
         fig.add_subplot(2, 2, 5)
 
 
-@image_comparison(baseline_images=['figure_suptitle'])
+@image_comparison(['figure_suptitle'])
 def test_suptitle():
     fig, _ = plt.subplots()
     fig.suptitle('hello', color='r')
@@ -193,7 +193,7 @@ def test_suptitle_fontproperties():
     assert txt.get_weight() == fps.get_weight()
 
 
-@image_comparison(baseline_images=['alpha_background'],
+@image_comparison(['alpha_background'],
                   # only test png and svg. The PDF output appears correct,
                   # but Ghostscript does not preserve the background color.
                   extensions=['png', 'svg'],

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -25,7 +25,7 @@ from matplotlib.transforms import Bbox, Affine2D, TransformedBbox
 import pytest
 
 
-@image_comparison(baseline_images=['image_interps'], style='mpl20')
+@image_comparison(['image_interps'], style='mpl20')
 def test_image_interps():
     'make the basic nearest, bilinear and bicubic interps'
     X = np.arange(100)
@@ -46,8 +46,7 @@ def test_image_interps():
     ax3.set_ylabel('bicubic')
 
 
-@image_comparison(baseline_images=['interp_alpha'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['interp_alpha.png'], remove_text=True)
 def test_alpha_interp():
     'Test the interpolation of the alpha channel on RGBA images'
     fig, (axl, axr) = plt.subplots(1, 2)
@@ -60,7 +59,7 @@ def test_alpha_interp():
     axr.imshow(img, interpolation="bilinear")
 
 
-@image_comparison(baseline_images=['interp_nearest_vs_none'],
+@image_comparison(['interp_nearest_vs_none'],
                   extensions=['pdf', 'svg'], remove_text=True)
 def test_interp_nearest_vs_none():
     'Test the effect of "nearest" and "none" interpolation'
@@ -95,13 +94,13 @@ def do_figimage(suppressComposite):
     fig.figimage(img[::-1, ::-1], xo=100, yo=100, origin='lower')
 
 
-@image_comparison(baseline_images=['figimage-0'], extensions=['png', 'pdf'])
+@image_comparison(['figimage-0'], extensions=['png', 'pdf'])
 def test_figimage0():
     suppressComposite = False
     do_figimage(suppressComposite)
 
 
-@image_comparison(baseline_images=['figimage-1'], extensions=['png', 'pdf'])
+@image_comparison(['figimage-1'], extensions=['png', 'pdf'])
 def test_figimage1():
     suppressComposite = True
     do_figimage(suppressComposite)
@@ -231,7 +230,7 @@ def test_imsave_pil_kwargs_tiff():
     assert tags["ImageDescription"] == "test image"
 
 
-@image_comparison(baseline_images=['image_alpha'], remove_text=True)
+@image_comparison(['image_alpha'], remove_text=True)
 def test_image_alpha():
     plt.figure()
 
@@ -335,7 +334,7 @@ def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
         == text_with_colorbar
 
 
-@image_comparison(baseline_images=['image_clip'], style='mpl20')
+@image_comparison(['image_clip'], style='mpl20')
 def test_image_clip():
     d = [[1, 2], [3, 4]]
 
@@ -345,7 +344,7 @@ def test_image_clip():
     im.set_clip_path(patch)
 
 
-@image_comparison(baseline_images=['image_cliprect'], style='mpl20')
+@image_comparison(['image_cliprect'], style='mpl20')
 def test_image_cliprect():
     import matplotlib.patches as patches
 
@@ -359,7 +358,7 @@ def test_image_cliprect():
     im.set_clip_path(rect)
 
 
-@image_comparison(baseline_images=['imshow'], remove_text=True, style='mpl20')
+@image_comparison(['imshow'], remove_text=True, style='mpl20')
 def test_imshow():
     fig, ax = plt.subplots()
     arr = np.arange(100).reshape((10, 10))
@@ -368,8 +367,7 @@ def test_imshow():
     ax.set_ylim(0, 3)
 
 
-@image_comparison(baseline_images=['no_interpolation_origin'],
-                  remove_text=True)
+@image_comparison(['no_interpolation_origin'], remove_text=True)
 def test_no_interpolation_origin():
     fig, axs = plt.subplots(2)
     axs[0].imshow(np.arange(100).reshape((2, 50)), origin="lower",
@@ -377,8 +375,7 @@ def test_no_interpolation_origin():
     axs[1].imshow(np.arange(100).reshape((2, 50)), interpolation='none')
 
 
-@image_comparison(baseline_images=['image_shift'], remove_text=True,
-                  extensions=['pdf', 'svg'])
+@image_comparison(['image_shift'], remove_text=True, extensions=['pdf', 'svg'])
 def test_image_shift():
     from matplotlib.colors import LogNorm
 
@@ -420,9 +417,8 @@ def test_image_edges():
     assert g != 100, 'Expected a non-green edge - but sadly, it was.'
 
 
-@image_comparison(baseline_images=['image_composite_background'],
-                  remove_text=True,
-                  style='mpl20')
+@image_comparison(['image_composite_background'],
+                  remove_text=True, style='mpl20')
 def test_image_composite_background():
     fig, ax = plt.subplots()
     arr = np.arange(12).reshape(4, 3)
@@ -432,8 +428,7 @@ def test_image_composite_background():
     ax.set_xlim([0, 12])
 
 
-@image_comparison(baseline_images=['image_composite_alpha'],
-                  remove_text=True)
+@image_comparison(['image_composite_alpha'], remove_text=True)
 def test_image_composite_alpha():
     """
     Tests that the alpha value is recognized and correctly applied in the
@@ -460,9 +455,8 @@ def test_image_composite_alpha():
     ax.set_ylim([5, 0])
 
 
-@image_comparison(baseline_images=['rasterize_10dpi'],
-                  extensions=['pdf', 'svg'],
-                  remove_text=True, style='mpl20')
+@image_comparison(['rasterize_10dpi'],
+                  extensions=['pdf', 'svg'], remove_text=True, style='mpl20')
 def test_rasterize_dpi():
     # This test should check rasterized rendering with high output resolution.
     # It plots a rasterized line and a normal image with imshow.  So it will
@@ -493,8 +487,7 @@ def test_rasterize_dpi():
     rcParams['savefig.dpi'] = 10
 
 
-@image_comparison(baseline_images=['bbox_image_inverted'], remove_text=True,
-                  style='mpl20')
+@image_comparison(['bbox_image_inverted'], remove_text=True, style='mpl20')
 def test_bbox_image_inverted():
     # This is just used to produce an image to feed to BboxImage
     image = np.arange(100).reshape((10, 10))
@@ -538,10 +531,8 @@ def test_get_window_extent_for_AxisImage():
     assert_array_equal(im_bbox.get_points(), [[400, 200], [700, 900]])
 
 
-@image_comparison(baseline_images=['zoom_and_clip_upper_origin'],
-                  remove_text=True,
-                  extensions=['png'],
-                  style='mpl20')
+@image_comparison(['zoom_and_clip_upper_origin.png'],
+                  remove_text=True, style='mpl20')
 def test_zoom_and_clip_upper_origin():
     image = np.arange(100)
     image = image.reshape((10, 10))
@@ -685,8 +676,7 @@ def test_load_from_url():
     plt.imread(urllib.request.urlopen(url))
 
 
-@image_comparison(baseline_images=['log_scale_image'],
-                  remove_text=True)
+@image_comparison(['log_scale_image'], remove_text=True)
 # The recwarn fixture captures a warning in image_comparison.
 def test_log_scale_image(recwarn):
     Z = np.zeros((10, 10))
@@ -698,8 +688,7 @@ def test_log_scale_image(recwarn):
     ax.set_yscale('log')
 
 
-@image_comparison(baseline_images=['rotate_image'],
-                  remove_text=True)
+@image_comparison(['rotate_image'], remove_text=True)
 def test_rotate_image():
     delta = 0.25
     x = y = np.arange(-3.0, 3.0, delta)
@@ -761,8 +750,7 @@ def test_image_preserve_size2():
                        np.identity(n, bool)[::-1])
 
 
-@image_comparison(baseline_images=['mask_image_over_under'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['mask_image_over_under.png'], remove_text=True)
 def test_mask_image_over_under():
     delta = 0.025
     x = y = np.arange(-3.0, 3.0, delta)
@@ -796,8 +784,7 @@ def test_mask_image_over_under():
                  orientation='horizontal', ax=ax2, aspect=10)
 
 
-@image_comparison(baseline_images=['mask_image'],
-                  remove_text=True)
+@image_comparison(['mask_image'], remove_text=True)
 def test_mask_image():
     # Test mask image two ways: Using nans and using a masked array.
 
@@ -815,8 +802,7 @@ def test_mask_image():
     ax2.imshow(A, interpolation='nearest')
 
 
-@image_comparison(baseline_images=['imshow_endianess'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['imshow_endianess.png'], remove_text=True)
 def test_imshow_endianess():
     x = np.arange(10)
     X, Y = np.meshgrid(x, x)
@@ -830,7 +816,7 @@ def test_imshow_endianess():
     ax2.imshow(Z.astype('>f8'), **kwargs)
 
 
-@image_comparison(baseline_images=['imshow_masked_interpolation'],
+@image_comparison(['imshow_masked_interpolation'],
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
@@ -895,18 +881,14 @@ def test_imshow_clips_rgb_to_valid_range(dtype):
         assert out.dtype == np.uint8
 
 
-@image_comparison(baseline_images=['imshow_flatfield'],
-                  remove_text=True, style='mpl20',
-                  extensions=['png'])
+@image_comparison(['imshow_flatfield.png'], remove_text=True, style='mpl20')
 def test_imshow_flatfield():
     fig, ax = plt.subplots()
     im = ax.imshow(np.ones((5, 5)))
     im.set_clim(.5, 1.5)
 
 
-@image_comparison(baseline_images=['imshow_bignumbers'],
-                  remove_text=True, style='mpl20',
-                  extensions=['png'])
+@image_comparison(['imshow_bignumbers.png'], remove_text=True, style='mpl20')
 def test_imshow_bignumbers():
     # putting a big number in an array of integers shouldn't
     # ruin the dynamic range of the resolved bits.
@@ -916,9 +898,8 @@ def test_imshow_bignumbers():
     pc.set_clim(0, 5)
 
 
-@image_comparison(baseline_images=['imshow_bignumbers_real'],
-                  remove_text=True, style='mpl20',
-                  extensions=['png'])
+@image_comparison(['imshow_bignumbers_real.png'],
+                  remove_text=True, style='mpl20')
 def test_imshow_bignumbers_real():
     # putting a big number in an array of integers shouldn't
     # ruin the dynamic range of the resolved bits.

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -34,7 +34,7 @@ def test_legend_ordereddict():
               loc='center left', bbox_to_anchor=(1, .5))
 
 
-@image_comparison(baseline_images=['legend_auto1'], remove_text=True)
+@image_comparison(['legend_auto1'], remove_text=True)
 def test_legend_auto1():
     'Test automatic legend placement'
     fig = plt.figure()
@@ -45,7 +45,7 @@ def test_legend_auto1():
     ax.legend(loc='best')
 
 
-@image_comparison(baseline_images=['legend_auto2'], remove_text=True)
+@image_comparison(['legend_auto2'], remove_text=True)
 def test_legend_auto2():
     'Test automatic legend placement'
     fig = plt.figure()
@@ -56,7 +56,7 @@ def test_legend_auto2():
     ax.legend([b1[0], b2[0]], ['up', 'down'], loc='best')
 
 
-@image_comparison(baseline_images=['legend_auto3'])
+@image_comparison(['legend_auto3'])
 def test_legend_auto3():
     'Test automatic legend placement'
     fig = plt.figure()
@@ -69,7 +69,7 @@ def test_legend_auto3():
     ax.legend(loc='best')
 
 
-@image_comparison(baseline_images=['legend_various_labels'], remove_text=True)
+@image_comparison(['legend_various_labels'], remove_text=True)
 def test_various_labels():
     # tests all sorts of label types
     fig = plt.figure()
@@ -80,8 +80,7 @@ def test_various_labels():
     ax.legend(numpoints=1, loc='best')
 
 
-@image_comparison(baseline_images=['legend_labels_first'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['legend_labels_first.png'], remove_text=True)
 def test_labels_first():
     # test labels to left of markers
     fig = plt.figure()
@@ -92,8 +91,7 @@ def test_labels_first():
     ax.legend(loc='best', markerfirst=False)
 
 
-@image_comparison(baseline_images=['legend_multiple_keys'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['legend_multiple_keys.png'], remove_text=True)
 def test_multiple_keys():
     # test legend entries with multiple keys
     fig = plt.figure()
@@ -107,9 +105,8 @@ def test_multiple_keys():
                            (p2, p1): HandlerTuple(ndivide=None, pad=0)})
 
 
-@image_comparison(baseline_images=['rgba_alpha'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'], remove_text=True)
+@image_comparison(['rgba_alpha.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_alpha_rgba():
     import matplotlib.pyplot as plt
 
@@ -119,9 +116,8 @@ def test_alpha_rgba():
     leg.legendPatch.set_facecolor([1, 0, 0, 0.5])
 
 
-@image_comparison(baseline_images=['rcparam_alpha'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'], remove_text=True)
+@image_comparison(['rcparam_alpha.png'], remove_text=True,
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_alpha_rcparam():
     import matplotlib.pyplot as plt
 
@@ -136,7 +132,7 @@ def test_alpha_rcparam():
         leg.legendPatch.set_facecolor([1, 0, 0, 0.5])
 
 
-@image_comparison(baseline_images=['fancy'], remove_text=True)
+@image_comparison(['fancy'], remove_text=True)
 def test_fancy():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.subplot(121)
@@ -148,7 +144,7 @@ def test_fancy():
                ncol=2, shadow=True, title="My legend", numpoints=1)
 
 
-@image_comparison(baseline_images=['framealpha'], remove_text=True,
+@image_comparison(['framealpha'], remove_text=True,
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_framealpha():
     x = np.linspace(1, 100, 100)
@@ -157,8 +153,7 @@ def test_framealpha():
     plt.legend(framealpha=0.5)
 
 
-@image_comparison(baseline_images=['scatter_rc3', 'scatter_rc1'],
-                  remove_text=True)
+@image_comparison(['scatter_rc3', 'scatter_rc1'], remove_text=True)
 def test_rc():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.figure()
@@ -175,7 +170,7 @@ def test_rc():
               title="My legend")
 
 
-@image_comparison(baseline_images=['legend_expand'], remove_text=True)
+@image_comparison(['legend_expand'], remove_text=True)
 def test_legend_expand():
     'Test expand mode'
     legend_modes = [None, "expand"]
@@ -191,8 +186,7 @@ def test_legend_expand():
         ax.legend(loc='lower left', mode=mode, ncol=2)
 
 
-@image_comparison(baseline_images=['hatching'], remove_text=True,
-                  style='default')
+@image_comparison(['hatching'], remove_text=True, style='default')
 def test_hatching():
     fig, ax = plt.subplots()
 
@@ -363,7 +357,7 @@ class TestLegendFigureFunction(object):
             "be discarded.")
 
 
-@image_comparison(baseline_images=['legend_stackplot'], extensions=['png'])
+@image_comparison(['legend_stackplot.png'])
 def test_legend_stackplot():
     '''test legend for PolyCollection using stackplot'''
     # related to #1341, #1943, and PR #3303
@@ -422,7 +416,7 @@ def test_legend_repeatcheckok():
     assert len(lab) == 2
 
 
-@image_comparison(baseline_images=['not_covering_scatter'], extensions=['png'])
+@image_comparison(['not_covering_scatter.png'])
 def test_not_covering_scatter():
     colors = ['b', 'g', 'r']
 
@@ -434,8 +428,7 @@ def test_not_covering_scatter():
     plt.gca().set_ylim(-0.5, 2.2)
 
 
-@image_comparison(baseline_images=['not_covering_scatter_transform'],
-                  extensions=['png'])
+@image_comparison(['not_covering_scatter_transform.png'])
 def test_not_covering_scatter_transform():
     # Offsets point to top left, the default auto position
     offset = mtransforms.Affine2D().translate(-20, 20)

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -70,7 +70,7 @@ def test_set_line_coll_dash():
     ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 
 
-@image_comparison(baseline_images=['line_dashes'], remove_text=True)
+@image_comparison(['line_dashes'], remove_text=True)
 def test_line_dashes():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -104,8 +104,7 @@ def test_valid_linestyles():
         line.set_linestyle('aardvark')
 
 
-@image_comparison(baseline_images=['drawstyle_variants'], remove_text=True,
-                  extensions=["png"])
+@image_comparison(['drawstyle_variants.png'], remove_text=True)
 def test_drawstyle_variants():
     fig, axs = plt.subplots(6)
     dss = ["default", "steps-mid", "steps-pre", "steps-post", "steps", None]
@@ -137,8 +136,7 @@ def test_set_drawstyle():
     assert len(line.get_path().vertices) == len(x)
 
 
-@image_comparison(baseline_images=['line_collection_dashes'],
-                  remove_text=True, style='mpl20')
+@image_comparison(['line_collection_dashes'], remove_text=True, style='mpl20')
 def test_set_line_coll_dash_image():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -146,8 +144,7 @@ def test_set_line_coll_dash_image():
     ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 
 
-@image_comparison(baseline_images=['marker_fill_styles'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['marker_fill_styles.png'], remove_text=True)
 def test_marker_fill_styles():
     colors = itertools.cycle([[0, 0, 1], 'g', '#ff0000', 'c', 'm', 'y',
                               np.array([0, 0, 0])])
@@ -175,7 +172,7 @@ def test_marker_fill_styles():
     ax.set_xlim([-5, 155])
 
 
-@image_comparison(baseline_images=['scaled_lines'], style='default')
+@image_comparison(['scaled_lines'], style='default')
 def test_lw_scaling():
     th = np.linspace(0, 32)
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -7,7 +7,7 @@ from matplotlib.offsetbox import (
         AnchoredOffsetbox, DrawingArea, _get_packed_offsets)
 
 
-@image_comparison(baseline_images=['offsetbox_clipping'], remove_text=True)
+@image_comparison(['offsetbox_clipping'], remove_text=True)
 def test_offsetbox_clipping():
     # - create a plot
     # - put an AnchoredOffsetbox with a child DrawingArea

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -84,7 +84,7 @@ def test_negative_rect():
     assert_array_equal(np.roll(neg_vertices, 2, 0), pos_vertices)
 
 
-@image_comparison(baseline_images=['clip_to_bbox'])
+@image_comparison(['clip_to_bbox'])
 def test_clip_to_bbox():
     fig = plt.figure()
 
@@ -114,7 +114,7 @@ def test_clip_to_bbox():
     ax.add_patch(result_patch)
 
 
-@image_comparison(baseline_images=['patch_alpha_coloring'], remove_text=True)
+@image_comparison(['patch_alpha_coloring'], remove_text=True)
 def test_patch_alpha_coloring():
     """
     Test checks that the patch and collection are rendered with the specified
@@ -145,7 +145,7 @@ def test_patch_alpha_coloring():
     ax.set_ylim([-1, 2])
 
 
-@image_comparison(baseline_images=['patch_alpha_override'], remove_text=True)
+@image_comparison(['patch_alpha_override'], remove_text=True)
 def test_patch_alpha_override():
     #: Test checks that specifying an alpha attribute for a patch or
     #: collection will override any alpha component of the facecolor
@@ -185,8 +185,7 @@ def test_patch_color_none():
     assert c.get_facecolor()[0] == 0
 
 
-@image_comparison(baseline_images=['patch_custom_linestyle'],
-                  remove_text=True)
+@image_comparison(['patch_custom_linestyle'], remove_text=True)
 def test_patch_custom_linestyle():
     #: A test to check that patches and collections accept custom dash
     #: patterns as linestyle and that they display correctly.
@@ -259,8 +258,7 @@ def test_wedge_movement():
 
 
 # png needs tol>=0.06, pdf tol>=1.617
-@image_comparison(baseline_images=['wedge_range'],
-                  remove_text=True, tol=1.65 if on_win else 0)
+@image_comparison(['wedge_range'], remove_text=True, tol=1.65 if on_win else 0)
 def test_wedge_range():
     ax = plt.axes()
 
@@ -351,8 +349,7 @@ def test_patch_str():
     # because they seem to exist only for historical reasons.
 
 
-@image_comparison(baseline_images=['multi_color_hatch'],
-                  remove_text=True, style='default')
+@image_comparison(['multi_color_hatch'], remove_text=True, style='default')
 def test_multi_color_hatch():
     fig, ax = plt.subplots()
 
@@ -371,7 +368,7 @@ def test_multi_color_hatch():
         ax.add_patch(r)
 
 
-@image_comparison(baseline_images=['units_rectangle'], extensions=['png'])
+@image_comparison(['units_rectangle.png'])
 def test_units_rectangle():
     import matplotlib.testing.jpl_units as U
     U.register()
@@ -384,8 +381,7 @@ def test_units_rectangle():
     ax.set_ylim([5*U.km, 9*U.km])
 
 
-@image_comparison(baseline_images=['connection_patch'], extensions=['png'],
-                  style='mpl20', remove_text=True)
+@image_comparison(['connection_patch.png'], style='mpl20', remove_text=True)
 def test_connection_patch():
     fig, (ax1, ax2) = plt.subplots(1, 2)
 

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -72,9 +72,8 @@ def test_nonlinear_containment():
         ax.transData.transform_point((50, .5)), ax.transData)
 
 
-@image_comparison(
-        baseline_images=['arrow_contains_point'], extensions=['png'],
-        remove_text=True, style='mpl20')
+@image_comparison(['arrow_contains_point.png'],
+                  remove_text=True, style='mpl20')
 def test_arrow_contains_point():
     # fix bug (#8384)
     fig, ax = plt.subplots()
@@ -112,8 +111,7 @@ def test_arrow_contains_point():
                 ax.scatter(x, y, s=5, c="r")
 
 
-@image_comparison(baseline_images=['path_clipping'],
-                  extensions=['svg'], remove_text=True)
+@image_comparison(['path_clipping.svg'], remove_text=True)
 def test_path_clipping():
     fig = plt.figure(figsize=(6.0, 6.2))
 
@@ -133,8 +131,7 @@ def test_path_clipping():
             xy, facecolor='none', edgecolor='red', closed=True))
 
 
-@image_comparison(baseline_images=['semi_log_with_zero'], extensions=['png'],
-                  style='mpl20')
+@image_comparison(['semi_log_with_zero.png'], style='mpl20')
 def test_log_transform_with_zero():
     x = np.arange(-10, 10)
     y = (1.0 - 1.0/(x**2+1))**20
@@ -152,8 +149,7 @@ def test_make_compound_path_empty():
     assert r.vertices.shape == (0, 2)
 
 
-@image_comparison(baseline_images=['xkcd'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['xkcd.png'], remove_text=True)
 def test_xkcd():
     np.random.seed(0)
 
@@ -165,8 +161,7 @@ def test_xkcd():
         ax.plot(x, y)
 
 
-@image_comparison(baseline_images=['xkcd_marker'], extensions=['png'],
-                  remove_text=True)
+@image_comparison(['xkcd_marker.png'], remove_text=True)
 def test_xkcd_marker():
     np.random.seed(0)
 
@@ -182,8 +177,7 @@ def test_xkcd_marker():
         ax.plot(x, y3, '^', ms=10)
 
 
-@image_comparison(baseline_images=['marker_paths'], extensions=['pdf'],
-                  remove_text=True)
+@image_comparison(['marker_paths.pdf'], remove_text=True)
 def test_marker_paths_pdf():
     N = 7
 
@@ -194,8 +188,8 @@ def test_marker_paths_pdf():
     plt.ylim(-1, 7)
 
 
-@image_comparison(baseline_images=['nan_path'], style='default',
-                  remove_text=True, extensions=['pdf', 'svg', 'eps', 'png'])
+@image_comparison(['nan_path'], style='default', remove_text=True,
+                  extensions=['pdf', 'svg', 'eps', 'png'])
 def test_nan_isolated_points():
 
     y0 = [0, np.nan, 2, np.nan, 4, 5, 6]

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import matplotlib.patheffects as path_effects
 
 
-@image_comparison(baseline_images=['patheffect1'], remove_text=True)
+@image_comparison(['patheffect1'], remove_text=True)
 def test_patheffect1():
     ax1 = plt.subplot(111)
     ax1.imshow([[1, 2], [2, 3]])
@@ -24,8 +24,7 @@ def test_patheffect1():
     ax1.grid(True, linestyle="-", path_effects=pe)
 
 
-@image_comparison(baseline_images=['patheffect2'], remove_text=True,
-                  style='mpl20')
+@image_comparison(['patheffect2'], remove_text=True, style='mpl20')
 def test_patheffect2():
 
     ax2 = plt.subplot(111)
@@ -43,7 +42,7 @@ def test_patheffect2():
                                                    foreground="w")])
 
 
-@image_comparison(baseline_images=['patheffect3'])
+@image_comparison(['patheffect3'])
 def test_patheffect3():
     p1, = plt.plot([1, 3, 5, 4, 3], 'o-b', lw=4)
     p1.set_path_effects([path_effects.SimpleLineShadow(),
@@ -70,7 +69,7 @@ def test_patheffect3():
     t.set_path_effects(pe)
 
 
-@image_comparison(baseline_images=['stroked_text'], extensions=['png'])
+@image_comparison(['stroked_text.png'])
 def test_patheffects_stroked_text():
     text_chunks = [
         'A B C D E F G H I J K L',
@@ -119,7 +118,7 @@ def test_SimplePatchShadow_offset():
     assert pe._offset == (4, 5)
 
 
-@image_comparison(baseline_images=['collection'], tol=0.02, style='mpl20')
+@image_comparison(['collection'], tol=0.02, style='mpl20')
 def test_collection():
     x, y = np.meshgrid(np.linspace(0, 10, 150), np.linspace(-5, 5, 100))
     data = np.sin(x) + np.cos(y)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -39,10 +39,8 @@ def test_simple():
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
 
-@image_comparison(baseline_images=['multi_pickle'],
-                  extensions=['png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  style='mpl20')
+@image_comparison(['multi_pickle.png'], remove_text=True, style='mpl20',
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_complete():
     fig = plt.figure('Figure with a label?', figsize=(10, 6))
 

--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -9,8 +9,7 @@ from matplotlib import pyplot as plt
 import matplotlib.cm as cm
 
 
-@image_comparison(baseline_images=['pngsuite'], extensions=['png'],
-                  tol=0.03)
+@image_comparison(['pngsuite.png'], tol=0.03)
 def test_pngsuite():
     dirname = os.path.join(
         os.path.dirname(__file__),

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -76,8 +76,7 @@ def test_zero_headlength():
     assert len(w) == 0
 
 
-@image_comparison(baseline_images=['quiver_animated_test_image'],
-                  extensions=['png'])
+@image_comparison(['quiver_animated_test_image.png'])
 def test_quiver_animate():
     # Tests fix for #2616
     fig, ax = plt.subplots()
@@ -86,8 +85,7 @@ def test_quiver_animate():
                  labelpos='W', fontproperties={'weight': 'bold'})
 
 
-@image_comparison(baseline_images=['quiver_with_key_test_image'],
-                  extensions=['png'])
+@image_comparison(['quiver_with_key_test_image.png'])
 def test_quiver_with_key():
     fig, ax = plt.subplots()
     ax.margins(0.1)
@@ -100,8 +98,7 @@ def test_quiver_with_key():
                  fontproperties={'weight': 'bold', 'size': 'large'})
 
 
-@image_comparison(baseline_images=['quiver_single_test_image'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['quiver_single_test_image.png'], remove_text=True)
 def test_quiver_single():
     fig, ax = plt.subplots()
     ax.margins(0.1)
@@ -116,8 +113,7 @@ def test_quiver_copy():
     assert q0.V[0] == 2.0
 
 
-@image_comparison(baseline_images=['quiver_key_pivot'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['quiver_key_pivot.png'], remove_text=True)
 def test_quiver_key_pivot():
     fig, ax = plt.subplots()
 
@@ -132,8 +128,7 @@ def test_quiver_key_pivot():
     ax.quiverkey(q, 0, 0.5, 1, 'W', labelpos='W')
 
 
-@image_comparison(baseline_images=['quiver_key_xy'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['quiver_key_xy.png'], remove_text=True)
 def test_quiver_key_xy():
     # With scale_units='xy', ensure quiverkey still matches its quiver.
     # Note that the quiver and quiverkey lengths depend on the axes aspect
@@ -157,8 +152,7 @@ def test_quiver_key_xy():
             ax.quiverkey(q, X=x, Y=0.8, U=1, angle=angle, label='', color='b')
 
 
-@image_comparison(baseline_images=['barbs_test_image'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['barbs_test_image.png'], remove_text=True)
 def test_barbs():
     x = np.linspace(-5, 5, 5)
     X, Y = np.meshgrid(x, x)
@@ -169,8 +163,7 @@ def test_barbs():
              cmap='viridis')
 
 
-@image_comparison(baseline_images=['barbs_pivot_test_image'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['barbs_pivot_test_image.png'], remove_text=True)
 def test_barbs_pivot():
     x = np.linspace(-5, 5, 5)
     X, Y = np.meshgrid(x, x)
@@ -203,8 +196,7 @@ def test_angles_and_scale():
     ax.quiver(X, Y, U, V, angles=phi, scale_units='xy')
 
 
-@image_comparison(baseline_images=['quiver_xy'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['quiver_xy.png'], remove_text=True)
 def test_quiver_xy():
     # simple arrow pointing from SW to NE
     fig, ax = plt.subplots(subplot_kw=dict(aspect='equal'))

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -22,8 +22,7 @@ def test_log_scales(fig_test, fig_ref):
     ax_ref.plot(xlim, [24.1, 24.1], 'b')
 
 
-@image_comparison(baseline_images=['logit_scales'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['logit_scales.png'], remove_text=True)
 def test_logit_scales():
     fig, ax = plt.subplots()
 
@@ -66,8 +65,7 @@ def test_logscale_subs():
     fig.canvas.draw()
 
 
-@image_comparison(baseline_images=['logscale_mask'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['logscale_mask.png'], remove_text=True)
 def test_logscale_mask():
     # Check that zero values are masked correctly on log scales.
     # See github issue 8045
@@ -106,8 +104,8 @@ def test_logscale_transform_repr():
         repr(Log10Transform(nonpos='clip'))
 
 
-@image_comparison(baseline_images=['logscale_nonpos_values'], remove_text=True,
-                  extensions=['png'], tol=0.02, style='mpl20')
+@image_comparison(['logscale_nonpos_values.png'],
+                  remove_text=True, tol=0.02, style='mpl20')
 def test_logscale_nonpos_values():
     np.random.seed(19680801)
     xs = np.random.normal(size=int(1e3))
@@ -157,8 +155,7 @@ def test_invalid_log_lims():
     assert ax.get_ylim() == original_ylim
 
 
-@image_comparison(baseline_images=['function_scales'], remove_text=True,
-                  extensions=['png'], style='mpl20')
+@image_comparison(['function_scales.png'], remove_text=True, style='mpl20')
 def test_function_scale():
     def inverse(x):
         return x**2

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -16,7 +16,7 @@ from matplotlib.path import Path
 # NOTE: All of these tests assume that path.simplify is set to True
 # (the default)
 
-@image_comparison(baseline_images=['clipping'], remove_text=True)
+@image_comparison(['clipping'], remove_text=True)
 def test_clipping():
     t = np.arange(0.0, 2.0, 0.01)
     s = np.sin(2*np.pi*t)
@@ -26,7 +26,7 @@ def test_clipping():
     ax.set_ylim((-0.20, -0.28))
 
 
-@image_comparison(baseline_images=['overflow'], remove_text=True)
+@image_comparison(['overflow'], remove_text=True)
 def test_overflow():
     x = np.array([1.0, 2.0, 3.0, 2.0e5])
     y = np.arange(len(x))
@@ -36,7 +36,7 @@ def test_overflow():
     ax.set_xlim(2, 6)
 
 
-@image_comparison(baseline_images=['clipping_diamond'], remove_text=True)
+@image_comparison(['clipping_diamond'], remove_text=True)
 def test_diamond():
     x = np.array([0.0, 1.0, 0.0, -1.0, 0.0])
     y = np.array([1.0, 0.0, -1.0, 0.0, 1.0])
@@ -207,7 +207,7 @@ def test_sine_plus_noise():
     assert simplified.vertices.size == 25240
 
 
-@image_comparison(baseline_images=['simplify_curve'], remove_text=True)
+@image_comparison(['simplify_curve'], remove_text=True)
 def test_simplify_curve():
     pp1 = patches.PathPatch(
         Path([(0, 0), (1, 0), (1, 1), (np.nan, 1), (0, 0), (2, 0), (2, 2),
@@ -222,7 +222,7 @@ def test_simplify_curve():
     ax.set_ylim((0, 2))
 
 
-@image_comparison(baseline_images=['hatch_simplify'], remove_text=True)
+@image_comparison(['hatch_simplify'], remove_text=True)
 def test_hatch():
     fig, ax = plt.subplots()
     ax.add_patch(plt.Rectangle((0, 0), 1, 1, fill=False, hatch="/"))
@@ -230,7 +230,7 @@ def test_hatch():
     ax.set_ylim((0.45, 0.55))
 
 
-@image_comparison(baseline_images=['fft_peaks'], remove_text=True)
+@image_comparison(['fft_peaks'], remove_text=True)
 def test_fft_peaks():
     fig, ax = plt.subplots()
     t = np.arange(65536)
@@ -292,7 +292,7 @@ def test_throw_rendering_complexity_exceeded():
         fig.savefig(io.BytesIO())
 
 
-@image_comparison(baseline_images=['clipper_edge'], remove_text=True)
+@image_comparison(['clipper_edge'], remove_text=True)
 def test_clipper():
     dat = (0, 1, 0, 2, 0, 3, 0, 4, 0, 5)
     fig = plt.figure(figsize=(2, 1))
@@ -308,7 +308,7 @@ def test_clipper():
     ax.set_xlim(5, 9)
 
 
-@image_comparison(baseline_images=['para_equal_perp'], remove_text=True)
+@image_comparison(['para_equal_perp'], remove_text=True)
 def test_para_equal_perp():
     x = np.array([0, 1, 2, 1, 0, -1, 0, 1] + [1] * 128)
     y = np.array([1, 1, 2, 1, 0, -1, 0, 0] + [0] * 128)
@@ -318,7 +318,7 @@ def test_para_equal_perp():
     ax.plot(x + 1, y + 1, 'ro')
 
 
-@image_comparison(baseline_images=['clipping_with_nans'])
+@image_comparison(['clipping_with_nans'])
 def test_clipping_with_nans():
     x = np.linspace(0, 3.14 * 2, 3000)
     y = np.sin(x)

--- a/lib/matplotlib/tests/test_skew.py
+++ b/lib/matplotlib/tests/test_skew.py
@@ -133,7 +133,7 @@ class SkewXAxes(Axes):
 register_projection(SkewXAxes)
 
 
-@image_comparison(baseline_images=['skew_axes'], remove_text=True)
+@image_comparison(['skew_axes'], remove_text=True)
 def test_set_line_coll_dash_image():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection='skewx')
@@ -145,7 +145,7 @@ def test_set_line_coll_dash_image():
     ax.axvline(0, color='b')
 
 
-@image_comparison(baseline_images=['skew_rects'], remove_text=True)
+@image_comparison(['skew_rects'], remove_text=True)
 def test_skew_rectangle():
 
     fix, axes = plt.subplots(5, 5, sharex=True, sharey=True, figsize=(8, 8))

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-@image_comparison(baseline_images=['spines_axes_positions'])
+@image_comparison(['spines_axes_positions'])
 def test_spines_axes_positions():
     # SF bug 2852168
     fig = plt.figure()
@@ -21,7 +21,7 @@ def test_spines_axes_positions():
     ax.spines['bottom'].set_color('none')
 
 
-@image_comparison(baseline_images=['spines_data_positions'])
+@image_comparison(['spines_data_positions'])
 def test_spines_data_positions():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -33,7 +33,7 @@ def test_spines_data_positions():
     ax.set_ylim([-2, 2])
 
 
-@image_comparison(baseline_images=['spines_capstyle'])
+@image_comparison(['spines_capstyle'])
 def test_spines_capstyle():
     # issue 2542
     plt.rc('axes', linewidth=20)

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -28,8 +28,7 @@ def swirl_velocity_field():
     return x, y, U, V
 
 
-@image_comparison(baseline_images=['streamplot_startpoints'],
-        remove_text=True, style='mpl20')
+@image_comparison(['streamplot_startpoints'], remove_text=True, style='mpl20')
 def test_startpoints():
     X, Y, U, V = velocity_field()
     start_x = np.linspace(X.min(), X.max(), 10)
@@ -39,7 +38,7 @@ def test_startpoints():
     plt.plot(start_x, start_y, 'ok')
 
 
-@image_comparison(baseline_images=['streamplot_colormap'],
+@image_comparison(['streamplot_colormap'],
                   tol=.04, remove_text=True, style='mpl20')
 def test_colormap():
     X, Y, U, V = velocity_field()
@@ -48,9 +47,8 @@ def test_colormap():
     plt.colorbar()
 
 
-@image_comparison(baseline_images=['streamplot_linewidth'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  remove_text=True, style='mpl20')
+@image_comparison(['streamplot_linewidth'], remove_text=True, style='mpl20',
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_linewidth():
     X, Y, U, V = velocity_field()
     speed = np.hypot(U, V)
@@ -64,9 +62,8 @@ def test_linewidth():
                   linewidth=lw)
 
 
-@image_comparison(baseline_images=['streamplot_masks_and_nans'],
-                  tol=0.04 if on_win else 0,
-                  remove_text=True, style='mpl20')
+@image_comparison(['streamplot_masks_and_nans'],
+                  remove_text=True, style='mpl20', tol=0.04 if on_win else 0)
 def test_masks_and_nans():
     X, Y, U, V = velocity_field()
     mask = np.zeros(U.shape, dtype=bool)
@@ -81,8 +78,8 @@ def test_masks_and_nans():
         ax.streamplot(X, Y, U, V, color=U, cmap=plt.cm.Blues)
 
 
-@image_comparison(baseline_images=['streamplot_maxlength'],
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['streamplot_maxlength.png'],
+                  remove_text=True, style='mpl20')
 def test_maxlength():
     x, y, U, V = swirl_velocity_field()
     ax = plt.figure().subplots()
@@ -93,8 +90,8 @@ def test_maxlength():
     ax.set(xlim=(None, 3.2555988021882305), ylim=(None, 3.078326760195413))
 
 
-@image_comparison(baseline_images=['streamplot_direction'],
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['streamplot_direction.png'],
+                  remove_text=True, style='mpl20')
 def test_direction():
     x, y, U, V = swirl_velocity_field()
     plt.streamplot(x, y, U, V, integration_direction='backward',

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -132,7 +132,7 @@ def test_exceptions():
         plt.subplots(2, 2, 5)
 
 
-@image_comparison(baseline_images=['subplots_offset_text'], remove_text=False)
+@image_comparison(['subplots_offset_text'], remove_text=False)
 def test_subplots_offsettext():
     x = numpy.arange(0, 1e10, 1e9)
     y = numpy.arange(0, 100, 10)+1e4

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -12,9 +12,7 @@ def test_non_square():
     plt.table(cellColours=cellcolors)
 
 
-@image_comparison(baseline_images=['table_zorder'],
-                  extensions=['png'],
-                  remove_text=True)
+@image_comparison(['table_zorder.png'], remove_text=True)
 def test_zorder():
     data = [[66386, 174296],
             [58230, 381139]]
@@ -47,8 +45,7 @@ def test_zorder():
     plt.yticks([])
 
 
-@image_comparison(baseline_images=['table_labels'],
-                  extensions=['png'])
+@image_comparison(['table_labels.png'])
 def test_label_colours():
     dim = 3
 
@@ -85,8 +82,7 @@ def test_label_colours():
               loc='best')
 
 
-@image_comparison(baseline_images=['table_cell_manipulation'],
-                  extensions=['png'], remove_text=True)
+@image_comparison(['table_cell_manipulation.png'], remove_text=True)
 def test_diff_cell_table():
     cells = ('horizontal', 'vertical', 'open', 'closed', 'T', 'R', 'B', 'L')
     cellText = [['1'] * len(cells)] * 2
@@ -123,8 +119,7 @@ def test_customcell():
         assert c == code
 
 
-@image_comparison(baseline_images=['table_auto_column'],
-                  extensions=['png'])
+@image_comparison(['table_auto_column.png'])
 def test_auto_column():
     fig = plt.figure()
 

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -19,7 +19,7 @@ with warnings.catch_warnings():
         reason="This test needs a TeX installation")
 
 
-@image_comparison(baseline_images=['font_styles'])
+@image_comparison(['font_styles'])
 def test_font_styles():
     from matplotlib import _get_data_path
     data_path = _get_data_path()
@@ -106,7 +106,7 @@ def test_font_styles():
     ax.set_yticks([])
 
 
-@image_comparison(baseline_images=['multiline'])
+@image_comparison(['multiline'])
 def test_multiline():
     plt.figure()
     ax = plt.subplot(1, 1, 1)
@@ -130,7 +130,7 @@ def test_multiline():
     ax.set_yticks([])
 
 
-@image_comparison(baseline_images=['multiline2'], style='mpl20')
+@image_comparison(['multiline2'], style='mpl20')
 def test_multiline2():
     fig, ax = plt.subplots()
 
@@ -178,7 +178,7 @@ def test_multiline2():
     ax.text(1.2, 0.1, 'Bot align, rot20', color='C2')
 
 
-@image_comparison(baseline_images=['antialiased'], extensions=['png'])
+@image_comparison(['antialiased.png'])
 def test_antialiasing():
     matplotlib.rcParams['text.antialiased'] = True
 
@@ -203,7 +203,7 @@ def test_afm_kerning():
     assert afm.string_width_height('VAVAVAVAVAVA') == (7174.0, 718)
 
 
-@image_comparison(baseline_images=['text_contains'], extensions=['png'])
+@image_comparison(['text_contains.png'])
 def test_contains():
     fig = plt.figure()
     ax = plt.axes()
@@ -247,7 +247,7 @@ def test_annotation_contains():
     assert ann.contains(event) == (False, {})
 
 
-@image_comparison(baseline_images=['titles'])
+@image_comparison(['titles'])
 def test_titles():
     # left and right side titles
     plt.figure()
@@ -258,7 +258,7 @@ def test_titles():
     ax.set_yticks([])
 
 
-@image_comparison(baseline_images=['text_alignment'], style='mpl20')
+@image_comparison(['text_alignment'], style='mpl20')
 def test_alignment():
     plt.figure()
     ax = plt.subplot(1, 1, 1)
@@ -282,7 +282,7 @@ def test_alignment():
     ax.set_yticks([])
 
 
-@image_comparison(baseline_images=['axes_titles'], extensions=['png'])
+@image_comparison(['axes_titles.png'])
 def test_axes_titles():
     # Related to issue #3327
     plt.figure()
@@ -373,15 +373,14 @@ def test_null_rotation_with_rotation_mode(ha, va):
                         t1.get_window_extent(fig.canvas.renderer).get_points())
 
 
-@image_comparison(baseline_images=['text_bboxclip'])
+@image_comparison(['text_bboxclip'])
 def test_bbox_clipping():
     plt.text(0.9, 0.2, 'Is bbox clipped?', backgroundcolor='r', clip_on=True)
     t = plt.text(0.9, 0.5, 'Is fancy bbox clipped?', clip_on=True)
     t.set_bbox({"boxstyle": "round, pad=0.1"})
 
 
-@image_comparison(baseline_images=['annotation_negative_ax_coords'],
-                  extensions=['png'])
+@image_comparison(['annotation_negative_ax_coords.png'])
 def test_annotation_negative_ax_coords():
     fig, ax = plt.subplots()
 
@@ -409,8 +408,7 @@ def test_annotation_negative_ax_coords():
                 va='top')
 
 
-@image_comparison(baseline_images=['annotation_negative_fig_coords'],
-                  extensions=['png'])
+@image_comparison(['annotation_negative_fig_coords.png'])
 def test_annotation_negative_fig_coords():
     fig, ax = plt.subplots()
 
@@ -461,8 +459,7 @@ def test_text_stale():
     assert not fig.stale
 
 
-@image_comparison(baseline_images=['agg_text_clip'],
-                  extensions=['png'])
+@image_comparison(['agg_text_clip.png'])
 def test_agg_text_clip():
     np.random.seed(1)
     fig, (ax1, ax2) = plt.subplots(2)
@@ -482,8 +479,7 @@ def test_text_size_binding():
     assert sz1 == fp.get_size_in_points()
 
 
-@image_comparison(baseline_images=['font_scaling'],
-                  extensions=['pdf'])
+@image_comparison(['font_scaling.pdf'])
 def test_font_scaling():
     matplotlib.rcParams['pdf.fonttype'] = 42
     fig, ax = plt.subplots(figsize=(6.4, 12.4))
@@ -547,8 +543,7 @@ def test_single_artist_usetex():
     fig.canvas.draw()
 
 
-@image_comparison(baseline_images=['text_as_path_opacity'],
-                  extensions=['svg'])
+@image_comparison(['text_as_path_opacity.svg'])
 def test_text_as_path_opacity():
     plt.figure()
     plt.gca().set_axis_off()
@@ -557,8 +552,7 @@ def test_text_as_path_opacity():
     plt.text(0.25, 0.75, 'x', alpha=0.5, color=(0, 0, 0, 1))
 
 
-@image_comparison(baseline_images=['text_as_text_opacity'],
-                  extensions=['svg'])
+@image_comparison(['text_as_text_opacity.svg'])
 def test_text_as_text_opacity():
     matplotlib.rcParams['svg.fonttype'] = 'none'
     plt.figure()
@@ -587,8 +581,7 @@ def test_annotation_update():
                            rtol=1e-6)
 
 
-@image_comparison(baseline_images=['large_subscript_title'],
-                  extensions=['png'], style='mpl20')
+@image_comparison(['large_subscript_title.png'], style='mpl20')
 def test_large_subscript_title():
     fig, axs = plt.subplots(1, 2, figsize=(9, 2.5), constrained_layout=True)
     ax = axs[0]

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -18,7 +18,7 @@ def example_plot(ax, fontsize=12):
     ax.set_title('Title', fontsize=fontsize)
 
 
-@image_comparison(baseline_images=['tight_layout1'])
+@image_comparison(['tight_layout1'])
 def test_tight_layout1():
     'Test tight_layout for a single subplot'
     fig, ax = plt.subplots()
@@ -26,7 +26,7 @@ def test_tight_layout1():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout2'])
+@image_comparison(['tight_layout2'])
 def test_tight_layout2():
     'Test tight_layout for multiple subplots'
     fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(nrows=2, ncols=2)
@@ -37,7 +37,7 @@ def test_tight_layout2():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout3'])
+@image_comparison(['tight_layout3'])
 def test_tight_layout3():
     'Test tight_layout for multiple subplots'
     ax1 = plt.subplot(221)
@@ -49,8 +49,7 @@ def test_tight_layout3():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout4'],
-                  freetype_version=('2.5.5', '2.6.1'))
+@image_comparison(['tight_layout4'], freetype_version=('2.5.5', '2.6.1'))
 def test_tight_layout4():
     'Test tight_layout for subplot2grid'
     ax1 = plt.subplot2grid((3, 3), (0, 0))
@@ -64,7 +63,7 @@ def test_tight_layout4():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout5'])
+@image_comparison(['tight_layout5'])
 def test_tight_layout5():
     'Test tight_layout for image'
     ax = plt.subplot(111)
@@ -73,7 +72,7 @@ def test_tight_layout5():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout6'])
+@image_comparison(['tight_layout6'])
 def test_tight_layout6():
     'Test tight_layout for gridspec'
 
@@ -117,7 +116,7 @@ def test_tight_layout6():
                          h_pad=0.45)
 
 
-@image_comparison(baseline_images=['tight_layout7'])
+@image_comparison(['tight_layout7'])
 def test_tight_layout7():
     # tight layout with left and right titles
     fontsize = 24
@@ -131,7 +130,7 @@ def test_tight_layout7():
     plt.tight_layout()
 
 
-@image_comparison(baseline_images=['tight_layout8'])
+@image_comparison(['tight_layout8'])
 def test_tight_layout8():
     'Test automatic use of tight_layout'
     fig = plt.figure()
@@ -140,7 +139,7 @@ def test_tight_layout8():
     example_plot(ax, fontsize=24)
 
 
-@image_comparison(baseline_images=['tight_layout9'])
+@image_comparison(['tight_layout9'])
 def test_tight_layout9():
     # Test tight_layout for non-visible subplots
     # GH 8244
@@ -212,8 +211,7 @@ def add_offsetboxes(ax, size=10, margin=.1, color='black'):
     return anchored_box
 
 
-@image_comparison(baseline_images=['tight_layout_offsetboxes1',
-                                   'tight_layout_offsetboxes2'])
+@image_comparison(['tight_layout_offsetboxes1', 'tight_layout_offsetboxes2'])
 def test_tight_layout_offsetboxes():
     # 1.
     # - Create 4 subplots

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -69,7 +69,7 @@ def test_external_transform_api():
                     mtransforms.Affine2D().scale(10).get_matrix())
 
 
-@image_comparison(baseline_images=['pre_transform_data'],
+@image_comparison(['pre_transform_data'],
                   tol=0.08, remove_text=True, style='mpl20')
 def test_pre_transform_plotting():
     # a catch-all for as many as possible plot layouts which handle

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -148,7 +148,7 @@ def test_delaunay_robust():
     triang = mtri.Triangulation(tri_points[1:, 0], tri_points[1:, 1])
 
 
-@image_comparison(baseline_images=['tripcolor1'], extensions=['png'])
+@image_comparison(['tripcolor1.png'])
 def test_tripcolor():
     x = np.asarray([0, 0.5, 1, 0,   0.5, 1,   0, 0.5, 1, 0.75])
     y = np.asarray([0, 0,   0, 0.5, 0.5, 0.5, 1, 1,   1, 0.75])
@@ -729,8 +729,7 @@ def test_triinterp_transformations():
             matest.assert_array_almost_equal(interpz, interp_z0[interp_key])
 
 
-@image_comparison(baseline_images=['tri_smooth_contouring'],
-                  extensions=['png'], remove_text=True, tol=0.07)
+@image_comparison(['tri_smooth_contouring.png'], remove_text=True, tol=0.07)
 def test_tri_smooth_contouring():
     # Image comparison based on example tricontour_smooth_user.
     n_angles = 20
@@ -769,8 +768,7 @@ def test_tri_smooth_contouring():
     plt.tricontour(tri_refi, z_test_refi, levels=levels, colors="black")
 
 
-@image_comparison(baseline_images=['tri_smooth_gradient'],
-                  extensions=['png'], remove_text=True, tol=0.092)
+@image_comparison(['tri_smooth_gradient.png'], remove_text=True, tol=0.092)
 def test_tri_smooth_gradient():
     # Image comparison based on example trigradient_demo.
 

--- a/lib/matplotlib/tests/test_ttconv.py
+++ b/lib/matplotlib/tests/test_ttconv.py
@@ -6,8 +6,7 @@ from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 
 
-@image_comparison(baseline_images=["truetype-conversion"],
-                  extensions=["pdf"])
+@image_comparison(["truetype-conversion.pdf"])
 # mpltest.ttf does not have "l"/"p" glyphs so we get a warning when trying to
 # get the font extents.
 def test_truetype_conversion(recwarn):

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -72,9 +72,8 @@ def quantity_converter():
 
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
-@image_comparison(baseline_images=['plot_pint'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'], remove_text=False, style='mpl20')
+@image_comparison(['plot_pint.png'], remove_text=False, style='mpl20',
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_numpy_facade(quantity_converter):
     # Register the class
     munits.registry[Quantity] = quantity_converter
@@ -97,9 +96,8 @@ def test_numpy_facade(quantity_converter):
 
 
 # Tests gh-8908
-@image_comparison(baseline_images=['plot_masked_units'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'], remove_text=True, style='mpl20')
+@image_comparison(['plot_masked_units.png'], remove_text=True, style='mpl20',
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_plot_masked_units():
     data = np.linspace(-5, 5)
     data_masked = np.ma.array(data, mask=(data > -2) & (data < 2))
@@ -118,7 +116,7 @@ def test_empty_set_limits_with_units(quantity_converter):
     ax.set_ylim(Quantity(-1, 'hours'), Quantity(16, 'hours'))
 
 
-@image_comparison(baseline_images=['jpl_bar_units'], extensions=['png'],
+@image_comparison(['jpl_bar_units.png'],
                   savefig_kwarg={'dpi': 120}, style='mpl20')
 def test_jpl_bar_units():
     from datetime import datetime
@@ -135,7 +133,7 @@ def test_jpl_bar_units():
     ax.set_ylim([b-1*day, b+w[-1]+1*day])
 
 
-@image_comparison(baseline_images=['jpl_barh_units'], extensions=['png'],
+@image_comparison(['jpl_barh_units.png'],
                   savefig_kwarg={'dpi': 120}, style='mpl20')
 def test_jpl_barh_units():
     from datetime import datetime

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -262,8 +262,7 @@ def test_CheckButtons():
     check.disconnect(cid)
 
 
-@image_comparison(baseline_images=['check_radio_buttons'], extensions=['png'],
-                  style='mpl20', remove_text=True)
+@image_comparison(['check_radio_buttons.png'], style='mpl20', remove_text=True)
 def test_check_radio_buttons_image():
     get_ax()
     plt.subplots_adjust(left=0.3)
@@ -274,8 +273,8 @@ def test_check_radio_buttons_image():
                          (False, True, True))
 
 
-@image_comparison(baseline_images=['check_bunch_of_radio_buttons'],
-                  style='mpl20', extensions=['png'], remove_text=True)
+@image_comparison(['check_bunch_of_radio_buttons.png'],
+                  style='mpl20', remove_text=True)
 def test_check_bunch_of_radio_buttons():
     rax = plt.axes([0.05, 0.1, 0.15, 0.7])
     widgets.RadioButtons(rax, ('B1', 'B2', 'B3', 'B4', 'B5', 'B6',

--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -5,10 +5,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-@image_comparison(baseline_images=['imagegrid_cbar_mode'],
-                  extensions=['png'],
-                  remove_text=True,
-                  style='mpl20')
+@image_comparison(['imagegrid_cbar_mode.png'], remove_text=True, style='mpl20')
 def test_imagegrid_cbar_mode_edge():
     X, Y = np.meshgrid(np.linspace(0, 6, 30), np.linspace(0, 6, 30))
     arr = np.sin(X) * np.cos(Y) + 1j*(np.sin(3*Y) * np.cos(Y/2.))

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -29,7 +29,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 
-@image_comparison(baseline_images=['divider_append_axes'])
+@image_comparison(['divider_append_axes'])
 def test_divider_append_axes():
 
     # the random data
@@ -71,8 +71,7 @@ def test_divider_append_axes():
     axHistright.yaxis.set_ticklabels(())
 
 
-@image_comparison(baseline_images=['twin_axes_empty_and_removed'],
-                  extensions=["png"], tol=1)
+@image_comparison(['twin_axes_empty_and_removed'], extensions=["png"], tol=1)
 def test_twin_axes_empty_and_removed():
     # Purely cosmetic font changes (avoid overlap)
     matplotlib.rcParams.update({"font.size": 8})
@@ -116,9 +115,7 @@ def test_axesgrid_colorbar_log_smoketest():
     grid.cbar_axes[0].colorbar(im)
 
 
-@image_comparison(
-    baseline_images=['inset_locator'], style='default', extensions=['png'],
-    remove_text=True)
+@image_comparison(['inset_locator.png'], style='default', remove_text=True)
 def test_inset_locator():
     def get_demo_image():
         from matplotlib.cbook import get_sample_data
@@ -166,9 +163,7 @@ def test_inset_locator():
     ax.add_artist(asb)
 
 
-@image_comparison(
-    baseline_images=['inset_axes'], style='default', extensions=['png'],
-    remove_text=True)
+@image_comparison(['inset_axes.png'], style='default', remove_text=True)
 def test_inset_axes():
     def get_demo_image():
         from matplotlib.cbook import get_sample_data
@@ -263,9 +258,7 @@ def test_inset_axes_complete():
                          bbox_transform=ax.transAxes)
 
 
-@image_comparison(
-    baseline_images=['fill_facecolor'], extensions=['png'],
-    remove_text=True, style='mpl20')
+@image_comparison(['fill_facecolor.png'], remove_text=True, style='mpl20')
 def test_fill_facecolor():
     fig, ax = plt.subplots(1, 5)
     fig.set_size_inches(5, 5)
@@ -343,9 +336,7 @@ def test_fill_facecolor():
     mark_inset(ax[3], axins, loc1=2, loc2=4, fc="g", ec="0.5", fill=False)
 
 
-@image_comparison(baseline_images=['zoomed_axes',
-                                   'inverted_zoomed_axes'],
-                  extensions=['png'])
+@image_comparison(['zoomed_axes.png', 'inverted_zoomed_axes.png'])
 def test_zooming_with_inverted_axes():
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3], [1, 2, 3])
@@ -360,9 +351,8 @@ def test_zooming_with_inverted_axes():
     inset_ax.axis([1.4, 1.1, 1.4, 1.1])
 
 
-@image_comparison(baseline_images=['anchored_direction_arrows'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
-                  extensions=['png'])
+@image_comparison(['anchored_direction_arrows.png'],
+                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((10, 10)))
@@ -371,8 +361,7 @@ def test_anchored_direction_arrows():
     ax.add_artist(simple_arrow)
 
 
-@image_comparison(baseline_images=['anchored_direction_arrows_many_args'],
-                  extensions=['png'])
+@image_comparison(['anchored_direction_arrows_many_args.png'])
 def test_anchored_direction_arrows_many_args():
     fig, ax = plt.subplots()
     ax.imshow(np.ones((10, 10)))
@@ -394,7 +383,7 @@ def test_axes_locatable_position():
                       0.03621495327102808)
 
 
-@image_comparison(baseline_images=['image_grid'], extensions=['png'],
+@image_comparison(['image_grid.png'],
                   remove_text=True, style='mpl20',
                   savefig_kwarg={'bbox_inches': 'tight'})
 def test_image_grid():

--- a/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
@@ -6,8 +6,7 @@ from mpl_toolkits.axisartist.axis_artist import (AxisArtist, AxisLabel,
                                                  LabelBase, Ticks, TickLabels)
 
 
-@image_comparison(baseline_images=['axis_artist_ticks'],
-                  extensions=['png'], style='default')
+@image_comparison(['axis_artist_ticks.png'], style='default')
 def test_ticks():
     fig, ax = plt.subplots()
 
@@ -25,8 +24,7 @@ def test_ticks():
     ax.add_artist(ticks_out)
 
 
-@image_comparison(baseline_images=['axis_artist_labelbase'],
-                  extensions=['png'], style='default')
+@image_comparison(['axis_artist_labelbase.png'], style='default')
 def test_labelbase():
     fig, ax = plt.subplots()
 
@@ -40,8 +38,7 @@ def test_labelbase():
     ax.add_artist(label)
 
 
-@image_comparison(baseline_images=['axis_artist_ticklabels'],
-                  extensions=['png'], style='default')
+@image_comparison(['axis_artist_ticklabels.png'], style='default')
 def test_ticklabels():
     fig, ax = plt.subplots()
 
@@ -73,8 +70,7 @@ def test_ticklabels():
     ax.set_ylim(0, 1)
 
 
-@image_comparison(baseline_images=['axis_artist'],
-                  extensions=['png'], style='default')
+@image_comparison(['axis_artist.png'], style='default')
 def test_axis_artist():
     fig, ax = plt.subplots()
 

--- a/lib/mpl_toolkits/tests/test_axisartist_axislines.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axislines.py
@@ -9,8 +9,7 @@ from mpl_toolkits.axisartist import SubplotHost, ParasiteAxesAuxTrans
 from mpl_toolkits.axisartist import Axes
 
 
-@image_comparison(baseline_images=['SubplotZero'],
-                  extensions=['png'], style='default')
+@image_comparison(['SubplotZero.png'], style='default')
 def test_SubplotZero():
     fig = plt.figure()
 
@@ -28,8 +27,7 @@ def test_SubplotZero():
     ax.set_ylabel("Test")
 
 
-@image_comparison(baseline_images=['Subplot'],
-                  extensions=['png'], style='default')
+@image_comparison(['Subplot.png'], style='default')
 def test_Subplot():
     fig = plt.figure()
 
@@ -55,9 +53,8 @@ def test_Axes():
     fig.canvas.draw()
 
 
-@image_comparison(baseline_images=['ParasiteAxesAuxTrans_meshplot'],
-                  extensions=['png'], remove_text=True, style='default',
-                  tol=0.075)
+@image_comparison(['ParasiteAxesAuxTrans_meshplot.png'],
+                  remove_text=True, style='default', tol=0.075)
 def test_ParasiteAxesAuxTrans():
 
     data = np.ones((6, 6))

--- a/lib/mpl_toolkits/tests/test_axisartist_clip_path.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_clip_path.py
@@ -6,8 +6,7 @@ from matplotlib.transforms import Bbox
 from mpl_toolkits.axisartist.clip_path import clip_line_to_rect
 
 
-@image_comparison(baseline_images=['clip_path'],
-                  extensions=['png'], style='default')
+@image_comparison(['clip_path.png'], style='default')
 def test_clip_path():
     x = np.array([-3, -2, -1, 0., 1, 2, 3, 2, 1, 0, -1, -2, -3, 5])
     y = np.arange(len(x))

--- a/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_floating_axes.py
@@ -18,8 +18,7 @@ def test_subplot():
     fig.add_subplot(ax)
 
 
-@image_comparison(baseline_images=['curvelinear3'],
-                  extensions=['png'], style='default', tol=0.01)
+@image_comparison(['curvelinear3.png'], style='default', tol=0.01)
 def test_curvelinear3():
     fig = plt.figure(figsize=(5, 5))
 
@@ -73,8 +72,7 @@ def test_curvelinear3():
     l.set_clip_path(ax1.patch)
 
 
-@image_comparison(baseline_images=['curvelinear4'],
-                  extensions=['png'], style='default', tol=0.015)
+@image_comparison(['curvelinear4.png'], style='default', tol=0.015)
 def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
 

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -16,8 +16,7 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
     GridHelperCurveLinear
 
 
-@image_comparison(baseline_images=['custom_transform'],
-                  extensions=['png'], style='default', tol=0.03)
+@image_comparison(['custom_transform.png'], style='default', tol=0.03)
 def test_custom_transform():
     class MyTransform(Transform):
         input_dims = 2
@@ -83,9 +82,8 @@ def test_custom_transform():
     ax1.grid(True)
 
 
-@image_comparison(baseline_images=['polar_box'],
-                  tol={'aarch64': 0.04}.get(platform.machine(), 0.03),
-                  extensions=['png'], style='default')
+@image_comparison(['polar_box.png'], style='default',
+                  tol={'aarch64': 0.04}.get(platform.machine(), 0.03))
 def test_polar_box():
     fig = plt.figure(figsize=(5, 5))
 
@@ -145,8 +143,7 @@ def test_polar_box():
     ax1.grid(True)
 
 
-@image_comparison(baseline_images=['axis_direction'],
-                  extensions=['png'], style='default', tol=0.03)
+@image_comparison(['axis_direction.png'], style='default', tol=0.03)
 def test_axis_direction():
     fig = plt.figure(figsize=(5, 5))
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -18,7 +18,7 @@ def test_aspect_equal_error():
         ax.set_aspect('equal')
 
 
-@image_comparison(baseline_images=['bar3d'], remove_text=True)
+@image_comparison(['bar3d'], remove_text=True)
 def test_bar3d():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -30,11 +30,7 @@ def test_bar3d():
         ax.bar(xs, ys, zs=z, zdir='y', align='edge', color=cs, alpha=0.8)
 
 
-@image_comparison(
-    baseline_images=['bar3d_shaded'],
-    remove_text=True,
-    extensions=['png']
-)
+@image_comparison(['bar3d_shaded.png'], remove_text=True)
 def test_bar3d_shaded():
     x = np.arange(4)
     y = np.arange(5)
@@ -54,11 +50,7 @@ def test_bar3d_shaded():
     fig.canvas.draw()
 
 
-@image_comparison(
-    baseline_images=['bar3d_notshaded'],
-    remove_text=True,
-    extensions=['png']
-)
+@image_comparison(['bar3d_notshaded.png'], remove_text=True)
 def test_bar3d_notshaded():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -71,8 +63,7 @@ def test_bar3d_notshaded():
     fig.canvas.draw()
 
 
-@image_comparison(baseline_images=['contour3d'],
-                  remove_text=True, style='mpl20')
+@image_comparison(['contour3d'], remove_text=True, style='mpl20')
 def test_contour3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -85,7 +76,7 @@ def test_contour3d():
     ax.set_zlim(-100, 100)
 
 
-@image_comparison(baseline_images=['contourf3d'], remove_text=True)
+@image_comparison(['contourf3d'], remove_text=True)
 def test_contourf3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -98,7 +89,7 @@ def test_contourf3d():
     ax.set_zlim(-100, 100)
 
 
-@image_comparison(baseline_images=['contourf3d_fill'], remove_text=True)
+@image_comparison(['contourf3d_fill'], remove_text=True)
 def test_contourf3d_fill():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -113,8 +104,7 @@ def test_contourf3d_fill():
     ax.set_zlim(-1, 1)
 
 
-@image_comparison(baseline_images=['tricontour'], remove_text=True,
-                  style='mpl20', extensions=['png'])
+@image_comparison(['tricontour.png'], remove_text=True, style='mpl20')
 def test_tricontour():
     fig = plt.figure()
 
@@ -129,7 +119,7 @@ def test_tricontour():
     ax.tricontourf(x, y, z)
 
 
-@image_comparison(baseline_images=['lines3d'], remove_text=True)
+@image_comparison(['lines3d'], remove_text=True)
 def test_lines3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -143,7 +133,7 @@ def test_lines3d():
 
 # Reason for flakiness of SVG test is still unknown.
 @image_comparison(
-    baseline_images=['mixedsubplot'], remove_text=True,
+    ['mixedsubplot'], remove_text=True,
     extensions=['png', 'pdf',
                 pytest.param('svg', marks=pytest.mark.xfail(strict=False))])
 def test_mixedsubplots():
@@ -182,7 +172,7 @@ def test_tight_layout_text(fig_test, fig_ref):
     ax2.text(.5, .5, .5, s='some string')
 
 
-@image_comparison(baseline_images=['scatter3d'], remove_text=True)
+@image_comparison(['scatter3d'], remove_text=True)
 def test_scatter3d():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -192,8 +182,7 @@ def test_scatter3d():
                c='b', marker='^')
 
 
-@image_comparison(baseline_images=['scatter3d_color'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['scatter3d_color.png'], remove_text=True)
 def test_scatter3d_color():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -203,8 +192,7 @@ def test_scatter3d_color():
                color='b', marker='s')
 
 
-@image_comparison(baseline_images=['plot_3d_from_2d'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['plot_3d_from_2d.png'], remove_text=True)
 def test_plot_3d_from_2d():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -214,7 +202,7 @@ def test_plot_3d_from_2d():
     ax.plot(xs, ys, zs=0, zdir='y')
 
 
-@image_comparison(baseline_images=['surface3d'], remove_text=True)
+@image_comparison(['surface3d'], remove_text=True)
 def test_surface3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -229,8 +217,7 @@ def test_surface3d():
     fig.colorbar(surf, shrink=0.5, aspect=5)
 
 
-@image_comparison(baseline_images=['surface3d_shaded'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['surface3d_shaded.png'], remove_text=True)
 def test_surface3d_shaded():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -244,7 +231,7 @@ def test_surface3d_shaded():
     ax.set_zlim(-1.01, 1.01)
 
 
-@image_comparison(baseline_images=['text3d'])
+@image_comparison(['text3d'])
 def test_text3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -268,7 +255,7 @@ def test_text3d():
     ax.set_zlabel('Z axis')
 
 
-@image_comparison(baseline_images=['trisurf3d'], remove_text=True, tol=0.03)
+@image_comparison(['trisurf3d'], remove_text=True, tol=0.03)
 def test_trisurf3d():
     n_angles = 36
     n_radii = 8
@@ -286,8 +273,7 @@ def test_trisurf3d():
     ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
 
 
-@image_comparison(baseline_images=['trisurf3d_shaded'], remove_text=True,
-                  tol=0.03, extensions=['png'])
+@image_comparison(['trisurf3d_shaded.png'], remove_text=True, tol=0.03)
 def test_trisurf3d_shaded():
     n_angles = 36
     n_radii = 8
@@ -305,7 +291,7 @@ def test_trisurf3d_shaded():
     ax.plot_trisurf(x, y, z, color=[1, 0.5, 0], linewidth=0.2)
 
 
-@image_comparison(baseline_images=['wireframe3d'], remove_text=True)
+@image_comparison(['wireframe3d'], remove_text=True)
 def test_wireframe3d():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -313,8 +299,7 @@ def test_wireframe3d():
     ax.plot_wireframe(X, Y, Z, rcount=13, ccount=13)
 
 
-@image_comparison(baseline_images=['wireframe3dzerocstride'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['wireframe3dzerocstride.png'], remove_text=True)
 def test_wireframe3dzerocstride():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -322,8 +307,7 @@ def test_wireframe3dzerocstride():
     ax.plot_wireframe(X, Y, Z, rcount=13, ccount=0)
 
 
-@image_comparison(baseline_images=['wireframe3dzerorstride'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['wireframe3dzerorstride.png'], remove_text=True)
 def test_wireframe3dzerorstride():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
@@ -349,7 +333,7 @@ def test_mixedsamplesraises():
         ax.plot_surface(X, Y, Z, cstride=50, rcount=10)
 
 
-@image_comparison(baseline_images=['quiver3d'], remove_text=True)
+@image_comparison(['quiver3d'], remove_text=True)
 def test_quiver3d():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -364,7 +348,7 @@ def test_quiver3d():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='tip', normalize=True)
 
 
-@image_comparison(baseline_images=['quiver3d_empty'], remove_text=True)
+@image_comparison(['quiver3d_empty'], remove_text=True)
 def test_quiver3d_empty():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -379,7 +363,7 @@ def test_quiver3d_empty():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='tip', normalize=True)
 
 
-@image_comparison(baseline_images=['quiver3d_masked'], remove_text=True)
+@image_comparison(['quiver3d_masked'], remove_text=True)
 def test_quiver3d_masked():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -398,8 +382,7 @@ def test_quiver3d_masked():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='tip', normalize=True)
 
 
-@image_comparison(baseline_images=['quiver3d_pivot_middle'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['quiver3d_pivot_middle.png'], remove_text=True)
 def test_quiver3d_pivot_middle():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -414,8 +397,7 @@ def test_quiver3d_pivot_middle():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='middle', normalize=True)
 
 
-@image_comparison(baseline_images=['quiver3d_pivot_tail'], remove_text=True,
-                  extensions=['png'])
+@image_comparison(['quiver3d_pivot_tail.png'], remove_text=True)
 def test_quiver3d_pivot_tail():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -430,8 +412,7 @@ def test_quiver3d_pivot_tail():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='tail', normalize=True)
 
 
-@image_comparison(baseline_images=['poly3dcollection_closed'],
-                  remove_text=True)
+@image_comparison(['poly3dcollection_closed'], remove_text=True)
 def test_poly3dcollection_closed():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -453,8 +434,7 @@ def test_poly_collection_2d_to_3d_empty():
     assert poly.get_paths() == []
 
 
-@image_comparison(baseline_images=['poly3dcollection_alpha'],
-                  remove_text=True, extensions=['png'])
+@image_comparison(['poly3dcollection_alpha.png'], remove_text=True)
 def test_poly3dcollection_alpha():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -471,7 +451,7 @@ def test_poly3dcollection_alpha():
     ax.add_collection3d(c2)
 
 
-@image_comparison(baseline_images=['axes3d_labelpad'], extensions=['png'])
+@image_comparison(['axes3d_labelpad.png'])
 def test_axes3d_labelpad():
     from matplotlib import rcParams
 
@@ -493,7 +473,7 @@ def test_axes3d_labelpad():
         tick.set_pad(tick.get_pad() - i * 5)
 
 
-@image_comparison(baseline_images=['axes3d_cla'], extensions=['png'])
+@image_comparison(['axes3d_cla.png'])
 def test_axes3d_cla():
     # fixed in pull request 4553
     fig = plt.figure()
@@ -557,8 +537,7 @@ def _test_proj_draw_axes(M, s=1, *args, **kwargs):
     return fig, ax
 
 
-@image_comparison(baseline_images=['proj3d_axes_cube'], extensions=['png'],
-                  remove_text=True, style='default')
+@image_comparison(['proj3d_axes_cube.png'], remove_text=True, style='default')
 def test_proj_axes_cube():
     M = _test_proj_make_M()
 
@@ -580,8 +559,8 @@ def test_proj_axes_cube():
     ax.set_ylim(-0.2, 0.2)
 
 
-@image_comparison(baseline_images=['proj3d_axes_cube_ortho'],
-                  extensions=['png'], remove_text=True, style='default')
+@image_comparison(['proj3d_axes_cube_ortho.png'],
+                  remove_text=True, style='default')
 def test_proj_axes_cube_ortho():
     E = np.array([200, 100, 100])
     R = np.array([0, 0, 0])
@@ -630,7 +609,7 @@ def test_world():
                                 [0, 0, 0, 1]])
 
 
-@image_comparison(baseline_images=['proj3d_lines_dists'], extensions=['png'],
+@image_comparison(['proj3d_lines_dists.png'],
                   remove_text=True, style='default')
 def test_lines_dists():
     fig, ax = plt.subplots(figsize=(4, 6), subplot_kw=dict(aspect='equal'))
@@ -665,7 +644,7 @@ def test_autoscale():
     assert ax.get_w_lims() == (0, 1, -.1, 1.1, -.4, 2.4)
 
 
-@image_comparison(baseline_images=['axes3d_ortho'], style='default')
+@image_comparison(['axes3d_ortho'], style='default')
 def test_axes3d_ortho():
     fig = plt.figure()
     ax = fig.gca(projection='3d')
@@ -690,11 +669,7 @@ def test_invalid_axes_limits(setter, side, value):
 
 
 class TestVoxels(object):
-    @image_comparison(
-        baseline_images=['voxels-simple'],
-        extensions=['png'],
-        remove_text=True
-    )
+    @image_comparison(['voxels-simple.png'], remove_text=True)
     def test_simple(self):
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
@@ -702,12 +677,8 @@ class TestVoxels(object):
         voxels = (x == y) | (y == z)
         ax.voxels(voxels)
 
-    @image_comparison(
-        baseline_images=['voxels-edge-style'],
-        extensions=['png'],
-        remove_text=True,
-        style='default'
-    )
+    @image_comparison(['voxels-edge-style.png'],
+                      remove_text=True, style='default')
     def test_edge_style(self):
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
@@ -718,11 +689,7 @@ class TestVoxels(object):
         # change the edge color of one voxel
         v[max(v.keys())].set_edgecolor('C2')
 
-    @image_comparison(
-        baseline_images=['voxels-named-colors'],
-        extensions=['png'],
-        remove_text=True
-    )
+    @image_comparison(['voxels-named-colors.png'], remove_text=True)
     def test_named_colors(self):
         """Test with colors set to a 3d object array of strings."""
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
@@ -735,11 +702,7 @@ class TestVoxels(object):
         colors[(x + z) < 10] = 'cyan'
         ax.voxels(voxels, facecolors=colors)
 
-    @image_comparison(
-        baseline_images=['voxels-rgb-data'],
-        extensions=['png'],
-        remove_text=True
-    )
+    @image_comparison(['voxels-rgb-data.png'], remove_text=True)
     def test_rgb_data(self):
         """Test with colors set to a 4d float array of rgb data."""
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
@@ -752,11 +715,7 @@ class TestVoxels(object):
         colors[..., 2] = z / 9
         ax.voxels(voxels, facecolors=colors)
 
-    @image_comparison(
-        baseline_images=['voxels-alpha'],
-        extensions=['png'],
-        remove_text=True
-    )
+    @image_comparison(['voxels-alpha.png'], remove_text=True)
     def test_alpha(self):
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
@@ -774,11 +733,7 @@ class TestVoxels(object):
             assert voxels[coord], "faces returned for absent voxel"
             assert isinstance(poly, art3d.Poly3DCollection)
 
-    @image_comparison(
-        baseline_images=['voxels-xyz'],
-        extensions=['png'],
-        tol=0.01
-    )
+    @image_comparison(['voxels-xyz.png'], tol=0.01)
     def test_xyz(self):
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 


### PR DESCRIPTION
```
@image_comparison(baseline_images=["foo"], extensions=["png"])
```
is quite a mouthful.  Shorten it to
```
@image_comparison(["foo.png"])
```
instead (in the common cases when either only one extension or all
extensions are tested).

The only interesting change is in `decorators.py`; the rest is just
regexps and manual changes (but I can split it if that helps with the review).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
