### PR TITLE
Fix backend_pgf header.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -212,9 +212,10 @@ class LatexManager:
         # fonts later when we don't expect the additional output on stdout.
         # TODO: is this sufficient?
         latex_header = [
-            # Include TeX program name as a comment for cache invalidation.
-            r"% !TeX program = {}".format(rcParams["pgf.texsystem"]),
             r"\documentclass{minimal}",
+            # Include TeX program name as a comment for cache invalidation.
+            # TeX does not allow this to be the first line.
+            r"% !TeX program = {}".format(rcParams["pgf.texsystem"]),
             latex_preamble,
             latex_fontspec,
             r"\begin{document}",


### PR DESCRIPTION
At least in some cases (i.e. locally...), tex appears to treat a first
line of `% TeX program = ...` passed to its stdin as an empty filename
followed by a comment, leading to a crash ("I can't find file ''").

Fix that by moving the comment to the second line.

Regression in 3.1.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
