### PR TITLE
In setup.py, inline the packages that need to be installed into setup().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ Make sure you have pip >= 9.0.1.
 import os
 from zipfile import ZipFile
 
-from setuptools import setup, Extension
+from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext as BuildExtCommand
 from setuptools.command.develop import develop as DevelopCommand
 from setuptools.command.install_lib import install_lib as InstallLibCommand
@@ -169,12 +169,7 @@ cmdclass['develop'] = develop_with_jquery
 # however, this is needed on Windows to avoid creating infinite subprocesses
 # when using multiprocessing.
 if __name__ == '__main__':
-    # These are distutils.setup parameters that the various packages add
-    # things to.
-    packages = []
-    namespace_packages = []
-    py_modules = []
-    package_data = {}
+    package_data = {}  # Will be filled below by the various components.
 
     # If the user just queries for information, don't bother figuring out which
     # packages to build or install.
@@ -224,9 +219,6 @@ if __name__ == '__main__':
         # Now collect all of the information we need to build all of the
         # packages.
         for package in good_packages:
-            packages.extend(package.get_packages())
-            namespace_packages.extend(package.get_namespace_packages())
-            py_modules.extend(package.get_py_modules())
             # Extension modules only get added in build_ext, as numpy will have
             # been installed (as setup_requires) at that point.
             data = package.get_package_data()
@@ -267,14 +259,14 @@ if __name__ == '__main__':
         interfaces and hardcopy output formats.
         """,
         license="PSF",
-        packages=packages,
-        namespace_packages=namespace_packages,
-        platforms='any',
-        py_modules=py_modules,
+        platforms="any",
+        package_dir={"": "lib"},
+        packages=find_packages("lib"),
+        namespace_packages=["mpl_toolkits"],
+        py_modules=["pylab"],
         # Dummy extension to trigger build_ext, which will swap it out with
         # real extensions that can depend on numpy for the build.
         ext_modules=[Extension("", [])],
-        package_dir={"": "lib"},
         package_data=package_data,
         classifiers=classifiers,
 

--- a/setupext.py
+++ b/setupext.py
@@ -8,7 +8,6 @@ import logging
 import os
 import pathlib
 import platform
-import setuptools
 import shlex
 import shutil
 import subprocess
@@ -310,30 +309,6 @@ class SetupPackage(object):
         """
         pass
 
-    def get_packages(self):
-        """
-        Get a list of package names to add to the configuration.
-        These are added to the `packages` list passed to
-        `distutils.setup`.
-        """
-        return []
-
-    def get_namespace_packages(self):
-        """
-        Get a list of namespace package names to add to the configuration.
-        These are added to the `namespace_packages` list passed to
-        `distutils.setup`.
-        """
-        return []
-
-    def get_py_modules(self):
-        """
-        Get a list of top-level modules to add to the configuration.
-        These are added to the `py_modules` list passed to
-        `distutils.setup`.
-        """
-        return []
-
     def get_package_data(self):
         """
         Get a package data dictionary to add to the configuration.
@@ -485,15 +460,6 @@ class Matplotlib(SetupPackage):
     def check(self):
         return versioneer.get_version()
 
-    def get_packages(self):
-        return setuptools.find_packages("lib", exclude=["*.tests"])
-
-    def get_namespace_packages(self):
-        return ['mpl_toolkits']
-
-    def get_py_modules(self):
-        return ['pylab']
-
     def get_package_data(self):
         return {
             'matplotlib': [
@@ -524,9 +490,6 @@ class SampleData(OptionalPackage):
 class Tests(OptionalPackage):
     name = "tests"
     default_config = False
-
-    def get_packages(self):
-        return setuptools.find_packages("lib", include=["*.tests"])
 
     def get_package_data(self):
         return {


### PR DESCRIPTION
... instead of hiding that behind a function call in setupext.

(See also #13542 which does the same with {install,setup}_requires.)

Also always install the test source files -- setting `tests = False` in
setup.cfg now only ignores the test data (this is also consistent with
the contents of `matplotlib/tests/__init__.py which is clearly intended
to handle the case where the test source files are installed but not the
baseline images).  This is done for simplicity of implementation and
also to make it possibly easier to separately install the baseline
images (as these are now pure "data") in the future (WIP in  #11732).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
