### PR TITLE
Prepare to change the default pad for AxesDivider.append_axes.

### DIFF
--- a/doc/api/next_api_changes/2019-05-08-AL.rst
+++ b/doc/api/next_api_changes/2019-05-08-AL.rst
@@ -1,0 +1,9 @@
+Deprecations
+````````````
+
+Passing a ``pad`` size of ``None`` (the default) as a synonym for zero to
+the ``append_axes``, ``new_horizontal`` and ``new_vertical`` methods of
+`.axes_grid1.axes_divider.AxesDivider` is deprecated.  In a future release, the
+default value of ``None`` will mean "use :rc:`figure.subplot.wspace` or
+:rc:`figure.subplot.hspace`" (depending on the orientation).  Explicitly pass
+``pad=0`` to keep the old behavior.

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -530,12 +530,17 @@ class AxesDivider(Divider):
             If False, the new axes is appended at the end
             of the list, i.e., it became the right-most axes. If True, it is
             inserted at the start of the list, and becomes the left-most axes.
-        kwargs
+        **kwargs
             All extra keywords arguments are passed to the created axes.
             If *axes_class* is given, the new axes will be created as an
             instance of the given class. Otherwise, the same class of the
             main axes will be used.
         """
+        if pad is None:
+            cbook.warn_deprecated(
+                "3.2", message="In a future version, 'pad' will default to "
+                "rcParams['figure.subplot.wspace'].  Set pad=0 to keep the "
+                "old behavior.")
         if pad:
             if not isinstance(pad, Size._Base):
                 pad = Size.from_any(pad, fraction_ref=self._xref)
@@ -574,12 +579,17 @@ class AxesDivider(Divider):
             If False, the new axes is appended at the end
             of the list, i.e., it became the right-most axes. If True, it is
             inserted at the start of the list, and becomes the left-most axes.
-        kwargs
+        **kwargs
             All extra keywords arguments are passed to the created axes.
             If *axes_class* is given, the new axes will be created as an
             instance of the given class. Otherwise, the same class of the
             main axes will be used.
         """
+        if pad is None:
+            cbook.warn_deprecated(
+                "3.2", message="In a future version, 'pad' will default to "
+                "rcParams['figure.subplot.hspace'].  Set pad=0 to keep the "
+                "old behavior.")
         if pad:
             if not isinstance(pad, Size._Base):
                 pad = Size.from_any(pad, fraction_ref=self._yref)


### PR DESCRIPTION
Using a nonzero default (configurable from the rcParams and identical to
what `plt.subplots()` use) should make this method a bit more
user-friendly (note that *none* of the uses of `append_axes` throughout
the codebase leaves `pad` to its current default of zero).

Inspired by #13775, which also shows the utility of axes_divider.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
