### PR TITLE
Add backend_inline to non_interactive_bk list

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -444,6 +444,7 @@ class Figure(Artist):
             except NonGuiException:
                 pass
         if (backends._get_running_interactive_framework() != "headless"
+                and get_backend() != "module://ipykernel.pylab.backend_inline"
                 and warn):
             cbook._warn_external('Matplotlib is currently using %s, which is '
                                  'a non-GUI backend, so cannot show the '

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -38,7 +38,8 @@ interactive_bk = ['GTK3Agg', 'GTK3Cairo',
                   'WebAgg',
                   'WX', 'WXAgg', 'WXCairo']
 non_interactive_bk = ['agg', 'cairo',
-                      'pdf', 'pgf', 'ps', 'svg', 'template']
+                      'pdf', 'pgf', 'ps', 'svg', 'template',
+                      'module://ipykernel.pylab.backend_inline']
 all_backends = interactive_bk + non_interactive_bk
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -38,8 +38,7 @@ interactive_bk = ['GTK3Agg', 'GTK3Cairo',
                   'WebAgg',
                   'WX', 'WXAgg', 'WXCairo']
 non_interactive_bk = ['agg', 'cairo',
-                      'pdf', 'pgf', 'ps', 'svg', 'template',
-                      'module://ipykernel.pylab.backend_inline']
+                      'pdf', 'pgf', 'ps', 'svg', 'template']
 all_backends = interactive_bk + non_interactive_bk
 
 


### PR DESCRIPTION
It tackles #14171. By adding module://ipykernel.pylab.backend_inline to the list of non interactive backends, the Jupyter notebook warning don't show up anymore. Let me know what you think!

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
