### PR TITLE
TST: register custom marks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,8 @@ python_files = test_*.py
 markers =
     backend: Set alternate Matplotlib backend temporarily.
     style: Set alternate Matplotlib style temporarily.
+    baseline_images: Compare output against a known reference
+    pytz: Tests that require pytz to be installed
 
 filterwarnings =
     error


### PR DESCRIPTION
pytest 4.5.0 became more strict about unknown marks


This un-breaks the build on master.  Intend to self-merge when CI passes.