### PR TITLE
Deprecate Path helpers in bezier.py

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -376,3 +376,13 @@ NavigationToolbar2QT.parent
 This attribute is deprecated.  In order to access the parent window, use
 ``toolbar.canvas.parent()``.  Once the deprecation period is elapsed, it will
 also be accessible as ``toolbar.parent()``.
+
+Path helpers in :mod:`.bezier`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``bezier.make_path_regular`` is deprecated.  Use ``Path.cleaned()`` (or
+``Path.cleaned(curves=True)``, etc.) instead (but note that these methods add a
+``STOP`` code at the end of the path).
+
+``bezier.concatenate_paths`` is deprecated.  Use ``Path.make_compound_path()``
+instead.

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -480,6 +480,8 @@ def make_wedged_bezier2(bezier2, width, w1=1., wm=0.5, w2=0.):
     return path_left, path_right
 
 
+@cbook.deprecated(
+    "3.2", alternative="Path.cleaned() and remove the final STOP if needed")
 def make_path_regular(p):
     """
     If the ``codes`` attribute of `.Path` *p* is None, return a copy of *p*
@@ -495,6 +497,7 @@ def make_path_regular(p):
         return p
 
 
+@cbook.deprecated("3.2", alternative="Path.make_compound_path()")
 def concatenate_paths(paths):
     """Concatenate a list of paths into a single path."""
     vertices = np.concatenate([p.vertices for p in paths])

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -10,10 +10,9 @@ import numpy as np
 import matplotlib as mpl
 from . import artist, cbook, colors, docstring, lines as mlines, transforms
 from .bezier import (
-    NonIntersectingPathException, concatenate_paths, get_cos_sin,
-    get_intersection, get_parallels, inside_circle, make_path_regular,
-    make_wedged_bezier2, split_bezier_intersecting_with_closedpath,
-    split_path_inout)
+    NonIntersectingPathException, get_cos_sin, get_intersection,
+    get_parallels, inside_circle, make_wedged_bezier2,
+    split_bezier_intersecting_with_closedpath, split_path_inout)
 from .path import Path
 
 
@@ -2873,8 +2872,6 @@ class ArrowStyle(_Style):
             and takes care of the aspect ratio.
             """
 
-            path = make_path_regular(path)
-
             if aspect_ratio is not None:
                 # Squeeze the given height by the aspect_ratio
                 vertices = path.vertices / [1, aspect_ratio]
@@ -2886,10 +2883,9 @@ class ArrowStyle(_Style):
                 if np.iterable(fillable):
                     path_list = []
                     for p in zip(path_mutated):
-                        v, c = p.vertices, p.codes
                         # Restore the height
-                        v[:, 1] = v[:, 1] * aspect_ratio
-                        path_list.append(Path(v, c))
+                        path_list.append(
+                            Path(p.vertices * [1, aspect_ratio], p.codes))
                     return path_list, fillable
                 else:
                     return path_mutated, fillable
@@ -4125,7 +4121,7 @@ default: 'arc3'
         """
         _path, fillable = self.get_path_in_displaycoord()
         if np.iterable(fillable):
-            _path = concatenate_paths(_path)
+            _path = Path.make_compound_path(*_path)
         return self.get_transform().inverted().transform_path(_path)
 
     def get_path_in_displaycoord(self):

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -100,10 +100,7 @@ def test_clipping():
     exterior.vertices -= 2
     interior = mpath.Path.unit_circle().deepcopy()
     interior.vertices = interior.vertices[::-1]
-    clip_path = mpath.Path(vertices=np.concatenate([exterior.vertices,
-                                                    interior.vertices]),
-                           codes=np.concatenate([exterior.codes,
-                                                 interior.codes]))
+    clip_path = mpath.Path.make_compound_path(exterior, interior)
 
     star = mpath.Path.unit_regular_star(6).deepcopy()
     star.vertices *= 2.6


### PR DESCRIPTION
... in favor of the corresponding ones in path.py.
(Strictly speaking, `make_path_regular` is closer to
`cleaned(remove_nans=False)` but in practice `cleaned()` works equally
well.)

Note that we may want to deprecate the STOP code, which is documented as "not required and ignored" but actually causes the rest of the path to be dropped silently; it gets appended by `cleaned()` and caused an earlier version of this PR to break (because the STOP would then cause the rest of the concatenated path to be dropped).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
