### PR TITLE
DOC: fix parameters line in Axes.axis docstring

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1628,7 +1628,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        xmin, ymin, xmax, ymax : float, optional
+        xmin, xmax, ymin, ymax : float, optional
             The axis limits to be set. Either none or all of the limits must
             be given. This can also be achieved using ::
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6450,6 +6450,22 @@ def test_axis_bool_arguments(fig_test, fig_ref):
     fig_ref.add_subplot(212).axis("on")
 
 
+def test_axis_extent_arg():
+    fig, ax = plt.subplots()
+    xmin = 5
+    xmax = 10
+    ymin = 15
+    ymax = 20
+    extent = ax.axis([xmin, xmax, ymin, ymax])
+
+    # test that the docstring is correct
+    assert tuple(extent) == (xmin, xmax, ymin, ymax)
+
+    # test that limits were set per the docstring
+    assert (xmin, xmax) == ax.get_xlim()
+    assert (ymin, ymax) == ax.get_ylim()
+
+
 def test_datetime_masked():
     # make sure that all-masked data falls back to the viewlim
     # set in convert.axisinfo....


### PR DESCRIPTION
## PR Summary
Hey gang -- this is a minor, but important edit to the docstring of `Axes.axis` with respect to setting the limits of the x- and y-axes. Also included a test to make sure everything was being set as documented.

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] ~Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant~
- [ ] ~New features are documented, with examples if plot related~
- [x] Documentation is sphinx and numpydoc compliant
- [ ] ~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~
- [ ] ~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
