### PR TITLE
Simplify StixFonts.get_sized_alternatives_for_symbol.

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1030,39 +1030,24 @@ class StixFonts(UnicodeFonts):
 
         return fontname, uniindex
 
-    _size_alternatives = {}
+    @functools.lru_cache()
     def get_sized_alternatives_for_symbol(self, fontname, sym):
-        fixes = {'\\{': '{', '\\}': '}', '\\[': '[', '\\]': ']'}
+        fixes = {
+            '\\{': '{', '\\}': '}', '\\[': '[', '\\]': ']',
+            '<': '\N{MATHEMATICAL LEFT ANGLE BRACKET}',
+            '>': '\N{MATHEMATICAL RIGHT ANGLE BRACKET}',
+        }
         sym = fixes.get(sym, sym)
-
-        alternatives = self._size_alternatives.get(sym)
-        if alternatives:
-            return alternatives
-
-        alternatives = []
         try:
             uniindex = get_unicode_index(sym)
         except ValueError:
             return [(fontname, sym)]
-
-        fix_ups = {
-            ord('<'): 0x27e8,
-            ord('>'): 0x27e9 }
-
-        uniindex = fix_ups.get(uniindex, uniindex)
-
-        for i in range(6):
-            font = self._get_font(i)
-            glyphindex = font.get_char_index(uniindex)
-            if glyphindex != 0:
-                alternatives.append((i, chr(uniindex)))
-
+        alternatives = [(i, chr(uniindex)) for i in range(6)
+                        if self._get_font(i).get_char_index(uniindex) != 0]
         # The largest size of the radical symbol in STIX has incorrect
         # metrics that cause it to be disconnected from the stem.
         if sym == r'\__sqrt__':
             alternatives = alternatives[:-1]
-
-        self._size_alternatives[sym] = alternatives
         return alternatives
 
 


### PR DESCRIPTION
- The intent of the `_size_alternatives` cache can be made more
  explicit and shorter using `@lru_cache`.
- The `fix_ups` mapping can be merged into the `fixes` mapping
  (MATHEMATICAL LEFT/RIGHT ANGLE BRACKET map to 0x27e8/0x27e9).
- `alternatives` can be built as a straight list comprehension.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
