### PR TITLE
DOC: note change in RBGA resampling

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -41,6 +41,13 @@ with nonfinite values are plotted using the bad color of the
 `.collections.PathCollection`\ 's colormap (as set by
 :meth:`.colors.Colormap.set_bad`).
 
+Alpha blending in imshow of RBGA input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The alpha-channel of RBGA images is now re-sampled independently of
+RGB channels.  While this is a bug fix, it does change the output and
+may result in some down-stream image comparison tests to fail.
+
 Autoscaling
 ~~~~~~~~~~~
 On log-axes where a single value is plotted at a "full" decade (1, 10, 100,

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,!=1.8.0<2.0.0
+sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,!=1.8.0,<2.0.0
 colorspacious
 ipython
 ipywidgets


### PR DESCRIPTION
Add API change note for RGBA resampling bug that minorly broke cartopy