### PR TITLE
Fix linear segmented colormap with one element

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -383,16 +383,20 @@ def makeMappingArray(N, data, gamma=1.0):
     if (np.diff(x) < 0).any():
         raise ValueError("data mapping points must have x in increasing order")
     # begin generation of lookup table
-    x = x * (N - 1)
-    xind = (N - 1) * np.linspace(0, 1, N) ** gamma
-    ind = np.searchsorted(x, xind)[1:-1]
+    if N == 1:
+        # convention: use the y = f(x=1) value for a 1-element lookup table
+        lut = np.array(y0[-1])
+    else:
+        x = x * (N - 1)
+        xind = (N - 1) * np.linspace(0, 1, N) ** gamma
+        ind = np.searchsorted(x, xind)[1:-1]
 
-    distance = (xind[1:-1] - x[ind - 1]) / (x[ind] - x[ind - 1])
-    lut = np.concatenate([
-        [y1[0]],
-        distance * (y0[ind] - y1[ind - 1]) + y1[ind - 1],
-        [y0[-1]],
-    ])
+        distance = (xind[1:-1] - x[ind - 1]) / (x[ind] - x[ind - 1])
+        lut = np.concatenate([
+            [y1[0]],
+            distance * (y0[ind] - y1[ind - 1]) + y1[ind - 1],
+            [y0[-1]],
+        ])
     # ensure that the lut is confined to values between 0 and 1 by clipping it
     return np.clip(lut, 0.0, 1.0)
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -16,6 +16,16 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
+@pytest.mark.parametrize('N, result', [
+    (5, [1, .6, .2, .1, 0]),
+    (2, [1, 0]),
+    (1, [0]),
+])
+def test_makeMappingArray(N, result):
+    data = [(0.0, 1.0, 1.0), (0.5, 0.2, 0.2), (1.0, 0.0, 0.0)]
+    assert_array_almost_equal(mcolors.makeMappingArray(N, data), result)
+
+
 def test_resample():
     """
     Github issue #6025 pointed to incorrect ListedColormap._resample;


### PR DESCRIPTION
## PR Summary

Fixes  #14232.

Bug was introduced via #13097 where https://github.com/matplotlib/matplotlib/pull/13097/files#diff-1417350fe654c637d773bb4eac12b8f0 will make at least a 2-element list even for N=1.

The fix special-casese N=1 instead of reverting. I think it's cleaner that way. In particular also because the chosen value for N=1 is an arbitrary choice and we can make that obvious in the special-casing. The choice (color at x=1) is compatible with the former behavior.
