### PR TITLE
Avoid a buffer copy in PillowWriter.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -563,12 +563,10 @@ class PillowWriter(MovieWriter):
         buf = BytesIO()
         self._fig.savefig(buf, **dict(savefig_kwargs, format="rgba"))
         renderer = self._fig.canvas.get_renderer()
-        # Using frombuffer / getbuffer may be slightly more efficient, but
-        # Py3-only.
-        self._frames.append(Image.frombytes(
+        self._frames.append(Image.frombuffer(
             "RGBA",
-            (int(renderer.width), int(renderer.height)),
-            buf.getvalue()))
+            (int(renderer.width), int(renderer.height)), buf.getbuffer(),
+            "raw", "RGBA", 0, 1))
 
     def finish(self):
         self._frames[0].save(


### PR DESCRIPTION
## PR Summary

frombuffer was added in Pillow 1.1.4 https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.frombuffer and we document only supporting Pillow>=3.4 (https://matplotlib.org/users/prev_whats_new/whats_new_2.2.html#writing-animations-with-pillow).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
