### PR TITLE
Deprecate public use of makeMappingArray

### DIFF
--- a/doc/api/next_api_changes/2019-05-18-TH.rst
+++ b/doc/api/next_api_changes/2019-05-18-TH.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The function `matplotlib.colors.makeMappingArray` is not considered part of
+the public API any longer. Thus, it's deprecated.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -65,6 +65,7 @@ import re
 
 import numpy as np
 import matplotlib.cbook as cbook
+from matplotlib import docstring
 from ._color_data import BASE_COLORS, TABLEAU_COLORS, CSS4_COLORS, XKCD_COLORS
 
 
@@ -354,7 +355,7 @@ colorConverter = ColorConverter()
 ### End of backwards-compatible color-conversion API
 
 
-def makeMappingArray(N, data, gamma=1.0):
+def _create_lookup_table(N, data, gamma=1.0):
     r"""Create an *N* -element 1-d lookup table.
 
     This assumes a mapping :math:`f : [0, 1] \rightarrow [0, 1]`. The returned
@@ -450,6 +451,13 @@ def makeMappingArray(N, data, gamma=1.0):
         ])
     # ensure that the lut is confined to values between 0 and 1 by clipping it
     return np.clip(lut, 0.0, 1.0)
+
+
+@cbook.deprecated("3.2",
+                  addendum='This is not considered public API any longer.')
+@docstring.copy(_create_lookup_table)
+def makeMappingArray(N, data, gamma=1.0):
+    return _create_lookup_table(N, data, gamma)
 
 
 class Colormap(object):
@@ -721,14 +729,14 @@ class LinearSegmentedColormap(Colormap):
 
     def _init(self):
         self._lut = np.ones((self.N + 3, 4), float)
-        self._lut[:-3, 0] = makeMappingArray(
+        self._lut[:-3, 0] = _create_lookup_table(
             self.N, self._segmentdata['red'], self._gamma)
-        self._lut[:-3, 1] = makeMappingArray(
+        self._lut[:-3, 1] = _create_lookup_table(
             self.N, self._segmentdata['green'], self._gamma)
-        self._lut[:-3, 2] = makeMappingArray(
+        self._lut[:-3, 2] = _create_lookup_table(
             self.N, self._segmentdata['blue'], self._gamma)
         if 'alpha' in self._segmentdata:
-            self._lut[:-3, 3] = makeMappingArray(
+            self._lut[:-3, 3] = _create_lookup_table(
                 self.N, self._segmentdata['alpha'], 1)
         self._isinit = True
         self._set_extremes()

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -21,9 +21,9 @@ from matplotlib.testing.decorators import image_comparison
     (2, [1, 0]),
     (1, [0]),
 ])
-def test_makeMappingArray(N, result):
+def test_create_lookup_table(N, result):
     data = [(0.0, 1.0, 1.0), (0.5, 0.2, 0.2), (1.0, 0.0, 0.0)]
-    assert_array_almost_equal(mcolors.makeMappingArray(N, data), result)
+    assert_array_almost_equal(mcolors._create_lookup_table(N, data), result)
 
 
 def test_resample():


### PR DESCRIPTION
## PR Summary

This is just an implementation detail of `LinearSegmentedColormap`. It should not be needed by the end-user.
