### PR TITLE
WIP  ENH: constrained layout: new layoutbox to store aspect info...

### DIFF
--- a/examples/lines_bars_and_markers/markevery_demo.py
+++ b/examples/lines_bars_and_markers/markevery_demo.py
@@ -92,10 +92,10 @@ theta = 2 * np.pi * r
 # Plot each markevery case for polar plots
 
 fig4, axs = plt.subplots(rows, cols, figsize=figsize,
-        subplot_kw={'projection': 'polar'}, constrained_layout=True)
+        subplot_kw={'projection': 'polar'}, constrained_layout=False)
 axs = trim_axs(axs, len(cases))
 for ax, case in zip(axs, cases):
     ax.set_title('markevery=%s' % str(case))
     ax.plot(theta, r, 'o', ls='-', ms=4, markevery=case)
-
+fig4.tight_layout()
 plt.show()

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -155,7 +155,6 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
 
     '''
 
-    print('Doin')
     invTransFig = fig.transFigure.inverted().transform_bbox
 
     # list of unique gridspecs that contain child axes:

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -78,6 +78,18 @@ def _axes_all_finite_sized(fig):
     return True
 
 
+def _make_aspects(ax):
+    """
+    Helper function to make sure all the _reallayoutboxes have the
+    correct size.
+    """
+    figW, figH = ax.get_figure().get_size_inches()
+    fig_aspect = figH / figW
+    if ax._box_aspect is not None:
+        asp = ax._box_aspect / fig_aspect
+        ax._reallayoutbox.constrain_aspect(asp, ax.get_anchor())
+
+
 ######################################################
 def do_constrained_layout(fig, renderer, h_pad, w_pad,
         hspace=None, wspace=None):
@@ -143,6 +155,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
 
     '''
 
+    print('Doin')
     invTransFig = fig.transFigure.inverted().transform_bbox
 
     # list of unique gridspecs that contain child axes:
@@ -173,6 +186,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
                 # make margins for each layout box based on the size of
                 # the decorators.
                 _make_layout_margins(ax, renderer, h_pad, w_pad)
+                _make_aspects(ax)
 
         # do layout for suptitle.
         suptitle = fig._suptitle

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -329,6 +329,10 @@ def _make_layout_margins(ax, renderer, h_pad, w_pad):
                 strength='weak')
         ax._poslayoutbox.constrain_right_margin(0, strength='weak')
         ax._poslayoutbox.constrain_left_margin(0, strength='weak')
+        if ax._reallayoutbox is not None:
+            ax._reallayoutbox.constrain_height_min(20, strength='weak')
+            ax._reallayoutbox.constrain_width_min(20, strength='weak')
+            ax._reallayoutbox.constrain_same(ax._poslayoutbox, strength='weak')
 
 
 def _align_spines(fig, gs):

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -164,6 +164,8 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
             gs = ax.get_subplotspec().get_gridspec()
             if gs._layoutbox is not None:
                 gss.add(gs)
+        _make_aspects(ax)
+        
     if len(gss) == 0:
         cbook._warn_external('There are no gridspecs with layoutboxes. '
                              'Possibly did not call parent GridSpec with the'
@@ -173,6 +175,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
         for gs in gss:
             # fill in any empty gridspec slots w/ ghost axes...
             _make_ghost_gridspec_slots(fig, gs)
+
 
     for nnn in range(2):
         # do the algorithm twice.  This has to be done because decorators
@@ -185,7 +188,6 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
                 # make margins for each layout box based on the size of
                 # the decorators.
                 _make_layout_margins(ax, renderer, h_pad, w_pad)
-                _make_aspects(ax)
 
         # do layout for suptitle.
         suptitle = fig._suptitle

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -289,10 +289,10 @@ class LayoutBox(object):
             cx, cy = anchor
         self.aspect_bottom_constraint = (self.bottom ==
             self.parent.bottom + cy *
-            (self.parent.height - self.height)) | strength
-        self.aspect_left_constraint = (self.left == self.parent.left +
-            cx * (self.parent.width - self.width)) | strength
+            (self.parent.height - self.height)) | "medium"
         self.solver.addConstraint(self.aspect_bottom_constraint)
+        self.aspect_left_constraint = (self.left == self.parent.left +
+            cx * (self.parent.width - self.width)) | "medium"
         self.solver.addConstraint(self.aspect_left_constraint)
 
     def constrain_left_margin(self, margin, strength='strong'):

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -284,7 +284,7 @@ class LayoutBox(object):
                  'NW': (0, 1.0),
                  'W':  (0, 0.5)}
         if isinstance(anchor, str):
-            cx, cy = self.coefs[anchor]
+            cx, cy = coefs[anchor]
         else:
             cx, cy = anchor
         self.aspect_bottom_constraint = (self.bottom ==

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -85,6 +85,7 @@ class SecondaryAxis(_AxesBase):
         # this gets positioned w/o constrained_layout so exclude:
         self._layoutbox = None
         self._poslayoutbox = None
+        self._reallayoutbox = None
 
         self.set_location(location)
         self.set_functions(functions)

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -92,7 +92,7 @@ class SubplotBase(object):
             self._reallayoutbox = layoutbox.LayoutBox(
                     parent=self._poslayoutbox,
                     name=self._poslayoutbox.name+'.real',
-                    pos=True, subplot=True, artist=self)
+                    pos=False, subplot=True, artist=self)
 
     def __reduce__(self):
         # get the first axes class which does not inherit from a subplotbase

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -77,6 +77,7 @@ class SubplotBase(object):
         if self._subplotspec._layoutbox is None:
             self._layoutbox = None
             self._poslayoutbox = None
+            self._reallayoutbox = None
         else:
             name = self._subplotspec._layoutbox.name + '.ax'
             name = name + layoutbox.seq_id()
@@ -87,6 +88,10 @@ class SubplotBase(object):
             self._poslayoutbox = layoutbox.LayoutBox(
                     parent=self._layoutbox,
                     name=self._layoutbox.name+'.pos',
+                    pos=True, subplot=True, artist=self)
+            self._reallayoutbox = layoutbox.LayoutBox(
+                    parent=self._poslayoutbox,
+                    name=self._poslayoutbox.name+'.real',
                     pos=True, subplot=True, artist=self)
 
     def __reduce__(self):
@@ -187,6 +192,7 @@ class SubplotBase(object):
             # make the layout boxes be explicitly the same
             twin._layoutbox.constrain_same(self._layoutbox)
             twin._poslayoutbox.constrain_same(self._poslayoutbox)
+            twin._reallayoutbox.constrain_same(self._reallayoutbox)
         self._twinned_axes.join(self, twin)
         return twin
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -403,3 +403,43 @@ def test_colorbar_location():
     fig.colorbar(pcm, ax=axs[-2, 3:], shrink=0.5, location='top')
     fig.colorbar(pcm, ax=axs[0, 0], shrink=0.5, location='left')
     fig.colorbar(pcm, ax=axs[1:3, 2], shrink=0.5, location='right')
+
+
+def test_reallayoutbox_aspect():
+    """
+    Tests that the layout boxes that give the "real" or "active" axes
+    position are correct.
+    """
+    fig, ax = plt.subplots(figsize=(6, 2), constrained_layout=True)
+    pc = ax.imshow(np.random.randn(60, 30))
+    ax.set_anchor('C')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.left.value(), 0.431273, atol=1e-4)
+    np.testing.assert_allclose(
+        ax._reallayoutbox.bottom.value(), 0.129963, atol=1e-4)
+    ax.set_anchor('E')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.left.value(), 0.855501, atol=1e-4)
+    ax.set_anchor('W')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.left.value(), 0.051981, atol=1e-4)
+
+    # now make so it can move around vertically:
+    ax.set_aspect(0.1)
+    ax.set_anchor('C')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.left.value(), 0.051981, atol=1e-4)
+    np.testing.assert_allclose(
+        ax._reallayoutbox.bottom.value(), 0.217708, atol=1e-4)
+    ax.set_anchor('N')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.bottom.value(), 0.387937, atol=1e-4)
+    ax.set_anchor('S')
+    fig.draw(fig.canvas.get_renderer())
+    np.testing.assert_allclose(
+        ax._reallayoutbox.bottom.value(), 0.129963, atol=1e-4)


### PR DESCRIPTION
## PR Summary

This PR has no user-facing changes but adds a *third* layoutbox to each axes.  There is the parent layout box that encompasses all the elements of the axes, there is the "pos" layout box that is the location where the axes should be placed, and now there is the "real" layout box that takes into account the aspect ratio of the axes. 

This will be needed for constrained layout to make colorbars match the displayed height (width) of their parent axes (#14154).  It will also allow other alignment tasks where the active size of the axes is needed, not just its "position"

### Example:

```python
import matplotlib.pyplot as plt
import numpy as np
import matplotlib._layoutbox as lb

fig, axs = plt.subplots(2, 2, figsize=(6, 6), constrained_layout=True)
asp = [0.1, 0.1, 2, 2]
anch = ['C', 'N', 'C', 'W']
for nn, ax in enumerate(axs.flat):
    pc = ax.imshow(np.random.randn(60, 30))
    ax.set_aspect(asp[nn])
    ax.set_anchor(anch[nn])

lb.plot_children(fig, fig._layoutbox)
plt.show()
```

Note that the purple boxes are properly placed.  Note also that this change doesn't actually *do* anything with the purple boxes; they are being created for information purposes only.  

![asp](https://user-images.githubusercontent.com/1562854/57977232-f4339a80-79a8-11e9-8789-045c587e055f.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->