### PR TITLE
Deprecate string as color sequence

### DIFF
--- a/doc/api/next_api_changes/2019-05-19-TH.rst
+++ b/doc/api/next_api_changes/2019-05-19-TH.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+Using a string of single-character colors as a color sequence (e.g. "rgb") is
+deprecated. Use an explicit list instead.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -286,10 +286,25 @@ def to_rgba_array(c, alpha=None):
         return np.array([to_rgba(c, alpha)], float)
     except (ValueError, TypeError):
         pass
+
     # Convert one at a time.
-    result = np.empty((len(c), 4), float)
-    for i, cc in enumerate(c):
-        result[i] = to_rgba(cc, alpha)
+    if isinstance(c, str):
+        # Single string as color sequence.
+        # This is deprecated and will be removed in the future.
+        try:
+            result = np.array([to_rgba(cc, alpha) for cc in c])
+        except ValueError:
+            raise ValueError(
+                "'%s' is neither a valid single color nor a color sequence "
+                "consisting of single character color specifiers such as "
+                "'rgb'. Note also that the latter is deprecated." % c)
+        else:
+            cbook.warn_deprecated("3.2", message="Using a string of single "
+                                  "character colors as a color sequence is "
+                                  "deprecated. Use an explicit list instead.")
+    else:
+        result = np.array([to_rgba(cc, alpha) for cc in c])
+
     return result
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1954,9 +1954,6 @@ class TestScatter(object):
         # single string:
         ('0.5', None),
         # Single letter-sequences
-        ("rgby", None),
-        ("rgb", "shape"),
-        ("rgbrgb", "shape"),
         (["rgby"], "conversion"),
         # Special cases
         ("red", None),
@@ -3506,7 +3503,6 @@ def test_eventplot_defaults():
     ('0.5',),  # string color with multiple characters: not OK before #8193 fix
     ('tab:orange', 'tab:pink', 'tab:cyan', 'bLacK'),  # case-insensitive
     ('red', (0, 1, 0), None, (1, 0, 1, 0.5)),  # a tricky case mixing types
-    ('rgbk',)  # len('rgbk') == len(data) and each character is a valid color
 ])
 def test_eventplot_colors(colors):
     '''Test the *colors* parameter of eventplot. Inspired by the issue #8193.

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -769,6 +769,23 @@ def test_conversions():
         hex_color
 
 
+def test_to_rgba_array_single_str():
+    # single color name is valid
+    assert_array_equal(mcolors.to_rgba_array("red"), [(1, 0, 0, 1)])
+
+    # single char color sequence is deprecated
+    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+                      match="Using a string of single character colors as a "
+                            "color sequence is deprecated"):
+        array = mcolors.to_rgba_array("rgb")
+    assert_array_equal(array, [(1, 0, 0, 1), (0, 0.5, 0, 1), (0, 0, 1, 1)])
+
+    with pytest.raises(ValueError,
+                       match="neither a valid single color nor a color "
+                             "sequence"):
+        mcolors.to_rgba_array("rgbx")
+
+
 def test_failed_conversions():
     with pytest.raises(ValueError):
         mcolors.to_rgba('5')
@@ -776,6 +793,8 @@ def test_failed_conversions():
         mcolors.to_rgba('-1')
     with pytest.raises(ValueError):
         mcolors.to_rgba('nan')
+    with pytest.raises(ValueError):
+        mcolors.to_rgba('unknown_color')
     with pytest.raises(ValueError):
         # Gray must be a string to distinguish 3-4 grays from RGB or RGBA.
         mcolors.to_rgba(0.4)


### PR DESCRIPTION
## PR Summary

Deprecate string such as 'rgb' as color sequence, As discussed here https://github.com/matplotlib/matplotlib/issues/14122#issuecomment-493702718.

~~~
In [5]: to_rgba_array('rgb')                                                      
/home/tim/anaconda3/envs/mpl/bin/ipython:1: MatplotlibDeprecationWarning: Using a string of single character colors as a color sequence is deprecated. Use an explicit list instead.
  #!/home/tim/anaconda3/envs/mpl/bin/python
Out[5]: 
array([[1. , 0. , 0. , 1. ],
       [0. , 0.5, 0. , 1. ],
       [0. , 0. , 1. , 1. ]])
~~~

Also improves the error message for invalid colors and thus closes #14122:
~~~
In [6]: to_rgba_array('nocolor')                                                  

~/dev/matplotlib/lib/matplotlib/colors.py in _to_rgba_no_colorcycle(c, alpha)
    236             return c, c, c, alpha if alpha is not None else 1.
--> 237         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")
    238     # tuple color.

ValueError: Invalid RGBA argument: 'n'

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
<ipython-input-6-9110a85f9770> in <module>
----> 1 to_rgba_array('nocolor')

~/dev/matplotlib/lib/matplotlib/colors.py in to_rgba_array(c, alpha)
    298                 "'%s' is neither a valid single color nor a color sequence "
    299                 "consisting of single character color specifiers such as "
--> 300                 "'rgb'. Note also that the latter is deprecated." % c)
    301         else:
    302             cbook.warn_deprecated("3.2", message="Using a string of single "

ValueError: 'nocolor' is neither a valid single color nor a color sequence consisting of single character color specifiers such as 'rgb'. Note also that the latter is deprecated.
