### PR TITLE
Make matplotlib.figure.AxesStack private

### DIFF
--- a/doc/api/next_api_changes/2019-05-20-TH.rst
+++ b/doc/api/next_api_changes/2019-05-20-TH.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``matplotlib.figure.AxesStack`` is considered private API and will be removed
+from the public API in future versions.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -51,16 +51,16 @@ def _stale_figure_callback(self, val):
         self.figure.stale = val
 
 
-class AxesStack(cbook.Stack):
+class _AxesStack(cbook.Stack):
     """
     Specialization of the `.Stack` to handle all tracking of
     `~matplotlib.axes.Axes` in a `.Figure`.
     This stack stores ``key, (ind, axes)`` pairs, where:
 
-        * **key** should be a hash of the args and kwargs
-          used in generating the Axes.
-        * **ind** is a serial number for tracking the order
-          in which axes were added.
+    * **key** should be a hash of the args and kwargs
+      used in generating the Axes.
+    * **ind** is a serial number for tracking the order
+      in which axes were added.
 
     The AxesStack is a callable, where ``ax_stack()`` returns
     the current axes. Alternatively the :meth:`current_key_axes` will
@@ -159,6 +159,11 @@ class AxesStack(cbook.Stack):
 
     def __contains__(self, a):
         return a in self.as_list()
+
+
+@cbook.deprecated("3.2")
+class AxesStack(_AxesStack):
+    pass
 
 
 class SubplotParams(object):
@@ -378,7 +383,7 @@ class Figure(Artist):
 
         self.set_tight_layout(tight_layout)
 
-        self._axstack = AxesStack()  # track all figure axes and current axes
+        self._axstack = _AxesStack()  # track all figure axes and current axes
         self.clf()
         self._cachedRenderer = None
 


### PR DESCRIPTION
## PR Summary

This should not be part of the public API. User should only modify the axes through the respective `Figure` or `pyplot` API.

For backward compatibility, the class is still available during a deprecation period.