### PR TITLE
Inset axes bug and docs fix

### DIFF
--- a/doc/api/next_api_changes/2019-05-21-CB.rst
+++ b/doc/api/next_api_changes/2019-05-21-CB.rst
@@ -1,0 +1,13 @@
+``matplotlib.axes.Axes.indicate_inset`` returns a 4-tuple as documented
+-----------------------------------------------------------------------
+
+In <= 3.1.0, ``matplotlib.axes.Axes.indicate_inset`` and
+``matplotlib.axes.Axes.indicate_inset_zoom`` were documented as returning
+a 4-tuple of ``matplotlib.patches.ConnectionPatch`` es, where in fact they
+returned a 4-length list.
+
+They now correctly return a 4-tuple.
+``matplotlib.axes.Axes.indicate_inset`` would previously raise an error if
+the optional *inset_ax* was not supplied; it now completes successfully,
+and returns *None* instead of the tuple of ``ConnectionPatch`` es.
+

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5959,6 +5959,35 @@ def test_tick_padding_tightbbox():
     assert bb.y0 < bb2.y0
 
 
+def test_inset():
+    """
+    Ensure that inset_ax argument is indeed optional
+    """
+    dx, dy = 0.05, 0.05
+    # generate 2 2d grids for the x & y bounds
+    y, x = np.mgrid[slice(1, 5 + dy, dy),
+                    slice(1, 5 + dx, dx)]
+    z = np.sin(x) ** 10 + np.cos(10 + y * x) * np.cos(x)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(x, y, z)
+    ax.set_aspect(1.)
+    ax.apply_aspect()
+    # we need to apply_aspect to make the drawing below work.
+
+    xlim = [1.5, 2.15]
+    ylim = [2, 2.5]
+
+    rect = [xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0]]
+
+    rec, connectors = ax.indicate_inset(bounds=rect)
+    assert connectors is None
+    fig.canvas.draw()
+    xx = np.array([[1.5, 2.],
+                   [2.15, 2.5]])
+    assert np.all(rec.get_bbox().get_points() == xx)
+
+
 def test_zoom_inset():
     dx, dy = 0.05, 0.05
     # generate 2 2d grids for the x & y bounds
@@ -5981,6 +6010,7 @@ def test_zoom_inset():
     axin1.set_aspect(ax.get_aspect())
 
     rec, connectors = ax.indicate_inset_zoom(axin1)
+    assert len(connectors) == 4
     fig.canvas.draw()
     xx = np.array([[1.5,  2.],
                    [2.15, 2.5]])


### PR DESCRIPTION
See #14275 

- Previously, `Axes.indicate_inset` would fail if the optional `inset_ax` argument was not given; now it doesn't. Test included.
- Previously, `Axes.indicate_inset*` methods' docstring incorrectly stated that they returned a tuple; now they correctly state that they return a list (which is empty if `inset_ax` is `None`).

Ideally, I would have preferred them to return a 4-tuple as documented (or `None`, in the case of `indicate_inset` with no `inset_ax`). However, that would technically be a breaking change: bringing the docs in line with the implementation seemed a less contentious idea that bringing the code in line with the docs.

That said, these methods are documented as experimental, so if others agree with my API preference, it may be worth raising a new issue to use tuples instead.