### PR TITLE
Simplify validate_markevery logic.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -580,37 +580,26 @@ def validate_markevery(s):
         length-2 tuple of floats, list of ints
 
     """
-    # Validate s against type slice
-    if isinstance(s, slice):
+    # Validate s against type slice float int and None
+    if isinstance(s, (slice, float, int, type(None))):
         return s
     # Validate s against type tuple
     if isinstance(s, tuple):
-        tupMaxLength = 2
-        tupType = type(s[0])
-        if len(s) != tupMaxLength:
-            raise TypeError("'markevery' tuple must have a length of "
-                            "%d" % (tupMaxLength))
-        if tupType is int and not all(isinstance(e, int) for e in s):
-            raise TypeError("'markevery' tuple with first element of "
-                            "type int must have all elements of type "
-                            "int")
-        if tupType is float and not all(isinstance(e, float) for e in s):
-            raise TypeError("'markevery' tuple with first element of "
-                            "type float must have all elements of type "
-                            "float")
-        if tupType is not float and tupType is not int:
-            raise TypeError("'markevery' tuple contains an invalid type")
+        if (len(s) == 2
+                and (all(isinstance(e, int) for e in s)
+                     or all(isinstance(e, float) for e in s))):
+            return s
+        else:
+            raise TypeError(
+                "'markevery' tuple must be pair of ints or of floats")
     # Validate s against type list
-    elif isinstance(s, list):
-        if not all(isinstance(e, int) for e in s):
-            raise TypeError("'markevery' list must have all elements of "
-                            "type int")
-    # Validate s against type float int and None
-    elif not isinstance(s, (float, int)):
-        if s is not None:
-            raise TypeError("'markevery' is of an invalid type")
-
-    return s
+    if isinstance(s, list):
+        if all(isinstance(e, int) for e in s):
+            return s
+        else:
+            raise TypeError(
+                "'markevery' list must have all elements of type int")
+    raise TypeError("'markevery' is of an invalid type")
 
 
 validate_markeverylist = _listify_validator(validate_markevery)


### PR DESCRIPTION
The tuple clause could even be rewritten to use
`any(... for t in [int, float])` but I don't think that helps
legibility.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
