### PR TITLE
Un-mask any masked offsets

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -149,6 +149,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._uniform_offsets = None
         if offsets is not None:
             offsets = np.asanyarray(offsets, float)
+            offsets = np.ma.filled(offsets, 0)
             # Broadcast (2,) -> (1, 2) but nothing else.
             if offsets.shape == (2,):
                 offsets = offsets[None, :]


### PR DESCRIPTION
Fixes #14265. The problem was because `offsets` to a `Collection` were being given as a masked array, which was causing some values to be converted to `nan` somewhere down the transform call stack, even if none of the values in the masked array were masked. See below for the warning.

Although this does fix the problem, something doesn't feel quite right, but I'm struggling to pin down exactly what the root cause of the problem is. Maybe others will have a better idea though?

```python
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    plt.scatter(x, y)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/pyplot.py", line 2844, in scatter
    None else {}), **kwargs)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/__init__.py", line 1569, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/axes/_axes.py", line 4528, in scatter
    self.add_collection(collection)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/axes/_base.py", line 1897, in add_collection
    self.update_datalim(collection.get_datalim(self.transData))
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/collections.py", line 203, in get_datalim
    result = result.inverse_transformed(transData)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/transforms.py", line 520, in inverse_transformed
    return self.transformed(transform.inverted())
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/transforms.py", line 513, in transformed
    return Bbox([ll, [lr[0], ul[1]]])
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/transforms.py", line 737, in __init__
    points = np.asarray(points, float)
  File "/Users/dstansby/miniconda3/lib/python3.7/site-packages/numpy/core/numeric.py", line 538, in asarray
    return array(a, dtype, copy=False, order=order)
  File "/Users/dstansby/miniconda3/lib/python3.7/site-packages/numpy/ma/core.py", line 4299, in __float__
    warnings.warn("Warning: converting a masked element to nan.", stacklevel=2)
UserWarning: Warning: converting a masked element to nan.
```