### PR TITLE
Fix toolmanager's destroy subplots in tk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -844,8 +844,9 @@ class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
         self.window.protocol("WM_DELETE_WINDOW", self.destroy)
 
     def destroy(self, *args, **kwargs):
-        self.window.destroy()
-        self.window = None
+        if self.window is not None:
+            self.window.destroy()
+            self.window = None
 
 
 class HelpTk(backend_tools.ToolHelpBase):


### PR DESCRIPTION
## PR Summary

Fixes issue raised in https://stackoverflow.com/questions/56220821/python-matplotlib-removing-configure-subplots-tool-from-toolbar-in-matplotlib

Using the Tk backend in conjunction with the `'toolmanager'` toolbar, the following line of code 

     fig.canvas.manager.toolmanager.remove_tool('subplots')

would fail with an error

    AttributeError: 'NoneType' object has no attribute 'destroy'

when being called before any window is instantiated.

This PR checks if `self.window` is None and only attempts to destroy existing windows.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
