### PR TITLE
Fix bug in SymmetricalLogTransform.

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -518,7 +518,8 @@ class InvertedSymmetricalLogTransform(Transform):
         abs_a = np.abs(a)
         with np.errstate(divide="ignore", invalid="ignore"):
             out = np.sign(a) * self.linthresh * (
-                np.power(self.base, abs_a / self.linthresh - self._linscale_adj))
+                np.power(self.base,
+                         abs_a / self.linthresh - self._linscale_adj))
             inside = abs_a <= self.invlinthresh
         out[inside] = a[inside] / self._linscale_adj
         return out

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -489,7 +489,7 @@ class SymmetricalLogTransform(Transform):
         masked = ma.masked_inside(a,
                                   -self.linthresh,
                                   self.linthresh,
-                                  copy=False)
+                                  copy=True)
         log = sign * self.linthresh * (
             self._linscale_adj +
             ma.log(np.abs(masked) / self.linthresh) / self._log_base)
@@ -521,7 +521,7 @@ class InvertedSymmetricalLogTransform(Transform):
     def transform_non_affine(self, a):
         sign = np.sign(a)
         masked = ma.masked_inside(a, -self.invlinthresh,
-                                  self.invlinthresh, copy=False)
+                                  self.invlinthresh, copy=True)
         exp = sign * self.linthresh * (
             ma.power(self.base, (sign * (masked / self.linthresh))
             - self._linscale_adj))

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -485,18 +485,14 @@ class SymmetricalLogTransform(Transform):
         self._log_base = np.log(base)
 
     def transform_non_affine(self, a):
-        sign = np.sign(a)
-        masked = ma.masked_inside(a,
-                                  -self.linthresh,
-                                  self.linthresh,
-                                  copy=True)
-        log = sign * self.linthresh * (
-            self._linscale_adj +
-            ma.log(np.abs(masked) / self.linthresh) / self._log_base)
-        if masked.mask.any():
-            return ma.where(masked.mask, a * self._linscale_adj, log)
-        else:
-            return log
+        abs_a = np.abs(a)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            out = np.sign(a) * self.linthresh * (
+                self._linscale_adj +
+                np.log(abs_a / self.linthresh) / self._log_base)
+            inside = abs_a <= self.linthresh
+        out[inside] = a[inside] * self._linscale_adj
+        return out
 
     def inverted(self):
         return InvertedSymmetricalLogTransform(self.base, self.linthresh,
@@ -519,16 +515,13 @@ class InvertedSymmetricalLogTransform(Transform):
         self._linscale_adj = (linscale / (1.0 - self.base ** -1))
 
     def transform_non_affine(self, a):
-        sign = np.sign(a)
-        masked = ma.masked_inside(a, -self.invlinthresh,
-                                  self.invlinthresh, copy=True)
-        exp = sign * self.linthresh * (
-            ma.power(self.base, (sign * (masked / self.linthresh))
-            - self._linscale_adj))
-        if masked.mask.any():
-            return ma.where(masked.mask, a / self._linscale_adj, exp)
-        else:
-            return exp
+        abs_a = np.abs(a)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            out = np.sign(a) * self.linthresh * (
+                np.power(self.base, abs_a / self.linthresh - self._linscale_adj))
+            inside = abs_a <= self.invlinthresh
+        out[inside] = a[inside] / self._linscale_adj
+        return out
 
     def inverted(self):
         return SymmetricalLogTransform(self.base,

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,9 +1,11 @@
 from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
-from matplotlib.scale import Log10Transform, InvertedLog10Transform
+from matplotlib.scale import (Log10Transform, InvertedLog10Transform,
+                              SymmetricalLogTransform)
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 import numpy as np
+from numpy.testing import assert_allclose
 import io
 import platform
 import pytest
@@ -20,6 +22,33 @@ def test_log_scales(fig_test, fig_ref):
     ax_ref.set(xlim=xlim, ylim=ylim)
     ax_ref.plot([24.1, 24.1], ylim, 'b')
     ax_ref.plot(xlim, [24.1, 24.1], 'b')
+
+
+def test_symlog_mask_nan():
+    # Use a transform round-trip to verify that the forward and inverse
+    # transforms work, and that they respect nans and/or masking.
+    slt = SymmetricalLogTransform(10, 2, 1)
+    slti = slt.inverted()
+
+    x = np.arange(-1.5, 5, 0.5)
+    out = slti.transform_non_affine(slt.transform_non_affine(x))
+    assert_allclose(out, x)
+    assert type(out) == type(x)
+
+    x[4] = np.nan
+    out = slti.transform_non_affine(slt.transform_non_affine(x))
+    assert_allclose(out, x)
+    assert type(out) == type(x)
+
+    x = np.ma.array(x)
+    out = slti.transform_non_affine(slt.transform_non_affine(x))
+    assert_allclose(out, x)
+    assert type(out) == type(x)
+
+    x[3] = np.ma.masked
+    out = slti.transform_non_affine(slt.transform_non_affine(x))
+    assert_allclose(out, x)
+    assert type(out) == type(x)
 
 
 @image_comparison(['logit_scales.png'], remove_text=True)


### PR DESCRIPTION
By failing the copy the input array, SymmetricalLogTransform.transform_non_affine
was returning an array with points in the linear range masked.
Closes #14265.   Replaces #14281.

In addition to fixing the bug, this re-implements the SymmetricalLogTransform and its
inverse so that they gracefully handle ndarrays and masked arrays, returning outputs
of the same type as their inputs.

A test is added to check this, and to verify that a round-trip returns the input values.

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
