### PR TITLE
travis: add c code coverage measurements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,12 +161,16 @@ install:
 
   # Set flag in a delayed manner to avoid issues with installing other packages
   - |
-    if [[ $RUN_PYTEST == 1 ]]; then
+    if [[ $TRAVIS_OS_NAME != 'osx' ]] && [[ $RUN_PYTEST == 1 ]]; then
       export CPPFLAGS=--coverage
     fi
   - |
     # Install matplotlib
     python -mpip install -ve .
+  - |
+    if [[ $TRAVIS_OS_NAME != 'osx' ]] && [[ $RUN_PYTEST == 1 ]]; then
+      unset CPPFLAGS
+    fi
 
 before_script: |
   if [[ $DELETE_FONT_CACHE == 1 ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
       - gir1.2-gtk-3.0
       - graphviz
       - inkscape
+      - lcov
       - libcairo2
       - libcairo2-dev
       - libffi-dev
@@ -86,11 +87,14 @@ matrix:
         - EXTRAREQS='-r requirements/testing/travis_flake8.txt'
     - python: 3.6
       env:
+        - CPPFLAGS=--coverage
         - PINNEDVERS='-c requirements/testing/travis36minver.txt'
         - DELETE_FONT_CACHE=1
         - EXTRAREQS='-r requirements/testing/travis36.txt'
     - python: 3.7
       sudo: true
+      env:
+        - CPPFLAGS=--coverage
     - python: "nightly"
       env:
         - PRE=--pre
@@ -194,4 +198,8 @@ after_failure: |
   fi
 
 after_success: |
-  codecov -e TRAVIS_PYTHON_VERSION
+  - lcov --capture --directory . --output-file coverage.info
+  - lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
+  - lcov --list coverage.info
+  # Uploading to CodeCov but excluding gcov reports
+  - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,7 @@ after_failure: |
     echo "The result images will only be uploaded if they are on the matplotlib/matplotlib repo - this is for security reasons to prevent arbitrary PRs echoing security details."
   fi
 
-after_success: |
+after_success:
   - lcov --capture --directory . --output-file coverage.info
   - lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
   - lcov --list coverage.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,7 @@ after_failure: |
 
 after_success:
   - lcov --capture --directory . --output-file coverage.info
-  - lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
+  - lcov --remove coverage.info --output-file coverage.info '/usr/*' '/home/travis/build/matplotlib/matplotlib/build/*' '/home/travis/build/matplotlib/matplotlib/extern/*' # filter system-files
   - lcov --list coverage.info
   # Uploading to CodeCov but excluding gcov reports
-  - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov || echo "Codecov did not collect coverage reports"
+  - bash <(curl -s https://codecov.io/bash) -f "!*.gcov" -X gcov -e TRAVIS_PYTHON_VERSION|| echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,14 +87,11 @@ matrix:
         - EXTRAREQS='-r requirements/testing/travis_flake8.txt'
     - python: 3.6
       env:
-        - CPPFLAGS=--coverage
         - PINNEDVERS='-c requirements/testing/travis36minver.txt'
         - DELETE_FONT_CACHE=1
         - EXTRAREQS='-r requirements/testing/travis36.txt'
     - python: 3.7
       sudo: true
-      env:
-        - CPPFLAGS=--coverage
     - python: "nightly"
       env:
         - PRE=--pre
@@ -162,6 +159,11 @@ install:
       echo 'wxPython is available' ||
       echo 'wxPython is not available'
 
+  # Set flag in a delayed manner to avoid issues with installing other packages
+  - |
+    if [[ $RUN_PYTEST == 1 ]]; then
+      export CPPFLAGS=--coverage
+    fi
   - |
     # Install matplotlib
     python -mpip install -ve .

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -1,6 +1,5 @@
 # pip requirements for all the travis builds
 
-codecov
 coverage
 cycler
 numpy


### PR DESCRIPTION
## PR Summary

Add c-code coverage measurement when testing under linux on Travis. Coverage uses lcov which allows to specify lines that should be ignored, contrary to gcov.

I will monitor the build and the coverage report to make sure they make sense before requesting a review.