### PR TITLE
Improve error message for kiwisolver import error (DLL load failed)

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -192,17 +192,7 @@ def _check_versions():
             ("numpy", "1.11"),
             ("pyparsing", "2.0.1"),
     ]:
-        try:
-            module = importlib.import_module(modname)
-        except ImportError as error:
-            if sys.platform == 'win32' and 'DLL' in error.msg:
-                msg = ('You may be missing MIcrosoft Visual C++ '
-                       'redistributable matching your Python version. '
-                       'Consult Kiwisolver documentation for more details')
-                raise ImportError(msg) from error
-            else:
-                raise
-
+        module = importlib.import_module(modname)
         if LooseVersion(module.__version__) < minver:
             raise ImportError("Matplotlib requires {}>={}; you have {}"
                               .format(modname, minver, module.__version__))

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -185,6 +185,11 @@ def compare_versions(a, b):
 
 
 def _check_versions():
+
+    # Quickfix to ensure Microsoft Visual C++ redistributable
+    # DLLs are loaded before importing kiwisolver
+    from . import ft2font
+
     for modname, minver in [
             ("cycler", "0.10"),
             ("dateutil", "2.1"),

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -192,7 +192,17 @@ def _check_versions():
             ("numpy", "1.11"),
             ("pyparsing", "2.0.1"),
     ]:
-        module = importlib.import_module(modname)
+        try:
+            module = importlib.import_module(modname)
+        except ImportError as error:
+            if sys.platform == 'win32' and 'DLL' in error.msg:
+                msg = ('You may be missing MIcrosoft Visual C++ '
+                       'redistributable matching your Python version. '
+                       'Consult Kiwisolver documentation for more details')
+                raise ImportError(msg) from error
+            else:
+                raise
+
         if LooseVersion(module.__version__) < minver:
             raise ImportError("Matplotlib requires {}>={}; you have {}"
                               .format(modname, minver, module.__version__))


### PR DESCRIPTION
Installing matplotlib with pip on a fresh/clean installation of Windows might fail with an unhelpful `ImportError: DLL load failed`. One reason for this could be missing Microsoft Visual C++ Redistributable dependencies. This PR adds a check for this condition and provides a more helpful error message if the import fails.

Tested on Windows 10 64bit, Python 3.7.3. The import error is caught and the helpful error message displayed. To test this I was unable to use `pip install -e .` from within the clone of the repo, because then the missing dependency is already an issue when building `matplotlib.ft2font`. To work around this I installed matplotlib from pypi `pip install matplotlib` (which does not perform the build) then replaced `my-vevn/Lib/site-packages/matplotlib/__init__.py` with my patched `__init__.py`.

I haven't written any pytest style tests for this, I have close to no idea how to mock the ImportError or simulate the missing dependency.

Thank you @MatthieuDartiailh for your input (https://github.com/nucleic/kiwi/issues/69).
