### PR TITLE
Backport PR #14295: Fix bug in SymmetricalLogTransform.

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -486,18 +486,14 @@ class SymmetricalLogTransform(Transform):
         self._log_base = np.log(base)
 
     def transform_non_affine(self, a):
-        sign = np.sign(a)
-        masked = ma.masked_inside(a,
-                                  -self.linthresh,
-                                  self.linthresh,
-                                  copy=False)
-        log = sign * self.linthresh * (
-            self._linscale_adj +
-            ma.log(np.abs(masked) / self.linthresh) / self._log_base)
-        if masked.mask.any():
-            return ma.where(masked.mask, a * self._linscale_adj, log)
-        else:
-            return log
+        abs_a = np.abs(a)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            out = np.sign(a) * self.linthresh * (
+                self._linscale_adj +
+                np.log(abs_a / self.linthresh) / self._log_base)
+            inside = abs_a <= self.linthresh
+        out[inside] = a[inside] * self._linscale_adj
+        return out
 
     def inverted(self):
         return InvertedSymmetricalLogTransform(self.base, self.linthresh,
@@ -520,16 +516,14 @@ class InvertedSymmetricalLogTransform(Transform):
         self._linscale_adj = (linscale / (1.0 - self.base ** -1))
 
     def transform_non_affine(self, a):
-        sign = np.sign(a)
-        masked = ma.masked_inside(a, -self.invlinthresh,
-                                  self.invlinthresh, copy=False)
-        exp = sign * self.linthresh * (
-            ma.power(self.base, (sign * (masked / self.linthresh))
-            - self._linscale_adj))
-        if masked.mask.any():
-            return ma.where(masked.mask, a / self._linscale_adj, exp)
-        else:
-            return exp
+        abs_a = np.abs(a)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            out = np.sign(a) * self.linthresh * (
+                np.power(self.base,
+                         abs_a / self.linthresh - self._linscale_adj))
+            inside = abs_a <= self.invlinthresh
+        out[inside] = a[inside] / self._linscale_adj
+        return out
 
     def inverted(self):
         return SymmetricalLogTransform(self.base,


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
