### PR TITLE
Correctly apply PNG palette when building ImageBase through Pillow.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -665,8 +665,15 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         Parameters
         ----------
-        A : array-like
+        A : array-like or `PIL.Image.Image`
         """
+        try:
+            from PIL import Image
+        except ImportError:
+            pass
+        else:
+            if isinstance(A, Image.Image):
+                A = pil_to_array(A)  # Needed e.g. to apply png palette.
         self._A = cbook.safe_masked_invalid(A, copy=True)
 
         if (self._A.dtype != np.uint8 and

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -14,7 +14,7 @@ from numpy import ma
 from numpy.testing import assert_array_equal
 
 from matplotlib import (
-    colors, image as mimage, patches, pyplot as plt,
+    colors, image as mimage, patches, pyplot as plt, style,
     rc_context, rcParams)
 from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
@@ -117,11 +117,16 @@ def test_image_python_io():
 
 @check_figures_equal()
 def test_imshow_pil(fig_test, fig_ref):
-    pytest.importorskip("PIL")
-    img = plt.imread(os.path.join(os.path.dirname(__file__),
-                     'baseline_images', 'test_image', 'uint16.tif'))
-    fig_test.subplots().imshow(img)
-    fig_ref.subplots().imshow(np.asarray(img))
+    style.use("default")
+    PIL = pytest.importorskip("PIL")
+    png_path = Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png"
+    tiff_path = Path(__file__).parent / "baseline_images/test_image/uint16.tif"
+    axs = fig_test.subplots(2)
+    axs[0].imshow(PIL.Image.open(png_path))
+    axs[1].imshow(PIL.Image.open(tiff_path))
+    axs = fig_ref.subplots(2)
+    axs[0].imshow(plt.imread(str(png_path)))
+    axs[1].imshow(plt.imread(tiff_path))
 
 
 def test_imread_pil_uint16():


### PR DESCRIPTION
## PR Summary

Closes #14293.
A test would be nice but I would prefer *not* adding a test image (as usual), so I'd need to think more about the best way to do it.  In the meantime, the fact that this closes #14293 can be checked manually...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
