### PR TITLE
Remove explicit inheritance from object

### DIFF
--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -43,7 +43,7 @@ def get_renderer(fig):
     return renderer
 
 
-class LayoutBox(object):
+class LayoutBox:
     """
     Basic rectangle representation using kiwi solver variables
     """

--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -6,7 +6,7 @@ import atexit
 import gc
 
 
-class Gcf(object):
+class Gcf:
     """
     Singleton to manage a set of integer-numbered figures.
 

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -393,7 +393,7 @@ def _parse_afm(fh):
     return header, cmetrics_by_ascii, cmetrics_by_name, kernpairs, composites
 
 
-class AFM(object):
+class AFM:
 
     def __init__(self, fh):
         """Parse the AFM file in file object *fh*."""

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -93,7 +93,7 @@ def adjusted_figsize(w, h, dpi, n):
 
 
 # A registry for available MovieWriter classes
-class MovieWriterRegistry(object):
+class MovieWriterRegistry:
     '''Registry of available writer classes by human readable name.'''
     def __init__(self):
         self.avail = dict()
@@ -576,7 +576,7 @@ class PillowWriter(MovieWriter):
 
 # Base class of ffmpeg information. Has the config keys and the common set
 # of arguments that controls the *output* side of things.
-class FFMpegBase(object):
+class FFMpegBase:
     '''Mixin class for FFMpeg output.
 
     To be useful this must be multiply-inherited from with a
@@ -696,7 +696,7 @@ class AVConvFileWriter(AVConvBase, FFMpegFileWriter):
 
 
 # Base class for animated GIFs with ImageMagick
-class ImageMagickBase(object):
+class ImageMagickBase:
     '''Mixin class for ImageMagick output.
 
     To be useful this must be multiply-inherited from with a
@@ -880,7 +880,7 @@ class HTMLWriter(FileMovieWriter):
                                              **mode_dict))
 
 
-class Animation(object):
+class Animation:
     '''This class wraps the creation of an animation using matplotlib.
 
     It is only a base class which should be subclassed to provide

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -54,7 +54,7 @@ def _stale_axes_callback(self, val):
 _XYPair = namedtuple("_XYPair", "x y")
 
 
-class Artist(object):
+class Artist:
     """
     Abstract base class for objects that render into a FigureCanvas.
 
@@ -1168,7 +1168,7 @@ class Artist(object):
                 ax._mouseover_set.discard(self)
 
 
-class ArtistInspector(object):
+class ArtistInspector:
     """
     A helper class to inspect an `~matplotlib.artist.Artist` and return
     information about its settable properties and their current values.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -114,7 +114,7 @@ def _process_plot_format(fmt):
     return linestyle, marker, color
 
 
-class _process_plot_var_args(object):
+class _process_plot_var_args:
     """
     Process variable length arguments to the plot command, so that
     plot commands like the following are supported::

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -8,7 +8,7 @@ from matplotlib.gridspec import GridSpec, SubplotSpec
 import matplotlib._layoutbox as layoutbox
 
 
-class SubplotBase(object):
+class SubplotBase:
     """
     Base class for subplots, which are :class:`Axes` instances with
     additional methods to facilitate generating and manipulating a set

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -628,7 +628,7 @@ class YTick(Tick):
         return self.axes.viewLim.intervaly
 
 
-class Ticker(object):
+class Ticker:
     """
     A container for the objects defining tick position and format.
 
@@ -671,7 +671,7 @@ class Ticker(object):
         self._formatter = formatter
 
 
-class _LazyTickList(object):
+class _LazyTickList:
     """
     A descriptor for lazy instantiation of tick lists.
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -127,7 +127,7 @@ def get_registered_canvas_class(format):
     return backend_class
 
 
-class RendererBase(object):
+class RendererBase:
     """An abstract base class to handle drawing/rendering operations.
 
     The following methods must be implemented in the backend for full
@@ -712,7 +712,7 @@ class RendererBase(object):
         """
 
 
-class GraphicsContextBase(object):
+class GraphicsContextBase:
     """An abstract base class that provides color, line styles, etc."""
 
     def __init__(self):
@@ -1032,7 +1032,7 @@ class GraphicsContextBase(object):
             else (scale, length or 128., randomness or 16.))
 
 
-class TimerBase(object):
+class TimerBase:
     """
     A base class for providing timer events, useful for things animations.
     Backends need to implement a few specific methods in order to use their
@@ -1203,7 +1203,7 @@ class TimerBase(object):
             self.stop()
 
 
-class Event(object):
+class Event:
     """
     A matplotlib event.  Attach additional attributes as defined in
     :meth:`FigureCanvasBase.mpl_connect`.  The following attributes
@@ -1552,7 +1552,7 @@ def _get_renderer(figure, print_method):
             return figure._cachedRenderer
 
 
-class FigureCanvasBase(object):
+class FigureCanvasBase:
     """
     The canvas the figure renders into.
 
@@ -2466,7 +2466,7 @@ class NonGuiException(Exception):
     pass
 
 
-class FigureManagerBase(object):
+class FigureManagerBase:
     """
     Helper class for pyplot mode, wraps everything up into a neat bundle
 
@@ -2567,7 +2567,7 @@ class FigureManagerBase(object):
 cursors = tools.cursors
 
 
-class NavigationToolbar2(object):
+class NavigationToolbar2:
     """
     Base class for the navigation cursor, version 2
 
@@ -3079,7 +3079,7 @@ class NavigationToolbar2(object):
         """Enable or disable the back/forward button."""
 
 
-class ToolContainerBase(object):
+class ToolContainerBase:
     """
     Base class for all tool containers, e.g. toolbars.
 
@@ -3223,7 +3223,7 @@ class ToolContainerBase(object):
         raise NotImplementedError
 
 
-class StatusbarBase(object):
+class StatusbarBase:
     """Base class for the statusbar"""
     def __init__(self, toolmanager):
         self.toolmanager = toolmanager
@@ -3246,7 +3246,7 @@ class StatusbarBase(object):
         pass
 
 
-class _Backend(object):
+class _Backend:
     # A backend can be defined by using the following pattern:
     #
     # @_Backend.export

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -8,7 +8,7 @@ import matplotlib.backend_tools as tools
 _log = logging.getLogger(__name__)
 
 
-class ToolEvent(object):
+class ToolEvent:
     """Event for tool manipulation (add/remove)."""
     def __init__(self, name, sender, tool, data=None):
         self.name = name
@@ -24,7 +24,7 @@ class ToolTriggerEvent(ToolEvent):
         self.canvasevent = canvasevent
 
 
-class ToolManagerMessageEvent(object):
+class ToolManagerMessageEvent:
     """
     Event carrying messages from toolmanager.
 
@@ -36,7 +36,7 @@ class ToolManagerMessageEvent(object):
         self.message = message
 
 
-class ToolManager(object):
+class ToolManager:
     """
     Manager for actions triggered by user interactions (key press, toolbar
     clicks, ...) on a Figure.

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -36,7 +36,7 @@ cursors = Cursors  # Backcompat.
 _views_positions = 'viewpos'
 
 
-class ToolBase(object):
+class ToolBase:
     """
     Base tool class
 

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -645,7 +645,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             NavigationToolbar2.update(self)
 
 
-class ToolTip(object):
+class ToolTip:
     """
     Tooltip recipe from
     http://www.voidspace.org.uk/python/weblog/arch_d7_2006_07_01.shtml#e387

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -4,7 +4,7 @@ from matplotlib.backends.backend_agg import RendererAgg
 from matplotlib.tight_bbox import process_figure_for_rasterizing
 
 
-class MixedModeRenderer(object):
+class MixedModeRenderer:
     """
     A helper class to implement a renderer that switches between
     vector and raster drawing.  An example may be a PDF writer, where

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -148,7 +148,7 @@ class FigureCanvasNbAgg(FigureCanvasWebAggCore):
         return TimerTornado(*args, **kwargs)
 
 
-class CommSocket(object):
+class CommSocket:
     """
     Manages the Comm connection between IPython and the browser (client).
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -223,7 +223,7 @@ def pdfRepr(obj):
                         .format(type(obj)))
 
 
-class Reference(object):
+class Reference:
     """PDF reference object.
     Use PdfFile.reserveObject() to create References.
     """
@@ -245,7 +245,7 @@ class Reference(object):
 
 
 @total_ordering
-class Name(object):
+class Name:
     """PDF name object."""
     __slots__ = ('name',)
     _regex = re.compile(r'[^!-~]')
@@ -281,7 +281,7 @@ class Name(object):
         return b'/' + self.name
 
 
-class Operator(object):
+class Operator:
     """PDF operator object."""
     __slots__ = ('op',)
 
@@ -295,7 +295,7 @@ class Operator(object):
         return self.op
 
 
-class Verbatim(object):
+class Verbatim:
     """Store verbatim PDF command content for later inclusion in the
     stream."""
     def __init__(self, x):
@@ -339,7 +339,7 @@ def _paint_path(fill, stroke):
 Op.paint_path = _paint_path
 
 
-class Stream(object):
+class Stream:
     """PDF stream object.
 
     This has no pdfRepr method. Instead, call begin(), then output the
@@ -420,7 +420,7 @@ class Stream(object):
             self.compressobj = None
 
 
-class PdfFile(object):
+class PdfFile:
     """PDF file object."""
 
     def __init__(self, filename, metadata=None):
@@ -2324,7 +2324,7 @@ class GraphicsContextPdf(GraphicsContextBase):
 ########################################################################
 
 
-class PdfPages(object):
+class PdfPages:
     """
     A multi-page PDF file.
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -42,7 +42,7 @@ backend_version = 'Level II'
 debugPS = 0
 
 
-class PsBackendHelper(object):
+class PsBackendHelper:
 
     def __init__(self):
         self._cached = {}
@@ -950,7 +950,7 @@ class FigureCanvasPS(FigureCanvasBase):
         self.figure.set_edgecolor(edgecolor)
 
         if dryrun:
-            class NullWriter(object):
+            class NullWriter:
                 def write(self, *args, **kwargs):
                     pass
 
@@ -1148,7 +1148,7 @@ class FigureCanvasPS(FigureCanvasBase):
         self.figure.set_edgecolor(edgecolor)
 
         if dryrun:
-            class NullWriter(object):
+            class NullWriter:
                 def write(self, *args, **kwargs):
                     pass
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -96,7 +96,7 @@ def short_float_fmt(x):
     return '{0:f}'.format(x).rstrip('0').rstrip('.')
 
 
-class XMLWriter(object):
+class XMLWriter:
     """
     Parameters
     ----------

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -57,7 +57,7 @@ def debug_on_error(type, value, tb):
 
 
 @cbook.deprecated("3.1")
-class fake_stderr(object):
+class fake_stderr:
     """
     Wx does strange things with stderr, as it makes the assumption that
     there is probably no console. This redirects stderr to the console, since

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -145,7 +145,7 @@ def find_bezier_t_intersecting_with_closedpath(
             start_inside = middle_inside
 
 
-class BezierSegment(object):
+class BezierSegment:
     """
     A simple class of a 2-dimensional bezier segment
     """

--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -27,7 +27,7 @@ import matplotlib.lines as mlines
 _log = logging.getLogger(__name__)
 
 
-class BlockingInput(object):
+class BlockingInput:
     """Callable for retrieving events in a blocking way."""
 
     def __init__(self, fig, eventslist=()):

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -155,7 +155,7 @@ class StrCategoryFormatter(ticker.Formatter):
         return value
 
 
-class UnitData(object):
+class UnitData:
     def __init__(self, data=None):
         """
         Create mapping between unique categorical values and integer ids.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -61,7 +61,7 @@ class _StrongRef:
         return hash(self._obj)
 
 
-class CallbackRegistry(object):
+class CallbackRegistry:
     """Handle registering and disconnecting for a set of signals and callbacks:
 
         >>> def oneat(x):
@@ -544,7 +544,7 @@ class maxdict(dict):
         dict.__setitem__(self, k, v)
 
 
-class Stack(object):
+class Stack:
     """
     Stack of elements with a movable cursor.
 
@@ -766,7 +766,7 @@ def print_cycles(objects, outstream=sys.stdout, show_progress=False):
         recurse(obj, obj, {}, [])
 
 
-class Grouper(object):
+class Grouper:
     """
     This class provides a lightweight way to group arbitrary objects
     together into disjoint sets when a full-blown graph data structure
@@ -781,7 +781,7 @@ class Grouper(object):
     For example:
 
         >>> from matplotlib.cbook import Grouper
-        >>> class Foo(object):
+        >>> class Foo:
         ...     def __init__(self, s):
         ...         self.s = s
         ...     def __repr__(self):

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -177,7 +177,7 @@ def get_cmap(name=None, lut=None):
         return cmap_d[name]._resample(lut)
 
 
-class ScalarMappable(object):
+class ScalarMappable:
     """
     This is a mixin class to support scalar data to RGBA mapping.
     The ScalarMappable makes use of data normalization before returning

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -309,7 +309,7 @@ class _ColorbarLogLocator(ticker.LogLocator):
         return ticks
 
 
-class _ColorbarMappableDummy(object):
+class _ColorbarMappableDummy:
     """
     Private class to hold deprecated ColorbarBase methods that used to be
     inhereted from ScalarMappable.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -344,7 +344,7 @@ rgb2hex = to_hex
 hex2color = to_rgb
 
 
-class ColorConverter(object):
+class ColorConverter:
     """
     This class is only kept for backwards compatibility.
 
@@ -468,7 +468,7 @@ def makeMappingArray(N, data, gamma=1.0):
     return _create_lookup_table(N, data, gamma)
 
 
-class Colormap(object):
+class Colormap:
     """
     Baseclass for all scalar to RGBA mappings.
 
@@ -911,7 +911,7 @@ class ListedColormap(Colormap):
         return ListedColormap(colors_r, name=name, N=self.N)
 
 
-class Normalize(object):
+class Normalize:
     """
     A class which, when called, can normalize data into
     the ``[0.0, 1.0]`` interval.
@@ -1568,7 +1568,7 @@ def _vector_magnitude(arr):
     return np.sqrt(sum_sq)
 
 
-class LightSource(object):
+class LightSource:
     """
     Create a light source coming from the specified azimuth and elevation.
     Angles are in degrees, with the azimuth measured

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -45,7 +45,7 @@ class ClabelText(text.Text):
         return new_angle
 
 
-class ContourLabeler(object):
+class ContourLabeler:
     """Mixin to provide labelling capability to `.ContourSet`."""
 
     def clabel(self, levels=None, *,

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -315,7 +315,7 @@ _from_ordinalf_np_vectorized = np.vectorize(_from_ordinalf)
 
 @cbook.deprecated(
     "3.1", alternative="time.strptime or dateutil.parser.parse or datestr2num")
-class strpdate2num(object):
+class strpdate2num:
     """
     Use this class to parse date strings to matplotlib datenums when
     you know the date format string of the date you are parsing.
@@ -936,7 +936,7 @@ class AutoDateFormatter(ticker.Formatter):
         return result
 
 
-class rrulewrapper(object):
+class rrulewrapper:
     def __init__(self, freq, tzinfo=None, **kwargs):
         kwargs['freq'] = freq
         self._base_tzinfo = tzinfo

--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -3,7 +3,7 @@ import inspect
 from matplotlib import cbook
 
 
-class Substitution(object):
+class Substitution:
     """
     A decorator that performs %-substitution on an object's docstring.
 
@@ -60,7 +60,7 @@ class Substitution(object):
 
 
 @cbook.deprecated("3.1")
-class Appender(object):
+class Appender:
     """
     A function decorator that will append an addendum to the docstring
     of the target function.

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -169,7 +169,7 @@ def _dispatch(table, min, max=None, state=None, args=('raw',)):
     return decorate
 
 
-class Dvi(object):
+class Dvi:
     """
     A reader for a dvi ("device-independent") file, as produced by TeX.
     The current implementation can only iterate through pages in order,
@@ -486,7 +486,7 @@ class Dvi(object):
         raise ValueError("unknown command: byte %d", 250 + offset)
 
 
-class DviFont(object):
+class DviFont:
     """
     Encapsulation of a font that a DVI file can refer to.
 
@@ -700,7 +700,7 @@ def _mul2012(num1, num2):
     return (num1*num2) >> 20
 
 
-class Tfm(object):
+class Tfm:
     """
     A TeX Font Metric file.
 
@@ -755,7 +755,7 @@ class Tfm(object):
 PsFont = namedtuple('Font', 'texname psname effects encoding filename')
 
 
-class PsfontsMap(object):
+class PsfontsMap:
     """
     A psfonts.map formatted file, mapping TeX fonts to PS fonts.
 
@@ -923,7 +923,7 @@ class PsfontsMap(object):
                 encoding=encoding, filename=filename)
 
 
-class Encoding(object):
+class Encoding:
     r"""
     Parses a \*.enc file referenced from a psfonts.map style file.
     The format this class understands is a very limited subset of

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -166,7 +166,7 @@ class AxesStack(_AxesStack):
     pass
 
 
-class SubplotParams(object):
+class SubplotParams:
     """
     A class to hold the parameters for a subplot.
     """

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -316,7 +316,7 @@ def findSystemFonts(fontpaths=None, fontext='ttf'):
     return [fname for fname in fontfiles if os.path.exists(fname)]
 
 
-class FontEntry(object):
+class FontEntry:
     """
     A class for storing Font properties.  It is used when populating
     the font lookup dictionary.
@@ -554,7 +554,7 @@ def createFontList(fontfiles, fontext='ttf'):
     return fontlist
 
 
-class FontProperties(object):
+class FontProperties:
     """
     A class for storing and manipulating font properties.
 
@@ -926,7 +926,7 @@ def _normalize_font_family(family):
     return family
 
 
-class FontManager(object):
+class FontManager:
     """
     On import, the :class:`FontManager` singleton instance creates a
     list of TrueType fonts based on the font properties: name, style,

--- a/lib/matplotlib/fontconfig_pattern.py
+++ b/lib/matplotlib/fontconfig_pattern.py
@@ -27,7 +27,7 @@ value_unescape = re.compile(r'\\([%s])' % value_punc).sub
 value_escape = re.compile(r'([%s])' % value_punc).sub
 
 
-class FontconfigPatternParser(object):
+class FontconfigPatternParser:
     """
     A simple pyparsing-based parser for `fontconfig patterns`_.
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -26,7 +26,7 @@ import matplotlib._layoutbox as layoutbox
 _log = logging.getLogger(__name__)
 
 
-class GridSpecBase(object):
+class GridSpecBase:
     """
     A base class of GridSpec that specifies the geometry of the grid
     that a subplot will be placed.
@@ -408,7 +408,7 @@ class GridSpecFromSubplotSpec(GridSpecBase):
         return self._subplot_spec.get_topmost_subplotspec()
 
 
-class SubplotSpec(object):
+class SubplotSpec:
     """Specifies the location of the subplot in the given `GridSpec`.
     """
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib.path import Path
 
 
-class HatchPatternBase(object):
+class HatchPatternBase:
     """
     The base class for a hatch pattern.
     """

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -40,7 +40,7 @@ def update_from_first_child(tgt, src):
         tgt.update_from(first_child)
 
 
-class HandlerBase(object):
+class HandlerBase:
     """
     A Base class for default legend handlers.
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1448,7 +1448,7 @@ class Line2D(Artist):
         return self._linestyle in ('--', '-.', ':')
 
 
-class VertexSelector(object):
+class VertexSelector:
     """
     Manage the callbacks to maintain a list of selected vertices for
     :class:`matplotlib.lines.Line2D`. Derived classes should override

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -162,7 +162,7 @@ from .transforms import IdentityTransform, Affine2D
 _empty_path = Path(np.empty((0, 2)))
 
 
-class MarkerStyle(object):
+class MarkerStyle:
 
     markers = {
         '.': 'point',

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -81,7 +81,7 @@ def get_unicode_index(symbol, math=True):
             .format(symbol))
 
 
-class MathtextBackend(object):
+class MathtextBackend:
     """
     The base class for the mathtext backend-specific code.  The
     purpose of :class:`MathtextBackend` subclasses is to interface
@@ -380,7 +380,7 @@ class MathtextBackendCairo(MathtextBackend):
                 self.rects)
 
 
-class Fonts(object):
+class Fonts:
     """
     An abstract base class for a system of fonts to use for mathtext.
 
@@ -1239,7 +1239,7 @@ GROW_FACTOR     = 1.0 / SHRINK_FACTOR
 NUM_SIZE_LEVELS = 6
 
 
-class FontConstantsBase(object):
+class FontConstantsBase:
     """
     A set of constants that controls how certain things, such as sub-
     and superscripts are laid out.  These are all metrics that can't
@@ -1351,7 +1351,7 @@ class MathTextWarning(Warning):
     pass
 
 
-class Node(object):
+class Node:
     """
     A node in the TeX box model
     """
@@ -1860,7 +1860,7 @@ class Glue(Node):
             self.glue_spec.width *= GROW_FACTOR
 
 
-class GlueSpec(object):
+class GlueSpec:
     """
     See :class:`Glue`.
     """
@@ -2064,7 +2064,7 @@ class AutoWidthChar(Hlist):
         self.width = char.width
 
 
-class Ship(object):
+class Ship:
     """
     Once the boxes have been set up, this sends them to output.  Since
     boxes can be inside of boxes inside of boxes, the main work of
@@ -2233,7 +2233,7 @@ def Error(msg):
     return empty
 
 
-class Parser(object):
+class Parser:
     """
     This is the pyparsing-based parser for math expressions.  It
     actually parses full strings *containing* math expressions, in
@@ -2592,7 +2592,7 @@ class Parser(object):
     # entering and leaving a group { } or math/non-math, the stack
     # is pushed and popped accordingly.  The current state always
     # exists in the top element of the stack.
-    class State(object):
+    class State:
         """
         Stores the state of the parser.
 
@@ -3289,7 +3289,7 @@ class Parser(object):
 # MAIN
 
 
-class MathTextParser(object):
+class MathTextParser:
     _parser = None
 
     _backend_mapping = {

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1399,7 +1399,7 @@ def _csv2rec(fname, comments='#', skiprows=0, checkrows=0, delimiter=',',
     return r
 
 
-class GaussianKDE(object):
+class GaussianKDE:
     """
     Representation of a kernel-density estimate using Gaussian kernels.
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1594,7 +1594,7 @@ class AnnotationBbox(martist.Artist, _AnnotationBase):
         self.stale = False
 
 
-class DraggableBase(object):
+class DraggableBase:
     """
     helper code for a draggable artist (legend, offsetbox)
     The derived class must override following two method.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1788,7 +1788,7 @@ def _simpleprint_styles(_styles):
     return "[{}]".format("|".join(map(" '{}' ".format, sorted(_styles))))
 
 
-class _Style(object):
+class _Style:
     """
     A base class for the Styles. It is meant to be a container class,
     where actual styles are declared as subclass of it, and it
@@ -1888,7 +1888,7 @@ class BoxStyle(_Style):
 
     _style_list = {}
 
-    class _Base(object):
+    class _Base:
         """
         :class:`BBoxTransmuterBase` and its derivatives are used to make a
         fancy box around a given rectangle. The :meth:`__call__` method
@@ -2629,7 +2629,7 @@ class ConnectionStyle(_Style):
 
     _style_list = {}
 
-    class _Base(object):
+    class _Base:
         """
         A base class for connectionstyle classes. The subclass needs
         to implement a *connect* method whose call signature is::
@@ -3071,7 +3071,7 @@ class ArrowStyle(_Style):
 
     _style_list = {}
 
-    class _Base(object):
+    class _Base:
         """
         Arrow Transmuter Base class
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -18,7 +18,7 @@ from . import _path, cbook, rcParams
 from .cbook import _to_unmasked_float_array, simple_linear_interpolation
 
 
-class Path(object):
+class Path:
     """
     A series of possibly disconnected, possibly closed, line and curve
     segments.

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -10,7 +10,7 @@ from matplotlib import patches as mpatches
 from matplotlib import transforms as mtransforms
 
 
-class AbstractPathEffect(object):
+class AbstractPathEffect:
     """
     A base class for path effects.
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -183,7 +183,7 @@ class ThetaFormatter(mticker.Formatter):
             return format_str.format(value=np.rad2deg(x), digits=digits)
 
 
-class _AxisWrapper(object):
+class _AxisWrapper:
     def __init__(self, axis):
         self._axis = axis
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -45,7 +45,7 @@ non_interactive_bk = ['agg', 'cairo',
 all_backends = interactive_bk + non_interactive_bk
 
 
-class ValidateInStrings(object):
+class ValidateInStrings:
     def __init__(self, key, valid, ignorecase=False):
         'valid is a list of legal strings'
         self.key = key
@@ -299,7 +299,7 @@ _str_err_msg = ('You must supply exactly {n} comma-separated values, you '
                 'provided {num} comma-separated values: {s}')
 
 
-class validate_nseq_float(object):
+class validate_nseq_float:
     def __init__(self, n=None, allow_none=False):
         self.n = n
         self.allow_none = allow_none
@@ -324,7 +324,7 @@ class validate_nseq_float(object):
             raise ValueError('Could not convert all entries to floats')
 
 
-class validate_nseq_int(object):
+class validate_nseq_int:
     def __init__(self, n=None):
         self.n = n
 
@@ -694,7 +694,7 @@ def validate_sketch(s):
     return result
 
 
-class ValidateInterval(object):
+class ValidateInterval:
     """
     Value must be in interval
     """

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -27,7 +27,7 @@ UP = 1
 DOWN = 3
 
 
-class Sankey(object):
+class Sankey:
     """
     Sankey diagram.
 

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -12,7 +12,7 @@ from matplotlib.ticker import (
 from matplotlib.transforms import Transform, IdentityTransform
 
 
-class ScaleBase(object):
+class ScaleBase:
     """
     The base class for all scales.
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -437,7 +437,7 @@ Exception occurred rendering plot.
 plot_context = dict()
 
 
-class ImageFile(object):
+class ImageFile:
     def __init__(self, basename, dirname):
         self.basename = basename
         self.dirname = dirname

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -233,7 +233,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     return stream_container
 
 
-class StreamplotSet(object):
+class StreamplotSet:
 
     def __init__(self, lines, arrows, **kwargs):
         self.lines = lines
@@ -243,7 +243,7 @@ class StreamplotSet(object):
 # Coordinate definitions
 # ========================
 
-class DomainMap(object):
+class DomainMap:
     """Map representing different coordinate systems.
 
     Coordinate definitions:
@@ -306,7 +306,7 @@ class DomainMap(object):
         self.mask._undo_trajectory()
 
 
-class Grid(object):
+class Grid:
     """Grid of data."""
     def __init__(self, x, y):
 
@@ -358,7 +358,7 @@ class Grid(object):
         return xi >= 0 and xi <= self.nx - 1 and yi >= 0 and yi <= self.ny - 1
 
 
-class StreamMask(object):
+class StreamMask:
     """Mask to keep track of discrete regions crossed by streamlines.
 
     The resolution of this grid determines the approximate spacing between

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -95,7 +95,7 @@ class _ConverterError(Exception):
     pass
 
 
-class _Converter(object):
+class _Converter:
     def __init__(self):
         self._proc = None
         # Explicitly register deletion from an atexit handler because if we

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -165,7 +165,7 @@ def _mark_skip_if_format_is_uncomparable(extension):
                         marks=[*marks, _skip_if_format_is_uncomparable(name)])
 
 
-class _ImageComparisonBase(object):
+class _ImageComparisonBase:
     """
     Image comparison base class
 

--- a/lib/matplotlib/testing/jpl_units/Duration.py
+++ b/lib/matplotlib/testing/jpl_units/Duration.py
@@ -3,7 +3,7 @@
 import operator
 
 
-class Duration(object):
+class Duration:
     """Class Duration in development.
     """
     allowed = ["ET", "UTC"]

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -6,7 +6,7 @@ import datetime as DT
 from matplotlib.dates import date2num
 
 
-class Epoch(object):
+class Epoch:
     # Frame conversion offsets in seconds
     # t(TO) = t(FROM) + allowed[ FROM ][ TO ]
     allowed = {

--- a/lib/matplotlib/testing/jpl_units/UnitDbl.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDbl.py
@@ -3,7 +3,7 @@
 import operator
 
 
-class UnitDbl(object):
+class UnitDbl:
     """Class UnitDbl in development.
     """
     # Unit conversion table.  Small subset of the full one but enough

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -97,7 +97,7 @@ def test_agg_filter():
 
         return A4
 
-    class BaseFilter(object):
+    class BaseFilter:
         def prepare_image(self, src_image, dpi, pad):
             ny, nx, depth = src_image.shape
             padded_src = np.zeros([pad*2 + ny, pad*2 + nx, depth], dtype="d")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1785,7 +1785,7 @@ def test_hist2d_density_normed():
             obj.hist2d(x, y, density=True, normed=True)
 
 
-class TestScatter(object):
+class TestScatter:
     @image_comparison(['scatter'], style='mpl20', remove_text=True)
     def test_scatter_plot(self):
         data = {"x": np.array([3, 4, 2, 6]), "y": np.array([2, 5, 2, 3]),
@@ -2039,7 +2039,7 @@ def test_as_mpl_axes_api():
     from matplotlib.projections.polar import PolarAxes
     import matplotlib.axes as maxes
 
-    class Polar(object):
+    class Polar:
         def __init__(self):
             self.theta_offset = 0
 

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -10,7 +10,7 @@ import matplotlib.category as cat
 _to_str = cat.StrCategoryFormatter._text
 
 
-class TestUnitData(object):
+class TestUnitData:
     test_cases = [('single', (["hello world"], [0])),
                   ('unicode', (["Здравствуйте мир"], [0])),
                   ('mixed', (['A', "np.nan", 'B', "3.14", "мир"],
@@ -56,12 +56,12 @@ class TestUnitData(object):
             unitdata.update(fdata)
 
 
-class FakeAxis(object):
+class FakeAxis:
     def __init__(self, units):
         self.units = units
 
 
-class TestStrCategoryConverter(object):
+class TestStrCategoryConverter:
     """Based on the pandas conversion and factorization tests:
 
     ref: /pandas/tseries/tests/test_converter.py
@@ -132,7 +132,7 @@ PLOT_LIST = [Axes.scatter, Axes.plot, Axes.bar]
 PLOT_IDS = ["scatter", "plot", "bar"]
 
 
-class TestStrCategoryLocator(object):
+class TestStrCategoryLocator:
     def test_StrCategoryLocator(self):
         locs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         unit = cat.UnitData([str(j) for j in locs])
@@ -145,7 +145,7 @@ class TestStrCategoryLocator(object):
         np.testing.assert_array_equal(ax.yaxis.major.locator(), range(3))
 
 
-class TestStrCategoryFormatter(object):
+class TestStrCategoryFormatter:
     test_cases = [("ascii", ["hello", "world", "hi"]),
                   ("unicode", ["Здравствуйте", "привет"])]
 
@@ -177,7 +177,7 @@ def axis_test(axis, labels):
     assert list(axis.units._mapping.values()) == ticks
 
 
-class TestPlotBytes(object):
+class TestPlotBytes:
     bytes_cases = [('string list', ['a', 'b', 'c']),
                    ('bytes list', [b'a', b'b', b'c']),
                    ('bytes ndarray', np.array([b'a', b'b', b'c']))]
@@ -192,7 +192,7 @@ class TestPlotBytes(object):
         axis_test(ax.xaxis, bdata)
 
 
-class TestPlotNumlike(object):
+class TestPlotNumlike:
     numlike_cases = [('string list', ['1', '11', '3']),
                      ('string ndarray', np.array(['1', '11', '3'])),
                      ('bytes list', [b'1', b'11', b'3']),
@@ -207,7 +207,7 @@ class TestPlotNumlike(object):
         axis_test(ax.xaxis, ndata)
 
 
-class TestPlotTypes(object):
+class TestPlotTypes:
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)
     def test_plot_unicode(self, ax, plotter):
         words = ['Здравствуйте', 'привет']

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -25,7 +25,7 @@ def test_is_hashable():
         assert not cbook.is_hashable(lst)
 
 
-class Test_delete_masked_points(object):
+class Test_delete_masked_points:
     def setup_method(self):
         self.mask1 = [False, False, True, True, False, False]
         self.arr0 = np.arange(1.0, 7.0)
@@ -67,7 +67,7 @@ class Test_delete_masked_points(object):
         assert_array_equal(actual[1], expected[1])
 
 
-class Test_boxplot_stats(object):
+class Test_boxplot_stats:
     def setup(self):
         np.random.seed(937)
         self.nrows = 37
@@ -194,7 +194,7 @@ class Test_boxplot_stats(object):
         assert_array_almost_equal(bstats_true[0]['fliers'], [])
 
 
-class Test_callback_registry(object):
+class Test_callback_registry:
     def setup(self):
         self.signal = 'test'
         self.callbacks = cbook.CallbackRegistry()

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -548,7 +548,7 @@ def test_picking():
     col = ax.scatter([0], [0], [1000], picker=True)
     fig.savefig(io.BytesIO(), dpi=fig.dpi)
 
-    class MouseEvent(object):
+    class MouseEvent:
         pass
     event = MouseEvent()
     event.x = 325

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -234,7 +234,7 @@ def test_iterability_axes_argument():
         def __init__(self, *args, myclass=None, **kwargs):
             return Axes.__init__(self, *args, **kwargs)
 
-    class MyClass(object):
+    class MyClass:
 
         def __getitem__(self, item):
             if item != 'a':

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -228,7 +228,7 @@ def test_legend_remove():
     assert ax.get_legend() is None
 
 
-class TestLegendFunction(object):
+class TestLegendFunction:
     # Tests the legend function on the Axes and pyplot.
     def test_legend_handle_label(self):
         lines = plt.plot(range(10))
@@ -297,7 +297,7 @@ class TestLegendFunction(object):
         Legend.assert_called_with(host, [p1, p2], ['Density', 'Temperature'])
 
 
-class TestLegendFigureFunction(object):
+class TestLegendFigureFunction:
     # Tests the legend function for figure
     def test_legend_handle_label(self):
         fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -15,7 +15,7 @@ def _stride_repeat(*args, **kwargs):
         return mlab.stride_repeat(*args, **kwargs)
 
 
-class TestStride(object):
+class TestStride:
     def get_base(self, x):
         y = x
         while y.base is not None:
@@ -189,7 +189,7 @@ def _apply_window(*args, **kwargs):
         return mlab.apply_window(*args, **kwargs)
 
 
-class TestWindow(object):
+class TestWindow:
     def setup(self):
         np.random.seed(0)
         n = 1000
@@ -439,7 +439,7 @@ class TestWindow(object):
         assert_allclose(ycontrol.T, result, atol=1e-08)
 
 
-class TestDetrend(object):
+class TestDetrend:
     def setup(self):
         np.random.seed(0)
         n = 1000
@@ -1076,7 +1076,7 @@ class TestDetrend(object):
         'nosig_overlap',
     ],
     scope='class')
-class TestSpectral(object):
+class TestSpectral:
     @pytest.fixture(scope='class', autouse=True)
     def stim(self, request, fstims, iscomplex, sides, len_x, NFFT_density,
              nover_density, pad_to_density, pad_to_spectrum):
@@ -2032,7 +2032,7 @@ def test_cohere():
 # https://github.com/scipy/scipy/blob/master/scipy/stats/tests/test_kdeoth.py
 #*****************************************************************
 
-class TestGaussianKDE(object):
+class TestGaussianKDE:
 
     def test_kde_integer_input(self):
         """Regression test for #1181."""
@@ -2077,7 +2077,7 @@ class TestGaussianKDE(object):
         assert kdepdf.all() == kdepdf3.all()
 
 
-class TestGaussianKDECustom(object):
+class TestGaussianKDECustom:
     def test_no_data(self):
         """Pass no data into the GaussianKDE class."""
         with pytest.raises(ValueError):
@@ -2166,7 +2166,7 @@ class TestGaussianKDECustom(object):
             mlab.GaussianKDE(data, bw_method="invalid")
 
 
-class TestGaussianKDEEvaluate(object):
+class TestGaussianKDEEvaluate:
 
     def test_evaluate_diff_dim(self):
         """

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -144,7 +144,7 @@ def test_polar():
     plt.draw()
 
 
-class TransformBlob(object):
+class TransformBlob:
     def __init__(self):
         self.identity = mtransforms.IdentityTransform()
         self.identity2 = mtransforms.IdentityTransform()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
 
-class TestMaxNLocator(object):
+class TestMaxNLocator:
     basic_data = [
         (20, 100, np.array([20., 40., 60., 80., 100.])),
         (0.001, 0.0001, np.array([0., 0.0002, 0.0004, 0.0006, 0.0008, 0.001])),
@@ -35,7 +35,7 @@ class TestMaxNLocator(object):
         assert_almost_equal(loc.tick_values(vmin, vmax), expected)
 
 
-class TestLinearLocator(object):
+class TestLinearLocator:
     def test_basic(self):
         loc = mticker.LinearLocator(numticks=3)
         test_value = np.array([-0.8, -0.3, 0.2])
@@ -52,7 +52,7 @@ class TestLinearLocator(object):
         assert loc.presets == {(0, 1): []}
 
 
-class TestMultipleLocator(object):
+class TestMultipleLocator:
     def test_basic(self):
         loc = mticker.MultipleLocator(base=3.147)
         test_value = np.array([-9.441, -6.294, -3.147, 0., 3.147, 6.294,
@@ -86,7 +86,7 @@ class TestMultipleLocator(object):
         assert mult._edge.step == 1.7
 
 
-class TestAutoMinorLocator(object):
+class TestAutoMinorLocator:
     def test_basic(self):
         fig, ax = plt.subplots()
         ax.set_xlim(0, 1.39)
@@ -188,7 +188,7 @@ class TestAutoMinorLocator(object):
         assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
 
-class TestLogLocator(object):
+class TestLogLocator:
     def test_basic(self):
         loc = mticker.LogLocator(numticks=5)
         with pytest.raises(ValueError):
@@ -226,7 +226,7 @@ class TestLogLocator(object):
         assert list(loc._subs) == [2.0]
 
 
-class TestNullLocator(object):
+class TestNullLocator:
     def test_set_params(self):
         """
         Create null locator, and attempt to call set_params() on it.
@@ -237,7 +237,7 @@ class TestNullLocator(object):
             loc.set_params()
 
 
-class TestLogitLocator(object):
+class TestLogitLocator:
     def test_set_params(self):
         """
         Create logit locator with default minor=False, and change it to
@@ -248,7 +248,7 @@ class TestLogitLocator(object):
         assert loc.minor
 
 
-class TestFixedLocator(object):
+class TestFixedLocator:
     def test_set_params(self):
         """
         Create fixed locator with 5 nbins, and change it to something else.
@@ -260,7 +260,7 @@ class TestFixedLocator(object):
         assert fixed.nbins == 7
 
 
-class TestIndexLocator(object):
+class TestIndexLocator:
     def test_set_params(self):
         """
         Create index locator with 3 base, 4 offset. and change it to something
@@ -273,7 +273,7 @@ class TestIndexLocator(object):
         assert index.offset == 7
 
 
-class TestSymmetricalLogLocator(object):
+class TestSymmetricalLogLocator:
     def test_set_params(self):
         """
         Create symmetrical log locator with default subs =[1.0] numticks = 15,
@@ -287,7 +287,7 @@ class TestSymmetricalLogLocator(object):
         assert sym.numticks == 8
 
 
-class TestScalarFormatter(object):
+class TestScalarFormatter:
     offset_data = [
         (123, 189, 0),
         (-189, -123, 0),
@@ -380,7 +380,7 @@ class TestScalarFormatter(object):
         assert orderOfMag == tmp_form.orderOfMagnitude
 
 
-class FakeAxis(object):
+class FakeAxis:
     """Allow Formatter to be called without having a "full" plot set up."""
     def __init__(self, vmin=1, vmax=10):
         self.vmin = vmin
@@ -390,7 +390,7 @@ class FakeAxis(object):
         return self.vmin, self.vmax
 
 
-class TestLogFormatterExponent(object):
+class TestLogFormatterExponent:
     param_data = [
         (True, 4, np.arange(-3, 4.0), np.arange(-3, 4.0),
          ['-3', '-2', '-1', '0', '1', '2', '3']),
@@ -443,7 +443,7 @@ class TestLogFormatterMathtext():
             assert self.fmt(value) == expected
 
 
-class TestLogFormatterSciNotation(object):
+class TestLogFormatterSciNotation:
     test_data = [
         (2, 0.03125, '$\\mathdefault{2^{-5}}$'),
         (2, 1, '$\\mathdefault{2^{0}}$'),
@@ -472,7 +472,7 @@ class TestLogFormatterSciNotation(object):
             assert formatter(value) == expected
 
 
-class TestLogFormatter(object):
+class TestLogFormatter:
     pprint_data = [
         (3.141592654e-05, 0.001, '3.142e-5'),
         (0.0003141592654, 0.001, '3.142e-4'),
@@ -670,14 +670,14 @@ class TestLogFormatter(object):
         assert temp_lf(val) == str(val)
 
 
-class TestFormatStrFormatter(object):
+class TestFormatStrFormatter:
     def test_basic(self):
         # test % style formatter
         tmp_form = mticker.FormatStrFormatter('%05d')
         assert '00002' == tmp_form(2)
 
 
-class TestStrMethodFormatter(object):
+class TestStrMethodFormatter:
     test_data = [
         ('{x:05d}', (2,), '00002'),
         ('{x:03d}-{pos:02d}', (2, 1), '002-01'),
@@ -689,7 +689,7 @@ class TestStrMethodFormatter(object):
         assert fmt(*input) == expected
 
 
-class TestEngFormatter(object):
+class TestEngFormatter:
     # (unicode_minus, input, expected) where ''expected'' corresponds to the
     # outputs respectively returned when (places=None, places=0, places=2)
     # unicode_minus is a boolean value for the rcParam['axes.unicode_minus']
@@ -814,7 +814,7 @@ def test_engformatter_usetex_useMathText():
         assert x_tick_label_text == ['$0$', '$500$', '$1$ k']
 
 
-class TestPercentFormatter(object):
+class TestPercentFormatter:
     percent_data = [
         # Check explicitly set decimals over different intervals and values
         (100, 0, '%', 120, 100, '120%'),

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -52,7 +52,7 @@ def test_non_affine_caching():
 
 
 def test_external_transform_api():
-    class ScaledBy(object):
+    class ScaledBy:
         def __init__(self, scale_factor):
             self._scale_factor = scale_factor
 

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -9,7 +9,7 @@ import pytest
 
 
 # Basic class that wraps numpy array and has units
-class Quantity(object):
+class Quantity:
     def __init__(self, data, units):
         self.magnitude = data
         self.units = units

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -46,7 +46,7 @@ from matplotlib import cbook, dviread, rcParams
 _log = logging.getLogger(__name__)
 
 
-class TexManager(object):
+class TexManager:
     """
     Convert strings to dvi files using TeX, caching the results to a directory.
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1657,7 +1657,7 @@ class TextWithDash(Text):
 docstring.interpd.update(TextWithDash=artist.kwdoc(TextWithDash))
 
 
-class OffsetFrom(object):
+class OffsetFrom:
     'Callable helper class for working with `Annotation`'
     def __init__(self, artist, ref_coord, unit="points"):
         '''
@@ -1740,7 +1740,7 @@ class OffsetFrom(object):
         return tr
 
 
-class _AnnotationBase(object):
+class _AnnotationBase:
     def __init__(self,
                  xy,
                  xycoords='data',

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -16,7 +16,7 @@ from matplotlib.transforms import Affine2D
 _log = logging.getLogger(__name__)
 
 
-class TextToPath(object):
+class TextToPath:
     """A class that converts strings to paths."""
 
     FONT_SCALE = 100.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -191,7 +191,7 @@ def _mathdefault(s):
     return '\\mathdefault{%s}' % s
 
 
-class _DummyAxis(object):
+class _DummyAxis:
     def __init__(self, minpos=0):
         self.dataLim = mtransforms.Bbox.unit()
         self.viewLim = mtransforms.Bbox.unit()
@@ -217,7 +217,7 @@ class _DummyAxis(object):
         return 9
 
 
-class TickHelper(object):
+class TickHelper:
     axis = None
 
     def set_axis(self, axis):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -51,7 +51,7 @@ def _indent_str(obj):  # textwrap.indent(str(obj), 4) on Py3.
     return re.sub("(^|\n)", r"\1    ", str(obj))
 
 
-class TransformNode(object):
+class TransformNode:
     """
     :class:`TransformNode` is the base class for anything that
     participates in the transform tree and needs to invalidate its

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-class Triangulation(object):
+class Triangulation:
     """
     An unstructured triangular grid consisting of npoints points and
     ntri triangles.  The triangles can either be specified by the user

--- a/lib/matplotlib/tri/trifinder.py
+++ b/lib/matplotlib/tri/trifinder.py
@@ -3,7 +3,7 @@ import numpy as np
 from matplotlib.tri import Triangulation
 
 
-class TriFinder(object):
+class TriFinder:
     """
     Abstract base class for classes used to find the triangles of a
     Triangulation in which (x,y) points lie.

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -12,7 +12,7 @@ from matplotlib.tri.tritools import TriAnalyzer
 __all__ = ('TriInterpolator', 'LinearTriInterpolator', 'CubicTriInterpolator')
 
 
-class TriInterpolator(object):
+class TriInterpolator:
     """
     Abstract base class for classes used to perform interpolation on
     triangular grids.
@@ -1230,7 +1230,7 @@ class _DOF_estimator_min_E(_DOF_estimator_geom):
 
 # The following private :class:_Sparse_Matrix_coo and :func:_cg provide
 # a PCG sparse solver for (symmetric) elliptic problems.
-class _Sparse_Matrix_coo(object):
+class _Sparse_Matrix_coo:
     def __init__(self, vals, rows, cols, shape):
         """
         Creates a sparse matrix in coo format

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -7,7 +7,7 @@ from matplotlib.tri.triangulation import Triangulation
 import matplotlib.tri.triinterpolate
 
 
-class TriRefiner(object):
+class TriRefiner:
     """
     Abstract base class for classes implementing mesh refinement.
 

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -7,7 +7,7 @@ import numpy as np
 from matplotlib.tri import Triangulation
 
 
-class TriAnalyzer(object):
+class TriAnalyzer:
     """
     Define basic tools for triangular mesh analysis and improvement.
 

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -36,7 +36,7 @@ _TokenType = enum.Enum('_TokenType',
                        'whitespace name string delimiter number')
 
 
-class Type1Font(object):
+class Type1Font:
     """
     A class representing a Type-1 font, for use by backends.
 

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -55,7 +55,7 @@ class ConversionError(TypeError):
     pass
 
 
-class AxisInfo(object):
+class AxisInfo:
     """
     Information to support default axis labeling, tick labeling, and limits.
 
@@ -91,7 +91,7 @@ class AxisInfo(object):
         self.default_limits = default_limits
 
 
-class ConversionInterface(object):
+class ConversionInterface:
     """
     The minimal interface for a converter to take custom data types (or
     sequences) and convert them to values Matplotlib can use.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -20,7 +20,7 @@ from .patches import Circle, Rectangle, Ellipse
 from .transforms import blended_transform_factory
 
 
-class LockDraw(object):
+class LockDraw:
     """
     Some widgets, like the cursor, draw onto the canvas, and this is not
     desirable under all circumstances, like when the toolbar is in zoom-to-rect
@@ -58,7 +58,7 @@ class LockDraw(object):
         return self._owner is not None
 
 
-class Widget(object):
+class Widget:
     """
     Abstract base class for GUI neutral widgets
     """
@@ -1912,7 +1912,7 @@ class SpanSelector(_SelectorWidget):
             self.rect.set_height(maxv - minv)
 
 
-class ToolHandles(object):
+class ToolHandles:
     """Control handles for canvas tools.
 
     Parameters


### PR DESCRIPTION
## PR Summary

This is not needed anymore in Python 3.

The main motivation is cleaning the docs from meaningless base references such as:
![grafik](https://user-images.githubusercontent.com/2836374/58381689-84cd3480-7fc0-11e9-9e05-a1138b1d643e.png)

But the overall cleanup of the code is a desired side-effect.

