### PR TITLE
Use raw docstrings instead of escaping backslashes

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7114,7 +7114,7 @@ optional.
     def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
             sides=None, scale_by_freq=None, return_line=None, **kwargs):
-        """
+        r"""
         Plot the cross-spectral density.
 
         The cross spectral density :math:`P_{xy}` by Welch's average
@@ -7181,7 +7181,7 @@ optional.
         Notes
         -----
         For plotting, the power is plotted as
-        :math:`10\\log_{10}(P_{xy})` for decibels, though `P_{xy}` itself
+        :math:`10 \log_{10}(P_{xy})` for decibels, though `P_{xy}` itself
         is returned.
 
         References
@@ -7459,7 +7459,7 @@ optional.
     def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
                window=mlab.window_hanning, noverlap=0, pad_to=None,
                sides='default', scale_by_freq=None, **kwargs):
-        """
+        r"""
         Plot the coherence between *x* and *y*.
 
         Plot the coherence between *x* and *y*.  Coherence is the
@@ -7467,7 +7467,7 @@ optional.
 
         .. math::
 
-          C_{xy} = \\frac{|P_{xy}|^2}{P_{xx}P_{yy}}
+          C_{xy} = \frac{|P_{xy}|^2}{P_{xx}P_{yy}}
 
         Parameters
         ----------

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1026,7 +1026,7 @@ def _combine_masks(*args):
 
 def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
                   autorange=False):
-    """
+    r"""
     Returns list of dictionaries of statistics used to draw a series
     of box and whisker plots. The `Returns` section enumerates the
     required keys of the dictionary. Users can skip this function and
@@ -1095,7 +1095,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
 
     .. math::
 
-        \\mathrm{med} \\pm 1.57 \\times \\frac{\\mathrm{iqr}}{\\sqrt{N}}
+        \mathrm{med} \pm 1.57 \times \frac{\mathrm{iqr}}{\sqrt{N}}
 
     General approach from:
     McGill, R., Tukey, J.W., and Larsen, W.A. (1978) "Variations of

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -2002,8 +2002,8 @@ def from_levels_and_colors(levels, colors, extend='neither'):
 
     Returns
     -------
-    (cmap, norm) : tuple containing a :class:`Colormap` and a \
-                   :class:`Normalize` instance
+    cmap : `~matplotlib.colors.Normalize`
+    norm : `~matplotlib.colors.Colormap`
     """
     colors_i0 = 0
     colors_i1 = None

--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -61,7 +61,7 @@ class Substitution:
 
 @cbook.deprecated("3.1")
 class Appender:
-    """
+    r"""
     A function decorator that will append an addendum to the docstring
     of the target function.
 

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module contains functions to handle markers.  Used by both the
 marker functionality of `~matplotlib.axes.Axes.plot` and
 `~matplotlib.axes.Axes.scatter`.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -412,7 +412,7 @@ class Fonts:
 
     def get_kern(self, font1, fontclass1, sym1, fontsize1,
                  font2, fontclass2, sym2, fontsize2, dpi):
-        """
+        r"""
         Get the kerning distance for font between *sym1* and *sym2*.
 
         *fontX*: one of the TeX font names::
@@ -421,7 +421,7 @@ class Fonts:
 
         *fontclassX*: TODO
 
-        *symX*: a symbol in raw TeX form. e.g., '1', 'x' or '\\sigma'
+        *symX*: a symbol in raw TeX form. e.g., '1', 'x' or '\sigma'
 
         *fontsizeX*: the fontsize in points
 
@@ -430,14 +430,14 @@ class Fonts:
         return 0.
 
     def get_metrics(self, font, font_class, sym, fontsize, dpi, math=True):
-        """
+        r"""
         *font*: one of the TeX font names::
 
           tt, it, rm, cal, sf, bf or default/regular (non-math)
 
         *font_class*: TODO
 
-        *sym*:  a symbol in raw TeX form. e.g., '1', 'x' or '\\sigma'
+        *sym*:  a symbol in raw TeX form. e.g., '1', 'x' or '\sigma'
 
         *fontsize*: font size in points
 
@@ -1647,13 +1647,13 @@ class Hlist(List):
 #         return 0.0
 
     def hpack(self, w=0., m='additional'):
-        """
+        r"""
         The main duty of :meth:`hpack` is to compute the dimensions of
         the resulting boxes, and to adjust the glue if one of those
         dimensions is pre-specified.  The computed sizes normally
         enclose all of the material inside the new box; but some items
         may stick out if negative glue is used, if the box is
-        overfull, or if a ``\\vbox`` includes other boxes that have
+        overfull, or if a ``\vbox`` includes other boxes that have
         been shifted left.
 
           - *w*: specifies a width

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1071,13 +1071,13 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
 @docstring.dedent_interpd
 def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
            noverlap=0, pad_to=None, sides='default', scale_by_freq=None):
-    """
+    r"""
     The coherence between *x* and *y*.  Coherence is the normalized
     cross spectral density:
 
     .. math::
 
-        C_{xy} = \\frac{|P_{xy}|^2}{P_{xx}P_{yy}}
+        C_{xy} = \frac{|P_{xy}|^2}{P_{xx}P_{yy}}
 
     Parameters
     ----------

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -730,10 +730,10 @@ validate_grid_axis = ValidateInStrings('axes.grid.axis', ['x', 'y', 'both'])
 
 
 def validate_hatch(s):
-    """
+    r"""
     Validate a hatch pattern.
     A hatch pattern string can have any sequence of the following
-    characters: ``\\ / | - + * . x o O``.
+    characters: ``\ / | - + * . x o O``.
 
     """
     if not isinstance(s, str):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1137,10 +1137,10 @@ class Text(Artist):
         self.stale = True
 
     def set_text(self, s):
-        """
+        r"""
         Set the text string *s*.
 
-        It may contain newlines (``\\n``) or math in LaTeX syntax.
+        It may contain newlines (``\n``) or math in LaTeX syntax.
 
         Parameters
         ----------

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1220,7 +1220,7 @@ class EngFormatter(Formatter):
 
     def __init__(self, unit="", places=None, sep=" ", *, usetex=None,
                  useMathText=None):
-        """
+        r"""
         Parameters
         ----------
         unit : str (default: "")
@@ -1242,9 +1242,9 @@ class EngFormatter(Formatter):
             other useful options may be:
 
             * ``sep=""`` to append directly the prefix/unit to the value;
-            * ``sep="\\N{THIN SPACE}"`` (``U+2009``);
-            * ``sep="\\N{NARROW NO-BREAK SPACE}"`` (``U+202F``);
-            * ``sep="\\N{NO-BREAK SPACE}"`` (``U+00A0``).
+            * ``sep="\N{THIN SPACE}"`` (``U+2009``);
+            * ``sep="\N{NARROW NO-BREAK SPACE}"`` (``U+202F``);
+            * ``sep="\N{NO-BREAK SPACE}"`` (``U+00A0``).
 
         usetex : bool (default: None)
             To enable/disable the use of TeX's math mode for rendering the
@@ -1441,11 +1441,11 @@ class PercentFormatter(Formatter):
 
     @property
     def symbol(self):
-        """
+        r"""
         The configured percent symbol as a string.
 
         If LaTeX is enabled via :rc:`text.usetex`, the special characters
-        ``{'#', '$', '%', '&', '~', '_', '^', '\\', '{', '}'}`` are
+        ``{'#', '$', '%', '&', '~', '_', '^', '\', '{', '}'}`` are
         automatically escaped in the string.
         """
         symbol = self._symbol

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1724,10 +1724,11 @@ class SpanSelector(_SelectorWidget):
       If True, the span stays visible after the mouse is released
 
     button : int or list of ints
-      Determines which mouse buttons activate the span selector
-        1 = left mouse button\n
-        2 = center mouse button (scroll wheel)\n
-        3 = right mouse button\n
+      Determines which mouse buttons activate the span selector:
+
+      - 1: left mouse button
+      - 2: center mouse button (scroll wheel)
+      - 3: right mouse button
 
     Examples
     --------

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -76,7 +76,7 @@ class AxisArtistHelper(object):
             return (x, y), trans
 
 
-        def get_label_offset_transform(self, \
+        def get_label_offset_transform(self,
                 axes,
                 pad_points, fontprops, renderer,
                 bboxes,


### PR DESCRIPTION
## PR Summary

Note: I would like to enforce [pydocstyle D301](http://www.pydocstyle.org/en/stable/error_codes.html) on this, but we have several cases of backslash as line continuation which would give false-positives. For now, we cannot check this automatically.