### PR TITLE
Simplify/pathlibify image_comparison.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -264,7 +264,7 @@ def convert(filename, cache):
     hash of the exact contents of the input file.  There is no limit on the
     size of the cache, so it may need to be manually cleared periodically.
     """
-    base, extension = filename.rsplit('.', 1)
+    base, extension = os.fspath(filename).rsplit('.', 1)
     if extension not in converter:
         import pytest
         pytest.skip(f"Don't know how to convert {extension} files to png")
@@ -369,18 +369,17 @@ def compare_images(expected, actual, tol, in_decorator=False):
     """
     from matplotlib import _png
 
+    actual = os.fspath(actual)
     if not os.path.exists(actual):
         raise Exception("Output image %s does not exist." % actual)
-
     if os.stat(actual).st_size == 0:
         raise Exception("Output image file %s is empty." % actual)
 
     # Convert the image to png
-    extension = expected.split('.')[-1]
-
+    expected = os.fspath(expected)
     if not os.path.exists(expected):
         raise IOError('Baseline image %r does not exist.' % expected)
-
+    extension = expected.split('.')[-1]
     if extension != 'png':
         actual = convert(actual, False)
         expected = convert(expected, True)


### PR DESCRIPTION
There's no public class that inherits from _ImageComparisonBase anymore,
so we can improve it by getting rid of the delayed_init mechanism and by
pathlibifying its internals without worrying about API breaks.

The changes in compare.py are necessary to make these functions also
support Path (now passed by _ImageComparisonBase) as arguments.

Preliminary to the PR mentioned in https://github.com/matplotlib/matplotlib/issues/14329#issuecomment-496007079.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
