### PR TITLE
acquiring and releaseing keypresslock when textbox is being activated

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -856,7 +856,8 @@ class TextBox(AxesWidget):
 
     def begin_typing(self, x):
         self.capturekeystrokes = True
-        if rcParams['toolbar'] != 'toolmanager':
+        # Check for toolmanager handling the keypress
+        if self.ax.figure.canvas.manager.key_press_handler_id is not None:
             # disable command keys so that the user can type without
             # command keys causing figure to be saved, etc
             self.reset_params = {}
@@ -872,7 +873,8 @@ class TextBox(AxesWidget):
         # user's code, we only want to call it once we've already done
         # our cleanup.
         if self.capturekeystrokes:
-            if rcParams['toolbar'] != 'toolmanager':
+            # Check for toolmanager handling the keypress
+            if self.ax.figure.canvas.manager.key_press_handler_id is not None:
                 # since the user is no longer typing,
                 # reactivate the standard command keys
                 for key in self.params_to_disable:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -856,12 +856,15 @@ class TextBox(AxesWidget):
 
     def begin_typing(self, x):
         self.capturekeystrokes = True
-        # disable command keys so that the user can type without
-        # command keys causing figure to be saved, etc
-        self.reset_params = {}
-        for key in self.params_to_disable:
-            self.reset_params[key] = rcParams[key]
-            rcParams[key] = []
+        if rcParams['toolbar'] != 'toolmanager':
+            # disable command keys so that the user can type without
+            # command keys causing figure to be saved, etc
+            self.reset_params = {}
+            for key in self.params_to_disable:
+                self.reset_params[key] = rcParams[key]
+                rcParams[key] = []
+        else:
+            self.ax.figure.canvas.manager.toolmanager.keypresslock(self)
 
     def stop_typing(self):
         notifysubmit = False
@@ -869,10 +872,13 @@ class TextBox(AxesWidget):
         # user's code, we only want to call it once we've already done
         # our cleanup.
         if self.capturekeystrokes:
-            # since the user is no longer typing,
-            # reactivate the standard command keys
-            for key in self.params_to_disable:
-                rcParams[key] = self.reset_params[key]
+            if rcParams['toolbar'] != 'toolmanager':
+                # since the user is no longer typing,
+                # reactivate the standard command keys
+                for key in self.params_to_disable:
+                    rcParams[key] = self.reset_params[key]
+            else:
+                self.ax.figure.canvas.manager.toolmanager.keypresslock.release(self)
             notifysubmit = True
         self.capturekeystrokes = False
         self.cursor.set_visible(False)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -878,7 +878,8 @@ class TextBox(AxesWidget):
                 for key in self.params_to_disable:
                     rcParams[key] = self.reset_params[key]
             else:
-                self.ax.figure.canvas.manager.toolmanager.keypresslock.release(self)
+                toolmanager = self.ax.figure.canvas.manager.toolmanager
+                toolmanager.keypresslock.release(self)
             notifysubmit = True
         self.capturekeystrokes = False
         self.cursor.set_visible(False)


### PR DESCRIPTION
## Making TextBox widget compatible with  ToolManager

As reported https://github.com/matplotlib/matplotlib/issues/7571 textbox widget doesn't exclude the keypress triggers when using toolmanager.
This PR uses the `toolmanager.keypresslock` to bypass triggering the tools instead of the current solution of removing the content of  `rcParams`


## PR Checklist

- [ ] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
