### PR TITLE
Deprecate rcsetup.validate_path_exists.

### DIFF
--- a/doc/api/next_api_changes/2019-05-27-AL.rst
+++ b/doc/api/next_api_changes/2019-05-27-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``rcsetup.validate_path_exists`` is deprecated (use ``os.path.exists`` to check
+whether a path exists).

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -108,6 +108,7 @@ def validate_any(s):
 validate_anylist = _listify_validator(validate_any)
 
 
+@cbook.deprecated("3.1", alternative="os.path.exists")
 def validate_path_exists(s):
     """If s is a path, return s, else False"""
     if s is None:
@@ -1022,8 +1023,7 @@ defaultParams = {
     'webagg.open_in_browser': [True, validate_bool],
     'webagg.port_retries': [50, validate_int],
     'toolbar':           ['toolbar2', validate_toolbar],
-    'datapath':          [None, validate_path_exists],  # handled by
-                                                        # _get_data_path_cached
+    'datapath':          [None, validate_any],  # see _get_data_path_cached
     'interactive':       [False, validate_bool],
     'timezone':          ['UTC', validate_string],
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -108,7 +108,7 @@ def validate_any(s):
 validate_anylist = _listify_validator(validate_any)
 
 
-@cbook.deprecated("3.1", alternative="os.path.exists")
+@cbook.deprecated("3.2", alternative="os.path.exists")
 def validate_path_exists(s):
     """If s is a path, return s, else False"""
     if s is None:


### PR DESCRIPTION
It's only used to validate setting the path to the matplotlib data, but
of course the path just existing hardly indicates that that's the
correct path to the matplotlib data; moreover, the intent (see
`_get_data_path`) is that it should not be user-settable to start with.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
