### PR TITLE
Remove some redundant check_in_list calls.

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -617,6 +617,7 @@ class LogitTransform(Transform):
 
     def __init__(self, nonpos='mask'):
         Transform.__init__(self)
+        cbook._check_in_list(['mask', 'clip'], nonpos=nonpos)
         self._nonpos = nonpos
         self._clip = {"clip": True, "mask": False}[nonpos]
 
@@ -633,8 +634,7 @@ class LogitTransform(Transform):
         return LogisticTransform(self._nonpos)
 
     def __str__(self):
-        return "{}({!r})".format(type(self).__name__,
-            "clip" if self._clip else "mask")
+        return "{}({!r})".format(type(self).__name__, self._nonpos)
 
 
 class LogisticTransform(Transform):
@@ -673,7 +673,6 @@ class LogitScale(ScaleBase):
           values beyond ]0, 1[ can be masked as invalid, or clipped to a number
           very close to 0 or 1
         """
-        cbook._check_in_list(['mask', 'clip'], nonpos=nonpos)
         self._transform = LogitTransform(nonpos)
 
     def get_transform(self):

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -482,7 +482,6 @@ class AxisLabel(LabelBase, AttributeCopier):
         Adjust the text angle and text alignment of axis label
         according to the matplotlib convention.
 
-
         =====================    ========== ========= ========== ==========
         property                 left       bottom    right      top
         =====================    ========== ========= ========== ==========
@@ -494,9 +493,7 @@ class AxisLabel(LabelBase, AttributeCopier):
         Note that the text angles are actually relative to (90 + angle
         of the direction to the ticklabel), which gives 0 for bottom
         axis.
-
         """
-        cbook._check_in_list(["left", "right", "top", "bottom"], d=d)
         self.set_default_alignment(d)
         self.set_default_angle(d)
 
@@ -566,11 +563,9 @@ class TickLabels(AxisLabel, AttributeCopier):  # mtext.Text
         of the direction to the ticklabel), which gives 0 for bottom
         axis.
         """
-        cbook._check_in_list(["left", "right", "top", "bottom"],
-                             label_direction=label_direction)
-        self._axis_direction = label_direction
         self.set_default_alignment(label_direction)
         self.set_default_angle(label_direction)
+        self._axis_direction = label_direction
 
     def invert_axis_direction(self):
         label_direction = self._get_opposite_direction(self._axis_direction)
@@ -841,8 +836,8 @@ class AxisArtist(martist.Artist):
         relative to (90 + angle of the direction to the ticklabel),
         which gives 0 for bottom axis.
         """
-        cbook._check_in_list(["left", "right", "top", "bottom"],
-                             axis_direction=axis_direction)
+        self.major_ticklabels.set_axis_direction(axis_direction)
+        self.label.set_axis_direction(axis_direction)
         self._axis_direction = axis_direction
         if axis_direction in ["left", "top"]:
             self.set_ticklabel_direction("-")
@@ -850,8 +845,6 @@ class AxisArtist(martist.Artist):
         else:
             self.set_ticklabel_direction("+")
             self.set_axislabel_direction("+")
-        self.major_ticklabels.set_axis_direction(axis_direction)
-        self.label.set_axis_direction(axis_direction)
 
     def set_ticklabel_direction(self, tick_direction):
         r"""


### PR DESCRIPTION
- In scale.py, moving the check from LogitScale to the LogitTransform
  constructor makes more calls benefit from it.
- In axis_artist, the checks are ultimately already performed by
  set_default_alignment and set_default_angle, so we don't need to
  repeat them everywhere in the call chain.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
