### PR TITLE
Remove redundant is_landscape kwarg from backend_ps helpers.

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -27,6 +27,7 @@ with warnings.catch_warnings():
 
 # This tests tends to hit a TeX cache lock on AppVeyor.
 @pytest.mark.flaky(reruns=3)
+@pytest.mark.parametrize('orientation', ['portrait', 'landscape'])
 @pytest.mark.parametrize('format, use_log, rcParams', [
     ('ps', False, {}),
     pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
@@ -45,7 +46,8 @@ with warnings.catch_warnings():
     'eps afm',
     'eps with usetex'
 ])
-def test_savefig_to_stringio(format, use_log, rcParams, monkeypatch):
+def test_savefig_to_stringio(format, use_log, rcParams, orientation,
+                             monkeypatch):
     mpl.rcParams.update(rcParams)
     monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")  # For reproducibility.
 
@@ -61,8 +63,8 @@ def test_savefig_to_stringio(format, use_log, rcParams, monkeypatch):
         if not mpl.rcParams["text.usetex"]:
             title += " \N{MINUS SIGN}\N{EURO SIGN}"
         ax.set_title(title)
-        fig.savefig(s_buf, format=format)
-        fig.savefig(b_buf, format=format)
+        fig.savefig(s_buf, format=format, orientation=orientation)
+        fig.savefig(b_buf, format=format, orientation=orientation)
 
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()


### PR DESCRIPTION
The internal backend_ps _print_figure and _print_figure_tex helpers get
passed both the orientation="portrait"/"landscape" and the
is_landscape=True/False kwargs.

Remove is_landscape and change orientation to be an enum.

Also deprecate dryrun from _print_figure_tex (this should have happened
at the same time as when it was deprecated from _print_figure (it's the
same public API).

Also remove unnecessary default parameters from _print_figure (these
arguments are always passed positionally to the helper, and not present
in _print_figure_tex).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
