### PR TITLE
Register flaky pytest marker.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,10 +5,11 @@ testpaths = lib
 python_files = test_*.py
 
 markers =
+    flaky: (Provided by pytest-rerunfailures.)
     backend: Set alternate Matplotlib backend temporarily.
     style: Set alternate Matplotlib style temporarily.
-    baseline_images: Compare output against a known reference
-    pytz: Tests that require pytz to be installed
+    baseline_images: Compare output against a known reference.
+    pytz: Tests that require pytz to be installed.
 
 filterwarnings =
     error


### PR DESCRIPTION
Otherwise, running the test suite without installing
pytest-rerunfailures now results in

    _____________________________ ERROR collecting lib/matplotlib/tests/test_backend_ps.py _____________________________
    lib/matplotlib/tests/test_backend_ps.py:29: in <module>
        @pytest.mark.flaky(reruns=3)
    ../../../.local/lib/python3.7/site-packages/_pytest/mark/structures.py:324: in __getattr__
        PytestUnknownMarkWarning,
    E   _pytest.warning_types.PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    collected 0 items / 1 errors

(The alternative is to add a hard requirement on pytest-rerunfailures to
run the test suite, but that seems overkill.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
