### PR TITLE
Add rcParams to set ndivs minor ticks on axes separately

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -233,7 +233,8 @@ def validate_int_or_None(s):
         return int(s)
     except ValueError:
         raise ValueError('Could not convert "%s" to int' % s)
-        
+
+
 def validate_int_or_auto(s):
     if s == 'auto':
         return s
@@ -1315,11 +1316,11 @@ defaultParams = {
     'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
     'xtick.major.top':   [True, validate_bool],  # draw x axis top major ticks
     'xtick.major.bottom':    [True, validate_bool],    # draw x axis bottom major ticks
-    'xtick.minor.ndivs':  ['auto', validate_int_or_auto],   #set ndivs value for x axis minor ticks
+    'xtick.minor.ndivs':  ['auto', validate_int_or_auto],   # set ndivs value for x axis minor ticks
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
-    'xtick.direction':   ['out', validate_string],            # direction of xticks
+    'xtick.direction':   ['out', validate_string],  # direction of xticks
     'xtick.alignment': ["center", _validate_alignment],
 
     'ytick.left':        [True, validate_bool],  # draw ticks on the left side
@@ -1338,11 +1339,11 @@ defaultParams = {
     'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
     'ytick.major.left':   [True, validate_bool],  # draw y axis left major ticks
     'ytick.major.right':    [True, validate_bool],    # draw y axis right major ticks
-    'ytick.minor.ndivs':  ['auto', validate_int_or_auto],   #set ndivs value for y axis minor ticks
+    'ytick.minor.ndivs':  ['auto', validate_int_or_auto],   # set ndivs value for y axis minor ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],
-    'ytick.direction':   ['out', validate_string],            # direction of yticks
+    'ytick.direction':   ['out', validate_string],  # direction of yticks
     'ytick.alignment': ["center_baseline", _validate_alignment],
 
     'grid.color':        ['#b0b0b0', validate_color],  # grid color

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1316,7 +1316,7 @@ defaultParams = {
     'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
     'xtick.major.top':   [True, validate_bool],  # draw x axis top major ticks
     'xtick.major.bottom':    [True, validate_bool],    # draw x axis bottom major ticks
-    'xtick.minor.ndivs':  ['auto', validate_int_or_auto],   # set ndivs value for x axis minor ticks
+    'xtick.minor.ndivs':  ['auto', validate_int_or_auto],   # sets ndivs value for x axis minor ticks
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
@@ -1339,7 +1339,7 @@ defaultParams = {
     'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
     'ytick.major.left':   [True, validate_bool],  # draw y axis left major ticks
     'ytick.major.right':    [True, validate_bool],    # draw y axis right major ticks
-    'ytick.minor.ndivs':  ['auto', validate_int_or_auto],   # set ndivs value for y axis minor ticks
+    'ytick.minor.ndivs':  ['auto', validate_int_or_auto],   # sets ndivs value for y axis minor ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -233,6 +233,11 @@ def validate_int_or_None(s):
         return int(s)
     except ValueError:
         raise ValueError('Could not convert "%s" to int' % s)
+        
+def validate_int_or_auto(s):
+    if s == 'auto':
+        return s
+    return validate_int(s)
 
 
 def validate_fonttype(s):
@@ -1310,7 +1315,7 @@ defaultParams = {
     'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
     'xtick.major.top':   [True, validate_bool],  # draw x axis top major ticks
     'xtick.major.bottom':    [True, validate_bool],    # draw x axis bottom major ticks
-    'xtick.minor.default':  [4,validate_int],   #set default value for x axis minor ticks
+    'xtick.minor.ndivs':  ['auto', validate_int_or_auto],   #set ndivs value for x axis minor ticks
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
@@ -1333,7 +1338,7 @@ defaultParams = {
     'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
     'ytick.major.left':   [True, validate_bool],  # draw y axis left major ticks
     'ytick.major.right':    [True, validate_bool],    # draw y axis right major ticks
-    'ytick.minor.default':  [4,validate_int],   #set default value for y axis minor ticks
+    'ytick.minor.ndivs':  ['auto', validate_int_or_auto],   #set ndivs value for y axis minor ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1310,6 +1310,7 @@ defaultParams = {
     'xtick.minor.bottom':    [True, validate_bool],    # draw x axis bottom minor ticks
     'xtick.major.top':   [True, validate_bool],  # draw x axis top major ticks
     'xtick.major.bottom':    [True, validate_bool],    # draw x axis bottom major ticks
+    'xtick.minor.default':  [4,validate_int],   #set default value for x axis minor ticks
 
     # fontsize of the xtick labels
     'xtick.labelsize':   ['medium', validate_fontsize],
@@ -1332,6 +1333,7 @@ defaultParams = {
     'ytick.minor.right':    [True, validate_bool],    # draw y axis right minor ticks
     'ytick.major.left':   [True, validate_bool],  # draw y axis left major ticks
     'ytick.major.right':    [True, validate_bool],    # draw y axis right major ticks
+    'ytick.minor.default':  [4,validate_int],   #set default value for y axis minor ticks
 
     # fontsize of the ytick labels
     'ytick.labelsize':   ['medium', validate_fontsize],

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2634,12 +2634,7 @@ class AutoMinorLocator(Locator):
 
         If *n* is omitted or None, it will be set to 5 or 4.
         """
-        if n is None:
-            self.ndivs = None
-        elif n == 'auto':
-            self.ndivs = 'auto'
-        else:
-            self.ndivs = n
+        self.ndivs = n
 
     def __call__(self):
         'Return the locations of the ticks'

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2634,8 +2634,7 @@ class AutoMinorLocator(Locator):
 
         If *n* is omitted or None, it will be set to 5 or 4.
         """
-        #print(self.ndivs)
-        if n == None:
+        if n is None:
             self.ndivs = None
         elif n == 'auto':
             self.ndivs = 'auto'
@@ -2649,7 +2648,7 @@ class AutoMinorLocator(Locator):
                 self.ndivs = rcParams['xtick.minor.ndivs']
             elif self.axis.__name__ == 'yaxis':
                 self.ndivs = rcParams['ytick.minor.ndivs']
-        
+
         if self.axis.get_scale() == 'log':
             cbook._warn_external('AutoMinorLocator does not work with '
                                  'logarithmic scale')

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2635,9 +2635,9 @@ class AutoMinorLocator(Locator):
         If *n* is omitted or None, it will be set to 5 or 4.
         """
         if n == None:
-            if self.axis.__name__ == 'x':
+            if Locator.axis.__name__ == 'xaxis':
                 self.ndivs = rcParams['xtick.minor.ndivs']
-            elif self.axis.__name__ == 'y':
+            elif Locator.axis.__name__ == 'yaxis':
                 self.ndivs = rcParams['ytick.minor.ndivs']
         elif n == 'auto':
             self.ndivs = None

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2634,7 +2634,15 @@ class AutoMinorLocator(Locator):
 
         If *n* is omitted or None, it will be set to 5 or 4.
         """
-        self.ndivs = n
+        if n == None:
+            if self.axis.__name__ == 'x':
+                self.ndivs = rcParams['xtick.minor.ndivs']
+            elif self.axis.__name__ == 'y':
+                self.ndivs = rcParams['ytick.minor.ndivs']
+        elif n == 'auto':
+            self.ndivs = None
+        else:
+            self.ndivs = n
 
     def __call__(self):
         'Return the locations of the ticks'
@@ -2658,9 +2666,9 @@ class AutoMinorLocator(Locator):
             majorstep_no_exponent = 10 ** (np.log10(majorstep) % 1)
 
             if np.isclose(majorstep_no_exponent, [1.0, 2.5, 5.0, 10.0]).any():
-                ndivs = rcParams['xtick.minor.default'] + 1
+                ndivs = 5
             else:
-                ndivs = rcParams['xtick.minor.default']
+                ndivs = 4
         else:
             ndivs = self.ndivs
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2634,18 +2634,22 @@ class AutoMinorLocator(Locator):
 
         If *n* is omitted or None, it will be set to 5 or 4.
         """
+        #print(self.ndivs)
         if n == None:
-            if Locator.axis.__name__ == 'xaxis':
-                self.ndivs = rcParams['xtick.minor.ndivs']
-            elif Locator.axis.__name__ == 'yaxis':
-                self.ndivs = rcParams['ytick.minor.ndivs']
-        elif n == 'auto':
             self.ndivs = None
+        elif n == 'auto':
+            self.ndivs = 'auto'
         else:
             self.ndivs = n
 
     def __call__(self):
         'Return the locations of the ticks'
+        if self.ndivs is None:
+            if self.axis.__name__ == 'xaxis':
+                self.ndivs = rcParams['xtick.minor.ndivs']
+            elif self.axis.__name__ == 'yaxis':
+                self.ndivs = rcParams['ytick.minor.ndivs']
+        
         if self.axis.get_scale() == 'log':
             cbook._warn_external('AutoMinorLocator does not work with '
                                  'logarithmic scale')
@@ -2661,7 +2665,7 @@ class AutoMinorLocator(Locator):
             # no ticks at all.
             return []
 
-        if self.ndivs is None:
+        if self.ndivs == 'auto':
 
             majorstep_no_exponent = 10 ** (np.log10(majorstep) % 1)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2658,9 +2658,9 @@ class AutoMinorLocator(Locator):
             majorstep_no_exponent = 10 ** (np.log10(majorstep) % 1)
 
             if np.isclose(majorstep_no_exponent, [1.0, 2.5, 5.0, 10.0]).any():
-                ndivs = 5
+                ndivs = rcParams['xtick.minor.default'] + 1
             else:
-                ndivs = 4
+                ndivs = rcParams['xtick.minor.default']
         else:
             ndivs = self.ndivs
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -377,7 +377,7 @@
 #xtick.minor.top      : True   ## draw x axis top minor ticks
 #xtick.minor.bottom   : True   ## draw x axis bottom minor ticks
 #xtick.alignment      : center ## alignment of xticks
-#xtick.minor.default  : 4	   ## set default value for x axis minor ticks
+#xtick.minor.ndivs    : auto   ## set ndivs value for x axis minor ticks
 
 #ytick.left           : True   ## draw ticks on the left side
 #ytick.right          : False  ## draw ticks on the right side
@@ -398,7 +398,7 @@
 #ytick.minor.left     : True   ## draw y axis left minor ticks
 #ytick.minor.right    : True   ## draw y axis right minor ticks
 #ytick.alignment      : center_baseline ## alignment of yticks
-#ytick.minor.default  : 4	   ## set default value for y axis minor ticks
+#ytick.minor.ndivs    : auto   ## set ndivs value for y axis minor ticks
 
 #### GRIDS
 #grid.color       :   b0b0b0    ## grid color

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -377,6 +377,7 @@
 #xtick.minor.top      : True   ## draw x axis top minor ticks
 #xtick.minor.bottom   : True   ## draw x axis bottom minor ticks
 #xtick.alignment      : center ## alignment of xticks
+#xtick.minor.default  : 4	   ## set default value for x axis minor ticks
 
 #ytick.left           : True   ## draw ticks on the left side
 #ytick.right          : False  ## draw ticks on the right side
@@ -397,6 +398,7 @@
 #ytick.minor.left     : True   ## draw y axis left minor ticks
 #ytick.minor.right    : True   ## draw y axis right minor ticks
 #ytick.alignment      : center_baseline ## alignment of yticks
+#ytick.minor.default  : 4	   ## set default value for y axis minor ticks
 
 #### GRIDS
 #grid.color       :   b0b0b0    ## grid color


### PR DESCRIPTION
## PR Summary
added the key in rcParams for xtick.minor.default. didn't change the number of parameters of Autominorticker. if the rcparams is set and the parameter value is none then use the parameter value for minor tick or else use the n value provided. for  #14233 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
