### PR TITLE
DOC boxplot `whis` parameter

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3503,15 +3503,14 @@ class Axes(_AxesBase):
             everything is drawn horizontally.
 
         whis : float, sequence, or string (default = 1.5)
-            As a float, determines the reach of the whiskers to the beyond the
+            As a float, determines the reach of the whiskers beyond the
             first and third quartiles. In other words, where IQR is the
             interquartile range (`Q3-Q1`), the upper whisker will extend to
             last datum less than `Q3 + whis*IQR`). Similarly, the lower whisker
             will extend to the first datum greater than `Q1 - whis*IQR`.
             Beyond the whiskers, data
             are considered outliers and are plotted as individual
-            points. Set this to an unreasonably high value to force the
-            whiskers to show the min and max values. Alternatively, set
+            points. Alternatively, set
             this to an ascending sequence of percentile (e.g., [5, 95])
             to set the whiskers at specific percentiles of the data.
             Finally, ``whis`` can be the string ``'range'`` to force the


### PR DESCRIPTION
## PR Summary

Fixed the typo on line 3506, then noticed that the suggestion on line 3513 seems to be redundant with the `'range'` option which I assume was added later?
