### PR TITLE
Deprecate `boxplot(..., whis="range")`.

### DIFF
--- a/doc/api/next_api_changes/2019-05-28-AL.rst
+++ b/doc/api/next_api_changes/2019-05-28-AL.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+Setting the ``whis`` parameter of `.Axes.boxplot` and `.cbook.boxplot_stats` to
+"range" to mean "the whole data range" is deprecated; set it to (0, 100) (which
+gets interpreted as percentiles) to achieve the same effect.

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -74,8 +74,8 @@ axs[0, 0].set_title('Custom boxprops', fontsize=fs)
 axs[0, 1].boxplot(data, flierprops=flierprops, medianprops=medianprops)
 axs[0, 1].set_title('Custom medianprops\nand flierprops', fontsize=fs)
 
-axs[0, 2].boxplot(data, whis='range')
-axs[0, 2].set_title('whis="range"', fontsize=fs)
+axs[0, 2].boxplot(data, whis=(0, 100))
+axs[0, 2].set_title('whis=(0, 100)', fontsize=fs)
 
 axs[1, 0].boxplot(data, meanprops=meanpointprops, meanline=False,
                   showmeans=True)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3502,19 +3502,26 @@ class Axes(_AxesBase):
             If `True` (default), makes the boxes vertical. If `False`,
             everything is drawn horizontally.
 
-        whis : float, sequence, or string (default = 1.5)
-            As a float, determines the reach of the whiskers beyond the
-            first and third quartiles. In other words, where IQR is the
-            interquartile range (`Q3-Q1`), the upper whisker will extend to
-            last datum less than `Q3 + whis*IQR`). Similarly, the lower whisker
-            will extend to the first datum greater than `Q1 - whis*IQR`.
-            Beyond the whiskers, data
-            are considered outliers and are plotted as individual
-            points. Alternatively, set
-            this to an ascending sequence of percentile (e.g., [5, 95])
-            to set the whiskers at specific percentiles of the data.
-            Finally, ``whis`` can be the string ``'range'`` to force the
-            whiskers to the min and max of the data.
+        whis : float or (float, float) (default = 1.5)
+            The position of the whiskers.
+
+            If a float, the lower whisker is at the lowest datum above
+            ``Q1 - whis*(Q3-Q1)``, and the upper whisker at the highest datum
+            below ``Q3 + whis*(Q3-Q1)``, where Q1 and Q3 are the first and
+            third quartiles.  The default value of ``whis = 1.5`` corresponds
+            to Tukey's original definition of boxplots.
+
+            If a pair of floats, they indicate the percentiles at which to
+            draw the whiskers (e.g., (5, 95)).  In particular, setting this to
+            (0, 100) results in whiskers covering the whole range of the data.
+            "range" is a deprecated synonym for (0, 100).
+
+            In the edge case where ``Q1 == Q3``, *whis* is automatically set
+            to (0, 100) (cover the whole range of the data) if *autorange* is
+            True.
+
+            Beyond the whiskers, data are considered outliers and are plotted
+            as individual points.
 
         bootstrap : int, optional
             Specifies whether to bootstrap the confidence intervals
@@ -3567,7 +3574,7 @@ class Axes(_AxesBase):
 
         autorange : bool, optional (False)
             When `True` and the data are distributed such that the 25th and
-            75th percentiles are equal, ``whis`` is set to ``'range'`` such
+            75th percentiles are equal, ``whis`` is set to (0, 100) such
             that the whisker ends are at the minimum and maximum of the data.
 
         meanline : bool, optional (False)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -503,6 +503,10 @@ def validate_verbose(s):
 
 def validate_whiskers(s):
     if s == 'range':
+        cbook.warn_deprecated(
+            "3.2", message="Support for setting the boxplot.whiskers rcParam "
+            "to 'range' is deprecated since %(since)s and will be removed "
+            "%(removal)s; set it to 0, 100 instead.")
         return 'range'
     else:
         try:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2182,7 +2182,7 @@ def test_bxp_baseline():
                   savefig_kwarg={'dpi': 40},
                   style='default')
 def test_bxp_rangewhis():
-    _bxp_test_helper(stats_kwargs=dict(whis='range'))
+    _bxp_test_helper(stats_kwargs=dict(whis=[0, 100]))
 
 
 @image_comparison(['bxp_precentilewhis.png'],
@@ -2500,7 +2500,7 @@ def test_boxplot_rc_parameters():
 
     rc_axis1 = {
         'boxplot.vertical': False,
-        'boxplot.whiskers': 'range',
+        'boxplot.whiskers': [0, 100],
         'boxplot.patchartist': True,
     }
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -147,7 +147,7 @@ class Test_boxplot_stats:
             assert_array_almost_equal(res[key], value)
 
     def test_results_whiskers_range(self):
-        results = cbook.boxplot_stats(self.data, whis='range')
+        results = cbook.boxplot_stats(self.data, whis=[0, 100])
         res = results[0]
         for key, value in self.known_res_range.items():
             assert_array_almost_equal(res[key], value)


### PR DESCRIPTION
It's a special-case that needs its own testing and documentation, when
it can be perfectly well folded into `whis=(percentile, percentile)`
(specifically, `whis=(0, 100)`).

Noted while reviewing #14358.

attn @phobson in can you think it's really worth keeping the special-cased API.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
