### PR TITLE
Rewrite assert np.* tests to use numpy.testing

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6320,8 +6320,8 @@ def test_hist_nan_data():
     with np.errstate(invalid='ignore'):
         nanbins, nanedges, _ = ax2.hist(nan_data)
 
-    assert np.allclose(bins, nanbins)
-    assert np.allclose(edges, nanedges)
+    np.testing.assert_allclose(bins, nanbins)
+    np.testing.assert_allclose(edges, nanedges)
 
 
 def test_hist_range_and_density():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -320,19 +320,17 @@ def test_colorbar_minorticks_on_off():
 
     # test that minorticks turn off for LogNorm
     cbar.minorticks_off()
-    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
-                          np.array([]))
+    np.testing.assert_equal(cbar.ax.yaxis.get_minorticklocs(), [])
 
     # test that minorticks turn back on for LogNorm
     cbar.minorticks_on()
-    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
-                          default_minorticklocks)
+    np.testing.assert_equal(cbar.ax.yaxis.get_minorticklocs(),
+                            default_minorticklocks)
 
     # test issue #13339: minorticks for LogNorm should stay off
     cbar.minorticks_off()
     cbar.set_ticks([3, 5, 7, 9])
-    assert np.array_equal(cbar.ax.yaxis.get_minorticklocs(),
-                          np.array([]))
+    np.testing.assert_equal(cbar.ax.yaxis.get_minorticklocs(), [])
 
 
 def test_colorbar_autoticks():
@@ -451,8 +449,8 @@ def test_colorbar_renorm():
     fig, ax = plt.subplots()
     im = ax.imshow(z)
     cbar = fig.colorbar(im)
-    assert np.allclose(cbar.ax.yaxis.get_majorticklocs(),
-                       np.arange(0, 120000.1, 15000))
+    np.testing.assert_allclose(cbar.ax.yaxis.get_majorticklocs(),
+                               np.arange(0, 120000.1, 15000))
 
     cbar.set_ticks([1, 2, 3])
     assert isinstance(cbar.locator, FixedLocator)
@@ -460,14 +458,14 @@ def test_colorbar_renorm():
     norm = LogNorm(z.min(), z.max())
     im.set_norm(norm)
     assert isinstance(cbar.locator, _ColorbarLogLocator)
-    assert np.allclose(cbar.ax.yaxis.get_majorticklocs(),
-                       np.logspace(-8, 5, 14))
+    np.testing.assert_allclose(cbar.ax.yaxis.get_majorticklocs(),
+                               np.logspace(-8, 5, 14))
     # note that set_norm removes the FixedLocator...
     assert np.isclose(cbar.vmin, z.min())
     cbar.set_ticks([1, 2, 3])
     assert isinstance(cbar.locator, FixedLocator)
-    assert np.allclose(cbar.ax.yaxis.get_majorticklocs(),
-                       [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(cbar.ax.yaxis.get_majorticklocs(),
+                               [1.0, 2.0, 3.0])
 
     norm = LogNorm(z.min() * 1000, z.max() * 1000)
     im.set_norm(norm)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -33,12 +33,12 @@ def test_date_numpyx():
     ax = fig.add_subplot(1, 1, 1)
     h, = ax.plot(time, data)
     hnp, = ax.plot(timenp, data)
-    assert np.array_equal(h.get_xdata(orig=False), hnp.get_xdata(orig=False))
+    np.testing.assert_equal(h.get_xdata(orig=False), hnp.get_xdata(orig=False))
     fig = plt.figure(figsize=(10, 2))
     ax = fig.add_subplot(1, 1, 1)
     h, = ax.plot(data, time)
     hnp, = ax.plot(data, timenp)
-    assert np.array_equal(h.get_ydata(orig=False), hnp.get_ydata(orig=False))
+    np.testing.assert_equal(h.get_ydata(orig=False), hnp.get_ydata(orig=False))
 
 
 @pytest.mark.parametrize('t0', [datetime.datetime(2017, 1, 1, 0, 1, 1),
@@ -58,7 +58,7 @@ def test_date_date2num_numpy(t0, dtype):
     time = mdates.date2num(t0)
     tnp = np.array(t0, dtype=dtype)
     nptime = mdates.date2num(tnp)
-    assert np.array_equal(time, nptime)
+    np.testing.assert_equal(time, nptime)
 
 
 @pytest.mark.parametrize('dtype', ['datetime64[s]',
@@ -827,4 +827,4 @@ def test_num2timedelta(x, tdelta):
 def test_datetime64_in_list():
     dt = [np.datetime64('2000-01-01'), np.datetime64('2001-01-01')]
     dn = mdates.date2num(dt)
-    assert np.array_equal(dn, [730120.,  730486.])
+    np.testing.assert_equal(dn, [730120.,  730486.])

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -38,17 +38,15 @@ def test_point_in_path():
     points = [(0.5, 0.5), (1.5, 0.5)]
     ret = path.contains_points(points)
     assert ret.dtype == 'bool'
-    assert np.all(ret == [True, False])
+    np.testing.assert_equal(ret, [True, False])
 
 
 def test_contains_points_negative_radius():
     path = Path.unit_circle()
 
     points = [(0.0, 0.0), (1.25, 0.0), (0.9, 0.9)]
-    expected = [True, False, False]
     result = path.contains_points(points, radius=-0.5)
-
-    assert np.all(result == expected)
+    np.testing.assert_equal(result, [True, False, False])
 
 
 def test_point_in_path_nan():
@@ -359,4 +357,4 @@ def test_full_arc(offset):
     mins = np.min(path.vertices, axis=0)
     maxs = np.max(path.vertices, axis=0)
     np.testing.assert_allclose(mins, -1)
-    assert np.allclose(maxs, 1)
+    np.testing.assert_allclose(maxs, 1)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -387,7 +387,7 @@ def generate_validator_testcases(valid):
 def test_validator_valid(validator, arg, target):
     res = validator(arg)
     if isinstance(target, np.ndarray):
-        assert np.all(res == target)
+        np.testing.assert_equal(res, target)
     elif not isinstance(target, Cycler):
         assert res == target
     else:

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -125,7 +125,8 @@ class TestAutoMinorLocator(object):
     def test_using_all_default_major_steps(self):
         with matplotlib.rc_context({'_internal.classic_mode': False}):
             majorsteps = [x[0] for x in self.majorstep_minordivisions]
-            assert np.allclose(majorsteps, mticker.AutoLocator()._steps)
+            np.testing.assert_allclose(majorsteps,
+                                       mticker.AutoLocator()._steps)
 
     @pytest.mark.parametrize('major_step, expected_nb_minordivisions',
                              majorstep_minordivisions)


### PR DESCRIPTION
## PR Summary

Use `np.testing.assert_allclose()` instead of `assert np.allclose()` and similar because the numpy assertions will give context on what fails whereas pytest cannot introspect `np.allclose()` and will just notify an overall failure.