### PR TITLE
Remove unnecessary uses of unittest.mock.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -206,23 +206,23 @@ def test_fig_signals(qt_module):
 ])
 def test_correct_key(backend, qt_key, qt_mods, answer):
     """
-    Make a figure
-    Send a key_press_event event (using non-public, qtX backend specific api)
-    Catch the event
-    Assert sent and caught keys are the same
+    Make a figure.
+    Send a key_press_event event (using non-public, qtX backend specific api).
+    Catch the event.
+    Assert sent and caught keys are the same.
     """
     qt_canvas = plt.figure().canvas
 
-    event = mock.Mock()
-    event.isAutoRepeat.return_value = False
-    event.key.return_value = qt_key
-    event.modifiers.return_value = qt_mods
+    class _Event:
+        def isAutoRepeat(self): return False
+        def key(self): return qt_key
+        def modifiers(self): return qt_mods
 
     def receive(event):
         assert event.key == answer
 
     qt_canvas.mpl_connect('key_press_event', receive)
-    qt_canvas.keyPressEvent(event)
+    qt_canvas.keyPressEvent(_Event())
 
 
 @pytest.mark.backend('Qt5Agg')

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1,6 +1,5 @@
 import datetime
 import tempfile
-from unittest.mock import Mock
 
 import dateutil.tz
 import dateutil.rrule
@@ -245,12 +244,14 @@ def test_locator_set_formatter():
 
 
 def test_date_formatter_callable():
-    scale = -11
-    locator = Mock(_get_unit=Mock(return_value=scale))
-    callable_formatting_function = (lambda dates, _:
-                                    [dt.strftime('%d-%m//%Y') for dt in dates])
 
-    formatter = mdates.AutoDateFormatter(locator)
+    class _Locator:
+        def _get_unit(self): return -11
+
+    def callable_formatting_function(dates, _):
+        return [dt.strftime('%d-%m//%Y') for dt in dates]
+
+    formatter = mdates.AutoDateFormatter(_Locator())
     formatter.scaled[-10] = callable_formatting_function
     assert formatter([datetime.datetime(2014, 12, 25)]) == ['25-12//2014']
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from types import SimpleNamespace
 
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
@@ -54,7 +54,7 @@ def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
     *step*
         number of scroll steps (positive for 'up', negative for 'down')
     """
-    event = Mock()
+    event = SimpleNamespace()
     event.button = button
     ax = tool.ax
     event.x, event.y = ax.transData.transform([(xdata, ydata),


### PR DESCRIPTION
Quite often it's just fine to create a throwaway class instead, which
actually makes the test tighter (mocks will automagically create missing
attributes, so using a throwaway class asserts that no such attribute is
accessed).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
