### PR TITLE
Remove the ``package_data.dlls`` setup.cfg entry.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -284,6 +284,9 @@ There are a few possibilities to build Matplotlib on Windows:
 * Wheels by using conda packages (see below)
 * Conda packages (see below)
 
+If you are building your own Matplotlib wheels (or sdists), note that any DLLs
+that you copy into the source tree will be packaged too.
+
 Wheel builds using conda packages
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -303,7 +306,6 @@ For building, call the script ``build_alllocal.cmd`` in the root folder of the
 repository::
 
   build_alllocal.cmd
-
 
 Conda packages
 ^^^^^^^^^^^^^^

--- a/doc/api/next_api_changes/2019-05-30-AL.rst
+++ b/doc/api/next_api_changes/2019-05-30-AL.rst
@@ -1,0 +1,10 @@
+Changes to the Matplotlib build
+```````````````````````````````
+
+Previously, it was possible to package Windows DLLs into the Maptlotlib
+wheel (or sdist) by copying them into the source tree and setting the
+``package_data.dlls`` entry in ``setup.cfg``.
+
+DLLs copied in the source tree are now always packaged; the
+``package_data.dlls`` entry has no effect anymore.  If you do not want to
+include the DLLs, don't copy them into the source tree.

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -66,9 +66,3 @@
 # modules.  The default is determined by fallback.
 #
 #backend = Agg
-
-[package_data]
-# Package additional files found in the lib/matplotlib directories.
-#
-# On Windows, package DLL files.
-#dlls = True

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,6 @@ mpl_packages = [
     setupext.BackendAgg(),
     setupext.BackendTkAgg(),
     setupext.BackendMacOSX(),
-    'Optional package data',
-    setupext.Dlls(),
     ]
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -401,6 +401,7 @@ class Matplotlib(SetupPackage):
                 *_pkg_data_helper('matplotlib', 'mpl-data/images'),
                 *_pkg_data_helper('matplotlib', 'mpl-data/stylelib'),
                 *_pkg_data_helper('matplotlib', 'backends/web_backend'),
+                '*.dll',  # Only actually matters on Windows.
             ],
         }
 
@@ -816,35 +817,3 @@ class BackendMacOSX(OptionalBackendPackage):
         if platform.python_implementation().lower() == 'pypy':
             ext.extra_compile_args.append('-DPYPY=1')
         return ext
-
-
-class OptionalPackageData(OptionalPackage):
-    config_category = "package_data"
-
-
-class Dlls(OptionalPackageData):
-    """
-    On Windows, this packages any DLL files that can be found in the
-    lib/matplotlib/* directories.
-    """
-    name = "dlls"
-
-    def check(self):
-        if sys.platform != 'win32':
-            raise CheckFailed("Microsoft Windows only")
-        return super().check()
-
-    def get_package_data(self):
-        return {'': ['*.dll']}
-
-    @classmethod
-    def get_config(cls):
-        """
-        Look at `setup.cfg` and return one of ["auto", True, False] indicating
-        if the package is at default state ("auto"), forced by the user (True)
-        or opted-out (False).
-        """
-        try:
-            return config.getboolean(cls.config_category, cls.name)
-        except Exception:
-            return False  # <-- default


### PR DESCRIPTION
See changelog for details.

DLLs won't end up in the source tree unless one explicitly copies them
there, so let's assume that whoever does this knows what they're doing.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
