### PR TITLE
MAINT: work around non-zero exit status of "pdftops -v" command.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -314,7 +314,7 @@ def _get_executable_info(name):
         If the executable is not one that we know how to query.
     """
 
-    def impl(args, regex, min_ver=None, ignore_error=False):
+    def impl(args, regex, min_ver=None, ignore_exit_code=False):
         # Execute the subprocess specified by args; capture stdout and stderr.
         # Search for a regex match in the output; if the match succeeds, the
         # first group of the match is the version.
@@ -324,7 +324,7 @@ def _get_executable_info(name):
             output = subprocess.check_output(
                 args, stderr=subprocess.STDOUT, universal_newlines=True)
         except subprocess.CalledProcessError as _cpe:
-            if ignore_error:
+            if ignore_exit_code:
                 output = _cpe.output
             else:
                 raise _cpe
@@ -385,7 +385,7 @@ def _get_executable_info(name):
         return impl([path, "--version"], r"^Version: ImageMagick (\S*)")
     elif name == "pdftops":
         info = impl(["pdftops", "-v"], "^pdftops version (.*)",
-                    ignore_error=True)
+                    ignore_exit_code=True)
         if info and not ("3.0" <= info.version
                          # poppler version numbers.
                          or "0.9" <= info.version <= "1.0"):


### PR DESCRIPTION
In the function responsible for probing the presence of external
command (`_get_executable_info`), add an optional argument
`ignore_error` (default `False`). If set to `True`, the external command is
allowed to exit with non-zero status, and the content of the output is
used anyway.

This works around the problem with certain xpdf versions where the
exit status of `pdftops -v` command is nonzero.

Compatibility is maintained because the optional argument defaults to
False which doesn't introduce any new behaviour.

## PR Summary

## PR Checklist

<s>- [ ] Has Pytest style unit tests</s> not applicable
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
<s>- [ ] New features are documented, with examples if plot related</s> not applicable
<s>- [ ] Documentation is sphinx and numpydoc compliant</s>
<s>- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)</s>
<s>- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way</s>

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
