### PR TITLE
Correctly set clip_path on pcolorfast return artist.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6309,6 +6309,9 @@ optional.
             ret.set_clim(vmin, vmax)
         elif np.ndim(C) == 2:  # C.ndim == 3 is RGB(A) so doesn't need scaling.
             ret.autoscale_None()
+        if ret.get_clip_path() is None:
+            # image does not already have clipping set, clip to axes patch
+            ret.set_clip_path(self.patch)
 
         ret.sticky_edges.x[:] = [xl, xr]
         ret.sticky_edges.y[:] = [yb, yt]

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -90,9 +90,21 @@ def test_bbox_inches_tight_raster():
 
 
 def test_only_on_non_finite_bbox():
-
     fig, ax = plt.subplots()
     ax.annotate("", xy=(0, float('nan')))
     ax.set_axis_off()
     # we only need to test that it does not error out on save
     fig.savefig(BytesIO(), bbox_inches='tight', format='png')
+
+
+def test_tight_pcolorfast():
+    fig, ax = plt.subplots()
+    ax.pcolorfast(np.arange(4).reshape((2, 2)))
+    ax.set(ylim=(0, .1))
+    buf = BytesIO()
+    fig.savefig(buf, bbox_inches="tight")
+    buf.seek(0)
+    height, width, _ = plt.imread(buf).shape
+    # Previously, the bbox would include the area of the image clipped out by
+    # the axes, resulting in a very tall image given the y limits of (0, 0.1).
+    assert width > height


### PR DESCRIPTION
## PR Summary

Closes #13576.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
