### PR TITLE
Improve warning for case where data kwarg entry is ambiguous.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -194,10 +194,13 @@ class _process_plot_var_args:
                 else:
                     if replaced[1] is not args[1]:  # case 2a)
                         cbook._warn_external(
-                            "Second argument {!r} is ambiguous: could be a "
-                            "color spec but is in data; using as data.  "
-                            "Either rename the entry in data or use three "
-                            "arguments to plot.".format(args[1]),
+                            f"Second argument {args[1]!r} is ambiguous: could "
+                            f"be a format string but is in 'data'; using as "
+                            f"data.  If it was intended as data, set the "
+                            f"format string to an empty string to suppress "
+                            f"this warning.  If it was intended as a format "
+                            f"string, explicitly pass the x-values as well.  "
+                            f"Alternatively, rename the entry in 'data'.",
                             RuntimeWarning)
                         label_namer_idx = 1
                     else:  # case 2b)


### PR DESCRIPTION
A call like `plot("x", "y", data={"x": ..., "y": ...})` currently
results in a warning suggesting to use a 3-arg call or renaming the
entry, because "y" is ambiguous.

Renaming the entry is not always an option (if you do not control
'data'), and it may not be obvious how to do a 3-arg call that just uses
the normal property cycle.  As it turns out, passing an empty string
works, so document that possibility.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
