### PR TITLE
Fix to_rgba_array() for empty input

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -311,10 +311,12 @@ def to_rgba_array(c, alpha=None):
             cbook.warn_deprecated("3.2", message="Using a string of single "
                                   "character colors as a color sequence is "
                                   "deprecated. Use an explicit list instead.")
-    else:
-        result = np.array([to_rgba(cc, alpha) for cc in c])
+            return result
 
-    return result
+    if len(c) == 0:
+        return np.zeros((0, 4), float)
+    else:
+        return np.array([to_rgba(cc, alpha) for cc in c])
 
 
 def to_rgb(c):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -806,6 +806,7 @@ def test_cn():
 def test_conversions():
     # to_rgba_array("none") returns a (0, 4) array.
     assert_array_equal(mcolors.to_rgba_array("none"), np.zeros((0, 4)))
+    assert_array_equal(mcolors.to_rgba_array([]), np.zeros((0, 4)))
     # a list of grayscale levels, not a single color.
     assert_array_equal(
         mcolors.to_rgba_array([".2", ".5", ".8"]),


### PR DESCRIPTION
## PR Summary

This fixes a regression introduced in #14259.

`to_rgba_array([])` must return a (0, 4) shape array, not a (0,) shape array.
