### PR TITLE
Assume that mpl-data is in its standard location.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -607,8 +607,16 @@ def _get_data_path():
             "3.1", name="MATPLOTLIBDATA", obj_type="environment variable")
         return path
 
+    path = Path(__file__).with_name("mpl-data")
+    if path.is_dir():
+        return str(path)
+
+    cbook.warn_deprecated(
+        "3.2", message="Matplotlib installs where the data is not in the "
+        "mpl-data subdirectory of the package are deprecated since %(since)s "
+        "and support for them will be removed %(removal)s.")
+
     def get_candidate_paths():
-        yield Path(__file__).with_name('mpl-data')
         # setuptools' namespace_packages may hijack this init file
         # so need to try something known to be in Matplotlib, not basemap.
         import matplotlib.afm


### PR DESCRIPTION
The previous candidates tested in get_candidate_paths were for

1) when matplotlib itself was a namespace package (a long time ago,
   before mpl_toolkits were move out of matplotlib proper), and
2) py2exe support, which is deprecated (see deprecation of
   get_py2exe_datafiles).

Just to be sure in case someone else is relying on the paths in
get_candidate_paths, emit a deprecation warning in case they are needed,
but let's not bother with an API changes note (it's not even clear how
to word that).

Note that redistributors (e.g. linux distro packagers) who may want to
move mpl-data out can still do so by patching out the entire
`_get_data_path` function.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
