### PR TITLE
Prefer `mpl.get_data_path()`, and support Paths in FontProperties.

### DIFF
--- a/doc/users/next_whats_new/2019-05-31-AL.rst
+++ b/doc/users/next_whats_new/2019-05-31-AL.rst
@@ -1,0 +1,4 @@
+The *fname* argument to `FontProperties` can now be an `os.PathLike`\s
+``````````````````````````````````````````````````````````````````````
+
+e.g. ``FontProperties(fname=pathlib.Path("/path/to/font.ttf"))``.

--- a/examples/text_labels_and_annotations/font_file.py
+++ b/examples/text_labels_and_annotations/font_file.py
@@ -15,16 +15,17 @@ For a more flexible solution, see
 :doc:`/gallery/text_labels_and_annotations/fonts_demo`.
 """
 
-import os
-from matplotlib import font_manager as fm, rcParams
+from pathlib import Path
+
+import matplotlib as mpl
+from matplotlib import font_manager as fm
 import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots()
 
-fpath = os.path.join(rcParams["datapath"], "fonts/ttf/cmr10.ttf")
+fpath = Path(mpl.get_data_path(), "fonts/ttf/cmr10.ttf")
 prop = fm.FontProperties(fname=fpath)
-fname = os.path.split(fpath)[1]
-ax.set_title('This is a special font: {}'.format(fname), fontproperties=prop)
+ax.set_title(f'This is a special font: {fpath.name}', fontproperties=prop)
 ax.set_xlabel('This is the default font')
 
 plt.show()

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -13,9 +13,9 @@ either:
 
 It is pretty easy to use, and requires only built-in python libs:
 
-    >>> from matplotlib import rcParams
+    >>> import matplotlib as mpl
     >>> import os.path
-    >>> afm_fname = os.path.join(rcParams['datapath'],
+    >>> afm_fname = os.path.join(mpl.get_data_path(),
     ...                         'fonts', 'afm', 'ptmr8a.afm')
     >>>
     >>> from matplotlib.afm import AFM

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1275,7 +1275,7 @@ fontManager = None
 def get_font(filename, hinting_factor=None):
     if hinting_factor is None:
         hinting_factor = rcParams['text.hinting_factor']
-    return _get_font(filename, hinting_factor)
+    return _get_font(os.fspath(filename), hinting_factor)
 
 
 def _rebuild():


### PR DESCRIPTION
1) Prefer using mpl.get_data_path() rather than rcParams["datapath"].
   I would like to ultimately kill that rcParams entry, because it
   does not make sense as a rcParam (for example one can't really
   meaningfully assign it to anything else than its default value, or
   set it in their matplotlibrc) and requires e.g. to be blacklisted
   in style/core.py; let's start by not using it in the docs.

2) As a side effect of that change, one of the examples (font_file.py)
   reads a bit more nicely if one can pass Paths to FontProperties, so
   let's support that.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
