### PR TITLE
Use aspect=1, not aspect=True.

### DIFF
--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -18,8 +18,7 @@ def test_fancyarrow():
     t = ["fancy", "simple", mpatches.ArrowStyle.Fancy()]
 
     fig, axs = plt.subplots(len(t), len(r), squeeze=False,
-                            subplot_kw=dict(aspect=True),
-                            figsize=(8, 4.5))
+                            figsize=(8, 4.5), subplot_kw=dict(aspect=1))
 
     for i_r, r1 in enumerate(r):
         for i_t, t1 in enumerate(t):


### PR DESCRIPTION
aspect=True seems like an obfuscated way to spell aspect=1 ("equal
aspect").

(Note that this should not be confused with uses of `aspect=True` in
AxesGrid, which is different and actually takes a bool as argument...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
