### PR TITLE
MAINT: Don't install pytest 4.6.0 on Travis

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,7 +66,7 @@ install:
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.4" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.4,<4.6" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -5,7 +5,7 @@ cycler
 numpy
 pillow
 pyparsing
-pytest
+pytest>=4.5.0,<4.6.0
 pytest-cov
 pytest-faulthandler
 pytest-rerunfailures


### PR DESCRIPTION
The most recent version of pytest seems to be causing test failures, see pytest-dev/pytest#5358
