### PR TITLE
Fix test_imshow_pil on Windows.

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -119,13 +119,17 @@ def test_image_python_io():
 def test_imshow_pil(fig_test, fig_ref):
     style.use("default")
     PIL = pytest.importorskip("PIL")
-    png_path = Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png"
-    tiff_path = Path(__file__).parent / "baseline_images/test_image/uint16.tif"
+    # Pillow<=6.0 fails to open pathlib.Paths on Windows (pillow#3823), and
+    # Matplotlib's builtin png opener doesn't handle them either.
+    png_path = str(
+        Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png")
+    tiff_path = str(
+        Path(__file__).parent / "baseline_images/test_image/uint16.tif")
     axs = fig_test.subplots(2)
     axs[0].imshow(PIL.Image.open(png_path))
     axs[1].imshow(PIL.Image.open(tiff_path))
     axs = fig_ref.subplots(2)
-    axs[0].imshow(plt.imread(str(png_path)))
+    axs[0].imshow(plt.imread(png_path))
     axs[1].imshow(plt.imread(tiff_path))
 
 


### PR DESCRIPTION
test_imshow_pil currently fails on Windows, but this was not detected
because PIL is not installed on the Appveyor CI so the test is skipped.

Noted while working on #13077.
The Pillow issue is https://github.com/python-pillow/Pillow/issues/3823.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
