### PR TITLE
Lic restore license paint

### DIFF
--- a/LICENSE/LICENSE_PAINT
+++ b/LICENSE/LICENSE_PAINT
@@ -1,0 +1,20 @@
+Copyright 2000 by Object Craft P/L, Melbourne, Australia.
+
+                        All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of Object Craft
+is not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior
+permission.
+
+OBJECT CRAFT DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL OBJECT CRAFT BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -1,9 +1,5 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
-// this code is heavily adapted from the paint license, which is in
-// the file LICENSE_PAINT (BSD compatible) included in this
-// distribution.
-
 /* For linux, png.h must be imported before Python.h because
    png.h needs to be the one to define setjmp.
    Undefining _POSIX_C_SOURCE and _XOPEN_SOURCE stops a couple
@@ -139,6 +135,9 @@ const char *Py_write_png__doc__ =
     "    Byte string containing the PNG content if None was passed in for\n"
     "    file, otherwise None is returned.\n";
 
+// this code is heavily adapted from the paint license, which is in
+// the file LICENSE_PAINT (BSD compatible) included in this
+// distribution.
 static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 {
     numpy::array_view<unsigned char, 3> buffer;

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -1,8 +1,8 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
 // this code is heavily adapted from the paint license, which is in
-// the file paint.license (BSD compatible) included in this
-// distribution.  TODO, add license file to MANIFEST.in and CVS
+// the file LICENSE_PAINT (BSD compatible) included in this
+// distribution.
 
 /* For linux, png.h must be imported before Python.h because
    png.h needs to be the one to define setjmp.

--- a/src/_png.cpp
+++ b/src/_png.cpp
@@ -135,9 +135,9 @@ const char *Py_write_png__doc__ =
     "    Byte string containing the PNG content if None was passed in for\n"
     "    file, otherwise None is returned.\n";
 
-// this code is heavily adapted from the paint license, which is in
-// the file LICENSE_PAINT (BSD compatible) included in this
-// distribution.
+// this code is heavily adapted from
+// https://www.object-craft.com.au/projects/paint/ which licensed under the
+// (BSD compatible) LICENSE_PAINT which is included in this distribution.
 static PyObject *Py_write_png(PyObject *self, PyObject *args, PyObject *kwds)
 {
     numpy::array_view<unsigned char, 3> buffer;


### PR DESCRIPTION
This is in response to a question on the mailing list about the provenance of the png writing code (https://mail.python.org/pipermail/matplotlib-devel/2019-May/001261.html).

Details of code forensics at https://mail.python.org/pipermail/matplotlib-devel/2019-June/001270.html and https://mail.python.org/pipermail/matplotlib-devel/2019-June/001271.html

There is possibly an argument to be had that our current code https://github.com/matplotlib/matplotlib/blob/4eb00372840f88800ed2c926dfbea8a427430ba6/src/_png.cpp#L142-L397 is so far from the original that is not recognizable, but it is far less effort and risk to carry the license file.

Marked as release critical to bring us back into license compliance.