### PR TITLE
Issue #14372 - Add degrees to documentation

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -963,12 +963,12 @@ class Axes3D(Axes):
 
     def view_init(self, elev=None, azim=None):
         """
-        Set the elevation and azimuth of the axes.
+        Set the elevation and azimuth of the axes in degrees (not radians).
 
         This can be used to rotate the axes programmatically.
 
-        'elev' stores the elevation angle in the z plane.
-        'azim' stores the azimuth angle in the x,y plane.
+        'elev' stores the elevation angle in the z plane (in degrees).
+        'azim' stores the azimuth angle in the x,y plane (in degrees).
 
         if elev or azim are None (default), then the initial value
         is used which was specified in the :class:`Axes3D` constructor.


### PR DESCRIPTION
This is in response to the issue #14372 which wanted the doco updated to reflect that it is in degrees, not radians.

https://github.com/matplotlib/matplotlib/issues/14372

## PR Summary
Update to documentation as per the issue. I have made it very clear that it is degrees that are required. Possibly a bit too much, but I know how easy it is to not see something when you are rushing.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
