### PR TITLE
FIX: allow secondary axes minor locators to be set

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -82,6 +82,7 @@ class SecondaryAxis(_AxesBase):
             self._axis = self.yaxis
             self._locstrings = ['right', 'left']
             self._otherstrings = ['top', 'bottom']
+        self._parentscale = self._axis.get_scale()
         # this gets positioned w/o constrained_layout so exclude:
         self._layoutbox = None
         self._poslayoutbox = None
@@ -272,6 +273,11 @@ class SecondaryAxis(_AxesBase):
         if self._orientation == 'y':
             pscale = self._parent.yaxis.get_scale()
             set_scale = self.set_yscale
+        if pscale == self._parentscale:
+            return
+        else:
+            self._parentscale = pscale
+
         if pscale == 'log':
             defscale = 'functionlog'
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -24,6 +24,7 @@ import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
 import matplotlib.colors as mcolors
+import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
@@ -6077,6 +6078,29 @@ def test_secondary_resize():
     fig.canvas.draw()
     fig.set_size_inches((7, 4))
     assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])
+
+
+def test_secondary_minorloc():
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(np.arange(2, 11), np.arange(2, 11))
+    def invert(x):
+        with np.errstate(divide='ignore'):
+            return 1 / x
+
+    secax = ax.secondary_xaxis('top', functions=(invert, invert))
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.NullLocator)
+    secax.minorticks_on()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.AutoMinorLocator)
+    ax.set_xscale('log')
+    plt.draw()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.LogLocator)
+    ax.set_xscale('linear')
+    plt.draw()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.NullLocator)
 
 
 def color_boxes(fig, axs):


### PR DESCRIPTION
## PR Summary

We set the scale for `secondary_axis` for each draw in case the parent scale has changed (i.e. from linear to log), but this means that we can't set the locators and formatters for the secondary axis.  This change keeps track of the parent scale and only resets the locators and formatters if the parent scale changes.  

Closes #14443


```python
import matplotlib.pyplot as plt
import numpy as np
import matplotlib.ticker as mticker

fig, ax = plt.subplots(constrained_layout=True)
x = np.arange(0, 360, 1)
y = np.sin(2 * x * np.pi / 180)
ax.plot(x, y)
ax.set_xlabel('angle [degrees]')
ax.set_ylabel('signal')
ax.set_title('Sine wave')

def deg2rad(x):
    return x * np.pi / 180

def rad2deg(x):
    return x * 180 / np.pi

secax = ax.secondary_xaxis('top', functions=(deg2rad, rad2deg))
secax.set_xlabel('angle [rad]')

ax.minorticks_on()
secax.minorticks_on()

plt.show()
```

now works as expected...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->