### PR TITLE
FIX: return points rather than path to fix regression

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -835,10 +835,10 @@ class Line2D(Artist):
                     self.recache()
                     self._transform_path(subslice)
                     tpath, affine = (self._get_transformed_path()
-                                    .get_transformed_path_and_affine())
+                                    .get_transformed_points_and_affine())
             else:
                 tpath, affine = (self._get_transformed_path()
-                                 .get_transformed_path_and_affine())
+                                 .get_transformed_points_and_affine())
 
             if len(tpath.vertices):
                 # subsample the markers if markevery is not None


### PR DESCRIPTION
Regression in an astropy plotting example (https://github.com/astropy/astropy/issues/8792) is due to https://github.com/matplotlib/matplotlib/pull/11407

Locally this PR fixes the issue and the test seem to be still working, but I didn't run the whole suite locally.

Please advise what kind of test is preferred to be added for this.
