### PR TITLE
Simplify implementation of svg.image_inline.

### DIFF
--- a/doc/api/next_api_changes/2019-06-10-AL.rst
+++ b/doc/api/next_api_changes/2019-06-10-AL.rst
@@ -1,0 +1,10 @@
+RendererSVG now uses a single counter for externally written images
+```````````````````````````````````````````````````````````````````
+
+When using `RendererSVG` with ``rcParams["svg.image_inline"] ==
+True``, externally written images now use a single counter even if the
+``renderer.basename`` attribute is overwritten, rather than a counter per
+basename.
+
+This change will only affect you if you used ``rcParams["svg.image_inline"] = True``
+(the default is False) *and* manually modified ``renderer.basename``.


### PR DESCRIPTION
RendererSVG._imaged is basically a single-entry dict (because
Renderer.basename never changes), so just replace it by a counter.

Also replace the assert by a proper exception, and only trigger it if
the user actually tries to save an image while the filesystem path is
unknown (otherwise, there's no problem).

The whole svg.image_inline system could probably use a test...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
