### PR TITLE
Deprecate checkdep_usetex.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -41,3 +41,11 @@ Flags containing "U" passed to `.cbook.to_filehandle` and `.cbook.open_file_cm`
 Please remove "U" from flags passed to `.cbook.to_filehandle` and
 `.cbook.open_file_cm`.  This is consistent with their removal from `open` in
 Python 3.9.
+
+``matplotlib.checkdep_usetex``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``matplotlib.checkdep_usetex`` is deprecated (it checks for the presence of
+tex, dvipng, and ghostscript, even though ghostscript is not needed for raster
+output and dvipng is not needed for vector output).  The
+``matplotlib.testing.decorators.needs_usetex`` is a partial replacement to
+decorate tests that depend on usetex mode.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -504,6 +504,8 @@ def checkdep_ps_distiller(s):
     return s
 
 
+@cbook.deprecated(
+    "3.3", alternative="matplotlib.testing.decorators.needs_usetex")
 def checkdep_usetex(s):
     if not s:
         return False

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -459,3 +459,28 @@ def switch_backend(backend):
         return backend_switcher
 
     return switch_backend_decorator
+
+
+def needs_usetex(func):
+    """
+    Decorate *func* with `unittest.skipIf` to skip the test if usetex
+    dependencies are missing.
+    """
+    has_tex = shutil.which("tex")
+    try:
+        mpl._get_executable_info("dvipng")
+    except FileNotFoundError:
+        has_dvipng = False
+    else:
+        has_dvipng = True
+    try:
+        mpl._get_executable_info("gs")
+    except FileNotFoundError:
+        has_gs = False
+    else:
+        has_gs = True
+    return (
+        unittest.skipIf(not has_tex, "usetex requires TeX.")(
+            unittest.skipIf(not has_dvipng, "usetex requires dvipng.")(
+                unittest.skipIf(not has_gs, "usetex requires ghostscript.")(
+                    func))))

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -10,12 +10,7 @@ import pytest
 from matplotlib import dviread, pyplot as plt, checkdep_usetex, rcParams
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.testing.compare import compare_images
-from matplotlib.testing.decorators import image_comparison
-
-
-needs_usetex = pytest.mark.skipif(
-    not checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing.decorators import image_comparison, needs_usetex
 
 
 @image_comparison(['pdf_use14corefonts.pdf'])

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -7,15 +7,12 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import cbook, patheffects
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, needs_usetex
 
 
 needs_ghostscript = pytest.mark.skipif(
     "eps" not in mpl.testing.compare.converter,
     reason="This test needs a ghostscript installation")
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
 
 
 # This tests tends to hit a TeX cache lock on AppVeyor.
@@ -26,11 +23,11 @@ needs_usetex = pytest.mark.skipif(
     pytest.param('ps', False, {'ps.usedistiller': 'ghostscript'},
                  marks=needs_ghostscript),
     pytest.param('ps', False, {'text.usetex': True},
-                 marks=[needs_ghostscript, needs_usetex]),
+                 marks=needs_usetex),
     ('eps', False, {}),
     ('eps', True, {'ps.useafm': True}),
     pytest.param('eps', False, {'text.usetex': True},
-                 marks=[needs_ghostscript, needs_usetex]),
+                 marks=needs_usetex),
 ], ids=[
     'ps',
     'ps with distiller',
@@ -75,7 +72,6 @@ def test_patheffects():
 
 
 @needs_usetex
-@needs_ghostscript
 def test_tilde_in_tempfilename(tmpdir):
     # Tilde ~ in the tempdir path (e.g. TMPDIR, TMP or TEMP on windows
     # when the username is very long and windows uses a short name) breaks

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -10,12 +10,7 @@ import matplotlib as mpl
 from matplotlib import dviread
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison
-
-
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing.decorators import image_comparison, needs_usetex
 
 
 def test_visibility():

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -9,12 +9,7 @@ import matplotlib
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import check_figures_equal, image_comparison
-
-
-needs_usetex = pytest.mark.skipif(
-    not matplotlib.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing.decorators import image_comparison, needs_usetex
 
 
 @image_comparison(['font_styles'])

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -2,17 +2,12 @@ import pytest
 import platform
 
 import matplotlib as mpl
-from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.testing.decorators import (
+    check_figures_equal, image_comparison, needs_usetex)
 import matplotlib.pyplot as plt
 
 
-@pytest.fixture(autouse=True)  # All tests in this module use usetex.
-def usetex():
-    if not mpl.checkdep_usetex(True):
-        pytest.skip('Missing TeX of Ghostscript or dvipng')
-    mpl.rcParams['text.usetex'] = True
-
-
+@needs_usetex
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
                   tol={'aarch64': 2.868}.get(platform.machine(), 0.3))
@@ -25,12 +20,13 @@ def test_usetex():
             # \sqrt and \frac draw horizontal rules, \mathrm changes the font
             r'\LaTeX\ $\left[\int\limits_e^{2e}'
             r'\sqrt\frac{\log^3 x}{x}\,\mathrm{d}x \right\}$',
-            fontsize=24)
+            usetex=True, fontsize=24)
     ax.set_xticks([])
     ax.set_yticks([])
 
 
+@needs_usetex
 @check_figures_equal()
 def test_unicode_minus(fig_test, fig_ref):
-    fig_test.text(.5, .5, "$-$")
-    fig_ref.text(.5, .5, "\N{MINUS SIGN}")
+    fig_test.text(.5, .5, "$-$", usetex=True)
+    fig_ref.text(.5, .5, "\N{MINUS SIGN}", usetex=True)


### PR DESCRIPTION
See changelog for rationale.  Note that checkdep_usetex was *only*
used to create a test decorator (and even then, the surrounding
catch_warnings was pointless after checkdep_usetex switched to using
logging -- one would really need to capture the *logs* instead).

This also goes well with the deprecation of all other checkdep_foo
helpers in the matplotlib toplevel module.

Instead, just directly write the proper test decorator.  Use
unittest.skipIf instead of pytest.skipif as pytest handles the unittest
decorator just as well, and this makes the decorator work if someone
*really* wants to use it in a non-pytest test suite.

--

edit: oops, but that doesn't work with pytest.param.  Will investigate more...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
