### PR TITLE
PyQT5 Backend Partial Redraw Fix

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -38,16 +38,15 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
         painter = QtGui.QPainter(self)
 
+        # get bounding box scaled to the figure
         rect = event.rect()
-        left = rect.left()
-        top = rect.top()
-        width = rect.width()
-        height = rect.height()
+        left, top = self.mouseEventCoords(rect.bottomLeft())
+        width = rect.width() * self._dpi_ratio
+        height = rect.height() * self._dpi_ratio
         # See documentation of QRect: bottom() and right() are off by 1, so use
         # left() + width() and top() + height().
-        bbox = Bbox(
-            [[left, self.renderer.height - (top + height * self._dpi_ratio)],
-             [left + width * self._dpi_ratio, self.renderer.height - top]])
+        bbox = Bbox([[left, top], [left + width, top + height]])
+        # create a buffer using this bounding box
         reg = self.copy_from_bbox(bbox)
         buf = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(
             memoryview(reg))
@@ -60,8 +59,8 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         if hasattr(qimage, 'setDevicePixelRatio'):
             # Not available on Qt4 or some older Qt5.
             qimage.setDevicePixelRatio(self._dpi_ratio)
-        origin = QtCore.QPoint(left, top)
-        painter.drawImage(origin / self._dpi_ratio, qimage)
+        origin = QtCore.QPoint(rect.left(), rect.top())
+        painter.drawImage(origin, qimage)
         # Adjust the buf reference count to work around a memory
         # leak bug in QImage under PySide on Python 3.
         if QT_API in ('PySide', 'PySide2'):

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -41,6 +41,8 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         # See documentation of QRect: bottom() and right() are off by 1, so use
         # left() + width() and top() + height().
         rect = event.rect()
+        # scale rect dimensions using the screen dpi ratio to get
+        # correct values for the Figure coordinates (rather than QT5's coords)
         width = rect.width() * self._dpi_ratio
         height = rect.height() * self._dpi_ratio
         left, top = self.mouseEventCoords(rect.topLeft())

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -38,13 +38,15 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
         painter = QtGui.QPainter(self)
 
-        # get bounding box scaled to the figure
-        rect = event.rect()
-        left, top = self.mouseEventCoords(rect.bottomLeft())
-        width = rect.width() * self._dpi_ratio
-        height = rect.height() * self._dpi_ratio
         # See documentation of QRect: bottom() and right() are off by 1, so use
         # left() + width() and top() + height().
+        rect = event.rect()
+        width = rect.width() * self._dpi_ratio
+        height = rect.height() * self._dpi_ratio
+        left, top = self.mouseEventCoords(rect.topLeft())
+        # shift the "top" by the height of the image to get the
+        # correct corner for our coordinate system
+        top -= height
         bbox = Bbox([[left, top], [left + width, top + height]])
         # create a buffer using this bounding box
         reg = self.copy_from_bbox(bbox)
@@ -59,6 +61,7 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         if hasattr(qimage, 'setDevicePixelRatio'):
             # Not available on Qt4 or some older Qt5.
             qimage.setDevicePixelRatio(self._dpi_ratio)
+        # set origin using original QT coordinates
         origin = QtCore.QPoint(rect.left(), rect.top())
         painter.drawImage(origin, qimage)
         # Adjust the buf reference count to work around a memory

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -48,9 +48,11 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         left, top = self.mouseEventCoords(rect.topLeft())
         # shift the "top" by the height of the image to get the
         # correct corner for our coordinate system
-        top -= height
-        bbox = Bbox([[left, top], [left + width, top + height]])
-        # create a buffer using this bounding box
+        bottom = top - height
+        # same with the right side of the image
+        right = left + width
+        # create a buffer using the image bounding box
+        bbox = Bbox([[left, bottom], [right, top]])
         reg = self.copy_from_bbox(bbox)
         buf = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(
             memoryview(reg))


### PR DESCRIPTION
## PR Summary

This PR is related to partial redraw buffers for QT5 on screens with `devicePixelRatio() > 1` from issue #14160. 

At first, this appeared to be a problem with the PyQT5/PySide2 `QRectangle`s being passed to `FigureCanvasQT`'s, but a deeper look showed that there was some confusion about when the `FigureCanvasQT._dpi_ratio` should be applied. This PR ensures that it is only applied when creating a partial buffer for redraw and that the original rectangle locations from PyQT5/Pyside2 are used to place redrawn region. It still addresses the off-by-one issue by using the bottom coordinate of the rectangle and shifting it by the rectangle's height.

