### PR TITLE
canvas.blit() already defaults to blitting the full figure canvas.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1650,7 +1650,7 @@ class DraggableBase:
             self.update_offset(dx, dy)
             self.canvas.restore_region(self.background)
             self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
-            self.canvas.blit(self.ref_artist.figure.bbox)
+            self.canvas.blit()
 
     def on_pick(self, evt):
         if self._check_still_parented() and evt.artist == self.ref_artist:
@@ -1665,7 +1665,7 @@ class DraggableBase:
                 self.background = self.canvas.copy_from_bbox(
                                     self.ref_artist.figure.bbox)
                 self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
-                self.canvas.blit(self.ref_artist.figure.bbox)
+                self.canvas.blit()
                 self._c1 = self.canvas.mpl_connect('motion_notify_event',
                                                    self.on_motion_blit)
             else:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1464,7 +1464,7 @@ class MultiCursor(Widget):
             if self.horizOn:
                 for ax, line in zip(self.axes, self.hlines):
                     ax.draw_artist(line)
-            self.canvas.blit(self.canvas.figure.bbox)
+            self.canvas.blit()
         else:
             self.canvas.draw_idle()
 


### PR DESCRIPTION
... so `canvas.blit(figure.bbox)` can be replaced by `canvas.blit()`.

The argumentless form is actually more accurate because the computation
of `figure.bbox` can suffer from floating point inaccuracies, which,
even if correctly taken into account, could lead to blitting one
row/column too few or too many, whereas `canvas.blit()` with no
arguments will, well, always blit the full canvas.

Noted in #14225 (which this fixes, even though a separate fix to bettertake into account the floating point inaccuracies is also coming).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
