### PR TITLE
Fix out of bounds read in backend_tk.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -67,8 +67,11 @@ def blit(photoimage, aggimage, offsets, bbox=None):
     dataptr = (height, width, data.ctypes.data)
     if bbox is not None:
         (x1, y1), (x2, y2) = bbox.__array__()
-        bboxptr = (math.floor(x1), math.ceil(x2),
-                   math.floor(y1), math.ceil(y2))
+        x1 = max(math.floor(x1), 0)
+        x2 = min(math.ceil(x2), width)
+        y1 = max(math.floor(y1), 0)
+        y2 = min(math.ceil(y2), height)
+        bboxptr = (x1, x2, y1, y2)
     else:
         photoimage.blank()
         bboxptr = (0, width, 0, height)


### PR DESCRIPTION
Really, we should specify somewhere how rounding of bboxes passed to
blit() (and to copy_from_bbox()) works, but at least this patch will
avoid out-of-bounds reads in the tk blit.

@aliaa @cgohlke I think this closes #14225, can you confirm?

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
