### PR TITLE
Mention origin and extent tutorial in API docs for origin kwarg

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5519,6 +5519,9 @@ optional.
             Note that the vertical axes points upward for 'lower'
             but downward for 'upper'.
 
+            See the :doc:`/tutorials/intermediate/imshow_extent` tutorial for
+            examples and a more detailed description.
+
         extent : scalars (left, right, bottom, top), optional
             The bounding box in data coordinates that the image will fill.
             The image is stretched individually along x and y to fill the box.
@@ -5536,8 +5539,8 @@ optional.
             - For ``origin == 'lower'`` the default is
               ``(-0.5, numcols-0.5, -0.5, numrows-0.5)``.
 
-            See the example :doc:`/tutorials/intermediate/imshow_extent` for a
-            more detailed description.
+            See the :doc:`/tutorials/intermediate/imshow_extent` tutorial for
+            examples and a more detailed description.
 
         filternorm : bool, optional, default: True
             A parameter for the antigrain image resize filter (see the


### PR DESCRIPTION
## PR Summary

This adds a link to the origin and extent tutorial. There's already a link for the extent kwarg below this but I don't think it hurts to have two links since at least for myself I tend to go tunnel vision in these API docs pages and ignore kwargs I don't think I need to care about.

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
