### PR TITLE
Let SecondaryAxis inherit get_tightbbox from _AxesBase.

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -306,44 +306,6 @@ class SecondaryAxis(_AxesBase):
             lims = lims[::-1]
         set_lim(lims)
 
-    def get_tightbbox(self, renderer, call_axes_locator=True):
-        """
-        Return the tight bounding box of the axes.
-        The dimension of the Bbox in canvas coordinate.
-
-        If *call_axes_locator* is *False*, it does not call the
-        _axes_locator attribute, which is necessary to get the correct
-        bounding box. ``call_axes_locator==False`` can be used if the
-        caller is only intereted in the relative size of the tightbbox
-        compared to the axes bbox.
-        """
-
-        bb = []
-
-        if not self.get_visible():
-            return None
-
-        self._set_lims()
-        locator = self.get_axes_locator()
-        if locator and call_axes_locator:
-            pos = locator(self, renderer)
-            self.apply_aspect(pos)
-        else:
-            self.apply_aspect()
-
-        if self._orientation == 'x':
-            bb_axis = self.xaxis.get_tightbbox(renderer)
-        else:
-            bb_axis = self.yaxis.get_tightbbox(renderer)
-        if bb_axis:
-            bb.append(bb_axis)
-
-        bb.append(self.get_window_extent(renderer))
-        _bbox = mtransforms.Bbox.union(
-            [b for b in bb if b.width != 0 or b.height != 0])
-
-        return _bbox
-
     def set_aspect(self, *args, **kwargs):
         """
         Secondary axes cannot set the aspect ratio, so calling this just


### PR DESCRIPTION
The only difference in the implementation of _AxesBase.get_tightbbox and
SecondaryAxis.get_tightbbox is that the latter explicitly ignores the
axis in the "other" direction, but because that axis is set to
invisible, its tightbbox is None.  So we can just directly inherit the
parent implementation.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
