### PR TITLE
MNT: protect from out-of-bounds data access at the c level

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -26,6 +26,8 @@ def mpl_test_settings(request):
             assert len(backend_marker.args) == 1, \
                 "Marker 'backend' must specify 1 backend."
             backend, = backend_marker.args
+            skip_on_importerror = backend_marker.kwargs.get(
+                'skip_on_importerror', False)
             prev_backend = matplotlib.get_backend()
 
         style = '_classic_test'  # Default of cleanup and image_comparison too.
@@ -45,7 +47,7 @@ def mpl_test_settings(request):
             except ImportError as exc:
                 # Should only occur for the cairo backend tests, if neither
                 # pycairo nor cairocffi are installed.
-                if 'cairo' in backend.lower():
+                if 'cairo' in backend.lower() or skip_on_importerror:
                     pytest.skip("Failed to switch to backend {} ({})."
                                 .format(backend, exc))
                 else:

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -20,10 +20,8 @@ def test_blit():
                       (1, 6, 0, 2),
                       (0, 2, -1, 2),
                       (0, 2, 2, 0),
-                      (0, 2, 1, 6),
-    ):
+                      (0, 2, 1, 6)):
         with pytest.raises(ValueError):
-            print(bad_boxes)
             evil_blit(fig.canvas._tkphoto,
                       np.ones((4, 4, 4)),
                       (0, 1, 2, 3),

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -1,11 +1,11 @@
 import pytest
 import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.backends import _tkagg
 
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
 def test_blit():
+    from matplotlib.backends import _tkagg
     def evil_blit(photoimage, aggimage, offsets, bboxptr):
         data = np.asarray(aggimage)
         height, width = data.shape[:2]

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -4,7 +4,7 @@ from matplotlib import pyplot as plt
 from matplotlib.backends import _tkagg
 
 
-@pytest.mark.backend('TkAgg')
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
 def test_blit():
     def evil_blit(photoimage, aggimage, offsets, bboxptr):
         data = np.asarray(aggimage)

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -1,0 +1,30 @@
+import pytest
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.backends import _tkagg
+
+
+@pytest.mark.backend('TkAgg')
+def test_blit():
+    def evil_blit(photoimage, aggimage, offsets, bboxptr):
+        data = np.asarray(aggimage)
+        height, width = data.shape[:2]
+        dataptr = (height, width, data.ctypes.data)
+        _tkagg.blit(
+            photoimage.tk.interpaddr(), str(photoimage), dataptr, offsets,
+            bboxptr)
+
+    fig, ax = plt.subplots()
+    for bad_boxes in ((-1, 2, 0, 2),
+                      (2, 0, 0, 2),
+                      (1, 6, 0, 2),
+                      (0, 2, -1, 2),
+                      (0, 2, 2, 0),
+                      (0, 2, 1, 6),
+    ):
+        with pytest.raises(ValueError):
+            print(bad_boxes)
+            evil_blit(fig.canvas._tkphoto,
+                      np.ones((4, 4, 4)),
+                      (0, 1, 2, 3),
+                      bad_boxes)

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -67,6 +67,12 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "Failed to extract Tk_PhotoHandle");
         goto exit;
     }
+    if (0 > y1 || y1 > y2 || y2 > height ||
+        0 > x1 || x1 > x2 || x2 > width ) {
+        PyErr_SetString(PyExc_ValueError, "Attempting to draw out of bounds");
+        goto exit;
+    }
+
     block.pixelPtr = data_ptr + 4 * ((height - y2) * width + x1);
     block.width = x2 - x1;
     block.height = y2 - y1;

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -67,8 +67,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "Failed to extract Tk_PhotoHandle");
         goto exit;
     }
-    if (0 > y1 || y1 > y2 || y2 > height ||
-        0 > x1 || x1 > x2 || x2 > width ) {
+    if (0 > y1 || y1 > y2 || y2 > height || 0 > x1 || x1 > x2 || x2 > width) {
         PyErr_SetString(PyExc_ValueError, "Attempting to draw out of bounds");
         goto exit;
     }


### PR DESCRIPTION
As suggested by @cgohlke


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->