### PR TITLE
Improve font weight guessing.

### DIFF
--- a/doc/api/next_api_changes/2019-06-09-AL.rst
+++ b/doc/api/next_api_changes/2019-06-09-AL.rst
@@ -1,0 +1,6 @@
+Changes in font weight guessing
+```````````````````````````````
+
+Font weight guessing now first checks for the presence of the FT_STYLE_BOLD_FLAG
+before trying to match substrings in the font name.  In particular, this means
+that Times New Roman Bold is now correctly detected as bold, not normal weight.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -395,12 +395,10 @@ def ttfFontProperty(font):
     else:
         variant = 'normal'
 
-    weight = next((w for w in weight_dict if sfnt4.find(w) >= 0), None)
-    if not weight:
-        if font.style_flags & ft2font.BOLD:
-            weight = 700
-        else:
-            weight = 400
+    if font.style_flags & ft2font.BOLD:
+        weight = 700
+    else:
+        weight = next((w for w in weight_dict if w in sfnt4), 400)
 
     #  Stretch can be absolute and relative
     #  Absolute stretches are: ultra-condensed, extra-condensed, condensed,


### PR DESCRIPTION
Previously, we would guess that "Times New Roman Bold" is a regular
weight font because its name contains the substring "Roman", even though
the font correctly sets the BOLD flag (FT_STYLE_FLAG_BOLD).  Invert the
logic to give priority to the flag, as its presence is clearly more
robust than a substring check.

`s.find(w) >= 0` is just an obfuscated way to write `w in s`, so change
that.

Obviously font properties extraction could be improved in a lot of ways, but this should close https://github.com/matplotlib/matplotlib/issues/5574.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
