### PR TITLE
Fix links of parameter types

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1629,7 +1629,7 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        formatter : ~matplotlib.ticker.Formatter
+        formatter : `~matplotlib.ticker.Formatter`
         """
         if not isinstance(formatter, mticker.Formatter):
             raise TypeError("formatter argument should be instance of "
@@ -1645,7 +1645,7 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        formatter : ~matplotlib.ticker.Formatter
+        formatter : `~matplotlib.ticker.Formatter`
         """
         if not isinstance(formatter, mticker.Formatter):
             raise TypeError("formatter argument should be instance of "
@@ -1661,7 +1661,7 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        locator : ~matplotlib.ticker.Locator
+        locator : `~matplotlib.ticker.Locator`
         """
         if not isinstance(locator, mticker.Locator):
             raise TypeError("locator argument should be instance of "
@@ -1679,7 +1679,7 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        locator : ~matplotlib.ticker.Locator
+        locator : `~matplotlib.ticker.Locator`
         """
         if not isinstance(locator, mticker.Locator):
             raise TypeError("locator argument should be instance of "


### PR DESCRIPTION
## PR Summary

Numpydoc does not link these if if they are not quoted with backticks. See e.g.
https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axis.Axis.set_major_formatter.html?highlight=set_major_formatter