### PR TITLE
Fix uses of PyObject_IsTrue.

### DIFF
--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -631,8 +631,12 @@ static PyObject *Py_cleanup_path(PyObject *self, PyObject *args, PyObject *kwds)
 
     if (simplifyobj == Py_None) {
         simplify = path.should_simplify();
-    } else if (PyObject_IsTrue(simplifyobj)) {
-        simplify = true;
+    } else {
+        switch (PyObject_IsTrue(simplifyobj)) {
+            case 0: simplify = false; break;
+            case 1: simplify = true; break;
+            default: return NULL;  // errored.
+        }
     }
 
     bool do_clip = (clip_rect.x1 < clip_rect.x2 && clip_rect.y1 < clip_rect.y2);
@@ -709,8 +713,12 @@ static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *
 
     if (simplifyobj == Py_None) {
         simplify = path.should_simplify();
-    } else if (PyObject_IsTrue(simplifyobj)) {
-        simplify = true;
+    } else {
+        switch (PyObject_IsTrue(simplifyobj)) {
+            case 0: simplify = false; break;
+            case 1: simplify = true; break;
+            default: return NULL;  // errored.
+        }
     }
 
     CALL_CPP("convert_to_string",

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -116,14 +116,11 @@ int convert_double(PyObject *obj, void *p)
 int convert_bool(PyObject *obj, void *p)
 {
     bool *val = (bool *)p;
-    int ret;
-
-    ret = PyObject_IsTrue(obj);
-    if (ret == -1) {
-        return 0;
+    switch (PyObject_IsTrue(obj)) {
+        case 0: *val = false; break;
+        case 1: *val = true; break;
+        default: return 0;  // errored.
     }
-    *val = ret != 0;
-
     return 1;
 }
 
@@ -389,7 +386,11 @@ int convert_path(PyObject *obj, void *pathp)
     if (should_simplify_obj == NULL) {
         goto exit;
     }
-    should_simplify = PyObject_IsTrue(should_simplify_obj) != 0;
+    switch (PyObject_IsTrue(should_simplify_obj)) {
+        case 0: should_simplify = 0; break;
+        case 1: should_simplify = 1; break;
+        default: goto exit;  // errored.
+    }
 
     simplify_threshold_obj = PyObject_GetAttrString(obj, "simplify_threshold");
     if (simplify_threshold_obj == NULL) {
@@ -438,15 +439,15 @@ int convert_clippath(PyObject *clippath_tuple, void *clippathp)
 int convert_snap(PyObject *obj, void *snapp)
 {
     e_snap_mode *snap = (e_snap_mode *)snapp;
-
     if (obj == NULL || obj == Py_None) {
         *snap = SNAP_AUTO;
-    } else if (PyObject_IsTrue(obj)) {
-        *snap = SNAP_TRUE;
     } else {
-        *snap = SNAP_FALSE;
+        switch (PyObject_IsTrue(obj)) {
+            case 0: *snap = SNAP_FALSE; break;
+            case 1: *snap = SNAP_TRUE; break;
+            default: return 0;  // errored.
+        }
     }
-
     return 1;
 }
 


### PR DESCRIPTION
PyObject_IsTrue can return -1 if an exception occurred when trying to
convert a Python object to a bool (a typical case is for numpy arrays,
which cannot be converted to bools).  Failure to handle this correctly
results e.g. in
```
l, = plt.plot([1, 2]); l.get_path().should_simplify = np.array([1, 2])
```
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/matplotlib/backends/backend_qt5.py", line 501, in _draw_idle
<elided>
  File "/usr/lib/python3.7/site-packages/matplotlib/backends/backend_agg.py", line 146, in draw_path
    self._renderer.draw_path(gc, path, transform, rgbFace)
SystemError: PyEval_EvalFrameEx returned a result with an error set
```
whereas after this PR, the ValueError gets correctly propagated out.

No tests, because one really needs to go out of their way to trigger the
faulty cases anyways...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
