### PR TITLE
Remove deprecated fig parameter form GridSpecBase.get_subplot_params()

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -56,7 +56,7 @@ class GridSpecBase:
         """
         return self._nrows, self._ncols
 
-    def get_subplot_params(self, figure=None, fig=None):
+    def get_subplot_params(self, figure=None):
         pass
 
     def new_subplotspec(self, loc, rowspan=1, colspan=1):


### PR DESCRIPTION
## PR Summary

The parameter was `fig` was deprecated in favor of `figure` in f8dfea7f7bc3f3fdc5d2755d63e236fe2d74958a. While it has already been removed in the derived classes, is is still present in the base class (probably because there was no explicit deprecation there).

Removing without further deprecation because
1. The deprecation has been announced in the change note in f8dfea7f7bc3.
2. Likely nobody will ever call `GridSpecBase.get_subplot_params()` as it does not have any effect.
3. If somebody still calls it, that's probably an undetected error.
