### PR TITLE
Improve custom figure example

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -223,6 +223,7 @@ per-file-ignores =
     examples/style_sheets/plot_solarizedlight2.py: E501
     examples/subplots_axes_and_figures/axes_margins.py: E402
     examples/subplots_axes_and_figures/axes_zoom_effect.py: E402
+    examples/subplots_axes_and_figures/custom_figure_class.py: E402
     examples/subplots_axes_and_figures/demo_constrained_layout.py: E402
     examples/subplots_axes_and_figures/demo_tight_layout.py: E402
     examples/subplots_axes_and_figures/secondary_axis.py: E402

--- a/examples/subplots_axes_and_figures/custom_figure_class.py
+++ b/examples/subplots_axes_and_figures/custom_figure_class.py
@@ -1,27 +1,55 @@
 """
-===================
-Custom Figure Class
-===================
+========================
+Custom Figure subclasses
+========================
 
-You can pass a custom Figure constructor to figure if you want to derive from
-the default Figure.  This simple example creates a figure with a figure title.
+You can pass a `.Figure` subclass to `.pyplot.figure` if you want to change
+the default behavior of the figure.
+
+This example defines a `.Figure` subclass ``WatermarkFigure`` that accepts an
+additional parameter ``watermark`` to display a custom watermark text. The
+figure is created using the ``FigureClass`` parameter of `.pyplot.figure`.
+The additional ``watermark`` parameter is passed on to the subclass
+constructor.
 """
 
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
+import numpy as np
 
 
-class MyFigure(Figure):
-    def __init__(self, *args, figtitle='hi mom', **kwargs):
-        """
-        custom kwarg figtitle is a figure title
-        """
+class WatermarkFigure(Figure):
+    """A figure with a text watermark."""
+
+    def __init__(self, *args, watermark=None, **kwargs):
         super().__init__(*args, **kwargs)
-        self.text(0.5, 0.95, figtitle, ha='center')
+
+        if watermark is not None:
+            bbox = dict(boxstyle='square', lw=3, ec='gray',
+                        fc=(0.9, 0.9, .9, .5), alpha=0.5)
+            self.text(0.5, 0.5, watermark,
+                      ha='center', va='center', rotation=30,
+                      fontsize=40, color='gray', alpha=0.5, bbox=bbox)
 
 
-fig = plt.figure(FigureClass=MyFigure, figtitle='my title')
-ax = fig.subplots()
-ax.plot([1, 2, 3])
+x = np.linspace(-3, 3, 201)
+y = np.tanh(x) + 0.1 * np.cos(5 * x)
 
-plt.show()
+plt.figure(FigureClass=WatermarkFigure, watermark='draft')
+plt.plot(x, y)
+
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.pyplot.figure
+matplotlib.figure.Figure
+matplotlib.figure.Figure.text


### PR DESCRIPTION
## PR Summary
Just wanted to do a bit style cleanup, but ended up rewriting the whole example. :smile:

I didn't like about the original example that it's not a reasonable application. Setting a fixed position `Text` as title is not quite suitable because it is not contained in any layout. If anything, one should use `Figure.suptitle`. But defining a subclass for this would be overkill. Using `fig.suptitle('my title')` explicitly is easier than `plt.figure(FigureClass=MyFigure, title='my title')`.
