### PR TITLE
Simplify handling of Qt modifier keys.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -594,6 +594,7 @@ APIs which support the values True, False, and "TeX" for ``ismath``.
 ~~~~~~~~~~~~~~~~~~~~~
 This module is deprecated.
 
+
 Stricter PDF metadata keys in PGF
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Saving metadata in PDF with the PGF backend currently normalizes all keys to
@@ -601,3 +602,12 @@ lowercase, unlike the PDF backend, which only accepts the canonical case.  This
 is deprecated; in a future version, only the canonically cased keys listed in
 the PDF specification (and the `~.backend_pgf.PdfPages` documentation) will be
 accepted.
+
+
+Qt modifier keys
+~~~~~~~~~~~~~~~~
+The ``MODIFIER_KEYS``, ``SUPER``, ``ALT``, ``CTRL``, and ``SHIFT``
+global variables of the :mod:`matplotlib.backends.backend_qt4agg`,
+:mod:`matplotlib.backends.backend_qt4cairo`,
+:mod:`matplotlib.backends.backend_qt5agg` and
+:mod:`matplotlib.backends.backend_qt5cairo` modules are deprecated.

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -1,6 +1,7 @@
 from .. import cbook
 from .backend_qt5 import (
-    backend_version, SPECIAL_KEYS, SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,
+    backend_version, SPECIAL_KEYS,
+    SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,  # These are deprecated.
     cursord, _create_qApp, _BackendQT5, TimerQT, MainWindow, FigureCanvasQT,
     FigureManagerQT, NavigationToolbar2QT, SubplotToolQt, exception_handler)
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -387,9 +387,12 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         event_mods = int(event.modifiers())  # actually a bitmask
 
         # get names of the pressed modifier keys
+        # 'control' is named 'control' when a standalone key, but 'ctrl' when a
+        # modifier
         # bit twiddling to pick out modifier keys from event_mods bitmask,
         # if event_key is a MODIFIER, it should not be duplicated in mods
-        mods = [SPECIAL_KEYS[key] for mod, key in _MODIFIER_KEYS
+        mods = [SPECIAL_KEYS[key].replace('control', 'ctrl')
+                for mod, key in _MODIFIER_KEYS
                 if event_key != key and event_mods & mod]
         try:
             # for certain keys (enter, left, backspace, etc) use a word for the


### PR DESCRIPTION
## PR Summary

- Replace MODIFIER_KEYS by a simpler private table that doesn't include
  the names used by Matplotlib ("super"/"alt"/...), instead just get
  these names from SPECIAL_KEYS (this avoids having to also update
  _MODIFIER_KEYS for osx, where we use different names).
- Delete the globals SUPER, ALT, CTLR, SHIFT which were just indices
  into MODIFIER_KEYS but otherwise meaningless.
- Invert the order of _MODIFIERS_KEYS to avoid having to do a
  `reverse()` later in the code.
- Get max_unicode value from Python's sys module.

No deprecation, as these can't be properly deprecated anyways.

Goes on top of #14506.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
