### PR TITLE
Fix too large icon spacing in Qt5 on non-HiDPI screens

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -709,7 +709,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         # Esthetic adjustments - we need to set these explicitly in PyQt5
         # otherwise the layout looks different - but we don't want to set it if
         # not using HiDPI icons otherwise they look worse than before.
-        if is_pyqt5():
+        if is_pyqt5() and self.canvas._dpi_ratio > 1:
             self.setIconSize(QtCore.QSize(24, 24))
             self.layout().setSpacing(12)
 


### PR DESCRIPTION
## PR Summary

When using Qt5 on a non-HiDPI screen, the icons have too large spacing. This was explicitly hard-coded. While I don't have a full overview of the HiDPI mechanisms, the comment next to the code already suggests that it should not be applied if not on a HiDPI screen. Also the result justifies the change.

Not sure if this is related to #10891.

before:
![image](https://user-images.githubusercontent.com/2836374/59157847-30db4900-8ab2-11e9-8c38-e1c89a39c1bd.png)

after:
![image](https://user-images.githubusercontent.com/2836374/59157858-66803200-8ab2-11e9-9435-15079d9f28ca.png)
