### PR TITLE
Deprecate allowing scalars for fill_between where

### DIFF
--- a/doc/api/next_api_changes/2019-06-09-TH.rst
+++ b/doc/api/next_api_changes/2019-06-09-TH.rst
@@ -1,0 +1,8 @@
+Passing scalars to parameter where in ``fill_between()`` and ``fill_betweenx()``
+````````````````````````````````````````````````````````````````````````````````
+
+Passing scalars to parameter *where* in ``fill_between()`` and
+``fill_betweenx()`` is deprecated. While the documentation already states that
+*where* must be of the same size as *x* (or *y*), scalars were accepted and
+broadcasted to the size of *x*. Non-matching sizes will raise a ``ValueError``
+in the future.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5175,6 +5175,14 @@ optional.
 
         if where is None:
             where = True
+        else:
+            where = np.asarray(where, dtype=bool)
+            if where.size != x.size:
+                cbook.warn_deprecated(
+                    "3.2",
+                    message="The parameter where must have the same size as x "
+                            "in fill_between(). This will become an error in "
+                            "future versions of Matplotlib.")
         where = where & ~functools.reduce(np.logical_or,
                                           map(np.ma.getmask, [x, y1, y2]))
 
@@ -5356,6 +5364,14 @@ optional.
 
         if where is None:
             where = True
+        else:
+            where = np.asarray(where, dtype=bool)
+            if where.size != y.size:
+                cbook.warn_deprecated(
+                    "3.2",
+                    message="The parameter where must have the same size as y "
+                            "in fill_between(). This will become an error in "
+                            "future versions of Matplotlib.")
         where = where & ~functools.reduce(np.logical_or,
                                           map(np.ma.getmask, [y, x1, x2]))
 


### PR DESCRIPTION
## PR Summary

When working on #14510, I realized that `fill_between(..., where=...)`  accepts scalars and broadcasts them. This is against the documentation, which requires data with the same size as x (https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.fill_between.html).

In particular the following caught me by surprise:
~~~
x = [0, 1, 2, 3]
y1 = [1, 1, 0, 0]
y2 = [0, 0, 1, 1]
plt.plot(x, y1, 'o--')
plt.plot(x, y2, 'o--')
plt.fill_between(x, y1, y2, where=y1 > y2, alpha=0.3)
~~~

![image](https://user-images.githubusercontent.com/2836374/59162187-2ee2ab80-8aed-11e9-8abd-f6333dc37d03.png)

I would have expected that only the left part is filled. That would indeed have happened if y1, y2 were numpy arrays, but the comparison of lists `y1 > y2` results in a single bool that is accepted by `fill_between`.

Because of this chance of mis-use I propose to deprecate the behavior and not just change the docs.