### PR TITLE
Logit scale, changes in LogitLocator and LogitFormatter

### DIFF
--- a/doc/users/next_whats_new/logit_scale_stuff.rst
+++ b/doc/users/next_whats_new/logit_scale_stuff.rst
@@ -1,0 +1,13 @@
+Improvements in Logit scale ticker and formatter
+------------------------------------------------
+
+Introduced in version 1.5, the logit scale didn't have appropriate ticker and
+formatter. Previously, location of ticks was not zoom dependent, too many label
+was displayed implying overlapping which break readability, and label formatting
+was not precision adaptive.
+
+Starting from this version, the locator have near the same behavior as the
+locator for the log scale or the same behavior as the locator for the linear
+scale, depending on used zoom. The number of ticks is controlled. Some minor
+labels are displayed adaptively as sublabels in log scale. Formatting is adapted
+for probabilities and the precision is adaptive depending on the scale.

--- a/doc/users/next_whats_new/logit_scale_stuff.rst
+++ b/doc/users/next_whats_new/logit_scale_stuff.rst
@@ -1,13 +1,13 @@
 Improvements in Logit scale ticker and formatter
 ------------------------------------------------
 
-Introduced in version 1.5, the logit scale didn't have appropriate ticker and
-formatter. Previously, location of ticks was not zoom dependent, too many label
-was displayed implying overlapping which break readability, and label formatting
-was not precision adaptive.
+Introduced in version 1.5, the logit scale didn't have an appropriate ticker and
+formatter. Previously, the location of ticks was not zoom dependent, too many labels
+were displayed causing overlapping which broke readability, and label formatting
+did not adapt to precision.
 
-Starting from this version, the locator have near the same behavior as the
-locator for the log scale or the same behavior as the locator for the linear
+Starting from this version, the logit locator has nearly the same behavior as the
+locator for the log scale or the linear
 scale, depending on used zoom. The number of ticks is controlled. Some minor
 labels are displayed adaptively as sublabels in log scale. Formatting is adapted
-for probabilities and the precision is adaptive depending on the scale.
+for probabilities and the precision is adapts to the scale.

--- a/examples/scales/logit_demo.py
+++ b/examples/scales/logit_demo.py
@@ -1,0 +1,61 @@
+"""
+================
+Logit Demo
+================
+
+Examples of plots with logit axes.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+xmax = 10
+x = np.linspace(-xmax, xmax, 10000)
+cdf_norm = np.array([np.math.erf(w / np.sqrt(2)) / 2 + 1 / 2 for w in x])
+cdf_laplacian = np.array(
+    [1 / 2 * np.exp(w) if w < 0 else 1 - 1 / 2 * np.exp(-w) for w in x]
+)
+cdf_cauchy = 1 / np.pi * np.arctan(x) + 1 / 2
+
+fig, axs = plt.subplots(nrows=3, ncols=2, figsize=(6.4, 8.5))
+
+# Common part, for the example, we will do the same plots on all graphs
+for i in range(3):
+    for j in range(2):
+        axs[i, j].plot(x, cdf_norm, label=r"$\mathcal{N}$")
+        axs[i, j].plot(x, cdf_laplacian, label=r"$\mathcal{L}$")
+        axs[i, j].plot(x, cdf_cauchy, label="Cauchy")
+        axs[i, j].legend()
+        axs[i, j].grid()
+
+# First line, logitscale, with standard notation
+axs[0, 0].set(title="logit scale")
+axs[0, 0].set_yscale("logit")
+axs[0, 0].set_ylim(1e-5, 1 - 1e-5)
+
+axs[0, 1].set(title="logit scale")
+axs[0, 1].set_yscale("logit")
+axs[0, 1].set_xlim(0, xmax)
+axs[0, 1].set_ylim(0.8, 1 - 5e-3)
+
+# Second line, logitscale, with survival notation (with `use_overline`), and
+# other format display 1/2
+axs[1, 0].set(title="logit scale")
+axs[1, 0].set_yscale("logit", one_half="1/2", use_overline=True)
+axs[1, 0].set_ylim(1e-5, 1 - 1e-5)
+
+axs[1, 1].set(title="logit scale")
+axs[1, 1].set_yscale("logit", one_half="1/2", use_overline=True)
+axs[1, 1].set_xlim(0, xmax)
+axs[1, 1].set_ylim(0.8, 1 - 5e-3)
+
+# Third line, linear scale
+axs[2, 0].set(title="linear scale")
+axs[2, 0].set_ylim(0, 1)
+
+axs[2, 1].set(title="linear scale")
+axs[2, 1].set_xlim(0, xmax)
+axs[2, 1].set_ylim(0.8, 1)
+
+fig.tight_layout()
+plt.show()

--- a/examples/scales/scales.py
+++ b/examples/scales/scales.py
@@ -55,9 +55,6 @@ ax.plot(x, y)
 ax.set_yscale('logit')
 ax.set_title('logit')
 ax.grid(True)
-# Format the minor tick labels of the y-axis into empty strings with
-# `NullFormatter`, to avoid cumbering the axis with too many labels.
-ax.yaxis.set_minor_formatter(NullFormatter())
 
 
 # Function x**(1/2)

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -654,8 +654,15 @@ class LogitScale(ScaleBase):
     """
     name = 'logit'
 
-    def __init__(self, axis, nonpos='mask'):
-        """
+    def __init__(
+        self,
+        axis,
+        nonpos='mask',
+        *,
+        one_half=r"\frac{1}{2}",
+        use_overline=False,
+    ):
+        r"""
         Parameters
         ----------
         axis : `matplotlib.axis.Axis`
@@ -664,8 +671,15 @@ class LogitScale(ScaleBase):
             Determines the behavior for values beyond the open interval ]0, 1[.
             They can either be masked as invalid, or clipped to a number very
             close to 0 or 1.
+        use_overline: bool (default: False)
+            indicate the usage of survival notation (\overline{x}) in place of
+            standard notation (1-x) for probability close to one.
+        one_half : str (default: r"\frac{1}{2}")
+            the string used for ticks formatter to represent 1/2.
         """
         self._transform = LogitTransform(nonpos)
+        self._use_overline = use_overline
+        self._one_half = one_half
 
     def get_transform(self):
         """Return the `.LogitTransform` associated with this scale."""
@@ -675,9 +689,20 @@ class LogitScale(ScaleBase):
         # docstring inherited
         # ..., 0.01, 0.1, 0.5, 0.9, 0.99, ...
         axis.set_major_locator(LogitLocator())
-        axis.set_major_formatter(LogitFormatter())
+        axis.set_major_formatter(
+            LogitFormatter(
+                one_half=self._one_half,
+                use_overline=self._use_overline
+            )
+        )
         axis.set_minor_locator(LogitLocator(minor=True))
-        axis.set_minor_formatter(LogitFormatter())
+        axis.set_minor_formatter(
+            LogitFormatter(
+                minor=True,
+                one_half=self._one_half,
+                use_overline=self._use_overline
+            )
+        )
 
     def limit_range_for_scale(self, vmin, vmax, minpos):
         """

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -671,11 +671,11 @@ class LogitScale(ScaleBase):
             Determines the behavior for values beyond the open interval ]0, 1[.
             They can either be masked as invalid, or clipped to a number very
             close to 0 or 1.
-        use_overline: bool (default: False)
-            indicate the usage of survival notation (\overline{x}) in place of
+        use_overline : bool, default: False
+            Indicate the usage of survival notation (\overline{x}) in place of
             standard notation (1-x) for probability close to one.
-        one_half : str (default: r"\frac{1}{2}")
-            the string used for ticks formatter to represent 1/2.
+        one_half : str, default: r"\frac{1}{2}"
+            The string used for ticks formatter to represent 1/2.
         """
         self._transform = LogitTransform(nonpos)
         self._use_overline = use_overline

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -238,6 +238,24 @@ class TestNullLocator:
             loc.set_params()
 
 
+class _LogitHelper:
+    @staticmethod
+    def isclose(x, y):
+        if x >= 1 or x <= 0 or y >= 1 or y <= 0:
+            return False
+        return np.isclose(-np.log(1/x-1), -np.log(1/y-1))
+
+    @staticmethod
+    def assert_almost_equal(x, y):
+        ax = np.array(x)
+        ay = np.array(y)
+        assert np.all(ax > 0) and np.all(ax < 1)
+        assert np.all(ay > 0) and np.all(ay < 1)
+        lx = -np.log(1/ax-1)
+        ly = -np.log(1/ay-1)
+        assert_almost_equal(lx, ly)
+
+
 class TestLogitLocator:
     def test_set_params(self):
         """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,4 +1,5 @@
 import warnings
+import re
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -786,6 +787,184 @@ class TestLogFormatter:
         temp_lf = mticker.LogFormatter()
         temp_lf.axis = FakeAxis()
         assert temp_lf(val) == str(val)
+
+
+class TestLogitFormatter:
+    @staticmethod
+    def logit_deformatter(string):
+        r"""
+        Parser to convert string as r'$\mathdefault{1.41\cdot10^{-4}}$' in
+        float 1.41e-4, as '0.5' or as r'$\mathdefault{\frac{1}{2}}$' in float
+        0.5,
+        """
+        match = re.match(
+            r"[^\d]*"
+            r"(?P<comp>1-)?"
+            r"(?P<mant>\d*\.?\d*)?"
+            r"(?:\\cdot)?"
+            r"(?:10\^\{(?P<expo>-?\d*)})?"
+            r"[^\d]*$",
+            string,
+        )
+        if match:
+            comp = match["comp"] is not None
+            mantissa = float(match["mant"]) if match["mant"] else 1
+            expo = int(match["expo"]) if match["expo"] is not None else 0
+            value = mantissa * 10 ** expo
+            if match["mant"] or match["expo"] is not None:
+                if comp:
+                    return 1 - value
+                return value
+        match = re.match(
+            r"[^\d]*\\frac\{(?P<num>\d+)\}\{(?P<deno>\d+)\}[^\d]*$", string
+        )
+        if match:
+            num, deno = float(match["num"]), float(match["deno"])
+            return num / deno
+        raise ValueError("not formatted by LogitFormatter")
+
+    @pytest.mark.parametrize(
+        "fx, x",
+        [
+            (r"STUFF0.41OTHERSTUFF", 0.41),
+            (r"STUFF1.41\cdot10^{-2}OTHERSTUFF", 1.41e-2),
+            (r"STUFF1-0.41OTHERSTUFF", 1 - 0.41),
+            (r"STUFF1-1.41\cdot10^{-2}OTHERSTUFF", 1 - 1.41e-2),
+            (r"STUFF", None),
+            (r"STUFF12.4e-3OTHERSTUFF", None),
+        ],
+    )
+    def test_logit_deformater(self, fx, x):
+        if x is None:
+            with pytest.raises(ValueError):
+                TestLogitFormatter.logit_deformatter(fx)
+        else:
+            y = TestLogitFormatter.logit_deformatter(fx)
+            assert _LogitHelper.isclose(x, y)
+
+    decade_test = sorted(
+        [10 ** (-i) for i in range(1, 10)]
+        + [1 - 10 ** (-i) for i in range(1, 10)]
+        + [1 / 2]
+    )
+
+    @pytest.mark.parametrize("x", decade_test)
+    def test_basic(self, x):
+        """
+        Test the formatted value correspond to the value for ideal ticks in
+        logit space.
+        """
+        formatter = mticker.LogitFormatter(use_overline=False)
+        formatter.set_locs(self.decade_test)
+        s = formatter(x)
+        x2 = TestLogitFormatter.logit_deformatter(s)
+        assert _LogitHelper.isclose(x, x2)
+
+    @pytest.mark.parametrize("x", (-1, -0.5, -0.1, 1.1, 1.5, 2))
+    def test_invalid(self, x):
+        """
+        Test that invalid value are formatted with empty string without
+        raising exception.
+        """
+        formatter = mticker.LogitFormatter(use_overline=False)
+        formatter.set_locs(self.decade_test)
+        s = formatter(x)
+        assert s == ""
+
+    @pytest.mark.parametrize("x", 1 / (1 + np.exp(-np.linspace(-7, 7, 10))))
+    def test_variablelength(self, x):
+        """
+        The format length should change depending on the neighbor labels.
+        """
+        formatter = mticker.LogitFormatter(use_overline=False)
+        for N in (10, 20, 50, 100, 200, 1000, 2000, 5000, 10000):
+            if x + 1 / N < 1:
+                formatter.set_locs([x - 1 / N, x, x + 1 / N])
+                sx = formatter(x)
+                sx1 = formatter(x + 1 / N)
+                d = (
+                    TestLogitFormatter.logit_deformatter(sx1)
+                    - TestLogitFormatter.logit_deformatter(sx)
+                )
+                assert 0 < d < 2 / N
+
+    lims_minor_major = [
+        (True, (5e-8, 1 - 5e-8), ((25, False), (75, False))),
+        (True, (5e-5, 1 - 5e-5), ((25, False), (75, True))),
+        (True, (5e-2, 1 - 5e-2), ((25, True), (75, True))),
+        (False, (0.75, 0.76, 0.77), ((7, True), (25, True), (75, True))),
+    ]
+
+    @pytest.mark.parametrize("method, lims, cases", lims_minor_major)
+    def test_minor_vs_major(self, method, lims, cases):
+        """
+        Test minor/major displays.
+        """
+
+        if method:
+            min_loc = mticker.LogitLocator(minor=True)
+            ticks = min_loc.tick_values(*lims)
+        else:
+            ticks = np.array(lims)
+        min_form = mticker.LogitFormatter(minor=True)
+        for threshold, has_minor in cases:
+            min_form.set_minor_threshold(threshold)
+            formatted = min_form.format_ticks(ticks)
+            labelled = [f for f in formatted if len(f) > 0]
+            if has_minor:
+                assert len(labelled) > 0, (threshold, has_minor)
+            else:
+                assert len(labelled) == 0, (threshold, has_minor)
+
+    def test_minor_number(self):
+        """
+        Test the parameter minor_number
+        """
+        min_loc = mticker.LogitLocator(minor=True)
+        min_form = mticker.LogitFormatter(minor=True)
+        ticks = min_loc.tick_values(5e-2, 1 - 5e-2)
+        for minor_number in (2, 4, 8, 16):
+            min_form.set_minor_number(minor_number)
+            formatted = min_form.format_ticks(ticks)
+            labelled = [f for f in formatted if len(f) > 0]
+            assert len(labelled) == minor_number
+
+    def test_use_overline(self):
+        """
+        Test the parameter use_overline
+        """
+        x = 1 - 1e-2
+        fx1 = r"$\mathdefault{1-10^{-2}}$"
+        fx2 = r"$\mathdefault{\overline{10^{-2}}}$"
+        form = mticker.LogitFormatter(use_overline=False)
+        assert form(x) == fx1
+        form.use_overline(True)
+        assert form(x) == fx2
+        form.use_overline(False)
+        assert form(x) == fx1
+
+    def test_one_half(self):
+        """
+        Test the parameter one_half
+        """
+        form = mticker.LogitFormatter()
+        assert r"\frac{1}{2}" in form(1/2)
+        form.set_one_half("1/2")
+        assert "1/2" in form(1/2)
+        form.set_one_half("one half")
+        assert "one half" in form(1/2)
+
+    @pytest.mark.parametrize("N", (100, 253, 754))
+    def test_format_data_short(self, N):
+        locs = np.linspace(0, 1, N)[1:-1]
+        form = mticker.LogitFormatter()
+        for x in locs:
+            fx = form.format_data_short(x)
+            if fx.startswith("1-"):
+                x2 = 1 - float(fx[2:])
+            else:
+                x2 = float(fx)
+            assert np.abs(x - x2) < 1 / N
 
 
 class TestFormatStrFormatter:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2079,13 +2079,13 @@ def decade_up(x, base=10):
     return base ** lx
 
 
-def is_decade(x, base=10):
+def is_decade(x, base=10, *, rtol=1e-10):
     if not np.isfinite(x):
         return False
     if x == 0.0:
         return True
     lx = np.log(np.abs(x)) / np.log(base)
-    return is_close_to_int(lx)
+    return is_close_to_int(lx, atol=rtol)
 
 
 def _decade_less_equal(x, base):
@@ -2138,8 +2138,8 @@ def _decade_greater(x, base):
     return greater
 
 
-def is_close_to_int(x):
-    return abs(x - np.round(x)) < 1e-10
+def is_close_to_int(x, *, atol=1e-10):
+    return abs(x - np.round(x)) < atol
 
 
 class LogLocator(Locator):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1183,25 +1183,25 @@ class LogitFormatter(Formatter):
         r"""
         Parameters
         ----------
-        use_overline : bool (default: False)
-            if x > 1/2, with x = 1-v, indicate if x should be displayed as
+        use_overline : bool, default: False
+            If x > 1/2, with x = 1-v, indicate if x should be displayed as
             $\overline{v}$. The default is to display $1-v$.
 
-        one_half : str (default: r"\frac{1}{2}")
-            the string used to represent 1/2.
+        one_half : str, default: r"\frac{1}{2}"
+            The string used to represent 1/2.
 
-        minor : bool (default: False)
-            indicate if the formatter is formatting minor ticks or not.
+        minor : bool, default: False
+            Indicate if the formatter is formatting minor ticks or not.
             Basically minor ticks are not labelled, except when only few ticks
             are provided, the most espaced ticks are labelled. See others
             parameters to change the default behavior.
 
-        minor_threshold : int (default: 25)
-            maximum number of locs for labelling some minor ticks. This
+        minor_threshold : int, default: 25
+            Maximum number of locs for labelling some minor ticks. This
             parameter have no effect if minor is False.
 
-        minor_number : int (default: 6)
-            number of ticks which are labelled when the number of ticks is
+        minor_number : int, default: 6
+            Number of ticks which are labelled when the number of ticks is
             below the threshold.
         """
         self._use_overline = use_overline
@@ -1217,8 +1217,8 @@ class LogitFormatter(Formatter):
 
         Parameters
         ----------
-        use_overline : bool (default: False)
-            if x > 1/2, with x = 1-v, indicate if x should be displayed as
+        use_overline : bool, default: False
+            If x > 1/2, with x = 1-v, indicate if x should be displayed as
             $\overline{v}$. The default is to display $1-v$.
         """
         self._use_overline = use_overline
@@ -1227,19 +1227,19 @@ class LogitFormatter(Formatter):
         r"""
         Set the way one half is displayed.
 
-        one_half : str (default: r"\frac{1}{2}")
-            the string used to represent 1/2.
+        one_half : str, default: r"\frac{1}{2}"
+            The string used to represent 1/2.
         """
         self._one_half = one_half
 
     def set_minor_threshold(self, minor_threshold):
         """
-        Set the threshold for labelling minors ticks
+        Set the threshold for labelling minors ticks.
 
         Parameters
         ----------
         minor_threshold : int
-            maximum number of locs for labelling some minor ticks. This
+            Maximum number of locations for labelling some minor ticks. This
             parameter have no effect if minor is False.
         """
         self._minor_threshold = minor_threshold
@@ -1252,7 +1252,7 @@ class LogitFormatter(Formatter):
         Parameters
         ----------
         minor_number : int
-            number of ticks which are labelled when the number of ticks is
+            Number of ticks which are labelled when the number of ticks is
             below the threshold.
         """
         self._minor_number = minor_number

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1193,8 +1193,8 @@ class LogitFormatter(Formatter):
         minor : bool, default: False
             Indicate if the formatter is formatting minor ticks or not.
             Basically minor ticks are not labelled, except when only few ticks
-            are provided, the most espaced ticks are labelled. See others
-            parameters to change the default behavior.
+            are provided, ticks with most space with neighbor ticks are
+            labelled. See other parameters to change the default behavior.
 
         minor_threshold : int, default: 25
             Maximum number of locs for labelling some minor ticks. This

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -463,9 +463,6 @@ plt.plot(x, y)
 plt.yscale('logit')
 plt.title('logit')
 plt.grid(True)
-# Format the minor tick labels of the y-axis into empty strings with
-# `NullFormatter`, to avoid cumbering the axis with too many labels.
-plt.gca().yaxis.set_minor_formatter(NullFormatter())
 # Adjust the subplot layout, because the logit one may take more space
 # than usual, due to y-tick labels like "1 - 10^{-3}"
 plt.subplots_adjust(top=0.92, bottom=0.08, left=0.10, right=0.95, hspace=0.25,


### PR DESCRIPTION
## PR Summary

I had a lot of bugs on the labelling on `logit` scale. For example, the following code:

```python
import numpy as np 
import scipy as sp 
import scipy.stats 
import matplotlib.pyplot as plt 
 
s = np.linspace(-5,5,10000) 
s2 = np.linspace(-10,10,10000) 
lims = [(1e-10,1-1e-10),(1e-5,1-1e-5),(11e-2,15e-2)] 
for k,lim in enumerate(lims): 
    fig,ax = plt.subplots() 
    ax.set_yscale('logit') 
    ax.plot(s,sp.stats.norm.cdf(s)) 
    for i in range(9): 
        ax.plot(s2,sp.stats.t(i+1).cdf(s2)) 
    ax.grid() 
    ax.set_ylim(*lim) 
    fig.savefig(f'/tmp/g{k}.png')
```                   

### Actual behavior

I obtain for the very large zoom:

![g0](https://user-images.githubusercontent.com/24868098/59163971-960d5980-8b07-11e9-9082-d5ce7bdf143b.png)

For normal zoom:

![g1](https://user-images.githubusercontent.com/24868098/59163973-a9202980-8b07-11e9-8472-9c5955b0ee6a.png)

For zoomed axis:

![g2](https://user-images.githubusercontent.com/24868098/59164017-3794ab00-8b08-11e9-9d14-eaff9726543d.png)

### Behavior on the proposed branch

All this graphs are obtained with the same code as above.

I change the locator to allow different behavior, on large zoom, some decade are not proposed on majors, but on minors. No minor ticks used for subdivision of decades. Label are present only on major ticks. I obtain:

![f0](https://user-images.githubusercontent.com/24868098/59164059-b5f14d00-8b08-11e9-8e4b-27ed4cf8d0cb.png)

On normal zoom, all decades are shown on major, minor are indicating subdecade. Most of the time only major ticks are labelled, but when only a few of major are present, a spaced subset of minors can be labelled. I obtain :

![f1](https://user-images.githubusercontent.com/24868098/59164118-15e7f380-8b09-11e9-966b-52fe6a70700c.png)

On a very zoomed graph, the logiscale is kind-of linear, so the `MaxNLocator` is used (in particular, my LogitLocator inherit from MaxNLocator to allows fallback to MaxNLocator in this case, I obtain:

![f2](https://user-images.githubusercontent.com/24868098/59164136-619a9d00-8b09-11e9-993b-92d2c6db68c3.png)

Also, two little things:
 - for ticks labelling, the precision of format is adaptative, and depends of the diff between the labelled tick and neighbors,
 - formater have `use_oveline` method, which allow use the survival notation (`\overline{x}` mean `1-x`). Not enabled by default.

Should solve #13698.

## PR Checklist

I putted my comments on each item.

- [X] Has Pytest style unit tests
   - I tried to test the most critical behaviors of my code.
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
   - Except for some new parameters, I did not add features.
- [ ] Documentation is sphinx and numpydoc compliant
   - I tried, but I did not test, and I don't know how to test that.
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
   - I don't know if this change is _major_. I think it is not.
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
   - No backward incompatible API changes.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
