### PR TITLE
Document and test _get_packed_offsets()

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -56,7 +56,7 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
 
     - 'fixed': The elements are packed tight to the left with a spacing of
       *sep* in between. If *total* is *None* the returned total will be the
-      right edge of the last box. A non-None total will be passed unchecked
+      right edge of the last box. A non-*None* total will be passed unchecked
       to the output. In particular this means that right edge of the last
       box will may be further to the right than the returned total.
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -65,7 +65,7 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
       *total*. The parameter *sep* is ignored in this mode. A total of *None*
       is accepted and considered equal to 1. The total is returned unchanged
       (except for the conversion *None* to 1). If the total is smaller than
-      the sum of the widths, the laid out boxed will overlap.
+      the sum of the widths, the laid out boxes will overlap.
 
     - 'equal': If *total* is given, the total space is divided in N equal
       ranges and each box is left-aligned within its subspace.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -58,7 +58,7 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
       *sep* in between. If *total* is *None* the returned total will be the
       right edge of the last box. A non-*None* total will be passed unchecked
       to the output. In particular this means that right edge of the last
-      box will may be further to the right than the returned total.
+      box may be further to the right than the returned total.
 
     - 'expand': Distribute the boxes with equal spacing so that the left edge
       of the first box is at 0, and the right edge of the last box is at

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -78,7 +78,7 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
     wd_list : list of (float, float)
         (width, xdescent) of boxes to be packed.
     total : float or None
-        Intended total length. None if not used.
+        Intended total length. *None* if not used.
     sep : float
         Spacing between boxes.
     mode : {'fixed', 'expand', 'equal'}


### PR DESCRIPTION
## PR Summary

Properly test and document `matplotlib.offsetbox._get_packed_offsets()`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant
