### PR TITLE
Deprecate PackerBase

### DIFF
--- a/doc/api/next_api_changes/2019-06-10-TH.rst
+++ b/doc/api/next_api_changes/2019-06-10-TH.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The class `matplotlib.offsetbox.PackerBase` is deprecated. It is considered
+an implementation detail and will become private in future versions.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -263,7 +263,7 @@ class OffsetBox(martist.Artist):
         self.stale = False
 
 
-class PackerBase(OffsetBox):
+class _PackerBase(OffsetBox):
     def __init__(self, pad=None, sep=None, width=None, height=None,
                  align=None, mode=None,
                  children=None):
@@ -307,7 +307,13 @@ class PackerBase(OffsetBox):
         self._children = children
 
 
-class VPacker(PackerBase):
+class PackerBase(_PackerBase):
+    def __init__(self, *args, **kwargs):
+        cbook.warn_deprecated("3.2", name='PackerBase', obj_type='class')
+        self.super(*args, *kwargs)
+
+
+class VPacker(_PackerBase):
     """
     The VPacker has its children packed vertically. It automatically
     adjust the relative positions of children in the drawing time.
@@ -356,7 +362,7 @@ class VPacker(PackerBase):
 
         if self.width is not None:
             for c in self.get_visible_children():
-                if isinstance(c, PackerBase) and c.mode == "expand":
+                if isinstance(c, _PackerBase) and c.mode == "expand":
                     c.set_width(self.width)
 
         whd_list = [c.get_extent(renderer)
@@ -383,7 +389,7 @@ class VPacker(PackerBase):
                 list(zip(xoffsets, yoffsets)))
 
 
-class HPacker(PackerBase):
+class HPacker(_PackerBase):
     """
     The HPacker has its children packed horizontally. It automatically
     adjusts the relative positions of children at draw time.


### PR DESCRIPTION
## PR Summary

PackerBase does not much. It just has an ``__init__`` that defines a common constructor and some attributes.

I don't see a need for this base class to be visible to the end-user. By making it private we save the effort of documenting it (``__init__`` docstrings have to be present in the derived classes because numpydoc does not inherit ``__init__`` docstrings if there is a class docstring).

We may also consider removing it alltogether later. 