### PR TITLE
Invalidate FT2Font cache when fork()ing.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1264,10 +1264,18 @@ def is_opentype_cff_font(filename):
         return False
 
 
-_get_font = lru_cache(64)(ft2font.FT2Font)
 _fmcache = os.path.join(
     mpl.get_cachedir(), 'fontlist-v{}.json'.format(FontManager.__version__))
 fontManager = None
+
+
+_get_font = lru_cache(64)(ft2font.FT2Font)
+# FT2Font objects cannot be used across fork()s because they reference the same
+# FT_Library object.  While invalidating *all* existing FT2Fonts after a fork
+# would be too complicated to be worth it, the main way FT2Fonts get reused is
+# via the cache of _get_font, which we can empty upon forking (in Py3.7+).
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_get_font.cache_clear)
 
 
 def get_font(filename, hinting_factor=None):


### PR DESCRIPTION
## PR Summary

Closes #13723 (on Py3.7+), I think.  @marcotama please confirm.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
