### PR TITLE
Slightly tighten the Bbox API.

### DIFF
--- a/doc/api/next_api_changes/2019-06-13-AL.rst
+++ b/doc/api/next_api_changes/2019-06-13-AL.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+``BboxBase.is_unit`` is deprecated (check the Bbox extents if needed).
+
+``axes3d.unit_bbox`` is deprecated (use ``Bbox.unit`` instead).

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -278,6 +278,7 @@ class BboxBase(TransformNode):
     def __array__(self, *args, **kwargs):
         return self.get_points()
 
+    @cbook.deprecated("3.2")
     def is_unit(self):
         """Return whether this is the unit box (from (0, 0) to (1, 1))."""
         return self.get_points().tolist() == [[0., 0.], [1., 1.]]

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -32,6 +32,7 @@ from . import proj3d
 from . import axis3d
 
 
+@cbook.deprecated("3.2", alternative="Bbox.unit()")
 def unit_bbox():
     box = Bbox(np.array([[0, 0], [1, 1]]))
     return box
@@ -82,10 +83,10 @@ class Axes3D(Axes):
         self.initial_elev = elev
         self.set_proj_type(proj_type)
 
-        self.xy_viewLim = unit_bbox()
-        self.zz_viewLim = unit_bbox()
-        self.xy_dataLim = unit_bbox()
-        self.zz_dataLim = unit_bbox()
+        self.xy_viewLim = Bbox.unit()
+        self.zz_viewLim = Bbox.unit()
+        self.xy_dataLim = Bbox.unit()
+        self.zz_dataLim = Bbox.unit()
         # inhibit autoscale_view until the axes are defined
         # they can't be defined until Axes.__init__ has been called
         self.view_init(self.initial_elev, self.initial_azim)


### PR DESCRIPTION
Bbox.is_unit was added in 23588bfd1 but never, ever used.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
