### PR TITLE
Deprecate hinting_factor.

### DIFF
--- a/doc/api/next_api_changes/2019-06-14-AL.rst
+++ b/doc/api/next_api_changes/2019-06-14-AL.rst
@@ -1,0 +1,7 @@
+Deprecation of hinting_factor
+`````````````````````````````
+
+The ``hinting_factor`` parameter of `.ft2font.FT2Font` and `.font_manager.get_font`,
+and :rc:`test.hinting_factor`, are deprecated.  Their default value have been
+changed to 1, which will be the only value supported in after the deprecation
+period ends.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -715,6 +715,7 @@ _deprecated_ignore_map = {
 # listed in the rcParams (not included in _all_deprecated).
 # Values are tuples of (version,)
 _deprecated_remain_as_none = {
+    'text.hinting_factor': ('3.2',),
     'text.latex.unicode': ('3.0',),
     'savefig.frameon': ('3.1',),
     'verbose.fileo': ('3.1',),

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1270,9 +1270,11 @@ _fmcache = os.path.join(
 fontManager = None
 
 
+@cbook._delete_parameter("3.2", "hinting_factor")
 def get_font(filename, hinting_factor=None):
     if hinting_factor is None:
-        hinting_factor = rcParams['text.hinting_factor']
+        with cbook._suppress_matplotlib_deprecation_warning():
+            hinting_factor = rcParams['text.hinting_factor']
     return _get_font(os.fspath(filename), hinting_factor)
 
 

--- a/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_classic_test.mplstyle
@@ -132,9 +132,6 @@ text.hinting : auto   # May be one of the following:
                       #             or the autohinter if none is available.
                       # For backward compatibility, this value may also be
                       # True === 'auto' or False === 'none'.
-text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
-                        # horizontal direction.  A value of 1 will hint to full
-                        # pixels.  A value of 2 will hint to half pixels etc.
 
 text.antialiased : True # If True (default), the text will be antialiased.
                         # This only affects the Agg backend.

--- a/lib/matplotlib/mpl-data/stylelib/bmh.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/bmh.mplstyle
@@ -8,8 +8,6 @@ patch.facecolor: blue
 patch.edgecolor: eeeeee
 patch.antialiased: True
 
-text.hinting_factor : 8
-
 mathtext.fontset : cm
 
 axes.facecolor: eeeeee

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -134,9 +134,6 @@ text.hinting : auto   # May be one of the following:
                       #             or the autohinter if none is available.
                       # For backward compatibility, this value may also be
                       # True === 'auto' or False === 'none'.
-text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
-                        # horizontal direction.  A value of 1 will hint to full
-                        # pixels.  A value of 2 will hint to half pixels etc.
 
 text.antialiased : True # If True (default), the text will be antialiased.
                         # This only affects the Agg backend.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1086,7 +1086,7 @@ defaultParams = {
     'text.latex.preamble': ['', _validate_tex_preamble],
     'text.latex.preview':  [False, validate_bool],
     'text.hinting':        ['auto', validate_hinting],
-    'text.hinting_factor': [8, validate_int],
+    'text.hinting_factor': [1, validate_int],
     'text.antialiased':    [True, validate_bool],
 
     'mathtext.cal':            ['cursive', validate_font_properties],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6163,8 +6163,8 @@ def test_normal_axes():
 
     # test the axis bboxes
     target = [
-        [123.375, 75.88888888888886, 983.25, 33.0],
-        [85.51388888888889, 99.99999999999997, 53.375, 993.0]
+        [123.5, 75.88888888888886, 983.0, 33.0],
+        [85.89, 100.0, 53.0, 993.0]
     ]
     for nn, b in enumerate(bbaxis):
         targetbb = mtransforms.Bbox.from_bounds(*target[nn])
@@ -6184,7 +6184,7 @@ def test_normal_axes():
     targetbb = mtransforms.Bbox.from_bounds(*target)
     assert_array_almost_equal(bbax.bounds, targetbb.bounds, decimal=2)
 
-    target = [85.5138, 75.88888, 1021.11, 1017.11]
+    target = [85.89, 75.88888, 1020.61, 1017.11]
     targetbb = mtransforms.Bbox.from_bounds(*target)
     assert_array_almost_equal(bbtb.bounds, targetbb.bounds, decimal=2)
 
@@ -6311,7 +6311,7 @@ def test_get_tightbbox_polar():
     fig.canvas.draw()
     bb = ax.get_tightbbox(fig.canvas.get_renderer())
     assert_allclose(bb.extents,
-        [107.7778,  29.2778, 539.7847, 450.7222], rtol=1e-03)
+        [108.7778,  29.2778, 539.2222, 450.7222], rtol=1e-03)
 
 
 @check_figures_equal(extensions=["png"])

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -444,13 +444,12 @@ def test_tightbbox():
     ax.set_xlim(0, 1)
     t = ax.text(1., 0.5, 'This dangles over end')
     renderer = fig.canvas.get_renderer()
-    x1Nom0 = 9.035  # inches
+    x1Nom0 = 8.9625  # inches
     assert abs(t.get_tightbbox(renderer).x1 - x1Nom0 * fig.dpi) < 2
     assert abs(ax.get_tightbbox(renderer).x1 - x1Nom0 * fig.dpi) < 2
     assert abs(fig.get_tightbbox(renderer).x1 - x1Nom0) < 0.05
     assert abs(fig.get_tightbbox(renderer).x0 - 0.679) < 0.05
-    # now exclude t from the tight bbox so now the bbox is quite a bit
-    # smaller
+    # now exclude t from the tight bbox so now the bbox is quite a bit smaller
     t.set_in_layout(False)
     x1Nom = 7.333
     assert abs(ax.get_tightbbox(renderer).x1 - x1Nom * fig.dpi) < 2

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -79,19 +79,21 @@ def test_get_fontconfig_fonts():
 def test_hinting_factor(factor):
     font = findfont(FontProperties(family=["sans-serif"]))
 
-    font1 = get_font(font, hinting_factor=1)
-    font1.clear()
-    font1.set_size(12, 100)
-    font1.set_text('abc')
-    expected = font1.get_width_height()
+    with cbook._suppress_matplotlib_deprecation_warning():
 
-    hinted_font = get_font(font, hinting_factor=factor)
-    hinted_font.clear()
-    hinted_font.set_size(12, 100)
-    hinted_font.set_text('abc')
-    # Check that hinting only changes text layout by a small (10%) amount.
-    np.testing.assert_allclose(hinted_font.get_width_height(), expected,
-                               rtol=0.1)
+        font1 = get_font(font, hinting_factor=1)
+        font1.clear()
+        font1.set_size(12, 100)
+        font1.set_text('abc')
+        expected = font1.get_width_height()
+
+        hinted_font = get_font(font, hinting_factor=factor)
+        hinted_font.clear()
+        hinted_font.set_size(12, 100)
+        hinted_font.set_text('abc')
+        # Check that hinting only changes text layout by a small (10%) amount.
+        np.testing.assert_allclose(hinted_font.get_width_height(), expected,
+                                   rtol=0.1)
 
 
 @pytest.mark.skipif(sys.platform != "win32",

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -518,7 +518,6 @@ def test_nonfinite_pos():
 
 
 def test_hinting_factor_backends():
-    plt.rcParams['text.hinting_factor'] = 1
     fig = plt.figure()
     t = fig.text(0.5, 0.5, 'some text')
 

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -149,7 +149,7 @@ def test_tight_layout9():
 
 
 def test_outward_ticks():
-    'Test automatic use of tight_layout'
+    """Test automatic use of tight_layout."""
     fig = plt.figure()
     ax = fig.add_subplot(221)
     ax.xaxis.set_tick_params(tickdir='out', length=16, width=3)
@@ -172,10 +172,10 @@ def test_outward_ticks():
     plt.tight_layout()
     # These values were obtained after visual checking that they correspond
     # to a tight layouting that did take the ticks into account.
-    ans = [[[0.091, 0.607], [0.433, 0.933]],
-           [[0.579, 0.607], [0.922, 0.933]],
-           [[0.091, 0.140], [0.433, 0.466]],
-           [[0.579, 0.140], [0.922, 0.466]]]
+    ans = [[[0.088, 0.607], [0.433, 0.933]],
+           [[0.577, 0.607], [0.922, 0.933]],
+           [[0.088, 0.140], [0.433, 0.466]],
+           [[0.577, 0.140], [0.922, 0.466]]]
     for nn, ax in enumerate(fig.axes):
         assert_array_equal(np.round(ax.get_position().get_points(), 3),
                            ans[nn])

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -250,9 +250,6 @@
                        #              or the autohinter if none is available.
                        ## For backward compatibility, this value may also be
                        ## True === 'auto' or False === 'none'.
-#text.hinting_factor : 8 ## Specifies the amount of softness for hinting in the
-                         ## horizontal direction.  A value of 1 will hint to full
-                         ## pixels.  A value of 2 will hint to half pixels etc.
 #text.antialiased : True ## If True (default), the text will be antialiased.
                          ## This only affects the Agg backend.
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -515,12 +515,18 @@ static int PyFT2Font_init(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
     PyObject *fname;
     FT_Open_Args open_args;
-    long hinting_factor = 8;
+    long hinting_factor = -0xdeadbeef;
     const char *names[] = { "filename", "hinting_factor", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(
              args, kwds, "O|l:FT2Font", (char **)names, &fname, &hinting_factor)) {
         return -1;
+    }
+
+    if (hinting_factor == -0xdeadbeef) {
+        hinting_factor = 1;
+    } else {
+        PyErr_WarnEx(PyExc_DeprecationWarning, "The 'hinting_factor' parameter is deprecated.", 1);
     }
 
     if (!convert_open_args(self, fname, &open_args)) {


### PR DESCRIPTION
## PR Summary

... as discussed in https://github.com/matplotlib/matplotlib/issues/9681.
attn @QuLogic, I guess?

Edit: Ah, of course, I missed the fact that tests forced its value to *8* and therefore its removal would lead to regeneration of the entire suite of baseline images :(  Closing for now, as this basically depends on fixing the baseline images problem.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
