### PR TITLE
Don't overindent enumerated list in plot_directive docstring.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -1,44 +1,43 @@
 """
 A directive for including a matplotlib plot in a Sphinx document.
 
-By default, in HTML output, `plot` will include a .png file with a
-link to a high-res .png and .pdf.  In LaTeX output, it will include a
-.pdf.
+By default, in HTML output, `plot` will include a .png file with a link to a
+high-res .png and .pdf.  In LaTeX output, it will include a .pdf.
 
 The source code for the plot may be included in one of three ways:
 
-  1. **A path to a source file** as the argument to the directive::
+1. **A path to a source file** as the argument to the directive::
 
-       .. plot:: path/to/plot.py
+     .. plot:: path/to/plot.py
 
-     When a path to a source file is given, the content of the
-     directive may optionally contain a caption for the plot::
+   When a path to a source file is given, the content of the
+   directive may optionally contain a caption for the plot::
 
-       .. plot:: path/to/plot.py
+     .. plot:: path/to/plot.py
 
-          This is the caption for the plot
+        This is the caption for the plot
 
-     Additionally, one may specify the name of a function to call (with
-     no arguments) immediately after importing the module::
+   Additionally, one may specify the name of a function to call (with
+   no arguments) immediately after importing the module::
 
-       .. plot:: path/to/plot.py plot_function1
+     .. plot:: path/to/plot.py plot_function1
 
-  2. Included as **inline content** to the directive::
+2. Included as **inline content** to the directive::
 
-       .. plot::
+     .. plot::
 
-          import matplotlib.pyplot as plt
-          import matplotlib.image as mpimg
-          import numpy as np
-          img = mpimg.imread('_static/stinkbug.png')
-          imgplot = plt.imshow(img)
+        import matplotlib.pyplot as plt
+        import matplotlib.image as mpimg
+        import numpy as np
+        img = mpimg.imread('_static/stinkbug.png')
+        imgplot = plt.imshow(img)
 
-  3. Using **doctest** syntax::
+3. Using **doctest** syntax::
 
-       .. plot::
-          A plotting example:
-          >>> import matplotlib.pyplot as plt
-          >>> plt.plot([1,2,3], [4,5,6])
+     .. plot::
+        A plotting example:
+        >>> import matplotlib.pyplot as plt
+        >>> plt.plot([1,2,3], [4,5,6])
 
 Options
 -------
@@ -53,30 +52,26 @@ The ``plot`` directive supports the following options:
         using the `plot_include_source` variable in conf.py
 
     encoding : str
-        If this source file is in a non-UTF8 or non-ASCII encoding,
-        the encoding must be specified using the `:encoding:` option.
-        The encoding will not be inferred using the ``-*- coding -*-``
-        metacomment.
+        If this source file is in a non-UTF8 or non-ASCII encoding, the
+        encoding must be specified using the `:encoding:` option.  The encoding
+        will not be inferred using the ``-*- coding -*-`` metacomment.
 
     context : bool or str
-        If provided, the code will be run in the context of all
-        previous plot directives for which the `:context:` option was
-        specified.  This only applies to inline code plot directives,
-        not those run from files. If the ``:context: reset`` option is
-        specified, the context is reset for this and future plots, and
-        previous figures are closed prior to running the code.
-        ``:context:close-figs`` keeps the context but closes previous figures
-        before running the code.
+        If provided, the code will be run in the context of all previous plot
+        directives for which the `:context:` option was specified.  This only
+        applies to inline code plot directives, not those run from files. If
+        the ``:context: reset`` option is specified, the context is reset
+        for this and future plots, and previous figures are closed prior to
+        running the code. ``:context: close-figs`` keeps the context but closes
+        previous figures before running the code.
 
     nofigs : bool
-        If specified, the code block will be run, but no figures will
-        be inserted.  This is usually useful with the ``:context:``
-        option.
+        If specified, the code block will be run, but no figures will be
+        inserted.  This is usually useful with the ``:context:`` option.
 
-Additionally, this directive supports all of the options of the
-`image` directive, except for `target` (since plot will add its own
-target).  These include `alt`, `height`, `width`, `scale`, `align` and
-`class`.
+Additionally, this directive supports all of the options of the `image`
+directive, except for `target` (since plot will add its own target).  These
+include `alt`, `height`, `width`, `scale`, `align` and `class`.
 
 Configuration options
 ---------------------
@@ -109,7 +104,7 @@ The plot directive has the following configuration options:
         that determine the file format and the DPI. For entries whose
         DPI was omitted, sensible defaults are chosen. When passing from
         the command line through sphinx_build the list should be passed as
-        suffix:dpi,suffix:dpi, ....
+        suffix:dpi,suffix:dpi, ...
 
     plot_html_show_formats
         Whether to show links to the files in HTML.
@@ -213,9 +208,8 @@ def _option_align(arg):
 
 def mark_plot_labels(app, document):
     """
-    To make plots referenceable, we need to move the reference from
-    the "htmlonly" (or "latexonly") node to the actual figure node
-    itself.
+    To make plots referenceable, we need to move the reference from the
+    "htmlonly" (or "latexonly") node to the actual figure node itself.
     """
     for name, explicit in document.nametypes.items():
         if not explicit:


### PR DESCRIPTION
The usual dedenting, plus rewrapping some paragraphs.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
