### PR TITLE
column headers now row -1 of the table

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -429,9 +429,12 @@ class Table(Artist):
         """Get a bbox, in axes co-ordinates for the cells.
 
         Only include those in the range (0,0) to (maxRow, maxCol)"""
+        start_row = 0
+        if self.has_column_labels:
+            start_row = -1
         boxes = [cell.get_window_extent(renderer)
                  for (row, col), cell in self._cells.items()
-                 if row >= 0 and col >= 0]
+                 if row >= start_row and col >= 0]
         bbox = Bbox.union(boxes)
         return bbox.inverse_transformed(self.get_transform())
 
@@ -787,14 +790,9 @@ def table(ax,
         if len(rowLabels) != rows:
             raise ValueError("'rowLabels' must be of length {0}".format(rows))
 
-    # If we have column labels, need to shift
-    # the text and colour arrays down 1 row
-    offset = 1
     if colLabels is None:
         if colColours is not None:
             colLabels = [''] * cols
-        else:
-            offset = 0
     elif colColours is None:
         colColours = 'w' * cols
 
@@ -810,15 +808,17 @@ def table(ax,
     # Add the cells
     for row in range(rows):
         for col in range(cols):
-            table.add_cell(row + offset, col,
+            table.add_cell(row, col,
                            width=colWidths[col], height=height,
                            text=cellText[row][col],
                            facecolor=cellColours[row][col],
                            loc=cellLoc)
     # Do column labels
+    table.has_column_labels = False
     if colLabels is not None:
+        table.has_column_labels = True
         for col in range(cols):
-            table.add_cell(0, col,
+            table.add_cell(-1, col,
                            width=colWidths[col], height=height,
                            text=colLabels[col], facecolor=colColours[col],
                            loc=colLoc)
@@ -826,7 +826,7 @@ def table(ax,
     # Do row labels
     if rowLabels is not None:
         for row in range(rows):
-            table.add_cell(row + offset, -1,
+            table.add_cell(row, -1,
                            width=rowLabelWidth or 1e-15, height=height,
                            text=rowLabels[row], facecolor=rowColours[row],
                            loc=rowLoc)


### PR DESCRIPTION
## PR Summary

This addresses https://github.com/matplotlib/matplotlib/issues/12931

It is an API change since cell indices for the body of the table are now the same regardless of whether the table has column headers.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
