### PR TITLE
In contributing.rst, encourage kwonly args and minimizing public APIs.

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -349,6 +349,23 @@ C/C++ extensions
   docstrings, and the Numpydoc format is well understood in the
   scientific Python community.
 
+New public APIs
+---------------
+
+Public APIs added to Matplotlib are bound by backwards compatibility, and
+therefore cumbersome to change.  Therefore, when adding new functionality, try
+to add as little public API as possible.  In particular, make sure that helper
+methods and internal attributes are private (i.e., start with an underscore).
+Remember that any non-private method can be directly called by the end user,
+and any non-private attribute can be directly set!
+
+In order to make it easier to evolve APIs, consider making as many arguments
+keyword-only as possible.
+
+.. seealso:: `API Evolution the Right Way -- Add Parameters Compatibly`__
+
+__ https://emptysqua.re/blog/api-evolution-the-right-way/#adding-parameters
+
 .. _keyword-argument-processing:
 
 Keyword argument processing


### PR DESCRIPTION
... so that we can just point PR authors to it instead of explaining
again and again why.

Thought of this while looking at https://github.com/matplotlib/matplotlib/pull/14512.

Rewordings welcome.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
