### PR TITLE
Improve @deprecated's docstring.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -135,15 +135,8 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
         object.
 
     name : str, optional
-        The name of the deprecated object; if not provided the name
-        is automatically determined from the passed in object,
-        though this is useful in the case of renamed functions, where
-        the new function is just assigned to the name of the
-        deprecated function.  For example::
-
-            def new_function():
-                ...
-            old_function = new_function
+        The name used in the deprecation message; if not provided, the name
+        is automatically determined from the deprecated object.
 
     alternative : str, optional
         An alternative API that the user may use in place of the deprecated
@@ -155,8 +148,8 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
         DeprecationWarning.  Cannot be used together with *removal*.
 
     obj_type : str, optional
-        The object type being deprecated; by default, 'function' if decorating
-        a function and 'class' if decorating a class.
+        The object type being deprecated; by default, 'class' if decorating
+        a class, 'attribute' if decorating a property, 'function' otherwise.
 
     addendum : str, optional
         Additional text appended directly to the final message.


### PR DESCRIPTION
- The example for `name` doesn't work (one would need
  ``old_function = deprecated("3.x", name="old_function")(new_function)
  but in practice that'll likely just be written using normal decorator
  syntax (there are no use cases of explicitly passing `name` in 3.1,
  AFAICT).
- `obj_type` is also automatically set for properties.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
