### PR TITLE
Ticks should not be affected by rcParams["lines.markeredgecolor"]

### DIFF
--- a/doc/api/next_api_changes/2019-06-16-TH.rst
+++ b/doc/api/next_api_changes/2019-06-16-TH.rst
@@ -1,0 +1,7 @@
+Tick line colors are no longer influenced by rcParams["lines.markeredgecolor"]
+``````````````````````````````````````````````````````````````````````````````
+
+Tick line colors are no longer influenced by :rc:`lines.markeredgecolor`.
+You may use :rc:`xtick.color` / :rc:`ytick.color` to color tick lines and
+labels simultaneously. If you just want to only the tick lines, do so
+programmatically.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -459,10 +459,14 @@ class XTick(Tick):
     def _get_tick1line(self):
         'Get the default line2D instance'
         # x in data coords, y in axes coords
-        l = mlines.Line2D(xdata=(0,), ydata=(0,), color=self._color,
-                          linestyle='None', marker=self._tickmarkers[0],
+        l = mlines.Line2D(xdata=(0,), ydata=(0,),
+                          color=self._color,
+                          linestyle='None',
+                          marker=self._tickmarkers[0],
                           markersize=self._size,
-                          markeredgewidth=self._width, zorder=self._zorder)
+                          markeredgecolor=self._color,
+                          markeredgewidth=self._width,
+                          zorder=self._zorder)
         l.set_transform(self.axes.get_xaxis_transform(which='tick1'))
         self._set_artist_props(l)
         return l
@@ -475,6 +479,7 @@ class XTick(Tick):
                           linestyle='None',
                           marker=self._tickmarkers[1],
                           markersize=self._size,
+                          markeredgecolor=self._color,
                           markeredgewidth=self._width,
                           zorder=self._zorder)
 
@@ -580,6 +585,7 @@ class YTick(Tick):
                           marker=self._tickmarkers[0],
                           linestyle='None',
                           markersize=self._size,
+                          markeredgecolor=self._color,
                           markeredgewidth=self._width,
                           zorder=self._zorder)
         l.set_transform(self.axes.get_yaxis_transform(which='tick1'))
@@ -594,6 +600,7 @@ class YTick(Tick):
                           marker=self._tickmarkers[1],
                           linestyle='None',
                           markersize=self._size,
+                          markeredgecolor=self._color,
                           markeredgewidth=self._width,
                           zorder=self._zorder)
         l.set_transform(self.axes.get_yaxis_transform(which='tick2'))


### PR DESCRIPTION
## PR Summary

Fixes #14546.

As argumented there https://github.com/matplotlib/matplotlib/issues/14546#issuecomment-502239281, axes ticks and data markers are fundamentally different. Therefore, ticks should not be affected by `rcParams["lines.markeredgecolor"]`.

That ticks are markers is just an implementation detail, it should not leak through via rcParams. If we're going to change the internal handling of ticks (e.g. #5665), that detail will change anyway.

