### PR TITLE
Make more of testing/ pytest-independent.

### DIFF
--- a/doc/api/api_changes_3.3/2019-05-19-AL.rst
+++ b/doc/api/api_changes_3.3/2019-05-19-AL.rst
@@ -1,0 +1,6 @@
+API changes
+```````````
+
+``testing.compare.convert`` now raises ``unittest.SkipTest`` instead of a
+pytest skip for uncomparable formats.  Note that pytest will correctly handle
+such tests as being skipped.

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 from tempfile import TemporaryFile
+import unittest
 
 import numpy as np
 import PIL
@@ -252,6 +253,12 @@ def comparable_formats():
     return ['png', *converter]
 
 
+def _skip_if_uncomparable(ext):
+    """Raise `unittest.SkipTest` if an *ext* files cannot be compared."""
+    if ext not in comparable_formats():
+        raise unittest.SkipTest(f"Lacking dependency to compare {ext} files")
+
+
 def convert(filename, cache):
     """
     Convert the named file to png; return the name of the created file.
@@ -264,6 +271,7 @@ def convert(filename, cache):
     path = Path(filename)
     if not path.exists():
         raise IOError(f"{path} does not exist")
+    _skip_if_uncomparable(path.suffix[1:])
     if path.suffix[1:] not in converter:
         import pytest
         pytest.skip(f"Don't know how to convert {path.suffix} files to png")


### PR DESCRIPTION
## PR Summary

This makes it actually possible to write tests independently of pytest
(the API is still private, but could be made public):

```
import unittest
from matplotlib import pyplot as plt
from matplotlib.testing.decorators import _make_image_comparator

class TestFoo(unittest.TestCase):

    @_make_image_comparator(baseline_images=["foo"], extension="png")
    def test_bar(self):
        fig, ax = plt.subplots()
```

works as expected.

See also discussion starting at https://gitter.im/matplotlib/matplotlib?at=5d064454a8d9871b3299790a.

~~Depends on #14338.~~

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
