### PR TITLE
Fix unicode_minus + usetex.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -989,7 +989,7 @@ def _parse_enc(path):
     with open(path, encoding="ascii") as file:
         no_comments = "\n".join(line.split("%")[0].rstrip() for line in file)
     array = re.search(r"(?s)\[(.*)\]", no_comments).group(1)
-    lines = [line for line in array.split("\n") if line]
+    lines = [line for line in array.split() if line]
     if all(line.startswith("/") for line in lines):
         return [line[1:] for line in lines]
     else:

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -1,26 +1,22 @@
-import warnings
-
 import pytest
 
-import matplotlib
-from matplotlib.testing.decorators import image_comparison
+import matplotlib as mpl
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.pyplot as plt
 from matplotlib.ticker import EngFormatter
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    needs_usetex = pytest.mark.skipif(
-        not matplotlib.checkdep_usetex(True),
-        reason='Missing TeX of Ghostscript or dvipng')
+@pytest.fixture(autouse=True)  # All tests in this module use usetex.
+def usetex():
+    if not mpl.checkdep_usetex(True):
+        pytest.skip('Missing TeX of Ghostscript or dvipng')
+    mpl.rcParams['text.usetex'] = True
 
 
-@needs_usetex
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
                   tol=0.3)
 def test_usetex():
-    matplotlib.rcParams['text.usetex'] = True
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.text(0.1, 0.2,
@@ -32,3 +28,9 @@ def test_usetex():
             fontsize=24)
     ax.set_xticks([])
     ax.set_yticks([])
+
+
+@check_figures_equal()
+def test_unicode_minus(fig_test, fig_ref):
+    fig_test.text(.5, .5, "$-$")
+    fig_ref.text(.5, .5, "\N{MINUS SIGN}")

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -206,11 +206,10 @@ class TexManager:
                                                        r'{\rmfamily %s}')
         tex = fontcmd % tex
 
-        if rcParams['text.latex.unicode']:
-            unicode_preamble = r"""
-\usepackage[utf8]{inputenc}"""
-        else:
-            unicode_preamble = ''
+        unicode_preamble = "\n".join([
+            r"\usepackage[utf8]{inputenc}",
+            r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
+        ]) if rcParams["text.latex.unicode"] else ""
 
         s = r"""
 \documentclass{article}
@@ -257,11 +256,10 @@ class TexManager:
                                                        r'{\rmfamily %s}')
         tex = fontcmd % tex
 
-        if rcParams['text.latex.unicode']:
-            unicode_preamble = r"""
-\usepackage[utf8]{inputenc}"""
-        else:
-            unicode_preamble = ''
+        unicode_preamble = "\n".join([
+            r"\usepackage[utf8]{inputenc}",
+            r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
+        ]) if rcParams["text.latex.unicode"] else ""
 
         # newbox, setbox, immediate, etc. are used to find the box
         # extent of the rendered text.


### PR DESCRIPTION
... by telling TeX to treat \u2212 (unicode minus) as a minus sign.

This also uncovered a bug in _parse_enc (basically, there can be
multiple character entries per line, so one needs to use `.split()`
instead of `.split("\n")`.

Closes #8423 (more accurately, https://github.com/matplotlib/matplotlib/issues/8423#issuecomment-503022419; the original version of the bug is already closed by #11381).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
