### PR TITLE
Cleanup jpl_units.

### DIFF
--- a/doc/api/next_api_changes/2019-06-18-AL.rst
+++ b/doc/api/next_api_changes/2019-06-18-AL.rst
@@ -1,0 +1,4 @@
+Deprecations
+````````````
+
+``testing.jpl_units.UnitDbl.UnitDbl.checkUnits`` is deprecated.

--- a/lib/matplotlib/testing/jpl_units/Duration.py
+++ b/lib/matplotlib/testing/jpl_units/Duration.py
@@ -2,6 +2,8 @@
 
 import operator
 
+from matplotlib import cbook
+
 
 class Duration:
     """Class Duration in development.
@@ -18,11 +20,7 @@ class Duration:
         - frame     The frame of the duration.  Must be 'ET' or 'UTC'
         - seconds  The number of seconds in the Duration.
         """
-        if frame not in self.allowed:
-            msg = "Input frame '%s' is not one of the supported frames of %s" \
-                    % (frame, str(self.allowed))
-            raise ValueError(msg)
-
+        cbook._check_in_list(self.allowed, frame=frame)
         self._frame = frame
         self._seconds = seconds
 
@@ -176,7 +174,7 @@ class Duration:
         - func    The name of the function doing the check.
         """
         if self._frame != rhs._frame:
-            msg = "Cannot %s Duration's with different frames.\n" \
-                    "LHS: %s\n" \
-                    "RHS: %s" % (func, self._frame, rhs._frame)
-            raise ValueError(msg)
+            raise ValueError(
+                f"Cannot {func} Durations with different frames.\n"
+                f"LHS: {self._frame}\n"
+                f"RHS: {rhs._frame}")

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -3,6 +3,8 @@
 import operator
 import math
 import datetime as DT
+
+from matplotlib import cbook
 from matplotlib.dates import date2num
 
 
@@ -56,11 +58,7 @@ class Epoch:
                 "dnum= %s\n"
                 "dt  = %s" % (sec, jd, daynum, dt))
 
-        if frame not in self.allowed:
-            raise ValueError(
-                "Input frame '%s' is not one of the supported frames of %s" %
-                (frame, list(self.allowed.keys())))
-
+        cbook._check_in_list(self.allowed, frame=frame)
         self._frame = frame
 
         if dt is not None:

--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -99,8 +99,7 @@ class EpochConverter(units.ConversionInterface):
 
         if not cbook.is_scalar_or_string(value):
             return [EpochConverter.convert(x, unit, axis) for x in value]
-        if (units.ConversionInterface.is_numlike(value)
-                and not isinstance(value, (U.Epoch, U.Duration))):
+        if units.ConversionInterface.is_numlike(value):
             return value
         if unit is None:
             unit = EpochConverter.default_units(value, axis)

--- a/lib/matplotlib/testing/jpl_units/UnitDbl.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDbl.py
@@ -2,6 +2,8 @@
 
 import operator
 
+from matplotlib import cbook
+
 
 class UnitDbl:
     """Class UnitDbl in development.
@@ -45,8 +47,7 @@ class UnitDbl:
         - value     The numeric value of the UnitDbl.
         - units     The string name of the units the value is in.
         """
-        self.checkUnits(units)
-
+        cbook._check_in_list(self.allowed, units=units)
         data = self.allowed[units]
         self._value = float(value * data[0])
         self._units = data[1]
@@ -66,17 +67,13 @@ class UnitDbl:
         """
         if self._units == units:
             return self._value
-
-        self.checkUnits(units)
-
+        cbook._check_in_list(self.allowed, units=units)
         data = self.allowed[units]
         if self._units != data[1]:
-            msg = "Error trying to convert to different units.\n" \
-                    "    Invalid conversion requested.\n" \
-                    "    UnitDbl: %s\n" \
-                    "    Units:    %s\n" % (str(self), units)
-            raise ValueError(msg)
-
+            raise ValueError(f"Error trying to convert to different units.\n"
+                             f"    Invalid conversion requested.\n"
+                             f"    UnitDbl: {self}\n"
+                             f"    Units:   {units}\n")
         return self._value / data[0]
 
     def __abs__(self):
@@ -236,6 +233,7 @@ class UnitDbl:
 
         return elems
 
+    @cbook.deprecated("3.2")
     def checkUnits(self, units):
         """Check to see if some units are valid.
 
@@ -262,7 +260,6 @@ class UnitDbl:
         - func    The name of the function doing the check.
         """
         if self._units != rhs._units:
-            msg = "Cannot %s units of different types.\n" \
-                    "LHS: %s\n" \
-                    "RHS: %s" % (func, self._units, rhs._units)
-            raise ValueError(msg)
+            raise ValueError(f"Cannot {func} units of different types.\n"
+                             f"LHS: {self._units}\n"
+                             f"RHS: {rhs._units}")

--- a/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
@@ -86,11 +86,10 @@ class UnitDblConverter(units.ConversionInterface):
 
         if not cbook.is_scalar_or_string(value):
             return [UnitDblConverter.convert(x, unit, axis) for x in value]
-        # If the incoming value behaves like a number, but is not a UnitDbl,
+        # If the incoming value behaves like a number,
         # then just return it because we don't know how to convert it
         # (or it is already converted)
-        if (units.ConversionInterface.is_numlike(value)
-                and not isinstance(value, U.UnitDbl)):
+        if units.ConversionInterface.is_numlike(value):
             return value
         # If no units were specified, then get the default units to use.
         if unit is None:

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -112,6 +112,7 @@ class ConversionInterface:
     The minimal interface for a converter to take custom data types (or
     sequences) and convert them to values Matplotlib can use.
     """
+
     @staticmethod
     def axisinfo(unit, axis):
         """


### PR DESCRIPTION
Not much to it, except for one point: Epoch, Duration and UnitDbl are
not Numbers, so the checks of the form `not isinstance(value, Epoch)`
are redundant with the is_numlike check.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
