### PR TITLE
Make ticklabel_format work both for 2D and 3D axes.

### DIFF
--- a/examples/ticks_and_spines/scalarformatter.py
+++ b/examples/ticks_and_spines/scalarformatter.py
@@ -1,9 +1,9 @@
 """
-=========================================
-Tick formatting using the ScalarFormatter
-=========================================
+==========================
+The default tick formatter
+==========================
 
-The example shows use of ScalarFormatter with different settings.
+The example shows use of the default `ScalarFormatter` with different settings.
 
 Example 1 : Default
 
@@ -11,34 +11,26 @@ Example 2 : With no Numerical Offset
 
 Example 3 : With Mathtext
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.ticker import ScalarFormatter
 
 ###############################################################################
 # Example 1
 
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
-fig.text(0.5, 0.975, 'The new formatter, default settings',
+fig.text(0.5, 0.975, 'Default settings',
          horizontalalignment='center',
          verticalalignment='top')
 
 ax1.plot(x * 1e5 + 1e10, x * 1e-10 + 1e-5)
-ax1.xaxis.set_major_formatter(ScalarFormatter())
-ax1.yaxis.set_major_formatter(ScalarFormatter())
 
 ax2.plot(x * 1e5, x * 1e-4)
-ax2.xaxis.set_major_formatter(ScalarFormatter())
-ax2.yaxis.set_major_formatter(ScalarFormatter())
 
 ax3.plot(-x * 1e5 - 1e10, -x * 1e-5 - 1e-10)
-ax3.xaxis.set_major_formatter(ScalarFormatter())
-ax3.yaxis.set_major_formatter(ScalarFormatter())
 
 ax4.plot(-x * 1e5, -x * 1e-4)
-ax4.xaxis.set_major_formatter(ScalarFormatter())
-ax4.yaxis.set_major_formatter(ScalarFormatter())
 
 fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
@@ -47,25 +39,21 @@ fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
-fig.text(0.5, 0.975, 'The new formatter, no numerical offset',
+fig.text(0.5, 0.975, 'No numerical offset',
          horizontalalignment='center',
          verticalalignment='top')
 
 ax1.plot(x * 1e5 + 1e10, x * 1e-10 + 1e-5)
-ax1.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
-ax1.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+ax1.ticklabel_format(useOffset=False)
 
 ax2.plot(x * 1e5, x * 1e-4)
-ax2.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
-ax2.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+ax2.ticklabel_format(useOffset=False)
 
 ax3.plot(-x * 1e5 - 1e10, -x * 1e-5 - 1e-10)
-ax3.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
-ax3.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+ax3.ticklabel_format(useOffset=False)
 
 ax4.plot(-x * 1e5, -x * 1e-4)
-ax4.xaxis.set_major_formatter(ScalarFormatter(useOffset=False))
-ax4.yaxis.set_major_formatter(ScalarFormatter(useOffset=False))
+ax4.ticklabel_format(useOffset=False)
 
 fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
@@ -74,25 +62,21 @@ fig.subplots_adjust(wspace=0.7, hspace=0.6)
 
 x = np.arange(0, 1, .01)
 fig, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, figsize=(6, 6))
-fig.text(0.5, 0.975, 'The new formatter, with mathtext',
+fig.text(0.5, 0.975, 'With mathtext',
          horizontalalignment='center',
          verticalalignment='top')
 
 ax1.plot(x * 1e5 + 1e10, x * 1e-10 + 1e-5)
-ax1.xaxis.set_major_formatter(ScalarFormatter(useMathText=True))
-ax1.yaxis.set_major_formatter(ScalarFormatter(useMathText=True))
+ax1.ticklabel_format(useMathText=True)
 
 ax2.plot(x * 1e5, x * 1e-4)
-ax2.xaxis.set_major_formatter(ScalarFormatter(useMathText=True))
-ax2.yaxis.set_major_formatter(ScalarFormatter(useMathText=True))
+ax2.ticklabel_format(useMathText=True)
 
 ax3.plot(-x * 1e5 - 1e10, -x * 1e-5 - 1e-10)
-ax3.xaxis.set_major_formatter(ScalarFormatter(useMathText=True))
-ax3.yaxis.set_major_formatter(ScalarFormatter(useMathText=True))
+ax3.ticklabel_format(useMathText=True)
 
 ax4.plot(-x * 1e5, -x * 1e-4)
-ax4.xaxis.set_major_formatter(ScalarFormatter(useMathText=True))
-ax4.yaxis.set_major_formatter(ScalarFormatter(useMathText=True))
+ax4.ticklabel_format(useMathText=True)
 
 fig.subplots_adjust(wspace=0.7, hspace=0.6)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2486,6 +2486,24 @@ class _AxesBase(martist.Artist):
     def _get_axis_list(self):
         return (self.xaxis, self.yaxis)
 
+    def _get_axis_map(self):
+        """
+        Return a mapping of `Axis` "names" to `Axis` instances.
+
+        The `Axis` name is derived from the attribute under which the instance
+        is stored, so e.g. for polar axes, the theta-axis is still named "x"
+        and the r-axis is still named "y" (for back-compatibility).
+
+        In practice, this means that the entries are typically "x" and "y", and
+        additionally "z" for 3D axes.
+        """
+        d = {}
+        axis_list = self._get_axis_list()
+        for k, v in vars(self).items():
+            if k.endswith("axis") and v in axis_list:
+                d[k[:-len("axis")]] = v
+        return d
+
     def _update_title_position(self, renderer):
         """
         Update the title position based on the bounding box enclosing
@@ -2825,35 +2843,24 @@ class _AxesBase(martist.Artist):
             sb = None
         else:
             raise ValueError("%s is not a valid style value")
+        axis_map = {**{k: [v] for k, v in self._get_axis_map().items()},
+                    'both': self._get_axis_list()}
+        axises = cbook._check_getitem(axis_map, axis=axis)
         try:
-            if sb is not None:
-                if axis == 'both' or axis == 'x':
-                    self.xaxis.major.formatter.set_scientific(sb)
-                if axis == 'both' or axis == 'y':
-                    self.yaxis.major.formatter.set_scientific(sb)
-            if scilimits is not None:
-                if axis == 'both' or axis == 'x':
-                    self.xaxis.major.formatter.set_powerlimits(scilimits)
-                if axis == 'both' or axis == 'y':
-                    self.yaxis.major.formatter.set_powerlimits(scilimits)
-            if useOffset is not None:
-                if axis == 'both' or axis == 'x':
-                    self.xaxis.major.formatter.set_useOffset(useOffset)
-                if axis == 'both' or axis == 'y':
-                    self.yaxis.major.formatter.set_useOffset(useOffset)
-            if useLocale is not None:
-                if axis == 'both' or axis == 'x':
-                    self.xaxis.major.formatter.set_useLocale(useLocale)
-                if axis == 'both' or axis == 'y':
-                    self.yaxis.major.formatter.set_useLocale(useLocale)
-            if useMathText is not None:
-                if axis == 'both' or axis == 'x':
-                    self.xaxis.major.formatter.set_useMathText(useMathText)
-                if axis == 'both' or axis == 'y':
-                    self.yaxis.major.formatter.set_useMathText(useMathText)
+            for axis in axises:
+                if sb is not None:
+                    axis.major.formatter.set_scientific(sb)
+                if scilimits is not None:
+                    axis.major.formatter.set_powerlimits(scilimits)
+                if useOffset is not None:
+                    axis.major.formatter.set_useOffset(useOffset)
+                if useLocale is not None:
+                    axis.major.formatter.set_useLocale(useLocale)
+                if useMathText is not None:
+                    axis.major.formatter.set_useMathText(useMathText)
         except AttributeError:
             raise AttributeError(
-                "This method only works with the ScalarFormatter.")
+                "This method only works with the ScalarFormatter")
 
     def locator_params(self, axis='both', tight=None, **kwargs):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1295,63 +1295,6 @@ class Axes3D(Axes):
         self._draw_grid = b
         self.stale = True
 
-    def ticklabel_format(
-            self, *, style='', scilimits=None, useOffset=None, axis='both'):
-        """
-        Convenience method for manipulating the ScalarFormatter
-        used by default for linear axes in Axed3D objects.
-
-        See :meth:`matplotlib.axes.Axes.ticklabel_format` for full
-        documentation.  Note that this version applies to all three
-        axes of the Axes3D object.  Therefore, the *axis* argument
-        will also accept a value of 'z' and the value of 'both' will
-        apply to all three axes.
-
-        .. versionadded :: 1.1.0
-            This function was added, but not tested. Please report any bugs.
-        """
-        style = style.lower()
-        axis = axis.lower()
-        if scilimits is not None:
-            try:
-                m, n = scilimits
-                m+n+1  # check that both are numbers
-            except (ValueError, TypeError):
-                raise ValueError("scilimits must be a sequence of 2 integers")
-        if style[:3] == 'sci':
-            sb = True
-        elif style == 'plain':
-            sb = False
-        elif style == '':
-            sb = None
-        else:
-            raise ValueError("%s is not a valid style value")
-        try:
-            if sb is not None:
-                if axis in ['both', 'z']:
-                    self.xaxis.major.formatter.set_scientific(sb)
-                if axis in ['both', 'y']:
-                    self.yaxis.major.formatter.set_scientific(sb)
-                if axis in ['both', 'z']:
-                    self.zaxis.major.formatter.set_scientific(sb)
-            if scilimits is not None:
-                if axis in ['both', 'x']:
-                    self.xaxis.major.formatter.set_powerlimits(scilimits)
-                if axis in ['both', 'y']:
-                    self.yaxis.major.formatter.set_powerlimits(scilimits)
-                if axis in ['both', 'z']:
-                    self.zaxis.major.formatter.set_powerlimits(scilimits)
-            if useOffset is not None:
-                if axis in ['both', 'x']:
-                    self.xaxis.major.formatter.set_useOffset(useOffset)
-                if axis in ['both', 'y']:
-                    self.yaxis.major.formatter.set_useOffset(useOffset)
-                if axis in ['both', 'z']:
-                    self.zaxis.major.formatter.set_useOffset(useOffset)
-        except AttributeError:
-            raise AttributeError(
-                "This method only works with the ScalarFormatter.")
-
     def locator_params(self, axis='both', tight=None, **kwargs):
         """
         Convenience method for controlling tick locators.


### PR DESCRIPTION
... instead of duplicating its implementation in axes3d with just minor
changes.

Note that ticklabel_format was not used anywhere either in the tests or
in the examples.  Exercise it in the scalarformatter example, which also
gets slightly updated -- ScalarFormatter has been the default formatter
for years, so doesn't really warrant the label "The new formatter".

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
