### PR TITLE
Let Axes3D share have_units, _on_units_changed with 2d axes.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -161,11 +161,9 @@ class Artist:
         # TODO: add legend support
 
     def have_units(self):
-        """Return *True* if units are set on the *x* or *y* axes."""
+        """Return *True* if units are set on any axis."""
         ax = self.axes
-        if ax is None or ax.xaxis is None:
-            return False
-        return ax.xaxis.have_units() or ax.yaxis.have_units()
+        return ax and any(axis.have_units() for axis in ax._get_axis_list())
 
     def convert_xunits(self, x):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1995,7 +1995,7 @@ class _AxesBase(martist.Artist):
         """
         Callback for processing changes to axis units.
 
-        Currently forces updates of data limits and view limits.
+        Currently requests updates of data limits and view limits.
         """
         self.relim()
         self._request_autoscale_view(scalex=scalex, scaley=scaley)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -9,6 +9,7 @@ Significant updates and revisions by Ben Root <ben.v.root@gmail.com>
 Module containing Axes3D, an object which can plot 3D objects on a
 2D matplotlib figure.
 """
+
 from collections import defaultdict
 from functools import reduce
 import math
@@ -140,14 +141,6 @@ class Axes3D(Axes):
         self._axis3don = True
         self.stale = True
 
-    def have_units(self):
-        """
-        Return *True* if units are set on the *x*, *y*, or *z* axes
-
-        """
-        return (self.xaxis.have_units() or self.yaxis.have_units() or
-                self.zaxis.have_units())
-
     def convert_zunits(self, z):
         """
         For artists in an axes, if the zaxis has units support,
@@ -187,11 +180,10 @@ class Axes3D(Axes):
     def set_top_view(self):
         # this happens to be the right view for the viewing coordinates
         # moved up and to the left slightly to fit labels and axes
-        xdwl = (0.95/self.dist)
-        xdw = (0.9/self.dist)
-        ydwl = (0.95/self.dist)
-        ydw = (0.9/self.dist)
-
+        xdwl = 0.95 / self.dist
+        xdw = 0.9 / self.dist
+        ydwl = 0.95 / self.dist
+        ydw = 0.9 / self.dist
         # This is purposely using the 2D Axes's set_xlim and set_ylim,
         # because we are trying to place our viewing pane.
         super().set_xlim(-xdwl, xdw, auto=None)
@@ -1088,12 +1080,8 @@ class Axes3D(Axes):
         return False
 
     def cla(self):
-        """
-        Clear axes
-        """
-        # Disabling mouse interaction might have been needed a long
-        # time ago, but I can't find a reason for it now - BVR (2012-03)
-        #self.disable_mouse_rotation()
+        # docstring inherited.
+
         super().cla()
         self.zaxis.cla()
 
@@ -1116,12 +1104,10 @@ class Axes3D(Axes):
         self.grid(rcParams['axes3d.grid'])
 
     def disable_mouse_rotation(self):
-        """Disable mouse button callbacks.
-        """
+        """Disable mouse button callbacks."""
         # Disconnect the various events we set.
         for cid in self._cids:
             self.figure.canvas.mpl_disconnect(cid)
-
         self._cids = []
 
     def _button_press(self, event):


### PR DESCRIPTION
plus some small cleanup to axes3d.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
