### PR TITLE
Fix inversion of 3d axis.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1890,6 +1890,36 @@ class Axis(martist.Artist):
         raise NotImplementedError()
 
 
+def _make_getset_interval(method_name, lim_name, attr_name):
+    """
+    Helper to generate ``get_{data,view}_interval`` and
+    ``set_{data,view}_interval`` implementations.
+    """
+
+    def getter(self):
+        # docstring inherited.
+        return getattr(getattr(self.axes, lim_name), attr_name)
+
+    def setter(self, vmin, vmax, ignore=False):
+        # docstring inherited.
+        if ignore:
+            setattr(getattr(self.axes, lim_name), attr_name, (vmin, vmax))
+        else:
+            oldmin, oldmax = getter(self)
+            if oldmin < oldmax:
+                setter(self, min(vmin, vmax, oldmin), max(vmin, vmax, oldmax),
+                       ignore=True)
+            else:
+                setter(self, max(vmin, vmax, oldmax), min(vmin, vmax, oldmin),
+                       ignore=True)
+        self.stale = True
+
+    getter.__name__ = f"get_{method_name}_interval"
+    setter.__name__ = f"set_{method_name}_interval"
+
+    return getter, setter
+
+
 class XAxis(Axis):
     __name__ = 'xaxis'
     axis_name = 'x'
@@ -2133,38 +2163,13 @@ class XAxis(Axis):
                 "default": "default", "unknown": "unknown"}[
                     self._get_ticks_position()]
 
-    def get_view_interval(self):
-        # docstring inherited
-        return self.axes.viewLim.intervalx
-
-    def set_view_interval(self, vmin, vmax, ignore=False):
-        # docstring inherited
-        if ignore:
-            self.axes.viewLim.intervalx = vmin, vmax
-        else:
-            Vmin, Vmax = self.get_view_interval()
-            if Vmin < Vmax:
-                self.axes.viewLim.intervalx = (min(vmin, vmax, Vmin),
-                                               max(vmin, vmax, Vmax))
-            else:
-                self.axes.viewLim.intervalx = (max(vmin, vmax, Vmin),
-                                               min(vmin, vmax, Vmax))
+    get_view_interval, set_view_interval = _make_getset_interval(
+        "view", "viewLim", "intervalx")
+    get_data_interval, set_data_interval = _make_getset_interval(
+        "data", "dataLim", "intervalx")
 
     def get_minpos(self):
         return self.axes.dataLim.minposx
-
-    def get_data_interval(self):
-        # docstring inherited
-        return self.axes.dataLim.intervalx
-
-    def set_data_interval(self, vmin, vmax, ignore=False):
-        # docstring inherited
-        if ignore:
-            self.axes.dataLim.intervalx = vmin, vmax
-        else:
-            Vmin, Vmax = self.get_data_interval()
-            self.axes.dataLim.intervalx = min(vmin, Vmin), max(vmax, Vmax)
-        self.stale = True
 
     def set_default_intervals(self):
         # docstring inherited
@@ -2460,39 +2465,13 @@ class YAxis(Axis):
                 "default": "default", "unknown": "unknown"}[
                     self._get_ticks_position()]
 
-    def get_view_interval(self):
-        # docstring inherited
-        return self.axes.viewLim.intervaly
-
-    def set_view_interval(self, vmin, vmax, ignore=False):
-        # docstring inherited
-        if ignore:
-            self.axes.viewLim.intervaly = vmin, vmax
-        else:
-            Vmin, Vmax = self.get_view_interval()
-            if Vmin < Vmax:
-                self.axes.viewLim.intervaly = (min(vmin, vmax, Vmin),
-                                               max(vmin, vmax, Vmax))
-            else:
-                self.axes.viewLim.intervaly = (max(vmin, vmax, Vmin),
-                                               min(vmin, vmax, Vmax))
-        self.stale = True
+    get_view_interval, set_view_interval = _make_getset_interval(
+        "view", "viewLim", "intervaly")
+    get_data_interval, set_data_interval = _make_getset_interval(
+        "data", "dataLim", "intervaly")
 
     def get_minpos(self):
         return self.axes.dataLim.minposy
-
-    def get_data_interval(self):
-        # docstring inherited
-        return self.axes.dataLim.intervaly
-
-    def set_data_interval(self, vmin, vmax, ignore=False):
-        # docstring inherited
-        if ignore:
-            self.axes.dataLim.intervaly = vmin, vmax
-        else:
-            Vmin, Vmax = self.get_data_interval()
-            self.axes.dataLim.intervaly = min(vmin, Vmin), max(vmax, Vmax)
-        self.stale = True
 
     def set_default_intervals(self):
         # docstring inherited

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -68,9 +68,6 @@ class Axis(maxis.XAxis):
                  rotate_label=None, **kwargs):
         # adir identifies which axes this is
         self.adir = adir
-        # data and viewing intervals for this direction
-        self.d_interval = d_intervalx
-        self.v_interval = v_intervalx
 
         # This is a temporary member variable.
         # Do not depend on this existing in future releases!
@@ -105,6 +102,10 @@ class Axis(maxis.XAxis):
                  })
 
         maxis.XAxis.__init__(self, axes, *args, **kwargs)
+
+        # data and viewing intervals for this direction
+        self.d_interval = d_intervalx
+        self.v_interval = v_intervalx
         self.set_rotate_label(rotate_label)
 
     def init3d(self):
@@ -420,18 +421,6 @@ class Axis(maxis.XAxis):
         renderer.close_group('axis3d')
         self.stale = False
 
-    def get_view_interval(self):
-        # docstring inherited
-        return self.v_interval
-
-    def set_view_interval(self, vmin, vmax, ignore=False):
-        # docstring inherited
-        if ignore:
-            self.v_interval = vmin, vmax
-        else:
-            Vmin, Vmax = self.get_view_interval()
-            self.v_interval = min(vmin, Vmin), max(vmax, Vmax)
-
     # TODO: Get this to work properly when mplot3d supports
     #       the transforms framework.
     def get_tightbbox(self, renderer):
@@ -439,23 +428,42 @@ class Axis(maxis.XAxis):
         # doesn't return junk info.
         return None
 
+    @property
+    def d_interval(self):
+        return self.get_data_interval()
+
+    @d_interval.setter
+    def d_interval(self, minmax):
+        return self.set_data_interval(*minmax)
+
+    @property
+    def v_interval(self):
+        return self.get_view_interval()
+
+    @d_interval.setter
+    def v_interval(self, minmax):
+        return self.set_view_interval(*minmax)
+
 
 # Use classes to look at different data limits
 
 
 class XAxis(Axis):
-    def get_data_interval(self):
-        # docstring inherited
-        return self.axes.xy_dataLim.intervalx
+    get_view_interval, set_view_interval = maxis._make_getset_interval(
+        "view", "xy_viewLim", "intervalx")
+    get_data_interval, set_data_interval = maxis._make_getset_interval(
+        "data", "xy_dataLim", "intervalx")
 
 
 class YAxis(Axis):
-    def get_data_interval(self):
-        # docstring inherited
-        return self.axes.xy_dataLim.intervaly
+    get_view_interval, set_view_interval = maxis._make_getset_interval(
+        "view", "xy_viewLim", "intervaly")
+    get_data_interval, set_data_interval = maxis._make_getset_interval(
+        "data", "xy_dataLim", "intervaly")
 
 
 class ZAxis(Axis):
-    def get_data_interval(self):
-        # docstring inherited
-        return self.axes.zz_dataLim.intervalx
+    get_view_interval, set_view_interval = maxis._make_getset_interval(
+        "view", "zz_viewLim", "intervalx")
+    get_data_interval, set_data_interval = maxis._make_getset_interval(
+        "data", "zz_dataLim", "intervalx")

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -801,6 +801,18 @@ def test_line3d_set_get_data_3d():
     np.testing.assert_array_equal((x2, y2, z2), line.get_data_3d())
 
 
+@check_figures_equal(extensions=["png"])
+def test_inverted(fig_test, fig_ref):
+    # Plot then invert.
+    ax = fig_test.add_subplot(projection="3d")
+    ax.plot([1, 1, 10, 10], [1, 10, 10, 10], [1, 1, 1, 10])
+    ax.invert_yaxis()
+    # Invert then plot.
+    ax = fig_ref.add_subplot(projection="3d")
+    ax.invert_yaxis()
+    ax.plot([1, 1, 10, 10], [1, 10, 10, 10], [1, 1, 1, 10])
+
+
 def test_inverted_cla():
     # Github PR #5450. Setting autoscale should reset
     # axes to be non-inverted.


### PR DESCRIPTION
... which was broken because 3d axises stored and accessed their viewlim
info sometimes in xy_viewLim/zz_viewLim and sometimes in v_interval (and
likewise for datalim), leading to out-of-sync info...

Not deprecating d_interval/v_interval for now both because this needs to
go to 3.1.1 to fix the breakage and because I think storing the info in
axis attributes actually makes *more* sense than in viewLim/dataLim --
but fully switching to d_interval/v_interval needs bigger surgery.

Closes #14577.

edit: now with tests.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
