### PR TITLE
Backport to 2.2.x removal of mpl_examples and setup.py cleanup

### DIFF
--- a/lib/mpl_examples
+++ b/lib/mpl_examples
@@ -1,1 +1,0 @@
-../examples

--- a/setup.py
+++ b/setup.py
@@ -11,23 +11,6 @@ from setuptools.command.build_ext import build_ext as BuildExtCommand
 
 import sys
 
-# distutils is breaking our sdists for files in symlinked dirs.
-# distutils will copy if os.link is not available, so this is a hack
-# to force copying
-import os
-try:
-    del os.link
-except AttributeError:
-    pass
-
-# This 'if' statement is needed to prevent spawning infinite processes
-# on Windows
-if __name__ == '__main__':
-    # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-    # update it when the contents of directories change.
-    if os.path.exists('MANIFEST'):
-        os.remove('MANIFEST')
-
 from io import BytesIO
 import os
 from string import Template


### PR DESCRIPTION
## PR Summary

- Backport the removal of the `lib/mpl_examples` symlink
- Backport GH-11722: Remove unnecessary hacks from setup.py

Both commits come from @anntzer

Fixes #14580 (Python 3.8 support).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
