### PR TITLE
In SecondaryAxis.set_functions, reuse _set_scale's parent scale caching.

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -62,7 +62,7 @@ class SecondaryAxis(_AxesBase):
             self._axis = self.yaxis
             self._locstrings = ['right', 'left']
             self._otherstrings = ['top', 'bottom']
-        self._parentscale = self._axis.get_scale()
+        self._parentscale = None
         # this gets positioned w/o constrained_layout so exclude:
         self._layoutbox = None
         self._poslayoutbox = None
@@ -195,21 +195,6 @@ class SecondaryAxis(_AxesBase):
             If a transform is supplied, then the transform must have an
             inverse.
         """
-
-        if self._orientation == 'x':
-            set_scale = self.set_xscale
-            parent_scale = self._parent.get_xscale()
-        else:
-            set_scale = self.set_yscale
-            parent_scale = self._parent.get_yscale()
-        # we need to use a modified scale so the scale can receive the
-        # transform.  Only types supported are linear and log10 for now.
-        # Probably possible to add other transforms as a todo...
-        if parent_scale == 'log':
-            defscale = 'functionlog'
-        else:
-            defscale = 'function'
-
         if (isinstance(functions, tuple) and len(functions) == 2 and
             callable(functions[0]) and callable(functions[1])):
             # make an arbitrary convert from a two-tuple of functions
@@ -222,8 +207,7 @@ class SecondaryAxis(_AxesBase):
                              'must be a two-tuple of callable functions '
                              'with the first function being the transform '
                              'and the second being the inverse')
-        # need to invert the roles here for the ticks to line up.
-        set_scale(defscale, functions=self._functions[::-1])
+        self._set_scale()
 
     def draw(self, renderer=None, inframe=False):
         """
@@ -252,8 +236,6 @@ class SecondaryAxis(_AxesBase):
             set_scale = self.set_yscale
         if pscale == self._parentscale:
             return
-        else:
-            self._parentscale = pscale
 
         if pscale == 'log':
             defscale = 'functionlog'
@@ -270,6 +252,9 @@ class SecondaryAxis(_AxesBase):
         # axsecond.set_ticks, we want to keep those.
         if self._ticks_set:
             self._axis.set_major_locator(mticker.FixedLocator(ticks))
+
+        # If the parent scale doesn't change, we can skip this next time.
+        self._parentscale = pscale
 
     def _set_lims(self):
         """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6544,6 +6544,16 @@ def test_secondary_minorloc():
                       mticker.NullLocator)
 
 
+def test_secondary_formatter():
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    secax = ax.secondary_xaxis("top")
+    secax.xaxis.set_major_formatter(mticker.ScalarFormatter())
+    fig.canvas.draw()
+    assert isinstance(
+        secax.xaxis.get_major_formatter(), mticker.ScalarFormatter)
+
+
 def color_boxes(fig, axs):
     """
     Helper for the tests below that test the extents of various axes elements


### PR DESCRIPTION
_set_scale checks whether the parent scale changed before modifying the
secondary scale.  set_functions should do the same.  See added test for
previously failing case.

(Basically a followup to #14447.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
