### PR TITLE
Simplify SecondaryAxis.set_color.

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -235,16 +235,12 @@ class SecondaryAxis(_AxesBase):
         ----------
         color : color
         """
-        if self._orientation == 'x':
-            self.tick_params(axis='x', colors=color)
-            self.spines.bottom.set_color(color)
-            self.spines.top.set_color(color)
-            self.xaxis.label.set_color(color)
-        else:  # 'y'
-            self.tick_params(axis='y', colors=color)
-            self.spines.left.set_color(color)
-            self.spines.right.set_color(color)
-            self.yaxis.label.set_color(color)
+        axis = self._axis_map[self._orientation]
+        axis.set_tick_params(colors=color)
+        for spine in self.spines.values():
+            if spine.axis is axis:
+                spine.set_color(color)
+        axis.label.set_color(color)
 
 
 _secax_docstring = '''

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8748,3 +8748,13 @@ def test_tick_param_labelfont():
     plt.title('Title in sans-serif')
     for text in ax.get_xticklabels():
         assert text.get_fontfamily()[0] == 'monospace'
+
+
+def test_set_secondary_axis_color():
+    fig, ax = plt.subplots()
+    sax = ax.secondary_xaxis("top", color="red")
+    assert mcolors.same_color(sax.spines["bottom"].get_edgecolor(), "red")
+    assert mcolors.same_color(sax.spines["top"].get_edgecolor(), "red")
+    assert mcolors.same_color(sax.xaxis.get_tick_params()["color"], "red")
+    assert mcolors.same_color(sax.xaxis.get_tick_params()["labelcolor"], "red")
+    assert mcolors.same_color(sax.xaxis.label.get_color(), "red")


### PR DESCRIPTION
The "orthogonal" axis is invisible, so we can just set the color of all
ticks, spines, and labels, regardless of orientation.

Note that the method is actually unused, untested, and could reasonably be lifted to the base class instead of only being provided for secondary axes, if we decide it's useful functionality (the new implementation doesn't use anything that's specific to secondary axes).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
