### PR TITLE
DOC: Make temperature scale example use a closure for easier reusability

### DIFF
--- a/examples/subplots_axes_and_figures/fahrenheit_celsius_scales.py
+++ b/examples/subplots_axes_and_figures/fahrenheit_celsius_scales.py
@@ -13,29 +13,34 @@ import numpy as np
 
 def fahrenheit2celsius(temp):
     """
-    Returns temperature in Celsius.
+    Returns temperature in Celsius given Fahrenheit temperature.
     """
     return (5. / 9.) * (temp - 32)
 
 
-def convert_ax_c_to_celsius(ax_f):
-    """
-    Update second axis according with first axis.
-    """
-    y1, y2 = ax_f.get_ylim()
-    ax_c.set_ylim(fahrenheit2celsius(y1), fahrenheit2celsius(y2))
-    ax_c.figure.canvas.draw()
+def make_plot():
 
-fig, ax_f = plt.subplots()
-ax_c = ax_f.twinx()
+    # Define a closure function to register as a callback
+    def convert_ax_c_to_celsius(ax_f):
+        """
+        Update second axis according with first axis.
+        """
+        y1, y2 = ax_f.get_ylim()
+        ax_c.set_ylim(fahrenheit2celsius(y1), fahrenheit2celsius(y2))
+        ax_c.figure.canvas.draw()
 
-# automatically update ylim of ax2 when ylim of ax1 changes.
-ax_f.callbacks.connect("ylim_changed", convert_ax_c_to_celsius)
-ax_f.plot(np.linspace(-40, 120, 100))
-ax_f.set_xlim(0, 100)
+    fig, ax_f = plt.subplots()
+    ax_c = ax_f.twinx()
 
-ax_f.set_title('Two scales: Fahrenheit and Celsius')
-ax_f.set_ylabel('Fahrenheit')
-ax_c.set_ylabel('Celsius')
+    # automatically update ylim of ax2 when ylim of ax1 changes.
+    ax_f.callbacks.connect("ylim_changed", convert_ax_c_to_celsius)
+    ax_f.plot(np.linspace(-40, 120, 100))
+    ax_f.set_xlim(0, 100)
 
-plt.show()
+    ax_f.set_title('Two scales: Fahrenheit and Celsius')
+    ax_f.set_ylabel('Fahrenheit')
+    ax_c.set_ylabel('Celsius')
+
+    plt.show()
+
+make_plot()


### PR DESCRIPTION
## PR Summary

It wasn't immediately obvious to me how to reuse this example in my own function without staring at it for a while. Better to not implicitly rely on the module level global scope and instead make the callback function a closure defined in another utility function explicitly. This will likely be more like a user's code and will still work for the simple example style usage the example currently models.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
