### PR TITLE
Fix inversion of shared axes.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1028,11 +1028,10 @@ class Axis(martist.Artist):
         the top for the y-axis; the "inverse" direction is increasing to the
         left for the x-axis and to the bottom for the y-axis.
         """
-        a, b = self.get_view_interval()
-        if inverted:
-            self.set_view_interval(max(a, b), min(a, b), ignore=True)
-        else:
-            self.set_view_interval(min(a, b), max(a, b), ignore=True)
+        # Currently, must be implemented in subclasses using set_xlim/set_ylim
+        # rather than generically using set_view_interval, so that shared
+        # axes get updated as well.
+        raise NotImplementedError('Derived must override')
 
     def set_default_intervals(self):
         """
@@ -2171,6 +2170,11 @@ class XAxis(Axis):
     def get_minpos(self):
         return self.axes.dataLim.minposx
 
+    def set_inverted(self, inverted):
+        # docstring inherited
+        a, b = self.get_view_interval()
+        self.axes.set_xlim(sorted((a, b), reverse=inverted), auto=None)
+
     def set_default_intervals(self):
         # docstring inherited
         xmin, xmax = 0., 1.
@@ -2472,6 +2476,11 @@ class YAxis(Axis):
 
     def get_minpos(self):
         return self.axes.dataLim.minposy
+
+    def set_inverted(self, inverted):
+        # docstring inherited
+        a, b = self.get_view_interval()
+        self.axes.set_ylim(sorted((a, b), reverse=inverted), auto=None)
 
     def set_default_intervals(self):
         # docstring inherited

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -240,17 +240,19 @@ def test_inverted_cla():
     ax.cla()
     ax.imshow(img)
     plt.autoscale()
-    assert not(ax.xaxis_inverted())
+    assert not ax.xaxis_inverted()
     assert ax.yaxis_inverted()
 
-    # 5. two shared axes. Clearing the master axis should bring axes in shared
-    # axes back to normal
+    # 5. two shared axes. Inverting the master axis should invert the shared
+    # axes; clearing the master axis should bring axes in shared
+    # axes back to normal.
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
-    ax0.imshow(img)
+    ax0.yaxis.set_inverted(True)
+    assert ax1.yaxis_inverted()
     ax1.plot(x, np.cos(x))
     ax0.cla()
-    assert not(ax1.yaxis_inverted())
+    assert not ax1.yaxis_inverted()
     ax1.cla()
     # 6. clearing the nonmaster should not touch limits
     ax0.imshow(img)


### PR DESCRIPTION
set_view_interval does not update shared axes, we must use
set_xlim/set_ylim to do so.

Update a test to explicitly invert an axis instead of relying on imshow
to implicitly do so.

Fix a regression due to #13330.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
