### PR TITLE
Simplify implementation of set_{x,y}bound.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3082,7 +3082,7 @@ class _AxesBase(martist.Artist):
         Set the lower and upper numerical bounds of the x-axis.
 
         This method will honor axes inversion regardless of parameter order.
-        It will not change the autoscaling setting (``Axes._autoscaleXon``).
+        It will not change the autoscaling setting (`.get_autoscalex_on()`).
 
         Parameters
         ----------
@@ -3100,22 +3100,13 @@ class _AxesBase(martist.Artist):
             lower, upper = lower
 
         old_lower, old_upper = self.get_xbound()
-
         if lower is None:
             lower = old_lower
         if upper is None:
             upper = old_upper
 
-        if self.xaxis_inverted():
-            if lower < upper:
-                self.set_xlim(upper, lower, auto=None)
-            else:
-                self.set_xlim(lower, upper, auto=None)
-        else:
-            if lower < upper:
-                self.set_xlim(lower, upper, auto=None)
-            else:
-                self.set_xlim(upper, lower, auto=None)
+        self.set_xlim(sorted((lower, upper), reverse=self.xaxis_inverted()),
+                      auto=None)
 
     def get_xlim(self):
         """
@@ -3480,7 +3471,7 @@ class _AxesBase(martist.Artist):
         Set the lower and upper numerical bounds of the y-axis.
 
         This method will honor axes inversion regardless of parameter order.
-        It will not change the autoscaling setting (``Axes._autoscaleYon``).
+        It will not change the autoscaling setting (`.get_autoscaley_on()`).
 
         Parameters
         ----------
@@ -3498,22 +3489,13 @@ class _AxesBase(martist.Artist):
             lower, upper = lower
 
         old_lower, old_upper = self.get_ybound()
-
         if lower is None:
             lower = old_lower
         if upper is None:
             upper = old_upper
 
-        if self.yaxis_inverted():
-            if lower < upper:
-                self.set_ylim(upper, lower, auto=None)
-            else:
-                self.set_ylim(lower, upper, auto=None)
-        else:
-            if lower < upper:
-                self.set_ylim(lower, upper, auto=None)
-            else:
-                self.set_ylim(upper, lower, auto=None)
+        self.set_ylim(sorted((lower, upper), reverse=self.yaxis_inverted()),
+                      auto=None)
 
     def get_ylim(self):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1464,30 +1464,24 @@ class Axes3D(Axes):
     def set_zbound(self, lower=None, upper=None):
         """
         Set the lower and upper numerical bounds of the z-axis.
+
         This method will honor axes inversion regardless of parameter order.
-        It will not change the :attr:`_autoscaleZon` attribute.
+        It will not change the autoscaling setting (`.get_autoscalez_on()`).
 
         .. versionadded :: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         if upper is None and np.iterable(lower):
             lower, upper = lower
+
         old_lower, old_upper = self.get_zbound()
         if lower is None:
             lower = old_lower
         if upper is None:
             upper = old_upper
 
-        if self.zaxis_inverted():
-            if lower < upper:
-                self.set_zlim(upper, lower, auto=None)
-            else:
-                self.set_zlim(lower, upper, auto=None)
-        else:
-            if lower < upper:
-                self.set_zlim(lower, upper, auto=None)
-            else:
-                self.set_zlim(upper, lower, auto=None)
+        self.set_zlim(sorted((lower, upper), reverse=self.zaxis_inverted()),
+                      auto=None)
 
     def text(self, x, y, z, s, zdir=None, **kwargs):
         '''


### PR DESCRIPTION
... and don't refer to a private attribute in the docstring.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
