### PR TITLE
Update some mplot3d docs.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1295,8 +1295,7 @@ class Axes3D(Axes):
             :meth:`matplotlib.axes.Axes.grid`, but it is intended to
             eventually support that behavior.
 
-        .. versionchanged :: 1.1.0
-            This function was changed, but not tested. Please report any bugs.
+        .. versionadded :: 1.1.0
         '''
         # TODO: Operate on each axes separately
         if len(kwargs):
@@ -1411,7 +1410,6 @@ class Axes3D(Axes):
             those who file bugs.
 
         .. versionadded :: 1.1.0
-            This function was added, but not tested. Please report any bugs.
         """
         cbook._check_in_list(['x', 'y', 'z', 'both'], axis=axis)
         if axis in ['x', 'y', 'both']:
@@ -1441,19 +1439,15 @@ class Axes3D(Axes):
         Returns True if the z-axis is inverted.
 
         .. versionadded :: 1.1.0
-            This function was added, but not tested. Please report any bugs.
         '''
         bottom, top = self.get_zlim()
         return top < bottom
 
     def get_zbound(self):
         """
-        Returns the z-axis numerical bounds where::
-
-          lowerBound < upperBound
+        Return the lower and upper z-axis bounds, in increasing order.
 
         .. versionadded :: 1.1.0
-            This function was added, but not tested. Please report any bugs.
         """
         bottom, top = self.get_zlim()
         if bottom < top:
@@ -1468,7 +1462,6 @@ class Axes3D(Axes):
         It will not change the :attr:`_autoscaleZon` attribute.
 
         .. versionadded :: 1.1.0
-            This function was added, but not tested. Please report any bugs.
         """
         if upper is None and np.iterable(lower):
             lower, upper = lower


### PR DESCRIPTION
Mostly removing "This function was added, but not tested" when codecov
indicates that the function is actually covered by CI (it may still not
be *directly* tested, but that's the case of a bunch of APIs and we
don't bother with peppering their docstrings with such statements).

The get_zbound docstring is adapted from the one of get_xbound.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
