### PR TITLE
Cleanup DateFormatter docstring.

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -589,21 +589,18 @@ def drange(dstart, dend, delta):
 
 class DateFormatter(ticker.Formatter):
     """
-    Tick location is seconds since the epoch.  Use a :func:`strftime`
-    format string.
-
-    Python only supports :mod:`datetime` :func:`strftime` formatting
-    for years greater than 1900.  Thanks to Andrew Dalke, Dalke
-    Scientific Software who contributed the :func:`strftime` code
-    below to include dates earlier than this year.
+    Format a tick (in seconds since the epoch) with a `strftime` format string.
     """
 
     illegal_s = re.compile(r"((^|[^%])(%%)*%s)")
 
     def __init__(self, fmt, tz=None):
         """
-        *fmt* is a :func:`strftime` format string; *tz* is the
-         :class:`tzinfo` instance.
+        Parameters
+        ----------
+        fmt : str
+            `strftime` format string
+        tz : `tzinfo`
         """
         if tz is None:
             tz = _get_rc_timezone()


### PR DESCRIPTION
The specific handling of <1900 dates was made unnecessary after the
switch to Py3-only (https://bugs.python.org/issue1777412) and recently
completely removed after the removal of pre-3.0 APIs.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
