### PR TITLE
Deprecate {x,y,z}axis_date.

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -391,8 +391,6 @@ Ticks and tick labels
    Axes.get_xgridlines
    Axes.get_xticklines
 
-   Axes.xaxis_date
-
    Axes.set_yticks
    Axes.get_yticks
 
@@ -403,8 +401,6 @@ Ticks and tick labels
 
    Axes.get_ygridlines
    Axes.get_yticklines
-
-   Axes.yaxis_date
 
    Axes.minorticks_off
    Axes.minorticks_on

--- a/doc/api/next_api_changes/2019-06-24-AL.rst
+++ b/doc/api/next_api_changes/2019-06-24-AL.rst
@@ -1,0 +1,8 @@
+Deprecations
+````````````
+
+``Axes.xaxis_date``, ``Axes.yaxis_date``, and ``Axes3D.zaxis_date`` are
+deprecated.  Matplotlib normally autodetects when dates are being plotted, or
+one can use `~.axes.Axes.plot_date` to explicitly plot data as dates.  If one
+needs to force a specific axis to use datetime formatters and locators without
+actually plotting data, one can use e.g. ``ax.xaxis.axis_date()``.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1704,14 +1704,11 @@ class Axes(_AxesBase):
         `.DateFormatter` instance).
         """
         if xdate:
-            self.xaxis_date(tz)
+            self.xaxis.axis_date(tz)
         if ydate:
-            self.yaxis_date(tz)
-
+            self.yaxis.axis_date(tz)
         ret = self.plot(x, y, fmt, **kwargs)
-
         self._request_autoscale_view()
-
         return ret
 
     # @_preprocess_data() # let 'plot' do the unpacking..

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3811,6 +3811,7 @@ class _AxesBase(martist.Artist):
         return self.yaxis.set_ticklabels(labels,
                                          minor=minor, **kwargs)
 
+    @cbook.deprecated("3.2", alternative="ax.xaxis.axis_date()")
     def xaxis_date(self, tz=None):
         """
         Sets up x-axis ticks and labels that treat the x data as dates.
@@ -3824,6 +3825,7 @@ class _AxesBase(martist.Artist):
         # dates are coming in
         self.xaxis.axis_date(tz)
 
+    @cbook.deprecated("3.2", alternative="ax.yaxis.axis_date()")
     def yaxis_date(self, tz=None):
         """
         Sets up y-axis ticks and labels that treat the y data as dates.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -615,7 +615,7 @@ class DateFormatter(ticker.Formatter):
             raise ValueError('DateFormatter found a value of x=0, which is '
                              'an illegal date; this usually occurs because '
                              'you have not informed the axis that it is '
-                             'plotting dates, e.g., with ax.xaxis_date()')
+                             'plotting dates, e.g., with ax.xaxis.axis_date()')
         return num2date(x, self.tz).strftime(self.fmt)
 
     def set_tzinfo(self, tz):

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -77,7 +77,7 @@ def test_date_empty():
     # http://sourceforge.net/tracker/?func=detail&aid=2850075&group_id=80706&atid=560720
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
-    ax.xaxis_date()
+    ax.xaxis.axis_date()
 
 
 @image_comparison(['date_axhspan.png'])

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -309,8 +309,8 @@ def test_autofmt_xdate(which):
     fig, ax = plt.subplots()
 
     ax.plot(x, y)
-    ax.yaxis_date()
-    ax.xaxis_date()
+    ax.xaxis.axis_date()
+    ax.yaxis.axis_date()
 
     ax.xaxis.set_minor_locator(AutoMinorLocator(2))
     ax.xaxis.set_minor_formatter(FixedFormatter(minors))

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -928,6 +928,7 @@ class Axes3D(Axes):
         return cbook.silent_list('Text zticklabel',
                                  self.zaxis.get_ticklabels(minor=minor))
 
+    @cbook.deprecated("3.2", alternative="ax.zaxis.axis_date()")
     def zaxis_date(self, tz=None):
         """
         Sets up z-axis ticks and labels that treat the z data as dates.


### PR DESCRIPTION
See changelog.

... mostly so that we can remove the rather ridiculous zaxis_date which
explains over multiple lines that it's provided for API completeness but
"may or may not work as expected"...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
