### PR TITLE
Fix axis inversion with loglocator and logitlocator.

### DIFF
--- a/doc/api/next_api_changes/2019-03-04-AL.rst
+++ b/doc/api/next_api_changes/2019-03-04-AL.rst
@@ -47,9 +47,3 @@ properties of the `.Collection` object:
 While this seems complicated, the logic is simply to use the information from
 the object that are in data space for the limits, but not information that is
 in physical units.
-
-LogLocator.nonsingular now maintains the orders of its arguments
-````````````````````````````````````````````````````````````````
-
-It no longer reorders them in increasing order.  The new behavior is consistent
-with MaxNLocator.

--- a/doc/api/next_api_changes/2019-06-25-AL.rst
+++ b/doc/api/next_api_changes/2019-06-25-AL.rst
@@ -1,0 +1,7 @@
+API changes
+```````````
+
+``Locator.nonsingular`` (introduced in mpl 3.1), ``DateLocator.nonsingular``, and
+``AutoDateLocator.nonsingular`` now returns a range ``v0, v1`` with ``v0 <= v1``.
+This behavior is consistent with the implementation of ``nonsingular`` by the
+``LogLocator`` and ``LogitLocator`` subclasses.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1117,8 +1117,9 @@ class DateLocator(ticker.Locator):
         """
         Given the proposed upper and lower extent, adjust the range
         if it is too close to being singular (i.e. a range of ~0).
-
         """
+        if vmax < vmin:
+            vmin, vmax = vmax, vmin
         unit = self._get_unit()
         interval = self._get_interval()
         if abs(vmax - vmin) < 1e-6:
@@ -1336,6 +1337,8 @@ class AutoDateLocator(DateLocator):
     def nonsingular(self, vmin, vmax):
         # whatever is thrown at us, we can scale the unit.
         # But default nonsingular date plots at an ~4 year period.
+        if vmax < vmin:
+            vmin, vmax = vmax, vmin
         if vmin == vmax:
             vmin = vmin - DAYS_PER_YEAR * 2
             vmax = vmax + DAYS_PER_YEAR * 2

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2495,9 +2495,7 @@ class LogLocator(Locator):
         return vmin, vmax
 
     def nonsingular(self, vmin, vmax):
-        swap_vlims = False
         if vmin > vmax:
-            swap_vlims = True
             vmin, vmax = vmax, vmin
         if not np.isfinite(vmin) or not np.isfinite(vmax):
             vmin, vmax = 1, 10  # Initial range, no data plotted yet.
@@ -2515,8 +2513,6 @@ class LogLocator(Locator):
             if vmin == vmax:
                 vmin = _decade_less(vmin, self._base)
                 vmax = _decade_greater(vmax, self._base)
-        if swap_vlims:
-            vmin, vmax = vmax, vmin
         return vmin, vmax
 
 


### PR DESCRIPTION
## PR Summary

Reverts a minor part of #13593 to provide a different fix to #14615 and #14162 

I chose to make nonsingular always order its arguments (and thus just change the behavior in the base class, which was only introduced in 3.1, rather than change the behavior of the subclass, which was only introduced in #13593 and not released yet) as that seems more likely to be respected by third-party implementations.  On the other hand in https://github.com/matplotlib/matplotlib/pull/14643 I realized we can't really trust (for now) whether third-party implementations (or our own) do this ordering, so redoing a sort after-the-fact is likely the most robust solution...

The 3.1.x version is at https://github.com/matplotlib/matplotlib/pull/14623; this PR should not be backported.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
