### PR TITLE
Don't double-wrap in silent_list.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1765,13 +1765,11 @@ class _AxesBase(martist.Artist):
 
     def get_xgridlines(self):
         """Get the x grid lines as a list of `Line2D` instances."""
-        return cbook.silent_list('Line2D xgridline',
-                                 self.xaxis.get_gridlines())
+        return self.xaxis.get_gridlines()
 
     def get_xticklines(self):
         """Get the x tick lines as a list of `Line2D` instances."""
-        return cbook.silent_list('Line2D xtickline',
-                                 self.xaxis.get_ticklines())
+        return self.xaxis.get_ticklines()
 
     def get_yaxis(self):
         """Return the YAxis instance."""
@@ -1779,13 +1777,11 @@ class _AxesBase(martist.Artist):
 
     def get_ygridlines(self):
         """Get the y grid lines as a list of `Line2D` instances."""
-        return cbook.silent_list('Line2D ygridline',
-                                 self.yaxis.get_gridlines())
+        return self.yaxis.get_gridlines()
 
     def get_yticklines(self):
         """Get the y tick lines as a list of `Line2D` instances."""
-        return cbook.silent_list('Line2D ytickline',
-                                 self.yaxis.get_ticklines())
+        return self.yaxis.get_ticklines()
 
     # Adding and tracking artists
 
@@ -3361,8 +3357,7 @@ class _AxesBase(martist.Artist):
         labels : list
             List of `~matplotlib.text.Text` instances
         """
-        return cbook.silent_list('Text xticklabel',
-                                 self.xaxis.get_majorticklabels())
+        return self.xaxis.get_majorticklabels()
 
     def get_xminorticklabels(self):
         """
@@ -3373,8 +3368,7 @@ class _AxesBase(martist.Artist):
         labels : list
             List of `~matplotlib.text.Text` instances
         """
-        return cbook.silent_list('Text xticklabel',
-                                 self.xaxis.get_minorticklabels())
+        return self.xaxis.get_minorticklabels()
 
     def get_xticklabels(self, minor=False, which=None):
         """
@@ -3396,9 +3390,7 @@ class _AxesBase(martist.Artist):
         ret : list
            List of `~matplotlib.text.Text` instances.
         """
-        return cbook.silent_list('Text xticklabel',
-                                 self.xaxis.get_ticklabels(minor=minor,
-                                                           which=which))
+        return self.xaxis.get_ticklabels(minor=minor, which=which)
 
     def set_xticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
@@ -3744,8 +3736,7 @@ class _AxesBase(martist.Artist):
         labels : list
             List of `~matplotlib.text.Text` instances
         """
-        return cbook.silent_list('Text yticklabel',
-                                 self.yaxis.get_majorticklabels())
+        return self.yaxis.get_majorticklabels()
 
     def get_yminorticklabels(self):
         """
@@ -3756,8 +3747,7 @@ class _AxesBase(martist.Artist):
         labels : list
             List of `~matplotlib.text.Text` instances
         """
-        return cbook.silent_list('Text yticklabel',
-                                 self.yaxis.get_minorticklabels())
+        return self.yaxis.get_minorticklabels()
 
     def get_yticklabels(self, minor=False, which=None):
         """
@@ -3779,9 +3769,7 @@ class _AxesBase(martist.Artist):
         ret : list
            List of `~matplotlib.text.Text` instances.
         """
-        return cbook.silent_list('Text yticklabel',
-                                 self.yaxis.get_ticklabels(minor=minor,
-                                                           which=which))
+        return self.yaxis.get_ticklabels(minor=minor, which=which)
 
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1504,7 +1504,7 @@ def xticks(ticks=None, labels=None, **kwargs):
     for l in labels:
         l.update(kwargs)
 
-    return locs, silent_list('Text xticklabel', labels)
+    return locs, labels
 
 
 def yticks(ticks=None, labels=None, **kwargs):
@@ -1579,7 +1579,7 @@ def yticks(ticks=None, labels=None, **kwargs):
     for l in labels:
         l.update(kwargs)
 
-    return locs, silent_list('Text yticklabel', labels)
+    return locs, labels
 
 
 def rgrids(*args, **kwargs):
@@ -1646,8 +1646,7 @@ def rgrids(*args, **kwargs):
         labels = ax.yaxis.get_ticklabels()
     else:
         lines, labels = ax.set_rgrids(*args, **kwargs)
-    return (silent_list('Line2D rgridline', lines),
-            silent_list('Text rgridlabel', labels))
+    return lines, labels
 
 
 def thetagrids(*args, **kwargs):
@@ -1711,8 +1710,7 @@ def thetagrids(*args, **kwargs):
         labels = ax.xaxis.get_ticklabels()
     else:
         lines, labels = ax.set_thetagrids(*args, **kwargs)
-    return (silent_list('Line2D thetagridline', lines),
-            silent_list('Text thetagridlabel', labels))
+    return lines, labels
 
 
 ## Plotting Info ##

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -887,8 +887,7 @@ class Axes3D(Axes):
 
         .. versionadded :: 1.1.0
         """
-        return cbook.silent_list('Text zticklabel',
-                                 self.zaxis.get_majorticklabels())
+        return self.zaxis.get_majorticklabels()
 
     def get_zminorticklabels(self):
         """
@@ -900,8 +899,7 @@ class Axes3D(Axes):
 
         .. versionadded :: 1.1.0
         """
-        return cbook.silent_list('Text zticklabel',
-                                 self.zaxis.get_minorticklabels())
+        return self.zaxis.get_minorticklabels()
 
     def set_zticklabels(self, *args, **kwargs):
         """
@@ -925,8 +923,7 @@ class Axes3D(Axes):
 
         .. versionadded:: 1.1.0
         """
-        return cbook.silent_list('Text zticklabel',
-                                 self.zaxis.get_ticklabels(minor=minor))
+        return self.zaxis.get_ticklabels(minor=minor)
 
     def zaxis_date(self, tz=None):
         """


### PR DESCRIPTION
Axis.get_ticklines, Axis.get_ticklabels, and Axis.get_gridlines already
wrap their return value in a silent_list; we don't need to rewrap it a
second time in the Axes methods.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
