### PR TITLE
gitignore pip-wheel-metadta/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ dist
 # Egg metadata
 *.egg-info
 .eggs
+# wheel metadata
+pip-wheel-metadata/*
 # tox testing tool
 .tox
 setup.cfg


### PR DESCRIPTION
I guess a new version of `pip` has introduced this directory??