### PR TITLE
matplotlib > Matplotlib in devel docs

### DIFF
--- a/doc/devel/add_new_projection.rst
+++ b/doc/devel/add_new_projection.rst
@@ -25,9 +25,9 @@ functions, e.g.::
     plot(x, y, projection="custom")
 
 This document is intended for developers and advanced users who need
-to create new scales and projections for matplotlib.  The necessary
+to create new scales and projections for Matplotlib.  The necessary
 code for scales and projections can be included anywhere: directly
-within a plot script, in third-party code, or in the matplotlib source
+within a plot script, in third-party code, or in the Matplotlib source
 tree itself.
 
 .. _creating-new-scale:
@@ -57,7 +57,7 @@ elements:
 - Formatters (major and minor) that specify how the tick labels
   should be drawn.
 
-Once the class is defined, it must be registered with matplotlib so
+Once the class is defined, it must be registered with Matplotlib so
 that the user can select it.
 
 A full-fledged and heavily annotated example is in
@@ -81,7 +81,7 @@ elements:
 
 - Transformations for the gridlines, ticks and ticklabels.  Custom
   projections will often need to place these elements in special
-  locations, and matplotlib has a facility to help with doing so.
+  locations, and Matplotlib has a facility to help with doing so.
 
 - Setting up default values (overriding :meth:`~matplotlib.axes.Axes.cla`),
   since the defaults for a rectilinear axes may not be appropriate.

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -807,7 +807,7 @@ which was used to setup the github account but can be used for other
 purposes, like hosting Google docs or Youtube videos.  You can embed a
 Matplotlib animation in the docs by first saving the animation as a
 movie using :meth:`matplotlib.animation.Animation.save`, and then
-uploading to `matplotlib's Youtube
+uploading to `Matplotlib's Youtube
 channel <https://www.youtube.com/user/matplotlib>`_ and inserting the
 embedding string youtube provides like:
 

--- a/doc/devel/license.rst
+++ b/doc/devel/license.rst
@@ -14,7 +14,7 @@ distributing L/GPL code through an separate channel, possibly a
 toolkit.  If you include code, make sure you include a copy of that
 code's license in the license directory if the code's license requires
 you to distribute the license with it.  Non-BSD compatible licenses
-are acceptable in matplotlib toolkits (e.g., basemap), but make sure you
+are acceptable in Matplotlib toolkits (e.g., basemap), but make sure you
 clearly state the licenses you are using.
 
 Why BSD compatible?
@@ -50,8 +50,8 @@ Famous projects released under a BSD-style license in the permissive
 sense of the last paragraph are the BSD operating system, python and
 TeX.
 
-There are several reasons why early matplotlib developers selected a
-BSD compatible license. matplotlib is a python extension, and we
+There are several reasons why early Matplotlib developers selected a
+BSD compatible license. Matplotlib is a python extension, and we
 choose a license that was based on the python license (BSD
 compatible).  Also, we wanted to attract as many users and developers
 as possible, and many software companies will not use GPL code in
@@ -60,9 +60,9 @@ to open source development, such as `enthought
 <https://www.enthought.com>`_, out of legitimate concern that use of the
 GPL will "infect" their code base by its viral nature. In effect, they
 want to retain the right to release some proprietary code. Companies
-and institutions who use matplotlib often make significant
+and institutions who use Matplotlib often make significant
 contributions, because they have the resources to get a job done, even
-a boring one. Two of the matplotlib backends (FLTK and WX) were
+a boring one. Two of the Matplotlib backends (FLTK and WX) were
 contributed by private companies.  The final reason behind the
 licensing choice is compatibility with the other python extensions for
 scientific computing: ipython, numpy, scipy, the enthought tool suite

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -7,9 +7,9 @@
 ===============
 
 
-.. admonition::  This document is only relevant for matplotlib release managers.
+.. admonition::  This document is only relevant for Matplotlib release managers.
 
-   A guide for developers who are doing a matplotlib release.
+   A guide for developers who are doing a Matplotlib release.
 
 
 .. note::

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -209,7 +209,7 @@ sees these new commits. It looks for a YAML file called
 ``.travis.yml`` in the root of the repository to see how to test the
 project.
 
-Travis CI is already enabled for the `main matplotlib GitHub
+Travis CI is already enabled for the `main Matplotlib GitHub
 repository <https://github.com/matplotlib/matplotlib/>`_ -- for
 example, see `its Travis page
 <https://travis-ci.org/matplotlib/matplotlib>`_.


### PR DESCRIPTION
A few places that have been missed, and I think all the instances in the development docs.