### PR TITLE
Delete HTML build sources to save on artefact upload time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ doc-run: &doc-build
   name: Build documentation
   command: |
     make html O=-T
-    rm -rv build/html/_sources
+    rm -r build/html/_sources
   working_directory: doc
 
 doc-bundle-run: &doc-bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ mpl-run: &mpl-install
 
 doc-run: &doc-build
   name: Build documentation
-  command: make html O=-T
+  command: |
+    make html O=-T
+    rm -rv build/html/_sources
   working_directory: doc
 
 doc-bundle-run: &doc-bundle


### PR DESCRIPTION
Currently uploading the doc build artefacts takes circleCI a **long** time because it uploads every single file individually. I don't think the files in `build/html/_sources` are needed for viewing the generated HTML docs though, so try deleting them to save time on the artefact upload.