### PR TITLE
Remove reference to old Tk/Windows bug.

### DIFF
--- a/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -39,17 +39,7 @@ def on_key_press(event):
 
 canvas.mpl_connect("key_press_event", on_key_press)
 
-
-def _quit():
-    root.quit()  # Stops mainloop.
-    # The following is necessary on Windows to prevent
-    # Fatal Python Error: PyEval_RestoreThread: NULL tstate
-    root.destroy()
-
-
-button = tkinter.Button(master=root, text="Quit", command=_quit)
+button = tkinter.Button(master=root, text="Quit", command=root.quit)
 button.pack(side=tkinter.BOTTOM)
 
 tkinter.mainloop()
-# If you put root.destroy() here, it will cause an error if the window is
-# closed with the window manager.

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -465,10 +465,6 @@ class FigureManagerTk(FigureManagerBase):
             self.toolbar.configure(width=width)
 
     def show(self):
-        """
-        this function doesn't segfault but causes the
-        PyEval_RestoreThread: NULL state bug on win32
-        """
         with _restore_foreground_window_at_end():
             if not self._shown:
                 def destroy(*args):


### PR DESCRIPTION
See patch.

At least I can't repro it on Windows, and you'd expect it to be
semi-regularly reported on the tracker if it still occurred.

In the example, don't bother calling `root.destroy()`, as `root.quit()`
already handles the destroying (both on Linux and Windows, an additional
call to `root.destroy()` results in "can't invoke "destroy" command:
application has been destroyed").

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
