### PR TITLE
Fix bug when setting negative limits and using log scale

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3249,7 +3249,10 @@ class _AxesBase(martist.Artist):
             if right is None:
                 right = old_right
 
-        if self.get_xscale() == 'log':
+        if self.get_xscale() == 'log' and (left <= 0 or right <= 0):
+            # Axes init calls set_xlim(0, 1) before get_xlim() can be called,
+            # so only grab the limits if we really need them.
+            old_left, old_right = self.get_xlim()
             if left <= 0:
                 cbook._warn_external(
                     'Attempted to set non-positive left xlim on a '

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3632,7 +3632,10 @@ class _AxesBase(martist.Artist):
             if top is None:
                 top = old_top
 
-        if self.get_yscale() == 'log':
+        if self.get_yscale() == 'log' and (bottom <= 0 or top <= 0):
+            # Axes init calls set_xlim(0, 1) before get_xlim() can be called,
+            # so only grab the limits if we really need them.
+            old_bottom, old_top = self.get_ylim()
             if bottom <= 0:
                 cbook._warn_external(
                     'Attempted to set non-positive bottom ylim on a '

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2147,6 +2147,9 @@ def test_log_scales_invalid():
     ax.set_xscale('log')
     with pytest.warns(UserWarning, match='Attempted to set non-positive'):
         ax.set_xlim(-1, 10)
+    ax.set_yscale('log')
+    with pytest.warns(UserWarning, match='Attempted to set non-positive'):
+        ax.set_ylim(-1, 10)
 
 
 @image_comparison(['stackplot_test_image', 'stackplot_test_image'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2141,6 +2141,14 @@ def test_log_scales():
     ax.set_xscale('log', basex=9.0)
 
 
+def test_log_scales_invalid():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    ax.set_xscale('log')
+    with pytest.warns(UserWarning, match='Attempted to set non-positive'):
+        ax.set_xlim(-1, 10)
+
+
 @image_comparison(['stackplot_test_image', 'stackplot_test_image'])
 def test_stackplot():
     fig = plt.figure()


### PR DESCRIPTION
This fixes an issue that caused the following error when setting negative limits on a log plot:

```
Traceback (most recent call last):
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/qt/connect.py", line 480, in update_prop
    setattr(self._instance, self._prop, data_wrapper.data)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/core.py", line 264, in __setattr__
    super(HasCallbackProperties, self).__setattr__(attribute, value)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/selection.py", line 39, in __set__
    super(SelectionCallbackProperty, self).__set__(instance, value)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/core.py", line 79, in __set__
    self.notify(instance, old, new)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/utils/matplotlib.py", line 170, in wrapper
    result = func(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/viewers/matplotlib/state.py", line 34, in notify
    super(DeferredDrawSelectionCallbackProperty, self).notify(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/core.py", line 128, in notify
    cback(new)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/state_objects.py", line 198, in _update_attribute
    self.update_values(attribute=self.component_id, use_default_modifiers=True)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/state_objects.py", line 378, in update_values
    self.set(lower=lower, upper=upper, percentile=percentile, log=log)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/core/state_objects.py", line 247, in set
    setattr(self, prop, value)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/core.py", line 541, in __exit__
    p.notify(*args)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/utils/matplotlib.py", line 165, in wrapper
    return func(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/viewers/matplotlib/state.py", line 23, in notify
    super(DeferredDrawCallbackProperty, self).notify(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/external/echo/core.py", line 128, in notify
    cback(new)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/utils/matplotlib.py", line 165, in wrapper
    return func(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/utils/matplotlib.py", line 165, in wrapper
    return func(*args, **kwargs)
  File "/Users/tom/Dropbox/Code/Glue/glue/glue/viewers/matplotlib/viewer.py", line 187, in limits_to_mpl
    self.axes.set_xlim(x_min, x_max)
  File "/Users/tom/tmp/matplotlib/lib/matplotlib/axes/_base.py", line 3282, in set_xlim
    left = old_left
UnboundLocalError: local variable 'old_left' referenced before assignment
```
