### PR TITLE
Don't capture stderr in _check_and_log_subprocess.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2030,24 +2030,28 @@ def _pformat_subprocess(command):
 
 def _check_and_log_subprocess(command, logger, **kwargs):
     """
-    Run *command* using `subprocess.check_output`.  If it succeeds, return the
-    output (stdout and stderr); if not, raise an exception whose text includes
-    the failed command and captured output.  Both the command and the output
-    are logged at DEBUG level on *logger*.
+    Run *command*, returning its stdout output if it succeeds.
+
+    If it fails (exits with nonzero return code), raise an exception whose text
+    includes the failed command and captured stdout and stderr output.
+
+    Regardless of the return code, the command is logged at DEBUG level on
+    *logger*.  In case of success, the output is likewise logged.
     """
     logger.debug('%s', _pformat_subprocess(command))
-    try:
-        report = subprocess.check_output(
-            command, stderr=subprocess.STDOUT, **kwargs)
-    except subprocess.CalledProcessError as exc:
+    proc = subprocess.run(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+    if proc.returncode:
         raise RuntimeError(
-            'The command\n'
-            '    {}\n'
-            'failed and generated the following output:\n'
-            '{}'
-            .format(_pformat_subprocess(command), exc.output.decode('utf-8')))
-    logger.debug(report)
-    return report
+            f"The command\n"
+            f"    {_pformat_subprocess(command)}\n"
+            f"failed and generated the following output:\n"
+            f"{proc.stdout.decode('utf-8')}\n"
+            f"and the following error:\n"
+            f"{proc.stderr.decode('utf-8')}")
+    logger.debug("stdout:\n%s", proc.stdout)
+    logger.debug("stderr:\n%s", proc.stderr)
+    return proc.stdout
 
 
 def _check_isinstance(types, **kwargs):


### PR DESCRIPTION
... to avoid capturing kpsewhich's "warning: running with administrator
privileges" (that occurs at the only place where we actually care about
the return value of _check_and_log_subprocess).

Should close #14633 (I checked that the error does indeed get printed on stderr).

Not sure how this got to be a regression in 3.1.0, but milestoning as release critical as a consequence.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
