### PR TITLE
Soft-deprecate transform_point.

### DIFF
--- a/examples/misc/custom_projection.py
+++ b/examples/misc/custom_projection.py
@@ -174,8 +174,8 @@ class GeoAxes(Axes):
 
     def _get_affine_transform(self):
         transform = self._get_core_transform(1)
-        xscale, _ = transform.transform_point((np.pi, 0))
-        _, yscale = transform.transform_point((0, np.pi / 2.0))
+        xscale, _ = transform.transform((np.pi, 0))
+        _, yscale = transform.transform((0, np.pi/2))
         return Affine2D() \
             .scale(0.5 / xscale, 0.5 / yscale) \
             .translate(0.5, 0.5)

--- a/examples/pyplots/annotate_transform.py
+++ b/examples/pyplots/annotate_transform.py
@@ -19,7 +19,7 @@ ax.set_xlim(0, 10)
 ax.set_ylim(-1, 1)
 
 xdata, ydata = 5, 0
-xdisplay, ydisplay = ax.transData.transform_point((xdata, ydata))
+xdisplay, ydisplay = ax.transData.transform((xdata, ydata))
 
 bbox = dict(boxstyle="round", fc="0.8")
 arrowprops = dict(
@@ -52,6 +52,6 @@ plt.show()
 # in this example:
 
 import matplotlib
-matplotlib.transforms.Transform.transform_point
+matplotlib.transforms.Transform.transform
 matplotlib.axes.Axes.annotate
 matplotlib.pyplot.annotate

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4058,8 +4058,7 @@ class _AxesBase(martist.Artist):
 
         # zoom to rect
         inverse = self.transData.inverted()
-        lastx, lasty = inverse.transform_point((lastx, lasty))
-        x, y = inverse.transform_point((x, y))
+        (lastx, lasty), (x, y) = inverse.transform([(lastx, lasty), (x, y)])
 
         if twinx:
             x0, x1 = Xmin, Xmax

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -737,8 +737,8 @@ class Axis(martist.Artist):
     OFFSETTEXTPAD = 3
 
     def __str__(self):
-        return self.__class__.__name__ \
-            + "(%f,%f)" % tuple(self.axes.transAxes.transform_point((0, 0)))
+        return "{}({},{})".format(
+            type(self).__name__, *self.axes.transAxes.transform((0, 0)))
 
     def __init__(self, axes, pickradius=15):
         """
@@ -1929,11 +1929,10 @@ class XAxis(Axis):
         x, y = mouseevent.x, mouseevent.y
         try:
             trans = self.axes.transAxes.inverted()
-            xaxes, yaxes = trans.transform_point((x, y))
+            xaxes, yaxes = trans.transform((x, y))
         except ValueError:
             return False, {}
-        l, b = self.axes.transAxes.transform_point((0, 0))
-        r, t = self.axes.transAxes.transform_point((1, 1))
+        (l, b), (r, t) = self.axes.transAxes.transform([(0, 0), (1, 1)])
         inaxis = 0 <= xaxes <= 1 and (
             b - self.pickradius < y < b or
             t < y < t + self.pickradius)
@@ -2218,11 +2217,10 @@ class YAxis(Axis):
         x, y = mouseevent.x, mouseevent.y
         try:
             trans = self.axes.transAxes.inverted()
-            xaxes, yaxes = trans.transform_point((x, y))
+            xaxes, yaxes = trans.transform((x, y))
         except ValueError:
             return False, {}
-        l, b = self.axes.transAxes.transform_point((0, 0))
-        r, t = self.axes.transAxes.transform_point((1, 1))
+        (l, b), (r, t) = self.axes.transAxes.transform([(0, 0), (1, 1)])
         inaxis = 0 <= yaxes <= 1 and (
             l - self.pickradius < x < l or
             r < x < r + self.pickradius)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -415,8 +415,8 @@ class RendererBase:
                             master_transform)
                     else:
                         transform = master_transform
-                    xo, yo = transform.transform_point((xo, yo))
-                    xp, yp = transform.transform_point((0, 0))
+                    (xo, yo), (xp, yp) = transform.transform(
+                        [(xo, yo), (0, 0)])
                     xo = -(xp - xo)
                     yo = -(yp - yo)
             if not (np.isfinite(xo) and np.isfinite(yo)):
@@ -1335,7 +1335,7 @@ class LocationEvent(Event):
         if self.inaxes is not None:
             try:
                 trans = self.inaxes.transData.inverted()
-                xdata, ydata = trans.transform_point((x, y))
+                xdata, ydata = trans.transform((x, y))
             except ValueError:
                 pass
             else:

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2060,7 +2060,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             if elt[0] == 'font':
                 self.file.output(elt[1], elt[2], Op.selectfont)
             elif elt[0] == 'text':
-                curx, cury = mytrans.transform_point((elt[1], elt[2]))
+                curx, cury = mytrans.transform((elt[1], elt[2]))
                 self._setup_textpos(curx, cury, angle, oldx, oldy)
                 oldx, oldy = curx, cury
                 if len(elt[3]) == 1:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -696,7 +696,7 @@ class RendererPgf(RendererBase):
             # if text anchoring can be supported, get the original coordinates
             # and add alignment information
             pos = mtext.get_unitless_position()
-            x, y = mtext.get_transform().transform_point(pos)
+            x, y = mtext.get_transform().transform(pos)
             text_args.append("x=%fin" % (x * f))
             text_args.append("y=%fin" % (y * f))
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1037,8 +1037,7 @@ class RendererSVG(RendererBase):
 
                 # Get anchor coordinates.
                 transform = mtext.get_transform()
-                ax, ay = transform.transform_point(
-                    mtext.get_unitless_position())
+                ax, ay = transform.transform(mtext.get_unitless_position())
                 ay = self.height - ay
 
                 # Don't do vertical anchor alignment. Most applications do not

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -402,7 +402,7 @@ class ContourLabeler:
         return rotation, nlc
 
     def _get_label_text(self, x, y, rotation):
-        dx, dy = self.ax.transData.inverted().transform_point((x, y))
+        dx, dy = self.ax.transData.inverted().transform((x, y))
         t = text.Text(dx, dy, rotation=rotation,
                       horizontalalignment='center',
                       verticalalignment='center')
@@ -414,7 +414,7 @@ class ContourLabeler:
         # class. This way, the rotation of the clabel is along the
         # contour line always.
         transDataInv = self.ax.transData.inverted()
-        dx, dy = transDataInv.transform_point((x, y))
+        dx, dy = transDataInv.transform((x, y))
         drotation = transDataInv.transform_angles(np.array([rotation]),
                                                   np.array([[x, y]]))
         t = ClabelText(dx, dy, rotation=drotation[0],
@@ -480,7 +480,7 @@ class ContourLabeler:
             transform = self.ax.transData
 
         if transform:
-            x, y = transform.transform_point((x, y))
+            x, y = transform.transform((x, y))
 
         # find the nearest contour _in screen units_
         conmin, segmin, imin, xmin, ymin = self.find_nearest_contour(
@@ -496,7 +496,7 @@ class ContourLabeler:
         # grab its vertices
         lc = active_path.vertices
         # sort out where the new vertex should be added data-units
-        xcmin = self.ax.transData.inverted().transform_point([xmin, ymin])
+        xcmin = self.ax.transData.inverted().transform([xmin, ymin])
         # if there isn't a vertex close enough
         if not np.allclose(xcmin, lc[imin]):
             # insert new data into the vertex list

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -906,8 +906,7 @@ class AxesImage(_ImageBase):
         data_extent = Bbox([[ymin, xmin], [ymax, xmax]])
         array_extent = Bbox([[0, 0], arr.shape[:2]])
         trans = BboxTransform(boxin=data_extent, boxout=array_extent)
-        y, x = event.ydata, event.xdata
-        point = trans.transform_point([y, x])
+        point = trans.transform([event.ydata, event.xdata])
         if any(np.isnan(point)):
             return None
         i, j = point.astype(int)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -93,15 +93,10 @@ class DraggableLegend(DraggableOffsetBox):
             bbox = self.legend.get_bbox_to_anchor()
 
         _bbox_transform = BboxTransformFrom(bbox)
-        self.legend._loc = tuple(
-            _bbox_transform.transform_point(loc_in_canvas)
-        )
+        self.legend._loc = tuple(_bbox_transform.transform(loc_in_canvas))
 
     def _update_bbox_to_anchor(self, loc_in_canvas):
-
-        tr = self.legend.axes.transAxes
-        loc_in_bbox = tr.transform_point(loc_in_canvas)
-
+        loc_in_bbox = self.legend.axes.transAxes.transform(loc_in_canvas)
         self.legend.set_bbox_to_anchor(loc_in_bbox)
 
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1592,7 +1592,7 @@ class Arc(Ellipse):
         theta2 = theta_stretch(self.theta2, width / height)
 
         # Get width and height in pixels
-        width, height = self.get_transform().transform_point((width, height))
+        width, height = self.get_transform().transform((width, height))
         inv_error = (1.0 / 1.89818e-6) * 0.5
         if width < inv_error and height < inv_error:
             self._path = Path.arc(theta1, theta2)
@@ -4168,8 +4168,7 @@ class FancyArrowPatch(Patch):
         if self._posA_posB is not None:
             posA = self._convert_xy_units(self._posA_posB[0])
             posB = self._convert_xy_units(self._posA_posB[1])
-            posA = self.get_transform().transform_point(posA)
-            posB = self.get_transform().transform_point(posB)
+            (posA, posB) = self.get_transform().transform((posA, posB))
             _path = self.get_connectionstyle()(posA, posB,
                                                patchA=self.patchA,
                                                patchB=self.patchB,
@@ -4327,7 +4326,7 @@ class ConnectionPatch(FancyArrowPatch):
             trans = axes.transData
             x = float(self.convert_xunits(x))
             y = float(self.convert_yunits(y))
-            return trans.transform_point((x, y))
+            return trans.transform((x, y))
         elif s == 'offset points':
             # convert the data point
             dx, dy = self.xy
@@ -4353,7 +4352,7 @@ class ConnectionPatch(FancyArrowPatch):
             x = r * np.cos(theta)
             y = r * np.sin(theta)
             trans = axes.transData
-            return trans.transform_point((x, y))
+            return trans.transform((x, y))
         elif s == 'figure points':
             # points from the lower left corner of the figure
             dpi = self.figure.dpi
@@ -4381,7 +4380,7 @@ class ConnectionPatch(FancyArrowPatch):
         elif s == 'figure fraction':
             # (0,0) is lower left, (1,1) is upper right of figure
             trans = self.figure.transFigure
-            return trans.transform_point((x, y))
+            return trans.transform((x, y))
         elif s == 'axes points':
             # points from the lower left corner of the axes
             dpi = self.figure.dpi
@@ -4415,9 +4414,9 @@ class ConnectionPatch(FancyArrowPatch):
         elif s == 'axes fraction':
             # (0,0) is lower left, (1,1) is upper right of axes
             trans = axes.transAxes
-            return trans.transform_point((x, y))
+            return trans.transform((x, y))
         elif isinstance(s, transforms.Transform):
-            return s.transform_point((x, y))
+            return s.transform((x, y))
         else:
             raise ValueError("{} is not a valid coordinate "
                              "transformation.".format(s))

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -111,8 +111,8 @@ class GeoAxes(Axes):
 
     def _get_affine_transform(self):
         transform = self._get_core_transform(1)
-        xscale, _ = transform.transform_point((np.pi, 0))
-        _, yscale = transform.transform_point((0, np.pi / 2))
+        xscale, _ = transform.transform((np.pi, 0))
+        _, yscale = transform.transform((0, np.pi/2))
         return Affine2D() \
             .scale(0.5 / xscale, 0.5 / yscale) \
             .translate(0.5, 0.5)

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -957,12 +957,12 @@ class PolarAxes(Axes):
         if isinstance(self.patch, mpatches.Wedge):
             # Backwards-compatibility: Any subclassed Axes might override the
             # patch to not be the Wedge that PolarAxes uses.
-            center = self.transWedge.transform_point((0.5, 0.5))
+            center = self.transWedge.transform((0.5, 0.5))
             self.patch.set_center(center)
             self.patch.set_theta1(thetamin)
             self.patch.set_theta2(thetamax)
 
-            edge, _ = self.transWedge.transform_point((1, 0))
+            edge, _ = self.transWedge.transform((1, 0))
             radius = edge - center[0]
             width = min(radius * (rmax - rmin) / rmax, radius)
             self.patch.set_radius(radius)
@@ -1419,7 +1419,7 @@ class PolarAxes(Axes):
         mode = ''
         if button == 1:
             epsilon = np.pi / 45.0
-            t, r = self.transData.inverted().transform_point((x, y))
+            t, r = self.transData.inverted().transform((x, y))
             if angle - epsilon <= t <= angle + epsilon:
                 mode = 'drag_r_labels'
         elif button == 3:
@@ -1441,8 +1441,8 @@ class PolarAxes(Axes):
         p = self._pan_start
 
         if p.mode == 'drag_r_labels':
-            startt, startr = p.trans_inverse.transform_point((p.x, p.y))
-            t, r = p.trans_inverse.transform_point((x, y))
+            (startt, startr), (t, r) = p.trans_inverse.transform(
+                [(p.x, p.y), (x, y)])
 
             # Deal with theta
             dt0 = t - startt
@@ -1463,8 +1463,8 @@ class PolarAxes(Axes):
                 t.label2.set_ha(horiz2)
 
         elif p.mode == 'zoom':
-            startt, startr = p.trans_inverse.transform_point((p.x, p.y))
-            t, r = p.trans_inverse.transform_point((x, y))
+            (startt, startr), (t, r) = p.trans_inverse.transform(
+                [(p.x, p.y), (x, y)])
 
             # Deal with r
             scale = r / startr

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -346,7 +346,7 @@ class QuiverKey(martist.Artist):
     def draw(self, renderer):
         self._init()
         self.vector.draw(renderer)
-        x, y = self.get_transform().transform_point((self.X, self.Y))
+        x, y = self.get_transform().transform((self.X, self.Y))
         self.text.set_x(self._text_x(x))
         self.text.set_y(self._text_y(y))
         self.text.draw(renderer)
@@ -552,9 +552,7 @@ class Quiver(mcollections.PolyCollection):
         if True:  # not self._initialized:
             trans = self._set_transform()
             ax = self.ax
-            sx, sy = trans.inverted().transform_point(
-                                            (ax.bbox.width, ax.bbox.height))
-            self.span = sx
+            self.span = trans.inverted().transform_bbox(ax.bbox).width
             if self.width is None:
                 sn = np.clip(math.sqrt(self.N), 8, 25)
                 self.width = 0.06 * self.span / sn

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -26,7 +26,7 @@ def test_patch_transform_of_none():
 
     # Draw an ellipse over data coord (2,2) by specifying device coords.
     xy_data = (2, 2)
-    xy_pix = ax.transData.transform_point(xy_data)
+    xy_pix = ax.transData.transform(xy_data)
 
     # Not providing a transform of None puts the ellipse in data coordinates .
     e = mpatches.Ellipse(xy_data, width=1, height=1, fc='yellow', alpha=0.5)
@@ -68,7 +68,7 @@ def test_collection_transform_of_none():
 
     # draw an ellipse over data coord (2,2) by specifying device coords
     xy_data = (2, 2)
-    xy_pix = ax.transData.transform_point(xy_data)
+    xy_pix = ax.transData.transform(xy_data)
 
     # not providing a transform of None puts the ellipse in data coordinates
     e = mpatches.Ellipse(xy_data, width=1, height=1)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -263,7 +263,7 @@ def test_cursor_data():
     im = ax.imshow(np.arange(100).reshape(10, 10), origin='upper')
 
     x, y = 4, 4
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == 44
@@ -271,7 +271,7 @@ def test_cursor_data():
     # Now try for a point outside the image
     # Tests issue #4957
     x, y = 10.1, 4
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) is None
@@ -279,7 +279,7 @@ def test_cursor_data():
     # Hmm, something is wrong here... I get 0, not None...
     # But, this works further down in the tests with extents flipped
     #x, y = 0.1, -0.1
-    #xdisp, ydisp = ax.transData.transform_point([x, y])
+    #xdisp, ydisp = ax.transData.transform([x, y])
     #event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     #z = im.get_cursor_data(event)
     #assert z is None, "Did not get None, got %d" % z
@@ -289,7 +289,7 @@ def test_cursor_data():
     im = ax.imshow(np.arange(100).reshape(10, 10), origin='lower')
 
     x, y = 4, 4
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == 44
@@ -298,7 +298,7 @@ def test_cursor_data():
     im = ax.imshow(np.arange(100).reshape(10, 10), extent=[0, 0.5, 0, 0.5])
 
     x, y = 0.25, 0.25
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == 55
@@ -306,13 +306,13 @@ def test_cursor_data():
     # Now try for a point outside the image
     # Tests issue #4957
     x, y = 0.75, 0.25
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) is None
 
     x, y = 0.01, -0.01
-    xdisp, ydisp = ax.transData.transform_point([x, y])
+    xdisp, ydisp = ax.transData.transform([x, y])
 
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) is None
@@ -329,7 +329,7 @@ def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
     fig, ax = plt.subplots()
     im = ax.imshow(data)
 
-    xdisp, ydisp = ax.transData.transform_point([0, 0])
+    xdisp, ydisp = ax.transData.transform([0, 0])
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == data[0][0]
     assert im.format_cursor_data(im.get_cursor_data(event)) \

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -63,11 +63,11 @@ def test_nonlinear_containment():
     ax.set(xscale="log", ylim=(0, 1))
     polygon = ax.axvspan(1, 10)
     assert polygon.get_path().contains_point(
-        ax.transData.transform_point((5, .5)), ax.transData)
+        ax.transData.transform((5, .5)), ax.transData)
     assert not polygon.get_path().contains_point(
-        ax.transData.transform_point((.5, .5)), ax.transData)
+        ax.transData.transform((.5, .5)), ax.transData)
     assert not polygon.get_path().contains_point(
-        ax.transData.transform_point((50, .5)), ax.transData)
+        ax.transData.transform((50, .5)), ax.transData)
 
 
 @image_comparison(['arrow_contains_point.png'],
@@ -100,7 +100,7 @@ def test_arrow_contains_point():
     X, Y = np.meshgrid(np.arange(0, 2, 0.1),
                        np.arange(0, 2, 0.1))
     for k, (x, y) in enumerate(zip(X.ravel(), Y.ravel())):
-        xdisp, ydisp = ax.transData.transform_point([x, y])
+        xdisp, ydisp = ax.transData.transform([x, y])
         event = MouseEvent('button_press_event', fig.canvas, xdisp, ydisp)
         for m, patch in enumerate(patches_list):
             # set the points to red only if the arrow contains the point

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -222,7 +222,7 @@ def test_contains():
     fig.canvas.draw()
 
     for x, y in zip(xs.flat, ys.flat):
-        mevent.x, mevent.y = plt.gca().transAxes.transform_point([x, y])
+        mevent.x, mevent.y = plt.gca().transAxes.transform([x, y])
         contains, _ = txt.contains(mevent)
         color = 'yellow' if contains else 'red'
 
@@ -240,8 +240,7 @@ def test_annotation_contains():
         "hello", xy=(.4, .4), xytext=(.6, .6), arrowprops={"arrowstyle": "->"})
     fig.canvas.draw()   # Needed for the same reason as in test_contains.
     event = MouseEvent(
-        "button_press_event", fig.canvas,
-        *ax.transData.transform_point((.5, .6)))
+        "button_press_event", fig.canvas, *ax.transData.transform((.5, .6)))
     assert ann.contains(event) == (False, {})
 
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1064,8 +1064,7 @@ class RadioButtons(AxesWidget):
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
             return
-        xy = self.ax.transAxes.inverted().transform_point((event.x, event.y))
-        pclicked = np.array([xy[0], xy[1]])
+        pclicked = self.ax.transAxes.inverted().transform((event.x, event.y))
         distances = {}
         for i, (p, t) in enumerate(zip(self.circles, self.labels)):
             if (t.get_window_extent().contains(event.x, event.y)
@@ -2185,12 +2184,12 @@ class RectangleSelector(_SelectorWidget):
         x1, x2, y1, y2 = self.extents
         self.eventpress.xdata = x1
         self.eventpress.ydata = y1
-        xy1 = self.ax.transData.transform_point([x1, y1])
+        xy1 = self.ax.transData.transform([x1, y1])
         self.eventpress.x, self.eventpress.y = xy1
 
         self.eventrelease.xdata = x2
         self.eventrelease.ydata = y2
-        xy2 = self.ax.transData.transform_point([x2, y2])
+        xy2 = self.ax.transData.transform([x2, y2])
         self.eventrelease.x, self.eventrelease.y = xy2
 
         if self.spancoords == 'data':

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -240,7 +240,7 @@ class AxisArtistHelperRectlinear:
                     c[self.nth_coord] = x
 
                     # check if the tick point is inside axes
-                    c2 = tr2ax.transform_point(c)
+                    c2 = tr2ax.transform(c)
                     if (0 - self.delta1
                             <= c2[self.nth_coord]
                             <= 1 + self.delta2):
@@ -260,7 +260,7 @@ class AxisArtistHelperRectlinear:
                                [1., 1.]])
 
             fixed_coord = 1 - self.nth_coord
-            p = (axes.transData + axes.transAxes.inverted()).transform_point(
+            p = (axes.transData + axes.transAxes.inverted()).transform(
                 [self._value, self._value])
             _verts[:, fixed_coord] = p[fixed_coord]
 
@@ -286,7 +286,7 @@ class AxisArtistHelperRectlinear:
             _verts = [0.5, 0.5]
 
             fixed_coord = 1-self.nth_coord
-            p = (axes.transData + axes.transAxes.inverted()).transform_point(
+            p = (axes.transData + axes.transAxes.inverted()).transform(
                 [self._value, self._value])
             _verts[fixed_coord] = p[fixed_coord]
             if not (0. <= _verts[fixed_coord] <= 1.):
@@ -329,7 +329,7 @@ class AxisArtistHelperRectlinear:
 
                     c = [self._value, self._value]
                     c[self.nth_coord] = x
-                    c1, c2 = tr2ax.transform_point(c)
+                    c1, c2 = tr2ax.transform(c)
                     if (0 <= c1 <= 1 and 0 <= c2 <= 1
                             and 0 - self.delta1
                                 <= [c1, c2][self.nth_coord]

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -132,7 +132,7 @@ class FixedAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):
             trans_tick = self.get_tick_transform(axes)
             tr2ax = trans_tick + axes.transAxes.inverted()
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
-                c2 = tr2ax.transform_point((x, y))
+                c2 = tr2ax.transform((x, y))
                 delta = 0.00001
                 if 0-delta <= c2[0] <= 1+delta and 0-delta <= c2[1] <= 1+delta:
                     d1, d2 = np.rad2deg([d, d2])

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -162,12 +162,12 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
         (xx1,), (yy1,) = grid_finder.transform_xy([xx0], [yy0])
 
         trans_passingthrough_point = axes.transData + axes.transAxes.inverted()
-        p = trans_passingthrough_point.transform_point([xx1, yy1])
+        p = trans_passingthrough_point.transform([xx1, yy1])
 
         if 0 <= p[0] <= 1 and 0 <= p[1] <= 1:
-            xx1c, yy1c = axes.transData.transform_point([xx1, yy1])
+            xx1c, yy1c = axes.transData.transform([xx1, yy1])
             (xx2,), (yy2,) = grid_finder.transform_xy([xx0 + dxx], [yy0 + dyy])
-            xx2c, yy2c = axes.transData.transform_point([xx2, yy2])
+            xx2c, yy2c = axes.transData.transform([xx2, yy2])
             return (xx1c, yy1c), np.rad2deg(np.arctan2(yy2c-yy1c, xx2c-xx1c))
         else:
             return None, None
@@ -256,7 +256,7 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
             trans_tick = self.get_tick_transform(axes)
             tr2ax = trans_tick + axes.transAxes.inverted()
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
-                c2 = tr2ax.transform_point((x, y))
+                c2 = tr2ax.transform((x, y))
                 delta = 0.00001
                 if 0-delta <= c2[0] <= 1+delta and 0-delta <= c2[1] <= 1+delta:
                     d1, d2 = np.rad2deg([d, d2])

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -146,7 +146,7 @@ ax.set_xlim(0, 10)
 ax.set_ylim(-1, 1)
 
 xdata, ydata = 5, 0
-xdisplay, ydisplay = ax.transData.transform_point((xdata, ydata))
+xdisplay, ydisplay = ax.transData.transform((xdata, ydata))
 
 bbox = dict(boxstyle="round", fc="0.8")
 arrowprops = dict(


### PR DESCRIPTION
The transform() method has explicit code to handle 1d input, so
transform_point() is redundant with transform() (... and is anyways
implemented in terms of transform(), so not faster either)... and longer
to type.

Replace it throughout the codebase.  Also compress consecutive calls
to transform_point() with a single call to transform(), which may be a
bit faster (one matrix multiplication instead of two); also a single
replacement to use transform_bbox as appropriate.

Only "deprecate" transform_point in the docs because I don't really want
to discuss here whether this would be too disruptive...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
