### PR TITLE
Remove some unnecessary prints from setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,7 @@ else:
 from distutils.dist import Distribution
 
 import setupext
-from setupext import (print_line, print_raw, print_message, print_status,
-                      download_or_cache)
+from setupext import print_raw, print_status, download_or_cache
 
 # Get the version from versioneer
 import versioneer
@@ -176,11 +175,10 @@ if __name__ == '__main__':
             or 'clean' in sys.argv):
         # Go through all of the packages and figure out which ones we are
         # going to build/install.
-        print_line()
+        print_raw()
         print_raw("Edit setup.cfg to change the build options; "
                   "suppress output with --quiet.")
 
-        required_failed = []
         good_packages = []
         for package in mpl_packages:
             if isinstance(package, str):
@@ -199,17 +197,10 @@ if __name__ == '__main__':
                     else:
                         print_status(package.name, 'no')
                     if not package.optional:
-                        required_failed.append(package)
+                        sys.exit("Failed to build %s" % package.name)
                 else:
                     good_packages.append(package)
         print_raw('')
-
-        # Abort if any of the required packages can not be built.
-        if required_failed:
-            print_line()
-            print_message("The following required packages can not be built: "
-                          "%s" % ", ".join(x.name for x in required_failed))
-            sys.exit(1)
 
         # Now collect all of the information we need to build all of the
         # packages.

--- a/setupext.py
+++ b/setupext.py
@@ -179,22 +179,11 @@ else:
     print_raw = print
 
 
-def print_line(char='='):
-    print_raw(char * 80)
-
-
 def print_status(package, status):
     initial_indent = "%12s: " % package
     indent = ' ' * 18
     print_raw(textwrap.fill(str(status), width=80,
                             initial_indent=initial_indent,
-                            subsequent_indent=indent))
-
-
-def print_message(message):
-    indent = ' ' * 18 + "* "
-    print_raw(textwrap.fill(str(message), width=80,
-                            initial_indent=indent,
                             subsequent_indent=indent))
 
 


### PR DESCRIPTION
- Instead of populating required_failed, we can just immediately fail
  when a component fails to build.  (Actually there is no case where
  this can happen -- no required package ever throws CheckFailed --
  but I'll further unravel that code in a later PR...)
- Then print_line becomes used in a single place (at the top of the
  build); using an empty line works just as well.
- Then print_message and print_line becomes no longer used and can be
  deleted.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
