### PR TITLE
colorbar(label=None) should give an empty label

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -724,7 +724,7 @@ class ColorbarBase(_ColorbarMappableDummy):
 
     def set_label(self, label, **kw):
         """Label the long axis of the colorbar."""
-        self._label = str(label)
+        self._label = label
         self._labelkw = kw
         self._set_label()
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -559,3 +559,24 @@ def test_mappable_no_alpha():
     fig.colorbar(sm)
     sm.set_cmap('plasma')
     plt.draw()
+
+
+def test_colorbar_label():
+    """
+    Test the label parameter. It should just be mapped to the xlabel/ylabel of
+    the axes, depending on the orientation.
+    """
+    fig, ax = plt.subplots()
+    im = ax.imshow([[1, 2], [3, 4]])
+    cbar = fig.colorbar(im, label='cbar')
+    assert cbar.ax.get_ylabel() == 'cbar'
+    cbar.set_label(None)
+    assert cbar.ax.get_ylabel() == ''
+    cbar.set_label('cbar 2')
+    assert cbar.ax.get_ylabel() == 'cbar 2'
+
+    cbar2 = fig.colorbar(im, label=None)
+    assert cbar2.ax.get_ylabel() == ''
+
+    cbar3 = fig.colorbar(im, orientation='horizontal', label='horizontal cbar')
+    assert cbar3.ax.get_xlabel() == 'horizontal cbar'


### PR DESCRIPTION
## PR Summary

Fixes #14563.

Instead of coercing *None* to '' directly as in #10392, I'm just passing it on unchanged to the respective axis label and let it handle it. This way, colorbar will behave the same also in case we the axes label implementation will change in the future.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant