### PR TITLE
Fix a typo in pyplot tutorial

### DIFF
--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -425,7 +425,7 @@ from matplotlib.ticker import NullFormatter  # useful for `logit` scale
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-# make up some data in the interval ]0, 1[
+# make up some data in the open interval (0, 1)
 y = np.random.normal(loc=0.5, scale=0.4, size=1000)
 y = y[(y > 0) & (y < 1)]
 y.sort()


### PR DESCRIPTION
## PR Summary

This PR changed a comment line in pyplot tutorial:

`interval ]0, 1[` --> `open interval (0, 1)`