### PR TITLE
Update IPython's doc link in Image tutorial

### DIFF
--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -12,7 +12,8 @@ Startup commands
 
 First, let's start IPython.  It is a most excellent enhancement to the
 standard Python prompt, and it ties in especially well with
-Matplotlib.  Start IPython either at a shell, or the IPython Notebook now.
+Matplotlib.  Start IPython either directly at a shell, or with the Jupyter
+Notebook (where IPython as a running kernel).
 
 With IPython started, we now need to connect to a GUI event loop.  This
 tells IPython where (and how) to display plots.  To connect to a GUI
@@ -21,7 +22,7 @@ detail on exactly what this does at `IPython's documentation on GUI
 event loops
 <https://ipython.readthedocs.io/en/stable/interactive/reference.html#gui-event-loop-support>`_.
 
-If you're using IPython Notebook, the same commands are available, but
+If you're using Jupyter Notebook, the same commands are available, but
 people commonly use a specific argument to the %matplotlib magic:
 
 .. sourcecode:: ipython
@@ -157,7 +158,7 @@ imgplot.set_cmap('nipy_spectral')
 #
 # .. note::
 #
-#    However, remember that in the IPython notebook with the inline backend,
+#    However, remember that in the Jupyter Notebook with the inline backend,
 #    you can't make changes to plots that have already been rendered.  If you
 #    create imgplot here in one cell, you cannot call set_cmap() on it in a later
 #    cell and expect the earlier plot to change.  Make sure that you enter these
@@ -208,7 +209,7 @@ plt.hist(lum_img.ravel(), bins=256, range=(0.0, 1.0), fc='k', ec='k')
 # imshow.  You could also do this by calling the
 # :meth:`~matplotlib.image.Image.set_clim` method of the image plot
 # object, but make sure that you do so in the same cell as your plot
-# command when working with the IPython Notebook - it will not change
+# command when working with the Jupyter Notebook - it will not change
 # plots from earlier cells.
 #
 # You can specify the clim in the call to ``plot``.

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -19,7 +19,7 @@ tells IPython where (and how) to display plots.  To connect to a GUI
 loop, execute the **%matplotlib** magic at your IPython prompt.  There's more
 detail on exactly what this does at `IPython's documentation on GUI
 event loops
-<http://ipython.org/ipython-doc/2/interactive/reference.html#gui-event-loop-support>`_.
+<https://ipython.readthedocs.io/en/stable/interactive/reference.html#gui-event-loop-support>`_.
 
 If you're using IPython Notebook, the same commands are available, but
 people commonly use a specific argument to the %matplotlib magic:


### PR DESCRIPTION
## PR Summary

This PR makes two changes:

- Commit 20c3061: Current Image tutorials has an old link for _IPython's documentation on GUI event loops_, this PR updates it to the latest one.
- Commit 5f8643c: Change outdated references from **IPython Notebook** to **Jupyter Notebook**.
