### PR TITLE
Move most of pytest's conf to conftest.py.

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -5,6 +5,21 @@ from matplotlib import cbook
 
 
 def pytest_configure(config):
+    # config is initialized here rather than in pytest.ini so that `pytest
+    # --pyargs matplotlib` (which would not find pytest.ini) works.  The only
+    # entries in pytest.ini set minversion (which is checked earlier) and
+    # testpaths/python_files, as they are required to properly find the tests.
+    for key, value in [
+        ("markers", "flaky: (Provided by pytest-rerunfailures.)"),
+        ("markers", "timeout: (Provided by pytest-timeout.)"),
+        ("markers", "backend: Set alternate Matplotlib backend temporarily."),
+        ("markers", "style: Set alternate Matplotlib style temporarily."),
+        ("markers", "baseline_images: Compare output against references."),
+        ("markers", "pytz: Tests that require pytz to be installed."),
+        ("filterwarnings", "error"),
+    ]:
+        config.addinivalue_line(key, value)
+
     matplotlib.use('agg', force=True)
     matplotlib._called_from_pytest = True
     matplotlib._init_tests()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,16 +1,6 @@
+# Additional configuration is in matplotlib/testing/conftest.py.
 [pytest]
 minversion = 3.6
 
 testpaths = lib
 python_files = test_*.py
-
-markers =
-    flaky: (Provided by pytest-rerunfailures.)
-    timeout: (Provided by pytest-timeout.)
-    backend: Set alternate Matplotlib backend temporarily.
-    style: Set alternate Matplotlib style temporarily.
-    baseline_images: Compare output against a known reference.
-    pytz: Tests that require pytz to be installed.
-
-filterwarnings =
-    error


### PR DESCRIPTION
pytest.ini is not found if running the test suite from anywhere but
a source checkout root.  For example, it is not found if running
`matplotlib.test()` from an installed Matplotlib (that includes test
data). mplcairo's test suite also relies on being able to run the
Matplotlib test suite from not-the-source-tree (via `pytest --pyargs
matplotlib`).

This is particularly problematic now that pytest requires markers to be
explicitly declared, and emits a warning when they are not.

Instead, declare most relevant options in pytest_configure().  (Note
that this actually only helps mplcairo when used in conjunction of
pytest>=5.0 due to https://github.com/pytest-dev/pytest/issues/5078, but the patch doesn't bump the
pytest version requirement for matplotlib.)

See also https://github.com/pytest-dev/pytest/issues/4039.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
