### PR TITLE
More shortening of setup.py prints.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,10 +49,8 @@ import versioneer
 __version__ = versioneer.get_version()
 
 
-# These are the packages in the order we want to display them.  This
-# list may contain strings to create section headers for the display.
+# These are the packages in the order we want to display them.
 mpl_packages = [
-    'Building Matplotlib',
     setupext.Matplotlib(),
     setupext.Python(),
     setupext.Platform(),
@@ -67,10 +65,8 @@ mpl_packages = [
     setupext.Contour(),
     setupext.QhullWrap(),
     setupext.Tri(),
-    'Optional subpackages',
     setupext.SampleData(),
     setupext.Tests(),
-    'Optional backend extensions',
     setupext.BackendAgg(),
     setupext.BackendTkAgg(),
     setupext.BackendMacOSX(),
@@ -178,29 +174,23 @@ if __name__ == '__main__':
         print_raw()
         print_raw("Edit setup.cfg to change the build options; "
                   "suppress output with --quiet.")
+        print_raw()
+        print_raw("BUILDING MATPLOTLIB")
 
         good_packages = []
         for package in mpl_packages:
-            if isinstance(package, str):
-                print_raw('')
-                print_raw(package.upper())
+            try:
+                result = package.check()
+                if result is not None:
+                    print_status(package.name, 'yes [%s]' % result)
+            except setupext.CheckFailed as e:
+                print_status(package.name, 'no  [%s]' % str(e))
+                if not package.optional:
+                    sys.exit("Failed to build %s" % package.name)
             else:
-                try:
-                    result = package.check()
-                    if result is not None:
-                        message = 'yes [%s]' % result
-                        print_status(package.name, message)
-                except setupext.CheckFailed as e:
-                    msg = str(e).strip()
-                    if len(msg):
-                        print_status(package.name, 'no  [%s]' % msg)
-                    else:
-                        print_status(package.name, 'no')
-                    if not package.optional:
-                        sys.exit("Failed to build %s" % package.name)
-                else:
-                    good_packages.append(package)
-        print_raw('')
+                good_packages.append(package)
+
+        print_raw()
 
         # Now collect all of the information we need to build all of the
         # packages.


### PR DESCRIPTION
We don't really need to support "sections" in the packages list.
This PR makes the output go from
```
BUILDING MATPLOTLIB
  matplotlib: yes [3.1.0+1287.g04d9d28b8]
      python: yes [3.7.3 (default, Jun 24 2019, 04:54:02)  [GCC 9.1.0]]
    platform: yes [linux]

OPTIONAL SUBPACKAGES
 sample_data: yes [installing]
       tests: no  [skipping due to configuration]

OPTIONAL BACKEND EXTENSIONS
         agg: yes [installing]
       tkagg: yes [installing; run-time loading from Python Tcl/Tk]
      macosx: no  [Mac OS-X only]
```
to
```
BUILDING MATPLOTLIB
  matplotlib: yes [3.1.0+1287.g04d9d28b8.dirty]
      python: yes [3.7.3 (default, Jun 24 2019, 04:54:02)  [GCC 9.1.0]]
    platform: yes [linux]
 sample_data: yes [installing]
       tests: no  [skipping due to configuration]
         agg: yes [installing]
       tkagg: yes [installing; run-time loading from Python Tcl/Tk]
      macosx: no  [Mac OS-X only]
```
(and note that the "agg" and "tkagg" entries are being removed by a
separate PR (#13075), as they're not configurable anyways...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
