### PR TITLE
Don't misclip axis when calling set_ticks on inverted axes.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1906,7 +1906,7 @@ def _make_getset_interval(method_name, lim_name, attr_name):
                 setter(self, min(vmin, vmax, oldmin), max(vmin, vmax, oldmax),
                        ignore=True)
             else:
-                setter(self, max(vmin, vmax, oldmax), min(vmin, vmax, oldmin),
+                setter(self, max(vmin, vmax, oldmin), min(vmin, vmax, oldmax),
                        ignore=True)
         self.stale = True
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6432,3 +6432,10 @@ def test_bar_errbar_zorder():
             assert capline.zorder > bar.zorder
         for barlinecol in barlinecols:
             assert barlinecol.zorder > bar.zorder
+
+
+def test_set_ticks_inverted():
+    fig, ax = plt.subplots()
+    ax.invert_xaxis()
+    ax.set_xticks([.3, .7])
+    assert ax.get_xlim() == (1, 0)


### PR DESCRIPTION
due to a small inversion in 0e41317 (compare https://github.com/matplotlib/matplotlib/pull/14579/files#diff-52127080e2783464f529df684d82d476L2145 and https://github.com/matplotlib/matplotlib/pull/14579/files#diff-52127080e2783464f529df684d82d476R1908)...

Closes https://github.com/matplotlib/matplotlib/issues/14675.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
