### PR TITLE
Further simplify colormap reversal.

### DIFF
--- a/doc/api/next_api_changes/2019-07-03-AL.rst
+++ b/doc/api/next_api_changes/2019-07-03-AL.rst
@@ -1,0 +1,7 @@
+Deprecations
+````````````
+
+``cm.revcmap`` is deprecated.  Use `.Colormap.reversed` to reverse a colormap.
+
+``cm.datad`` no longer contains entries for reversed colormaps in their
+"unconverted" form.


### PR DESCRIPTION
Instead of implementing reversal of colormaps in the various formats
in `_cm` and `_cm_listed`, we can just rely on Colormap.reversed() to do
the job...

`revcmap` was a public helper to a private function
(`_reverse_cmap_spec`) so I'm not too worried with deprecating it.  The
private `_reverser` gets deprecated rather than deleted because
`revcmap` depends on it.

The `cmapname` toplevel variable used to leak out of the loop; I deleted
it without deprecation or notice and moved cmap generation to a private
function to avoid such leakage.

The `datad` global now no longer contains "unconverted" entries for
reversed cmaps (as not generating them is the whole point of the PR...);
I'm not even sure it's worth an API note...

Followup to #14674 (when I wrote #14674 I didn't realize this could be made much simpler).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
