### PR TITLE
Format parameters in descriptions with emph instead of backticks

### DIFF
--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -11,7 +11,7 @@ Inset Locator Demo
 # height and optionally a location (loc) that accepts locations as codes,
 # similar to `~matplotlib.axes.Axes.legend`.
 # By default, the inset is offset by some points from the axes,
-# controlled via the `borderpad` parameter.
+# controlled via the *borderpad* parameter.
 
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
@@ -44,11 +44,11 @@ plt.show()
 
 
 ###############################################################################
-# The arguments `bbox_to_anchor` and `bbox_transfrom` can be used for a more
+# The arguments *bbox_to_anchor* and *bbox_transfrom* can be used for a more
 # fine grained control over the inset position and size or even to position
 # the inset at completely arbitrary positions.
-# The `bbox_to_anchor` sets the bounding box in coordinates according to the
-# `bbox_transform`.
+# The *bbox_to_anchor* sets the bounding box in coordinates according to the
+# *bbox_transform*.
 #
 
 fig = plt.figure(figsize=[5.5, 2.8])

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -40,7 +40,7 @@ import matplotlib.transforms as transforms
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):
     """
-    Create a plot of the covariance confidence ellipse of `x` and `y`
+    Create a plot of the covariance confidence ellipse of *x* and *y*.
 
     Parameters
     ----------

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -515,7 +515,7 @@ def layoutcolorbarsingle(ax, cax, shrink, aspect, location, pad=0.05):
     """
     Do the layout for a colorbar, to not overly pollute colorbar.py
 
-    `pad` is in fraction of the original axis size.
+    *pad* is in fraction of the original axis size.
     """
     axlb = ax._layoutbox
     axpos = ax._poslayoutbox
@@ -604,7 +604,7 @@ def layoutcolorbargridspec(parents, cax, shrink, aspect, location, pad=0.05):
     """
     Do the layout for a colorbar, to not overly pollute colorbar.py
 
-    `pad` is in fraction of the original axis size.
+    *pad* is in fraction of the original axis size.
     """
 
     gs = parents[0].get_subplotspec().get_gridspec()

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -319,10 +319,10 @@ class LayoutBox:
         sol.suggestValue(self.width, width)
 
     def constrain_width(self, width, strength='strong'):
-        '''
-        Constrain the width of the layout box.  `width` is
+        """
+        Constrain the width of the layout box.  *width* is
         either a float or a layoutbox.width.
-        '''
+        """
         c = (self.width == width)
         self.solver.addConstraint(c | strength)
 
@@ -471,7 +471,7 @@ class LayoutBox:
 def hstack(boxes, padding=0, strength='strong'):
     '''
     Stack LayoutBox instances from left to right.
-    `padding` is in figure-relative units.
+    *padding* is in figure-relative units.
     '''
 
     for i in range(1, len(boxes)):

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -681,7 +681,7 @@ class Artist:
         if self.figure is fig:
             return
         # if we currently have a figure (the case of both `self.figure`
-        # and `fig` being none is taken care of above) we then user is
+        # and *fig* being none is taken care of above) we then user is
         # trying to change the figure an artist is associated with which
         # is not allowed for the same reason as adding the same instance
         # to more than one Axes
@@ -1518,7 +1518,7 @@ def setp(obj, *args, **kwargs):
           ... long output listing omitted
 
     You may specify another output file to `setp` if `sys.stdout` is not
-    acceptable for some reason using the `file` keyword-only argument::
+    acceptable for some reason using the *file* keyword-only argument::
 
       >>> with fopen('output.log') as f:
       >>>     setp(line, file=f)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -160,7 +160,7 @@ class Axes(_AxesBase):
 
         fontdict : dict
             A dictionary controlling the appearance of the title text,
-            the default `fontdict` is::
+            the default *fontdict* is::
 
                {'fontsize': rcParams['axes.titlesize'],
                 'fontweight' : rcParams['axes.titleweight'],
@@ -723,7 +723,7 @@ class Axes(_AxesBase):
             ...      verticalalignment='center', transform=ax.transAxes)
 
         You can put a rectangular box around the text instance (e.g., to
-        set a background color) by using the keyword `bbox`.  `bbox` is
+        set a background color) by using the keyword *bbox*.  *bbox* is
         a dictionary of `~matplotlib.patches.Rectangle`
         properties.  For example::
 
@@ -967,8 +967,8 @@ class Axes(_AxesBase):
         """
         Add a vertical span (rectangle) across the axes.
 
-        Draw a vertical span (rectangle) from `xmin` to `xmax`.  With
-        the default values of `ymin` = 0 and `ymax` = 1. This always
+        Draw a vertical span (rectangle) from *xmin* to *xmax*.  With
+        the default values of *ymin* = 0 and *ymax* = 1. This always
         spans the yrange, regardless of the ylim settings, even if you
         change them, e.g., with the :meth:`set_ylim` command.  That is,
         the vertical extent is in axes coords: 0=bottom, 0.5=middle,
@@ -3680,7 +3680,7 @@ class Axes(_AxesBase):
         # if non-default sym value, put it into the flier dictionary
         # the logic for providing the default symbol ('b+') now lives
         # in bxp in the initial value of final_flierprops
-        # handle all of the `sym` related logic here so we only have to pass
+        # handle all of the *sym* related logic here so we only have to pass
         # on the flierprops dict.
         if sym is not None:
             # no-flier case, which should really be done with
@@ -6351,12 +6351,12 @@ optional.
             If an integer is given, ``bins + 1`` bin edges are calculated and
             returned, consistent with `numpy.histogram`.
 
-            If `bins` is a sequence, gives bin edges, including left edge of
-            first bin and right edge of last bin.  In this case, `bins` is
+            If *bins* is a sequence, gives bin edges, including left edge of
+            first bin and right edge of last bin.  In this case, *bins* is
             returned unmodified.
 
             All but the last (righthand-most) bin is half-open.  In other
-            words, if `bins` is::
+            words, if *bins* is::
 
                 [1, 2, 3, 4]
 
@@ -7911,7 +7911,7 @@ optional.
                showmeans=False, showextrema=True, showmedians=False):
         """Drawing function for violin plots.
 
-        Draw a violin plot for each column of `vpstats`. Each filled area
+        Draw a violin plot for each column of *vpstats*. Each filled area
         extends to represent the entire data range, with optional lines at the
         mean, the median, the minimum, the maximum, and the quantiles values.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3387,7 +3387,7 @@ class _AxesBase(martist.Artist):
            else return the major ticklabels.
 
         which : None, ('minor', 'major', 'both')
-           Overrides `minor`.
+           Overrides *minor*.
 
            Selects which ticklabels to return
 
@@ -3411,7 +3411,7 @@ class _AxesBase(martist.Artist):
 
         fontdict : dict, optional
             A dictionary controlling the appearance of the ticklabels.
-            The default `fontdict` is::
+            The default *fontdict* is::
 
                {'fontsize': rcParams['axes.titlesize'],
                 'fontweight': rcParams['axes.titleweight'],
@@ -3770,7 +3770,7 @@ class _AxesBase(martist.Artist):
            else return the major ticklabels
 
         which : None, ('minor', 'major', 'both')
-           Overrides `minor`.
+           Overrides *minor*.
 
            Selects which ticklabels to return
 
@@ -3794,7 +3794,7 @@ class _AxesBase(martist.Artist):
 
         fontdict : dict, optional
             A dictionary controlling the appearance of the ticklabels.
-            The default `fontdict` is::
+            The default *fontdict* is::
 
                {'fontsize': rcParams['axes.titlesize'],
                 'fontweight': rcParams['axes.titleweight'],

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1295,7 +1295,7 @@ class Axis(martist.Artist):
            else return the major ticklabels
 
         which : None, ('minor', 'major', 'both')
-           Overrides `minor`.
+           Overrides *minor*.
 
            Selects which ticklabels to return
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -481,9 +481,9 @@ class RendererBase:
             form of a :class:`~matplotlib.transforms.Affine2DBase` instance.
             The translation vector of the transformation is given in physical
             units (i.e., dots or pixels). Note that the transformation does not
-            override `x` and `y`, and has to be applied *before* translating
-            the result by `x` and `y` (this can be accomplished by adding `x`
-            and `y` to the translation vector defined by `transform`).
+            override *x* and *y*, and has to be applied *before* translating
+            the result by *x* and *y* (this can be accomplished by adding *x*
+            and *y* to the translation vector defined by *transform*).
         """
         raise NotImplementedError
 
@@ -1000,10 +1000,10 @@ class GraphicsContextBase:
 
             A 3-tuple with the following elements:
 
-            * `scale`: The amplitude of the wiggle perpendicular to the
+            * ``scale``: The amplitude of the wiggle perpendicular to the
               source line.
-            * `length`: The length of the wiggle along the line.
-            * `randomness`: The scale factor by which the length is
+            * ``length``: The length of the wiggle along the line.
+            * ``randomness``: The scale factor by which the length is
               shrunken or expanded.
 
             May return `None` if no sketch parameters were set.

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -75,7 +75,7 @@ class ToolBase:
     Filename of the image
 
     **String**: Filename of the image to use in the toolbar. If None, the
-    `name` is used as a label in the toolbar button
+    *name* is used as a label in the toolbar button
     """
 
     def __init__(self, toolmanager, name):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -1075,7 +1075,7 @@ class PdfPages:
     def close(self):
         """
         Finalize this object, running LaTeX in a temporary directory
-        and moving the final pdf file to `filename`.
+        and moving the final pdf file to *filename*.
         """
         self._file.write(rb'\end{document}\n')
         self._file.close()

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -78,9 +78,9 @@ def figure_edit(axes, parent=None):
     def prepare_data(d, init):
         """Prepare entry for FormLayout.
 
-        `d` is a mapping of shorthands to style names (a single style may
+        *d* is a mapping of shorthands to style names (a single style may
         have multiple shorthands, in particular the shorthands `None`,
-        `"None"`, `"none"` and `""` are synonyms); `init` is one shorthand
+        `"None"`, `"none"` and `""` are synonyms); *init* is one shorthand
         of the initial style.
 
         This function returns an list suitable for initializing a

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1083,7 +1083,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
 
     labels : array-like, optional
         Labels for each dataset. Length must be compatible with
-        dimensions of `X`.
+        dimensions of *X*.
 
     autorange : bool, optional (False)
         When `True` and the data are distributed such that the 25th and 75th
@@ -1478,7 +1478,7 @@ def pts_to_prestep(x, *args):
     >>> x_s, y1_s, y2_s = pts_to_prestep(x, y1, y2)
     """
     steps = np.zeros((1 + len(args), max(2 * len(x) - 1, 0)))
-    # In all `pts_to_*step` functions, only assign *once* using `x` and `args`,
+    # In all `pts_to_*step` functions, only assign once using *x* and *args*,
     # as converting to an array may be expensive.
     steps[0, 0::2] = x
     steps[0, 1::2] = steps[0, 0:-2:2]

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -291,7 +291,7 @@ def _from_ordinalf(x, tz=None):
                          'expects datetime objects.'.format(ix))
     dt = datetime.datetime.fromordinal(ix).replace(tzinfo=UTC)
 
-    # Since the input date `x` float is unable to preserve microsecond
+    # Since the input date *x* float is unable to preserve microsecond
     # precision of time representation in non-antique years, the
     # resulting datetime is rounded to the nearest multiple of
     # `musec_prec`. A value of 20 is appropriate for current dates.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -185,7 +185,7 @@ fontsize : int or float or {'xx-small', 'x-small', 'small', 'medium', \
     Controls the font size of the legend. If the value is numeric the
     size will be the absolute font size in points. String values are
     relative to the current default font size. This argument is only
-    used if `prop` is not specified.
+    used if *prop* is not specified.
 
 numpoints : None or int
     The number of marker points in the legend when creating a legend
@@ -254,7 +254,7 @@ edgecolor : None or "inherit" or color
     :rc:`axes.edgecolor`.
 
 mode : {"expand", None}
-    If `mode` is set to ``"expand"`` the legend will be horizontally
+    If *mode* is set to ``"expand"`` the legend will be horizontally
     expanded to fill the axes area (or `bbox_to_anchor` if defines
     the legend's size).
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1427,11 +1427,11 @@ class GaussianKDE:
         the covariance matrix is multiplied.
 
     covariance : ndarray
-        The covariance matrix of `dataset`, scaled by the calculated bandwidth
+        The covariance matrix of *dataset*, scaled by the calculated bandwidth
         (`kde.factor`).
 
     inv_cov : ndarray
-        The inverse of `covariance`.
+        The inverse of *covariance*.
 
     Methods
     -------

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -460,7 +460,7 @@ class Path:
         if transform is not None:
             transform = transform.frozen()
         # `point_in_path` does not handle nonlinear transforms, so we
-        # transform the path ourselves.  If `transform` is affine, letting
+        # transform the path ourselves.  If *transform* is affine, letting
         # `point_in_path` handle the transform avoids allocating an extra
         # buffer.
         if transform and not transform.is_affine:

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -292,7 +292,7 @@ class SimpleLineShadow(AbstractPathEffect):
         shadow_color : color
             The shadow color. Default is black.
             A value of ``None`` takes the original artist's color
-            with a scale factor of `rho`.
+            with a scale factor of *rho*.
         alpha : float
             The alpha transparency of the created shadow patch.
             Default is 0.3.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -445,7 +445,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
         it active, and returns a reference to it. If this figure does not
         exists, create it and returns it.
         If num is a string, the window title will be set to this figure's
-        `num`.
+        *num*.
 
     figsize : (float, float), optional, default: None
         width, height in inches. If not provided, defaults to

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -71,7 +71,7 @@ The ``plot`` directive supports the following options:
         inserted.  This is usually useful with the ``:context:`` option.
 
 Additionally, this directive supports all of the options of the `image`
-directive, except for `target` (since plot will add its own target).  These
+directive, except for *target* (since plot will add its own target).  These
 include `alt`, `height`, `width`, `scale`, `align` and `class`.
 
 Configuration options

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -352,7 +352,7 @@ class Grid:
     def within_grid(self, xi, yi):
         """Return True if point is a valid index of grid."""
         # Note that xi/yi can be floats; so, for example, we can't simply check
-        # `xi < self.nx` since `xi` can be `self.nx - 1 < xi < self.nx`
+        # `xi < self.nx` since *xi* can be `self.nx - 1 < xi < self.nx`
         return xi >= 0 and xi <= self.nx - 1 and yi >= 0 and yi <= self.ny - 1
 
 

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -24,8 +24,7 @@ __all__ = ['compare_images', 'comparable_formats']
 
 def make_test_filename(fname, purpose):
     """
-    Make a new filename by inserting `purpose` before the file's
-    extension.
+    Make a new filename by inserting *purpose* before the file's extension.
     """
     base, ext = os.path.splitext(fname)
     return '%s-%s%s' % (base, purpose, ext)

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -56,7 +56,7 @@ def cleanup(style=None):
         The name of the style to apply.
     """
 
-    # If cleanup is used without arguments, `style` will be a callable, and we
+    # If cleanup is used without arguments, *style* will be a callable, and we
     # pass it directly to the wrapper generator.  If cleanup if called with an
     # argument, it is a string naming a style, and the function will be passed
     # as an argument to what we return.  This is a confusing, but somewhat

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -238,7 +238,7 @@ def test_setp():
     martist.setp(chain(lines1, lines2), 'lw', 5)
     plt.setp(ax.spines.values(), color='green')
 
-    # Check `file` argument
+    # Check *file* argument
     sio = io.StringIO()
     plt.setp(lines1, 'zorder', file=sio)
     assert sio.getvalue() == '  zorder: float\n'

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1663,11 +1663,11 @@ class OffsetFrom:
             The object to compute the offset from.
 
         ref_coord : length 2 sequence
-            If `artist` is an `Artist` or `BboxBase`, this values is
+            If *artist* is an `Artist` or `BboxBase`, this values is
             the location to of the offset origin in fractions of the
-            `artist` bounding box.
+            *artist* bounding box.
 
-            If `artist` is a transform, the offset origin is the
+            If *artist* is a transform, the offset origin is the
             transform applied to this value.
 
         unit : {'points, 'pixels'}

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -316,7 +316,7 @@ class IndexFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick value `x` at position pos.
+        Return the format for tick value *x* at position pos.
 
         The position is ignored and the value is rounded to the nearest
         integer, which is used to look up the label.
@@ -355,8 +355,8 @@ class FixedFormatter(Formatter):
         Returns the label that matches the position regardless of the
         value.
 
-        For positions ``pos < len(seq)``, return `seq[i]` regardless of
-        `x`. Otherwise return empty string. `seq` is the sequence of
+        For positions ``pos < len(seq)``, return ``seq[i]`` regardless of
+        *x*. Otherwise return empty string. ``seq`` is the sequence of
         strings that this object was initialized with.
         """
         if pos is None or pos >= len(self.seq):
@@ -386,7 +386,7 @@ class FuncFormatter(Formatter):
         """
         Return the value of the user defined function.
 
-        `x` and `pos` are passed through as-is.
+        *x* and *pos* are passed through as-is.
         """
         return self.func(x, pos)
 
@@ -405,7 +405,7 @@ class FormatStrFormatter(Formatter):
         """
         Return the formatted label string.
 
-        Only the value `x` is formatted. The position is ignored.
+        Only the value *x* is formatted. The position is ignored.
         """
         return self.fmt % x
 
@@ -415,8 +415,8 @@ class StrMethodFormatter(Formatter):
     Use a new-style format string (as used by `str.format()`)
     to format the tick.
 
-    The field used for the value must be labeled `x` and the field used
-    for the position must be labeled `pos`.
+    The field used for the value must be labeled *x* and the field used
+    for the position must be labeled *pos*.
     """
     def __init__(self, fmt):
         self.fmt = fmt
@@ -425,7 +425,7 @@ class StrMethodFormatter(Formatter):
         """
         Return the formatted label string.
 
-        `x` and `pos` are passed to `str.format` as keyword arguments
+        *x* and *pos* are passed to `str.format` as keyword arguments
         with those exact names.
         """
         return self.fmt.format(x=x, pos=pos)
@@ -438,9 +438,9 @@ class OldScalarFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick val `x` based on the width of the axis.
+        Return the format for tick val *x* based on the width of the axis.
 
-        The position `pos` is ignored.
+        The position *pos* is ignored.
         """
         xmin, xmax = self.axis.get_view_interval()
         # If the number is not too big and it's an int, format it as an int.
@@ -466,7 +466,7 @@ class OldScalarFormatter(Formatter):
     @cbook.deprecated("3.1")
     def pprint_val(self, x, d):
         """
-        Formats the value `x` based on the size of the axis range `d`.
+        Formats the value *x* based on the size of the axis range *d*.
         """
         # If the number is not too big and it's an int, format it as an int.
         if abs(x) < 1e4 and x == int(x):
@@ -575,7 +575,7 @@ class ScalarFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick value `x` at position `pos`.
+        Return the format for tick value *x* at position *pos*.
         """
         if len(self.locs) == 0:
             return ''
@@ -1359,7 +1359,7 @@ class PercentFormatter(Formatter):
         *xmax* is the data value that corresponds to 100%.
         Percentages are computed as ``x / xmax * 100``. So if the data is
         already scaled to be percentages, *xmax* will be 100. Another common
-        situation is where `xmax` is 1.0.
+        situation is where *xmax* is 1.0.
 
     decimals : None or int
         The number of decimal places to place after the point.

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -28,7 +28,7 @@ class Triangulation:
         Masked out triangles.
     is_delaunay : bool
         Whether the Triangulation is a calculated Delaunay
-        triangulation (where `triangles` was not specified) or not.
+        triangulation (where *triangles* was not specified) or not.
 
     Notes
     -----

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -132,7 +132,7 @@ class TriInterpolator:
         :meth:`_interpolate_single_key`.)
 
         It is guaranteed that the calls to :meth:`_interpolate_single_key`
-        will be done with flattened (1-d) array_like input parameters `x`, `y`
+        will be done with flattened (1-d) array_like input parameters *x*, *y*
         and with flattened, valid `tri_index` arrays (no -1 index allowed).
 
         Parameters
@@ -319,7 +319,7 @@ class CubicTriInterpolator(TriInterpolator):
             - if 'geom': The derivatives at each node is computed as a
               weighted average of relevant triangle normals. To be used for
               speed optimization (large grids).
-            - if 'user': The user provides the argument `dz`, no computation
+            - if 'user': The user provides the argument *dz*, no computation
               is hence needed.
 
     trifinder : :class:`~matplotlib.tri.TriFinder` object, optional
@@ -1137,7 +1137,7 @@ class _DOF_estimator_geom(_DOF_estimator):
             # modulo 1. is safer regarding round-off errors (flat triangles).
             angle = np.abs(((alpha2-alpha1) / np.pi) % 1)
             # Weight proportional to angle up np.pi/2; null weight for
-            # degenerated cases 0 and np.pi (note that `angle` is normalized
+            # degenerated cases 0 and np.pi (note that *angle* is normalized
             # by np.pi).
             weights[:, ipt] = 0.5 - np.abs(angle-0.5)
         return weights


### PR DESCRIPTION
## PR Summary

This applies our own style requirements to existing code.
https://matplotlib.org/devdocs/devel/documenting_mpl.html#function-arguments