### PR TITLE
Confluence builder in plot directive

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -792,7 +792,6 @@ def run(arguments, content, options, state_machine, state, lineno):
         only_texinfo = ".. only:: texinfo"
         only_confluence = ".. only:: confluence"
 
-
         # Not-None src_link signals the need for a source link in the generated
         # html
         if j == 0 and config.plot_html_show_source_link:

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -409,6 +409,16 @@ TEMPLATE = """
    {% endif -%}
    {% endfor %}
 
+{{ only_confluence }}
+
+   {% for img in images %}
+   .. image:: {{ build_dir }}/{{ img.basename }}.png
+      {% for option in options -%}
+      {{ option }}
+      {% endfor %}
+
+   {% endfor %}
+
 """
 
 exception_template = """
@@ -780,6 +790,8 @@ def run(arguments, content, options, state_machine, state, lineno):
         only_html = ".. only:: html"
         only_latex = ".. only:: latex"
         only_texinfo = ".. only:: texinfo"
+        only_confluence = ".. only:: confluence"
+
 
         # Not-None src_link signals the need for a source link in the generated
         # html
@@ -797,6 +809,7 @@ def run(arguments, content, options, state_machine, state, lineno):
             only_html=only_html,
             only_latex=only_latex,
             only_texinfo=only_texinfo,
+            only_confluence=only_confluence,
             options=opts,
             images=images,
             source_code=source_code,


### PR DESCRIPTION
## PR Summary
Added "confluence" as a possible builder in plot_directive.py.
This allows using _matplotlib_ with this sphinx extension: https://github.com/sphinx-contrib/confluencebuilder
The images were already properly generated, the only pending thing was to consider confluence as a builder and then add the images within the template.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
