### PR TITLE
Fix NavigationToolbar2QT height

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -727,14 +727,14 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
     def adj_window(self):
         return None
 
-    if is_pyqt5():
-        # For some reason, self.setMinimumHeight doesn't seem to carry over to
-        # the actual sizeHint, so override it instead in order to make the
-        # aesthetic adjustments noted above.
-        def sizeHint(self):
-            size = super().sizeHint()
+    def sizeHint(self):
+        size = super().sizeHint()
+        if is_pyqt5() and self.canvas._dpi_ratio > 1:
+            # For some reason, self.setMinimumHeight doesn't seem to carry over
+            # to the actual sizeHint, so override it instead in order to make
+            # the aesthetic adjustments noted above.
             size.setHeight(max(48, size.height()))
-            return size
+        return size
 
     def edit_parameters(self):
         axes = self.canvas.figure.get_axes()


### PR DESCRIPTION
## PR Summary

Fixes #10891. See also #14518.

Before:

![grafik](https://user-images.githubusercontent.com/2836374/60688508-e8972700-9eb5-11e9-8069-1ca52d8eb54e.png)

After:
![grafik](https://user-images.githubusercontent.com/2836374/60688473-aff74d80-9eb5-11e9-9359-a280f8325cad.png)

### Note
This and #14518 only change the behavior for non-HiDPI screens.
I'm wondering if the distinction is still necessary. I would assume that Qt should handle this out of the box without manual tuning.
