### PR TITLE
Try to improve the readability and styling of matplotlibrc.template file

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -27,9 +27,37 @@
 ##     - a hex string, such as ff00ff
 ##     - a scalar grayscale intensity such as 0.75
 ##     - a legal html color name, e.g., red, blue, darkslategray
+##
+## Configurations are currently divided into following parts:
+##     - BACKENDS
+##     - LINES
+##     - PATCHES
+##     - HATCHES
+##     - BOXPLOT
+##     - FONT
+##     - TEXT
+##     - LaTeX
+##     - AXES
+##     - DATES
+##     - TICKS
+##     - GRIDS
+##     - LEGEND
+##     - FIGURE
+##     - IMAGES
+##     - CONTOUR PLOTS
+##     - ERRORBAR PLOTS
+##     - HISTOGRAM PLOTS
+##     - SCATTER PLOTS
+##     - AGG RENDERING
+##     - PATHS
+##     - SAVING FIGURES
+##     - INTERACTIVE KEYMAPS
+##     - ANIMATION
 
 ##### CONFIGURATION BEGINS HERE
 
+
+#### BACKENDS
 ## The default backend. If you omit this parameter, the first
 ## working backend from the following list is used:
 ## MacOSX Qt5Agg Qt4Agg Gtk3Agg TkAgg WxAgg Agg
@@ -55,7 +83,7 @@
 ## When True, open the webbrowser to the plot that is shown
 #webagg.open_in_browser : True
 
-## if you are running pyplot inside a GUI and your backend choice
+## If you are running pyplot inside a GUI and your backend choice
 ## conflicts, we will automatically try to find a compatible one for
 ## you if backend_fallback is True
 #backend_fallback: True
@@ -94,6 +122,7 @@
 
 #markers.fillstyle: full ## full|left|right|bottom|top|none
 
+
 #### PATCHES
 ## Patches are graphical objects that fill 2D space, like polygons or circles.
 ## See https://matplotlib.org/api/artist_api.html#module-matplotlib.patches
@@ -104,11 +133,13 @@
 #patch.force_edgecolor  : False   ## True to always use edgecolor
 #patch.antialiased      : True    ## render patches in antialiased (no jaggies)
 
+
 #### HATCHES
 #hatch.color     : black
 #hatch.linewidth : 1.0
 
-#### Boxplot
+
+#### BOXPLOT
 #boxplot.notch       : False
 #boxplot.vertical    : True
 #boxplot.whiskers    : 1.5
@@ -206,11 +237,13 @@
 #font.fantasy        : Comic Sans MS, Chicago, Charcoal, ImpactWestern, Humor Sans, xkcd, fantasy
 #font.monospace      : DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
 
+
 #### TEXT
 ## The text properties used by `text.Text`.
 ## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
 ## for more information on text properties
 #text.color          : black
+
 
 #### LaTeX
 ## See following links for more information on LaTex properties:
@@ -280,6 +313,7 @@
                        ## the special name "regular" for the same font
                        ## used in regular text.
 
+
 #### AXES
 ## Following are default face and edge colors, default tick sizes,
 ## default fontsizes for ticklabels, and so on.  See
@@ -342,6 +376,7 @@
 #polaraxes.grid      : True    ## display grid on polar axes
 #axes3d.grid         : True    ## display grid on 3d axes
 
+
 #### DATES
 ## These control the default format strings used in AutoDateFormatter.
 ## Any valid format datetime format string can be used (see the python
@@ -358,6 +393,7 @@
 #date.autoformatter.minute   : %d %H:%M
 #date.autoformatter.second   : %H:%M:%S
 #date.autoformatter.microsecond   : %M:%S.%f
+
 
 #### TICKS
 ## See https://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
@@ -401,13 +437,15 @@
 #ytick.minor.right    : True   ## draw y axis right minor ticks
 #ytick.alignment      : center_baseline ## alignment of yticks
 
+
 #### GRIDS
 #grid.color       :   b0b0b0    ## grid color
 #grid.linestyle   :   -         ## solid
 #grid.linewidth   :   0.8       ## in points
 #grid.alpha       :   1.0       ## transparency, between 0.0 and 1.0
 
-#### Legend
+
+#### LEGEND
 #legend.loc           : best
 #legend.frameon       : True     ## if True, draw the legend on a background patch
 #legend.framealpha    : 0.8      ## legend patch transparency
@@ -429,6 +467,7 @@
 #legend.handletextpad : 0.8      ## the space between the legend line and legend text
 #legend.borderaxespad : 0.5      ## the border between the axes and legend edge
 #legend.columnspacing : 2.0      ## column separation
+
 
 #### FIGURE
 ## See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
@@ -464,6 +503,7 @@
 #figure.constrained_layout.hspace : 0.02   ## Space between subplot groups. Float representing
 #figure.constrained_layout.wspace : 0.02   ##  a fraction of the subplot widths being separated.
 
+
 #### IMAGES
 #image.aspect : equal             ## equal | auto | a number
 #image.interpolation  : nearest   ## see help(imshow) for options
@@ -476,12 +516,15 @@
                                   ## saving a figure as a vector graphics file,
                                   ## such as a PDF.
 
+
 #### CONTOUR PLOTS
 #contour.negative_linestyle : dashed ## string or on-off ink sequence
 #contour.corner_mask        : True   ## True | False | legacy
 
+
 #### ERRORBAR PLOTS
 #errorbar.capsize : 0             ## length of end cap on error bars in pixels
+
 
 #### HISTOGRAM PLOTS
 #hist.bins : 10                   ## The default number of histogram bins.
@@ -492,8 +535,9 @@
 #scatter.marker : o               ## The default marker type for scatter plots.
 #scatter.edgecolors : face        ## The default edgecolors for scatter plots.
 
-#### Agg rendering
-#### Warning: experimental, 2008/10/10
+
+#### AGG RENDERING
+## Warning: experimental, 2008/10/10
 #agg.path.chunksize : 0           ## 0 to disable; values in the range
                                   ## 10000 to 100000 can improve speed slightly
                                   ## and prevent an Agg rendering failure
@@ -502,6 +546,8 @@
                                   ## It may cause minor artifacts, though.
                                   ## A value of 20000 is probably a good
                                   ## starting point.
+
+
 #### PATHS
 #path.simplify : True   ## When True, simplify paths by removing "invisible"
                         ## points to reduce file size and increase rendering
@@ -521,8 +567,9 @@
                     ## the length is randomly scaled.
 #path.effects : []  ##
 
+
 #### SAVING FIGURES
-## the default savefig params can be different from the display params
+## The default savefig params can be different from the display params
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
 #savefig.dpi         : figure   ## figure dots per inch or 'figure'
@@ -555,14 +602,14 @@
 #ps.distiller.res  : 6000      ## dpi
 #ps.fonttype       : 3         ## Output Type 3 (Type3) or Type 42 (TrueType)
 
-### pdf backend params
+### PDF backend params
 #pdf.compression   : 6   ## integer from 0 to 9
                          ## 0 disables compression (good for debugging)
 #pdf.fonttype       : 3         ## Output Type 3 (Type3) or Type 42 (TrueType)
 #pdf.use14corefonts : False
 #pdf.inheritcolor : False
 
-### svg backend params
+### SVG backend params
 #svg.image_inline : True       ## write raster image data directly into the svg file
 #svg.fonttype :   path         ## How to handle SVG fonts:
    ##     none: Assume fonts are installed on the machine where the SVG will be viewed.
@@ -578,6 +625,8 @@
 ### docstring params
 ##docstring.hardcopy = False  ## set this when you want to generate hardcopy docstring
 
+
+#### INTERACTIVE KEYMAPS
 ## Event keys to interact with figures/plots via keyboard.
 ## See https://matplotlib.org/users/navigation_toolbar.html for more details on
 ## interactive navigation.  Customize these settings according to your needs.
@@ -599,7 +648,8 @@
 #keymap.all_axes : a                 ## enable all axes
 #keymap.copy : ctrl+c, cmd+c         ## Copy figure to clipboard
 
-###ANIMATION settings
+
+#### ANIMATION
 #animation.html :  none            ## How to display the animation as HTML in
                                    ## the IPython notebook. 'html5' uses
                                    ## HTML5 video tag; 'jshtml' creates a

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -1,25 +1,36 @@
 #### MATPLOTLIBRC FORMAT
 
 ## This is a sample matplotlib configuration file - you can find a copy
-## of it on your system in
-## site-packages/matplotlib/mpl-data/matplotlibrc.  If you edit it
-## there, please note that it will be overwritten in your next install.
-## If you want to keep a permanent local copy that will not be
-## overwritten, place it in the following location:
+## of it on your system in site-packages/matplotlib/mpl-data/matplotlibrc
+## (which related to your Python installation location).
+##
+## If you edit it there, please note that it will be overwritten in your
+## next install.  If you want to keep a permanent local copy that will not
+## be overwritten, place it in one of the following locations:
 ## unix/linux:
-##      $HOME/.config/matplotlib/matplotlibrc or
-##      $XDG_CONFIG_HOME/matplotlib/matplotlibrc (if $XDG_CONFIG_HOME is set)
+##     $HOME/.config/matplotlib/matplotlibrc OR
+##     $XDG_CONFIG_HOME/matplotlib/matplotlibrc (if $XDG_CONFIG_HOME is set)
 ## other platforms:
-##      $HOME/.matplotlib/matplotlibrc
+##     $HOME/.matplotlib/matplotlibrc
 ##
-## See https://matplotlib.org/users/customizing.html#the-matplotlibrc-file for
-## more details on the paths which are checked for the configuration file.
+## See https://matplotlib.org/users/customizing.html#the-matplotlibrc-file
+## for more details on the paths which are checked for the configuration file.
 ##
-## This file is best viewed in a editor which supports python mode
-## syntax highlighting. Blank lines, or lines starting with a comment
-## symbol, are ignored, as are trailing comments.  Other lines must
-## have the format
-##     key : val ## optional comment
+## This file is best viewed in a editor which supports python mode syntax
+## highlighting.  Blank lines, or lines starting with a comment symbol, are
+## ignored, as are trailing comments.  Other lines must have the format:
+##     key : val  ## optional comment
+##
+## Formatting and style conventions for this file:
+##     - at least one whitesapce AROUND `:` to seperate key and val
+##         * prefer one whitesapce except for block colon alignment
+##     - at least two whitesapces BEFORE `##` to seperate the key-val pair and
+##       the trailing comments
+##         * prefer two whitesapces except for block `##` alignment
+##     - at least one whitesapce AFTER `##` to seperate the `##` marker and
+##       the comment text
+##         * prefer one whitesapce except for indentation (listing, etc.), in
+##           which case, four more whitespaces are preferred
 ##
 ## Colors: for the color values below, you can either use
 ##     - a matplotlib color string, such as r, k, or b
@@ -28,7 +39,7 @@
 ##     - a scalar grayscale intensity such as 0.75
 ##     - a legal html color name, e.g., red, blue, darkslategray
 ##
-## Configurations are currently divided into following parts:
+## Matplotlib configuration are currently divided into following parts:
 ##     - BACKENDS
 ##     - LINES
 ##     - PATCHES
@@ -57,18 +68,18 @@
 ##### CONFIGURATION BEGINS HERE
 
 
-#### BACKENDS
-## The default backend. If you omit this parameter, the first
-## working backend from the following list is used:
-## MacOSX Qt5Agg Qt4Agg Gtk3Agg TkAgg WxAgg Agg
-##
+## ***************************************************************************
+## * BACKENDS                                                                *
+## ***************************************************************************
+## The default backend.  If you omit this parameter, the first working
+## backend from the following list is used:
+##     MacOSX Qt5Agg Qt4Agg Gtk3Agg TkAgg WxAgg Agg
 ## Other choices include:
-## Qt5Cairo Qt4Cairo GTK3Cairo TkCairo WxCairo Cairo Wx PS PDF SVG Template.
-##
-## You can also deploy your own backend outside of matplotlib by
-## referring to the module name (which must be in the PYTHONPATH) as
-## 'module://my_backend'.
-#backend      : Agg
+##     Qt5Cairo Qt4Cairo GTK3Cairo TkCairo WxCairo Cairo Wx
+##     PS PDF SVG Template
+## You can also deploy your own backend outside of matplotlib by referring to
+## the module name (which must be in the PYTHONPATH) as 'module://my_backend'.
+#backend : Agg
 
 ## The port to use for the web server in the WebAgg backend.
 #webagg.port : 8988
@@ -86,33 +97,35 @@
 ## If you are running pyplot inside a GUI and your backend choice
 ## conflicts, we will automatically try to find a compatible one for
 ## you if backend_fallback is True
-#backend_fallback: True
+#backend_fallback : True
 
-#interactive  : False
-#toolbar      : toolbar2   ## None | toolbar2  ("classic" is deprecated)
-#timezone     : UTC        ## a pytz timezone string, e.g., US/Central or Europe/Paris
+#interactive : False
+#toolbar     : toolbar2  ## None | toolbar2  ("classic" is deprecated)
+#timezone    : UTC       ## a pytz timezone string, e.g., US/Central or Europe/Paris
 
 ## Where your matplotlib data lives if you installed to a non-default
 ## location.  This is where the matplotlib fonts, bitmaps, etc reside
 #datapath : /home/jdhunter/mpldata
 
 
-#### LINES
+## ***************************************************************************
+## * LINES                                                                   *
+## ***************************************************************************
 ## See https://matplotlib.org/api/artist_api.html#module-matplotlib.lines
 ## for more information on line properties.
-#lines.linewidth   : 1.5     ## line width in points
-#lines.linestyle   : -       ## solid line
-#lines.color       : C0      ## has no affect on plot(); see axes.prop_cycle
-#lines.marker      : None    ## the default marker
-#lines.markerfacecolor  : auto    ## the default markerfacecolor
-#lines.markeredgecolor  : auto    ## the default markeredgecolor
-#lines.markeredgewidth  : 1.0     ## the line width around the marker symbol
-#lines.markersize  : 6            ## markersize, in points
-#lines.dash_joinstyle : round        ## miter|round|bevel
-#lines.dash_capstyle : butt          ## butt|round|projecting
-#lines.solid_joinstyle : round       ## miter|round|bevel
-#lines.solid_capstyle : projecting   ## butt|round|projecting
-#lines.antialiased : True         ## render lines in antialiased (no jaggies)
+#lines.linewidth : 1.5  ## line width in points
+#lines.linestyle : -    ## solid line
+#lines.color     : C0   ## has no affect on plot(); see axes.prop_cycle
+#lines.marker          : None  ## the default marker
+#lines.markerfacecolor : auto  ## the default marker face color
+#lines.markeredgecolor : auto  ## the default marker edge color
+#lines.markeredgewidth : 1.0   ## the line width around the marker symbol
+#lines.markersize      : 6     ## marker size, in points
+#lines.dash_joinstyle  : round       ## miter | round | bevel
+#lines.dash_capstyle   : butt        ## butt  | round | projecting
+#lines.solid_joinstyle : round       ## miter | round | bevel
+#lines.solid_capstyle  : projecting  ## butt  | round | projecting
+#lines.antialiased : True  ## render lines in antialiased (no jaggies)
 
 ## The three standard dash patterns.  These are scaled by the linewidth.
 #lines.dashed_pattern : 3.7, 1.6
@@ -120,26 +133,32 @@
 #lines.dotted_pattern : 1, 1.65
 #lines.scale_dashes : True
 
-#markers.fillstyle: full ## full|left|right|bottom|top|none
+#markers.fillstyle : full  ## full|left|right|bottom|top|none
 
 
-#### PATCHES
+## ***************************************************************************
+## * PATCHES                                                                 *
+## ***************************************************************************
 ## Patches are graphical objects that fill 2D space, like polygons or circles.
 ## See https://matplotlib.org/api/artist_api.html#module-matplotlib.patches
 ## for more information on patch properties.
-#patch.linewidth        : 1        ## edge width in points.
-#patch.facecolor        : C0
-#patch.edgecolor        : black   ## if forced, or patch is not filled
-#patch.force_edgecolor  : False   ## True to always use edgecolor
-#patch.antialiased      : True    ## render patches in antialiased (no jaggies)
+#patch.linewidth       : 1      ## edge width in points.
+#patch.facecolor       : C0
+#patch.edgecolor       : black  ## if forced, or patch is not filled
+#patch.force_edgecolor : False  ## True to always use edgecolor
+#patch.antialiased     : True   ## render patches in antialiased (no jaggies)
 
 
-#### HATCHES
+## ***************************************************************************
+## * HATCHES                                                                 *
+## ***************************************************************************
 #hatch.color     : black
 #hatch.linewidth : 1.0
 
 
-#### BOXPLOT
+## ***************************************************************************
+## * BOXPLOT                                                                 *
+## ***************************************************************************
 #boxplot.notch       : False
 #boxplot.vertical    : True
 #boxplot.whiskers    : 1.5
@@ -185,16 +204,21 @@
 #boxplot.meanprops.linewidth       : 1.0
 
 
-#### FONT
+## ***************************************************************************
+## * FONT                                                                    *
+## ***************************************************************************
 ## The font properties used by `text.Text`.
 ## See https://matplotlib.org/api/font_manager_api.html for more information
 ## on font properties.  The 6 font properties used for font matching are
 ## given below with their default values.
 ##
-## The font.family property has five values: 'serif' (e.g., Times),
-## 'sans-serif' (e.g., Helvetica), 'cursive' (e.g., Zapf-Chancery),
-## 'fantasy' (e.g., Western), and 'monospace' (e.g., Courier).  Each of
-## these font families has a default list of font names in decreasing
+## The font.family property has five values:
+##     - 'serif' (e.g., Times),
+##     - 'sans-serif' (e.g., Helvetica),
+##     - 'cursive' (e.g., Zapf-Chancery),
+##     - 'fantasy' (e.g., Western), and
+##     - 'monospace' (e.g., Courier).
+## Each of these font families has a default list of font names in decreasing
 ## order of priority associated with them.  When text.usetex is False,
 ## font.family may also be one or more concrete font names.
 ##
@@ -219,45 +243,51 @@
 ##
 ## The font.size property is the default font size for text, given in pts.
 ## 10 pt is the standard value.
-
-#font.family         : sans-serif
-#font.style          : normal
-#font.variant        : normal
-#font.weight         : normal
-#font.stretch        : normal
-## note that font.size controls default text sizes.  To configure
+##
+## Note that font.size controls default text sizes.  To configure
 ## special text sizes tick labels, axes, labels, title, etc, see the rc
-## settings for axes and ticks. Special text sizes can be defined
+## settings for axes and ticks.  Special text sizes can be defined
 ## relative to font.size, using the following values: xx-small, x-small,
 ## small, medium, large, x-large, xx-large, larger, or smaller
-#font.size           : 10.0
-#font.serif          : DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
-#font.sans-serif     : DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
-#font.cursive        : Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, cursive
-#font.fantasy        : Comic Sans MS, Chicago, Charcoal, ImpactWestern, Humor Sans, xkcd, fantasy
-#font.monospace      : DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+
+#font.family  : sans-serif
+#font.style   : normal
+#font.variant : normal
+#font.weight  : normal
+#font.stretch : normal
+#font.size    : 10.0
+
+#font.serif      : DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
+#font.sans-serif : DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+#font.cursive    : Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, cursive
+#font.fantasy    : Comic Sans MS, Chicago, Charcoal, ImpactWestern, Humor Sans, xkcd, fantasy
+#font.monospace  : DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
 
 
-#### TEXT
+## ***************************************************************************
+## * TEXT                                                                    *
+## ***************************************************************************
 ## The text properties used by `text.Text`.
 ## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
 ## for more information on text properties
-#text.color          : black
+#text.color : black
 
 
-#### LaTeX
+## ***************************************************************************
+## * LaTeX                                                                   *
+## ***************************************************************************
 ## See following links for more information on LaTex properties:
 ## https://matplotlib.org/tutorials/text/usetex.html
 ## https://scipy-cookbook.readthedocs.io/items/idx_matplotlib_typesetting.html
-#text.usetex         : False  ## use latex for all text handling. The following fonts
-                              ## are supported through the usual rc parameter settings:
-                              ## new century schoolbook, bookman, times, palatino,
-                              ## zapf chancery, charter, serif, sans-serif, helvetica,
-                              ## avant garde, courier, monospace, computer modern roman,
-                              ## computer modern sans serif, computer modern typewriter
-                              ## If another font is desired which can loaded using the
-                              ## LaTeX \usepackage command, please inquire at the
-                              ## matplotlib mailing list
+#text.usetex : False  ## use latex for all text handling. The following fonts
+                      ## are supported through the usual rc parameter settings:
+                      ## new century schoolbook, bookman, times, palatino,
+                      ## zapf chancery, charter, serif, sans-serif, helvetica,
+                      ## avant garde, courier, monospace, computer modern roman,
+                      ## computer modern sans serif, computer modern typewriter
+                      ## If another font is desired which can loaded using the
+                      ## LaTeX \usepackage command, please inquire at the
+                      ## matplotlib mailing list
 #text.latex.preamble :      ## IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
                             ## AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
                             ## IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
@@ -275,177 +305,192 @@
                             ## loaded, depending on your font settings.
 #text.latex.preview : False
 
-#text.hinting : auto   ## May be one of the following:
-                       ##   none: Perform no hinting
-                       ##   auto: Use FreeType's autohinter
-                       ##   native: Use the hinting information in the
-                       #              font file, if available, and if your
-                       #              FreeType library supports it
-                       ##   either: Use the native hinting information,
-                       #              or the autohinter if none is available.
-                       ## For backward compatibility, this value may also be
-                       ## True === 'auto' or False === 'none'.
-#text.hinting_factor : 8 ## Specifies the amount of softness for hinting in the
-                         ## horizontal direction.  A value of 1 will hint to full
-                         ## pixels.  A value of 2 will hint to half pixels etc.
-#text.antialiased : True ## If True (default), the text will be antialiased.
-                         ## This only affects the Agg backend.
+#text.hinting : auto  ## May be one of the following:
+                      ##     - none: Perform no hinting
+                      ##     - auto: Use FreeType's autohinter
+                      ##     - native: Use the hinting information in the
+                      ##               font file, if available, and if your
+                      ##               FreeType library supports it
+                      ##     - either: Use the native hinting information,
+                      ##               or the autohinter if none is available.
+                      ## For backward compatibility, this value may also be
+                      ##     True === 'auto' or False === 'none'.
+#text.hinting_factor : 8  ## Specifies the amount of softness for hinting in the
+                          ## horizontal direction.  A value of 1 will hint to full
+                          ## pixels.  A value of 2 will hint to half pixels etc.
+#text.antialiased : True  ## If True (default), the text will be antialiased.
+                          ## This only affects the Agg backend.
 
 ## The following settings allow you to select the fonts in math mode.
 ## They map from a TeX font name to a fontconfig font pattern.
 ## These settings are only used if mathtext.fontset is 'custom'.
-## Note that this "custom" mode is unsupported and may go away in the
-## future.
+## Note that this "custom" mode is unsupported and may go away in the future.
 #mathtext.cal : cursive
 #mathtext.rm  : sans
 #mathtext.tt  : monospace
 #mathtext.it  : sans:italic
 #mathtext.bf  : sans:bold
 #mathtext.sf  : sans
-#mathtext.fontset : dejavusans ## Should be 'dejavusans' (default),
-                               ## 'dejavuserif', 'cm' (Computer Modern), 'stix',
-                               ## 'stixsans' or 'custom'
+#mathtext.fontset : dejavusans  ## Should be 'dejavusans' (default),
+                                ## 'dejavuserif', 'cm' (Computer Modern), 'stix',
+                                ## 'stixsans' or 'custom'
 #mathtext.fallback_to_cm : True  ## When True, use symbols from the Computer Modern
                                  ## fonts when a symbol can not be found in one of
                                  ## the custom math fonts.
-#mathtext.default : it ## The default font to use for math.
-                       ## Can be any of the LaTeX font names, including
-                       ## the special name "regular" for the same font
-                       ## used in regular text.
+#mathtext.default : it  ## The default font to use for math.
+                        ## Can be any of the LaTeX font names, including
+                        ## the special name "regular" for the same font
+                        ## used in regular text.
 
 
-#### AXES
+## ***************************************************************************
+## * AXES                                                                    *
+## ***************************************************************************
 ## Following are default face and edge colors, default tick sizes,
 ## default fontsizes for ticklabels, and so on.  See
 ## https://matplotlib.org/api/axes_api.html#module-matplotlib.axes
-#axes.facecolor      : white   ## axes background color
-#axes.edgecolor      : black   ## axes edge color
-#axes.linewidth      : 0.8     ## edge linewidth
-#axes.grid           : False   ## display grid or not
-#axes.grid.axis      : both    ## which axis the grid should apply to
-#axes.grid.which     : major   ## gridlines at major, minor or both ticks
-#axes.titlelocation  : center  ## alignment of the title,
-                               ## possible values are left, right and center
-#axes.titlesize      : large   ## fontsize of the axes title
-#axes.titleweight    : normal  ## font weight of title
-#axes.titlepad       : 6.0     ## pad between axes and title in points
-#axes.labelsize      : medium  ## fontsize of the x any y labels
-#axes.labelpad       : 4.0     ## space between label and axis
-#axes.labelweight    : normal  ## weight of the x and y labels
-#axes.labelcolor     : black
-#axes.axisbelow      : line    ## draw axis gridlines and ticks below
-                               ## patches (True); above patches but below
-                               ## lines ('line'); or above all (False)
-#axes.formatter.limits : -7, 7 ## use scientific notation if log10
-                               ## of the axis range is smaller than the
-                               ## first or larger than the second
-#axes.formatter.use_locale : False ## When True, format tick labels
-                                   ## according to the user's locale.
-                                   ## For example, use ',' as a decimal
-                                   ## separator in the fr_FR locale.
-#axes.formatter.use_mathtext : False ## When True, use mathtext for scientific
-                                     ## notation.
-#axes.formatter.min_exponent: 0 ## minimum exponent to format in scientific notation
-#axes.formatter.useoffset      : True    ## If True, the tick label formatter
-                                         ## will default to labeling ticks relative
-                                         ## to an offset when the data range is
-                                         ## small compared to the minimum absolute
-                                         ## value of the data.
-#axes.formatter.offset_threshold : 4     ## When useoffset is True, the offset
-                                         ## will be used when it can remove
-                                         ## at least this number of significant
-                                         ## digits from tick labels.
-#axes.spines.left   : True   ## display axis spines
+#axes.facecolor     : white   ## axes background color
+#axes.edgecolor     : black   ## axes edge color
+#axes.linewidth     : 0.8     ## edge linewidth
+#axes.grid          : False   ## display grid or not
+#axes.grid.axis     : both    ## which axis the grid should apply to
+#axes.grid.which    : major   ## gridlines at major, minor or both ticks
+#axes.titlelocation : center  ## alignment of the title, possible values are:
+                              ##     left, right and center
+#axes.titlesize     : large   ## fontsize of the axes title
+#axes.titleweight   : normal  ## font weight of title
+#axes.titlepad      : 6.0     ## pad between axes and title in points
+#axes.labelsize     : medium  ## fontsize of the x any y labels
+#axes.labelpad      : 4.0     ## space between label and axis
+#axes.labelweight   : normal  ## weight of the x and y labels
+#axes.labelcolor    : black
+#axes.axisbelow     : line    ## draw axis gridlines and ticks:
+                              ##     - below patches (True)
+                              ##     - above patches but below lines ('line')
+                              ##     - above all (False)
+
+#axes.formatter.limits : -7, 7  ## use scientific notation if log10
+                                ## of the axis range is smaller than the
+                                ## first or larger than the second
+#axes.formatter.use_locale : False  ## When True, format tick labels
+                                    ## according to the user's locale.
+                                    ## For example, use ',' as a decimal
+                                    ## separator in the fr_FR locale.
+#axes.formatter.use_mathtext : False  ## When True, use mathtext for scientific
+                                      ## notation.
+#axes.formatter.min_exponent : 0  ## minimum exponent to format in scientific notation
+#axes.formatter.useoffset : True  ## If True, the tick label formatter
+                                  ## will default to labeling ticks relative
+                                  ## to an offset when the data range is
+                                  ## small compared to the minimum absolute
+                                  ## value of the data.
+#axes.formatter.offset_threshold : 4  ## When useoffset is True, the offset
+                                      ## will be used when it can remove
+                                      ## at least this number of significant
+                                      ## digits from tick labels.
+
+#axes.spines.left   : True  ## display axis spines
 #axes.spines.bottom : True
 #axes.spines.top    : True
 #axes.spines.right  : True
-#axes.unicode_minus  : True    ## use unicode for the minus symbol
-                               ## rather than hyphen.  See
-                               ## https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
-#axes.prop_cycle    : cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
-                      ## color cycle for plot lines  as list of string
-                      ## colorspecs: single letter, long name, or web-style hex
-					  ## Note the use of string escapes here ('1f77b4', instead of 1f77b4)
-                      ## as opposed to the rest of this file.
-                      ## See also https://matplotlib.org/tutorials/intermediate/color_cycle.html
-#axes.autolimit_mode : data ## How to scale axes limits to the data.
-                            ## Use "data" to use data limits, plus some margin
-                            ## Use "round_numbers" move to the nearest "round" number
-#axes.xmargin        : .05  ## x margin.  See `axes.Axes.margins`
-#axes.ymargin        : .05  ## y margin See `axes.Axes.margins`
-#polaraxes.grid      : True    ## display grid on polar axes
-#axes3d.grid         : True    ## display grid on 3d axes
+
+#axes.unicode_minus : True  ## use Unicode for the minus symbol
+                            ## rather than hyphen.  See
+                            ## https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
+#axes.prop_cycle : cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
+                   ## color cycle for plot lines as list of string colorspecs:
+                   ##     single letter, long name, or web-style hex
+				   ## Note the use of string escapes here ('1f77b4', instead of 1f77b4)
+                   ## as opposed to the rest of this file.
+                   ## See also https://matplotlib.org/tutorials/intermediate/color_cycle.html
+                   ## for more details on prop_cycle usage.
+#axes.autolimit_mode : data  ## How to scale axes limits to the data.  By using:
+                             ##     - "data" to use data limits, plus some margin
+                             ##     - "round_numbers" move to the nearest "round" number
+#axes.xmargin   : .05   ## x margin.  See `axes.Axes.margins`
+#axes.ymargin   : .05   ## y margin.  See `axes.Axes.margins`
+#polaraxes.grid : True  ## display grid on polar axes
+#axes3d.grid    : True  ## display grid on 3d axes
 
 
-#### DATES
+## ***************************************************************************
+## * DATES                                                                   *
+## ***************************************************************************
 ## These control the default format strings used in AutoDateFormatter.
 ## Any valid format datetime format string can be used (see the python
-## `datetime` for details).  For example using '%%x' will use the locale date representation
-## '%%X' will use the locale time representation and '%%c' will use the full locale datetime
-## representation.
+## `datetime` for details).  For example, by using:
+##     - '%%x' will use the locale date representation
+##     - '%%X' will use the locale time representation
+##     - '%%c' will use the full locale datetime representation
 ## These values map to the scales:
 ##     {'year': 365, 'month': 30, 'day': 1, 'hour': 1/24, 'minute': 1 / (24 * 60)}
 
-#date.autoformatter.year     : %Y
-#date.autoformatter.month    : %Y-%m
-#date.autoformatter.day      : %Y-%m-%d
-#date.autoformatter.hour     : %m-%d %H
-#date.autoformatter.minute   : %d %H:%M
-#date.autoformatter.second   : %H:%M:%S
-#date.autoformatter.microsecond   : %M:%S.%f
+#date.autoformatter.year        : %Y
+#date.autoformatter.month       : %Y-%m
+#date.autoformatter.day         : %Y-%m-%d
+#date.autoformatter.hour        : %m-%d %H
+#date.autoformatter.minute      : %d %H:%M
+#date.autoformatter.second      : %H:%M:%S
+#date.autoformatter.microsecond : %M:%S.%f
 
 
-#### TICKS
+## ***************************************************************************
+## * TICKS                                                                   *
+## ***************************************************************************
 ## See https://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
-#xtick.top            : False  ## draw ticks on the top side
-#xtick.bottom         : True   ## draw ticks on the bottom side
-#xtick.labeltop       : False  ## draw label on the top
-#xtick.labelbottom    : True   ## draw label on the bottom
-#xtick.major.size     : 3.5    ## major tick size in points
-#xtick.minor.size     : 2      ## minor tick size in points
-#xtick.major.width    : 0.8    ## major tick width in points
-#xtick.minor.width    : 0.6    ## minor tick width in points
-#xtick.major.pad      : 3.5    ## distance to major tick label in points
-#xtick.minor.pad      : 3.4    ## distance to the minor tick label in points
-#xtick.color          : black  ## color of the tick labels
-#xtick.labelsize      : medium ## fontsize of the tick labels
-#xtick.direction      : out    ## direction: in, out, or inout
-#xtick.minor.visible  : False  ## visibility of minor ticks on x-axis
-#xtick.major.top      : True   ## draw x axis top major ticks
-#xtick.major.bottom   : True   ## draw x axis bottom major ticks
-#xtick.minor.top      : True   ## draw x axis top minor ticks
-#xtick.minor.bottom   : True   ## draw x axis bottom minor ticks
-#xtick.alignment      : center ## alignment of xticks
+#xtick.top           : False   ## draw ticks on the top side
+#xtick.bottom        : True    ## draw ticks on the bottom side
+#xtick.labeltop      : False   ## draw label on the top
+#xtick.labelbottom   : True    ## draw label on the bottom
+#xtick.major.size    : 3.5     ## major tick size in points
+#xtick.minor.size    : 2       ## minor tick size in points
+#xtick.major.width   : 0.8     ## major tick width in points
+#xtick.minor.width   : 0.6     ## minor tick width in points
+#xtick.major.pad     : 3.5     ## distance to major tick label in points
+#xtick.minor.pad     : 3.4     ## distance to the minor tick label in points
+#xtick.color         : black   ## color of the tick labels
+#xtick.labelsize     : medium  ## fontsize of the tick labels
+#xtick.direction     : out     ## direction: in, out, or inout
+#xtick.minor.visible : False   ## visibility of minor ticks on x-axis
+#xtick.major.top     : True    ## draw x axis top major ticks
+#xtick.major.bottom  : True    ## draw x axis bottom major ticks
+#xtick.minor.top     : True    ## draw x axis top minor ticks
+#xtick.minor.bottom  : True    ## draw x axis bottom minor ticks
+#xtick.alignment     : center  ## alignment of xticks
 
-#ytick.left           : True   ## draw ticks on the left side
-#ytick.right          : False  ## draw ticks on the right side
-#ytick.labelleft      : True   ## draw tick labels on the left side
-#ytick.labelright     : False  ## draw tick labels on the right side
-#ytick.major.size     : 3.5    ## major tick size in points
-#ytick.minor.size     : 2      ## minor tick size in points
-#ytick.major.width    : 0.8    ## major tick width in points
-#ytick.minor.width    : 0.6    ## minor tick width in points
-#ytick.major.pad      : 3.5    ## distance to major tick label in points
-#ytick.minor.pad      : 3.4    ## distance to the minor tick label in points
-#ytick.color          : black  ## color of the tick labels
-#ytick.labelsize      : medium ## fontsize of the tick labels
-#ytick.direction      : out    ## direction: in, out, or inout
-#ytick.minor.visible  : False  ## visibility of minor ticks on y-axis
-#ytick.major.left     : True   ## draw y axis left major ticks
-#ytick.major.right    : True   ## draw y axis right major ticks
-#ytick.minor.left     : True   ## draw y axis left minor ticks
-#ytick.minor.right    : True   ## draw y axis right minor ticks
-#ytick.alignment      : center_baseline ## alignment of yticks
-
-
-#### GRIDS
-#grid.color       :   b0b0b0    ## grid color
-#grid.linestyle   :   -         ## solid
-#grid.linewidth   :   0.8       ## in points
-#grid.alpha       :   1.0       ## transparency, between 0.0 and 1.0
+#ytick.left          : True    ## draw ticks on the left side
+#ytick.right         : False   ## draw ticks on the right side
+#ytick.labelleft     : True    ## draw tick labels on the left side
+#ytick.labelright    : False   ## draw tick labels on the right side
+#ytick.major.size    : 3.5     ## major tick size in points
+#ytick.minor.size    : 2       ## minor tick size in points
+#ytick.major.width   : 0.8     ## major tick width in points
+#ytick.minor.width   : 0.6     ## minor tick width in points
+#ytick.major.pad     : 3.5     ## distance to major tick label in points
+#ytick.minor.pad     : 3.4     ## distance to the minor tick label in points
+#ytick.color         : black   ## color of the tick labels
+#ytick.labelsize     : medium  ## fontsize of the tick labels
+#ytick.direction     : out     ## direction: in, out, or inout
+#ytick.minor.visible : False   ## visibility of minor ticks on y-axis
+#ytick.major.left    : True    ## draw y axis left major ticks
+#ytick.major.right   : True    ## draw y axis right major ticks
+#ytick.minor.left    : True    ## draw y axis left minor ticks
+#ytick.minor.right   : True    ## draw y axis right minor ticks
+#ytick.alignment     : center_baseline  ## alignment of yticks
 
 
-#### LEGEND
+## ***************************************************************************
+## * GRIDS                                                                   *
+## ***************************************************************************
+#grid.color     : b0b0b0  ## grid color
+#grid.linestyle : -       ## solid
+#grid.linewidth : 0.8     ## in points
+#grid.alpha     : 1.0     ## transparency, between 0.0 and 1.0
+
+
+## ***************************************************************************
+## * LEGEND                                                                  *
+## ***************************************************************************
 #legend.loc           : best
 #legend.frameon       : True     ## if True, draw the legend on a background patch
 #legend.framealpha    : 0.8      ## legend patch transparency
@@ -458,217 +503,244 @@
 #legend.scatterpoints : 1        ## number of scatter points
 #legend.markerscale   : 1.0      ## the relative size of legend markers vs. original
 #legend.fontsize      : medium
-#legend.title_fontsize    : None ## None sets to the same as the default axes.
+#legend.title_fontsize : None    ## None sets to the same as the default axes.
+
 ## Dimensions as fraction of fontsize:
-#legend.borderpad     : 0.4      ## border whitespace
-#legend.labelspacing  : 0.5      ## the vertical space between the legend entries
-#legend.handlelength  : 2.0      ## the length of the legend lines
-#legend.handleheight  : 0.7      ## the height of the legend handle
-#legend.handletextpad : 0.8      ## the space between the legend line and legend text
-#legend.borderaxespad : 0.5      ## the border between the axes and legend edge
-#legend.columnspacing : 2.0      ## column separation
+#legend.borderpad     : 0.4  ## border whitespace
+#legend.labelspacing  : 0.5  ## the vertical space between the legend entries
+#legend.handlelength  : 2.0  ## the length of the legend lines
+#legend.handleheight  : 0.7  ## the height of the legend handle
+#legend.handletextpad : 0.8  ## the space between the legend line and legend text
+#legend.borderaxespad : 0.5  ## the border between the axes and legend edge
+#legend.columnspacing : 2.0  ## column separation
 
 
-#### FIGURE
+## ***************************************************************************
+## * FIGURE                                                                  *
+## ***************************************************************************
 ## See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
-#figure.titlesize : large      ## size of the figure title (Figure.suptitle())
-#figure.titleweight : normal   ## weight of the figure title
-#figure.figsize   : 6.4, 4.8   ## figure size in inches
-#figure.dpi       : 100        ## figure dots per inch
-#figure.facecolor : white      ## figure facecolor
-#figure.edgecolor : white      ## figure edgecolor
-#figure.frameon : True         ## enable figure frame
-#figure.max_open_warning : 20  ## The maximum number of figures to open through
-                               ## the pyplot interface before emitting a warning.
-                               ## If less than one this feature is disabled.
-## The figure subplot parameters.  All dimensions are a fraction of the
-#figure.subplot.left    : 0.125  ## the left side of the subplots of the figure
-#figure.subplot.right   : 0.9    ## the right side of the subplots of the figure
-#figure.subplot.bottom  : 0.11   ## the bottom of the subplots of the figure
-#figure.subplot.top     : 0.88   ## the top of the subplots of the figure
-#figure.subplot.wspace  : 0.2    ## the amount of width reserved for space between subplots,
-                                 ## expressed as a fraction of the average axis width
-#figure.subplot.hspace  : 0.2    ## the amount of height reserved for space between subplots,
-                                 ## expressed as a fraction of the average axis height
+#figure.titlesize   : large     ## size of the figure title (``Figure.suptitle()``)
+#figure.titleweight : normal    ## weight of the figure title
+#figure.figsize     : 6.4, 4.8  ## figure size in inches
+#figure.dpi         : 100       ## figure dots per inch
+#figure.facecolor   : white     ## figure facecolor
+#figure.edgecolor   : white     ## figure edgecolor
+#figure.frameon     : True      ## enable figure frame
+#figure.max_open_warning : 20   ## The maximum number of figures to open through
+                                ## the pyplot interface before emitting a warning.
+                                ## If less than one this feature is disabled.
+
+## The figure subplot parameters.  All dimensions are a fraction of the figure width and height.
+#figure.subplot.left   : 0.125  ## the left side of the subplots of the figure
+#figure.subplot.right  : 0.9    ## the right side of the subplots of the figure
+#figure.subplot.bottom : 0.11   ## the bottom of the subplots of the figure
+#figure.subplot.top    : 0.88   ## the top of the subplots of the figure
+#figure.subplot.wspace : 0.2    ## the amount of width reserved for space between subplots,
+                                ## expressed as a fraction of the average axis width
+#figure.subplot.hspace : 0.2    ## the amount of height reserved for space between subplots,
+                                ## expressed as a fraction of the average axis height
 
 ## Figure layout
-#figure.autolayout : False     ## When True, automatically adjust subplot
-                               ## parameters to make the plot fit the figure
-                               ## using `tight_layout`
-#figure.constrained_layout.use: False ## When True, automatically make plot
-                                      ## elements fit on the figure. (Not compatible
-                                      ## with `autolayout`, above).
-#figure.constrained_layout.h_pad : 0.04167 ## Padding around axes objects. Float representing
-#figure.constrained_layout.w_pad : 0.04167 ##  inches. Default is 3./72. inches (3 pts)
-#figure.constrained_layout.hspace : 0.02   ## Space between subplot groups. Float representing
-#figure.constrained_layout.wspace : 0.02   ##  a fraction of the subplot widths being separated.
+#figure.autolayout : False  ## When True, automatically adjust subplot
+                            ## parameters to make the plot fit the figure
+                            ## using `tight_layout`
+#figure.constrained_layout.use : False  ## When True, automatically make plot
+                                        ## elements fit on the figure. (Not
+                                        ## compatible with `autolayout`, above).
+#figure.constrained_layout.h_pad  : 0.04167  ## Padding around axes objects. Float representing
+#figure.constrained_layout.w_pad  : 0.04167  ## inches. Default is 3./72. inches (3 pts)
+#figure.constrained_layout.hspace : 0.02     ## Space between subplot groups. Float representing
+#figure.constrained_layout.wspace : 0.02     ## a fraction of the subplot widths being separated.
 
 
-#### IMAGES
-#image.aspect : equal             ## equal | auto | a number
-#image.interpolation  : nearest   ## see help(imshow) for options
-#image.cmap   : viridis           ## A colormap name, gray etc...
-#image.lut    : 256               ## the size of the colormap lookup table
-#image.origin : upper             ## lower | upper
+## ***************************************************************************
+## * IMAGES                                                                  *
+## ***************************************************************************
+#image.aspect : equal            ## equal | auto | a number
+#image.interpolation  : nearest  ## see help(imshow) for options
+#image.cmap   : viridis          ## A colormap name, gray etc...
+#image.lut    : 256              ## the size of the colormap lookup table
+#image.origin : upper            ## lower | upper
 #image.resample  : True
-#image.composite_image : True     ## When True, all the images on a set of axes are
-                                  ## combined into a single composite image before
-                                  ## saving a figure as a vector graphics file,
-                                  ## such as a PDF.
+#image.composite_image : True  ## When True, all the images on a set of axes are
+                               ## combined into a single composite image before
+                               ## saving a figure as a vector graphics file,
+                               ## such as a PDF.
 
 
-#### CONTOUR PLOTS
-#contour.negative_linestyle : dashed ## string or on-off ink sequence
-#contour.corner_mask        : True   ## True | False | legacy
+## ***************************************************************************
+## * CONTOUR PLOTS                                                           *
+## ***************************************************************************
+#contour.negative_linestyle : dashed  ## string or on-off ink sequence
+#contour.corner_mask        : True    ## True | False | legacy
 
 
-#### ERRORBAR PLOTS
-#errorbar.capsize : 0             ## length of end cap on error bars in pixels
+## ***************************************************************************
+## * ERRORBAR PLOTS                                                          *
+## ***************************************************************************
+#errorbar.capsize : 0  ## length of end cap on error bars in pixels
 
 
-#### HISTOGRAM PLOTS
-#hist.bins : 10                   ## The default number of histogram bins.
-                                  ## If Numpy 1.11 or later is
-                                  ## installed, may also be `auto`
-
-#### SCATTER PLOTS
-#scatter.marker : o               ## The default marker type for scatter plots.
-#scatter.edgecolors : face        ## The default edgecolors for scatter plots.
+## ***************************************************************************
+## * HISTOGRAM PLOTS                                                         *
+## ***************************************************************************
+#hist.bins : 10  ## The default number of histogram bins.
+                 ## If Numpy 1.11 or later is installed, may also be `auto`
 
 
-#### AGG RENDERING
+## ***************************************************************************
+## * SCATTER PLOTS                                                           *
+## ***************************************************************************
+#scatter.marker : o         ## The default marker type for scatter plots.
+#scatter.edgecolors : face  ## The default edge colors for scatter plots.
+
+
+## ***************************************************************************
+## * AGG RENDERING                                                           *
+## ***************************************************************************
 ## Warning: experimental, 2008/10/10
-#agg.path.chunksize : 0           ## 0 to disable; values in the range
-                                  ## 10000 to 100000 can improve speed slightly
-                                  ## and prevent an Agg rendering failure
-                                  ## when plotting very large data sets,
-                                  ## especially if they are very gappy.
-                                  ## It may cause minor artifacts, though.
-                                  ## A value of 20000 is probably a good
-                                  ## starting point.
+#agg.path.chunksize : 0  ## 0 to disable; values in the range
+                         ## 10000 to 100000 can improve speed slightly
+                         ## and prevent an Agg rendering failure
+                         ## when plotting very large data sets,
+                         ## especially if they are very gappy.
+                         ## It may cause minor artifacts, though.
+                         ## A value of 20000 is probably a good
+                         ## starting point.
 
 
-#### PATHS
-#path.simplify : True   ## When True, simplify paths by removing "invisible"
-                        ## points to reduce file size and increase rendering
-                        ## speed
-#path.simplify_threshold : 0.111111111111  ## The threshold of similarity below which
-                                           ## vertices will be removed in the
-                                           ## simplification process
-#path.snap : True ## When True, rectilinear axis-aligned paths will be snapped to
-                  ## the nearest pixel when certain criteria are met.  When False,
-                  ## paths will never be snapped.
-#path.sketch : None ## May be none, or a 3-tuple of the form (scale, length,
-                    ## randomness).
-                    ## *scale* is the amplitude of the wiggle
-                    ## perpendicular to the line (in pixels).  *length*
-                    ## is the length of the wiggle along the line (in
-                    ## pixels).  *randomness* is the factor by which
-                    ## the length is randomly scaled.
-#path.effects : []  ##
+## ***************************************************************************
+## * PATHS                                                                   *
+## ***************************************************************************
+#path.simplify : True  ## When True, simplify paths by removing "invisible"
+                       ## points to reduce file size and increase rendering
+                       ## speed
+#path.simplify_threshold : 0.111111111111  ## The threshold of similarity below
+                                           ## which vertices will be removed in
+                                           ## the simplification process.
+#path.snap : True  ## When True, rectilinear axis-aligned paths will be snapped
+                   ## to the nearest pixel when certain criteria are met.
+                   ## When False, paths will never be snapped.
+#path.sketch : None  ## May be None, or a 3-tuple of the form:
+                     ## (scale, length, randomness).
+                     ##     - *scale* is the amplitude of the wiggle
+                     ##         perpendicular to the line (in pixels).
+                     ##     - *length* is the length of the wiggle along the
+                     ##         line (in pixels).
+                     ##     - *randomness* is the factor by which the length is
+                     ##         randomly scaled.
+#path.effects : []   ##
 
 
-#### SAVING FIGURES
+## ***************************************************************************
+## * SAVING FIGURES                                                          *
+## ***************************************************************************
 ## The default savefig params can be different from the display params
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
-#savefig.dpi         : figure   ## figure dots per inch or 'figure'
-#savefig.facecolor   : white    ## figure facecolor when saving
-#savefig.edgecolor   : white    ## figure edgecolor when saving
-#savefig.format      : png      ## png, ps, pdf, svg
-#savefig.bbox        : standard ## 'tight' or 'standard'.
-                                ## 'tight' is incompatible with pipe-based animation
-                                ## backends but will workd with temporary file based ones:
-                                ## e.g. setting animation.writer to ffmpeg will not work,
-                                ## use ffmpeg_file instead
-#savefig.pad_inches  : 0.1      ## Padding to be used when bbox is set to 'tight'
-#savefig.jpeg_quality: 95       ## when a jpeg is saved, the default quality parameter.
-#savefig.directory   : ~        ## default directory in savefig dialog box,
-                                ## leave empty to always use current working directory
-#savefig.transparent : False    ## setting that controls whether figures are saved with a
-                                ## transparent background by default
-#savefig.orientation : portrait	## Orientation of saved figure
+#savefig.dpi       : figure      ## figure dots per inch or 'figure'
+#savefig.facecolor : white       ## figure facecolor when saving
+#savefig.edgecolor : white       ## figure edgecolor when saving
+#savefig.format    : png         ## png, ps, pdf, svg
+#savefig.bbox      : standard    ## 'tight' or 'standard'.
+                                 ## 'tight' is incompatible with pipe-based animation
+                                 ## backends but will workd with temporary file based ones:
+                                 ## e.g. setting animation.writer to ffmpeg will not work,
+                                 ## use ffmpeg_file instead
+#savefig.pad_inches   : 0.1      ## Padding to be used when bbox is set to 'tight'
+#savefig.jpeg_quality : 95       ## when a jpeg is saved, the default quality parameter.
+#savefig.directory    : ~        ## default directory in savefig dialog box,
+                                 ## leave empty to always use current working directory
+#savefig.transparent : False     ## setting that controls whether figures are saved with a
+                                 ## transparent background by default
+#savefig.orientation : portrait  ## Orientation of saved figure
 
 ### tk backend params
-#tk.window_focus   : False    ## Maintain shell focus for TkAgg
+#tk.window_focus   : False  ## Maintain shell focus for TkAgg
 
 ### ps backend params
-#ps.papersize      : letter   ## auto, letter, legal, ledger, A0-A10, B0-B10
-#ps.useafm         : False    ## use of afm fonts, results in small files
-#ps.usedistiller   : False    ## can be: None, ghostscript or xpdf
-                                          ## Experimental: may produce smaller files.
-                                          ## xpdf intended for production of publication quality files,
-                                          ## but requires ghostscript, xpdf and ps2eps
-#ps.distiller.res  : 6000      ## dpi
-#ps.fonttype       : 3         ## Output Type 3 (Type3) or Type 42 (TrueType)
+#ps.papersize      : letter  ## auto, letter, legal, ledger, A0-A10, B0-B10
+#ps.useafm         : False   ## use of afm fonts, results in small files
+#ps.usedistiller   : False   ## can be: None, ghostscript or xpdf
+                             ## Experimental: may produce smaller files.
+                             ## xpdf intended for production of publication quality files,
+                             ## but requires ghostscript, xpdf and ps2eps
+#ps.distiller.res  : 6000    ## dpi
+#ps.fonttype       : 3       ## Output Type 3 (Type3) or Type 42 (TrueType)
 
 ### PDF backend params
-#pdf.compression   : 6   ## integer from 0 to 9
+#pdf.compression    : 6  ## integer from 0 to 9
                          ## 0 disables compression (good for debugging)
-#pdf.fonttype       : 3         ## Output Type 3 (Type3) or Type 42 (TrueType)
+#pdf.fonttype       : 3  ## Output Type 3 (Type3) or Type 42 (TrueType)
 #pdf.use14corefonts : False
-#pdf.inheritcolor : False
+#pdf.inheritcolor   : False
 
 ### SVG backend params
-#svg.image_inline : True       ## write raster image data directly into the svg file
-#svg.fonttype :   path         ## How to handle SVG fonts:
-   ##     none: Assume fonts are installed on the machine where the SVG will be viewed.
-   ##     path: Embed characters as paths -- supported by most SVG renderers
-#svg.hashsalt : None           ## if not None, use this string as hash salt
-                               ## instead of uuid4
+#svg.image_inline : True  ## Write raster image data directly into the SVG file
+#svg.fonttype : path      ## How to handle SVG fonts:
+                          ##     path: Embed characters as paths -- supported
+                          ##           by most SVG renderers
+                          ##     None: Assume fonts are installed on the
+                          ##           machine where the SVG will be viewed.
+#svg.hashsalt : None      ## If not None, use this string as hash salt instead of uuid4
+
 ### pgf parameter
 ## See https://matplotlib.org/tutorials/text/pgf.html for more information.
 #pgf.rcfonts : True
-#pgf.preamble :            ## see text.latex.preamble for documentation
+#pgf.preamble :          ## See text.latex.preamble for documentation
 #pgf.texsystem : xelatex
 
 ### docstring params
 ##docstring.hardcopy = False  ## set this when you want to generate hardcopy docstring
 
 
-#### INTERACTIVE KEYMAPS
+## ***************************************************************************
+## * INTERACTIVE KEYMAPS                                                     *
+## ***************************************************************************
 ## Event keys to interact with figures/plots via keyboard.
 ## See https://matplotlib.org/users/navigation_toolbar.html for more details on
 ## interactive navigation.  Customize these settings according to your needs.
 ## Leave the field(s) empty if you don't need a key-map. (i.e., fullscreen : '')
-#keymap.fullscreen : f, ctrl+f       ## toggling
-#keymap.home : h, r, home            ## home or reset mnemonic
+#keymap.fullscreen : f, ctrl+f   ## toggling
+#keymap.home : h, r, home        ## home or reset mnemonic
 #keymap.back : left, c, backspace, MouseButton.BACK  ## forward / backward keys
 #keymap.forward : right, v, MouseButton.FORWARD      ## for quick navigation
-#keymap.pan : p                      ## pan mnemonic
-#keymap.zoom : o                     ## zoom mnemonic
-#keymap.save : s, ctrl+s             ## saving current figure
-#keymap.help : f1                    ## display help about active tools
-#keymap.quit : ctrl+w, cmd+w, q      ## close the current figure
-#keymap.quit_all : W, cmd+W, Q       ## close all figures
-#keymap.grid : g                     ## switching on/off major grids in current axes
-#keymap.grid_minor : G               ## switching on/off minor grids in current axes
-#keymap.yscale : l                   ## toggle scaling of y-axes ('log'/'linear')
-#keymap.xscale : k, L                ## toggle scaling of x-axes ('log'/'linear')
-#keymap.all_axes : a                 ## enable all axes
-#keymap.copy : ctrl+c, cmd+c         ## Copy figure to clipboard
+#keymap.pan : p                  ## pan mnemonic
+#keymap.zoom : o                 ## zoom mnemonic
+#keymap.save : s, ctrl+s         ## saving current figure
+#keymap.help : f1                ## display help about active tools
+#keymap.quit : ctrl+w, cmd+w, q  ## close the current figure
+#keymap.quit_all : W, cmd+W, Q   ## close all figures
+#keymap.grid : g                 ## switching on/off major grids in current axes
+#keymap.grid_minor : G           ## switching on/off minor grids in current axes
+#keymap.yscale : l               ## toggle scaling of y-axes ('log'/'linear')
+#keymap.xscale : k, L            ## toggle scaling of x-axes ('log'/'linear')
+#keymap.all_axes : a             ## enable all axes
+#keymap.copy : ctrl+c, cmd+c     ## Copy figure to clipboard
 
 
-#### ANIMATION
-#animation.html :  none            ## How to display the animation as HTML in
-                                   ## the IPython notebook. 'html5' uses
-                                   ## HTML5 video tag; 'jshtml' creates a
-                                   ## Javascript animation
-#animation.writer : ffmpeg         ## MovieWriter 'backend' to use
-#animation.codec : h264            ## Codec to use for writing movie
-#animation.bitrate: -1             ## Controls size/quality tradeoff for movie.
-                                   ## -1 implies let utility auto-determine
-#animation.frame_format:  png      ## Controls frame format used by temp files
-#animation.html_args:              ## Additional arguments to pass to html writer
-#animation.ffmpeg_path:  ffmpeg    ## Path to ffmpeg binary. Without full path
+## ***************************************************************************
+## * ANIMATION                                                               *
+## ***************************************************************************
+#animation.html : none  ## How to display the animation as HTML in
+                        ## the IPython notebook:
+                        ##     - 'html5' uses HTML5 video tag
+                        ##     - 'jshtml' creates a Javascript animation
+#animation.writer  : ffmpeg  ## MovieWriter 'backend' to use
+#animation.codec   : h264    ## Codec to use for writing movie
+#animation.bitrate : -1      ## Controls size/quality tradeoff for movie.
+                             ## -1 implies let utility auto-determine
+#animation.frame_format : png      ## Controls frame format used by temp files
+#animation.html_args    :          ## Additional arguments to pass to html writer
+#animation.ffmpeg_path  : ffmpeg   ## Path to ffmpeg binary. Without full path
                                    ## $PATH is searched
-#animation.ffmpeg_args:            ## Additional arguments to pass to ffmpeg
-#animation.avconv_path:  avconv    ## Path to avconv binary. Without full path
+#animation.ffmpeg_args  :          ## Additional arguments to pass to ffmpeg
+#animation.avconv_path  : avconv   ## Path to avconv binary. Without full path
                                    ## $PATH is searched
-#animation.avconv_args:            ## Additional arguments to pass to avconv
-#animation.convert_path:  convert  ## Path to ImageMagick's convert binary.
+#animation.avconv_args  :          ## Additional arguments to pass to avconv
+#animation.convert_path : convert  ## Path to ImageMagick's convert binary.
                                    ## On Windows use the full path since convert
                                    ## is also the name of a system tool.
-#animation.convert_args:           ## Additional arguments to pass to convert
-#animation.embed_limit : 20.0      ## Limit, in MB, of size of base64 encoded
+#animation.convert_args :          ## Additional arguments to pass to convert
+#animation.embed_limit  : 20.0     ## Limit, in MB, of size of base64 encoded
                                    ## animation in HTML (i.e. IPython notebook)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -12,7 +12,7 @@
 ## other platforms:
 ##      $HOME/.matplotlib/matplotlibrc
 ##
-## See http://matplotlib.org/users/customizing.html#the-matplotlibrc-file for
+## See https://matplotlib.org/users/customizing.html#the-matplotlibrc-file for
 ## more details on the paths which are checked for the configuration file.
 ##
 ## This file is best viewed in a editor which supports python mode
@@ -70,8 +70,8 @@
 
 
 #### LINES
-## See http://matplotlib.org/api/artist_api.html#module-matplotlib.lines for more
-## information on line properties.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.lines
+## for more information on line properties.
 #lines.linewidth   : 1.5     ## line width in points
 #lines.linestyle   : -       ## solid line
 #lines.color       : C0      ## has no affect on plot(); see axes.prop_cycle
@@ -95,10 +95,9 @@
 #markers.fillstyle: full ## full|left|right|bottom|top|none
 
 #### PATCHES
-## Patches are graphical objects that fill 2D space, like polygons or
-## circles.  See
-## http://matplotlib.org/api/artist_api.html#module-matplotlib.patches
-## information on patch properties
+## Patches are graphical objects that fill 2D space, like polygons or circles.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.patches
+## for more information on patch properties.
 #patch.linewidth        : 1        ## edge width in points.
 #patch.facecolor        : C0
 #patch.edgecolor        : black   ## if forced, or patch is not filled
@@ -156,11 +155,10 @@
 
 
 #### FONT
-
-## font properties used by text.Text.  See
-## http://matplotlib.org/api/font_manager_api.html for more
-## information on font properties.  The 6 font properties used for font
-## matching are given below with their default values.
+## The font properties used by `text.Text`.
+## See https://matplotlib.org/api/font_manager_api.html for more information
+## on font properties.  The 6 font properties used for font matching are
+## given below with their default values.
 ##
 ## The font.family property has five values: 'serif' (e.g., Times),
 ## 'sans-serif' (e.g., Helvetica), 'cursive' (e.g., Zapf-Chancery),
@@ -209,12 +207,15 @@
 #font.monospace      : DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
 
 #### TEXT
-## text properties used by text.Text.  See
-## http://matplotlib.org/api/artist_api.html#module-matplotlib.text for more
-## information on text properties
+## The text properties used by `text.Text`.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
+## for more information on text properties
 #text.color          : black
 
-#### LaTeX customizations. See http://wiki.scipy.org/Cookbook/Matplotlib/UsingTex
+#### LaTeX
+## See following links for more information on LaTex properties:
+## https://matplotlib.org/tutorials/text/usetex.html
+## https://scipy-cookbook.readthedocs.io/items/idx_matplotlib_typesetting.html
 #text.usetex         : False  ## use latex for all text handling. The following fonts
                               ## are supported through the usual rc parameter settings:
                               ## new century schoolbook, bookman, times, palatino,
@@ -280,9 +281,9 @@
                        ## used in regular text.
 
 #### AXES
-## default face and edge color, default tick sizes,
+## Following are default face and edge colors, default tick sizes,
 ## default fontsizes for ticklabels, and so on.  See
-## http://matplotlib.org/api/axes_api.html#module-matplotlib.axes
+## https://matplotlib.org/api/axes_api.html#module-matplotlib.axes
 #axes.facecolor      : white   ## axes background color
 #axes.edgecolor      : black   ## axes edge color
 #axes.linewidth      : 0.8     ## edge linewidth
@@ -326,12 +327,13 @@
 #axes.spines.right  : True
 #axes.unicode_minus  : True    ## use unicode for the minus symbol
                                ## rather than hyphen.  See
-                               ## http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
+                               ## https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
 #axes.prop_cycle    : cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
                       ## color cycle for plot lines  as list of string
                       ## colorspecs: single letter, long name, or web-style hex
 					  ## Note the use of string escapes here ('1f77b4', instead of 1f77b4)
                       ## as opposed to the rest of this file.
+                      ## See also https://matplotlib.org/tutorials/intermediate/color_cycle.html
 #axes.autolimit_mode : data ## How to scale axes limits to the data.
                             ## Use "data" to use data limits, plus some margin
                             ## Use "round_numbers" move to the nearest "round" number
@@ -358,7 +360,7 @@
 #date.autoformatter.microsecond   : %M:%S.%f
 
 #### TICKS
-## see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
+## See https://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
 #xtick.top            : False  ## draw ticks on the top side
 #xtick.bottom         : True   ## draw ticks on the bottom side
 #xtick.labeltop       : False  ## draw label on the top
@@ -429,7 +431,7 @@
 #legend.columnspacing : 2.0      ## column separation
 
 #### FIGURE
-## See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
+## See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
 #figure.titlesize : large      ## size of the figure title (Figure.suptitle())
 #figure.titleweight : normal   ## weight of the figure title
 #figure.figsize   : 6.4, 4.8   ## figure size in inches
@@ -568,6 +570,7 @@
 #svg.hashsalt : None           ## if not None, use this string as hash salt
                                ## instead of uuid4
 ### pgf parameter
+## See https://matplotlib.org/tutorials/text/pgf.html for more information.
 #pgf.rcfonts : True
 #pgf.preamble :            ## see text.latex.preamble for documentation
 #pgf.texsystem : xelatex
@@ -576,7 +579,8 @@
 ##docstring.hardcopy = False  ## set this when you want to generate hardcopy docstring
 
 ## Event keys to interact with figures/plots via keyboard.
-## Customize these settings according to your needs.
+## See https://matplotlib.org/users/navigation_toolbar.html for more details on
+## interactive navigation.  Customize these settings according to your needs.
 ## Leave the field(s) empty if you don't need a key-map. (i.e., fullscreen : '')
 #keymap.fullscreen : f, ctrl+f       ## toggling
 #keymap.home : h, r, home            ## home or reset mnemonic


### PR DESCRIPTION
## PR Summary

This PR did NOT change any thing in `key` : `value` pairs, mainly change the formatting and styling in the comments, with blank lines or new lines. There are 3 commits, each for a set of modifications:

1. Commit f47cc5d: Update links, `http` -> `https`, update a outdated link, add few new links
2. Commit 7f7c0a0: Add a table of content at the top for quick skimming and navigation.
3. Commit a2c2555: Try to set and follow a few relaxed formatting and style conventions:

    ```
    ## Formatting and style conventions for this file:
    ##    - at least one whitesapce AROUND `:` to seperate key and val
    ##        * prefer one whitesapce except for colon alignment
    ##    - at least two whitesapces BEFORE `##` to seperate the key:val pair and
    ##      the trailing comments
    ##        * prefer two whitesapces except for block `##` alignment
    ##    - at least one whitesapce AFTER `##` to seperate the `##` marker and
    ##      the comment text
    ##        * prefer one whitesapce except for indentation (listing, etc.), in
    ##          which case, four more whitespaces are preferred
    ```
   I am not very sure about the third commit, whether it's necessary or will it pollute the `git blame` info. If this commit doesn't make sense, I can just drop the commit.