### PR TITLE
Pin pydocstyle<4.0

### DIFF
--- a/requirements/testing/travis_flake8.txt
+++ b/requirements/testing/travis_flake8.txt
@@ -1,4 +1,5 @@
 # Extra pip requirements for the travis flake8 build
 
 flake8>=3.7
+pydocstyle<4.0
 flake8-docstrings


### PR DESCRIPTION
## PR Summary

pydocstyle 4.0.0 was released yesterday and removed a function that is used in flake8-docstrings.
See https://gitlab.com/pycqa/flake8-docstrings/issues/36

This breaks our flake8 tests. Until the above issue is resolved, we should not use pydocstyle 4.0.