### PR TITLE
Use array-like in docs

### DIFF
--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -44,7 +44,7 @@ def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):
 
     Parameters
     ----------
-    x, y : array_like, shape (n, )
+    x, y : array-like, shape (n, )
         Input data.
 
     ax : matplotlib.axes.Axes

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1053,11 +1053,11 @@ class Axes(_AxesBase):
         y : scalar or sequence of scalar
             y-indexes where to plot the lines.
 
-        xmin, xmax : scalar or 1D array_like
+        xmin, xmax : scalar or 1D array-like
             Respective beginning and end of each line. If scalars are
             provided, all lines will have same length.
 
-        colors : array_like of colors, optional, default: 'k'
+        colors : array-like of colors, optional, default: 'k'
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
@@ -1128,14 +1128,14 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x : scalar or 1D array_like
+        x : scalar or 1D array-like
             x-indexes where to plot the lines.
 
-        ymin, ymax : scalar or 1D array_like
+        ymin, ymax : scalar or 1D array-like
             Respective beginning and end of each line. If scalars are
             provided, all lines will have same length.
 
-        colors : array_like of colors, optional, default: 'k'
+        colors : array-like of colors, optional, default: 'k'
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
@@ -1803,7 +1803,7 @@ class Axes(_AxesBase):
         basex : scalar, optional, default 10
             Base of the x logarithm.
 
-        subsx : array_like, optional
+        subsx : array-like, optional
             The location of the minor xticks. If *None*, reasonable locations
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_xscale` for details.
@@ -1852,7 +1852,7 @@ class Axes(_AxesBase):
         basey : scalar, optional, default 10
             Base of the y logarithm.
 
-        subsy : array_like, optional
+        subsy : array-like, optional
             The location of the minor yticks. If *None*, reasonable locations
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_yscale` for details.
@@ -2061,11 +2061,11 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x : array_like
+        x : array-like
             1-D sequence of x positions. It is assumed, but not checked, that
             it is uniformly increasing.
 
-        y : array_like
+        y : array-like
             1-D sequence of y levels.
 
         fmt : str, optional
@@ -4290,10 +4290,10 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x, y : scalar or array_like, shape (n, )
+        x, y : scalar or array-like, shape (n, )
             The data positions.
 
-        s : scalar or array_like, shape (n, ), optional
+        s : scalar or array-like, shape (n, ), optional
             The marker size in points**2.
             Default is ``rcParams['lines.markersize'] ** 2``.
 
@@ -4345,7 +4345,7 @@ class Axes(_AxesBase):
         alpha : scalar, optional, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
-        linewidths : scalar or array_like, optional, default: None
+        linewidths : scalar or array-like, optional, default: None
             The linewidth of the marker edges. Note: The default *edgecolors*
             is 'face'. You may want to change this as well.
             If *None*, defaults to :rc:`lines.linewidth`.
@@ -5707,10 +5707,10 @@ optional.
 
         Parameters
         ----------
-        C : array_like
+        C : array-like
             A scalar 2-D array. The values will be color-mapped.
 
-        X, Y : array_like, optional
+        X, Y : array-like, optional
             The coordinates of the quadrilateral corners. The quadrilateral
             for ``C[i, j]`` has corners at::
 
@@ -5938,10 +5938,10 @@ optional.
 
         Parameters
         ----------
-        C : array_like
+        C : array-like
             A scalar 2-D array. The values will be color-mapped.
 
-        X, Y : array_like, optional
+        X, Y : array-like, optional
             The coordinates of the quadrilateral corners. The quadrilateral
             for ``C[i, j]`` has corners at::
 
@@ -6405,7 +6405,7 @@ optional.
 
             Default is ``False``.
 
-        weights : (n, ) array_like or None, optional
+        weights : (n, ) array-like or None, optional
             An array of weights, of the same shape as *x*.  Each value in *x*
             only contributes its associated weight towards the bin count
             (instead of 1).  If *normed* or *density* is ``True``,
@@ -6438,7 +6438,7 @@ optional.
 
             Default is ``False``
 
-        bottom : array_like, scalar, or None
+        bottom : array-like, scalar, or None
             Location of the bottom baseline of each bin.  If a scalar,
             the base line for each bin is shifted by the same amount.
             If an array, each bin is shifted independently and the length
@@ -6487,7 +6487,7 @@ optional.
 
             Default is ``False``
 
-        color : color or array_like of colors or None, optional
+        color : color or array-like of colors or None, optional
             Color or sequence of colors, one per dataset.  Default (``None``)
             uses the standard line color sequence.
 
@@ -6850,10 +6850,10 @@ optional.
 
         Parameters
         ----------
-        x, y : array_like, shape (n, )
+        x, y : array-like, shape (n, )
             Input values
 
-        bins : None or int or [int, int] or array_like or [array, array]
+        bins : None or int or [int, int] or array-like or [array, array]
 
             The bin specification:
 
@@ -6861,14 +6861,14 @@ optional.
               (nx=ny=bins).
             - If ``[int, int]``, the number of bins in each dimension
               (nx, ny = bins).
-            - If array_like, the bin edges for the two dimensions
+            - If array-like, the bin edges for the two dimensions
               (x_edges=y_edges=bins).
             - If ``[array, array]``, the bin edges in each dimension
               (x_edges, y_edges = bins).
 
             The default value is 10.
 
-        range : array_like shape(2, 2), optional, default: None
+        range : array-like shape(2, 2), optional, default: None
             The leftmost and rightmost edges of the bins along each dimension
             (if not specified explicitly in the bins parameters): ``[[xmin,
             xmax], [ymin, ymax]]``. All values outside of this range will be
@@ -6878,7 +6878,7 @@ optional.
             Normalize histogram.  *normed* is a deprecated synonym for this
             parameter.
 
-        weights : array_like, shape (n, ), optional, default: None
+        weights : array-like, shape (n, ), optional, default: None
             An array of values w_i weighing each sample (x_i, y_i).
 
         cmin : scalar, optional, default: None

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -269,10 +269,10 @@ class RendererBase:
 
         Parameters
         ----------
-        points : array_like, shape=(3, 2)
+        points : array-like, shape=(3, 2)
             Array of (x, y) points for the triangle.
 
-        colors : array_like, shape=(3, 4)
+        colors : array-like, shape=(3, 4)
             RGBA colors for each point of the triangle.
 
         transform : `matplotlib.transforms.Transform`
@@ -288,10 +288,10 @@ class RendererBase:
 
         Parameters
         ----------
-        points : array_like, shape=(N, 3, 2)
+        points : array-like, shape=(N, 3, 2)
             Array of *N* (x, y) points for the triangles.
 
-        colors : array_like, shape=(N, 3, 4)
+        colors : array-like, shape=(N, 3, 4)
             Array of *N* RGBA colors for each point of the triangles.
 
         transform : `matplotlib.transforms.Transform`
@@ -471,7 +471,7 @@ class RendererBase:
             the distance in physical units (i.e., dots or pixels) from the
             bottom side of the canvas.
 
-        im : array_like, shape=(N, M, 4), dtype=np.uint8
+        im : array-like, shape=(N, M, 4), dtype=np.uint8
             An array of RGBA pixels.
 
         transform : `matplotlib.transforms.Affine2DBase`
@@ -668,7 +668,7 @@ class RendererBase:
 
         Parameters
         ----------
-        points : scalar or array_like
+        points : scalar or array-like
             a float or a numpy array of float
 
         Returns
@@ -899,7 +899,7 @@ class GraphicsContextBase:
         ----------
         dash_offset : float or None
             The offset (usually 0).
-        dash_list : array_like or None
+        dash_list : array-like or None
             The on-off sequence as points.
 
         Notes

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -231,7 +231,7 @@ class MarkerStyle:
 
         Parameters
         ----------
-        marker : string or array_like, optional, default: None
+        marker : string or array-like, optional, default: None
             See the descriptions of possible markers in the module docstring.
 
         fillstyle : string, optional, default: 'full'

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -981,7 +981,7 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     Parameters
     ----------
-    x : array_like
+    x : array-like
         1-D array or sequence.
 
     %(Spectral)s
@@ -1010,13 +1010,13 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     Returns
     -------
-    spectrum : array_like
+    spectrum : array-like
         2-D array, columns are the periodograms of successive segments.
 
-    freqs : array_like
+    freqs : array-like
         1-D array, frequencies corresponding to the rows in *spectrum*.
 
-    t : array_like
+    t : array-like
         1-D array, the times corresponding to midpoints of segments
         (i.e the columns in *spectrum*).
 
@@ -1392,7 +1392,7 @@ class GaussianKDE:
 
     Parameters
     ----------
-    dataset : array_like
+    dataset : array-like
         Datapoints to estimate from. In case of univariate data this is a 1-D
         array, otherwise a 2-D array with shape (# of dims, # of data).
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -100,15 +100,15 @@ class Path:
 
         Parameters
         ----------
-        vertices : array_like
-            The ``(n, 2)`` float array, masked array or sequence of pairs
+        vertices : array-like
+            The ``(N, 2)`` float array, masked array or sequence of pairs
             representing the vertices of the path.
 
             If *vertices* contains masked values, they will be converted
             to NaNs which are then handled correctly by the Agg
             PathIterator and other consumers of path data, such as
             :meth:`iter_segments`.
-        codes : {None, array_like}, optional
+        codes : array-like or None, optional
             n-length array integers representing the codes of the path.
             If not None, codes must be the same length as vertices.
             If None, *vertices* will be treated as a series of line segments.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1443,11 +1443,11 @@ def xticks(ticks=None, labels=None, **kwargs):
 
     Parameters
     ----------
-    ticks : array_like
+    ticks : array-like
         A list of positions at which ticks should be placed. You can pass an
         empty list to disable xticks.
 
-    labels : array_like, optional
+    labels : array-like, optional
         A list of explicit labels to place at the given *locs*.
 
     **kwargs
@@ -1518,11 +1518,11 @@ def yticks(ticks=None, labels=None, **kwargs):
 
     Parameters
     ----------
-    ticks : array_like
+    ticks : array-like
         A list of positions at which ticks should be placed. You can pass an
         empty list to disable yticks.
 
-    labels : array_like, optional
+    labels : array-like, optional
         A list of explicit labels to place at the given *locs*.
 
     **kwargs

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1101,7 +1101,7 @@ def test_internal_cpp_api():
 
     with pytest.raises(ValueError) as excinfo:
         trifinder.find_many([0], [0, 1])
-    excinfo.match(r'x and y must be array_like with same shape')
+    excinfo.match(r'x and y must be array-like with same shape')
 
 
 def test_qhull_large_offset():

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -11,7 +11,7 @@ class Triangulation:
     ----------
     x, y : array-like of shape (npoints)
         Coordinates of grid points.
-    triangles : integer array_like of shape (ntri, 3), optional
+    triangles : integer array-like of shape (ntri, 3), optional
         For each triangle, the indices of the three points that make
         up the triangle, ordered in an anticlockwise manner.  If not
         specified, the Delaunay triangulation is calculated.

--- a/lib/matplotlib/tri/trifinder.py
+++ b/lib/matplotlib/tri/trifinder.py
@@ -13,7 +13,7 @@ class TriFinder:
     usually better to use the function
     :func:`matplotlib.tri.Triangulation.get_trifinder`.
 
-    Derived classes implement __call__(x, y) where x and y are array_like point
+    Derived classes implement __call__(x, y) where x and y are array-like point
     coordinates of the same shape.
     """
     def __init__(self, triangulation):
@@ -46,7 +46,7 @@ class TrapezoidMapTriFinder(TriFinder):
         specified *x*, *y* points lie, or -1 for points that do not lie within
         a triangle.
 
-        *x*, *y* are array_like x and y coordinates of the same shape and any
+        *x*, *y* are array-like x and y coordinates of the same shape and any
         number of dimensions.
 
         Returns integer array with the same shape and *x* and *y*.

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -20,12 +20,12 @@ class TriInterpolator:
     Derived classes implement the following methods:
 
         - ``__call__(x, y)`` ,
-          where x, y are array_like point coordinates of the same shape, and
+          where x, y are array-like point coordinates of the same shape, and
           that returns a masked array of the same shape containing the
           interpolated z-values.
 
         - ``gradient(x, y)`` ,
-          where x, y are array_like point coordinates of the same
+          where x, y are array-like point coordinates of the same
           shape, and that returns a list of 2 masked arrays of the same shape
           containing the 2 derivatives of the interpolator (derivatives of
           interpolated z values with respect to x and y).
@@ -132,15 +132,15 @@ class TriInterpolator:
         :meth:`_interpolate_single_key`.)
 
         It is guaranteed that the calls to :meth:`_interpolate_single_key`
-        will be done with flattened (1-d) array_like input parameters *x*, *y*
+        will be done with flattened (1-d) array-like input parameters *x*, *y*
         and with flattened, valid `tri_index` arrays (no -1 index allowed).
 
         Parameters
         ----------
-        x, y : array_like
+        x, y : array-like
             x and y coordinates indicating where interpolated values are
             requested.
-        tri_index : integer array_like, optional
+        tri_index : array-like of int, optional
             Array of the containing triangle indices, same shape as
             *x* and *y*. Defaults to None. If None, these indices
             will be computed by a TriFinder instance.
@@ -244,7 +244,7 @@ class LinearTriInterpolator(TriInterpolator):
     ----------
     triangulation : :class:`~matplotlib.tri.Triangulation` object
         The triangulation to interpolate over.
-    z : array_like of shape (npoints,)
+    z : array-like of shape (npoints,)
         Array of values, defined at grid points, to interpolate between.
     trifinder : :class:`~matplotlib.tri.TriFinder` object, optional
           If this is not specified, the Triangulation's default TriFinder will
@@ -308,7 +308,7 @@ class CubicTriInterpolator(TriInterpolator):
     ----------
     triangulation : :class:`~matplotlib.tri.Triangulation` object
         The triangulation to interpolate over.
-    z : array_like of shape (npoints,)
+    z : array-like of shape (npoints,)
         Array of values, defined at grid points, to interpolate between.
     kind : {'min_E', 'geom', 'user'}, optional
         Choice of the smoothing algorithm, in order to compute
@@ -326,7 +326,7 @@ class CubicTriInterpolator(TriInterpolator):
         If not specified, the Triangulation's default TriFinder will
         be used by calling
         :func:`matplotlib.tri.Triangulation.get_trifinder`.
-    dz : tuple of array_likes (dzdx, dzdy), optional
+    dz : tuple of array-likes (dzdx, dzdy), optional
         Used only if  *kind* ='user'. In this case *dz* must be provided as
         (dzdx, dzdy) where dzdx, dzdy are arrays of the same shape as *z* and
         are the interpolant first derivatives at the *triangulation* points.
@@ -461,13 +461,13 @@ class CubicTriInterpolator(TriInterpolator):
         kind : {'min_E', 'geom', 'user'}
             Choice of the _DOF_estimator subclass to perform the gradient
             estimation.
-        dz : tuple of array_likes (dzdx, dzdy), optional
+        dz : tuple of array-likes (dzdx, dzdy), optional
             Used only if *kind*=user; in this case passed to the
             :class:`_DOF_estimator_user`.
 
         Returns
         -------
-        dof : array_like, shape (npts, 2)
+        dof : array-like, shape (npts, 2)
               Estimation of the gradient at triangulation nodes (stored as
               degree of freedoms of reduced-HCT triangle elements).
         """

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -168,16 +168,16 @@ class Line3D(lines.Line2D):
 
         Parameters
         ----------
-        x : array_like
-            The x-data to be plotted
-        y : array_like
-            The y-data to be plotted
-        z : array_like
-            The z-data to be plotted
+        x : array-like
+            The x-data to be plotted.
+        y : array-like
+            The y-data to be plotted.
+        z : array-like
+            The z-data to be plotted.
 
         Notes
         -----
-        Accepts x, y, z arguments or a single array_like (x, y, z)
+        Accepts x, y, z arguments or a single array-like (x, y, z)
         """
         if len(args) == 1:
             self._verts3d = args[0]
@@ -191,8 +191,8 @@ class Line3D(lines.Line2D):
 
         Returns
         -------
-        verts3d : length-3 tuple or array_likes
-            The current data as a tuple or array_likes
+        verts3d : length-3 tuple or array-likes
+            The current data as a tuple or array-likes.
         """
         return self._verts3d
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1714,7 +1714,7 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        polygons: list of (M_i, 3) array_like, or (..., M, 3) array_like
+        polygons: list of (M_i, 3) array-like, or (..., M, 3) array-like
             A sequence of polygons to compute normals for, which can have
             varying numbers of vertices. If the polygons all have the same
             number of vertices and array is passed, then the operation will
@@ -1722,7 +1722,7 @@ class Axes3D(Axes):
 
         Returns
         -------
-        normals: (..., 3) array_like
+        normals: (..., 3) array-like
             A normal vector estimated for the polygon.
 
         """
@@ -2751,7 +2751,7 @@ pivot='tail', normalize=False, **kwargs)
             As indicated by the ``/`` in the function signature, these
             arguments can only be passed positionally.
 
-        facecolors, edgecolors : array_like, optional
+        facecolors, edgecolors : array-like, optional
             The color to draw the faces and edges of the voxels. Can only be
             passed as keyword arguments.
             This parameter can be:

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -415,7 +415,7 @@ static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self
 
     if (x.empty() || y.empty() || x.dim(0) != y.dim(0)) {
         PyErr_SetString(PyExc_ValueError,
-            "x and y must be array_like with same shape");
+            "x and y must be array-like with same shape");
         return NULL;
     }
 


### PR DESCRIPTION
## PR Summary

Consistently use `array-like` instead of `array_like` as documented in https://matplotlib.org/devdocs/devel/documenting_mpl.html#parameter-type-descriptions.

