### PR TITLE
Use str instead of string as type in docstrings

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1479,7 +1479,7 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
     replace_names : list of str or None, optional, default: None
         The list of parameter names for which lookup into *data* should be
         attempted. If None, replacement is attempted for all arguments.
-    label_namer : string, optional, default: None
+    label_namer : str, optional, default: None
         If set e.g. to "namer" (which must be a kwarg in the function's
         signature -- not as ``**kwargs``), if the *namer* argument passed in is
         a (string) key of *data* and no *label* kwarg is passed, then use the

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -195,7 +195,7 @@ class AbstractMovieWriter(abc.ABC):
         ----------
         fig : `~matplotlib.figure.Figure`
             The figure object that contains the information for frames
-        outfile : string
+        outfile : str
             The filename of the resulting movie file
         dpi : int, optional
             The DPI (or resolution) for the file.  This controls the size
@@ -231,7 +231,8 @@ class AbstractMovieWriter(abc.ABC):
 
 
 class MovieWriter(AbstractMovieWriter):
-    '''Base class for writing movies.
+    """
+    Base class for writing movies.
 
     This is a base class for MovieWriter subclasses that write a movie frame
     data to a pipe. You cannot instantiate this class directly.
@@ -240,39 +241,38 @@ class MovieWriter(AbstractMovieWriter):
     Attributes
     ----------
     frame_format : str
-        The format used in writing frame data, defaults to 'rgba'
+        The format used in writing frame data, defaults to 'rgba'.
     fig : `~matplotlib.figure.Figure`
         The figure to capture data from.
         This must be provided by the sub-classes.
 
-    '''
+    """
 
     def __init__(self, fps=5, codec=None, bitrate=None, extra_args=None,
                  metadata=None):
-        '''MovieWriter
-
+        """
         Parameters
         ----------
         fps : int
             Framerate for movie.
-        codec : string or None, optional
-            The codec to use. If ``None`` (the default) the ``animation.codec``
-            rcParam is used.
+        codec : str or None, optional
+            The codec to use. If ``None`` (the default) :rc:`animation.codec`
+            is used.
         bitrate : int or None, optional
             The bitrate for the saved movie file, which is one way to control
             the output file size and quality. The default value is ``None``,
-            which uses the ``animation.bitrate`` rcParam.  A value of -1
-            implies that the bitrate should be determined automatically by the
-            underlying utility.
-        extra_args : list of strings or None, optional
+            which uses :rc:`animation.bitrate`.  A value of -1 implies that
+            the bitrate should be determined automatically by the underlying
+            utility.
+        extra_args : list of str or None, optional
             A list of extra string arguments to be passed to the underlying
             movie utility. The default is ``None``, which passes the additional
-            arguments in the ``animation.extra_args`` rcParam.
+            arguments in :rc:`animation.extra_args`.
         metadata : Dict[str, str] or None
             A dictionary of keys and values for metadata to include in the
             output file. Some keys that may be of use include:
             title, artist, genre, subject, copyright, srcform, comment.
-        '''
+        """
         if self.__class__ is MovieWriter:
             # TODO MovieWriter is still an abstract class and needs to be
             #      extended with a mixin. This should be clearer in naming

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -364,7 +364,7 @@ class Axes(_AxesBase):
             The length of handles and labels should be the same in this
             case. If they are not, they are truncated to the smaller length.
 
-        labels : sequence of strings, optional
+        labels : list of str, optional
             A list of labels to show next to the artists.
             Use this together with *handles*, if you need full control on what
             is shown in the legend and the automatic mechanism described above
@@ -1061,7 +1061,7 @@ class Axes(_AxesBase):
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
-        label : string, optional, default: ''
+        label : str, optional, default: ''
 
         Returns
         -------
@@ -1139,7 +1139,7 @@ class Axes(_AxesBase):
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
-        label : string, optional, default: ''
+        label : str, optional, default: ''
 
         Returns
         -------
@@ -2218,7 +2218,7 @@ class Axes(_AxesBase):
         linewidth : scalar or array-like, optional
             Width of the bar edge(s). If 0, don't draw edges.
 
-        tick_label : string or array-like, optional
+        tick_label : str or array-like, optional
             The tick labels of the bars.
             Default: None (Use default numeric labels.)
 
@@ -2514,7 +2514,7 @@ class Axes(_AxesBase):
         linewidth : scalar or array-like, optional
             Width of the bar edge(s). If 0, don't draw edges.
 
-        tick_label : string or array-like, optional
+        tick_label : str or array-like, optional
             The tick labels of the bars.
             Default: None (Use default numeric labels.)
 
@@ -2862,7 +2862,7 @@ class Axes(_AxesBase):
             will cycle.  If *None*, will use the colors in the currently
             active cycle.
 
-        autopct : None (default), string, or function, optional
+        autopct : None (default), str, or function, optional
             If not *None*, is a string or function used to label the wedges
             with their numeric value.  The label will be placed inside the
             wedge.  If it is a format string, the label will be ``fmt%pct``.
@@ -3097,7 +3097,7 @@ class Axes(_AxesBase):
             See :doc:`/gallery/statistics/errorbar_features`
             for an example on the usage of ``xerr`` and ``yerr``.
 
-        fmt : plot format string, optional, default: ''
+        fmt : str, optional, default: ''
             The format for the data points / data lines. See `.plot` for
             details.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2924,7 +2924,7 @@ class _AxesBase(martist.Artist):
             Transparency of gridlines: 0 (transparent) to 1 (opaque).
         grid_linewidth : float
             Width of gridlines in points.
-        grid_linestyle : string
+        grid_linestyle : str
             Any valid `~matplotlib.lines.Line2D` line style spec.
 
         Examples
@@ -3755,7 +3755,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        tz : string or `tzinfo` instance, optional
+        tz : str or `tzinfo` instance, optional
             Timezone.  Defaults to :rc:`timezone`.
         """
         # should be enough to inform the unit conversion interface
@@ -3768,7 +3768,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        tz : string or `tzinfo` instance, optional
+        tz : str or `tzinfo` instance, optional
             Timezone.  Defaults to :rc:`timezone`.
         """
         self.yaxis.axis_date(tz)

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -121,12 +121,12 @@ class SecondaryAxis(_AxesBase):
 
         Parameters
         ----------
-        location : string or scalar
+        location : {'top', 'bottom', 'left', 'right'} or float
             The position to put the secondary axis.  Strings can be 'top' or
             'bottom' for orientation='x' and 'right' or 'left' for
-            orientation='y', scalar can be a float indicating the relative
-            position on the parent axes to put the new axes, 0.0 being the
-            bottom (or left) and 1.0 being the top (or right).
+            orientation='y'. A float indicates the relative position on the
+            parent axes to put the new axes, 0.0 being the bottom (or left)
+            and 1.0 being the top (or right).
         """
 
         # This puts the rectangle into figure-relative coordinates.
@@ -374,12 +374,12 @@ This method is experimental as of 3.1, and the API may change.
 
 Parameters
 ----------
-location : string or scalar
+location : {'top', 'bottom', 'left', 'right'} or float
     The position to put the secondary axis.  Strings can be 'top' or
-    'bottom', for x-oriented axises or 'left' or 'right' for y-oriented axises
-    or a scalar can be a float indicating the relative position
-    on the axes to put the new axes (0 being the bottom (left), and 1.0 being
-    the top (right).)
+    'bottom' for orientation='x' and 'right' or 'left' for
+    orientation='y'. A float indicates the relative position on the
+    parent axes to put the new axes, 0.0 being the bottom (or left)
+    and 1.0 being the top (or right).
 
 functions : 2-tuple of func, or Transform with an inverse
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3168,8 +3168,8 @@ class ToolContainerBase:
 
         Parameters
         ----------
-        name : string
-            Name (id) of the tool triggered from within the container
+        name : str
+            Name (id) of the tool triggered from within the container.
         """
         self.toolmanager.trigger_tool(name, sender=self)
 
@@ -3184,7 +3184,7 @@ class ToolContainerBase:
 
         Parameters
         ----------
-        name : string
+        name : str
             Name of the tool to add, this gets used as the tool's ID and as the
             default label of the buttons
         group : String
@@ -3226,7 +3226,7 @@ class ToolContainerBase:
 
         Parameters
         ----------
-        name : string
+        name : str
             Name of the tool to remove.
         """
         raise NotImplementedError

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -163,8 +163,8 @@ class ToolManager:
 
         Parameters
         ----------
-        name : string
-            Name of the Tool
+        name : str
+            Name of the Tool.
 
         Returns
         -------
@@ -184,8 +184,8 @@ class ToolManager:
 
         Parameters
         ----------
-        name : string
-            Name of the Tool
+        name : str
+            Name of the Tool.
         keys : keys to associate with the Tool
         """
 
@@ -207,8 +207,8 @@ class ToolManager:
 
         Parameters
         ----------
-        name : string
-            Name of the Tool
+        name : str
+            Name of the Tool.
         """
 
         tool = self.get_tool(name)
@@ -355,8 +355,8 @@ class ToolManager:
 
         Parameters
         ----------
-        name : string
-            Name of the tool
+        name : str
+            Name of the tool.
         sender : object
             Object that wishes to trigger the tool
         canvasevent : Event

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -49,7 +49,7 @@ class ToolBase:
         ToolManager that controls this Tool
     figure : `FigureCanvas`
         Figure instance that is affected by this Tool
-    name : string
+    name : str
         Used as **Id** of the tool, has to be unique among tools of the same
         ToolManager
     """

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -437,7 +437,7 @@ class PdfFile:
         Parameters
         ----------
 
-        filename : file-like object or string
+        filename : str or path-like or file-like
             Output target; if a string, a file will be opened for writing.
         metadata : dict from strings to strings and dates
             Information dictionary object (see PDF reference section 10.2.1
@@ -2472,7 +2472,7 @@ class PdfPages:
 
         Parameters
         ----------
-        filename : str
+        filename : str or path-like or file-like
             Plots using :meth:`PdfPages.savefig` will be written to a file at
             this location. The file is opened at once and any older file with
             the same name is overwritten.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -989,7 +989,7 @@ class PdfPages:
 
         Parameters
         ----------
-        filename : str
+        filename : str or path-like
             Plots using :meth:`PdfPages.savefig` will be written to a file at
             this location. Any older file with the same name is overwritten.
         keep_empty : bool, optional

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -491,8 +491,8 @@ def fedit(data, title="", comment="", icon=None, parent=None, apply=None):
     (if Cancel button is pressed, return None)
 
     data: datalist, datagroup
-    title: string
-    comment: string
+    title: str
+    comment: str
     icon: QIcon instance
     parent: parent QWidget
     apply: apply callback (function)

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -32,7 +32,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         Parameters
         ----------
-        value : string or iterable
+        value : str or iterable
             Value or list of values to be converted.
         unit : `.UnitData`
             An object mapping strings to integers.
@@ -93,7 +93,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         Parameters
         ----------
-        data : string or iterable of strings
+        data : str or iterable of str
         axis : `~matplotlib.axis.Axis`
             axis on which the data is plotted
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -360,7 +360,7 @@ def to_filehandle(fname, flag='r', return_opened=False, encoding=None):
 
     Parameters
     ----------
-    fname : str or PathLike or file-like object
+    fname : str or path-like or file-like object
         If `str` or `os.PathLike`, the file is opened using the flags specified
         by *flag* and *encoding*.  If a file-like object, it is passed through.
     flag : str, default 'r'

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -906,7 +906,7 @@ class PathCollection(_CollectionWithSizes):
             to a `~.ticker.Locator` being used to find useful locations.
             If a list or array, use exactly those elements for the legend.
             Finally, a `~.ticker.Locator` can be provided.
-        fmt : string, `~matplotlib.ticker.Formatter`, or None (default)
+        fmt : str, `~matplotlib.ticker.Formatter`, or None (default)
             The format or formatter to use for the labels. If a string must be
             a valid input for a `~.StrMethodFormatter`. If None (the default),
             use a `~.ScalarFormatter`.
@@ -1240,8 +1240,8 @@ class LineCollection(Collection):
         antialiaseds : sequence, optional
             A sequence of ones or zeros.
 
-        linestyles : string, tuple, optional
-            Either one of [ 'solid' | 'dashed' | 'dashdot' | 'dotted' ], or
+        linestyles : str or tuple, optional
+            Either one of {'solid', 'dashed', 'dashdot', 'dotted'}, or
             a dash tuple. The dash tuple is::
 
                 (offset, onoffseq)
@@ -1252,7 +1252,7 @@ class LineCollection(Collection):
         norm : Normalize, optional
             `~.colors.Normalize` instance.
 
-        cmap : string or Colormap, optional
+        cmap : str or Colormap, optional
             Colormap name or `~.colors.Colormap` instance.
 
         pickradius : float, optional

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -64,7 +64,7 @@ class ContourLabeler:
             A list of level values, that should be labeled. The list must be
             a subset of ``cs.levels``. If not given, all levels are labeled.
 
-        fontsize : string or float, optional
+        fontsize : str or float, optional
             Size in points or relative size e.g., 'smaller', 'x-large'.
             See `.Text.set_size` for accepted string values.
 
@@ -92,7 +92,7 @@ class ContourLabeler:
             This spacing will be exact for labels at locations where the
             contour is straight, less so for labels on curved contours.
 
-        fmt : string or dict, optional
+        fmt : str or dict, optional
             A format string for the label. Default is '%1.3f'
 
             Alternatively, this can be a dictionary matching contour levels

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -380,7 +380,7 @@ def datestr2num(d, default=None):
 
     Parameters
     ----------
-    d : string or sequence of strings
+    d : str or sequence of str
         The dates to convert.
 
     default : datetime instance, optional
@@ -480,7 +480,7 @@ def num2date(x, tz=None):
     x : float or sequence of floats
         Number of days (fraction part represents hours, minutes, seconds)
         since 0001-01-01 00:00:00 UTC, plus one.
-    tz : string, optional
+    tz : str, optional
         Timezone of *x* (defaults to rcparams ``timezone``).
 
     Returns
@@ -654,7 +654,7 @@ class ConciseDateFormatter(ticker.Formatter):
     locator : `.ticker.Locator`
         Locator that this axis is using.
 
-    tz : string, optional
+    tz : str, optional
         Passed to `.dates.date2num`.
 
     formats : list of 6 strings, optional

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -583,7 +583,7 @@ class Vf(Dvi):
 
     Parameters
     ----------
-    filename : string or bytestring
+    filename : str or path-like
 
     Notes
     -----
@@ -704,7 +704,7 @@ class Tfm:
 
     Parameters
     ----------
-    filename : string or bytestring
+    filename : str or path-like
 
     Attributes
     ----------
@@ -771,7 +771,7 @@ class PsfontsMap:
 
     Parameters
     ----------
-    filename : string or bytestring
+    filename : str or path-like
 
     Notes
     -----
@@ -930,7 +930,7 @@ class Encoding:
 
     Parameters
     ----------
-    filename : string or bytestring
+    filename : str or path-like
 
     Attributes
     ----------
@@ -1011,8 +1011,8 @@ def find_tex_file(filename, format=None):
 
     Parameters
     ----------
-    filename : string or bytestring
-    format : string or bytestring
+    filename : str or path-like
+    format : str or bytes
         Used as the value of the `--format` option to :program:`kpsewhich`.
         Could be e.g. 'tfm' or 'vf' to limit the search to that type of files.
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -624,7 +624,7 @@ class Figure(Artist):
         rotation : angle in degrees
             The rotation of the xtick labels.
 
-        ha : string
+        ha : str
             The horizontal alignment of the xticklabels.
 
         which : {None, 'major', 'minor', 'both'}
@@ -1778,7 +1778,7 @@ default: 'top'
 
         Parameters
         ----------
-        handles : sequence of `.Artist`, optional
+        handles : list of `.Artist`, optional
             A list of Artists (lines, patches) to be added to the legend.
             Use this together with *labels*, if you need full control on what
             is shown in the legend and the automatic mechanism described above
@@ -1787,7 +1787,7 @@ default: 'top'
             The length of handles and labels should be the same in this
             case. If they are not, they are truncated to the smaller length.
 
-        labels : sequence of strings, optional
+        labels : list of str, optional
             A list of labels to show next to the artists.
             Use this together with *handles*, if you need full control on what
             is shown in the legend and the automatic mechanism described above

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -381,10 +381,10 @@ class Legend(Artist):
         parent : `~matplotlib.axes.Axes` or `.Figure`
             The artist that contains the legend.
 
-        handles : sequence of `.Artist`
+        handles : list of `.Artist`
             A list of Artists (lines, patches) to be added to the legend.
 
-        labels : sequence of strings
+        labels : list of str
             A list of labels to show next to the artists. The length of handles
             and labels should be the same. If they are not, they are truncated
             to the smaller of both lengths.

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -231,10 +231,10 @@ class MarkerStyle:
 
         Parameters
         ----------
-        marker : string or array-like, optional, default: None
+        marker : str or array-like, optional, default: None
             See the descriptions of possible markers in the module docstring.
 
-        fillstyle : string, optional, default: 'full'
+        fillstyle : str, optional, default: 'full'
             'full', 'left", 'right', 'bottom', 'top', 'none'
         """
         self._marker_function = None

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1311,7 +1311,7 @@ class AnchoredText(AnchoredOffsetbox):
         """
         Parameters
         ----------
-        s : string
+        s : str
             Text.
 
         loc : str

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4036,7 +4036,7 @@ class FancyArrowPatch(Patch):
 
         Parameters
         ----------
-        connectionstyle : None, ConnectionStyle instance, or string
+        connectionstyle : str or `.ConnectionStyle` or None, optional
             Can be a string with connectionstyle name with
             optional comma-separated attributes, e.g.::
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -437,7 +437,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
     Parameters
     ----------
-    num : integer or string, optional, default: None
+    num : int or str, optional, default: None
         If not provided, a new figure will be created, and the figure number
         will be incremented. The figure objects holds this number in a `number`
         attribute.
@@ -1081,7 +1081,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
           always a 2D array containing Axes instances, even if it ends up
           being 1x1.
 
-    num : integer or string, optional, default: None
+    num : int or str, optional, default: None
         A `.pyplot.figure` keyword that sets the figure number or label.
 
     subplot_kw : dict, optional

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -94,7 +94,7 @@ def _listify_validator(scalar_validator, allow_stringlist=False, *, doc=None):
             return [scalar_validator(v) for v in s
                     if not isinstance(v, str) or v]
         else:
-            raise ValueError("{!r} must be of type: string or non-dictionary "
+            raise ValueError("{!r} must be of type: str or non-dictionary "
                              "iterable".format(s))
     try:
         f.__name__ = "{}list".format(scalar_validator.__name__)

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -35,13 +35,21 @@ class Spine(mpatches.Patch):
     @docstring.dedent_interpd
     def __init__(self, axes, spine_type, path, **kwargs):
         """
-        - *axes* : the Axes instance containing the spine
-        - *spine_type* : a string specifying the spine type
-        - *path* : the path instance used to draw the spine
+        Parameters
+        ----------
+        axes : `~matplotlib.axes.Axes`
+            The `~.axes.Axes` instance containing the spine.
+        spine_type : str
+            The spine type.
+        path : `~matplotlib.path.Path`
+            The `.Path` instance used to draw the spine.
 
-        Valid kwargs are:
+        Other Parameters
+        ----------------
+        **kwargs
+            Valid keyword arguments are:
 
-        %(Patch)s
+            %(Patch)s
         """
         super().__init__(**kwargs)
         self.axes = axes

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -319,7 +319,7 @@ def image_comparison(baseline_images, extensions=None, tol=0,
     savefig_kwarg : dict
         Optional arguments that are passed to the savefig method.
 
-    style : string
+    style : str
         Optional name for the base style to apply to the image test. The test
         itself can also apply additional styles if desired. Defaults to the
         '_classic_test' style.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1365,7 +1365,7 @@ class PercentFormatter(Formatter):
         The number of decimal places to place after the point.
         If *None* (the default), the number will be computed automatically.
 
-    symbol : string or None
+    symbol : str or None
         A string that will be appended to the label. It may be
         *None* or empty to indicate that no symbol should be used. LaTeX
         special characters are escaped in *symbol* whenever latex mode is
@@ -2153,7 +2153,7 @@ class LogLocator(Locator):
 
         Parameters
         ----------
-        subs : None, string, or sequence of float, optional, default (1.0,)
+        subs : None, str, or sequence of float, optional, default (1.0,)
             Gives the multiples of integer powers of the base at which
             to place ticks.  The default places ticks only at
             integer powers of the base.

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -215,7 +215,7 @@ class TriInterpolator:
 
         Parameters
         ----------
-        return_index : string key from {'z', 'dzdx', 'dzdy'}
+        return_index : {'z', 'dzdx', 'dzdy'}
             Identifies the requested values (z or its derivatives)
         tri_index : 1d integer array
             Valid triangle index (-1 prohibited)

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -387,7 +387,7 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
             The transformation object for the coordinate system in use, i.e.,
             :attr:`matplotlib.axes.Axes.transAxes`.
 
-        label_x, label_y : string
+        label_x, label_y : str
             Label text for the x and y arrows
 
         length : int or float, optional

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -512,11 +512,11 @@ class AxesDivider(Divider):
 
         Parameters
         ----------
-        size : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or string
+        size : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or str
             A width of the axes. If float or string is given, *from_any*
             function is used to create the size, with *ref_size* set to AxesX
             instance of the current axes.
-        pad : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or string
+        pad : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or str
             Pad between the axes. It takes same argument as *size*.
         pack_start : bool
             If False, the new axes is appended at the end
@@ -561,11 +561,11 @@ class AxesDivider(Divider):
 
         Parameters
         ----------
-        size : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or string
+        size : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or str
             A height of the axes. If float or string is given, *from_any*
             function is used to create the size, with *ref_size* set to AxesX
             instance of the current axes.
-        pad : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or string
+        pad : :mod:`~mpl_toolkits.axes_grid.axes_size` or float or str
             Pad between the axes. It takes same argument as *size*.
         pack_start : bool
             If False, the new axes is appended at the end

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -430,7 +430,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
         are relative to the parent_axes. Otherwise they are to be understood
         relative to the bounding box provided via *bbox_to_anchor*.
 
-    loc : int or string, optional, default to 1
+    loc : int or str, optional, default to 1
         Location to place the inset axes. The valid locations are::
 
             'upper right'  : 1,
@@ -549,7 +549,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
         coordinates (i.e., "zoomed in"), while *zoom* < 1 will shrink the
         coordinates (i.e., "zoomed out").
 
-    loc : int or string, optional, default to 1
+    loc : int or str, optional, default to 1
         Location to place the inset axes. The valid locations are::
 
             'upper right'  : 1,


### PR DESCRIPTION
## PR Summary

See also https://matplotlib.org/devdocs/devel/documenting_mpl.html#parameter-type-descriptions and the `Parameters` section of the [numpydoc docstring guide](https://numpydoc.readthedocs.io/en/latest/format.html).