### PR TITLE
Add explanations for single character color names.

### DIFF
--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -2,14 +2,15 @@ from collections import OrderedDict
 
 
 BASE_COLORS = {
-    'b': (0, 0, 1),
-    'g': (0, 0.5, 0),
-    'r': (1, 0, 0),
-    'c': (0, 0.75, 0.75),
-    'm': (0.75, 0, 0.75),
-    'y': (0.75, 0.75, 0),
-    'k': (0, 0, 0),
-    'w': (1, 1, 1)}
+    'b': (0, 0, 1),        # blue
+    'g': (0, 0.5, 0),      # green
+    'r': (1, 0, 0),        # red
+    'c': (0, 0.75, 0.75),  # cyan
+    'm': (0.75, 0, 0.75),  # magenta
+    'y': (0.75, 0.75, 0),  # yellow
+    'k': (0, 0, 0),        # black
+    'w': (1, 1, 1),        # white
+}
 
 
 # These colors are from Tableau
@@ -32,8 +33,10 @@ TABLEAU_COLORS = OrderedDict(
 
 # This mapping of color names -> hex values is taken from
 # a survey run by Randall Munroe see:
-# http://blog.xkcd.com/2010/05/03/color-survey-results/
+# https://blog.xkcd.com/2010/05/03/color-survey-results/
 # for more details.  The results are hosted at
+# https://xkcd.com/color/rgb
+# and also available as a text file at
 # https://xkcd.com/color/rgb.txt
 #
 # License: http://creativecommons.org/publicdomain/zero/1.0/

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -36,13 +36,15 @@ RGBA array (:func:`to_rgba_array`).  Caching is used for efficiency.
 
 Matplotlib recognizes the following formats to specify a color:
 
-* an RGB or RGBA tuple of float values in ``[0, 1]`` (e.g., ``(0.1, 0.2, 0.5)``
-  or ``(0.1, 0.2, 0.5, 0.3)``);
+* an RGB or RGBA (red, green, blue, alpha) tuple of float values in closed
+  interval ``[0, 1]`` (e.g., ``(0.1, 0.2, 0.5)`` or ``(0.1, 0.2, 0.5, 0.3)``);
 * a hex RGB or RGBA string (e.g., ``'#0f0f0f'`` or ``'#0f0f0f80'``;
   case-insensitive);
 * a string representation of a float value in ``[0, 1]`` inclusive for gray
   level (e.g., ``'0.5'``);
-* one of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``;
+* one of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, they are the single
+  character short-hand notations for blue, green, red, cyan, magenta, yellow,
+  black, and white.
 * a X11/CSS4 color name (case-insensitive);
 * a name from the `xkcd color survey`_, prefixed with ``'xkcd:'`` (e.g.,
   ``'xkcd:sky blue'``; case insensitive);

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -5,13 +5,15 @@ Specifying Colors
 
 Matplotlib recognizes the following formats to specify a color:
 
-* an RGB or RGBA (red, green, blue, alpha) tuple of float values in ``[0, 1]``
-  (e.g., ``(0.1, 0.2, 0.5)`` or ``(0.1, 0.2, 0.5, 0.3)``);
+* an RGB or RGBA (red, green, blue, alpha) tuple of float values in closed
+  interval ``[0, 1]`` (e.g., ``(0.1, 0.2, 0.5)`` or ``(0.1, 0.2, 0.5, 0.3)``);
 * a hex RGB or RGBA string (e.g., ``'#0f0f0f'`` or ``'#0f0f0f80'``;
   case-insensitive);
 * a string representation of a float value in ``[0, 1]`` inclusive for gray
   level (e.g., ``'0.5'``);
-* one of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``;
+* one of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, they are the single
+  character short-hand notations for blue, green, red, cyan, magenta, yellow,
+  black, and white.
 * a X11/CSS4 color name (case-insensitive);
 * a name from the `xkcd color survey`_, prefixed with ``'xkcd:'`` (e.g.,
   ``'xkcd:sky blue'``; case insensitive);


### PR DESCRIPTION
## PR Summary

Main changes in 3 files:

* `lib/matplotlib/_color_data.py`: add comments for single character color names.
* `lib/matplotlib/colors.py`: add explanations for single character color names in docstring;
* `tutorials/colors/colors.py`: sync the color descriptions with the `lib/matplotlib/colors.py`