### PR TITLE
Make Qt navtoolbar more robust against removal of either pan or zoom.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -680,6 +680,8 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
     def _init_toolbar(self):
         self.basedir = str(cbook._get_data_path('images'))
+        # Ensure that zoom and pan are mutually exclusive.
+        self._button_group = QtWidgets.QButtonGroup()
 
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:
@@ -690,6 +692,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                 self._actions[callback] = a
                 if callback in ['zoom', 'pan']:
                     a.setCheckable(True)
+                    self._button_group.addButton(self.widgetForAction(a))
                 if tooltip_text is not None:
                     a.setToolTip(tooltip_text)
                 if text == 'Subplots':
@@ -763,18 +766,13 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             ax = axes[titles.index(item)]
         figureoptions.figure_edit(ax, self)
 
-    def _update_buttons_checked(self):
-        # sync button checkstates to match active mode
-        self._actions['pan'].setChecked(self._active == 'PAN')
-        self._actions['zoom'].setChecked(self._active == 'ZOOM')
-
     def pan(self, *args):
         super().pan(*args)
-        self._update_buttons_checked()
+        self._actions['pan'].setChecked(self._active == 'PAN')
 
     def zoom(self, *args):
         super().zoom(*args)
-        self._update_buttons_checked()
+        self._actions['zoom'].setChecked(self._active == 'ZOOM')
 
     def set_message(self, s):
         self.message.emit(s)


### PR DESCRIPTION
... by using a QButtonGroup to ensure that a button gets unchecked when
the other gets checked.

Closes #12893.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
