### PR TITLE
Move the debug-mode TransformNode.write_graphviz out.

### DIFF
--- a/lib/matplotlib/_internal_utils.py
+++ b/lib/matplotlib/_internal_utils.py
@@ -1,0 +1,64 @@
+"""
+Internal debugging utilities, that are not expected to be used in the rest of
+the codebase.
+
+WARNING: Code in this module may change without prior notice!
+"""
+
+from io import StringIO
+from pathlib import Path
+import subprocess
+
+from matplotlib.transforms import TransformNode
+
+
+def graphviz_dump_transform(transform, dest, *, highlight=None):
+    """
+    Generate a graphical representation of the transform tree for *transform*
+    using the :program:`dot` program (which this function depends on).  The
+    output format (png, dot, etc.) is determined from the suffix of *dest*.
+
+    Parameters
+    ----------
+    transform : `~matplotlib.transform.Transform`
+        The represented transform.
+    dest : str
+        Output filename.  The extension must be one of the formats supported
+        by :program:`dot`, e.g. png, svg, dot, ...
+        (see https://www.graphviz.org/doc/info/output.html).
+    highlight : list of `~matplotlib.transform.Transform` or None
+        The transforms in the tree to be drawn in bold.
+        If *None*, *transform* is highlighted.
+    """
+
+    if highlight is None:
+        highlight = [transform]
+    seen = set()
+
+    def recurse(root, buf):
+        if id(root) in seen:
+            return
+        seen.add(id(root))
+        props = {}
+        label = type(root).__name__
+        if root._invalid:
+            label = f'[{label}]'
+        if root in highlight:
+            props['style'] = 'bold'
+        props['shape'] = 'box'
+        props['label'] = '"%s"' % label
+        props = ' '.join(map('{0[0]}={0[1]}'.format, props.items()))
+        buf.write(f'{id(root)} [{props}];\n')
+        for key, val in vars(root).items():
+            if isinstance(val, TransformNode) and id(root) in val._parents:
+                buf.write(f'"{id(root)}" -> "{id(val)}" '
+                          f'[label="{key}", fontsize=10];\n')
+                recurse(val, buf)
+
+    buf = StringIO()
+    buf.write('digraph G {\n')
+    recurse(transform, buf)
+    buf.write('}\n')
+    subprocess.run(
+        ['dot', '-T', Path(dest).suffix[1:], '-o', dest],
+        input=buf.getvalue().encode('utf-8'), check=True)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -200,14 +200,6 @@ class TransformNode:
                 self, lambda _, pop=child._parents.pop, k=id(self): pop(k))
             child._parents[id(self)] = ref
 
-    if DEBUG:
-        _set_children = set_children
-
-        def set_children(self, *children):
-            self._set_children(*children)
-            self._children = children
-        set_children.__doc__ = _set_children.__doc__
-
     def frozen(self):
         """
         Returns a frozen copy of this transform node.  The frozen copy
@@ -216,56 +208,6 @@ class TransformNode:
         ``copy.deepcopy()`` might normally be used.
         """
         return self
-
-    if DEBUG:
-        def write_graphviz(self, fobj, highlight=[]):
-            """
-            For debugging purposes.
-
-            Writes the transform tree rooted at 'self' to a graphviz "dot"
-            format file.  This file can be run through the "dot" utility
-            to produce a graph of the transform tree.
-
-            Affine transforms are marked in blue.  Bounding boxes are
-            marked in yellow.
-
-            *fobj*: A Python file-like object
-
-            Once the "dot" file has been created, it can be turned into a
-            png easily with::
-
-                $> dot -Tpng -o $OUTPUT_FILE $DOT_FILE
-
-            """
-            seen = set()
-
-            def recurse(root):
-                if root in seen:
-                    return
-                seen.add(root)
-                props = {}
-                label = root.__class__.__name__
-                if root._invalid:
-                    label = '[%s]' % label
-                if root in highlight:
-                    props['style'] = 'bold'
-                props['shape'] = 'box'
-                props['label'] = '"%s"' % label
-                props = ' '.join(map('{0[0]}={0[1]}'.format, props.items()))
-
-                fobj.write('%s [%s];\n' % (hash(root), props))
-
-                if hasattr(root, '_children'):
-                    for child in root._children:
-                        name = next((key for key, val in root.__dict__.items()
-                                     if val is child), '?')
-                        fobj.write('"%s" -> "%s" [label="%s", fontsize=10];\n'
-                                   % (hash(root), hash(child), name))
-                        recurse(child)
-
-            fobj.write("digraph G {\n")
-            recurse(self)
-            fobj.write("}\n")
 
 
 class BboxBase(TransformNode):


### PR DESCRIPTION
It was only accessible by modifying the source of transforms.py to set
DEBUG to True (before the module is imported), and anyways broken
because transforms are not hashable in Py3 (so the call to hash()
fails).

Instead move it to a private module.

Example use:
```
from matplotlib._internal_utils import graphviz_dump_transform
graphviz_dump_transform(plt.gca().transAxes, "/tmp/test.png")
```

Also, stop tracking transform node children even in debug mode, as it
was only used when dumping the transform but that's not even necessary
-- one can just inspect `vars(node)` to look for children.

Also fix `AffineBase.__eq__` to check that the "other" object has a
get_matrix method, to not raise an AttributeError when comparing with
Bboxes (which don't).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
