### PR TITLE
Small simplifications.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -163,15 +163,11 @@ def _mark_every_path(markevery, tpath, affine, ax_transform):
             delta = np.empty((len(disp_coords), 2))
             delta[0, :] = 0
             delta[1:, :] = disp_coords[1:, :] - disp_coords[:-1, :]
-            delta = np.sum(delta**2, axis=1)
-            delta = np.sqrt(delta)
-            delta = np.cumsum(delta)
+            delta = np.hypot(*delta.T).cumsum()
             # calc distance between markers along path based on the axes
             # bounding box diagonal being a distance of unity:
-            scale = ax_transform.transform(np.array([[0, 0], [1, 1]]))
-            scale = np.diff(scale, axis=0)
-            scale = np.sum(scale**2)
-            scale = np.sqrt(scale)
+            (x0, y0), (x1, y1) = ax_transform.transform([[0, 0], [1, 1]])
+            scale = np.hypot(x1 - x0, y1 - y0)
             marker_delta = np.arange(start * scale, delta[-1], step * scale)
             # find closest actual data point that is closest to
             # the theoretical distance along the path:

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1484,9 +1484,8 @@ class GaussianKDE:
 
         self.covariance = self.data_covariance * self.factor ** 2
         self.inv_cov = self.data_inv_cov / self.factor ** 2
-        self.norm_factor = np.sqrt(
-            np.linalg.det(
-                2 * np.pi * self.covariance)) * self.num_dp
+        self.norm_factor = (np.sqrt(np.linalg.det(2 * np.pi * self.covariance))
+                            * self.num_dp)
 
     def scotts_factor(self):
         return np.power(self.num_dp, -1. / (self.dim + 4))

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -691,7 +691,7 @@ def test_pathcollection_legend_elements():
     l3 = ax.legend(h, l, loc=4)
 
     h, l = sc.legend_elements(prop="sizes", num=4, fmt="{x:.2f}",
-                           func=lambda x: 2*x)
+                              func=lambda x: 2*x)
     actsizes = [line.get_markersize() for line in h]
     labeledsizes = np.sqrt(np.array(l).astype(float)/2)
     assert_array_almost_equal(actsizes, labeledsizes)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1967,15 +1967,13 @@ class ToolHandles:
 
     def closest(self, x, y):
         """Return index and pixel distance to closest index."""
-        pts = np.transpose((self.x, self.y))
+        pts = np.column_stack([self.x, self.y])
         # Transform data coordinates to pixel coordinates.
         pts = self.ax.transData.transform(pts)
-        diff = pts - ((x, y))
-        if diff.ndim == 2:
-            dist = np.sqrt(np.sum(diff ** 2, axis=1))
-            return np.argmin(dist), np.min(dist)
-        else:
-            return 0, np.sqrt(np.sum(diff ** 2))
+        diff = pts - [x, y]
+        dist = np.hypot(*diff.T)
+        min_index = np.argmin(dist)
+        return min_index, dist[min_index]
 
 
 class RectangleSelector(_SelectorWidget):


### PR DESCRIPTION
I'm fine with preferring sqrt(x**2+y**2) to hypot() for legibility, but
when the first form is written sqrt(sum(..., axis=1)) then hypot() is
really just as good.

Likewise, np.column_stack([x, y]) indicates the shape of the result
better than np.transpose((x, y)).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
