### PR TITLE
Deduplicate wx configure_subplots tool.

### DIFF
--- a/doc/api/next_api_changes/2019-07-10-AL.rst
+++ b/doc/api/next_api_changes/2019-07-10-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``backend_wx.ConfigureSubplotsWx.configure_subplots`` and
+``backend_wx.ConfigureSubplotsWx.get_canvas`` are deprecated.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1406,13 +1406,13 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self.ToggleTool(self.wx_ids['Zoom'], False)
         NavigationToolbar2.pan(self, *args)
 
-    def configure_subplots(self, evt):
+    def configure_subplots(self, *args):
         global FigureManager  # placates pyflakes: created by @_Backend.export
         frame = wx.Frame(None, -1, "Configure subplots")
         _set_frame_icon(frame)
 
         toolfig = Figure((6, 3))
-        canvas = self.get_canvas(frame, toolfig)
+        canvas = type(self.canvas)(frame, -1, toolfig)
 
         # Create a figure manager to manage things
         FigureManager(canvas, 1, frame)
@@ -1653,8 +1653,10 @@ class StatusbarWx(StatusbarBase, wx.StatusBar):
 
 class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
-        self.configure_subplots()
+        NavigationToolbar2Wx.configure_subplots(
+            self._make_classic_style_pseudo_toolbar())
 
+    @cbook.deprecated("3.2")
     def configure_subplots(self):
         frame = wx.Frame(None, -1, "Configure subplots")
         _set_frame_icon(frame)
@@ -1671,6 +1673,7 @@ class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
         SubplotTool(self.canvas.figure, toolfig)
         frame.Show()
 
+    @cbook.deprecated("3.2")
     def get_canvas(self, frame, fig):
         return type(self.canvas)(frame, -1, fig)
 


### PR DESCRIPTION
... by using the old toolbar implementation instead.

Basically the same as #14569, but for wx.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
