### PR TITLE
Deprecate FigureFrameWx.statusbar & NavigationToolbar2Wx.statbar.

### DIFF
--- a/doc/api/next_api_changes/2019-07-11-AL.rst
+++ b/doc/api/next_api_changes/2019-07-11-AL.rst
@@ -1,0 +1,6 @@
+Deprecations
+````````````
+
+``FigureFrameWx.statusbar`` and ``NavigationToolbar2Wx.statbar`` are deprecated.
+The status bar can be retrieved by calling standard wx methods
+(``frame.GetStatusBar()`` and ``toolbar.GetTopLevelParent().GetStatusBar()``).

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1029,12 +1029,10 @@ class FigureFrameWx(wx.Frame):
         # of the frame - so appearance is closer to GTK version
 
         self.toolmanager = self._get_toolmanager()
-        if self.toolmanager:
-            self.statusbar = StatusbarWx(self, self.toolmanager)
-        else:
-            self.statusbar = StatusBarWx(self)
-        self.SetStatusBar(self.statusbar)
-        self.toolbar = self._get_toolbar(self.statusbar)
+        statusbar = (StatusbarWx(self, self.toolmanager)
+                     if self.toolmanager else StatusBarWx(self))
+        self.SetStatusBar(statusbar)
+        self.toolbar = self._get_toolbar()
 
         if self.toolmanager:
             backend_tools.add_tools_to_manager(self.toolmanager)
@@ -1060,10 +1058,14 @@ class FigureFrameWx(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self._onClose)
 
-    def _get_toolbar(self, statbar):
+    @cbook.deprecated("3.2", alternative="self.GetStatusBar()")
+    @property
+    def statusbar(self):
+        return self.GetStatusBar()
+
+    def _get_toolbar(self):
         if rcParams['toolbar'] == 'toolbar2':
             toolbar = NavigationToolbar2Wx(self.canvas)
-            toolbar.set_status_bar(statbar)
         elif matplotlib.rcParams['toolbar'] == 'toolmanager':
             toolbar = ToolbarWx(self.toolmanager, self)
         else:
@@ -1305,7 +1307,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         NavigationToolbar2.__init__(self, canvas)
         self.canvas = canvas
         self._idle = True
-        self.statbar = None
         self.prevZoomRect = None
         # for now, use alternate zoom-rectangle drawing on all
         # Macs. N.B. In future versions of wx it may be possible to
@@ -1485,12 +1486,20 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         dc.SetBrush(wx.Brush(color))
         dc.DrawRectangle(rect)
 
+    @cbook.deprecated("3.2")
     def set_status_bar(self, statbar):
-        self.statbar = statbar
+        self.GetTopLevelParent().SetStatusBar(statbar)
+
+    @cbook.deprecated("3.2",
+                      alternative="self.GetTopLevelParent().GetStatusBar()")
+    @property
+    def statbar(self):
+        return self.GetTopLevelParent().GetStatusBar()
 
     def set_message(self, s):
-        if self.statbar is not None:
-            self.statbar.set_function(s)
+        status_bar = self.GetTopLevelParent().GetStatusBar()
+        if status_bar is not None:
+            status_bar.set_function(s)
 
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0


### PR DESCRIPTION
The attributes doesn't exist in any other backends, are named
inconsistently, and can be easily retrieved from the frame or
toolbar.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
