### PR TITLE
Remove sudo tag in travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 dist: xenial
-sudo: false
 
 services:
   - xvfb


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).