### PR TITLE
DOC: Update description of properties of Line2D in 'plot' documentation.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1095,6 +1095,7 @@ class Line2D(Artist):
         Parameters
         ----------
         w : float
+	     Line width, in points.
         """
         w = float(w)
 
@@ -1227,6 +1228,7 @@ class Line2D(Artist):
         Parameters
         ----------
         ew : float
+	      Marker edge width, in points.
         """
         if ew is None:
             ew = rcParams['lines.markeredgewidth']
@@ -1269,6 +1271,7 @@ class Line2D(Artist):
         Parameters
         ----------
         sz : float
+	      Marker size, in points.
         """
         sz = float(sz)
         if self._markersize != sz:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1095,7 +1095,7 @@ class Line2D(Artist):
         Parameters
         ----------
         w : float
-	     Line width, in points.
+            Line width, in points.
         """
         w = float(w)
 
@@ -1228,7 +1228,7 @@ class Line2D(Artist):
         Parameters
         ----------
         ew : float
-	      Marker edge width, in points.
+             Marker edge width, in points.
         """
         if ew is None:
             ew = rcParams['lines.markeredgewidth']
@@ -1271,7 +1271,7 @@ class Line2D(Artist):
         Parameters
         ----------
         sz : float
-	      Marker size, in points.
+             Marker size, in points.
         """
         sz = float(sz)
         if self._markersize != sz:


### PR DESCRIPTION
Line2D properties on plot documentation had only mentioned property value to be float and had not given any info on unit used.
Added info on unit used for properties is points.

closes #14720

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
