### PR TITLE
Deprecate AxisArtist.dpi_transform.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -465,3 +465,8 @@ keyword-only, consistently with ``Colorbar``.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Passing ``None`` as either the ``radius`` or ``startangle`` of an `.Axes.pie`
 is deprecated; use the explicit defaults of 1 and 0, respectively, instead.
+
+``AxisArtist.dpi_transform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  Scale ``Figure.dpi_scale_trans`` by 1/72 to achieve the
+same effect.


### PR DESCRIPTION
Figures already keep dpi_scale_trans correctly up-to-date; no need to
have additional code to keep a 1/72-scale version up-to-date as well.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
