### PR TITLE
Fix get_canvas_width_height() for pgf backend.

### DIFF
--- a/doc/api/next_api_changes/2019-07-20-AL.rst
+++ b/doc/api/next_api_changes/2019-07-20-AL.rst
@@ -1,0 +1,4 @@
+The pgf backend's get_canvas_width_height now returns the canvas size in display units
+``````````````````````````````````````````````````````````````````````````````````````
+
+... rather than in inches, which it previously did.  The new behavior is the correct one given the uses of ``get_canvas_width_height`` in the rest of the codebase.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -736,7 +736,8 @@ class RendererPgf(RendererBase):
 
     def get_canvas_width_height(self):
         # docstring inherited
-        return self.figure.get_figwidth(), self.figure.get_figheight()
+        return (self.figure.get_figwidth() * self.dpi,
+                self.figure.get_figheight() * self.dpi)
 
     def points_to_pixels(self, points):
         # docstring inherited


### PR DESCRIPTION
The pgf backend's get_canvas_width_height returns the canvas size in
inches, but it should return it in display units ("pixels", or
inches*dpi) instead.

get_canvas_width_height is actually barely used (only in text.py for
some backends (not pgf), in collections.py as an optimization, and in
BboxImage -- the only really relevant case), so to show the failure,
apply

    diff --git i/examples/text_labels_and_annotations/demo_text_path.py w/examples/text_labels_and_annotations/demo_text_path.py
    index 47ed5dde6..d45a922f4 100644
    --- i/examples/text_labels_and_annotations/demo_text_path.py
    +++ w/examples/text_labels_and_annotations/demo_text_path.py
    @@ -61,6 +61,7 @@ class PathClippedImagePatch(mpatches.PathPatch):

    if __name__ == "__main__":

    +    import matplotlib; matplotlib.use("pgf")
        usetex = plt.rcParams["text.usetex"]

        fig = plt.figure()
    @@ -156,4 +157,5 @@ if __name__ == "__main__":
        ax.set_xlim(0, 1)
        ax.set_ylim(0, 1)

    +    plt.savefig("/tmp/test.pdf")
        plt.show()

and observe that the image is incorrectly drawn before the patch, but
correctly after.

before:
[old.pdf](https://github.com/matplotlib/matplotlib/files/3387461/old.pdf)

after:
[new.pdf](https://github.com/matplotlib/matplotlib/files/3387462/new.pdf)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
