### PR TITLE
Remove incorrect color/cmap docstring line in contour.py

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1663,6 +1663,8 @@ class QuadContourSet(ContourSet):
             maps the level values to colors.
             Defaults to :rc:`image.cmap`.
 
+            If both *colors* and *cmap* are given, an error is raised.
+
         norm : `~matplotlib.colors.Normalize`, optional
             If a colormap is used, the `.Normalize` instance scales the level
             values to the canonical colormap range [0, 1] for mapping to

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1663,8 +1663,6 @@ class QuadContourSet(ContourSet):
             maps the level values to colors.
             Defaults to :rc:`image.cmap`.
 
-            If given, *colors* take precedence over *cmap*.
-
         norm : `~matplotlib.colors.Normalize`, optional
             If a colormap is used, the `.Normalize` instance scales the level
             values to the canonical colormap range [0, 1] for mapping to


### PR DESCRIPTION
## PR Summary
* Modified incorrect docstring, such that the docs match the code for color/cmap usage in contour.py
* Closing https://github.com/matplotlib/matplotlib/issues/14618
* Discussion: should the error raised be a ValueError (current state) or TypeError?

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->