### PR TITLE
Compiling C-ext with incorrect FreeType libs makes future compiles break

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -96,7 +96,8 @@ formed characters, causing these image comparisons to fail.  To make
 them reproducible, Matplotlib can be built with a special local copy
 of FreeType.  This is recommended for all Matplotlib developers.
 
-Copy :file:`setup.cfg.template` to :file:`setup.cfg` and edit it to contain::
+Prior to compiling the C-extensions, copy :file:`setup.cfg.template` to
+:file:`setup.cfg` and edit it to contain::
 
   [test]
   local_freetype = True


### PR DESCRIPTION
Compiling C-ext with incorrect FreeType libs makes future compiles also incorrect

## PR Summary
Minor update to developer setup documentation. If FreeType settings are not configured properly during the first attempt at compiling matplotlib from source, subsequent executions of `python -mpip install -ev .` will not rebuild the C-extensions.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
