### PR TITLE
DOC: minor CoC wording change

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -5,9 +5,12 @@ Contributing
 ============
 
 This project is a community effort, and everyone is welcome to
-contribute.
+contribute.  We follow the `Python Software Foundation Code of Conduct
+<coc_>`_ in everything we do.
 
 The project is hosted on https://github.com/matplotlib/matplotlib
+
+.. _coc: http://www.python.org/psf/codeofconduct/
 
 Submitting a bug report
 =======================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -112,7 +112,7 @@ including printed material, videos and tutorials.
 Need help?
 ~~~~~~~~~~
 
-Matplotlib is a welcoming, inclusive project, and we try to follow the `Python
+Matplotlib is a welcoming, inclusive project, and we follow the `Python
 Software Foundation Code of Conduct <coc_>`_ in everything we do.
 
 .. _coc: http://www.python.org/psf/codeofconduct/


### PR DESCRIPTION
- add note to the contributing guide
 - remove qualifier about following CoC on main page

This is not a replacement for a bigger discussion about CoC, possibly
changing which one we use (but under no condition writing our own!),
and setting up reporting and enforcement mechanism.