### PR TITLE
Deprecate math_symbol_table function directive

### DIFF
--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -1,4 +1,7 @@
+from docutils.parsers.rst import Directive
+
 from matplotlib import mathtext
+from matplotlib import cbook
 
 
 symbols = [
@@ -137,16 +140,26 @@ def run(state_machine):
     return []
 
 
+@cbook.deprecated("3.2", alternative="MathSymbolTableDirective")
 def math_symbol_table_directive(
         name, arguments, options, content, lineno,
         content_offset, block_text, state, state_machine):
     return run(state_machine)
 
 
+class MathSymbolTableDirective(Directive):
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {}
+
+    def run(self):
+        return run(self.state_machine)
+
+
 def setup(app):
-    app.add_directive(
-        'math_symbol_table', math_symbol_table_directive,
-        False, (0, 1, 0))
+    app.add_directive("math_symbol_table", MathSymbolTableDirective)
 
     metadata = {'parallel_read_safe': True, 'parallel_write_safe': True}
     return metadata


### PR DESCRIPTION
## PR Summary

The function-style Directive for sphinx [app.add_directive](https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_directive) is deprecated in Sphinx 1.8, and should be replaced with the class-style directive. This updates `math_symbol_table_directive` to use the new style directive.

This will help move towards warnings-free use of sphinx 2.0

I have not added a changelog entry as this is part of the `sphinxext` which are in the `doc/` folder, and so aren't an exposed API – but please let me know if you should add a changelog.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
