### PR TITLE
DOC: Fixes the links in the see-also section of Axes.get_tightbbox

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4324,9 +4324,9 @@ class _AxesBase(martist.Artist):
 
         See Also
         --------
-        matplotlib.axis.Axes.get_window_extent
+        matplotlib.axes.Axes.get_window_extent
         matplotlib.axis.Axis.get_tightbbox
-        matplotlib.spines.get_window_extent
+        matplotlib.spines.Spine.get_window_extent
 
         """
 


### PR DESCRIPTION
## PR Summary

Two of the members in the "See Also" section of Axes.get_tightbbox referred to other python objects which don't exist. I have inferred the correct values, but I could be wrong!