### PR TITLE
DOC: Fix documentation location for patheffects

### DIFF
--- a/tutorials/advanced/patheffects_guide.py
+++ b/tutorials/advanced/patheffects_guide.py
@@ -5,7 +5,7 @@ Path effects guide
 
 Defining paths that objects follow on a canvas.
 
-.. py:module:: matplotlib.patheffects
+.. py:currentmodule:: matplotlib.patheffects
 
 
 Matplotlib's :mod:`~matplotlib.patheffects` module provides functionality to


### PR DESCRIPTION
## PR Summary

Patheffects is primarily documented via automodule [here](https://github.com/matplotlib/matplotlib/blob/master/doc/api/patheffects_api.rst) so the guide should use `.. py:currentmodule::` not `.. py:module::`