### PR TITLE
DOC: Fix CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run:
            <<: *deps-install
            environment:
-             NUMPY_VERSION: "==1.11.0"
+             NUMPY_VERSION: "==1.13.0"
       - run: *mpl-install
 
       - run: *doc-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ apt-run:  &apt-install
     sudo apt-get -qq update
     sudo apt-get install -y \
       inkscape \
-      libav-tools \
+      ffmpeg \
       dvipng \
       pgf \
       lmodern \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,18 +16,18 @@ apt-run:  &apt-install
       inkscape \
       ffmpeg \
       dvipng \
-      pgf \
       lmodern \
       cm-super \
       texlive-latex-base \
       texlive-latex-extra \
       texlive-fonts-recommended \
       texlive-latex-recommended \
+      texlive-pictures \
       texlive-xetex \
       graphviz \
       libgeos-dev \
       fonts-crosextra-carlito \
-      otf-freefont
+      fonts-freefont-otf
 
 fonts-run:  &fonts-install
   name: Install custom fonts


### PR DESCRIPTION
## PR Summary

CircleCI changed their linux distro. I had to do the following to get back to a good state:

For `apt-get`
- `libav-tools` is now called `ffmpeg`
- `pgf` is provided by `texlive-pictures`
- `otf-freefont` is now `fonts-freefont-otf`

I also had to bump NumPy to 1.13 from 1.11 (1.11 doesn't build on Circle's Ubuntu any more). I spoke to 
@rgommers at SciPy2019, and he recommended 1.13 because it supports python 3.6 & 3.7 and is the version of numpy that SciPy uses to build docs.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
