### PR TITLE
Make ExecutableUnavailableError

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -284,8 +284,10 @@ _ExecInfo = namedtuple("_ExecInfo", "executable version")
 
 
 class ExecutableNotFoundError(FileNotFoundError):
-    """Error raised when an executable that Matplotlib optionally
-    depends on can't be found."""
+    """
+    Error raised when an executable that Matplotlib optionally
+    depends on can't be found.
+    """
     pass
 
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -282,9 +282,12 @@ def _logged_cached(fmt, func=None):
 
 _ExecInfo = namedtuple("_ExecInfo", "executable version")
 
+
 class ExecutableUnavailableError(FileNotFoundError):
-    """Error raised when an executable that Matplotlib optionally depends on can't be found."""
+    """Error raised when an executable that Matplotlib optionally
+    depends on can't be found."""
     pass
+
 
 @functools.lru_cache()
 def _get_executable_info(name):
@@ -357,7 +360,8 @@ def _get_executable_info(name):
                 return impl([e, "--version"], "(.*)", "9")
             except ExecutableUnavailableError:
                 pass
-        raise ExecutableUnavailableError("Failed to find a Ghostscript installation")
+        message = "Failed to find a Ghostscript installation"
+        raise ExecutableUnavailableError(message)
     elif name == "inkscape":
         return impl(["inkscape", "-V"], "^Inkscape ([^ ]*)")
     elif name == "magick":

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -725,7 +725,8 @@ class ImageMagickBase:
     def isAvailable(cls):
         try:
             return super().isAvailable()
-        except mpl.ExecutableUnavailableError:  # May be raised by get_executable_info.
+        except mpl.ExecutableUnavailableError:
+            # May be raised by get_executable_info.
             return False
 
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -725,7 +725,7 @@ class ImageMagickBase:
     def isAvailable(cls):
         try:
             return super().isAvailable()
-        except mpl.ExecutableUnavailableError:
+        except mpl.ExecutableNotFoundError:
             # May be raised by get_executable_info.
             return False
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -725,7 +725,7 @@ class ImageMagickBase:
     def isAvailable(cls):
         try:
             return super().isAvailable()
-        except FileNotFoundError:  # May be raised by get_executable_info.
+        except mpl.ExecutableUnavailableError:  # May be raised by get_executable_info.
             return False
 
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -157,7 +157,7 @@ def make_pdf_to_png_converter():
         return cairo_convert
     try:
         gs_info = mpl._get_executable_info("gs")
-    except FileNotFoundError:
+    except mpl.ExecutableUnavailableError:
         pass
     else:
         def gs_convert(pdffile, pngfile, dpi):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -157,7 +157,7 @@ def make_pdf_to_png_converter():
         return cairo_convert
     try:
         gs_info = mpl._get_executable_info("gs")
-    except mpl.ExecutableUnavailableError:
+    except mpl.ExecutableNotFoundError:
         pass
     else:
         def gs_convert(pdffile, pngfile, dpi):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -483,14 +483,14 @@ def validate_ps_distiller(s):
     elif s in ('ghostscript', 'xpdf'):
         try:
             mpl._get_executable_info("gs")
-        except FileNotFoundError:
+        except mpl.ExecutableUnavailableError:
             _log.warning("Setting rcParams['ps.usedistiller'] requires "
                          "ghostscript.")
             return None
         if s == "xpdf":
             try:
                 mpl._get_executable_info("pdftops")
-            except FileNotFoundError:
+            except mpl.ExecutableUnavailableError:
                 _log.warning("Setting rcParams['ps.usedistiller'] to 'xpdf' "
                              "requires xpdf.")
                 return None

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -483,14 +483,14 @@ def validate_ps_distiller(s):
     elif s in ('ghostscript', 'xpdf'):
         try:
             mpl._get_executable_info("gs")
-        except mpl.ExecutableUnavailableError:
+        except mpl.ExecutableNotFoundError:
             _log.warning("Setting rcParams['ps.usedistiller'] requires "
                          "ghostscript.")
             return None
         if s == "xpdf":
             try:
                 mpl._get_executable_info("pdftops")
-            except mpl.ExecutableUnavailableError:
+            except mpl.ExecutableNotFoundError:
                 _log.warning("Setting rcParams['ps.usedistiller'] to 'xpdf' "
                              "requires xpdf.")
                 return None

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -220,13 +220,13 @@ class _SVGConverter(_Converter):
 def _update_converter():
     try:
         mpl._get_executable_info("gs")
-    except mpl.ExecutableUnavailableError:
+    except mpl.ExecutableNotFoundError:
         pass
     else:
         converter['pdf'] = converter['eps'] = _GSConverter()
     try:
         mpl._get_executable_info("inkscape")
-    except mpl.ExecutableUnavailableError:
+    except mpl.ExecutableNotFoundError:
         pass
     else:
         converter['svg'] = _SVGConverter()

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -220,13 +220,13 @@ class _SVGConverter(_Converter):
 def _update_converter():
     try:
         mpl._get_executable_info("gs")
-    except FileNotFoundError:
+    except mpl.ExecutableUnavailableError:
         pass
     else:
         converter['pdf'] = converter['eps'] = _GSConverter()
     try:
         mpl._get_executable_info("inkscape")
-    except FileNotFoundError:
+    except mpl.ExecutableUnavailableError:
         pass
     else:
         converter['svg'] = _SVGConverter()


### PR DESCRIPTION
## PR Summary

When checking for executables which are optional dependencies, this makes matplotlib more forgiving of badly-behaved executables. Motivated by #14756, but should be generally helpful.

The new exception (`ExecutableUnavailableError`) inherits from `FileNotFoundError` to ensure that we don't break anyones existing code which uses `except FileNotFoundError:` to catch this kind of exception.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->