### PR TITLE
Deprecate axis_artist.BezierPath.

### DIFF
--- a/doc/api/next_api_changes/2019-07-15-AL.rst
+++ b/doc/api/next_api_changes/2019-07-15-AL.rst
@@ -1,0 +1,8 @@
+API changes and deprecations
+````````````````````````````
+
+``axisartist.axis_artist.BezierPath`` is deprecated (use `.patches.PathPatch`
+to draw arbitrary Paths).
+
+``AxisArtist.line`` is now a `.patches.PathPatch` instance instead of a
+``BezierPath`` instance.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -941,6 +941,9 @@ class PathPatch(Patch):
     def get_path(self):
         return self._path
 
+    def set_path(self, path):
+        self._path = path
+
 
 class Polygon(Patch):
     """

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -96,6 +96,7 @@ import matplotlib.font_manager as font_manager
 from matplotlib.artist import Artist
 from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
+from matplotlib.patches import PathPatch
 from matplotlib.path import Path
 from matplotlib.transforms import (
     Affine2D, Bbox, IdentityTransform, ScaledTranslation, TransformedPath)
@@ -103,6 +104,7 @@ from matplotlib.transforms import (
 from .axisline_style import AxislineStyle
 
 
+@cbook.deprecated("3.2", alternative="matplotlib.patches.PathPatch")
 class BezierPath(Line2D):
 
     def __init__(self, path, *args, **kwargs):
@@ -926,10 +928,13 @@ class AxisArtist(martist.Artist):
 
         axisline_style = self.get_axisline_style()
         if axisline_style is None:
-            self.line = BezierPath(
+            self.line = PathPatch(
                 self._axis_artist_helper.get_line(self.axes),
                 color=rcParams['axes.edgecolor'],
+                fill=False,
                 linewidth=rcParams['axes.linewidth'],
+                capstyle=rcParams['lines.solid_capstyle'],
+                joinstyle=rcParams['lines.solid_joinstyle'],
                 transform=tran)
         else:
             self.line = axisline_style(self, transform=tran)


### PR DESCRIPTION
Throughout the library the advice to draw an arbitrary Path object is to
use PathPatch; there's no reason to do differently with a one-off class
in axisartist.

Technically that's an API break because the type of AxisArtist.line
changed, but most common APIs do overlap (e.g. `set_color`, which is
exercised by the tests) so I'm not going to bother with a deprecation
period which would be quite painful (likely involving a global rcParam
controlling the switch from the old API to the new one).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
