### PR TITLE
DOC:Add link to style examples in matplotlib.style documentation

### DIFF
--- a/doc/api/style_api.rst
+++ b/doc/api/style_api.rst
@@ -4,7 +4,7 @@
 
 .. seealso::
 
-   Examples on using style sheets with :func:`matplotlib.style.use` can be found at :doc:`/gallery/style_sheets/style_sheets_reference`.
+   Examples of using style sheets with :func:`matplotlib.style.use` can be found at :doc:`/gallery/style_sheets/style_sheets_reference`.
 
 .. automodule:: matplotlib.style
    :members:

--- a/doc/api/style_api.rst
+++ b/doc/api/style_api.rst
@@ -2,6 +2,10 @@
 ``matplotlib.style``
 ********************
 
+.. seealso::
+
+   Examples on using style sheets with :func:`matplotlib.style.use` can be found at :doc:`/gallery/style_sheets/style_sheets_reference`.
+
 .. automodule:: matplotlib.style
    :members:
    :undoc-members:
@@ -15,7 +19,3 @@
 .. data:: matplotlib.style.available
 
    List of available styles
-
-.. seealso::
-
-   :doc:`/gallery/style_sheets/style_sheets_reference`

--- a/doc/api/style_api.rst
+++ b/doc/api/style_api.rst
@@ -15,3 +15,7 @@
 .. data:: matplotlib.style.available
 
    List of available styles
+
+.. seealso::
+
+   :doc:`/gallery/style_sheets/style_sheets_reference`


### PR DESCRIPTION
The documentation for matplotlib.style isn't very helpful for those wanting to use a style sheet, so added reference to stylesheet references.

PS: I messed up the commit history of my previous PR on the same issue, so made a new PR.
closes #14362

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
