### PR TITLE
Make 'extended' and 'expanded' synonymous in font_manager

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -62,9 +62,13 @@ stretch_dict = {
     'semi-condensed'  : 400,
     'normal'          : 500,
     'semi-expanded'   : 600,
+    'semi-extended'   : 600,
     'expanded'        : 700,
+    'extended'        : 700,
     'extra-expanded'  : 800,
-    'ultra-expanded'  : 900}
+    'extra-extended'  : 800,
+    'ultra-expanded'  : 900,
+    'ultra-extended'  : 900}
 
 weight_dict = {
     'ultralight' : 100,
@@ -412,7 +416,7 @@ def ttfFontProperty(font):
         stretch = 'condensed'
     elif sfnt4.find('demi cond') >= 0:
         stretch = 'semi-condensed'
-    elif sfnt4.find('wide') >= 0 or sfnt4.find('expanded') >= 0:
+    elif sfnt4.find('wide') >= 0 or sfnt4.find('expanded') >= 0 or sfnt4.find('extended') >= 0:
         stretch = 'expanded'
     else:
         stretch = 'normal'
@@ -480,7 +484,7 @@ def afmFontProperty(fontpath, font):
         stretch = 'semi-condensed'
     elif 'narrow' in fontname or 'cond' in fontname:
         stretch = 'condensed'
-    elif 'wide' in fontname or 'expanded' in fontname:
+    elif 'wide' in fontname or 'expanded' in fontname or 'extended' in fontname:
         stretch = 'expanded'
     else:
         stretch = 'normal'


### PR DESCRIPTION
## PR Summary

Several fonts (e.g. Helvetica Neue LT, Myriad, etc.) use the term "extended" rather than "expanded".  Currently, font_manager deals with fonts which use "expanded" but not with "extended".  Thus, for fonts which use "extended" instead of "expanded", font_manager will sometime choose the extended version instead of the normal version when the normal version is requested.

This PR fixes this behavior by making matplotlib recognize both "extended" and "expanded".

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
