### PR TITLE
Remove sudo tag in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,6 @@ matrix:
         - DELETE_FONT_CACHE=1
         - EXTRAREQS='-r requirements/testing/travis36.txt'
     - python: 3.7
-      sudo: true
     - python: "nightly"
       env:
         - PRE=--pre


### PR DESCRIPTION
Travis are now recommending removing the sudo tag.
Check out [this](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).