### PR TITLE
Deprecate dates.mx2num.

### DIFF
--- a/doc/api/next_api_changes/2019-07-16-AL.rst
+++ b/doc/api/next_api_changes/2019-07-16-AL.rst
@@ -1,0 +1,4 @@
+Deprecations
+````````````
+
+``dates.mx2num`` is deprecated.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -25,7 +25,6 @@ objects and Matplotlib dates:
    num2timedelta
    epoch2num
    num2epoch
-   mx2num
    drange
 
 .. note::
@@ -1779,6 +1778,7 @@ def num2epoch(d):
     return (np.asarray(d) - EPOCH_OFFSET) * SEC_PER_DAY
 
 
+@cbook.deprecated("3.2")
 def mx2num(mxdates):
     """
     Convert mx :class:`datetime` instance (or sequence of mx


### PR DESCRIPTION
mxDateTime never supported Py3, so heh.

(see downloads at https://www.egenix.com/products/python/mxBase/; last release was in 2015 per https://www.egenix.com/company/news/eGenix-mx-Base-Distribution-3.2.9-GA.html).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
