### PR TITLE
Clearer calls to ConnectionPatch.

### DIFF
--- a/examples/pie_and_polar_charts/bar_of_pie.py
+++ b/examples/pie_and_polar_charts/bar_of_pie.py
@@ -15,7 +15,7 @@ from matplotlib.patches import ConnectionPatch
 import numpy as np
 
 # make figure and assign axis objects
-fig = plt.figure(figsize=(9, 5.0625))
+fig = plt.figure(figsize=(9, 5))
 ax1 = fig.add_subplot(121)
 ax2 = fig.add_subplot(122)
 fig.subplots_adjust(wspace=0)
@@ -59,8 +59,8 @@ bar_height = sum([item.get_height() for item in ax2.patches])
 # draw top connecting line
 x = r * np.cos(np.pi / 180 * theta2) + center[0]
 y = np.sin(np.pi / 180 * theta2) + center[1]
-con = ConnectionPatch(xyA=(- width / 2, bar_height), xyB=(x, y),
-                      coordsA="data", coordsB="data", axesA=ax2, axesB=ax1)
+con = ConnectionPatch(xyA=(-width / 2, bar_height), coordsA=ax2.transData,
+                      xyB=(x, y), coordsB=ax1.transData)
 con.set_color([0, 0, 0])
 con.set_linewidth(4)
 ax2.add_artist(con)
@@ -68,8 +68,8 @@ ax2.add_artist(con)
 # draw bottom connecting line
 x = r * np.cos(np.pi / 180 * theta1) + center[0]
 y = np.sin(np.pi / 180 * theta1) + center[1]
-con = ConnectionPatch(xyA=(- width / 2, 0), xyB=(x, y), coordsA="data",
-                      coordsB="data", axesA=ax2, axesB=ax1)
+con = ConnectionPatch(xyA=(-width / 2, 0), coordsA=ax2.transData,
+                      xyB=(x, y), coordsB=ax1.transData)
 con.set_color([0, 0, 0])
 ax2.add_artist(con)
 con.set_linewidth(4)

--- a/examples/userdemo/connect_simple01.py
+++ b/examples/userdemo/connect_simple01.py
@@ -6,6 +6,7 @@ Connect Simple01
 A `ConnectionPatch` can be used to draw a line (possibly with arrow head)
 between points defined in different coordinate systems and/or axes.
 """
+
 from matplotlib.patches import ConnectionPatch
 import matplotlib.pyplot as plt
 
@@ -26,21 +27,20 @@ ax1.add_artist(con)
 # Draw an arrow between the same point in data coordinates,
 # but in different axes.
 xy = (0.3, 0.2)
-coordsA = "data"
-coordsB = "data"
-con = ConnectionPatch(xyA=xy, xyB=xy, coordsA=coordsA, coordsB=coordsB,
-                      axesA=ax2, axesB=ax1,
-                      arrowstyle="->", shrinkB=5)
+con = ConnectionPatch(
+    xyA=xy, coordsA=ax2.transData,
+    xyB=xy, coordsB=ax1.transData,
+    arrowstyle="->", shrinkB=5)
 ax2.add_artist(con)
 
 # Draw a line between the different points, defined in different coordinate
 # systems.
-xyA = (0.6, 1.0)  # in axes coordinates
-xyB = (0.0, 0.2)  # x in axes coordinates, y in data coordinates
-coordsA = "axes fraction"
-coordsB = ax2.get_yaxis_transform()
-con = ConnectionPatch(xyA=xyA, xyB=xyB, coordsA=coordsA, coordsB=coordsB,
-                      arrowstyle="-")
+con = ConnectionPatch(
+    # in axes coordinates
+    xyA=(0.6, 1.0), coordsA=ax2.transAxes,
+    # x in axes coordinates, y in data coordinates
+    xyB=(0.0, 0.2), coordsB=ax2.get_yaxis_transform(),
+    arrowstyle="-")
 ax2.add_artist(con)
 
 ax1.set_xlim(0, 1)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -548,12 +548,11 @@ class Axes(_AxesBase):
                 if self.yaxis.get_inverted():
                     ey = 1 - ey
                 xy_data = x + ex * width, y + ey * height
-                p = mpatches.ConnectionPatch(xy_inset_ax, xy_data,
-                                             coordsA='axes fraction',
-                                             coordsB='data',
-                                             axesA=inset_ax, axesB=self,
-                                             arrowstyle="-", zorder=zorder,
-                                             edgecolor=edgecolor, alpha=alpha)
+                p = mpatches.ConnectionPatch(
+                    xyA=xy_inset_ax, coordsA=inset_ax.transAxes,
+                    xyB=xy_data, coordsB=self.transData,
+                    arrowstyle="-", zorder=zorder,
+                    edgecolor=edgecolor, alpha=alpha)
                 connects.append(p)
                 self.add_patch(p)
 
@@ -606,17 +605,12 @@ class Axes(_AxesBase):
             Two are set with visibility to *False*,  but the user can
             set the visibility to *True* if the automatic choice is not deemed
             correct.
-
         """
 
         xlim = inset_ax.get_xlim()
         ylim = inset_ax.get_ylim()
         rect = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
-        rectpatch, connects = self.indicate_inset(
-            rect, inset_ax, **kwargs
-        )
-
-        return rectpatch, connects
+        return self.indicate_inset(rect, inset_ax, **kwargs)
 
     @docstring.dedent_interpd
     def secondary_xaxis(self, location, *, functions=None, **kwargs):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4240,9 +4240,7 @@ class ConnectionPatch(FancyArrowPatch):
         """
         Connect point *xyA* in *coordsA* with point *xyB* in *coordsB*
 
-
         Valid keys are
-
 
         ===============  ======================================================
         Key              Description
@@ -4258,7 +4256,6 @@ class ConnectionPatch(FancyArrowPatch):
         mutation_aspect  default is 1.
         ?                any key for :class:`matplotlib.patches.PathPatch`
         ===============  ======================================================
-
 
         *coordsA* and *coordsB* are strings that indicate the
         coordinates of *xyA* and *xyB*.


### PR DESCRIPTION
... by moving the transform next to the xy values, and by using
transforms rather than splitting the transform in two separate keyword
arguments (axesA and coordsA).

I know a similar suggestion for Annotation was rejected in https://github.com/matplotlib/matplotlib/pull/13515, but for the case of ConnectorPatch I think the split of the transform in two argument hampers readibility even more...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
