### PR TITLE
FIX: restore special casing of shift-enter in notebook

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -166,12 +166,9 @@ mpl.figure.prototype._key_event_extra = function(event, name) {
     // Check for shift+enter
     if (event.shiftKey && event.which == 13) {
         this.canvas_div.blur();
-        event.shiftKey = false;
-        // Send a "J" for go to next cell
-        event.which = 74;
-        event.keyCode = 74;
-        manager.command_mode();
-        manager.handle_keydown(event);
+        // select the cell after this one
+        var index = IPython.notebook.find_cell_index(this.cell_info[0]);
+        IPython.notebook.select(index + 1);
     }
 }
 


### PR DESCRIPTION
This PR re-applies the fix from  @minrk from last time

previous reports:
https://github.com/jupyter/notebook/issues/1124
https://github.com/jupyter/notebook/issues/949

current report:
closes https://github.com/jupyter/notebook/issues/4636

fix:
https://github.com/matplotlib/matplotlib/pull/6752

accidental revert:
https://github.com/matplotlib/matplotlib/pull/9027



- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->