### PR TITLE
ENH:made default tick formatter to switch to scientific notation earlier

### DIFF
--- a/doc/api/next_api_changes/2019-07-18-SL.rst
+++ b/doc/api/next_api_changes/2019-07-18-SL.rst
@@ -1,0 +1,4 @@
+Reduced default value of `axes.formatter.limits`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 5 for better readability.

--- a/doc/api/next_api_changes/2019-07-18-SL.rst
+++ b/doc/api/next_api_changes/2019-07-18-SL.rst
@@ -1,4 +1,4 @@
 Reduced default value of `axes.formatter.limits`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 5 for better readability.
+Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 6 for better readability.

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -1157,8 +1157,3 @@ result in undefined behavior.  It now throws a `ValueError`.
 
 The signature of the (private) ``Axis._update_ticks`` has been changed to not
 take the renderer as argument anymore (that argument is unused).
-
-Reduced default value of `axes.formatter.limits`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 5

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -1157,3 +1157,8 @@ result in undefined behavior.  It now throws a `ValueError`.
 
 The signature of the (private) ``Axis._update_ticks`` has been changed to not
 take the renderer as argument anymore (that argument is unused).
+
+Reduced default value of `axes.formatter.limits`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 5

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1145,7 +1145,7 @@ defaultParams = {
     'axes.labelpad':         [4.0, validate_float],  # space between label and axis
     'axes.labelweight':      ['normal', validate_string],  # fontsize of the x any y labels
     'axes.labelcolor':       ['black', validate_color],    # color of axis label
-    'axes.formatter.limits': [[-5, 5], validate_nseq_int(2)],
+    'axes.formatter.limits': [[-5, 6], validate_nseq_int(2)],
                                # use scientific notation if log10
                                # of the axis range is smaller than the
                                # first or larger than the second

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1145,7 +1145,7 @@ defaultParams = {
     'axes.labelpad':         [4.0, validate_float],  # space between label and axis
     'axes.labelweight':      ['normal', validate_string],  # fontsize of the x any y labels
     'axes.labelcolor':       ['black', validate_color],    # color of axis label
-    'axes.formatter.limits': [[-7, 7], validate_nseq_int(2)],
+    'axes.formatter.limits': [[-5, 5], validate_nseq_int(2)],
                                # use scientific notation if log10
                                # of the axis range is smaller than the
                                # first or larger than the second

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -547,6 +547,9 @@ def test_single_point():
 
 @image_comparison(['single_date.png'], style='mpl20')
 def test_single_date():
+    # use former defaults to match existing baseline image
+    plt.rcParams['axes.formatter.limits'] = -7, 7
+
     time1 = [721964.0]
     data1 = [-65.54]
 

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -76,6 +76,9 @@ def quantity_converter():
 @image_comparison(['plot_pint.png'], remove_text=False, style='mpl20',
                   tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
 def test_numpy_facade(quantity_converter):
+    # use former defaults to match existing baseline image
+    plt.rcParams['axes.formatter.limits'] = -7, 7
+
     # Register the class
     munits.registry[Quantity] = quantity_converter
 


### PR DESCRIPTION
The default tick formatter switches to scientific notation only for very small values,
but there is a range of slightly bigger values where scientific notation would be better too.

changed the formatter limits from -7,7 to -5,5

closes #14800

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
