### PR TITLE
Don't assume transform is valid on access to matrix.

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -176,6 +176,17 @@ def test_Affine2D_from_values():
     assert_almost_equal(actual, expected)
 
 
+def test_affine_inverted_invalidated():
+    # Ensure that the an affine transform is not declared valid on access
+    point = [1.0, 1.0]
+    t = mtransforms.Affine2D()
+
+    assert_almost_equal(point, t.transform(t.inverted().transform(point)))
+    # Change and access the transform
+    t.translate(1.0, 1.0).get_matrix()
+    assert_almost_equal(point, t.transform(t.inverted().transform(point)))
+
+
 def test_clipping_of_log():
     # issue 804
     M, L, C = Path.MOVETO, Path.LINETO, Path.CLOSEPOLY

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1850,7 +1850,6 @@ class Affine2D(Affine2DBase):
 
         .
         """
-        self._invalid = 0
         return self._mtx
 
     def set_matrix(self, mtx):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1850,6 +1850,9 @@ class Affine2D(Affine2DBase):
 
         .
         """
+        if self._invalid:
+            self._inverted = None
+            self._invalid = 0
         return self._mtx
 
     def set_matrix(self, mtx):


### PR DESCRIPTION
## PR Summary

Accessing the matrix of an Affine2D transform via get_matrix sets _invalid to 0.
This can cause the transform returned by inverted() to be incorrect if the matrix is accessed between a transform and the call to inverted().
Another possible fix would be to check if invalid and set _inverted to None and _invalid to 0.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
