### PR TITLE
More cleanups.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -501,8 +501,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
             # Subset the input image to only the part that will be
             # displayed
-            subset = TransformedBbox(
-                clip_bbox, t0.frozen().inverted()).frozen()
+            subset = TransformedBbox(clip_bbox, t0.inverted()).frozen()
             output = output[
                 int(max(subset.ymin, 0)):
                 int(min(subset.ymax + 1, output.shape[0])),

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1638,11 +1638,10 @@ class Arc(Ellipse):
                     yield x, y
 
         # Transforms the axes box_path so that it is relative to the unit
-        # circle in the same way that it is relative to the desired
-        # ellipse.
+        # circle in the same way that it is relative to the desired ellipse.
         box_path = Path.unit_rectangle()
-        box_path_transform = transforms.BboxTransformTo(self.axes.bbox) + \
-            self.get_transform().inverted()
+        box_path_transform = (transforms.BboxTransformTo(self.axes.bbox)
+                              - self.get_transform())
         box_path = box_path.transformed(box_path_transform)
 
         thetas = set()
@@ -4146,10 +4145,8 @@ class FancyArrowPatch(Patch):
         in display coordinates.
         """
         _path, fillable = self.get_path_in_displaycoord()
-
         if np.iterable(fillable):
             _path = concatenate_paths(_path)
-
         return self.get_transform().inverted().transform_path(_path)
 
     def get_path_in_displaycoord(self):

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -123,10 +123,9 @@ class FixedAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):
             mm = (yy1b - yy1a == 0) & (xx1b - xx1a == 0)  # mask not defined dd
             dd[mm] = dd2[mm] + np.pi / 2
 
-            trans_tick = self.get_tick_transform(axes)
-            tr2ax = trans_tick + axes.transAxes.inverted()
+            tick_to_axes = self.get_tick_transform(axes) - axes.transAxes
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
-                c2 = tr2ax.transform((x, y))
+                c2 = tick_to_axes.transform((x, y))
                 delta = 0.00001
                 if 0-delta <= c2[0] <= 1+delta and 0-delta <= c2[1] <= 1+delta:
                     d1, d2 = np.rad2deg([d, d2])

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -161,8 +161,8 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
         grid_finder = self.grid_helper.grid_finder
         (xx1,), (yy1,) = grid_finder.transform_xy([xx0], [yy0])
 
-        trans_passingthrough_point = axes.transData + axes.transAxes.inverted()
-        p = trans_passingthrough_point.transform([xx1, yy1])
+        data_to_axes = axes.transData - axes.transAxes
+        p = data_to_axes.transform([xx1, yy1])
 
         if 0 <= p[0] <= 1 and 0 <= p[1] <= 1:
             xx1c, yy1c = axes.transData.transform([xx1, yy1])
@@ -253,10 +253,9 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
             mm = (yy1b == yy1a) & (xx1b == xx1a)  # mask where dd not defined
             dd[mm] = dd2[mm] + np.pi / 2
 
-            trans_tick = self.get_tick_transform(axes)
-            tr2ax = trans_tick + axes.transAxes.inverted()
+            tick_to_axes = self.get_tick_transform(axes) - axes.transAxes
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
-                c2 = tr2ax.transform((x, y))
+                c2 = tick_to_axes.transform((x, y))
                 delta = 0.00001
                 if 0-delta <= c2[0] <= 1+delta and 0-delta <= c2[1] <= 1+delta:
                     d1, d2 = np.rad2deg([d, d2])


### PR DESCRIPTION
- `transformA + transformB.inverted()` === `transformA - transformB`,
  and give the result a more meaningful name.
- Other cleanups in axislines.py (which used the above pattern quite a
  bit).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
