### PR TITLE
Fix tests with pandas 0.25

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -103,9 +103,8 @@ def pd():
     """Fixture to import and configure pandas."""
     pd = pytest.importorskip('pandas')
     try:
-        from pandas.plotting import (
-            deregister_matplotlib_converters as deregister)
-        deregister()
+        from pandas.plotting import register_matplotlib_converters
+        register_matplotlib_converters()
     except ImportError:
         pass
     return pd


### PR DESCRIPTION
From pandas 0.25 onwards the converters have to be explicitly registered or a warning is raised. I'm guessing they were never meant to be *deregistered* for the tests, so I've just changed that bit. Someone else may know better though?