### PR TITLE
Don't use pandas 0.25.0 for testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,11 +63,11 @@ install:
   #
   - conda create -q -n test-environment python=%PYTHON_VERSION%
     msinttypes freetype=2.6 "libpng>=1.6.21,<1.7" zlib=1.2 tk=8.5
-    pip setuptools numpy pandas sphinx tornado
+    pip setuptools numpy sphinx tornado
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
-  - pip install -q "pytest>=3.4,!=4.6.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist
+  - pip install -q "pytest>=3.4,!=4.6.0" "pytest-cov>=2.3.1" pytest-rerunfailures pytest-timeout pytest-xdist "pandas!=0.25.0"
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1610,11 +1610,9 @@ def test_bar_pandas(pd):
     forecast = monthly['value']
     baseline = monthly['value']
 
-    pd.plotting.register_matplotlib_converters()
     fig, ax = plt.subplots()
     ax.bar(dates, forecast, width=10, align='center')
     ax.plot(dates, baseline, color='orange', lw=4)
-    pd.plotting.deregister_matplotlib_converters()
 
 
 @image_comparison(['hist_log'], remove_text=True)

--- a/requirements/testing/travis36.txt
+++ b/requirements/testing/travis36.txt
@@ -2,5 +2,5 @@
 
 ipykernel
 nbconvert[execute]
-pandas
+pandas!=0.25.0
 pytz


### PR DESCRIPTION
Thanks @bingyao for putting in a quick fix here: https://github.com/matplotlib/matplotlib/pull/14860; I think blacklisting pandas 0.25.0 is the correct long term thing to do however, as a fix (https://github.com/pandas-dev/pandas/pull/27481) should hopefully go into 0.25.1