### PR TITLE
changed all readme headings to verbs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ being dropped.
 
 `Home page <http://matplotlib.org/>`_
 
-Installation
+Install
 ============
 
 For installation instructions and requirements, see the INSTALL.rst file or the
@@ -52,7 +52,7 @@ think you may want to contribute to matplotlib, check out the `guide to
 working with the source code
 <http://matplotlib.org/devel/gitwash/index.html>`_.
 
-Testing
+Test
 =======
 
 After installation, you can launch the test suite::

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ being dropped.
 `Home page <http://matplotlib.org/>`_
 
 Install
-============
+=======
 
 For installation instructions and requirements, see the INSTALL.rst file or the
 `install <http://matplotlib.org/users/installing.html>`_ documentation. If you
@@ -53,7 +53,7 @@ working with the source code
 <http://matplotlib.org/devel/gitwash/index.html>`_.
 
 Test
-=======
+====
 
 After installation, you can launch the test suite::
 


### PR DESCRIPTION
Two word change: installation to install, testing to test, so that all the README headings are now  the same type - action verbs.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
