### PR TITLE
FT2Font.get_char_index never returns None.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2198,29 +2198,27 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                     for c in chunk:
                         ccode = ord(c)
                         gind = font.get_char_index(ccode)
-                        if gind is not None:
-                            if mode == 2 and chunk_type == 2:
-                                glyph_name = font.get_glyph_name(gind)
-                                self.file.output(Op.gsave)
-                                self.file.output(0.001 * fontsize, 0,
-                                                 0, 0.001 * fontsize,
-                                                 newx, 0, Op.concat_matrix)
-                                name = self.file._get_xobject_symbol_name(
-                                    font.fname, glyph_name)
-                                self.file.output(Name(name), Op.use_xobject)
-                                self.file.output(Op.grestore)
+                        if mode == 2 and chunk_type == 2:
+                            glyph_name = font.get_glyph_name(gind)
+                            self.file.output(Op.gsave)
+                            self.file.output(0.001 * fontsize, 0,
+                                             0, 0.001 * fontsize,
+                                             newx, 0, Op.concat_matrix)
+                            name = self.file._get_xobject_symbol_name(
+                                font.fname, glyph_name)
+                            self.file.output(Name(name), Op.use_xobject)
+                            self.file.output(Op.grestore)
 
-                            # Move the pointer based on the character width
-                            # and kerning
-                            glyph = font.load_char(ccode,
-                                                   flags=LOAD_NO_HINTING)
-                            if lastgind is not None:
-                                kern = font.get_kerning(
-                                    lastgind, gind, KERNING_UNFITTED)
-                            else:
-                                kern = 0
-                            lastgind = gind
-                            newx += kern/64.0 + glyph.linearHoriAdvance/65536.0
+                        # Move the pointer based on the character width
+                        # and kerning
+                        glyph = font.load_char(ccode, flags=LOAD_NO_HINTING)
+                        if lastgind is not None:
+                            kern = font.get_kerning(
+                                lastgind, gind, KERNING_UNFITTED)
+                        else:
+                            kern = 0
+                        lastgind = gind
+                        newx += kern / 64 + glyph.linearHoriAdvance / 65536
 
                 if mode == 1:
                     self.file.output(Op.end_text)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -630,12 +630,7 @@ grestore
             for c in s:
                 ccode = ord(c)
                 gind = font.get_char_index(ccode)
-                if gind is None:
-                    ccode = ord('?')
-                    name = '.notdef'
-                    gind = 0
-                else:
-                    name = font.get_glyph_name(gind)
+                name = font.get_glyph_name(gind)
                 glyph = font.load_char(ccode, flags=LOAD_NO_HINTING)
 
                 if lastgind is not None:

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -183,9 +183,6 @@ class TextToPath:
         for c in s:
             ccode = ord(c)
             gind = font.get_char_index(ccode)
-            if gind is None:
-                ccode = ord('?')
-                gind = 0
 
             if lastgind is not None:
                 kern = font.get_kerning(lastgind, gind, KERNING_DEFAULT)


### PR DESCRIPTION
... because its body is
```
    FT_UInt index;
    FT_ULong ccode;

    if (!PyArg_ParseTuple(args, "k:get_char_index", &ccode)) {
        return NULL;
    }

    index = FT_Get_Char_Index(self->x->get_face(), ccode);

    return PyLong_FromLong(index);
```

so kill code paths which handle a None-return.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
