### PR TITLE
Unify text layout paths.

### DIFF
--- a/lib/matplotlib/_text_layout.py
+++ b/lib/matplotlib/_text_layout.py
@@ -1,0 +1,40 @@
+"""
+Text layouting utilities.
+"""
+
+from .ft2font import KERNING_DEFAULT, LOAD_NO_HINTING
+
+
+def layout(string, font, *, x0=0, kern_mode=KERNING_DEFAULT):
+    """
+    Render *string* with *font*.  For each character in *string*, yield a
+    (character-index, x-position) pair.  When such a pair is yielded, the
+    font's glyph is set to the corresponding character.
+
+    Parameters
+    ----------
+    string : str
+        The string to be rendered.
+    font : FT2Font
+        The font.
+    x0 : float
+        The initial x-value
+    kern_mode : int
+        A FreeType kerning mode.
+
+    Yields
+    ------
+    character_index : int
+    x_position : float
+    """
+    x = x0
+    last_char_idx = None
+    for char in string:
+        char_idx = font.get_char_index(ord(char))
+        kern = (font.get_kerning(last_char_idx, char_idx, kern_mode)
+                if last_char_idx is not None else 0) / 64
+        x += kern
+        glyph = font.load_glyph(char_idx, flags=LOAD_NO_HINTING)
+        yield char_idx, x
+        x += glyph.linearHoriAdvance / 65536
+        last_char_idx = char_idx

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2176,43 +2176,46 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                              -math.sin(a), math.cos(a),
                              x, y, Op.concat_matrix)
 
-            # Output all the 1-byte characters in a BT/ET group, then
-            # output all the 2-byte characters.
-            for mode in (1, 2):
-                newx = oldx = 0
-                # Output a 1-byte character chunk
-                if mode == 1:
-                    self.file.output(Op.begin_text,
-                                     self.file.fontName(prop),
-                                     fontsize,
-                                     Op.selectfont)
+            # Output all the 1-byte characters in a BT/ET group.
+            self.file.output(Op.begin_text,
+                             self.file.fontName(prop),
+                             fontsize,
+                             Op.selectfont)
+            newx = oldx = 0
+            for chunk_type, chunk in chunks:
+                if chunk_type == 1:
+                    self._setup_textpos(newx, 0, 0, oldx, 0, 0)
+                    self.file.output(self.encode_string(chunk, fonttype),
+                                     Op.show)
+                    oldx = newx
+                # Update newx to include the advance from this chunk,
+                # regardless of its mode...
+                for char_idx, char_x in _text_layout.layout(
+                        chunk, font, x0=newx, kern_mode=KERNING_UNFITTED):
+                    pass
+                newx = char_x + (  # ... including the last character's advance
+                    font.load_glyph(char_idx, flags=LOAD_NO_HINTING)
+                    .linearHoriAdvance / 65536)
+            self.file.output(Op.end_text)
 
-                for chunk_type, chunk in chunks:
-                    if mode == 1 and chunk_type == 1:
-                        self._setup_textpos(newx, 0, 0, oldx, 0, 0)
-                        self.file.output(self.encode_string(chunk, fonttype),
-                                         Op.show)
-                        oldx = newx
-
-                    for char_idx, newx in _text_layout.layout(
-                            chunk, font, x0=newx, kern_mode=KERNING_UNFITTED):
-
-                        if mode == 2 and chunk_type == 2:
-                            glyph_name = font.get_glyph_name(char_idx)
-                            self.file.output(Op.gsave)
-                            self.file.output(0.001 * fontsize, 0,
-                                             0, 0.001 * fontsize,
-                                             newx, 0, Op.concat_matrix)
-                            name = self.file._get_xobject_symbol_name(
-                                font.fname, glyph_name)
-                            self.file.output(Name(name), Op.use_xobject)
-                            self.file.output(Op.grestore)
-                        newx += (
-                            font.load_glyph(char_idx, flags=LOAD_NO_HINTING)
-                            .linearHoriAdvance / 65536)
-
-                if mode == 1:
-                    self.file.output(Op.end_text)
+            # Then output all the 2-byte characters.
+            newx = 0
+            for chunk_type, chunk in chunks:
+                for char_idx, char_x in _text_layout.layout(
+                        chunk, font, x0=newx, kern_mode=KERNING_UNFITTED):
+                    if chunk_type == 2:
+                        glyph_name = font.get_glyph_name(char_idx)
+                        self.file.output(Op.gsave)
+                        self.file.output(0.001 * fontsize, 0,
+                                         0, 0.001 * fontsize,
+                                         char_x, 0, Op.concat_matrix)
+                        name = self.file._get_xobject_symbol_name(
+                            font.fname, glyph_name)
+                        self.file.output(Name(name), Op.use_xobject)
+                        self.file.output(Op.grestore)
+                newx = char_x + (  # ... including the last character's advance
+                    font.load_glyph(char_idx, flags=LOAD_NO_HINTING)
+                    .linearHoriAdvance / 65536)
 
             self.file.output(Op.grestore)
 


### PR DESCRIPTION
## PR Summary

... i.e. the logic for advancing one character at a time, positioning
that character and taking kerning between consecutive characters into
account.

Such a factoring would also be useful if we ever get to use a text
layout engine that supports right-to-left languages (we'd just need to
fix `layout` (and the C-version used by agg)).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
