### PR TITLE
On POSIX, allow testing from non-localfreetype builds.

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -117,6 +117,10 @@ consider putting ::
 
 in your shell start up files.
 
+On Linux and macOS, as long as you have built Matplotlib locally at least once
+with the local_freetype option, the correct version of FreeType will be loaded
+into any process as long as the MPLLOCALFREETYPE environment variable is set.
+
 
 Installing Matplotlib in developer mode
 ---------------------------------------

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -167,6 +167,35 @@ __bibtex__ = r"""@Article{Hunter:2007,
 }"""
 
 
+def _get_xdg_config_dir():
+    """
+    Return the XDG configuration directory, according to the `XDG
+    base directory spec
+    <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
+    """
+    return os.environ.get('XDG_CONFIG_HOME') or str(Path.home() / ".config")
+
+
+def _get_xdg_cache_dir():
+    """
+    Return the XDG cache directory, according to the `XDG
+    base directory spec
+    <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
+    """
+    return os.environ.get('XDG_CACHE_HOME') or str(Path.home() / ".cache")
+
+
+if sys.platform != "win32" and os.environ.get("MPLLOCALFREETYPE"):
+    from ctypes import CDLL, RTLD_GLOBAL
+    try:
+        CDLL(os.path.join(_get_xdg_cache_dir(), "matplotlib/libfreetype.so"),
+             RTLD_GLOBAL)
+    except OSError:
+        raise ImportError(
+            "Please build Matplotlib with MPLLOCALFREETYPE=1 to cache the "
+            "FreeType shared library, or unset MPLLOCALFREETYPE.")
+
+
 @cbook.deprecated("3.2")
 def compare_versions(a, b):
     "Return whether version *a* is greater than or equal to version *b*."
@@ -544,24 +573,6 @@ def _create_tmp_config_or_cache_dir():
         tempfile.mkdtemp(prefix='matplotlib-'))
     atexit.register(shutil.rmtree, configdir)
     return configdir
-
-
-def _get_xdg_config_dir():
-    """
-    Return the XDG configuration directory, according to the `XDG
-    base directory spec
-    <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
-    """
-    return os.environ.get('XDG_CONFIG_HOME') or str(Path.home() / ".config")
-
-
-def _get_xdg_cache_dir():
-    """
-    Return the XDG cache directory, according to the `XDG
-    base directory spec
-    <http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
-    """
-    return os.environ.get('XDG_CACHE_HOME') or str(Path.home() / ".cache")
 
 
 def _get_config_or_cache_dir(xdg_base):


### PR DESCRIPTION
The workflow is

- Build Matplotlib at least once with the local_freetype option set.
  This now caches libfreetype.so (2.6.1) in ~/.cache/matplotlib.
- Now one can run the test suite from any Matplotlib build; as long as
  MPLLOCALFREETYPE is set to 1, Matplotlib will force that instance of
  FreeType to be used (even if it has been linked to another version).

Just a rough patch for now as a proof of concept.

Hiding the runtime load under an environment variable because some (e.g.
distro packagers) may want to run the tests without it anyways.

attn @tacaswell, who was possibly interested...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
