### PR TITLE
Cleanup afm module docstring.

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -1,36 +1,32 @@
 """
 This is a python interface to Adobe Font Metrics Files.  Although a
 number of other python implementations exist, and may be more complete
-than this, it was decided not to go with them because they were
-either:
+than this, it was decided not to go with them because they were either:
 
-  1) copyrighted or used a non-BSD compatible license
-
-  2) had too many dependencies and a free standing lib was needed
-
-  3) Did more than needed and it was easier to write afresh rather than
-     figure out how to get just what was needed.
+1) copyrighted or used a non-BSD compatible license
+2) had too many dependencies and a free standing lib was needed
+3) did more than needed and it was easier to write afresh rather than
+   figure out how to get just what was needed.
 
 It is pretty easy to use, and requires only built-in python libs:
 
-    >>> import matplotlib as mpl
-    >>> import os.path
-    >>> afm_fname = os.path.join(mpl.get_data_path(),
-    ...                         'fonts', 'afm', 'ptmr8a.afm')
-    >>>
-    >>> from matplotlib.afm import AFM
-    >>> with open(afm_fname, 'rb') as fh:
-    ...     afm = AFM(fh)
-    >>> afm.string_width_height('What the heck?')
-    (6220.0, 694)
-    >>> afm.get_fontname()
-    'Times-Roman'
-    >>> afm.get_kern_dist('A', 'f')
-    0
-    >>> afm.get_kern_dist('A', 'y')
-    -92.0
-    >>> afm.get_bbox_char('!')
-    [130, -9, 238, 676]
+>>> import matplotlib as mpl
+>>> from pathlib import Path
+>>> afm_path = Path(mpl.get_data_path(), 'fonts', 'afm', 'ptmr8a.afm')
+>>>
+>>> from matplotlib.afm import AFM
+>>> with afm_path.open('rb') as fh:
+...     afm = AFM(fh)
+>>> afm.string_width_height('What the heck?')
+(6220.0, 694)
+>>> afm.get_fontname()
+'Times-Roman'
+>>> afm.get_kern_dist('A', 'f')
+0
+>>> afm.get_kern_dist('A', 'y')
+-92.0
+>>> afm.get_bbox_char('!')
+[130, -9, 238, 676]
 
 As in the Adobe Font Metrics File Format Specification, all dimensions
 are given in units of 1/1000 of the scale factor (point size) of the font


### PR DESCRIPTION
## PR Summary

Note that doctest blocks do not need to be indented, per http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
