### PR TITLE
Inline some afm parsing code.

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -85,25 +85,6 @@ def _to_bool(s):
         return True
 
 
-def _sanity_check(fh):
-    """
-    Check if the file looks like AFM; if it doesn't, raise `RuntimeError`.
-    """
-    # Remember the file position in case the caller wants to
-    # do something else with the file.
-    pos = fh.tell()
-    try:
-        line = next(fh)
-    finally:
-        fh.seek(pos, 0)
-    # AFM spec, Section 4: The StartFontMetrics keyword [followed by a
-    # version number] must be the first line in the file, and the
-    # EndFontMetrics keyword must be the last non-empty line in the
-    # file. We just check the first line.
-    if not line.startswith(b'StartFontMetrics'):
-        raise RuntimeError('Not an AFM file')
-
-
 def _parse_header(fh):
     """
     Reads the font metrics header (up to the char metrics) and returns
@@ -157,13 +138,11 @@ def _parse_header(fh):
         if line.startswith(b'Comment'):
             continue
         lst = line.split(b' ', 1)
-
         key = lst[0]
         if len(lst) == 2:
             val = lst[1]
         else:
             val = b''
-
         try:
             converter = header_converters[key]
         except KeyError:
@@ -175,8 +154,16 @@ def _parse_header(fh):
             _log.error('Value error parsing header in AFM: %s, %s', key, val)
             continue
         if key == b'StartCharMetrics':
-            return d
-    raise RuntimeError('Bad parse')
+            break
+    else:
+        raise RuntimeError('Bad parse')
+    # AFM spec, Section 4: The StartFontMetrics keyword [followed by a version
+    # number] must be the first line in the file, and the EndFontMetrics
+    # keyword must be the last non-empty line in the file.  We just check the
+    # first header entry.
+    if next(iter(d)) != b'StartFontMetrics':
+        raise RuntimeError('Not an AFM file')
+    return d
 
 
 CharMetrics = namedtuple('CharMetrics', 'width, name, bbox')
@@ -366,40 +353,13 @@ def _parse_optional(fh):
     return d[b'StartKernData'], d[b'StartComposites']
 
 
-def _parse_afm(fh):
-    """
-    Parse the Adobe Font Metrics file in file handle *fh*.
-
-    Returns
-    -------
-    header : dict
-        A header dict. See :func:`_parse_header`.
-    cmetrics_by_ascii : dict
-        From :func:`_parse_char_metrics`.
-    cmetrics_by_name : dict
-        From :func:`_parse_char_metrics`.
-    kernpairs : dict
-        From :func:`_parse_kern_pairs`.
-    composites : dict
-        From :func:`_parse_composites`
-
-    """
-    _sanity_check(fh)
-    header = _parse_header(fh)
-    cmetrics_by_ascii, cmetrics_by_name = _parse_char_metrics(fh)
-    kernpairs, composites = _parse_optional(fh)
-    return header, cmetrics_by_ascii, cmetrics_by_name, kernpairs, composites
-
-
 class AFM:
 
     def __init__(self, fh):
         """Parse the AFM file in file object *fh*."""
-        (self._header,
-         self._metrics,
-         self._metrics_by_name,
-         self._kern,
-         self._composite) = _parse_afm(fh)
+        self._header = _parse_header(fh)
+        self._metrics, self._metrics_by_name = _parse_char_metrics(fh)
+        self._kern, self._composite = _parse_optional(fh)
 
     def get_bbox_char(self, c, isord=False):
         if not isord:

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -133,12 +133,22 @@ def _parse_header(fh):
         }
 
     d = {}
+    first_line = True
     for line in fh:
         line = line.rstrip()
         if line.startswith(b'Comment'):
             continue
         lst = line.split(b' ', 1)
         key = lst[0]
+        if first_line:
+            # AFM spec, Section 4: The StartFontMetrics keyword
+            # [followed by a version number] must be the first line in
+            # the file, and the EndFontMetrics keyword must be the
+            # last non-empty line in the file.  We just check the
+            # first header entry.
+            if key != b'StartFontMetrics':
+                raise RuntimeError('Not an AFM file')
+            first_line = False
         if len(lst) == 2:
             val = lst[1]
         else:
@@ -157,12 +167,6 @@ def _parse_header(fh):
             break
     else:
         raise RuntimeError('Bad parse')
-    # AFM spec, Section 4: The StartFontMetrics keyword [followed by a version
-    # number] must be the first line in the file, and the EndFontMetrics
-    # keyword must be the last non-empty line in the file.  We just check the
-    # first header entry.
-    if next(iter(d)) != b'StartFontMetrics':
-        raise RuntimeError('Not an AFM file')
     return d
 
 

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import pytest
 
 from matplotlib import afm
 from matplotlib import font_manager as fm
@@ -88,3 +89,21 @@ def test_font_manager_weight_normalization():
     font = afm.AFM(BytesIO(
         AFM_TEST_DATA.replace(b"Weight Bold\n", b"Weight Custom\n")))
     assert fm.afmFontProperty("", font).weight == "normal"
+
+
+@pytest.mark.parametrize(
+    "afm_data",
+    [
+        b"""nope
+really nope""",
+        b"""StartFontMetrics 2.0
+Comment Comments are ignored.
+Comment Creation Date:Mon Nov 13 12:34:11 GMT 2017
+FontName MyFont-Bold
+EncodingScheme FontSpecific""",
+    ],
+)
+def test_bad_afm(afm_data):
+    fh = BytesIO(afm_data)
+    with pytest.raises(RuntimeError):
+        header = afm._parse_header(fh)


### PR DESCRIPTION
Splitting _parse_afm out of `__init__` doesn't buy much, and its
docstring is not particularly informative either, so just inline
it to the AFM constructor.  Likewise, most of the benefits from
`_sanity_check` can be obtained by just looking for the first entry of
the header (this admittedly relies on dict-order-maintaining, which is
present on Py3.6 though not mandated (it is mandated in Py3.7), but I'm
not aware of Matplotlib running on an alternative Py3.6 that does not
support that behavior...).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
