### PR TITLE
Error out when unsupported kwargs are passed to Scale.

### DIFF
--- a/doc/api/next_api_changes/2019-07-24-AL.rst
+++ b/doc/api/next_api_changes/2019-07-24-AL.rst
@@ -2,4 +2,7 @@ API changes
 ```````````
 
 Passing unsupported keyword arguments to `.ScaleBase` and its subclasses
-`.LinearScale`, `.LogScale`, and `.SymLogScale` now raises a TypeError.
+`.LinearScale`, and `.SymLogScale` is deprecated and will raise a `TypeError` in 3.3.
+
+If extra kwargs are pased to `.LogScale`, `TypeError` will now be
+raised instead of `ValueError`.

--- a/doc/api/next_api_changes/2019-07-24-AL.rst
+++ b/doc/api/next_api_changes/2019-07-24-AL.rst
@@ -1,0 +1,5 @@
+API changes
+```````````
+
+Passing unsupported keyword arguments to `.ScaleBase` and its subclasses
+`.LinearScale`, `.LogScale`, and `.SymLogScale` now raises a TypeError.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -19,7 +19,7 @@ from matplotlib.ticker import (
     NullLocator, LogLocator, AutoLocator, AutoMinorLocator,
     SymmetricalLogLocator, LogitLocator)
 from matplotlib.transforms import Transform, IdentityTransform
-
+from matplotlib.cbook import warn_deprecated
 
 class ScaleBase:
     """
@@ -39,7 +39,7 @@ class ScaleBase:
 
     """
 
-    def __init__(self, axis):
+    def __init__(self, axis, **kwargs):
         r"""
         Construct a new scale.
 
@@ -52,6 +52,14 @@ class ScaleBase:
         be used: a single scale object should be usable by multiple
         `~matplotlib.axis.Axis`\es at the same time.
         """
+        if kwargs:
+            warn_deprecated(
+                '3.2.0',
+                message=(
+                    f"ScaleBase got an unexpected keyword "
+                    f"argument {next(iter(kwargs))!r}. "
+                    'In the future this will raise TypeError')
+            )
 
     def get_transform(self):
         """
@@ -564,8 +572,16 @@ class SymmetricalLogScale(ScaleBase):
             subs = kwargs.pop('subsy', None)
             linscale = kwargs.pop('linscaley', 1.0)
         if kwargs:
-            raise TypeError(f"SymmetricalLogScale got an unexpected keyword "
-                            f"argument {next(iter(kwargs))!r}")
+            warn_deprecated(
+                '3.2.0',
+                message=(
+                    f"SymmetricalLogScale got an unexpected keyword "
+                    f"argument {next(iter(kwargs))!r}. "
+                    'In the future this will raise TypeError')
+            )
+            # raise TypeError(f"SymmetricalLogScale got an unexpected keyword "
+            #                 f"argument {next(iter(kwargs))!r}")
+
         if base <= 1.0:
             raise ValueError("'basex/basey' must be larger than 1")
         if linthresh <= 0.0:

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -39,7 +39,7 @@ class ScaleBase:
 
     """
 
-    def __init__(self, axis, **kwargs):
+    def __init__(self, axis):
         r"""
         Construct a new scale.
 
@@ -143,8 +143,7 @@ class FuncTransform(Transform):
             self._forward = forward
             self._inverse = inverse
         else:
-            raise ValueError('arguments to FuncTransform must '
-                             'be functions')
+            raise ValueError('arguments to FuncTransform must be functions')
 
     def transform_non_affine(self, values):
         return self._forward(values)
@@ -382,16 +381,14 @@ class LogScale(ScaleBase):
             nonpos = kwargs.pop('nonposy', 'clip')
             cbook._check_in_list(['mask', 'clip'], nonposy=nonpos)
 
-        if len(kwargs):
-            raise ValueError(("provided too many kwargs, can only pass "
-                              "{'basex', 'subsx', nonposx'} or "
-                              "{'basey', 'subsy', nonposy'}.  You passed ") +
-                             "{!r}".format(kwargs))
+        if kwargs:
+            raise TypeError(f"LogScale got an unexpected keyword "
+                            f"argument {next(iter(kwargs))!r}")
 
         if base <= 0 or base == 1:
             raise ValueError('The log base cannot be <= 0 or == 1')
 
-        self._transform = self.LogTransform(base, nonpos)
+        self._transform = LogTransform(base, nonpos)
         self.subs = subs
 
     @property
@@ -566,7 +563,9 @@ class SymmetricalLogScale(ScaleBase):
             linthresh = kwargs.pop('linthreshy', 2.0)
             subs = kwargs.pop('subsy', None)
             linscale = kwargs.pop('linscaley', 1.0)
-
+        if kwargs:
+            raise TypeError(f"SymmetricalLogScale got an unexpected keyword "
+                            f"argument {next(iter(kwargs))!r}")
         if base <= 1.0:
             raise ValueError("'basex/basey' must be larger than 1")
         if linthresh <= 0.0:
@@ -574,10 +573,7 @@ class SymmetricalLogScale(ScaleBase):
         if linscale <= 0.0:
             raise ValueError("'linscalex/linthreshy' must be positive")
 
-        self._transform = self.SymmetricalLogTransform(base,
-                                                       linthresh,
-                                                       linscale)
-
+        self._transform = SymmetricalLogTransform(base, linthresh, linscale)
         self.base = base
         self.linthresh = linthresh
         self.linscale = linscale

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -21,6 +21,7 @@ from matplotlib.ticker import (
 from matplotlib.transforms import Transform, IdentityTransform
 from matplotlib.cbook import warn_deprecated
 
+
 class ScaleBase:
     """
     The base class for all scales.

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -106,13 +106,18 @@ def test_logscale_mask():
     ax.set(yscale="log")
 
 
-def test_extra_kwargs_raise():
+def test_extra_kwargs_raise_or_warn():
     fig, ax = plt.subplots()
-    with pytest.raises(TypeError):
+
+    # with pytest.raises(TypeError):
+    with pytest.warns(MatplotlibDeprecationWarning):
         ax.set_yscale('linear', nonpos='mask')
+
     with pytest.raises(TypeError):
         ax.set_yscale('log', nonpos='mask')
-    with pytest.raises(TypeError):
+
+    # with pytest.raises(TypeError):
+    with pytest.warns(MatplotlibDeprecationWarning):
         ax.set_yscale('symlog', nonpos='mask')
 
 

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -108,8 +108,12 @@ def test_logscale_mask():
 
 def test_extra_kwargs_raise():
     fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
+        ax.set_yscale('linear', nonpos='mask')
+    with pytest.raises(TypeError):
         ax.set_yscale('log', nonpos='mask')
+    with pytest.raises(TypeError):
+        ax.set_yscale('symlog', nonpos='mask')
 
 
 def test_logscale_invert_transform():


### PR DESCRIPTION
No deprecation period, both because 6357245 likewise added the exception
for LogScale without deprecation, and because this is by far most likely
to be catching bugs rather than real uses.

Closes #5619, closes  #14878.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
