### PR TITLE
Fix animation blitting for plots with shared axes

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1216,12 +1216,18 @@ class Animation:
         # Handles blitted drawing, which renders only the artists given instead
         # of the entire figure.
         updated_ax = []
+
+        # Enumerate artists to cache axes' backgrounds. We do not draw
+        # artists yet to not cache foreground from plots with shared axes
         for a in artists:
             # If we haven't cached the background for this axes object, do
             # so now. This might not always be reliable, but it's an attempt
             # to automate the process.
             if a.axes not in bg_cache:
                 bg_cache[a.axes] = a.figure.canvas.copy_from_bbox(a.axes.bbox)
+
+        # Make a separate pass to draw foreground
+        for a in artists:
             a.axes.draw_artist(a)
             updated_ax.append(a.axes)
 


### PR DESCRIPTION
Hi there!

Let me introduce a small but very useful fix for animation blitting for plots which share axes.

Currently, we enumerate artists to both cache background and draw artists in a single pass. But imagine we've got twin plot that share the same axis. As the first sibling draws foreground before the second managed to cache the background we've got incorrect background for the second sibling!

Fortunately, it's easy to fix if we cache background and draw foreground with two distinct passes. Please apply this change because it's very annoying to not have animated twin plots.