### PR TITLE
Support pixel-by-pixel alpha in imshow.

### DIFF
--- a/examples/images_contours_and_fields/image_transparency_blend.py
+++ b/examples/images_contours_and_fields/image_transparency_blend.py
@@ -6,12 +6,10 @@ Blend transparency with color in 2-D images
 Blend transparency with color to highlight parts of data with imshow.
 
 A common use for :func:`matplotlib.pyplot.imshow` is to plot a 2-D statistical
-map. While ``imshow`` makes it easy to visualize a 2-D matrix as an image,
-it doesn't easily let you add transparency to the output. For example, one can
-plot a statistic (such as a t-statistic) and color the transparency of
-each pixel according to its p-value. This example demonstrates how you can
-achieve this effect using :class:`matplotlib.colors.Normalize`. Note that it is
-not possible to directly pass alpha values to :func:`matplotlib.pyplot.imshow`.
+map. The function makes it easy to visualize a 2-D matrix as an image and add
+transparency to the output. For example, one can plot a statistic (such as a
+t-statistic) and color the transparency of each pixel according to its p-value.
+This example demonstrates how you can achieve this effect.
 
 First we will generate some data, in this case, we'll create two 2-D "blobs"
 in a 2-D grid. One blob will be positive, and the other negative.
@@ -50,14 +48,18 @@ weights = (np.outer(gauss_y_high, gauss_x_high)
 # We'll also create a grey background into which the pixels will fade
 greys = np.full((*weights.shape, 3), 70, dtype=np.uint8)
 
-# First we'll plot these blobs using only ``imshow``.
+# First we'll plot these blobs using ``imshow`` without transparency.
 vmax = np.abs(weights).max()
-vmin = -vmax
-cmap = plt.cm.RdYlBu
+imshow_kwargs = {
+    'vmax': vmax,
+    'vmin': -vmax,
+    'cmap': 'RdYlBu',
+    'extent': (xmin, xmax, ymin, ymax),
+}
 
 fig, ax = plt.subplots()
 ax.imshow(greys)
-ax.imshow(weights, extent=(xmin, xmax, ymin, ymax), cmap=cmap)
+ax.imshow(weights, **imshow_kwargs)
 ax.set_axis_off()
 
 ###############################################################################
@@ -65,27 +67,19 @@ ax.set_axis_off()
 # ========================
 #
 # The simplest way to include transparency when plotting data with
-# :func:`matplotlib.pyplot.imshow` is to convert the 2-D data array to a
-# 3-D image array of rgba values. This can be done with
-# :class:`matplotlib.colors.Normalize`. For example, we'll create a gradient
+# :func:`matplotlib.pyplot.imshow` is to pass an array matching the shape of
+# the data to the ``alpha`` argument. For example, we'll create a gradient
 # moving from left to right below.
 
 # Create an alpha channel of linearly increasing values moving to the right.
 alphas = np.ones(weights.shape)
 alphas[:, 30:] = np.linspace(1, 0, 70)
 
-# Normalize the colors b/w 0 and 1, we'll then pass an MxNx4 array to imshow
-colors = Normalize(vmin, vmax, clip=True)(weights)
-colors = cmap(colors)
-
-# Now set the alpha channel to the one we created above
-colors[..., -1] = alphas
-
 # Create the figure and image
 # Note that the absolute values may be slightly different
 fig, ax = plt.subplots()
 ax.imshow(greys)
-ax.imshow(colors, extent=(xmin, xmax, ymin, ymax))
+ax.imshow(weights, alpha=alphas, **imshow_kwargs)
 ax.set_axis_off()
 
 ###############################################################################
@@ -102,18 +96,11 @@ ax.set_axis_off()
 alphas = Normalize(0, .3, clip=True)(np.abs(weights))
 alphas = np.clip(alphas, .4, 1)  # alpha value clipped at the bottom at .4
 
-# Normalize the colors b/w 0 and 1, we'll then pass an MxNx4 array to imshow
-colors = Normalize(vmin, vmax)(weights)
-colors = cmap(colors)
-
-# Now set the alpha channel to the one we created above
-colors[..., -1] = alphas
-
 # Create the figure and image
 # Note that the absolute values may be slightly different
 fig, ax = plt.subplots()
 ax.imshow(greys)
-ax.imshow(colors, extent=(xmin, xmax, ymin, ymax))
+ax.imshow(weights, alpha=alphas, **imshow_kwargs)
 
 # Add contour lines to further highlight different levels.
 ax.contour(weights[::-1], levels=[-.1, .1], colors='k', linestyles='-')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5506,8 +5506,8 @@ optional.
 
         alpha : [scalar | array_like], optional, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
-            If `alpha` is an array, the alpha blending values are applied pixel
-            by pixel, and `alpha` must have the same shape as `X`. This
+            If *alpha* is an array, the alpha blending values are applied pixel
+            by pixel, and *alpha* must have the same shape as *X*. This
             parameter is ignored for RGBA input data.
 
         vmin, vmax : scalar, optional

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5504,9 +5504,11 @@ optional.
             which can be set by *filterrad*. Additionally, the antigrain image
             resize filter is controlled by the parameter *filternorm*.
 
-        alpha : scalar, optional
+        alpha : [scalar | array_like], optional, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
-            This parameter is ignored for RGBA input data.
+            If `alpha` is an array, the alpha blending values are applied pixel
+            by pixel, and `alpha` must have the same shape as `X`. This
+            parameter is ignored for RGBA input data.
 
         vmin, vmax : scalar, optional
             When using scalar data and no explicit *norm*, *vmin* and *vmax*

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5507,8 +5507,7 @@ optional.
         alpha : scalar or array_like, optional, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
             If *alpha* is an array, the alpha blending values are applied pixel
-            by pixel, and *alpha* must have the same shape as *X*. This
-            parameter is ignored for RGBA input data.
+            by pixel, and *alpha* must have the same shape as *X*.
 
         vmin, vmax : scalar, optional
             When using scalar data and no explicit *norm*, *vmin* and *vmax*

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5504,7 +5504,7 @@ optional.
             which can be set by *filterrad*. Additionally, the antigrain image
             resize filter is controlled by the parameter *filternorm*.
 
-        alpha : [scalar | array_like], optional, default: None
+        alpha : scalar or array_like, optional, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
             If *alpha* is an array, the alpha blending values are applied pixel
             by pixel, and *alpha* must have the same shape as *X*. This

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -293,6 +293,15 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         self._imcache = None
 
     def _get_scalar_alpha(self):
+        """
+        Get a scalar alpha value to be applied to the artist as a whole.
+
+        If the alpha value is a matrix, the method returns 1.0 because pixels
+        have individual alpha values (see `~._ImageBase._make_image` for
+        details). If the alpha value is a scalar, the method returns said value
+        to be applied to the artist as a whole because pixels do not have
+        individual alpha values.
+        """
         return 1.0 if self._alpha is None or np.ndim(self._alpha) > 0 \
             else self._alpha
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -293,7 +293,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         self._imcache = None
 
     def _get_scalar_alpha(self):
-        return self._alpha if np.ndim(self._alpha) == 0 else 1.0
+        return 1.0 if self._alpha is None or np.ndim(self._alpha) > 0 \
+            else self._alpha
 
     def changed(self):
         """

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -293,7 +293,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         self._imcache = None
 
     def _get_scalar_alpha(self):
-        return self._alpha if np.isscalar(self._alpha) else 1.0
+        return self._alpha if np.ndim(self._alpha) == 0 else 1.0
 
     def changed(self):
         """
@@ -500,7 +500,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 out_alpha[out_mask] = 1
                 # Apply the pixel-by-pixel alpha values if present
                 alpha = self.get_alpha()
-                if alpha is not None and not np.isscalar(alpha):
+                if alpha is not None and np.ndim(alpha) > 0:
                     out_alpha *= _resample(self, alpha, out_shape,
                                            t, resample=True)
                 # mask and run through the norm

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1118,3 +1118,22 @@ def test_image_cursor_formatting():
 
     data = np.nan
     assert im.format_cursor_data(data) == '[nan]'
+
+
+@check_figures_equal()
+def test_image_array_alpha(fig_test, fig_ref):
+    '''per-pixel alpha channel test'''
+    x = np.linspace(0, 1)
+    xx, yy = np.meshgrid(x, x)
+
+    zz = np.exp(- 3 * ((xx - 0.5) ** 2) + (yy - 0.7 ** 2))
+    alpha = zz / zz.max()
+
+    cmap = plt.get_cmap('viridis')
+    ax = fig_test.add_subplot(111)
+    ax.imshow(zz, alpha=alpha, cmap=cmap, interpolation='nearest')
+
+    ax = fig_ref.add_subplot(111)
+    rgba = cmap(colors.Normalize()(zz))
+    rgba[..., -1] = alpha
+    ax.imshow(rgba, interpolation='nearest')


### PR DESCRIPTION
## PR Summary

This PR supports pixel-by-pixel alpha channels in `imshow` and is a replacement for #8183.

cc @jklymak 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
  - ~Likely too minor a change to need a dedicated example?~
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
  - Not a major new feature.
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
  - No API changes.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
