### PR TITLE
Fix nightly test errors

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1645,7 +1645,7 @@ class _AxesBase(martist.Artist):
                     self.set_autoscale_on(False)
                     xlim = self.get_xlim()
                     ylim = self.get_ylim()
-                    edge_size = max(np.diff(xlim), np.diff(ylim))
+                    edge_size = max(np.diff(xlim), np.diff(ylim))[0]
                     self.set_xlim([xlim[0], xlim[0] + edge_size],
                                   emit=emit, auto=False)
                     self.set_ylim([ylim[0], ylim[0] + edge_size],

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -298,7 +298,7 @@ class FormWidget(QtWidgets.QWidget):
                     field.setCheckState(QtCore.Qt.Unchecked)
             elif isinstance(value, Integral):
                 field = QtWidgets.QSpinBox(self)
-                field.setRange(-1e9, 1e9)
+                field.setRange(-10**9, 10**9)
                 field.setValue(value)
             elif isinstance(value, Real):
                 field = QtWidgets.QLineEdit(repr(value), self)


### PR DESCRIPTION
## PR Summary

This fixes 2 of the 3 test errors on the nightly build. There's still one more error slicing a masked array, but I can't figure out how to reproduce that locally and it seems like a bug in NumPy.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way