### PR TITLE
Update layout.html for sphinx themes

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -70,6 +70,9 @@ endtrans %}
 {% trans sphinx_version=sphinx_version|e %}Created using
 <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
 {%- endif %}
+{%- if sha %}
+Doc version {{ sha }}.
+{%- endif %}
     </div>
 </footer>
 <script>

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -52,7 +52,23 @@
 
 {%- block footer %}
 <footer>
-{{super()}}
+{%- if show_copyright %}
+{%- if hasdoc('copyright') %}
+    {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a
+href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+{%- else %}
+    {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{%
+endtrans %}
+{%- endif %}
+{%- endif %}
+<br />
+{%- if last_updated %}
+    {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+{%- endif %}
+{%- if show_sphinx %}
+{% trans sphinx_version=sphinx_version|e %}Created using
+<a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
+{%- endif %}
 </footer>
 <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,164 +1,28 @@
-{#
-    basic/layout.html
-    ~~~~~~~~~~~~~~~~~
+{% extends "!layout.html" %}
 
-    Master layout template for Sphinx themes.
-
-    :copyright: Copyright 2007-2013 by the Sphinx team, see AUTHORS.
-    :license: BSD, see LICENSE for details.
-#}
-{%- block doctype -%}
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-{%- endblock %}
-{%- set reldelim1 = reldelim1 is not defined and ' &raquo;' or reldelim1 %}
-{%- set reldelim2 = reldelim2 is not defined and ' |' or reldelim2 %}
-{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and
-                         (sidebars != []) %}
-{%- set url_root = pathto('', 1) %}
-{# XXX necessary? #}
-{%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
-{%- if not embedded and docstitle %}
-  {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
-{%- else %}
-  {%- set titlesuffix = "" %}
-{%- endif %}
-
-{%- macro relbar() %}
-    <div class="related">
-      <h3>{{ _('Navigation') }}</h3>
-      <ul>
-        {%- for rellink in rellinks %}
-        <li class="right" {% if loop.first %}style="margin-right: 10px"{%
-endif %}>
-          <a href="{{ pathto(rellink[0]) }}" title="{{ rellink[1]|striptags|e
-}}"
-             {{ accesskey(rellink[2]) }}>{{ rellink[3] }}</a>
-          {%- if not loop.first %}{{ reldelim2 }}{% endif %}</li>
-        {%- endfor %}
-
+{%- block rootrellink %}
         <li><a href="{{ pathto('index') }}">home</a>|&nbsp;</li>
         <li><a href="{{ pathto('gallery/index') }}">examples</a>|&nbsp;</li>
         <li><a href="{{ pathto('tutorials/index') }}">tutorials</a>|&nbsp;</li>
         <li><a href="{{ pathto('api/index') }}">API</a>|&nbsp;</li>
         <li><a href="{{ pathto('contents') }}">contents</a> &raquo;</li>
-
-        {%- for parent in parents %}
-          <li><a href="{{ parent.link|e }}" {% if loop.last %}{{
-accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
-        {%- endfor %}
-        {%- block relbaritems %} {% endblock %}
-      </ul>
-    </div>
-{%- endmacro %}
-
-{%- macro sidebar() %}
-      {%- if render_sidebar %}
-      <div class="sphinxsidebar">
-        <div class="sphinxsidebarwrapper">
-          {%- block sidebarlogo %}
-          {%- if logo %}
-            <p class="logo"><a href="{{ pathto(master_doc) }}">
-              <img class="logo" src="{{ pathto('_static/' + logo, 1) }}"
-alt="Logo"/>
-            </a></p>
-          {%- endif %}
-          {%- endblock %}
-          {%- if sidebars != None %}
-            {#- new style sidebar: explicitly include/exclude templates #}
-            {%- for sidebartemplate in sidebars %}
-            {%- include sidebartemplate %}
-            {%- endfor %}
-          {%- endif %}
-        </div>
-      </div>
-      {%- endif %}
-{%- endmacro %}
-
-{%- macro script() %}
-    <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
-    {%- for scriptfile in script_files %}
-      {{ js_tag(scriptfile) }}
-    {%- endfor %}
-{%- endmacro %}
-
-{%- macro css() %}
-    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}"
-type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}"
-type="text/css" />
-    {%- for cssfile in css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
-    {%- endfor %}
-{%- endmacro %}
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset={{ encoding
-}}" />
-    {{ metatags }}
-    {%- block htmltitle %}
-    <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
-    {%- endblock %}
-    {{ css() }}
-    {%- if not embedded %}
-    {{ script() }}
-    {%- if use_opensearch %}
-    <link rel="search" type="application/opensearchdescription+xml"
-          title="{% trans docstitle=docstitle|e %}Search within {{ docstitle
-}}{% endtrans %}"
-          href="{{ pathto('_static/opensearch.xml', 1) }}"/>
-    {%- endif %}
-    {%- if favicon %}
-    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
-    {%- endif %}
-    {%- endif %}
-{%- block linktags %}
-    {%- if hasdoc('about') %}
-    <link rel="author" title="{{ _('About these documents') }}" href="{{
-pathto('about') }}" />
-    {%- endif %}
-    {%- if hasdoc('genindex') %}
-    <link rel="index" title="{{ _('Index') }}" href="{{ pathto('genindex') }}"
-/>
-    {%- endif %}
-    {%- if hasdoc('search') %}
-    <link rel="search" title="{{ _('Search') }}" href="{{ pathto('search') }}"
-/>
-    {%- endif %}
-    {%- if hasdoc('copyright') %}
-    <link rel="copyright" title="{{ _('Copyright') }}" href="{{
-pathto('copyright') }}" />
-    {%- endif %}
-    <link rel="top" title="{{ docstitle|e }}" href="{{ pathto('index') }}" />
-    {%- if parents %}
-    <link rel="up" title="{{ parents[-1].title|striptags|e }}" href="{{
-parents[-1].link|e }}" />
-    {%- endif %}
-    {%- if next %}
-    <link rel="next" title="{{ next.title|striptags|e }}" href="{{ next.link|e
-}}" />
-    {%- endif %}
-    {%- if prev %}
-    <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e
-}}" />
-    {%- endif %}
 {%- endblock %}
-{%- block extrahead %}
+
+{%- block relbar1 %}{{ relbar() }}{% endblock %}
+{%- block relbar2 %}{% endblock %}
+
+{%- block linktags %}
+{{ super() }}
+<link rel="top" title="{{ docstitle }}" href="#" />
 {%- if '+' in release %}
     <link rel="canonical" href="https://matplotlib.org/devdocs/{{pagename}}.html" />
 {%- else %}
     <link rel="canonical" href="https://matplotlib.org/{{version}}/{{pagename}}.html" />
 {%- endif %}
-{% endblock %}
+{%- endblock %}
 
-
-  </head>
-  <body>
-{%- block header %}{% endblock %}
-
-{% block relbar1 %}
-
+{%- block header %}
+{{super()}}
 {%- if '+' in release %}
 <div id="unreleased-message">
     You are reading documentation for the unreleased version of Matplotlib.
@@ -167,91 +31,37 @@ parents[-1].link|e }}" />
     </a>
 </div>
 {%- endif %}
-
 <div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; position: relative;">
-{%- if builder in ('htmlhelp', 'devhelp', 'latex') %}
-<a href="{{ pathto('index') }}">
-    <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
-    <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
-{%- else %}
-<a href="{{ pathto('index') }}">
-    <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
-    <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
-{%- endif %}
-
-<!-- The "Fork me on github" ribbon -->
-<div id="forkongithub"><a href="https://github.com/matplotlib/matplotlib">Fork me on GitHub</a></div>
-</div>
-
-{% endblock %}
-
-{%- block relbar2 %}
-
-{{ relbar() }}
-
-{% endblock %}
-
-
-
-{%- block content %}
-  {%- block sidebar1 %} {# possible location for sidebar #} {% endblock %}
-
-  {%- block sidebar2 %}{{ sidebar() }}{% endblock %}
-    <div class="document">
-  {%- block document %}
-      <div class="documentwrapper">
-      {%- if render_sidebar %}
-        <div class="bodywrapper">
-      {%- endif %}
-          <div class="body">
-            {% block body %} {% endblock %}
-          </div>
-      {%- if render_sidebar %}
-        </div>
-      {%- endif %}
-      </div>
-  {%- endblock %}
-
-      <div class="clearer"></div>
+    {%- if builder in ('htmlhelp', 'devhelp', 'latex') %}
+    <a href="{{ pathto('index') }}">
+        <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
+        <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
+    {%- else %}
+    <a href="{{ pathto('index') }}">
+        <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version {{ version|e }}</span></div>
+        <img src="{{pathto("_static/logo2.png", 1) }}" height="125px" border="0" alt="matplotlib"/></a>
+    {%- endif %}
+    
+    <!-- The "Fork me on github" ribbon -->
+    <div id="forkongithub"><a href="https://github.com/matplotlib/matplotlib">Fork me on GitHub</a></div>
     </div>
 {%- endblock %}
 
+{%- block sidebar1 %}{{ sidebar() }}{% endblock %}
+{%- block sidebar2 %}{% endblock %}
+
 {%- block footer %}
-    <div class="footer">
-    {%- if show_copyright %}
-      {%- if hasdoc('copyright') %}
-        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a
-href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
-      {%- else %}
-        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{%
-endtrans %}
-      {%- endif %}
-    {%- endif %}
-        <br />
-    {%- if last_updated %}
-      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
-    {%- endif %}
-    {%- if show_sphinx %}
-	{% trans sphinx_version=sphinx_version|e %}Created using
-	<a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
-    {%- endif %}
-    {%- if sha %}
-	Doc version {{ sha }}.
-    {%- endif %}
-    </div>
- {%- endblock %}
-
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-55954603-1', 'auto');
-  ga('send', 'pageview');
-
-</script>
-</body>
 <footer>
+{{super()}}
 </footer>
-</html>
+<script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      
+        ga('create', 'UA-55954603-1', 'auto');
+        ga('send', 'pageview');
+      
+</script>
+{%- endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -52,6 +52,7 @@
 
 {%- block footer %}
 <footer>
+    <div class="footer">
 {%- if show_copyright %}
 {%- if hasdoc('copyright') %}
     {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a
@@ -69,6 +70,7 @@ endtrans %}
 {% trans sphinx_version=sphinx_version|e %}Created using
 <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}
 {%- endif %}
+    </div>
 </footer>
 <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
## PR Summary

Matplotlib had a copy of the [base sphinx theme `layout.html`](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/basic/layout.html) – but this file was slowly getting out of sync with Sphinx.

It turns out that Sphinx (and the default theme, alabaster) have added a lot of theming customization hooks, and it is possible to make the docs _almost_ identical without carrying around an entire copy of `layout.html`. This allows matplotlib to take advantage of the maintenance done on `layout.html` by Sphinx upstream, without having to merge those changes occasionally into matplotlib itself.

Here are some examples of the difference between generating the docs before and now:

- A `<meta viewport=...` tag has been added.
- A reference to `custom.css` is now emitted (this is harmless, but is the now supported way to provide CSS overrides to alabaster, the default sphinx theme).
- Additional HTML attributes have been added in some places where appropriate (e.g. `role=`, which should improve screen reader accessibility).
- The footer is now wrapped in a `<footer> <footer />` tag.

As far as I can tell, there are no material differences to the way the docs look, but I would appreciate more eyes/further feedback.

## PR Checklist

_This isn't really a python change, so no tests are provided, and it shouldn't be user-facing (docs should look the same after this change) so I don't think it needs a "what's new" or "API changelog"._