### PR TITLE
Make slowness warning for legend(loc="best") more accurate.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -22,6 +22,7 @@ information.
 """
 
 import logging
+import time
 
 import numpy as np
 
@@ -1112,13 +1113,9 @@ class Legend(Artist):
         # should always hold because function is only called internally
         assert self.isaxes
 
+        start_time = time.perf_counter()
+
         verts, bboxes, lines, offsets = self._auto_legend_data()
-        if self._loc_used_default and verts.shape[0] > 200000:
-            # this size results in a 3+ second render time on a good machine
-            cbook._warn_external(
-                'Creating legend with loc="best" can be slow with large '
-                'amounts of data.'
-            )
 
         bbox = Bbox.from_bounds(0, 0, width, height)
         if consider is None:
@@ -1145,6 +1142,12 @@ class Legend(Artist):
             candidates.append((badness, idx, (l, b)))
 
         _, _, (l, b) = min(candidates)
+
+        if self._loc_used_default and time.perf_counter() - start_time > 1:
+            cbook._warn_external(
+                'Creating legend with loc="best" can be slow with large '
+                'amounts of data.')
+
         return l, b
 
     def contains(self, event):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -550,24 +550,28 @@ def test_alpha_handles():
 
 def test_warn_big_data_best_loc():
     fig, ax = plt.subplots()
-    ax.plot(np.arange(200001), label='Is this big data?')
+    fig.canvas.draw()  # So that we can call draw_artist later.
+    for idx in range(1000):
+        ax.plot(np.arange(5000), label=idx)
+    with rc_context({'legend.loc': 'best'}):
+        legend = ax.legend()
     with pytest.warns(UserWarning) as records:
-        with rc_context({'legend.loc': 'best'}):
-            ax.legend()
-        fig.canvas.draw()
+        fig.draw_artist(legend)  # Don't bother drawing the lines -- it's slow.
     # The _find_best_position method of Legend is called twice, duplicating
     # the warning message.
     assert len(records) == 2
     for record in records:
         assert str(record.message) == (
-            'Creating legend with loc="best" can be slow with large'
-            ' amounts of data.')
+            'Creating legend with loc="best" can be slow with large '
+            'amounts of data.')
 
 
 def test_no_warn_big_data_when_loc_specified():
     fig, ax = plt.subplots()
-    ax.plot(np.arange(200001), label='Is this big data?')
+    fig.canvas.draw()
+    for idx in range(1000):
+        ax.plot(np.arange(5000), label=idx)
+    legend = ax.legend('best')
     with pytest.warns(None) as records:
-        ax.legend('best')
-        fig.canvas.draw()
+        fig.draw_artist(legend)
     assert len(records) == 0


### PR DESCRIPTION
... by actually timing the call duration.  Locally I can best-locate
legends even with plots with hundreds of thousands of points basically
instantly, so the old warning was spurious.

The new test is obviously a bit brittle because it depends on how fast
the machine running it is.  It's also slower than the test before
(intentionally, because now you *actually* need a slow-to-place legend
to trigger the warning).

The warning is only emitted after the legend has been placed, but that
seems fine -- if the best-placement is so slow that you ctrl-c the
process, you'll have a traceback anyways.  Also, spawning a separate
thread to always emit the warning after exactly 5s will likely just make
things worse performance-wise on average.

The 5s delay is the same as used in font_manager.py.

The original warning went in as #12455.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
