### PR TITLE
Fix GH14900: numpy 1.17.0 breaks test_colors.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1724,7 +1724,7 @@ class LightSource:
             # visually appears better than a "hard" clip.
             intensity -= imin
             intensity /= (imax - imin)
-        intensity = np.clip(intensity, 0, 1, intensity)
+        intensity = np.clip(intensity, 0, 1)
 
         return intensity
 


### PR DESCRIPTION
## PR Summary

Try to fix #14900 

### Part I

In the original file(`colors.py`), the following lines should be (functionally) equivalent:

```python
>>> # A: using assignment and output arguments AT THE SAME TIME
>>> intensity = np.clip(intensity, 0, 1, intensity)
>>> # B: using output arguments
>>> np.clip(intensity, 0, 1, out=intensity)
>>> # C: WITHOUT using output arguments
>>> intensity = np.clip(intensity, 0, 1)
``` 
Although I know the `ufunc`'s output argument can save memory, but I don't quite understand why the original file used A instead of B? (whether was a misusage or there is some advantage?)

### Part II

Everything was fine until Numpy 1.17.0 where `np.clip` breaks the equivalence with `MaskedArray`:

```python
In [1]: import numpy as np                                                                                                                                                 

In [2]: np.__version__                                                                                                                                                     
Out[2]: '1.17.0'

In [3]: a = np.arange(10)                                                                                                                                                  

In [4]: m = np.ma.MaskedArray(a, mask=[0, 1] * 5)                                                                                                                          

In [5]: np.clip(m, 0, 5)                                                                                                                                                   
Out[5]: 
masked_array(data=[0, --, 2, --, 4, --, 5, --, 5, --],
             mask=[False,  True, False,  True, False,  True, False,  True,
                   False,  True],
       fill_value=999999)

In [6]: m                                                                                                                                                                  
Out[6]: 
masked_array(data=[0, --, 2, --, 4, --, 6, --, 8, --],
             mask=[False,  True, False,  True, False,  True, False,  True,
                   False,  True],
       fill_value=999999)

In [7]: np.clip(m, 0, 5, m)                                                                                                                                                
Out[7]: 
masked_array(data=[0, 1, 2, 3, 4, 5, 5, 5, 5, 5],
             mask=False,
       fill_value=999999)

In [8]: m                                                                                                                                                                  
Out[8]: 
masked_array(data=[0, 1, 2, 3, 4, 5, 5, 5, 5, 5],
             mask=False,
       fill_value=999999)
```

I also opened an issue in numpy's repo: https://github.com/numpy/numpy/issues/14140