### PR TITLE
Make matplotlib.style.available sorted alphabetically.

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -83,8 +83,6 @@ def use(style):
         | list | A list of style specifiers (str or dict) applied from first |
         |      | to last in the list.                                        |
         +------+-------------------------------------------------------------+
-
-
     """
     style_alias = {'mpl20': 'default',
                    'mpl15': 'classic'}
@@ -218,5 +216,8 @@ available = []
 def reload_library():
     """Reload style library."""
     global library
-    available[:] = library = update_user_library(_base_library)
+    library = update_user_library(_base_library)
+    available[:] = sorted(library.keys())
+
+
 reload_library()


### PR DESCRIPTION
## PR Summary

### Before:
```python
>>> mpl.style.available
['seaborn-dark',
 'seaborn-darkgrid',
 'seaborn-ticks',
 'fivethirtyeight',
 'seaborn-whitegrid',
 'classic',
 '_classic_test',
 'fast',
 'seaborn-talk',
 'seaborn-dark-palette',
 'seaborn-bright',
 'seaborn-pastel',
 'grayscale',
 'seaborn-notebook',
 'ggplot',
 'seaborn-colorblind',
 'seaborn-muted',
 'seaborn',
 'Solarize_Light2',
 'seaborn-paper',
 'bmh',
 'tableau-colorblind10',
 'seaborn-white',
 'dark_background',
 'seaborn-poster',
 'seaborn-deep']
```

### After:

```python
>>> mpl.style.available
['Solarize_Light2',
 '_classic_test',
 'bmh',
 'classic',
 'dark_background',
 'fast',
 'fivethirtyeight',
 'ggplot',
 'grayscale',
 'seaborn',
 'seaborn-bright',
 'seaborn-colorblind',
 'seaborn-dark',
 'seaborn-dark-palette',
 'seaborn-darkgrid',
 'seaborn-deep',
 'seaborn-muted',
 'seaborn-notebook',
 'seaborn-paper',
 'seaborn-pastel',
 'seaborn-poster',
 'seaborn-talk',
 'seaborn-ticks',
 'seaborn-white',
 'seaborn-whitegrid',
 'tableau-colorblind10']
```