### PR TITLE
Use harfbuzz for text layout (proof of concept).

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -620,6 +620,7 @@ class FT2Font(SetupPackage):
             ]
         ext = Extension('matplotlib.ft2font', sources)
         FreeType().add_flags(ext)
+        pkg_config_setup_extension(ext, 'harfbuzz')
         add_numpy_flags(ext)
         LibAgg().add_flags(ext, add_sources=False)
         return ext


### PR DESCRIPTION
Support languages requiring complex text layout, e.g. Arabic, Hebrew,
Indic scripts, etc.

Nearly all test images will need to be regenerated.  Probably
hinting_factor should be killed at the same time.  Alternatively the old
code path could be left just for the purposes of testing and things
could be rcParam-switchable.

For vector output, the functionality implemented here in C will need to
be exposed in Python _text_layout::layout.

Doesn't support bidi (mixed left-to-right and right-to-left) mostly
because the main bidi library (fribidi) is LGPL.

Needs docs.

Test with e.g.
```
figtext(.5, .5, "العَرَبِيَّة‎")
```
(I don't speak any of these languages, this is just copy-pasted from
Wikipedia :))

Note that this should improve kerning even for latin-script languages
(even after fixing bugs currently present), because FreeType is unable
to read kerning info for some modern fonts.  See notes about 'kern' and
'GPOS' at https://www.freetype.org/freetype2/docs/glyphs/glyphs-4.html.

Closes https://github.com/matplotlib/matplotlib/issues/5941 and its duplicates (e.g. https://github.com/matplotlib/matplotlib/issues/8765), https://github.com/matplotlib/matplotlib/issues/14887.

Mostly needs to decide whether we want to add that dependency...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
