### PR TITLE
Don't redownload jquery when installing from an sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ Make sure you have pip >= 9.0.1.
     sys.exit(error)
 
 import os
+import shutil
 from zipfile import ZipFile
 
 from setuptools import setup, find_packages, Extension
@@ -115,6 +116,16 @@ cmdclass['build_ext'] = BuildExtraLibraries
 
 
 def _download_jquery_to(dest):
+    if os.path.exists(os.path.join(dest, "jquery-ui-1.12.1")):
+        return
+
+    # If we are installing from an sdist, use the already downloaded jquery-ui
+    sdist_src = os.path.join(
+        "lib/matplotlib/backends/web_backend", "jquery-ui-1.12.1")
+    if os.path.exists(sdist_src):
+        shutil.copytree(sdist_src, os.path.join(dest, "jquery-ui-1.12.1"))
+        return
+
     # Note: When bumping the jquery-ui version, also update the versions in
     # single_figure.html and all_figures.html.
     url = "https://jqueryui.com/resources/download/jquery-ui-1.12.1.zip"


### PR DESCRIPTION
Closes #14585

## PR Summary
The source for jquery-ui is already made available as part of the sdist. This change avoids downloading jquery-ui at all if installing from the sdist and jquery-ui can be found locally.

The use case I have is we don't have access to the internet. We access matplotlib through a devpi mirror. Unfortunately our build system requires us to install from an sdist rather than a wheel.

Ideally this would be backported to the v2.2.x branch. Should I submit a separate pull request for that?

## PR Checklist

- [N/A] Has Pytest style unit tests
- [/] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way