### PR TITLE
Make kwargs names in scale.py not include the axis direction.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -189,10 +189,13 @@ log/symlog scale base, ticks, and nonpos specification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `~.Axes.semilogx`, `~.Axes.semilogy`, `~.Axes.loglog`, `.LogScale`, and
 `.SymmetricalLogScale` used to take keyword arguments that depends on the axis
-orientation ("basex" vs "basey", "nonposx" vs "nonposy"); these parameter names
-are now deprecated in favor of "base", "nonpos", etc.  This deprecation also
-affects e.g. ``ax.set_yscale("log", basey=...)`` which must now be spelled
-``ax.set_yscale("log", base=...)``.
+orientation ("basex" vs "basey", "subsx" vs "subsy", "nonposx" vs "nonposy");
+these parameter names are now deprecated in favor of "base", "subs",
+"nonpositive".  This deprecation also affects e.g. ``ax.set_yscale("log",
+basey=...)`` which must now be spelled ``ax.set_yscale("log", base=...)``.
+
+The change from "nonpos" to "nonpositive" also affects `~.scale.LogTransform`,
+`~.scale.InvertedLogTransform`, `~.scale.SymmetricalLogTransform`, etc.
 
 To use *different* bases for the x-axis and y-axis of a `~.Axes.loglog` plot,
 use e.g. ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.

--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -184,3 +184,13 @@ Debian 8 (2015, EOL 06/2020) and Ubuntu 14.04 (EOL 04/2019) were the
 last versions of Debian and Ubuntu to ship avconv.  It remains possible
 to force the use of avconv by using the ffmpeg-based writers with
 :rc:`animation.ffmpeg_path` set to "avconv".
+
+Signature of `.LogScale` and `.SymmetricalLogScale`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These classes used to take keyword arguments that depends on the axis
+orientation ("basex" vs "basey", "nonposx" vs "nonposy"); these parameter
+names are now deprecated in favor of "base", "nonpos", etc.  This deprecation
+also affects e.g. ``ax.set_yscale("log", basey=...)`` which must now be
+spelled ``ax.set_yscale("log", base=...)``.  The only place where "basex", etc.
+remain in use is in the helper functions `~.Axes.loglog`, `~.Axes.semilogx`,
+and `~.Axes.semilogy` (because `~.Axes.loglog` takes both "basex" and "basey").

--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -185,12 +185,14 @@ last versions of Debian and Ubuntu to ship avconv.  It remains possible
 to force the use of avconv by using the ffmpeg-based writers with
 :rc:`animation.ffmpeg_path` set to "avconv".
 
-Signature of `.LogScale` and `.SymmetricalLogScale`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-These classes used to take keyword arguments that depends on the axis
-orientation ("basex" vs "basey", "nonposx" vs "nonposy"); these parameter
-names are now deprecated in favor of "base", "nonpos", etc.  This deprecation
-also affects e.g. ``ax.set_yscale("log", basey=...)`` which must now be
-spelled ``ax.set_yscale("log", base=...)``.  The only place where "basex", etc.
-remain in use is in the helper functions `~.Axes.loglog`, `~.Axes.semilogx`,
-and `~.Axes.semilogy` (because `~.Axes.loglog` takes both "basex" and "basey").
+log/symlog scale base, ticks, and nonpos specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`~.Axes.semilogx`, `~.Axes.semilogy`, `~.Axes.loglog`, `.LogScale`, and
+`.SymmetricalLogScale` used to take keyword arguments that depends on the axis
+orientation ("basex" vs "basey", "nonposx" vs "nonposy"); these parameter names
+are now deprecated in favor of "base", "nonpos", etc.  This deprecation also
+affects e.g. ``ax.set_yscale("log", basey=...)`` which must now be spelled
+``ax.set_yscale("log", base=...)``.
+
+To use *different* bases for the x-axis and y-axis of a `~.Axes.loglog` plot,
+use e.g. ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.

--- a/examples/scales/log_demo.py
+++ b/examples/scales/log_demo.py
@@ -36,8 +36,8 @@ ax3.grid()
 x = 10.0**np.linspace(0.0, 2.0, 20)
 y = x**2.0
 
-ax4.set_xscale("log", nonpos='clip')
-ax4.set_yscale("log", nonpos='clip')
+ax4.set_xscale("log", nonpositive='clip')
+ax4.set_yscale("log", nonpositive='clip')
 ax4.set(title='Errorbars go negative')
 ax4.errorbar(x, y, xerr=0.1 * x, yerr=5.0 + 0.75 * y)
 # ylim must be set after errorbar to allow errorbar to autoscale limits

--- a/examples/scales/log_demo.py
+++ b/examples/scales/log_demo.py
@@ -26,7 +26,8 @@ ax2.set(title='semilogx')
 ax2.grid()
 
 # log x and y axis
-ax3.loglog(t, 20 * np.exp(-t / 10.0), basex=2)
+ax3.loglog(t, 20 * np.exp(-t / 10.0))
+ax3.set_xscale('log', base=2)
 ax3.set(title='loglog base 2 on x')
 ax3.grid()
 
@@ -35,8 +36,8 @@ ax3.grid()
 x = 10.0**np.linspace(0.0, 2.0, 20)
 y = x**2.0
 
-ax4.set_xscale("log", nonposx='clip')
-ax4.set_yscale("log", nonposy='clip')
+ax4.set_xscale("log", nonpos='clip')
+ax4.set_yscale("log", nonpos='clip')
 ax4.set(title='Errorbars go negative')
 ax4.errorbar(x, y, xerr=0.1 * x, yerr=5.0 + 0.75 * y)
 # ylim must be set after errorbar to allow errorbar to autoscale limits

--- a/examples/scales/scales.py
+++ b/examples/scales/scales.py
@@ -45,7 +45,7 @@ ax.grid(True)
 # symmetric log
 ax = axs[1, 1]
 ax.plot(x, y - y.mean())
-ax.set_yscale('symlog', linthreshy=0.02)
+ax.set_yscale('symlog', linthresh=0.02)
 ax.set_title('symlog')
 ax.grid(True)
 

--- a/examples/scales/symlog_demo.py
+++ b/examples/scales/symlog_demo.py
@@ -27,7 +27,7 @@ plt.ylabel('symlogy')
 plt.subplot(313)
 plt.plot(x, np.sin(x / 3.0))
 plt.xscale('symlog')
-plt.yscale('symlog', linthreshy=0.015)
+plt.yscale('symlog', linthresh=0.015)
 plt.grid(True)
 plt.ylabel('symlog both')
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1766,7 +1766,7 @@ class Axes(_AxesBase):
         both the x-axis and the y-axis to log scaling. All of the concepts and
         parameters of plot can be used here as well.
 
-        The additional parameters *base*, *subs* and *nonpos* control the
+        The additional parameters *base*, *subs* and *nonpositive* control the
         x/y-axis properties. They are just forwarded to `.Axes.set_xscale` and
         `.Axes.set_yscale`. To use different properties on the x-axis and the
         y-axis, use e.g.
@@ -1782,7 +1782,7 @@ class Axes(_AxesBase):
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_xscale`/`.Axes.set_yscale` for details.
 
-        nonpos : {'mask', 'clip'}, default: 'mask'
+        nonpositive : {'mask', 'clip'}, default: 'mask'
             Non-positive values can be masked as invalid, or clipped to a very
             small positive number.
 
@@ -1797,10 +1797,12 @@ class Axes(_AxesBase):
             All parameters supported by `.plot`.
         """
         dx = {k: v for k, v in kwargs.items()
-              if k in ['base', 'subs', 'nonpos', 'basex', 'subsx', 'nonposx']}
+              if k in ['base', 'subs', 'nonpositive',
+                       'basex', 'subsx', 'nonposx']}
         self.set_xscale('log', **dx)
         dy = {k: v for k, v in kwargs.items()
-              if k in ['base', 'subs', 'nonpos', 'basey', 'subsy', 'nonposy']}
+              if k in ['base', 'subs', 'nonpositive',
+                       'basey', 'subsy', 'nonposy']}
         self.set_yscale('log', **dy)
         return self.plot(
             *args, **{k: v for k, v in kwargs.items() if k not in {*dx, *dy}})
@@ -1820,7 +1822,7 @@ class Axes(_AxesBase):
         the x-axis to log scaling. All of the concepts and parameters of plot
         can be used here as well.
 
-        The additional parameters *base*, *subs*, and *nonpos* control the
+        The additional parameters *base*, *subs*, and *nonpositive* control the
         x-axis properties. They are just forwarded to `.Axes.set_xscale`.
 
         Parameters
@@ -1833,7 +1835,7 @@ class Axes(_AxesBase):
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_xscale` for details.
 
-        nonpos : {'mask', 'clip'}, default: 'mask'
+        nonpositive : {'mask', 'clip'}, default: 'mask'
             Non-positive values in x can be masked as invalid, or clipped to a
             very small positive number.
 
@@ -1848,7 +1850,8 @@ class Axes(_AxesBase):
             All parameters supported by `.plot`.
         """
         d = {k: v for k, v in kwargs.items()
-             if k in ['base', 'subs', 'nonpos', 'basex', 'subsx', 'nonposx']}
+             if k in ['base', 'subs', 'nonpositive',
+                      'basex', 'subsx', 'nonposx']}
         self.set_xscale('log', **d)
         return self.plot(
             *args, **{k: v for k, v in kwargs.items() if k not in d})
@@ -1868,7 +1871,7 @@ class Axes(_AxesBase):
         the y-axis to log scaling. All of the concepts and parameters of plot
         can be used here as well.
 
-        The additional parameters *base*, *subs*, and *nonpos* control the
+        The additional parameters *base*, *subs*, and *nonpositive* control the
         y-axis properties. They are just forwarded to `.Axes.set_yscale`.
 
         Parameters
@@ -1881,7 +1884,7 @@ class Axes(_AxesBase):
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_yscale` for details.
 
-        nonpos : {'mask', 'clip'}, default: 'mask'
+        nonpositive : {'mask', 'clip'}, default: 'mask'
             Non-positive values in y can be masked as invalid, or clipped to a
             very small positive number.
 
@@ -1896,7 +1899,8 @@ class Axes(_AxesBase):
             All parameters supported by `.plot`.
         """
         d = {k: v for k, v in kwargs.items()
-             if k in ['base', 'subs', 'nonpos', 'basey', 'subsy', 'nonposy']}
+             if k in ['base', 'subs', 'nonpositive',
+                      'basey', 'subsy', 'nonposy']}
         self.set_yscale('log', **d)
         return self.plot(
             *args, **{k: v for k, v in kwargs.items() if k not in d})
@@ -2340,11 +2344,11 @@ class Axes(_AxesBase):
         if orientation == 'vertical':
             self._process_unit_info(xdata=x, ydata=height, kwargs=kwargs)
             if log:
-                self.set_yscale('log', nonpos='clip')
+                self.set_yscale('log', nonpositive='clip')
         elif orientation == 'horizontal':
             self._process_unit_info(xdata=width, ydata=y, kwargs=kwargs)
             if log:
-                self.set_xscale('log', nonpos='clip')
+                self.set_xscale('log', nonpositive='clip')
 
         # lets do some conversions now since some types cannot be
         # subtracted uniformly
@@ -6712,9 +6716,9 @@ default: :rc:`scatter.edgecolors`
 
             if log:
                 if orientation == 'horizontal':
-                    self.set_xscale('log', nonpos='clip')
+                    self.set_xscale('log', nonpositive='clip')
                 else:  # orientation == 'vertical'
-                    self.set_yscale('log', nonpos='clip')
+                    self.set_yscale('log', nonpositive='clip')
 
             if align == 'left':
                 x -= 0.5*(bins[1]-bins[0])

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1795,16 +1795,13 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        dx = {k: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
+        dx = {k[:-1]: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
               if k in kwargs}
-        dy = {k: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
-              if k in kwargs}
-
         self.set_xscale('log', **dx)
+        dy = {k[:-1]: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
+              if k in kwargs}
         self.set_yscale('log', **dy)
-
-        l = self.plot(*args, **kwargs)
-        return l
+        return self.plot(*args, **kwargs)
 
     # @_preprocess_data() # let 'plot' do the unpacking..
     @docstring.dedent_interpd
@@ -1848,12 +1845,10 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        d = {k: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
+        d = {k[:-1]: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
              if k in kwargs}
-
         self.set_xscale('log', **d)
-        l = self.plot(*args, **kwargs)
-        return l
+        return self.plot(*args, **kwargs)
 
     # @_preprocess_data() # let 'plot' do the unpacking..
     @docstring.dedent_interpd
@@ -1897,12 +1892,10 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        d = {k: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
+        d = {k[:-1]: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
              if k in kwargs}
         self.set_yscale('log', **d)
-        l = self.plot(*args, **kwargs)
-
-        return l
+        return self.plot(*args, **kwargs)
 
     @_preprocess_data(replace_names=["x"], label_namer="x")
     def acorr(self, x, **kwargs):
@@ -2343,11 +2336,11 @@ class Axes(_AxesBase):
         if orientation == 'vertical':
             self._process_unit_info(xdata=x, ydata=height, kwargs=kwargs)
             if log:
-                self.set_yscale('log', nonposy='clip')
+                self.set_yscale('log', nonpos='clip')
         elif orientation == 'horizontal':
             self._process_unit_info(xdata=width, ydata=y, kwargs=kwargs)
             if log:
-                self.set_xscale('log', nonposx='clip')
+                self.set_xscale('log', nonpos='clip')
 
         # lets do some conversions now since some types cannot be
         # subtracted uniformly
@@ -6715,9 +6708,9 @@ default: :rc:`scatter.edgecolors`
 
             if log:
                 if orientation == 'horizontal':
-                    self.set_xscale('log', nonposx='clip')
+                    self.set_xscale('log', nonpos='clip')
                 else:  # orientation == 'vertical'
-                    self.set_yscale('log', nonposy='clip')
+                    self.set_yscale('log', nonpos='clip')
 
             if align == 'left':
                 x -= 0.5*(bins[1]-bins[0])

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1766,24 +1766,25 @@ class Axes(_AxesBase):
         both the x-axis and the y-axis to log scaling. All of the concepts and
         parameters of plot can be used here as well.
 
-        The additional parameters *basex/y*, *subsx/y* and *nonposx/y* control
-        the x/y-axis properties. They are just forwarded to `.Axes.set_xscale`
-        and `.Axes.set_yscale`.
+        The additional parameters *base*, *subs* and *nonpos* control the
+        x/y-axis properties. They are just forwarded to `.Axes.set_xscale` and
+        `.Axes.set_yscale`. To use different properties on the x-axis and the
+        y-axis, use e.g.
+        ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.
 
         Parameters
         ----------
-        basex, basey : float, default: 10
-            Base of the x/y logarithm.
+        base : float, default: 10
+            Base of the logarithm.
 
-        subsx, subsy : sequence, optional
-            The location of the minor x/y ticks. If *None*, reasonable
-            locations are automatically chosen depending on the number of
-            decades in the plot.
-            See `.Axes.set_xscale` / `.Axes.set_yscale` for details.
+        subs : sequence, optional
+            The location of the minor ticks. If *None*, reasonable locations
+            are automatically chosen depending on the number of decades in the
+            plot. See `.Axes.set_xscale`/`.Axes.set_yscale` for details.
 
-        nonposx, nonposy : {'mask', 'clip'}, default: 'mask'
-            Non-positive values in x or y can be masked as invalid, or clipped
-            to a very small positive number.
+        nonpos : {'mask', 'clip'}, default: 'mask'
+            Non-positive values can be masked as invalid, or clipped to a very
+            small positive number.
 
         Returns
         -------
@@ -1795,13 +1796,14 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        dx = {k[:-1]: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
-              if k in kwargs}
+        dx = {k: v for k, v in kwargs.items()
+              if k in ['base', 'subs', 'nonpos', 'basex', 'subsx', 'nonposx']}
         self.set_xscale('log', **dx)
-        dy = {k[:-1]: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
-              if k in kwargs}
+        dy = {k: v for k, v in kwargs.items()
+              if k in ['base', 'subs', 'nonpos', 'basey', 'subsy', 'nonposy']}
         self.set_yscale('log', **dy)
-        return self.plot(*args, **kwargs)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in {*dx, *dy}})
 
     # @_preprocess_data() # let 'plot' do the unpacking..
     @docstring.dedent_interpd
@@ -1818,20 +1820,20 @@ class Axes(_AxesBase):
         the x-axis to log scaling. All of the concepts and parameters of plot
         can be used here as well.
 
-        The additional parameters *basex*, *subsx* and *nonposx* control the
+        The additional parameters *base*, *subs*, and *nonpos* control the
         x-axis properties. They are just forwarded to `.Axes.set_xscale`.
 
         Parameters
         ----------
-        basex : float, default: 10
+        base : float, default: 10
             Base of the x logarithm.
 
-        subsx : array-like, optional
+        subs : array-like, optional
             The location of the minor xticks. If *None*, reasonable locations
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_xscale` for details.
 
-        nonposx : {'mask', 'clip'}, default: 'mask'
+        nonpos : {'mask', 'clip'}, default: 'mask'
             Non-positive values in x can be masked as invalid, or clipped to a
             very small positive number.
 
@@ -1845,10 +1847,11 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        d = {k[:-1]: kwargs.pop(k) for k in ['basex', 'subsx', 'nonposx']
-             if k in kwargs}
+        d = {k: v for k, v in kwargs.items()
+             if k in ['base', 'subs', 'nonpos', 'basex', 'subsx', 'nonposx']}
         self.set_xscale('log', **d)
-        return self.plot(*args, **kwargs)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in d})
 
     # @_preprocess_data() # let 'plot' do the unpacking..
     @docstring.dedent_interpd
@@ -1865,20 +1868,20 @@ class Axes(_AxesBase):
         the y-axis to log scaling. All of the concepts and parameters of plot
         can be used here as well.
 
-        The additional parameters *basey*, *subsy* and *nonposy* control the
+        The additional parameters *base*, *subs*, and *nonpos* control the
         y-axis properties. They are just forwarded to `.Axes.set_yscale`.
 
         Parameters
         ----------
-        basey : float, default: 10
+        base : float, default: 10
             Base of the y logarithm.
 
-        subsy : array-like, optional
+        subs : array-like, optional
             The location of the minor yticks. If *None*, reasonable locations
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_yscale` for details.
 
-        nonposy : {'mask', 'clip'}, default: 'mask'
+        nonpos : {'mask', 'clip'}, default: 'mask'
             Non-positive values in y can be masked as invalid, or clipped to a
             very small positive number.
 
@@ -1892,10 +1895,11 @@ class Axes(_AxesBase):
         **kwargs
             All parameters supported by `.plot`.
         """
-        d = {k[:-1]: kwargs.pop(k) for k in ['basey', 'subsy', 'nonposy']
-             if k in kwargs}
+        d = {k: v for k, v in kwargs.items()
+             if k in ['base', 'subs', 'nonpos', 'basey', 'subsy', 'nonposy']}
         self.set_yscale('log', **d)
-        return self.plot(*args, **kwargs)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in d})
 
     @_preprocess_data(replace_names=["x"], label_namer="x")
     def acorr(self, x, **kwargs):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5683,15 +5683,15 @@ def test_loglog_nonpos(new_api):
         if new_api:
             if mcx == mcy:
                 if mcx:
-                    ax.loglog(x, y**3, lw=2, nonpos=mcx)
+                    ax.loglog(x, y**3, lw=2, nonpositive=mcx)
                 else:
                     ax.loglog(x, y**3, lw=2)
             else:
                 ax.loglog(x, y**3, lw=2)
                 if mcx:
-                    ax.set_xscale("log", nonpos=mcx)
+                    ax.set_xscale("log", nonpositive=mcx)
                 if mcy:
-                    ax.set_yscale("log", nonpos=mcy)
+                    ax.set_yscale("log", nonpositive=mcy)
         else:
             kws = {}
             if mcx:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1150,9 +1150,9 @@ def test_symlog2():
     x = np.arange(-50, 50, 0.001)
 
     fig, axs = plt.subplots(5, 1)
-    for ax, linthreshx in zip(axs, [20., 2., 1., 0.1, 0.01]):
+    for ax, linthresh in zip(axs, [20., 2., 1., 0.1, 0.01]):
         ax.plot(x, x)
-        ax.set_xscale('symlog', linthreshx=linthreshx)
+        ax.set_xscale('symlog', linthresh=linthresh)
         ax.grid(True)
     axs[-1].set_ylim(-0.1, 0.1)
 
@@ -2241,9 +2241,9 @@ def test_log_scales():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
     ax.plot(np.log(np.linspace(0.1, 100)))
-    ax.set_yscale('log', basey=5.5)
+    ax.set_yscale('log', base=5.5)
     ax.invert_yaxis()
-    ax.set_xscale('log', basex=9.0)
+    ax.set_xscale('log', base=9.0)
 
 
 def test_log_scales_no_data():

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,7 +1,8 @@
 from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
-from matplotlib.scale import (Log10Transform, InvertedLog10Transform,
-                              SymmetricalLogTransform)
+from matplotlib.scale import (
+    LogTransform, Log10Transform, InvertedLog10Transform,
+    SymmetricalLogTransform)
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 import numpy as np
@@ -132,11 +133,8 @@ def test_logscale_invert_transform():
 def test_logscale_transform_repr():
     fig, ax = plt.subplots()
     ax.set_yscale('log')
-    repr(ax.transData)  # check that repr of log transform succeeds
-
-    # check that repr of log transform succeeds
-    with pytest.warns(MatplotlibDeprecationWarning):
-        repr(Log10Transform(nonpos='clip'))
+    repr(ax.transData)
+    repr(LogTransform(10, nonpositive='clip'))
 
 
 @image_comparison(['logscale_nonpos_values.png'],
@@ -148,7 +146,7 @@ def test_logscale_nonpos_values():
     ax1.hist(xs, range=(-5, 5), bins=10)
     ax1.set_yscale('log')
     ax2.hist(xs, range=(-5, 5), bins=10)
-    ax2.set_yscale('log', nonpos='mask')
+    ax2.set_yscale('log', nonpositive='mask')
 
     xdata = np.arange(0, 10, 0.01)
     ydata = np.exp(-xdata)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -88,7 +88,7 @@ def test_log_scatter():
 
 def test_logscale_subs():
     fig, ax = plt.subplots()
-    ax.set_yscale('log', subsy=np.array([2, 3, 4]))
+    ax.set_yscale('log', subs=np.array([2, 3, 4]))
     # force draw
     fig.canvas.draw()
 
@@ -108,16 +108,14 @@ def test_logscale_mask():
 def test_extra_kwargs_raise_or_warn():
     fig, ax = plt.subplots()
 
-    # with pytest.raises(TypeError):
     with pytest.warns(MatplotlibDeprecationWarning):
-        ax.set_yscale('linear', nonpos='mask')
+        ax.set_yscale('linear', foo='mask')
 
     with pytest.raises(TypeError):
-        ax.set_yscale('log', nonpos='mask')
+        ax.set_yscale('log', foo='mask')
 
-    # with pytest.raises(TypeError):
     with pytest.warns(MatplotlibDeprecationWarning):
-        ax.set_yscale('symlog', nonpos='mask')
+        ax.set_yscale('symlog', foo='mask')
 
 
 def test_logscale_invert_transform():
@@ -150,7 +148,7 @@ def test_logscale_nonpos_values():
     ax1.hist(xs, range=(-5, 5), bins=10)
     ax1.set_yscale('log')
     ax2.hist(xs, range=(-5, 5), bins=10)
-    ax2.set_yscale('log', nonposy='mask')
+    ax2.set_yscale('log', nonpos='mask')
 
     xdata = np.arange(0, 10, 0.01)
     ydata = np.exp(-xdata)

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -443,7 +443,7 @@ plt.grid(True)
 # symmetric log
 plt.subplot(223)
 plt.plot(x, y - y.mean())
-plt.yscale('symlog', linthreshy=0.01)
+plt.yscale('symlog', linthresh=0.01)
 plt.title('symlog')
 plt.grid(True)
 


### PR DESCRIPTION
- Make names of kwargs to Scale subclasses independent of whether the
  underlying axis is x or y (so that after the deprecation period, one
  can just have a normal signature --
  `def __init__(self, *, base=10, ...)`.

  We could possibly also change semilogx and semilogy to use the
  unsuffixed names (with deprecation), leaving only loglog with the
  suffixed names, or even also make loglog use unsuffixed names, in
  which case it would become impossible to set separate x and y bases
  directly in loglog -- one should then do `gca().set_xscale("log",
  base=...)` which doesn't seem too onerous.  (loglog is the only case
  where the suffixed names has *some* utility.)
  EDIT: see https://github.com/matplotlib/matplotlib/pull/14916#issuecomment-581777741.

  In general, note that having kwargs that depend on the axis direction
  doesn't really scale -- for example, if we were to finally add
  log-scale support to mplot3d, should scale.py know about it and add
  `basez`?  Should we have `baser` for log-scale polar plots? (at least
  in the radial direction, they make sense)

- Move argument validation up the the Transform subclasses.

- Make SymmetricalLogScale.{base,linthresh,linscale} properties
  mapping to the underlying transform so that they can't go out of sync.

As discussed with @tacaswell during the dev call.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
