### PR TITLE
ENH: box aspect for axes

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -369,6 +369,9 @@ Aspect ratio
    Axes.set_aspect
    Axes.get_aspect
 
+   Axes.set_box_aspect
+   Axes.get_box_aspect
+
    Axes.set_adjustable
    Axes.get_adjustable
 

--- a/doc/users/next_whats_new/2019-07-31_axes-box-aspect.rst
+++ b/doc/users/next_whats_new/2019-07-31_axes-box-aspect.rst
@@ -1,0 +1,14 @@
+:orphan:
+
+Setting axes box aspect
+-----------------------
+
+It is now possible to set the aspect of an axes box directly via
+`~.Axes.set_box_aspect`. The box aspect is the ratio between axes height
+and axes width in physical units, independent of the data limits.
+This is useful to e.g. produce a square plot, independent of the data it
+contains, or to have a usual plot with the same axes dimensions next to
+an image plot with fixed (data-)aspect.
+
+For use cases check out the :doc:`Axes box aspect
+</gallery/subplots_axes_and_figures/axes_box_aspect>` example.

--- a/examples/subplots_axes_and_figures/axes_box_aspect.py
+++ b/examples/subplots_axes_and_figures/axes_box_aspect.py
@@ -1,0 +1,157 @@
+"""
+===============
+Axes box aspect
+===============
+
+This demo shows how to set the aspect of an axes box directly via
+`~.Axes.set_box_aspect`. The box aspect is the ratio between axes height
+and axes width in physical units, independent of the data limits.
+This is useful to e.g. produce a square plot, independent of the data it
+contains, or to have a usual plot with the same axes dimensions next to
+an image plot with fixed (data-)aspect.
+
+The following lists a few use cases for `~.Axes.set_box_aspect`.
+"""
+
+############################################################################
+# A square axes, independent of data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Produce a square axes, no matter what the data limits are.
+
+import matplotlib
+import numpy as np
+import matplotlib.pyplot as plt
+
+fig1, ax = plt.subplots()
+
+ax.set_xlim(300, 400)
+ax.set_box_aspect(1)
+
+plt.show()
+
+############################################################################
+# Shared square axes
+# ~~~~~~~~~~~~~~~~~~
+#
+# Produce shared subplots that are squared in size.
+#
+fig2, (ax, ax2) = plt.subplots(ncols=2, sharey=True)
+
+ax.plot([1, 5], [0, 10])
+ax2.plot([100, 500], [10, 15])
+
+ax.set_box_aspect(1)
+ax2.set_box_aspect(1)
+
+plt.show()
+
+############################################################################
+# Square twin axes
+# ~~~~~~~~~~~~~~~~
+#
+# Produce a square axes, with a twin axes. The twinned axes takes over the
+# box aspect of the parent.
+#
+
+fig3, ax = plt.subplots()
+
+ax2 = ax.twinx()
+
+ax.plot([0, 10])
+ax2.plot([12, 10])
+
+ax.set_box_aspect(1)
+
+plt.show()
+
+
+############################################################################
+# Normal plot next to image
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# When creating an image plot with fixed data aspect and the default
+# ``adjustable="box"`` next to a normal plot, the axes would be unequal in
+# height. `~.Axes.set_box_aspect` provides an easy solution to that by allowing
+# to have the normal plot's axes use the images dimensions as box aspect.
+#
+# This example also shows that ``constrained_layout`` interplays nicely with
+# a fixed box aspect.
+
+fig4, (ax, ax2) = plt.subplots(ncols=2, constrained_layout=True)
+
+im = np.random.rand(16, 27)
+ax.imshow(im)
+
+ax2.plot([23, 45])
+ax2.set_box_aspect(im.shape[0]/im.shape[1])
+
+plt.show()
+
+############################################################################
+# Square joint/marginal plot
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# It may be desireable to show marginal distributions next to a plot of joint
+# data. The following creates a square plot with the box aspect of the
+# marginal axes being equal to the width- and height-ratios of the gridspec.
+# This ensures that all axes align perfectly, independent on the size of the
+# figure.
+
+fig5, axs = plt.subplots(2, 2, sharex="col", sharey="row",
+                        gridspec_kw=dict(height_ratios=[1, 3],
+                                         width_ratios=[3, 1]))
+axs[0, 1].set_visible(False)
+axs[0, 0].set_box_aspect(1/3)
+axs[1, 0].set_box_aspect(1)
+axs[1, 1].set_box_aspect(3/1)
+
+x, y = np.random.randn(2, 400) * np.array([[.5], [180]])
+axs[1, 0].scatter(x, y)
+axs[0, 0].hist(x)
+axs[1, 1].hist(y, orientation="horizontal")
+
+plt.show()
+
+############################################################################
+# Square joint/marginal plot
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# When setting the box aspect, one may still set the data aspect as well.
+# Here we create an axes with a box twice as long as tall and use an "equal"
+# data aspect for its contents, i.e. the circle actually stays circular.
+
+fig6, ax = plt.subplots()
+
+ax.add_patch(plt.Circle((5, 3), 1))
+ax.set_aspect("equal", adjustable="datalim")
+ax.set_box_aspect(0.5)
+ax.autoscale()
+
+plt.show()
+
+############################################################################
+# Box aspect for many subplots
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# It is possible to pass the box aspect to an axes at initialization. The
+# following creates a 2 by 3 subplot grid with all square axes.
+
+fig7, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
+                        sharex=True, sharey=True, constrained_layout=True)
+
+for i, ax in enumerate(axs.flat):
+    ax.scatter(i % 3, -((i // 3) - 0.5)*200, c=[plt.cm.hsv(i / 6)], s=300)
+plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods and classes is shown
+# in this example:
+
+matplotlib.axes.Axes.set_box_aspect

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6546,5 +6546,70 @@ def test_aspect_nonlinear_adjustable_datalim():
            aspect=1, adjustable="datalim")
     ax.margins(0)
     ax.apply_aspect()
+
     assert ax.get_xlim() == pytest.approx([1*10**(1/2), 100/10**(1/2)])
     assert ax.get_ylim() == (1 / 101, 1 / 11)
+
+
+def test_box_aspect():
+    # Test if axes with box_aspect=1 has same dimensions
+    # as axes with aspect equal and adjustable="box"
+
+    fig1, ax1 = plt.subplots()
+    axtwin = ax1.twinx()
+    axtwin.plot([12, 344])
+
+    ax1.set_box_aspect(1)
+
+    fig2, ax2 = plt.subplots()
+    ax2.margins(0)
+    ax2.plot([0, 2], [6, 8])
+    ax2.set_aspect("equal", adjustable="box")
+
+    fig1.canvas.draw()
+    fig2.canvas.draw()
+
+    bb1 = ax1.get_position()
+    bbt = axtwin.get_position()
+    bb2 = ax2.get_position()
+
+    assert_array_equal(bb1.extents, bb2.extents)
+    assert_array_equal(bbt.extents, bb2.extents)
+
+
+def test_box_aspect_custom_position():
+    # Test if axes with custom position and box_aspect
+    # behaves the same independent of the order of setting those.
+
+    fig1, ax1 = plt.subplots()
+    ax1.set_position([0.1, 0.1, 0.9, 0.2])
+    fig1.canvas.draw()
+    ax1.set_box_aspect(1.)
+
+    fig2, ax2 = plt.subplots()
+    ax2.set_box_aspect(1.)
+    fig2.canvas.draw()
+    ax2.set_position([0.1, 0.1, 0.9, 0.2])
+
+    fig1.canvas.draw()
+    fig2.canvas.draw()
+
+    bb1 = ax1.get_position()
+    bb2 = ax2.get_position()
+
+    assert_array_equal(bb1.extents, bb2.extents)
+
+
+def test_bbox_aspect_axes_init():
+    # Test that box_aspect can be given to axes init and produces
+    # all equal square axes.
+    fig, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
+                        constrained_layout=True)
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    sizes = []
+    for ax in axs.flat:
+        bb = ax.get_window_extent(renderer)
+        sizes.extend([bb.width, bb.height])
+
+    assert_allclose(sizes, sizes[0])


### PR DESCRIPTION
## PR Summary

Matplotlib axes' `aspect` refers to the *data*, i.e. it defines the ratio of vertical vs. horizontal data units. However, it seems people often (mis)use it in order to set the aspect of the axes box, which is of course possible by knowing the limits of the data and using `adjustable="box"`. But it inevitably leads to problems, e.g.

* It doesn't work when there is a twinned axes in the game (as in https://github.com/matplotlib/matplotlib/pull/10033#issuecomment-515405046, or [Define aspect ratio when using twinx in new version of matplotlib](https://stackoverflow.com/questions/57216993/define-aspect-ratio-when-using-twinx-in-new-version-of-matplotlib))
* It breaks down when limits change, i.e. in most interactive cases (zoom/pan...)
* It may lead to overly complicated solutions ([Create equal aspect (square) plot with multiple axes when data limits are different?](https://stackoverflow.com/questions/54545758/create-equal-aspect-square-plot-with-multiple-axes-when-data-limits-are-differ)), not even the `axes_grid1` toolkit is able to solve natively.

In short, sometimes people just want to make a square plot.

So it seems useful to introduce a **`box_aspect`** parameter, which sets the aspect (i.e. the ratio between height and width) of the **axes box**, independent of the data.

### Some usecases:


**A. A square axes, independent of data**
```
fig1, ax = plt.subplots()

ax.set_xlim(300,400)
ax.set_box_aspect(1)
```
![fig1](https://user-images.githubusercontent.com/23121882/62092380-3d3f7f00-b275-11e9-9cb7-c96b664a8783.png)



**B.  Shared square axes**

```
fig2, (ax, ax2) = plt.subplots(ncols=2, sharey=True)

ax.plot([0,10])
ax2.plot([10,20])

ax.set_box_aspect(1)
ax2.set_box_aspect(1)

```
![fig2](https://user-images.githubusercontent.com/23121882/62092385-416b9c80-b275-11e9-9c1e-a225f1cb2f99.png)



**C. Square twin axes**
```
fig3, ax = plt.subplots()

ax2 = ax.twinx()

ax.plot([0,10])
ax2.plot([12,10])

ax.set_box_aspect(1)
```
![fig3](https://user-images.githubusercontent.com/23121882/62092392-44ff2380-b275-11e9-95d5-262186f37350.png)



**D. Normal plot next to image** (works with constrained_layout)
```
fig4, (ax, ax2) = plt.subplots(ncols=2, constrained_layout=True)

im = np.random.rand(16,27)
ax.imshow(im)

ax2.plot([23,45])
ax2.set_box_aspect(im.shape[0]/im.shape[1])
```

![fig4](https://user-images.githubusercontent.com/23121882/62092397-4a5c6e00-b275-11e9-9887-fbb38d7156e4.png)



**E. Square joint/marginal plot**
```
fig5, axs = plt.subplots(2,2, sharex="col", sharey="row", 
                        gridspec_kw = dict(height_ratios=[1,3], 
                                           width_ratios=[3,1]))
axs[0,1].set_visible(False)
axs[0,0].set_box_aspect(1/3)
axs[1,0].set_box_aspect(1)
axs[1,1].set_box_aspect(3/1)

x,y = np.random.randn(2,400) * np.array([[.5],[180]])
axs[1,0].scatter(x,y)
axs[0,0].hist(x)
axs[1,1].hist(y, orientation="horizontal")
```

![fig5](https://user-images.githubusercontent.com/23121882/62092399-4fb9b880-b275-11e9-8cf9-d3181308e4c4.png)

**F. Equal data aspect, unequal box aspect**
```
fig6, ax = plt.subplots()

ax.add_patch(plt.Circle((5,3), 1))
ax.set_aspect("equal", adjustable="datalim")
ax.set_box_aspect(0.5)
ax.autoscale()
```

![fig6](https://user-images.githubusercontent.com/23121882/62092408-55170300-b275-11e9-9761-b27fb52eb8da.png)


### Issues:

* <strike>As @jklymak already [pointed out](https://github.com/matplotlib/matplotlib/pull/10033#issuecomment-515542521), there might be a problem with layout managers, and indeed at least case **E.** from above fails with contrained_layout. </strike> (fixed by https://github.com/matplotlib/matplotlib/pull/14919)

* Obviously  a fixed box_aspect only makes sense with `adjustable="datalim"`. Since the order in which `box_aspect` and `adjustable` are set is arbitrary, this still needs to define in which cases to error out, or silently fall back.




## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is finally [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)


