### PR TITLE
FIX constrained_layout w/ hidden axes

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -272,7 +272,11 @@ def _make_layout_margins(ax, renderer, h_pad, w_pad):
     invTransFig = fig.transFigure.inverted().transform_bbox
     pos = ax.get_position(original=True)
     tightbbox = ax.get_tightbbox(renderer=renderer)
-    bbox = invTransFig(tightbbox)
+    if tightbbox is None:
+        bbox = pos
+    else:
+        bbox = invTransFig(tightbbox)
+
     # this can go wrong:
     if not (np.isfinite(bbox.width) and np.isfinite(bbox.height)):
         # just abort, this is likely a bad set of co-ordinates that

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -387,3 +387,16 @@ def test_colorbar_location():
     fig.colorbar(pcm, ax=axs[-2, 3:], shrink=0.5, location='top')
     fig.colorbar(pcm, ax=axs[0, 0], shrink=0.5, location='left')
     fig.colorbar(pcm, ax=axs[1:3, 2], shrink=0.5, location='right')
+
+
+def test_hidden_axes():
+    # test that if we make an axes not visible that constrained_layout
+    # still works.  Note the axes still takes space in the layout
+    # (as does a gridspec slot that is empty)
+    fig, axs = plt.subplots(2, 2, constrained_layout=True)
+    axs[0, 1].set_visible(False)
+    fig.canvas.draw()
+    extents1 = np.copy(axs[0, 0].get_position().extents)
+
+    np.testing.assert_allclose(extents1,
+        [0.045552, 0.548288, 0.47319, 0.982638], rtol=1e-5)


### PR DESCRIPTION
## PR Summary

If an axes is hidden (set_visible(False)) then it has no tightbbox.  But we still need to position it w/ `constrained_layout`, pointed out in #14917 (thanks @ImportanceOfBeingErnest )

Closes #14918


```python
import numpy as np
import matplotlib.pyplot as plt

fig5, axs = plt.subplots(2, 2, constrained_layout=True)
axs[0,1].set_visible(False)
plt.show()
```


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
