### PR TITLE
DOC: Declutter the matplotlibrc file.

### DIFF
--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -1,45 +1,24 @@
-#### MATPLOTLIBRC FORMAT
-
-## This is a sample matplotlib configuration file - you can find a copy
-## of it on your system in site-packages/matplotlib/mpl-data/matplotlibrc
-## (which related to your Python installation location).
-##
-## If you edit it there, please note that it will be overwritten in your
-## next install.  If you want to keep a permanent local copy that will not
-## be overwritten, place it in one of the following locations:
-## unix/linux:
-##     $HOME/.config/matplotlib/matplotlibrc OR
-##     $XDG_CONFIG_HOME/matplotlib/matplotlibrc (if $XDG_CONFIG_HOME is set)
-## other platforms:
-##     $HOME/.matplotlib/matplotlibrc
+## ############################################################################
+## # MATPLOTLIBRC CONFIGURATION FILE                                          #
+## ############################################################################
 ##
 ## See https://matplotlib.org/users/customizing.html#the-matplotlibrc-file
-## for more details on the paths which are checked for the configuration file.
+## for more details on path resolution and formats of this file.
 ##
-## This file is best viewed in a editor which supports python mode syntax
-## highlighting.  Blank lines, or lines starting with a comment symbol, are
-## ignored, as are trailing comments.  Other lines must have the format:
-##     key : val  ## optional comment
-##
-## Formatting and style conventions for this file:
-##     - at least one whitesapce AROUND `:` to seperate key and val
-##         * prefer one whitesapce except for block colon alignment
-##     - at least two whitesapces BEFORE `##` to seperate the key-val pair and
-##       the trailing comments
-##         * prefer two whitesapces except for block `##` alignment
-##     - at least one whitesapce AFTER `##` to seperate the `##` marker and
-##       the comment text
-##         * prefer one whitesapce except for indentation (listing, etc.), in
+## Style conventions:
+##     - to seperate key and val
+##         + at least one whitespace AROUND ``:``
+##         + prefer one whitespace except for block colon alignment
+##     - to seperate the trailing comments and the key-val pair
+##         + at least two whitespaces BEFORE ``##``
+##         + prefer two whitespaces except for block trailing comments alignment
+##     - to seperate the comment symbol and the comment text
+##         + at least one whitespace AFTER ``##``
+##         + prefer one whitespace except for indentation (listing, etc.), in
 ##           which case, four more whitespaces are preferred
+##     - to seperate different sections: use two blank lines
 ##
-## Colors: for the color values below, you can either use
-##     - a matplotlib color string, such as r, k, or b
-##     - an rgb tuple, such as (1.0, 0.5, 0.0)
-##     - a hex string, such as ff00ff
-##     - a scalar grayscale intensity such as 0.75
-##     - a legal html color name, e.g., red, blue, darkslategray
-##
-## Matplotlib configuration are currently divided into following parts:
+## Matplotlib configuration are currently divided into following sections:
 ##     - BACKENDS
 ##     - LINES
 ##     - PATCHES
@@ -64,8 +43,6 @@
 ##     - SAVING FIGURES
 ##     - INTERACTIVE KEYMAPS
 ##     - ANIMATION
-
-##### CONFIGURATION BEGINS HERE
 
 
 ## ***************************************************************************

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -1,7 +1,15 @@
 """
-*****************
+=================
 Specifying Colors
-*****************
+=================
+
+Tips on how to specify colors in Matplotlib.
+
+
+.. valid-color-values:
+
+Valid color values
+==================
 
 Matplotlib recognizes the following formats to specify a color:
 
@@ -47,8 +55,9 @@ For more information on colors in matplotlib see
 * the `matplotlib.colors` API;
 * the :doc:`/gallery/color/named_colors` example.
 
+
 "CN" color selection
---------------------
+====================
 
 "CN" colors are converted to RGBA as soon as the artist is created.  For
 example,
@@ -82,8 +91,8 @@ demo('seaborn')
 #
 # .. _xkcd-colors:
 #
-# xkcd v X11/CSS4
-# ---------------
+# xkcd vs. X11/CSS4
+# =================
 #
 # The xkcd colors are derived from a user survey conducted by the
 # webcomic xkcd.  `Details of the survey are available on the xkcd blog

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -1,7 +1,7 @@
 """
-================================
+========================
 Constrained Layout Guide
-================================
+========================
 
 How to use constrained-layout to fit plots within your figure cleanly.
 
@@ -37,6 +37,7 @@ Those are described in detail throughout the following sections.
     running Constrained Layout and use ``ax.set_position()`` in your code
     with ``constrained_layout=False``.
 
+
 Simple Example
 ==============
 
@@ -44,7 +45,6 @@ In Matplotlib, the location of axes (including subplots) are specified in
 normalized figure coordinates. It can happen that your axis labels or
 titles (or sometimes even ticklabels) go outside the figure area, and are thus
 clipped.
-
 """
 
 # sphinx_gallery_thumbnail_number = 18

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -1,11 +1,13 @@
 """
+=====================================================
 Customizing Matplotlib with style sheets and rcParams
 =====================================================
 
 Tips for customizing the properties and default styles of Matplotlib.
 
+
 Using style sheets
-------------------
+==================
 
 The ``style`` package adds support for easy-to-switch plotting "styles" with
 the same parameters as a
@@ -93,8 +95,8 @@ plt.show()
 ###############################################################################
 # .. _matplotlib-rcparams:
 #
-# matplotlib rcParams
-# ===================
+# Using Matplotlib rcParams
+# =========================
 #
 # .. _customizing-with-dynamic-rc-settings:
 #
@@ -103,8 +105,8 @@ plt.show()
 #
 # You can also dynamically change the default rc settings in a python script or
 # interactively from the python shell. All of the rc settings are stored in a
-# dictionary-like variable called :data:`matplotlib.rcParams`, which is global to
-# the matplotlib package. rcParams can be modified directly, for example:
+# dictionary-like variable called :data:`matplotlib.rcParams`, which is global
+# to the matplotlib package. rcParams can be modified directly, for example:
 
 mpl.rcParams['lines.linewidth'] = 2
 mpl.rcParams['lines.color'] = 'r'
@@ -119,8 +121,8 @@ mpl.rc('lines', linewidth=4, color='g')
 plt.plot(data)
 
 ###############################################################################
-# The :func:`matplotlib.rcdefaults` command will restore the standard matplotlib
-# default settings.
+# The :func:`matplotlib.rcdefaults` command will restore the standard default
+# settings of matplotlib.
 #
 # There is some degree of validation when setting the values of rcParams, see
 # :mod:`matplotlib.rcsetup` for details.
@@ -130,52 +132,88 @@ plt.plot(data)
 # The :file:`matplotlibrc` file
 # -----------------------------
 #
-# matplotlib uses :file:`matplotlibrc` configuration files to customize all kinds
-# of properties, which we call `rc settings` or `rc parameters`. You can control
-# the defaults of almost every property in matplotlib: figure size and dpi, line
-# width, color and style, axes, axis and grid properties, text and font
-# properties and so on. matplotlib looks for :file:`matplotlibrc` in four
-# locations, in the following order:
+# matplotlib uses :file:`matplotlibrc` configuration file to customize all
+# kinds of properties, which we call `rc settings` or `rc parameters`. By
+# modifying this file, we can control the defaults of almost every property in
+# matplotlib: figure size and dpi, line width, color and style, axes, axis and
+# grid properties, text and font properties and so on.
+#
+# Every matplotlib installation comes with a default copy of this file on our
+# system in :file:`{PYINSTALL}/site-packages/matplotlib/mpl-data/matplotlibrc`,
+# where :file:`{PYINSTALL}` is related to the specific Python installation
+# location (i.e. considering there might be multiple versions of Python
+# installations, or multiple Python virtual environments, or on different OS).
+# For example, it could be :file:`C:\\Python37\\Lib` on Windows, or something
+# like :file:`/usr/lib/python3.7` on Linux, or some Python virtual environments
+# containing path :file:`$HOME/venvs/py37/lib/python3.7`.
+#
+# Every time when we *import* matplotlib, it will look for :file:`matplotlibrc`
+# in four locations, in the following order:
 #
 # 1. :file:`matplotlibrc` in the current working directory, usually used for
 #    specific customizations that you do not want to apply elsewhere.
 #
-# 2. :file:`$MATPLOTLIBRC` if it is a file, else :file:`$MATPLOTLIBRC/matplotlibrc`.
+# 2. When environment variable ``$MATPLOTLIBRC`` exists, matplotlib then looks
+#    for :file:`$MATPLOTLIBRC` if it is a file, else :file:`$MATPLOTLIBRC/matplotlibrc`.
 #
 # 3. It next looks in a user-specific place, depending on your platform:
 #
-#    - On Linux and FreeBSD, it looks in :file:`.config/matplotlib/matplotlibrc`
-#      (or `$XDG_CONFIG_HOME/matplotlib/matplotlibrc`) if you've customized
-#      your environment.
+#    - On Linux and FreeBSD, it looks in :file:`$HOME/.config/matplotlib/matplotlibrc`
+#      or :file:`$XDG_CONFIG_HOME/matplotlib/matplotlibrc` if the environment
+#      variable ``$XDG_CONFIG_HOME`` is set.
 #
-#    - On other platforms, it looks in :file:`.matplotlib/matplotlibrc`.
+#    - On other platforms, it looks in :file:`$HOME/.matplotlib/matplotlibrc`.
 #
-#    See :ref:`locating-matplotlib-config-dir`.
+#    See :ref:`locating-matplotlib-config-dir` for more details on how to find
+#    out these locations.
 #
-# 4. :file:`{INSTALL}/matplotlib/mpl-data/matplotlibrc`, where
-#    :file:`{INSTALL}` is something like
-#    :file:`/usr/lib/python3.7/site-packages` on Linux, and maybe
-#    :file:`C:\\Python37\\Lib\\site-packages` on Windows. Every time you
-#    install matplotlib, this file will be overwritten, so if you want
-#    your customizations to be saved, please move this file to your
+# 4. :file:`{PYINSTALL}/site-packages/matplotlib/mpl-data/matplotlibrc`. Every
+#    time you install/update matplotlib, this file will be overwritten, so if
+#    you want your customizations to be saved, please move this file to your
 #    user-specific matplotlib directory.
 #
 # Once a :file:`matplotlibrc` file has been found, it will *not* search any of
-# the other paths.
+# the other locations.
 #
 # To display where the currently active :file:`matplotlibrc` file was
 # loaded from, one can do the following::
 #
-#   >>> import matplotlib
-#   >>> matplotlib.matplotlib_fname()
+#   >>> import matplotlib as mpl
+#   >>> mpl.matplotlib_fname()
 #   '/home/foo/.config/matplotlib/matplotlibrc'
 #
-# See below for a sample :ref:`matplotlibrc file<matplotlibrc-sample>`.
+#
+# Formats of :file:`matplotlibrc` file
+# ------------------------------------
+#
+# The :file:`matplotlibrc` file is best viewed in a editor which supports Python
+# mode syntax highlighting. Blank lines, lines starting with a comment symbol
+# are ignored, as are trailing comments.  Other lines must have the format::
+#
+#     key : val  ## optional comment
+#
+#
+# Colors, to specify color values in :file:`matplotlibrc` file, we can either use:
+#
+# - an RGB or RGBA tuple, e.g. ``(1.0, 0.5, 0.0)`` or ``(0.1, 0.2, 0.5, 0.3)``
+# - a hex RGB or RGBA string, e.g. ``0f0f0f`` or ``0f0f0f80``
+# - a scalar grayscale intensity, e.g. ``0.75``
+# - a matplotlib color string, e.g. ``r``, ``k``, or ``b``
+# - a X11/CSS4 color name, e.g. ``red``, ``blue``, ``darkslategray``
+# - a name from the xkcd color survey, e.g. ``xkcd:sky blue``
+# - one of the Tableau Colors from the 'T10' categorical palette, e.g. ``tab:blue``
+# - a "CN" color spec, i.e. `'C'` followed by a number, e.g. ``C3``
+#
+# See the :doc:`Specifying Colors guide</tutorials/colors/colors>` for more
+# details on valid color names.
+#
+#
+# Following is a default sample of :ref:`matplotlibrc file<matplotlibrc-sample>`.
 #
 # .. _matplotlibrc-sample:
 #
-# A sample matplotlibrc file
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# A sample :file:`matplotlibrc` file
+# ----------------------------------
 #
 # .. literalinclude:: ../../../matplotlibrc.template
 #


### PR DESCRIPTION
## PR Summary

This PR is related to a suggestion by @timhoffm :https://github.com/matplotlib/matplotlib/pull/14709#discussion_r300867862

Mainly, move those description of path resolution, formats and styling from the `matplotlibrc` file to `customizing.py` guide.