### PR TITLE
DOC: Make abbreviation of versus consistent.

### DIFF
--- a/doc/devel/MEP/MEP10.rst
+++ b/doc/devel/MEP/MEP10.rst
@@ -133,8 +133,8 @@ that docstring in the parsed content on the example page.  These
 docstrings could easily include references to any other part of the
 documentation.
 
-Documentation using help() vs a browser
----------------------------------------
+Documentation using help() vs. a browser
+----------------------------------------
 
 Using Sphinx markup in the source allows for good-looking docs in your
 browser, but the markup also makes the raw text returned using help()

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -519,7 +519,7 @@ Picking exercise
 Create a data set of 100 arrays of 1000 Gaussian random numbers and
 compute the sample mean and standard deviation of each of them (hint:
 numpy arrays have a mean and std method) and make a xy marker plot of
-the 100 means vs the 100 standard deviations.  Connect the line
+the 100 means vs. the 100 standard deviations.  Connect the line
 created by the plot command to the pick event, and plot the original
 time series of the data that generated the clicked on points.  If more
 than one point is within the tolerance of the clicked on point, you
@@ -528,7 +528,7 @@ can use multiple subplots to plot the multiple time series.
 Exercise solution::
 
     """
-    compute the mean and stddev of 100 data sets and plot mean vs stddev.
+    compute the mean and stddev of 100 data sets and plot mean vs. stddev.
     When you click on one of the mu, sigma points, plot the raw data from
     the dataset that generated the mean and stddev
     """

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -2827,7 +2827,7 @@ the `API changes <../../api/api_changes.html>`_.
            now looks correct - SC
 
 2007-01-11 Added Axes.xcorr and Axes.acorr to plot the cross
-           correlation of x vs y or the autocorrelation of x.  pylab
+           correlation of x vs. y or the autocorrelation of x.  pylab
            wrappers also provided.  See examples/xcorr_demo.py - JDH
 
 2007-01-10 Added "Subplot.label_outer" method.  It will set the

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -504,7 +504,7 @@ Artist-level {get,set}_usetex for text
 ``````````````````````````````````````
 
 Add ``{get,set}_usetex`` methods to :class:`~matplotlib.text.Text` objects
-which allow artist-level control of LaTeX rendering vs the internal mathtex
+which allow artist-level control of LaTeX rendering vs. the internal mathtex
 rendering.
 
 

--- a/examples/shapes_and_collections/line_collection.py
+++ b/examples/shapes_and_collections/line_collection.py
@@ -19,7 +19,7 @@ import numpy as np
 # simple example showing how it is done.
 
 x = np.arange(100)
-# Here are many sets of y to plot vs x
+# Here are many sets of y to plot vs. x
 ys = x[:50, np.newaxis] + x[np.newaxis, :]
 
 segs = np.zeros((50, 100, 2))
@@ -56,7 +56,7 @@ plt.show()
 
 N = 50
 x = np.arange(N)
-# Here are many sets of y to plot vs x
+# Here are many sets of y to plot vs. x
 ys = [x + i for i in x]
 
 # We need to set the plot limits, they will not autoscale

--- a/examples/statistics/barchart_demo.py
+++ b/examples/statistics/barchart_demo.py
@@ -49,7 +49,7 @@ def format_score(scr, test):
     """
     Build up the score labels for the right Y-axis by first
     appending a carriage return to each string and then tacking on
-    the appropriate meta information (i.e., 'laps' vs 'seconds'). We
+    the appropriate meta information (i.e., 'laps' vs. 'seconds'). We
     want the labels centered on the ticks, so if there is no meta
     info (like for pushups) then don't add the carriage return to
     the string

--- a/examples/subplots_axes_and_figures/shared_axis_demo.py
+++ b/examples/subplots_axes_and_figures/shared_axis_demo.py
@@ -9,7 +9,7 @@ passing an axes instance as a sharex or sharey kwarg.
 Changing the axis limits on one axes will be reflected automatically
 in the other, and vice-versa, so when you navigate with the toolbar
 the axes will follow each other on their shared axes.  Ditto for
-changes in the axis scaling (e.g., log vs linear).  However, it is
+changes in the axis scaling (e.g., log vs. linear).  However, it is
 possible to have differences in tick labeling, e.g., you can selectively
 turn off the tick labels on one axes.
 

--- a/extern/agg24-svn/include/agg_span_gradient_contour.h
+++ b/extern/agg24-svn/include/agg_span_gradient_contour.h
@@ -2,7 +2,7 @@
 // AGG Contribution Pack - Gradients 1 (AGG CP - Gradients 1)
 // http://milan.marusinec.sk/aggcp
 //
-// For Anti-Grain Geometry - Version 2.4 
+// For Anti-Grain Geometry - Version 2.4
 // http://www.antigrain.org
 //
 // Contribution Created By:
@@ -49,7 +49,7 @@ namespace agg
 		int    m_frame;
 
 		double m_d1;
-		double m_d2; 
+		double m_d2;
 
 	public:
 		gradient_contour() :
@@ -90,7 +90,7 @@ namespace agg
 
 		void   frame(int f ) { m_frame = f; }
 		int    frame() { return m_frame; }
-		
+
 		int calculate(int x, int y, int d) const
 		{
 			if (m_buffer)
@@ -193,7 +193,7 @@ namespace agg
 				   // Setup VG Engine & Render
 					agg::rendering_buffer rb;
 					rb.attach(buffer ,width ,height ,width );
-					
+
 					agg::pixfmt_gray8 pf(rb);
 					agg::renderer_base<agg::pixfmt_gray8> renb(pf );
 
@@ -209,14 +209,14 @@ namespace agg
 					ras.add_path(trans );
 
 				   // II. Distance Transform
-				   // Create Float Buffer + 0 vs infinity (1e20) assignment
+				   // Create Float Buffer + 0 vs. infinity (1e20) assignment
 					float* image = new float[width * height];
 
 					if (image)
 					{
-						for (int y = 0, l = 0; y < height; y++ ) 
+						for (int y = 0, l = 0; y < height; y++ )
 						{
-							for (int x = 0; x < width; x++, l++ ) 
+							for (int x = 0; x < width; x++, l++ )
 							{
 								if (buffer[l ] == 0)
 								{
@@ -227,7 +227,7 @@ namespace agg
 									image[l ] = float(infinity );
 								}
 							}
-													
+
 						}
 
 					   // DT of 2d
@@ -247,9 +247,9 @@ namespace agg
 						if ((spanf) && (spang) && (spanr) && (spann))
 						{
 						   // Transform along columns
-							for (int x = 0; x < width; x++ ) 
+							for (int x = 0; x < width; x++ )
 							{
-								for (int y = 0; y < height; y++ ) 
+								for (int y = 0; y < height; y++ )
 								{
 									spanf[y] = image[y * width + x];
 								}
@@ -257,16 +257,16 @@ namespace agg
 							   // DT of 1d
 								dt(spanf ,spang ,spanr ,spann ,height );
 
-								for (int y = 0; y < height; y++ ) 
+								for (int y = 0; y < height; y++ )
 								{
 									image[y * width + x] = spanr[y];
 								}
 							}
 
 						   // Transform along rows
-							for (int y = 0; y < height; y++ ) 
+							for (int y = 0; y < height; y++ )
 							{
-								for (int x = 0; x < width; x++ ) 
+								for (int x = 0; x < width; x++ )
 								{
 									spanf[x] = image[y * width + x];
 								}
@@ -274,7 +274,7 @@ namespace agg
 							   // DT of 1d
 								dt(spanf ,spang ,spanr ,spann ,width );
 
-								for (int x = 0; x < width; x++ ) 
+								for (int x = 0; x < width; x++ )
 								{
 									image[y * width + x] = spanr[x];
 								}
@@ -284,9 +284,9 @@ namespace agg
 							float min = sqrt(image[0] );
 							float max = min;
 
-							for (int y = 0, l = 0; y < height; y++ ) 
+							for (int y = 0, l = 0; y < height; y++ )
 							{
-								for (int x = 0; x < width; x++, l++ ) 
+								for (int x = 0; x < width; x++, l++ )
 								{
 									image[l] = sqrt(image[l]);
 
@@ -312,9 +312,9 @@ namespace agg
 							{
 								float scale = 255 / (max - min );
 
-								for (int y = 0, l = 0; y < height; y++ ) 
+								for (int y = 0, l = 0; y < height; y++ )
 								{
-									for (int x = 0; x < width; x++ ,l++ ) 
+									for (int x = 0; x < width; x++ ,l++ )
 									{
 										buffer[l] = int8u(int((image[l] - min ) * scale ));
 									}
@@ -335,7 +335,7 @@ namespace agg
 							result = m_buffer;
 
 						}
-	
+
 						if (spanf) { delete [] spanf; }
 						if (spang) { delete [] spang; }
 						if (spanr) { delete [] spanr; }

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1145,8 +1145,8 @@ class rc_context:
                 plt.plot(x, b)
             plt.plot(x, c)
 
-    The 'a' vs 'x' and 'c' vs 'x' plots would have settings from
-    'screen.rc', while the 'b' vs 'x' plot would have settings from
+    The 'a' vs. 'x' and 'c' vs. 'x' plots would have settings from
+    'screen.rc', while the 'b' vs. 'x' plot would have settings from
     'print.rc'.
 
     A dictionary can also be passed to the context manager::

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4284,7 +4284,7 @@ class Axes(_AxesBase):
                 verts=None, edgecolors=None, *, plotnonfinite=False,
                 **kwargs):
         """
-        A scatter plot of *y* vs *x* with varying marker size and/or color.
+        A scatter plot of *y* vs. *x* with varying marker size and/or color.
 
         Parameters
         ----------

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1646,8 +1646,8 @@ class LightSource:
             The amount to exaggerate the elevation values by when calculating
             illumination. This can be used either to correct for differences in
             units between the x-y coordinate system and the elevation
-            coordinate system (e.g. decimal degrees vs meters) or to exaggerate
-            or de-emphasize topographic effects.
+            coordinate system (e.g. decimal degrees vs. meters) or to
+            exaggerate or de-emphasize topographic effects.
         dx : number, optional
             The x-spacing (columns) of the input *elevation* grid.
         dy : number, optional
@@ -1770,8 +1770,8 @@ class LightSource:
             The amount to exaggerate the elevation values by when calculating
             illumination. This can be used either to correct for differences in
             units between the x-y coordinate system and the elevation
-            coordinate system (e.g. decimal degrees vs meters) or to exaggerate
-            or de-emphasize topography.
+            coordinate system (e.g. decimal degrees vs. meters) or to
+            exaggerate or de-emphasize topography.
         dx : number, optional
             The x-spacing (columns) of the input *elevation* grid.
         dy : number, optional
@@ -1836,8 +1836,8 @@ class LightSource:
             The amount to exaggerate the elevation values by when calculating
             illumination. This can be used either to correct for differences in
             units between the x-y coordinate system and the elevation
-            coordinate system (e.g. decimal degrees vs meters) or to exaggerate
-            or de-emphasize topography.
+            coordinate system (e.g. decimal degrees vs. meters) or to
+            exaggerate or de-emphasize topography.
         dx : number, optional
             The x-spacing (columns) of the input *elevation* grid.
         dy : number, optional

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1678,7 +1678,7 @@ class AffineBase(Transform):
         self._inverted = None
 
     def __array__(self, *args, **kwargs):
-        # optimises the access of the transform matrix vs the superclass
+        # optimises the access of the transform matrix vs. the superclass
         return self.get_matrix()
 
     def __eq__(self, other):

--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -16,8 +16,8 @@ to highlight some neat features and best-practices using Matplotlib.
     `this excellent blog post <http://pbpython.com/effective-matplotlib.html>`_
     by Chris Moffitt. It was transformed into this tutorial by Chris Holdgraf.
 
-A note on the Object-Oriented API vs Pyplot
-===========================================
+A note on the Object-Oriented API vs. Pyplot
+============================================
 
 Matplotlib has two interfaces. The first is an object-oriented (OO)
 interface. In this case, we utilize an instance of :class:`axes.Axes`


### PR DESCRIPTION
## PR Summary

This is just an English grammar thing. Currently in the project files, there are two different usage of abbreviation of versus: `vs` and `vs.`.

For consistency and according to:

- https://english.stackexchange.com/questions/52378/versus-versus-vs-in-writing
- https://www.quora.com/Is-it-vs-vs-or-v-s

this PR unifies the abbreviation of versus to `vs.`

As for this C file: `extern/agg24-svn/include/agg_span_gradient_contour.h`, I also removed some trailing spaces in it.
