### PR TITLE
Autodetect some transform properties.

### DIFF
--- a/examples/scales/custom_scale.py
+++ b/examples/scales/custom_scale.py
@@ -114,10 +114,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
         # being connected together.  When defining transforms for a
         # scale, which are, by definition, separable and have only one
         # dimension, these members should always be set to 1.
-        input_dims = 1
-        output_dims = 1
-        is_separable = True
-        has_inverse = True
+        input_dims = output_dims = 1
 
         def __init__(self, thresh):
             mtransforms.Transform.__init__(self)
@@ -150,10 +147,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
                 self.thresh)
 
     class InvertedMercatorLatitudeTransform(mtransforms.Transform):
-        input_dims = 1
-        output_dims = 1
-        is_separable = True
-        has_inverse = True
+        input_dims = output_dims = 1
 
         def __init__(self, thresh):
             mtransforms.Transform.__init__(self)
@@ -164,6 +158,7 @@ class MercatorLatitudeScale(mscale.ScaleBase):
 
         def inverted(self):
             return MercatorLatitudeScale.MercatorLatitudeTransform(self.thresh)
+
 
 # Now that the Scale class has been defined, it must be registered so
 # that ``matplotlib`` can find it.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -128,10 +128,7 @@ class FuncTransform(Transform):
     forward and inverse transform.
     """
 
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, forward, inverse):
         """
@@ -205,10 +202,7 @@ class FuncScale(ScaleBase):
 
 @cbook.deprecated("3.1", alternative="LogTransform")
 class LogTransformBase(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, nonpos='clip'):
         Transform.__init__(self)
@@ -224,10 +218,7 @@ class LogTransformBase(Transform):
 
 @cbook.deprecated("3.1", alternative="InvertedLogTransform")
 class InvertedLogTransformBase(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def transform_non_affine(self, a):
         return ma.power(self.base, a)
@@ -285,10 +276,7 @@ class InvertedNaturalLogTransform(InvertedLogTransformBase):
 
 
 class LogTransform(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, base, nonpos='clip'):
         Transform.__init__(self)
@@ -326,10 +314,7 @@ class LogTransform(Transform):
 
 
 class InvertedLogTransform(InvertedLogTransformBase):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, base):
         Transform.__init__(self)
@@ -466,10 +451,7 @@ class FuncScaleLog(LogScale):
 
 
 class SymmetricalLogTransform(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, base, linthresh, linscale):
         Transform.__init__(self)
@@ -495,10 +477,7 @@ class SymmetricalLogTransform(Transform):
 
 
 class InvertedSymmetricalLogTransform(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, base, linthresh, linscale):
         Transform.__init__(self)
@@ -610,10 +589,7 @@ class SymmetricalLogScale(ScaleBase):
 
 
 class LogitTransform(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, nonpos='mask'):
         Transform.__init__(self)
@@ -638,10 +614,7 @@ class LogitTransform(Transform):
 
 
 class LogisticTransform(Transform):
-    input_dims = 1
-    output_dims = 1
-    is_separable = True
-    has_inverse = True
+    input_dims = output_dims = 1
 
     def __init__(self, nonpos='mask'):
         Transform.__init__(self)


### PR DESCRIPTION
- 1d transforms are always separable, no need to repeat `is_separable =
  True` again and again.
- If a subclass overrides `inverted()` then it is most likely invertible
  (though not always), no need to repeat `has_inverse = True` again and
  again (but subclasses can always override to `has_inverse = False`).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
