### PR TITLE
In examples, prefer buffer_rgba to print_to_buffer.

### DIFF
--- a/examples/misc/agg_buffer.py
+++ b/examples/misc/agg_buffer.py
@@ -3,8 +3,8 @@
 Agg Buffer
 ==========
 
-Use backend agg to access the figure canvas as an RGB string and then
-convert it to an array and pass it to Pillow for rendering.
+Use backend agg to access the figure canvas as an RGBA buffer, convert it to an
+array, and pass it to Pillow for rendering.
 """
 
 import numpy as np
@@ -18,14 +18,11 @@ canvas = plt.gcf().canvas
 
 agg = canvas.switch_backends(FigureCanvasAgg)
 agg.draw()
-s, (width, height) = agg.print_to_buffer()
-
-# Convert to a NumPy array.
-X = np.frombuffer(s, np.uint8).reshape((height, width, 4))
+X = np.asarray(agg.buffer_rgba())
 
 # Pass off to PIL.
 from PIL import Image
-im = Image.frombytes("RGBA", (width, height), s)
+im = Image.fromarray(X)
 
 # Uncomment this line to display the image using ImageMagick's `display` tool.
 # im.show()

--- a/examples/user_interfaces/canvasagg.py
+++ b/examples/user_interfaces/canvasagg.py
@@ -37,16 +37,14 @@ ax.plot([1, 2, 3])
 # etc.).
 fig.savefig("test.png")
 
-# Option 2: Save the figure to a string.
+# Option 2: Retrieve a view on the renderer buffer...
 canvas.draw()
-s, (width, height) = canvas.print_to_buffer()
-
-# Option 2a: Convert to a NumPy array.
-X = np.frombuffer(s, np.uint8).reshape((height, width, 4))
-
-# Option 2b: Pass off to PIL.
+buf = canvas.buffer_rgba()
+# ... convert to a NumPy array ...
+X = np.asarray(buf)
+# ... and pass it to PIL.
 from PIL import Image
-im = Image.frombytes("RGBA", (width, height), s)
+im = Image.fromarray(X)
 
 # Uncomment this line to display the image using ImageMagick's `display` tool.
 # im.show()


### PR DESCRIPTION
buffer_rgba avoids a copy and returns an object (a memoryview) that
knows its shape and can readily be converted to a numpy array, rather
than separately a string and a shape.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
