### PR TITLE
Support passing spine bounds as single tuple.

### DIFF
--- a/examples/ticks_and_spines/spines_bounds.py
+++ b/examples/ticks_and_spines/spines_bounds.py
@@ -27,7 +27,7 @@ ax.set_ylim((-1.5, 1.5))
 ax.set_yticks([-1, 0, 1])
 
 # Only draw spine between the y-ticks
-ax.spines['left'].set_bounds(-1, 1)
+ax.spines['left'].set_bounds((-1, 1))
 # Hide the right and top spines
 ax.spines['right'].set_visible(False)
 ax.spines['top'].set_visible(False)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3106,7 +3106,7 @@ class _AxesBase(martist.Artist):
             The left xlim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
-            The left and right xlims may be passed as the tuple
+            The left and right xlims may also be passed as the tuple
             (*left*, *right*) as the first positional argument (or as
             the *left* keyword argument).
 
@@ -3486,7 +3486,7 @@ class _AxesBase(martist.Artist):
             The bottom ylim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
-            The bottom and top ylims may be passed as the tuple
+            The bottom and top ylims may also be passed as the tuple
             (*bottom*, *top*) as the first positional argument (or as
             the *bottom* keyword argument).
 

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -534,11 +534,33 @@ class Spine(mpatches.Patch):
         else:
             raise ValueError("unknown spine_transform type: %s" % what)
 
-    def set_bounds(self, low, high):
-        """Set the bounds of the spine."""
+    def set_bounds(self, low=None, high=None):
+        """
+        Set the spine bounds.
+
+        .. ACCEPTS: (low: float, high: float)
+
+        Parameters
+        ----------
+        low : scalar, optional
+            The lower spine bound. Passing *None* leaves the limit unchanged.
+
+            The bounds may also be passed as the tuple (*low*, *high*) as the
+            first positional argument.
+
+        high : scalar, optional
+            The higher spine bound. Passing *None* leaves the limit unchanged.
+        """
         if self.spine_type == 'circle':
             raise ValueError(
                 'set_bounds() method incompatible with circular spines')
+        if high is None and np.iterable(low):
+            low, high = low
+        old_low, old_high = self.get_bounds() or (None, None)
+        if low is None:
+            low = old_low
+        if high is None:
+            high = old_high
         self._bounds = (low, high)
         self.stale = True
 


### PR DESCRIPTION
For consistency with Axes.set_xlim.

There's no test whatsoever for Spine.set_bounds, but we can at least
exercise that code path in the examples.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
