### PR TITLE
Logit scale nonsingular

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -387,7 +387,7 @@ class TestLogitLocator:
         """
         loc = mticker.LogitLocator()
         lims2 = loc.nonsingular(*lims)
-        assert lims == lims2
+        assert sorted(lims) == sorted(lims2)
 
     @pytest.mark.parametrize("okval", acceptable_vmin_vmax)
     def test_nonsingular_nok(self, okval):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,5 +1,6 @@
 import warnings
 import re
+import itertools
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -365,6 +366,44 @@ class TestLogitLocator:
         assert loc.minor
         loc.set_params(minor=False)
         assert not loc.minor
+
+    acceptable_vmin_vmax = [
+        *(2.5 ** np.arange(-3, 0)),
+        *(1 - 2.5 ** np.arange(-3, 0)),
+    ]
+
+    @pytest.mark.parametrize(
+        "lims",
+        [
+            (a, b)
+            for (a, b) in itertools.product(acceptable_vmin_vmax, repeat=2)
+            if a != b
+        ],
+    )
+    def test_nonsingular_ok(self, lims):
+        """
+        Create logit locator, and test the nonsingular method for acceptable
+        value
+        """
+        loc = mticker.LogitLocator()
+        lims2 = loc.nonsingular(*lims)
+        assert lims == lims2
+
+    @pytest.mark.parametrize("okval", acceptable_vmin_vmax)
+    def test_nonsingular_nok(self, okval):
+        """
+        Create logit locator, and test the nonsingular method for non
+        acceptable value
+        """
+        loc = mticker.LogitLocator()
+        vmin, vmax = (-1, okval)
+        vmin2, vmax2 = loc.nonsingular(vmin, vmax)
+        assert vmax2 == vmax
+        assert 0 < vmin2 < vmax2
+        vmin, vmax = (okval, 2)
+        vmin2, vmax2 = loc.nonsingular(vmin, vmax)
+        assert vmin2 == vmin
+        assert vmin2 < vmax2 < 1
 
 
 class TestFixedLocator:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2794,9 +2794,7 @@ class LogitLocator(MaxNLocator):
     def nonsingular(self, vmin, vmax):
         standard_minpos = 1e-7
         initial_range = (standard_minpos, 1 - standard_minpos)
-        swap_vlims = False
         if vmin > vmax:
-            swap_vlims = True
             vmin, vmax = vmax, vmin
         if not np.isfinite(vmin) or not np.isfinite(vmax):
             vmin, vmax = initial_range  # Initial range, no data plotted yet.
@@ -2826,8 +2824,7 @@ class LogitLocator(MaxNLocator):
                 vmax = 1 - minpos
             if vmin == vmax:
                 vmin, vmax = 0.1 * vmin, 1 - 0.1 * vmin
-        if swap_vlims:
-            vmin, vmax = vmax, vmin
+
         return vmin, vmax
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2800,16 +2800,12 @@ class LogitLocator(MaxNLocator):
             vmin, vmax = vmax, vmin
         if not np.isfinite(vmin) or not np.isfinite(vmax):
             vmin, vmax = initial_range  # Initial range, no data plotted yet.
-        elif vmax <= 0:
+        elif vmax <= 0 or vmin >= 1:
+            # vmax <= 0 occurs when all values are negative
+            # vmin >= 1 occurs when all values are greater than one
             cbook._warn_external(
-                "Data has no positive values, and therefore cannot be "
+                "Data has no values between 0 and 1, and therefore cannot be "
                 "logit-scaled."
-            )
-            vmin, vmax = initial_range
-        elif vmin >= 1:
-            cbook._warn_external(
-                "Data has no values smaller than one, and therefore cannot "
-                "be logit-scaled."
             )
             vmin, vmax = initial_range
         else:


### PR DESCRIPTION
## PR Summary

This PR solves issues #14743.

This issues was present from the `nonsingular` method of the `LogitLocator`. In the PR #14512 I rewrite most of this locator, but I keep the nonsingular method from the old code. I was not the author of this bug. I fixed it because I know this very small part of the matplotlib code.

Also, I added some tests.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
