### PR TITLE
Set Dock icon on the macosx backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -67,6 +67,8 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     """
     def __init__(self, canvas, num):
         _macosx.FigureManager.__init__(self, canvas)
+        icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
+        _macosx.FigureManager.set_icon(icon_path)
         FigureManagerBase.__init__(self, canvas, num)
         if mpl.rcParams['toolbar'] == 'toolbar2':
             self.toolbar = NavigationToolbar2Mac(canvas)

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -698,11 +698,9 @@ FigureManager_destroy(FigureManager* self)
 }
 
 static PyObject*
-FigureManager_set_icon(PyObject* null, PyObject* args, PyObject* kwds) {
+FigureManager_set_icon(PyObject* null, PyObject* args) {
     PyObject* icon_path;
-    static char* kwlist[3] = { "icon_path", NULL };
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&", kwlist,
-	  &PyUnicode_FSDecoder, &icon_path)) {
+    if (!PyArg_ParseTuple(args, "O&", &PyUnicode_FSDecoder, &icon_path)) {
 	return NULL;
     }
     const char* icon_path_ptr = PyUnicode_AsUTF8(icon_path);
@@ -726,8 +724,14 @@ FigureManager_set_icon(PyObject* null, PyObject* args, PyObject* kwds) {
             PyErr_SetString(PyExc_RuntimeError, "Image is not valid");
             return NULL;
         }
-        NSApplication* app = [NSApplication sharedApplication];
-        app.applicationIconImage = image;
+	@try {
+	  NSApplication* app = [NSApplication sharedApplication];
+	  app.applicationIconImage = image;
+	}
+	@catch (NSException* exception) {
+	    PyErr_SetString(PyExc_RuntimeError, exception.reason.UTF8String);
+	    return NULL;
+	}
     }
     Py_RETURN_NONE;
 }
@@ -806,7 +810,7 @@ static PyTypeObject FigureManagerType = {
          METH_NOARGS},
 	{"set_icon",
     	 (PyCFunction)FigureManager_set_icon,
-    	 METH_STATIC | METH_VARARGS | METH_KEYWORDS,
+    	 METH_STATIC | METH_VARARGS,
 	 "Set application icon"},
         {"set_window_title",
          (PyCFunction)FigureManager_set_window_title,

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -698,6 +698,41 @@ FigureManager_destroy(FigureManager* self)
 }
 
 static PyObject*
+FigureManager_set_icon(PyObject* null, PyObject* args, PyObject* kwds) {
+    PyObject* icon_path;
+    static char* kwlist[3] = { "icon_path", NULL };
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&", kwlist,
+	  &PyUnicode_FSDecoder, &icon_path)) {
+	return NULL;
+    }
+    const char* icon_path_ptr = PyUnicode_AsUTF8(icon_path);
+    if (!icon_path_ptr) {
+        Py_DECREF(icon_path);
+        return NULL;
+    }
+    @autoreleasepool {
+        NSString* ns_icon_path = [NSString stringWithUTF8String: icon_path_ptr];
+	Py_DECREF(icon_path);
+        if (!ns_icon_path) {
+            PyErr_SetString(PyExc_RuntimeError, "Could not convert to NSString*");
+            return NULL;
+        }
+        NSImage* image = [[[NSImage alloc] initByReferencingFile: ns_icon_path] autorelease];
+        if (!image) {
+            PyErr_SetString(PyExc_RuntimeError, "Could not create NSImage*");
+            return NULL;
+        }
+        if (!image.valid) {
+            PyErr_SetString(PyExc_RuntimeError, "Image is not valid");
+            return NULL;
+        }
+        NSApplication* app = [NSApplication sharedApplication];
+        app.applicationIconImage = image;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject*
 FigureManager_set_window_title(FigureManager* self,
                                PyObject *args, PyObject *kwds)
 {
@@ -769,6 +804,10 @@ static PyTypeObject FigureManagerType = {
         {"destroy",
          (PyCFunction)FigureManager_destroy,
          METH_NOARGS},
+	{"set_icon",
+    	 (PyCFunction)FigureManager_set_icon,
+    	 METH_STATIC | METH_VARARGS | METH_KEYWORDS,
+	 "Set application icon"},
         {"set_window_title",
          (PyCFunction)FigureManager_set_window_title,
          METH_VARARGS},


### PR DESCRIPTION
## PR Summary

This issue is similar to #14850/#14927. The issue is not isolated to the macos backend. It also happens in Qt5 (at least, possibly others).

Turns out Qt5 broke setWindowIcon. It seems like it is similar to this bug report: https://bugreports.qt.io/browse/QTBUG-55932. It fails silently, you request an icon change and nothing happens on macOS.

I have doubts this will be fixed without some pretty large Qt5 changes. Apple's API doesn't support .svg files. It does support a wide variety of other graphics, including vector graphics: pdf, and postscript, for instance. But Qt's API only supports .svg vector graphics.

We can work around this with png's, etc., but we already have a far superior .pdf logo. Apple users have come to expect high-quality vector graphics on their Retina displays. We should use the vector .pdf logo.

We can work around by using the ctypes lib to call Apple routines directly to avoid adding any more dependencies. It's done fairly lazily, so as not to be a performance hit on non-Apple platforms.

This appears to work for me. Could use comments and/or tests, although I have no idea how to write a unit test for an app icon in macOS.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant