### PR TITLE
DOC: update axes_demo to directly manipulate fig, ax

### DIFF
--- a/examples/subplots_axes_and_figures/axes_demo.py
+++ b/examples/subplots_axes_and_figures/axes_demo.py
@@ -3,7 +3,7 @@
 Axes Demo
 =========
 
-Example use of ``plt.axes`` to create inset axes within the main plot axes.
+Example use of ``fig.add_axes`` to create inset axes within the main plot axes.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -19,27 +19,27 @@ r = np.exp(-t[:1000] / 0.05)  # impulse response
 x = np.random.randn(len(t))
 s = np.convolve(x, r)[:len(x)] * dt  # colored noise
 
-# the main axes is subplot(111) by default
-plt.plot(t, s)
-plt.xlim(0, 1)
-plt.ylim(1.1 * np.min(s), 2 * np.max(s))
-plt.xlabel('time (s)')
-plt.ylabel('current (nA)')
-plt.title('Gaussian colored noise')
+fig, main_ax = plt.subplots()
+main_ax.plot(t, s)
+main_ax.set_xlim(0, 1)
+main_ax.set_ylim(1.1 * np.min(s), 2 * np.max(s))
+main_ax.set_xlabel('time (s)')
+main_ax.set_ylabel('current (nA)')
+main_ax.set_title('Gaussian colored noise')
 
 # this is an inset axes over the main axes
-a = plt.axes([.65, .6, .2, .2], facecolor='k')
-n, bins, patches = plt.hist(s, 400, density=True)
-plt.title('Probability')
-plt.xticks([])
-plt.yticks([])
+right_inset_ax = fig.add_axes([.65, .6, .2, .2], facecolor='k')
+right_inset_ax.hist(s, 400, density=True)
+right_inset_ax.set_title('Probability')
+right_inset_ax.set_xticks([])
+right_inset_ax.set_yticks([])
 
 # this is another inset axes over the main axes
-a = plt.axes([0.2, 0.6, .2, .2], facecolor='k')
-plt.plot(t[:len(r)], r)
-plt.title('Impulse response')
-plt.xlim(0, 0.2)
-plt.xticks([])
-plt.yticks([])
+left_inset_ax = fig.add_axes([.2, .6, .2, .2], facecolor='k')
+left_inset_ax.plot(t[:len(r)], r)
+left_inset_ax.set_title('Impulse response')
+left_inset_ax.set_xlim(0, 0.2)
+left_inset_ax.set_xticks([])
+left_inset_ax.set_yticks([])
 
 plt.show()

--- a/examples/subplots_axes_and_figures/axes_demo.py
+++ b/examples/subplots_axes_and_figures/axes_demo.py
@@ -4,6 +4,13 @@ Axes Demo
 =========
 
 Example use of ``fig.add_axes`` to create inset axes within the main plot axes.
+
+Please see also the :ref:`axes_grid_examples` section, and the following three
+examples:
+
+   - :doc:`/gallery/subplots_axes_and_figures/zoom_inset_axes`
+   - :doc:`/gallery/axes_grid1/inset_locator_demo`
+   - :doc:`/gallery/axes_grid1/inset_locator_demo2`
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## PR Summary

Directly call method on each individual axis; instead of the global
``plt.`` one, same to create inset; directly refer to the figure on
which wee create an inset.

I also use some more explicit renaming for each axis,
and remove assignments on the LHS when those were unused as it seem like
a distraction on the subject at hand.


## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way