### PR TITLE
Fix inaccuracy re: backends in intro tutorial.

### DIFF
--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -357,12 +357,10 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # the concept of the renderer (the thing that actually does the drawing)
 # from the canvas (the place where the drawing goes).  The canonical
 # renderer for user interfaces is ``Agg`` which uses the `Anti-Grain
-# Geometry`_ C++ library to make a raster (pixel) image of the figure.
-# All of the user interfaces except ``macosx`` can be used with
-# agg rendering, e.g., ``WXAgg``, ``GTK3Agg``, ``QT4Agg``, ``QT5Agg``,
-# ``TkAgg``.  In addition, some of the user interfaces support other rendering
-# engines.  For example, with GTK+ 3, you can also select Cairo rendering
-# (backend ``GTK3Cairo``).
+# Geometry`_ C++ library to make a raster (pixel) image of the figure; it
+# is used by the ``Qt5Agg``, ``Qt4Agg``, ``GTK3Agg``, ``wxAgg``, ``TkAgg``, and
+# ``macosx`` backends.  An alternative renderer is based on the Cairo library,
+# used by ``Qt5Cairo``, ``Qt4Cairo``, etc.
 #
 # For the rendering engines, one can also distinguish between `vector
 # <https://en.wikipedia.org/wiki/Vector_graphics>`_ or `raster
@@ -422,7 +420,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # Qt4Agg    Agg rendering to a :term:`Qt4` canvas (requires PyQt4_ or
 #           ``pyside``).  This backend can be activated in IPython with
 #           ``%matplotlib qt4``.
-# WXAgg     Agg rendering to a :term:`wxWidgets` canvas (requires wxPython_ 4).
+# wxAgg     Agg rendering to a :term:`wxWidgets` canvas (requires wxPython_ 4).
 #           This backend can be activated in IPython with ``%matplotlib wx``.
 # ========= ================================================================
 #


### PR DESCRIPTION
All GUI toolkits (well, except macosx) can use cairo for rendering
(not that I would recommend using the builtin cairo backend for any of
them..).

Also prefer not capitalizing wx.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
