### PR TITLE
Use fix_minus in format_data_short.

### DIFF
--- a/doc/api/next_api_changes/2019-08-01-AL.rst
+++ b/doc/api/next_api_changes/2019-08-01-AL.rst
@@ -1,0 +1,10 @@
+API changes
+```````````
+
+`.Formatter.fix_minus` now performs hyphen-to-unicode-minus replacement
+whenever :rc:`axes.unicode_minus` is True; i.e. its behavior matches the one
+of ``.ScalarFormatter.fix_minus`` (`.ScalarFormatter` now just inherits that
+implementation).
+
+This replacement is now used by the ``format_data_short`` method of the various
+builtin formatter classes, which affects the cursor value in the GUI toolbars.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -455,6 +455,14 @@ class TestScalarFormatter:
         (True, (6, 6), (-1e5, 1e5), 6, False),
     ]
 
+    @pytest.mark.parametrize('unicode_minus, result',
+                             [(True, "\N{MINUS SIGN}1"), (False, "-1")])
+    def test_unicode_minus(self, unicode_minus, result):
+        matplotlib.rcParams['axes.unicode_minus'] = unicode_minus
+        assert (
+            plt.gca().xaxis.get_major_formatter().format_data_short(-1).strip()
+            == result)
+
     @pytest.mark.parametrize('left, right, offset', offset_data)
     def test_offset_value(self, left, right, offset):
         fig, ax = plt.subplots()


### PR DESCRIPTION
See changelog.  AFAICS, all GUI toolkits (at least qt5/gtk3/wx/tk)
display the unicode minus properly.

before:
![old](https://user-images.githubusercontent.com/1322974/62254984-9b966a00-b3fb-11e9-884a-53c6b84743ef.png)

after:
![new](https://user-images.githubusercontent.com/1322974/62254988-9e915a80-b3fb-11e9-827a-1a4ebbdaad5b.png)

(compare the minus in "x=-...")

Moving the implementation of the replacement to the base Formatter class
is because it is otherwise confusing as to whether `self.fix_minus`
does the replacement or not -- one needs to check whether the current
class overrides the do-nothing fix_minus.  Instead, one can just have a
base-class implementation that performs the replacement, and not call
`self.fix_minus` if the replacement is not desired.

For example, LogFormatter.fix_minus used to do nothing; there are tests
that check that.  Just don't call fix_minus instead.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
