### PR TITLE
Sort examples by title, not by filename.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -84,7 +84,7 @@ _check_dependencies()
 # Import only after checking for dependencies.
 # gallery_order.py from the sphinxext folder provides the classes that
 # allow custom ordering of sections and subsections of the gallery
-import sphinxext.gallery_order as gallery_order
+from sphinxext import gallery_order
 # The following import is only necessary to monkey patch the signature later on
 from sphinx_gallery import gen_rst
 

--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -3,7 +3,7 @@ Configuration for the order of gallery sections and examples.
 Paths are relative to the conf.py file.
 """
 
-from sphinx_gallery.sorting import ExplicitOrder
+from sphinx_gallery.sorting import ExplicitOrder, ExampleTitleSortKey
 
 # Gallery sections shall be displayed in the following order.
 # Non-matching sections are appended.
@@ -64,19 +64,12 @@ list_all = [
 explicit_subsection_order = [item + ".py" for item in list_all]
 
 
-class MplExplicitSubOrder:
-    """For use within the 'within_subsection_order' key."""
-    def __init__(self, src_dir):
-        self.src_dir = src_dir  # src_dir is unused here
-        self.ordered_list = explicit_subsection_order
-
-    def __call__(self, item):
-        """Return a string determining the sort order."""
-        if item in self.ordered_list:
-            return "{:04d}".format(self.ordered_list.index(item))
+class MplExplicitSubOrder(ExampleTitleSortKey):
+    def __call__(self, filename):
+        if filename in explicit_subsection_order:
+            return "{:04d}".format(explicit_subsection_order.index(filename))
         else:
-            # ensure not explicitly listed items come last.
-            return "zzz" + item
+            return "zzz" + super().__call__(filename)
 
 
 # Provide the above classes for use in conf.py


### PR DESCRIPTION
Sorting by filename results in a gallery nearly ordered by title, but
not really (because most title names are directly derived from the
filename, with some exceptions), which is slightly jarring.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
