### PR TITLE
Cleanup polar_legend example.

### DIFF
--- a/examples/pie_and_polar_charts/polar_legend.py
+++ b/examples/pie_and_polar_charts/polar_legend.py
@@ -9,21 +9,21 @@ Demo of a legend on a polar-axis plot.
 import matplotlib.pyplot as plt
 import numpy as np
 
-# radar green, solid grid lines
-plt.rc('grid', color='#316931', linewidth=1, linestyle='-')
-plt.rc('xtick', labelsize=15)
-plt.rc('ytick', labelsize=15)
+fig = plt.figure()
+ax = fig.add_subplot(projection="polar", facecolor="lightgoldenrodyellow")
 
-# force square figure and square axes looks better for polar, IMO
-fig = plt.figure(figsize=(8, 8))
-ax = fig.add_axes([0.1, 0.1, 0.8, 0.8],
-                  projection='polar', facecolor='#d5de9c')
-
-r = np.arange(0, 3.0, 0.01)
+r = np.linspace(0, 3, 301)
 theta = 2 * np.pi * r
-ax.plot(theta, r, color='#ee8d18', lw=3, label='a line')
-ax.plot(0.5 * theta, r, color='blue', ls='--', lw=3, label='another line')
-ax.legend()
+ax.plot(theta, r, color="tab:orange", lw=3, label="a line")
+ax.plot(0.5 * theta, r, color="tab:blue", ls="--", lw=3, label="another line")
+ax.tick_params(grid_color="palegoldenrod")
+# For polar axes, it may be useful to move the legend slightly away from the
+# axes center, to avoid overlap between the legend and the axes.  The following
+# snippet places the legend's lower left corner just outside of the polar axes
+# at an angle of 67.5 degrees in polar coordinates.
+angle = np.deg2rad(67.5)
+ax.legend(loc="lower left",
+          bbox_to_anchor=(.5 + np.cos(angle)/2, .5 + np.sin(angle)/2))
 
 plt.show()
 


### PR DESCRIPTION
## PR Summary

old: https://matplotlib.org/gallery/pie_and_polar_charts/polar_legend.html
new (local):
![withpad](https://user-images.githubusercontent.com/1322974/62282594-1d17e780-b450-11e9-9210-d91197774c84.png)
without the padding mentioned in the example:
![withoutpad](https://user-images.githubusercontent.com/1322974/62282613-23a65f00-b450-11e9-904e-81dd46754a40.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
