### PR TITLE
Documentation for using ConnectionPatch across Axes with constrained_…

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4273,6 +4273,22 @@ class ConnectionPatch(FancyArrowPatch):
 
         Alternatively they can be set to any valid
         `~matplotlib.transforms.Transform`.
+
+        .. note::
+           Using :class:`~matplotlib.patches.ConnectionPatch` across
+           two :class:`~matplotlib.axes.Axes` is not directly
+           compatible with :doc:`constrained layout
+           </tutorials/intermediate/constrainedlayout_guide>`. Remove
+           the patch from layout consideration using
+           :meth:`~matplotlib.artist.Artist.set_in_layout` before
+           adding it to the :class:`~matplotlib.axes.Axes`:
+
+           .. code-block:: default
+
+              con = ConnectionPatch(...)
+              con.set_in_layout(False)
+              ax.add_artist(con)
+
         """
         if coordsB is None:
             coordsB = coordsA

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4229,8 +4229,7 @@ class ConnectionPatch(FancyArrowPatch):
                  clip_on=False,
                  dpi_cor=1.,
                  **kwargs):
-        """
-        Connect point *xyA* in *coordsA* with point *xyB* in *coordsB*
+        """Connect point *xyA* in *coordsA* with point *xyB* in *coordsB*
 
         Valid keys are
 
@@ -4275,19 +4274,19 @@ class ConnectionPatch(FancyArrowPatch):
         `~matplotlib.transforms.Transform`.
 
         .. note::
+
            Using :class:`~matplotlib.patches.ConnectionPatch` across
-           two :class:`~matplotlib.axes.Axes` is not directly
-           compatible with :doc:`constrained layout
-           </tutorials/intermediate/constrainedlayout_guide>`. Remove
-           the patch from layout consideration using
-           :meth:`~matplotlib.artist.Artist.set_in_layout` before
-           adding it to the :class:`~matplotlib.axes.Axes`:
+           two :class:`~matplotlib.axes.Axes` instances is not
+           directly compatible with :doc:`constrained layout
+           </tutorials/intermediate/constrainedlayout_guide>`. Add the
+           artist directly to the :class:`~matplotlib.figure.Figure`
+           instead of adding it to a specific Axes.
 
            .. code-block:: default
 
-              con = ConnectionPatch(...)
-              con.set_in_layout(False)
-              ax.add_artist(con)
+              fig, ax = plt.subplots(1, 2, constrained_layout=True)
+              con = ConnectionPatch(..., axesA=ax[0], axesB=ax[1])
+              fig.add_artist(con)
 
         """
         if coordsB is None:

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -581,6 +581,12 @@ example_plot(ax4)
 #
 # * There are small differences in how the backends handle rendering fonts,
 #   so the results will not be pixel-identical.
+#
+# * A :class:`~matplotlib.patches.ConnectionPatch` across two
+#   :class:`~matplotlib.axes.Axes` must be removed from the layout
+#   using :meth:`~matplotlib.artist.Artist.set_in_layout` before
+#   calling :meth:`~matplotlib.axes.Axes.add_artist`. See
+#   :class:`~matplotlib.patches.ConnectionPatch` for more information.
 
 ###########################################################
 # Debugging

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -582,11 +582,13 @@ example_plot(ax4)
 # * There are small differences in how the backends handle rendering fonts,
 #   so the results will not be pixel-identical.
 #
-# * A :class:`~matplotlib.patches.ConnectionPatch` across two
-#   :class:`~matplotlib.axes.Axes` must be removed from the layout
-#   using :meth:`~matplotlib.artist.Artist.set_in_layout` before
-#   calling :meth:`~matplotlib.axes.Axes.add_artist`. See
-#   :class:`~matplotlib.patches.ConnectionPatch` for more information.
+# * An :meth:`~matplotlib.artist.Artist` using axes coordinates will
+#   result in unusual layouts when added to an
+#   :class:`~matplotlib.axes.Axes` if the artist extends beyond the
+#   axes boundary. This can be avoided by passing *False* to
+#   :meth:`~matplotlib.artist.Artist.set_in_layout` before calling
+#   :meth:`~matplotlib.axes.Axes.add_artist`. See
+#   :class:`~matplotlib.patches.ConnectionPatch` for an example.
 
 ###########################################################
 # Debugging

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -582,12 +582,11 @@ example_plot(ax4)
 # * There are small differences in how the backends handle rendering fonts,
 #   so the results will not be pixel-identical.
 #
-# * An :meth:`~matplotlib.artist.Artist` using axes coordinates will
-#   result in unusual layouts when added to an
-#   :class:`~matplotlib.axes.Axes` if the artist extends beyond the
-#   axes boundary. This can be avoided by passing *False* to
-#   :meth:`~matplotlib.artist.Artist.set_in_layout` before calling
-#   :meth:`~matplotlib.axes.Axes.add_artist`. See
+# * An artist using axes coordinates that extend beyond the axes
+#   boundary will result in unusual layouts when added to an
+#   axes. This can be avoided by adding the artist directly to the
+#   :class:`~matplotlib.figure.Figure` using
+#   :meth:`~matplotlib.figure.Figure.add_artist`. See
 #   :class:`~matplotlib.patches.ConnectionPatch` for an example.
 
 ###########################################################


### PR DESCRIPTION
…layout.

When using a figure with contrained layout management, adding a
ConnectionPatch between different subplot Axes breaks the layout. The
artist should be removed from layout considerations before being added
to the axes. This commit notes this fix in the documentation.

https://github.com/matplotlib/matplotlib/issues/14907

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
