### PR TITLE
Improve docs of toplevel module.

### DIFF
--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -4,25 +4,38 @@
 
 .. py:currentmodule:: matplotlib
 
+Backend management
+==================
+
 .. autofunction:: use
 
 .. autofunction:: get_backend
 
+.. autofunction:: interactive
+
+.. autofunction:: is_interactive
+
+Default values and styling
+==========================
+
 .. py:data:: rcParams
 
-    An instance of :class:`RcParams` for handling default matplotlib values.
+   An instance of `RcParams` for handling default Matplotlib values.
+
+.. autoclass:: RcParams
+   :no-members:
+
+   .. automethod:: find_all
 
 .. autofunction:: rc_context
 
 .. autofunction:: rc
 
-.. autofunction:: rc_file
-
 .. autofunction:: rcdefaults
 
 .. autofunction:: rc_file_defaults
 
-.. autoclass:: RcParams
+.. autofunction:: rc_file
 
 .. autofunction:: rc_params
 
@@ -30,8 +43,7 @@
 
 .. autofunction:: matplotlib_fname
 
-.. autofunction:: interactive
-
-.. autofunction:: is_interactive
+Logging
+=======
 
 .. autofunction:: set_loglevel

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -688,7 +688,7 @@ def matplotlib_fname():
         - or ``$HOME/.config/matplotlib/matplotlibrc`` (if ``$XDG_CONFIG_HOME``
           is not defined)
     - On other platforms,
-        - ``$HOME/.matplotlib/matplotlibrc`` if ``$HOME`` is defined
+      - ``$HOME/.matplotlib/matplotlibrc`` if ``$HOME`` is defined
     - Lastly, it looks in ``$MATPLOTLIBDATA/matplotlibrc``, which should always
       exist.
     """
@@ -743,6 +743,10 @@ class RcParams(MutableMapping, dict):
 
     Validating functions are defined and associated with rc parameters in
     :mod:`matplotlib.rcsetup`.
+
+    See Also
+    --------
+    :ref:`customizing-with-matplotlibrc-files`
     """
 
     validate = {key: converter
@@ -846,9 +850,7 @@ class RcParams(MutableMapping, dict):
 
 
 def rc_params(fail_on_error=False):
-    """Return a :class:`matplotlib.RcParams` instance from the
-    default matplotlib rc file.
-    """
+    """Construct a `RcParams` instance from the default Matplotlib rc file."""
     return rc_params_from_file(matplotlib_fname(), fail_on_error)
 
 
@@ -876,7 +878,8 @@ def _open_file_or_url(fname):
 
 
 def _rc_params_in_file(fname, fail_on_error=False):
-    """Return :class:`matplotlib.RcParams` from the contents of the given file.
+    """
+    Construct a `RcParams` instance from file *fname*.
 
     Unlike `rc_params_from_file`, the configuration class only contains the
     parameters specified in the file (i.e. default values are not filled in).
@@ -940,12 +943,13 @@ or from the matplotlib source distribution""", file=sys.stderr)
 
 
 def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
-    """Return :class:`matplotlib.RcParams` from the contents of the given file.
+    """
+    Construct a `RcParams` from file *fname*.
 
     Parameters
     ----------
     fname : str
-        Name of file parsed for matplotlib settings.
+        Name of file parsed for Matplotlib settings.
     fail_on_error : bool
         If True, raise an error when the parser fails to convert a parameter.
     use_default_template : bool
@@ -1009,8 +1013,7 @@ def rc(group, **kwargs):
       rcParams['lines.linewidth'] = 2
       rcParams['lines.color'] = 'r'
 
-    The following aliases are available to save typing for interactive
-    users:
+    The following aliases are available to save typing for interactive users:
 
     =====   =================
     Alias   Property
@@ -1028,7 +1031,6 @@ def rc(group, **kwargs):
 
           rc('lines', lw=2, c='r')
 
-
     Note you can use python's kwargs dictionary facility to store
     dictionaries of default parameters.  e.g., you can customize the
     font rc as follows::
@@ -1036,12 +1038,17 @@ def rc(group, **kwargs):
       font = {'family' : 'monospace',
               'weight' : 'bold',
               'size'   : 'larger'}
-
       rc('font', **font)  # pass in the font dict as kwargs
 
     This enables you to easily switch between several configurations.  Use
     ``matplotlib.style.use('default')`` or :func:`~matplotlib.rcdefaults` to
     restore the default rc params after changes.
+
+    Notes
+    -----
+    Similar functionality is available by using the normal dict interface, i.e.
+    ``rcParams.update({"lines.linewidth": 2, ...})`` (but ``rcParams.update``
+    does not support abbreviations or grouping).
     """
 
     aliases = {
@@ -1122,7 +1129,6 @@ def rc_file(fname, *, use_default_template=True):
         If True, initialize with default parameters before updating with those
         in the given file. If False, the current configuration persists
         and only the parameters specified in the file are updated.
-
     """
     # Deprecation warnings were already handled in rc_params_from_file, no need
     # to reemit them here.
@@ -1141,14 +1147,10 @@ class rc_context:
     This allows one to do::
 
         with mpl.rc_context(fname='screen.rc'):
-            plt.plot(x, a)
+            plt.plot(x, a)  # uses 'screen.rc'
             with mpl.rc_context(fname='print.rc'):
-                plt.plot(x, b)
-            plt.plot(x, c)
-
-    The 'a' vs. 'x' and 'c' vs. 'x' plots would have settings from
-    'screen.rc', while the 'b' vs. 'x' plot would have settings from
-    'print.rc'.
+                plt.plot(x, b)  # uses 'print.rc'
+            plt.plot(x, c)  # uses 'screen.rc'
 
     A dictionary can also be passed to the context manager::
 


### PR DESCRIPTION
Hiding the huge RcParams.validators list, putting some sections, and
reordering some functions in a more logical order?

Before: https://matplotlib.org/devdocs/api/matplotlib_configuration_api.html
After: https://8397-7439715-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/api/matplotlib_configuration_api.html

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
