### PR TITLE
Replace inspect.getfullargspec by inspect.signature.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1308,18 +1308,12 @@ class ArtistInspector:
             if not name.startswith('set_'):
                 continue
             func = getattr(self.o, name)
-            if not callable(func):
+            if (not callable(func)
+                    or len(inspect.signature(func).parameters) < 2
+                    or self.is_alias(func)):
                 continue
-            nargs = len(inspect.getfullargspec(func).args)
-            if nargs < 2 or self.is_alias(func):
-                continue
-            source_class = self.o.__module__ + "." + self.o.__name__
-            for cls in self.o.mro():
-                if name in cls.__dict__:
-                    source_class = cls.__module__ + "." + cls.__name__
-                    break
-            source_class = self._replace_path(source_class)
-            setters.append((name[4:], source_class + "." + name))
+            setters.append(
+                (name[4:], f"{func.__module__}.{func.__qualname__}"))
         return setters
 
     def _replace_path(self, source_class):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1733,47 +1733,33 @@ def draw_bbox(bbox, renderer, color='k', trans=None):
     r.draw(renderer)
 
 
-def _pprint_table(table, leadingspace=2):
-    """
-    Given the list of list of strings, return a string of REST table format.
-    """
-    col_len = [max(len(cell) for cell in column) for column in zip(*table)]
-    table_formatstr = '   '.join('=' * cl for cl in col_len)
-    lines = [
-        '',
-        table_formatstr,
-        '   '.join(cell.ljust(cl) for cell, cl in zip(table[0], col_len)),
-        table_formatstr,
-        *['   '.join(cell.ljust(cl) for cell, cl in zip(row, col_len))
-          for row in table[1:]],
-        table_formatstr,
-        '',
-    ]
-    return textwrap.indent('\n'.join(lines), ' ' * leadingspace)
-
-
 def _pprint_styles(_styles):
     """
     A helper function for the _Style class.  Given the dictionary of
     {stylename: styleclass}, return a formatted string listing all the
     styles. Used to update the documentation.
     """
-    import inspect
-
-    _table = [["Class", "Name", "Attrs"]]
-
-    for name, cls in sorted(_styles.items()):
-        spec = inspect.getfullargspec(cls.__init__)
-        if spec.defaults:
-            argstr = ", ".join(map(
-                "{}={}".format, spec.args[-len(spec.defaults):], spec.defaults
-            ))
-        else:
-            argstr = 'None'
-        # adding ``quotes`` since - and | have special meaning in reST
-        _table.append([cls.__name__, "``%s``" % name, argstr])
-
-    return _pprint_table(_table)
+    table = [('Class', 'Name', 'Attrs'),
+             *[(cls.__name__,
+                # adding backquotes since - and | have special meaning in reST
+                f'``{name}``',
+                # [1:-1] drops the surrounding parentheses.
+                str(inspect.signature(cls))[1:-1] or 'None')
+               for name, cls in sorted(_styles.items())]]
+    # Convert to rst table.
+    col_len = [max(len(cell) for cell in column) for column in zip(*table)]
+    table_formatstr = '  '.join('=' * cl for cl in col_len)
+    rst_table = '\n'.join([
+        '',
+        table_formatstr,
+        '  '.join(cell.ljust(cl) for cell, cl in zip(table[0], col_len)),
+        table_formatstr,
+        *['  '.join(cell.ljust(cl) for cell, cl in zip(row, col_len))
+          for row in table[1:]],
+        table_formatstr,
+        '',
+    ])
+    return textwrap.indent(rst_table, prefix=' ' * 2)
 
 
 def _simpleprint_styles(_styles):


### PR DESCRIPTION
... and inline _pprint_table into _pprint_styles -- they're short
enough.

Unless @tacaswell wants to revive https://github.com/matplotlib/matplotlib/pull/14138 first...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
