### PR TITLE
Revert "Fix typo in documentation of table"

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -712,7 +712,7 @@ def table(ax,
     colColours : list of matplotlib color specs, optional
         The colors of the column header cells.
 
-    colLoc : {'left', 'center', 'right'}, optional, default: 'left'
+    rowLoc : {'left', 'center', 'right'}, optional, default: 'left'
         The text alignment of the column header cells.
 
     loc : str, optional


### PR DESCRIPTION
_Reverts_ matplotlib/matplotlib#14965

Noticed after this was merged that this went against the wrong branch!

The -doc branch should only get changes to rst files, not the .py files.  I'm going to revert this and open a new PR putting the fix on master.

Thank you @vm-asd2015 !  This was just a process glitch, not a comment on your contribution!