### PR TITLE
FIX: Don't enable IPython integration if not entering REPL.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1553,7 +1553,7 @@ def _get_renderer(figure, print_method):
             return figure._cachedRenderer
 
 
-def is_non_interactive_terminal_ipython(ip):
+def _is_non_interactive_terminal_ipython(ip):
     """
     Return whether we are in a a terminal IPython, but non interactive.
 
@@ -1666,7 +1666,7 @@ class FigureCanvasBase:
 
             try:
                 mpl.rcParamsOrig["backend"] = mpl.rcParams["backend"]
-                if is_non_interactive_terminal_ipython(ip):
+                if _is_non_interactive_terminal_ipython(ip):
                     pass
                 else:
                     ip.enable_matplotlib()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1669,7 +1669,12 @@ class FigureCanvasBase:
                 if _is_non_interactive_terminal_ipython(ip):
                     pass
                 else:
-                    ip.enable_matplotlib()
+                    was_interacive = mpl.is_interactive()
+                    try:
+                        ip.enable_matplotlib()
+                    finally:
+                        mpl.interactive(was_interacive)
+
             finally:
                 mpl.rcParamsOrig["backend"] = orig_origbackend
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1659,20 +1659,8 @@ class FigureCanvasBase:
         backend2gui_rif = {"qt5": "qt", "qt4": "qt", "gtk3": "gtk3",
                            "wx": "wx", "macosx": "osx"}.get(rif)
         if backend2gui_rif:
-            pt.backend2gui[get_backend()] = backend2gui_rif
-            # Work around pylabtools.find_gui_and_backend always reading from
-            # rcParamsOrig.
-            orig_origbackend = mpl.rcParamsOrig["backend"]
-
-            try:
-                mpl.rcParamsOrig["backend"] = mpl.rcParams["backend"]
-                if _is_non_interactive_terminal_ipython(ip):
-                    pass
-                else:
-                    ip.enable_gui()
-
-            finally:
-                mpl.rcParamsOrig["backend"] = orig_origbackend
+            if _is_non_interactive_terminal_ipython(ip):
+                ip.enable_gui(backend2gui_rif)
 
     @contextmanager
     def _idle_draw_cntx(self):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1669,11 +1669,7 @@ class FigureCanvasBase:
                 if _is_non_interactive_terminal_ipython(ip):
                     pass
                 else:
-                    was_interactive = mpl.is_interactive()
-                    try:
-                        ip.enable_matplotlib()
-                    finally:
-                        mpl.interactive(was_interactive)
+                    ip.enable_gui()
 
             finally:
                 mpl.rcParamsOrig["backend"] = orig_origbackend

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1553,6 +1553,20 @@ def _get_renderer(figure, print_method):
             return figure._cachedRenderer
 
 
+def is_non_interactive_terminal_ipython(ip):
+    """
+    Return whether we are in a a terminal IPython, but non interactive.
+
+    When in _terminal_ IPython, ip.parent will have and `interact` attribute,
+    if this attribute is False we do not setup eventloop integration as the
+    user will _not_ interact with IPython. In all other case (ZMQKernel, or is
+    interactive), we do.
+    """
+    return (hasattr(ip, 'parent')
+        and (ip.parent is not None)
+        and getattr(ip.parent, 'interact', None) is False)
+
+
 class FigureCanvasBase:
     """
     The canvas the figure renders into.
@@ -1649,9 +1663,13 @@ class FigureCanvasBase:
             # Work around pylabtools.find_gui_and_backend always reading from
             # rcParamsOrig.
             orig_origbackend = mpl.rcParamsOrig["backend"]
+
             try:
                 mpl.rcParamsOrig["backend"] = mpl.rcParams["backend"]
-                ip.enable_matplotlib()
+                if is_non_interactive_terminal_ipython(ip):
+                    pass
+                else:
+                    ip.enable_matplotlib()
             finally:
                 mpl.rcParamsOrig["backend"] = orig_origbackend
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1669,11 +1669,11 @@ class FigureCanvasBase:
                 if _is_non_interactive_terminal_ipython(ip):
                     pass
                 else:
-                    was_interacive = mpl.is_interactive()
+                    was_interactive = mpl.is_interactive()
                     try:
                         ip.enable_matplotlib()
                     finally:
-                        mpl.interactive(was_interacive)
+                        mpl.interactive(was_interactive)
 
             finally:
                 mpl.rcParamsOrig["backend"] = orig_origbackend


### PR DESCRIPTION
IPython can also be used to simply run files; when this is the case we
are not going to be interactive; and we do not want to enable the
eventloop integration. Otherwise someone doing:

    $ ipython script.py

Will simply see a window blink, as IPython will exit immediately instead
of showing the window and exit.

I'm not quite sure how to test that are we basically _want_ something to
block forever and wait for user input; so no test added

Closes: https://github.com/ipython/ipython/issues/11837

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


