### PR TITLE
Fix nonsensical transform in mixed-mode axes aspect computation.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1507,8 +1507,8 @@ class _AxesBase(martist.Artist):
             return
 
         dL = self.dataLim
-        x0, x1 = map(x_trf.inverted().transform, dL.intervalx)
-        y0, y1 = map(y_trf.inverted().transform, dL.intervaly)
+        x0, x1 = map(x_trf.transform, dL.intervalx)
+        y0, y1 = map(y_trf.transform, dL.intervaly)
         xr = 1.05 * (x1 - x0)
         yr = 1.05 * (y1 - y0)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1410,12 +1410,10 @@ class _AxesBase(martist.Artist):
         -----
         This method is intended to be overridden by new projection types.
         """
-        trf_xmin, trf_xmax = map(
-            self.xaxis.get_transform().transform, self.get_xbound())
-        trf_ymin, trf_ymax = map(
-            self.yaxis.get_transform().transform, self.get_ybound())
-        xsize = max(abs(trf_xmax - trf_xmin), 1e-30)
-        ysize = max(abs(trf_ymax - trf_ymin), 1e-30)
+        txmin, txmax = self.xaxis.get_transform().transform(self.get_xbound())
+        tymin, tymax = self.yaxis.get_transform().transform(self.get_ybound())
+        xsize = max(abs(txmax - txmin), 1e-30)
+        ysize = max(abs(tymax - tymin), 1e-30)
         return ysize / xsize
 
     @cbook.deprecated("3.2")
@@ -1492,8 +1490,8 @@ class _AxesBase(martist.Artist):
 
         x_trf = self.xaxis.get_transform()
         y_trf = self.yaxis.get_transform()
-        xmin, xmax = map(x_trf.transform, self.get_xbound())
-        ymin, ymax = map(y_trf.transform, self.get_ybound())
+        xmin, xmax = x_trf.transform(self.get_xbound())
+        ymin, ymax = y_trf.transform(self.get_ybound())
         xsize = max(abs(xmax - xmin), 1e-30)
         ysize = max(abs(ymax - ymin), 1e-30)
 
@@ -1507,8 +1505,8 @@ class _AxesBase(martist.Artist):
             return
 
         dL = self.dataLim
-        x0, x1 = map(x_trf.transform, dL.intervalx)
-        y0, y1 = map(y_trf.transform, dL.intervaly)
+        x0, x1 = x_trf.transform(dL.intervalx)
+        y0, y1 = y_trf.transform(dL.intervaly)
         xr = 1.05 * (x1 - x0)
         yr = 1.05 * (y1 - y0)
 
@@ -1544,12 +1542,12 @@ class _AxesBase(martist.Artist):
             yc = 0.5 * (ymin + ymax)
             y0 = yc - Ysize / 2.0
             y1 = yc + Ysize / 2.0
-            self.set_ybound(*map(y_trf.inverted().transform, (y0, y1)))
+            self.set_ybound(y_trf.inverted().transform([y0, y1]))
         else:
             xc = 0.5 * (xmin + xmax)
             x0 = xc - Xsize / 2.0
             x1 = xc + Xsize / 2.0
-            self.set_xbound(*map(x_trf.inverted().transform, (x0, x1)))
+            self.set_xbound(x_trf.inverted().transform([x0, x1]))
 
     def axis(self, *args, emit=True, **kwargs):
         """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6559,7 +6559,5 @@ def test_aspect_nonlinear_adjustable_datalim():
            aspect=1, adjustable="datalim")
     ax.margins(0)
     ax.apply_aspect()
-    # Currently the autoscaler chooses to reduce the x-limits by half a decade
-    # on each end, but this may change later.
     assert ax.get_xlim() == pytest.approx([1*10**(1/2), 100/10**(1/2)])
     assert ax.get_ylim() == (1 / 101, 1 / 11)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6554,9 +6554,12 @@ def test_aspect_nonlinear_adjustable_datalim():
 
     ax = fig.add_axes([.1, .1, .8, .8])  # Square.
     ax.plot([.4, .6], [.4, .6])  # Set minpos to keep logit happy.
-    ax.set(xscale="log", xlim=(1, 10),
-           yscale="logit", ylim=(1/11, 1/1001),
+    ax.set(xscale="log", xlim=(1, 100),
+           yscale="logit", ylim=(1 / 101, 1 / 11),
            aspect=1, adjustable="datalim")
     ax.margins(0)
     ax.apply_aspect()
-    assert ax.get_xlim() == pytest.approx(np.array([1/10, 10]) * np.sqrt(10))
+    # Currently the autoscaler chooses to reduce the x-limits by half a decade
+    # on each end, but this may change later.
+    assert ax.get_xlim() == pytest.approx([1*10**(1/2), 100/10**(1/2)])
+    assert ax.get_ylim() == (1 / 101, 1 / 11)


### PR DESCRIPTION
## PR Summary

The first commit fixes the nonsensical transform mentioned in https://github.com/matplotlib/matplotlib/pull/14899, while changing the test introduced in https://github.com/matplotlib/matplotlib/pull/14727 to match the behavior of autoscale which we decided in https://github.com/matplotlib/matplotlib/pull/14899 to keep at least for now (as refactoring it is going to require more work).

The second commit fixes the fact that I missed, in https://github.com/matplotlib/matplotlib/pull/14727, that I could just write `trf.transform(array)` rather than `map(trf.transform, array)`, i.e. `Transform.transform` works on arrays (and is documented to do so).

attn @efiring 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
