### PR TITLE
Handle inherited is_separable, has_inverse in transform props detection.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1227,14 +1227,16 @@ class Transform(TransformNode):
 
     def __init_subclass__(cls):
         # 1d transforms are always separable; we assume higher-dimensional ones
-        # are not but subclasses can also directly set is_separable.
-        if ("is_separable" not in vars(cls)  # Was it overridden explicitly?
+        # are not but subclasses can also directly set is_separable -- this is
+        # verified by checking whether "is_separable" appears more than once in
+        # the class's MRO (it appears once in Transform).
+        if (sum("is_separable" in vars(parent) for parent in cls.__mro__) == 1
                 and cls.input_dims == cls.output_dims == 1):
             cls.is_separable = True
         # Transform.inverted raises NotImplementedError; we assume that if this
         # is overridden then the transform is invertible but subclass can also
         # directly set has_inverse.
-        if ("has_inverse" not in vars(cls)  # Was it overridden explicitly?
+        if (sum("has_inverse" in vars(parent) for parent in cls.__mro__) == 1
                 and hasattr(cls, "inverted")
                 and cls.inverted is not Transform.inverted):
             cls.has_inverse = True


### PR DESCRIPTION
Using `__init_subclass__` is more subtle than directly overriding with
`@property`...

followup to #14922.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
