### PR TITLE
Further improve backend tutorial.

### DIFF
--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -345,11 +345,10 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #    :func:`matplotlib.use`::
 #
 #       import matplotlib
-#       matplotlib.use('PS')   # generate postscript output by default
+#       matplotlib.use('qt5agg')
 #
-#    If you use the `~matplotlib.use` function, this should be done before
-#    importing :mod:`matplotlib.pyplot`. Calling `~matplotlib.use` after pyplot
-#    has been imported may fail to switch the backend and raise an ImportError.
+#    This should be done before any figure is created; otherwise Matplotlib may
+#    fail to switch the backend and raise an ImportError.
 #
 #    Using `~matplotlib.use` will require changes in your code if users want to
 #    use a different backend.  Therefore, you should avoid explicitly calling
@@ -359,12 +358,13 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # The builtin backends
 # --------------------
 #
-# With a typical installation of matplotlib, such as from a
-# binary installer or a linux distribution package, a good default
-# backend will already be set, allowing both interactive work and
-# plotting from scripts, with output to the screen and/or to
-# a file, so at least initially you will not need to use any of the
-# methods given above.
+# By default, Matplotlib should automatically select a default backend which
+# allows both interactive work and plotting from scripts, with output to the
+# screen and/or to a file, so at least initially you will not need to worry
+# about the backend.  The most common exception is if your Python distribution
+# comes without :mod:`tkinter` and you have no other GUI toolkit installed;
+# this happens on certain Linux distributions, where you need to install a
+# Linux package named ``python-tk`` (or similar).
 #
 # If, however, you want to write graphical user interfaces, or a web
 # application server (:ref:`howto-webapp`), or need a better


### PR DESCRIPTION
1) Don't do `use("ps")` (in practice one never needs to set that backend
   manually as we autoswitch to "ps" when saving a postscript); instead
   have `use("qt5agg")` as example.
2) The requirement to call `use()` before importing pyplot is obsolete.
   Actually even "use() needs to be called before creating any figure"
   is a bit too restrictive because switching to noninteractive backends
   is always possible... but no need to go into this in the intro
   tutorial.
3) Reword description of "default" backend selection.

followup to #14549.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
