### PR TITLE
Correctly set formatters and locators on removed shared axis

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1596,25 +1596,37 @@ default: 'top'
             return axarr
 
     def _remove_ax(self, ax):
-        def _reset_loc_form(axis):
+        def _reset_locators_and_formatters(axis):
             # Set the formatters and locators to be associated with axis
             # (where previously they may have been associated with another
             # Axis isntance)
+            #
+            # Because set_major_formatter() etc. force isDefault_* to be False,
+            # we have to manually check if the original formatter was a
+            # default and manually set isDefault_* if that was the case.
             majfmt = axis.get_major_formatter()
-            if not majfmt.axis.isDefault_majfmt:
-                axis.set_major_formatter(majfmt)
+            isDefault = majfmt.axis.isDefault_majfmt
+            axis.set_major_formatter(majfmt)
+            if isDefault:
+                majfmt.axis.isDefault_majfmt = True
 
             majloc = axis.get_major_locator()
-            if not majloc.axis.isDefault_majloc:
-                axis.set_major_locator(majloc)
+            isDefault = majloc.axis.isDefault_majloc
+            axis.set_major_locator(majloc)
+            if isDefault:
+                majloc.axis.isDefault_majloc = True
 
             minfmt = axis.get_minor_formatter()
-            if not minfmt.axis.isDefault_minfmt:
-                axis.set_minor_formatter(minfmt)
+            isDefault = majloc.axis.isDefault_minfmt
+            axis.set_minor_formatter(minfmt)
+            if isDefault:
+                minfmt.axis.isDefault_minfmt = True
 
             minloc = axis.get_minor_locator()
-            if not minfmt.axis.isDefault_minloc:
-                axis.set_minor_locator(minloc)
+            isDefault = majloc.axis.isDefault_minloc
+            axis.set_minor_locator(minloc)
+            if isDefault:
+                minloc.axis.isDefault_minloc = True
 
         def _break_share_link(ax, grouper):
             siblings = grouper.get_siblings(ax)
@@ -1628,11 +1640,11 @@ default: 'top'
         self.delaxes(ax)
         last_ax = _break_share_link(ax, ax._shared_y_axes)
         if last_ax is not None:
-            _reset_loc_form(last_ax.yaxis)
+            _reset_locators_and_formatters(last_ax.yaxis)
 
         last_ax = _break_share_link(ax, ax._shared_x_axes)
         if last_ax is not None:
-            _reset_loc_form(last_ax.xaxis)
+            _reset_locators_and_formatters(last_ax.xaxis)
 
     def clf(self, keep_observers=False):
         """

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -480,3 +480,10 @@ def test_axes_removal():
     axs[0].plot([datetime(2000, 1, 1), datetime(2000, 2, 1)], [0, 1])
     assert isinstance(axs[0].xaxis.get_major_formatter(),
                       ScalarFormatter)
+
+
+def test_removed_axis():
+    # Simple smoke test to make sure removing a shared axis works
+    fig, axs = plt.subplots(2, sharex=True)
+    axs[0].remove()
+    fig.canvas.draw()


### PR DESCRIPTION
Fixes #14911 

The issue was that a shared axis might never have it's `Formatter/Locator` set, which is fine when it is shared, but when the axis storing the `Formatter/Locator` it relies on is removed, the previous shared axis needs to have the `Formatter/Locator`s set.

Also fixed typo `_reset_axis_form` > `_reset_axis_from`.

I've tried a few things, but cannot come up with a more elegant solution than this; if anyone has any ideas suggestions welcome.