### PR TITLE
Use warnings.warn, not logging.warning, in microseconds locator warning.

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1457,9 +1457,10 @@ class AutoDateLocator(DateLocator):
         else:
             locator = MicrosecondLocator(interval, tz=self.tz)
             if dmin.year > 20 and interval < 1000:
-                _log.warning('Plotting microsecond time intervals is not well '
-                             'supported. Please see the MicrosecondLocator '
-                             'documentation for details.')
+                cbook._warn_external(
+                    'Plotting microsecond time intervals is not well '
+                    'supported; please see the MicrosecondLocator '
+                    'documentation for details.')
 
         locator.set_axis(self.axis)
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1,4 +1,8 @@
 import datetime
+try:
+    from contextlib import nullcontext
+except ImportError:
+    from contextlib import ExitStack as nullcontext  # Py 3.6.
 
 import dateutil.tz
 import dateutil.rrule
@@ -369,7 +373,9 @@ def test_auto_date_locator():
     for t_delta, expected in results:
         d2 = d1 + t_delta
         locator = _create_auto_date_locator(d1, d2)
-        assert list(map(str, mdates.num2date(locator()))) == expected
+        with (pytest.warns(UserWarning) if t_delta.microseconds
+              else nullcontext()):
+            assert list(map(str, mdates.num2date(locator()))) == expected
 
 
 def test_auto_date_locator_intmult():
@@ -444,7 +450,9 @@ def test_auto_date_locator_intmult():
     for t_delta, expected in results:
         d2 = d1 + t_delta
         locator = _create_auto_date_locator(d1, d2)
-        assert list(map(str, mdates.num2date(locator()))) == expected
+        with (pytest.warns(UserWarning) if t_delta.microseconds
+              else nullcontext()):
+            assert list(map(str, mdates.num2date(locator()))) == expected
 
 
 def test_concise_formatter():


### PR DESCRIPTION
Otherwise something like
```
from pylab import *
from matplotlib import dates; from datetime import *
plt.plot([datetime(1990, 1, 1), datetime(1990, 1, 1) + timedelta(microseconds=1500)], [0, 0])
plt.show()
```
results in the same warning being emitted multiple times *for every
draw* (e.g. when zooming/panning), which is pretty needless spam.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
