### PR TITLE
Deprecate trying to set minor ticks in 3D

### DIFF
--- a/doc/api/next_api_changes/2019-08-07-TH.rst
+++ b/doc/api/next_api_changes/2019-08-07-TH.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+`Axes3D` does not support minor ticks. Passing a ``minor`` parameter to
+``set_x/y/zticks`` did not have an effect and is now deprecated.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -841,17 +841,56 @@ class Axes3D(Axes):
         self._update_transScale()
         self.stale = True
 
-    def set_zticks(self, *args, **kwargs):
+    def set_xticks(self, ticks, minor=False):
         """
-        Set z-axis tick locations.
-        See :meth:`matplotlib.axes.Axes.set_yticks` for more details.
+        Set the x-axis tick locations.
 
         .. note::
-            Minor ticks are not supported.
+            Minor ticks are not supported by Axes3D objects.
+        """
+        # overridden to remove the non-working 'minor' parameter from the API
+        if minor is not False:
+            cbook.warn_deprecated(
+                "3.2", message="Minor ticks are not supported by Axes3D "
+                               "objects. Passing minor=True will become an "
+                               "error in future versions of matplotlib."
+            )
+        return super().set_xticks(ticks)
+
+    def set_yticks(self, ticks, minor=False):
+        """
+        Set the y-axis tick locations.
+
+        .. note::
+            Minor ticks are not supported by Axes3D objects.
+        """
+        # overridden to remove the non-working 'minor' parameter from the API
+        if minor is not False:
+            cbook.warn_deprecated(
+                "3.2", message="Minor ticks are not supported by Axes3D "
+                               "objects. Passing minor=True will become an "
+                               "error in future versions of matplotlib."
+            )
+        return super().set_yticks(ticks)
+
+    def set_zticks(self, ticks, minor=False):
+        """
+        Set the z-axis tick locations.
+
+        .. note::
+            Minor ticks are not supported by Axes3D objects.
 
         .. versionadded:: 1.1.0
         """
-        return self.zaxis.set_ticks(*args, **kwargs)
+        if minor is not False:
+            cbook.warn_deprecated(
+                "3.2", message="Minor ticks are not supported by Axes3D "
+                               "objects. Passing minor=True will become an "
+                               "error in future versions of matplotlib."
+            )
+        ret = self.zaxis.set_ticks(ticks)
+        self.stale = True
+        return ret
 
     def get_zticks(self, minor=False):
         """
@@ -859,7 +898,7 @@ class Axes3D(Axes):
         See :meth:`matplotlib.axes.Axes.get_yticks` for more details.
 
         .. note::
-            Minor ticks are not supported.
+            Minor ticks are not supported by Axes3D objects.
 
         .. versionadded:: 1.1.0
         """


### PR DESCRIPTION
## PR Summary

they are not supported anyway. It's better to warn now and fail in the future than to silently do nothing. The ultimate plan is to drop the `minor` parameter in the future so that we have a clean API at least.

- Also changes the signature of `set_zticks(*args, **kwargs)` to to explicit parameters.
- Also marks the Axes as stale for `set_zticks` (`set_xticks/yticks` does this already).

Inspired from user problems in  #14980.



