### PR TITLE
Deprecate get/set_*ticks minor positional use

### DIFF
--- a/doc/api/next_api_changes/2019-08-08-TH
+++ b/doc/api/next_api_changes/2019-08-08-TH
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+Using the parameter ``minor`` to ``get_*ticks()`` / ``set_*ticks()`` as a
+positional parameter is deprecated. It will become keyword-only in future
+versions.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3265,10 +3265,12 @@ class _AxesBase(martist.Artist):
             ax.stale = True
         self._request_autoscale_view(scaley=False)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def get_xticks(self, minor=False):
         """Return the x ticks as a list of locations"""
         return self.xaxis.get_ticklocs(minor=minor)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def set_xticks(self, ticks, minor=False):
         """
         Set the x ticks with list of *ticks*
@@ -3645,10 +3647,12 @@ class _AxesBase(martist.Artist):
             ax.stale = True
         self._request_autoscale_view(scalex=False)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def get_yticks(self, minor=False):
         """Return the y ticks as a list of locations"""
         return self.yaxis.get_ticklocs(minor=minor)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def set_yticks(self, ticks, minor=False):
         """
         Set the y ticks with list of *ticks*

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -161,6 +161,7 @@ class SecondaryAxis(_AxesBase):
         self._set_lims()
         super().apply_aspect(position)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def set_ticks(self, ticks, minor=False):
         """
         Set the x ticks with list of *ticks*

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1753,6 +1753,7 @@ class Axis(martist.Artist):
         self.stale = True
         return ret
 
+    @cbook._make_keyword_only("3.2", "minor")
     def set_ticks(self, ticks, minor=False):
         """
         Set the locations of the tick marks from sequence ticks

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -853,6 +853,7 @@ class Axes3D(Axes):
         """
         return self.zaxis.set_ticks(*args, **kwargs)
 
+    @cbook._make_keyword_only("3.2", "minor")
     def get_zticks(self, minor=False):
         """
         Return the z ticks as a list of locations


### PR DESCRIPTION
## PR Summary
``minor`` should become keyword-only in future versions.

- A positional use ``set_xticks(positions, True)`` is not quite readable.
- Prepares for #15005.

## PR Checklist

- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
