### PR TITLE
Fix bad missing-references.json due to PR merge race condition.

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -669,7 +669,6 @@
       "doc/gallery/animation/animated_histogram.rst:112",
       "doc/gallery/statistics/errorbars_and_boxes.rst:21",
       "doc/users/prev_whats_new/whats_new_1.5.rst:514",
-      "lib/matplotlib/colorbar.py:docstring of matplotlib.colorbar.ColorbarBase:38",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.delaxes:2",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.plotting:33"
     ],
@@ -1372,7 +1371,6 @@
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.convert_xunits:4"
     ],
     "LineCollection": [
-      "lib/matplotlib/colorbar.py:docstring of matplotlib.colorbar.ColorbarBase:41",
       "lib/matplotlib/container.py:docstring of matplotlib.container.StemContainer:40"
     ],
     "#rrggbb": [
@@ -3227,9 +3225,6 @@
     ],
     "set_color": [
       "doc/faq/howto_faq.rst:45"
-    ],
-    "https://virtualenv.pypa.io/": [
-      "doc/faq/virtualenv_faq.rst:54"
     ],
     "Patch": [
       "doc/gallery/animation/animated_histogram.rst:112",

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -496,9 +496,9 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # Using non-builtin backends
 # --------------------------
 # More generally, any importable backend can be selected by using any of the
-# methods above. If `name.of.the.backend` is the module containing the backend,
-# use `module://name.of.the.backend` as the backend name, e.g.
-# `matplotlib.use('module://name.of.the.backend')`.
+# methods above. If ``name.of.the.backend`` is the module containing the
+# backend, use ``module://name.of.the.backend`` as the backend name, e.g.
+# ``matplotlib.use('module://name.of.the.backend')``.
 #
 #
 # .. _interactive-mode:


### PR DESCRIPTION
aka some missing references were fixed between the last build of the
nitpicky-mode PR and its merge.

fixes the broken doc build, so will selfmerge on pass

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
