### PR TITLE
Let connectionpatch be drawn on figure level

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4454,7 +4454,11 @@ class ConnectionPatch(FancyArrowPatch):
         if b or (b is None and self.coords1 == "data"):
             x, y = self.xy1
             xy_pixel = self._get_xy(x, y, self.coords1, self.axesA)
-            if not self.axes.contains_point(xy_pixel):
+            if self.axesA is None:
+                axes = self.axes
+            else:
+                axes = self.axesA
+            if not axes.contains_point(xy_pixel):
                 return False
 
         if b or (b is None and self.coords2 == "data"):

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -396,6 +396,18 @@ def test_connection_patch():
     ax2.add_artist(con)
 
 
+def test_connection_patch_fig():
+    # Test that connection patch can be added as figure artist
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    xy = (0.3, 0.2)
+    con = mpatches.ConnectionPatch(xyA=xy, xyB=xy,
+                                   coordsA="data", coordsB="data",
+                                   axesA=ax1, axesB=ax2,
+                                   arrowstyle="->", shrinkB=5)
+    fig.add_artist(con)
+    fig.canvas.draw()
+
+
 def test_datetime_rectangle():
     # Check that creating a rectangle with timedeltas doesn't fail
     from datetime import datetime, timedelta


### PR DESCRIPTION
## PR Summary

Previously adding a ConnectionPatch to a figure as `fig.add_artist(ConnectionPatch(..))` would fail with an error (error shown in https://github.com/matplotlib/matplotlib/issues/8744#issuecomment-520036804). 

However it would be good to be able to use ConnectionPatch on a figure level because
* It would allow to not take part in layout management, see https://github.com/matplotlib/matplotlib/pull/14957
* It would allow to have it be drawn on top of all axes, see https://github.com/matplotlib/matplotlib/issues/8744

Thereby closes #8744 in the sense that we would advise users to use `fig.add_artist` in such case.

Documentation and examples for that would be part of #14957

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
