### PR TITLE
Re-write text wrapping logic

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -592,3 +592,17 @@ def test_large_subscript_title():
     tt.set_position((x, 1.01))
     ax.set_title('Old Way', loc='left')
     ax.set_xticklabels('')
+
+
+def test_long_word_wrap():
+    fig = plt.figure(figsize=(6, 4))
+    text = fig.text(9.5, 8, 'Alonglineoftexttowrap', wrap=True)
+    fig.canvas.draw()
+    assert text._get_wrapped_text() == 'Alonglineoftexttowrap'
+
+
+def test_wrap_no_wrap():
+    fig = plt.figure(figsize=(6, 4))
+    text = fig.text(0, 0, 'non wrapped text', wrap=True)
+    fig.canvas.draw()
+    assert text._get_wrapped_text() == 'non wrapped text'

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -594,6 +594,16 @@ def test_large_subscript_title():
     ax.set_xticklabels('')
 
 
+def test_wrap():
+    fig = plt.figure(figsize=(6, 4))
+    s = 'This is a very long text that should be wrapped multiple times.'
+    text = fig.text(0.7, 0.5, s, wrap=True)
+    fig.canvas.draw()
+    assert text._get_wrapped_text() == ('This is a very long text\n'
+                                        'that should be wrapped\n'
+                                        'multiple times.')
+
+
 def test_long_word_wrap():
     fig = plt.figure(figsize=(6, 4))
     text = fig.text(9.5, 8, 'Alonglineoftexttowrap', wrap=True)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -599,9 +599,10 @@ def test_wrap():
     s = 'This is a very long text that should be wrapped multiple times.'
     text = fig.text(0.7, 0.5, s, wrap=True)
     fig.canvas.draw()
-    assert text._get_wrapped_text() == ('This is a very long text\n'
-                                        'that should be wrapped\n'
-                                        'multiple times.')
+    assert text._get_wrapped_text() == ('This is a very long\n'
+                                        'text that should be\n'
+                                        'wrapped multiple\n'
+                                        'times.')
 
 
 def test_long_word_wrap():

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -631,7 +631,7 @@ class Text(Artist):
 
         # Build the line incrementally, for a more accurate measure of length
         line_width = self._get_wrap_line_width()
-        wrapped_str = ""
+        wrapped_lines = []
 
         # New lines in the user's text force a split
         unwrapped_lines = self.get_text().split('\n')
@@ -644,7 +644,7 @@ class Text(Artist):
             while len(sub_words) > 0:
                 if len(sub_words) == 1:
                     # Only one word, so just add it to the end
-                    wrapped_str += sub_words.pop(0)
+                    wrapped_lines.append(sub_words.pop(0))
                     continue
 
                 for i in range(2, len(sub_words) + 1):
@@ -655,17 +655,17 @@ class Text(Artist):
                     # If all these words are too wide, append all not including
                     # last word
                     if current_width > line_width:
-                        wrapped_str += ' '.join(sub_words[:i - 1]) + '\n'
+                        wrapped_lines.append(' '.join(sub_words[:i - 1]))
                         sub_words = sub_words[i - 1:]
                         break
 
                     # Otherwise if all words fit in the width, append them all
                     elif i == len(sub_words):
-                        wrapped_str += ' '.join(sub_words[:i])
+                        wrapped_lines.append(' '.join(sub_words[:i]))
                         sub_words = []
                         break
 
-        return wrapped_str
+        return '\n'.join(wrapped_lines)
 
     @artist.allow_rasterization
     def draw(self, renderer):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -632,27 +632,37 @@ class Text(Artist):
         # Build the line incrementally, for a more accurate measure of length
         line_width = self._get_wrap_line_width()
         wrapped_str = ""
-        line = ""
 
-        for word in self.get_text().split(' '):
-            # New lines in the user's test need to force a split, so that it's
-            # not using the longest current line width in the line being built
-            sub_words = word.split('\n')
-            for i in range(len(sub_words)):
-                current_width = self._get_rendered_text_width(
-                    line + ' ' + sub_words[i])
+        # New lines in the user's text force a split
+        unwrapped_lines = self.get_text().split('\n')
 
-                # Split long lines, and each newline found in the current word
-                if current_width > line_width or i > 0:
-                    wrapped_str += line + '\n'
-                    line = ""
+        # Now wrap each individual unwrapped line
+        for unwrapped_line in unwrapped_lines:
 
-                if line == "":
-                    line = sub_words[i]
-                else:
-                    line += ' ' + sub_words[i]
+            sub_words = unwrapped_line.split(' ')
+            # Remove items from sub_words as we go, so stop when empty
+            while len(sub_words) > 0:
+                if len(sub_words) == 1:
+                    # Only one word, so just add it to the end
+                    wrapped_str += sub_words.pop(0)
+                    continue
 
-        return wrapped_str + line
+                for i in range(2, len(sub_words) + 1):
+                    # Get width of all words up to and including here
+                    line = ' '.join(sub_words[:i])
+                    current_width = self._get_rendered_text_width(line)
+
+                    # If all these words are too wide, append all not including
+                    # last word
+                    if current_width > line_width:
+                        wrapped_str += ' '.join(sub_words[:i - 1]) + '\n'
+                        sub_words = sub_words[i - 1:]
+                    # Otherwise if all words fit in the width, append them all
+                    elif i == len(sub_words):
+                        wrapped_str += ' '.join(sub_words[:i])
+                        sub_words = []
+
+        return wrapped_str
 
     @artist.allow_rasterization
     def draw(self, renderer):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -657,10 +657,13 @@ class Text(Artist):
                     if current_width > line_width:
                         wrapped_str += ' '.join(sub_words[:i - 1]) + '\n'
                         sub_words = sub_words[i - 1:]
+                        break
+
                     # Otherwise if all words fit in the width, append them all
                     elif i == len(sub_words):
                         wrapped_str += ' '.join(sub_words[:i])
                         sub_words = []
+                        break
 
         return wrapped_str
 


### PR DESCRIPTION
I did not really understand the previous logic, and I think it got some things wrong (see below), so I've re-written it. I hope this is more understandable... in particular

- Doesn't include spurious newlines at the beginning of long single word lines (fixes #15014)
- Doesn't include extra newlines at the end of wrapped text
- Hopefully the code is more readable