### PR TITLE
Add references to animations in Figure for Animations Persistence

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -937,6 +937,8 @@ class Animation:
         if self._blit:
             self._setup_blit()
 
+        fig.animations.append(self)
+
     def _start(self, *args):
         '''
         Starts interactive animation. Adds the draw frame command to the GUI

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -396,6 +396,9 @@ class Figure(Artist):
         # list of child gridspecs for this figure
         self._gridspecs = []
 
+        # list of animations for this figure
+        self.animations = []
+
     # TODO: I'd like to dynamically add the _repr_html_ method
     # to the figure in the right context, but then IPython doesn't
     # use it, for some reason.


### PR DESCRIPTION
## PR Summary
[issue#1656:Animations & Object Persistence 
](https://github.com/matplotlib/matplotlib/issues/1656)

The problem has been clearly described in the issue. We just add references to animations in Figure for Animations Persistence.

## PR Checklist

- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
