### PR TITLE
More readability improvements on axis3d.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -283,8 +283,7 @@ class Axis(maxis.XAxis):
             outeredgep = edgep2
             outerindex = 1
 
-        pos = outeredgep.copy()
-        pos = move_from_center(pos, centers, labeldeltas, axmask)
+        pos = move_from_center(outeredgep, centers, labeldeltas, axmask)
         olx, oly, olz = proj3d.proj_transform(*pos, renderer.M)
         self.offsetText.set_text(self.major.formatter.get_offset())
         self.offsetText.set_position((olx, oly))
@@ -339,19 +338,14 @@ class Axis(maxis.XAxis):
         self.offsetText.set_ha(align)
         self.offsetText.draw(renderer)
 
-        # Draw grid lines
         if self.axes._draw_grid and len(ticks):
-            # Grid points at end of one plane
-            xyz1 = xyz0.copy()
-            newindex = (index + 1) % 3
-            xyz1[:, newindex] = maxmin[newindex]
-
-            # Grid points at end of the other plane
-            xyz2 = xyz0.copy()
-            newindex = (index + 2) % 3
-            xyz2[:, newindex] = maxmin[newindex]
-
-            lines = np.stack([xyz1, xyz0, xyz2], axis=1)
+            # Grid lines go from the end of one plane through the plane
+            # intersection (at xyz0) to the end of the other plane.  The first
+            # point (0) differs along dimension index-2 and the last (2) along
+            # dimension index-1.
+            lines = np.stack([xyz0, xyz0, xyz0], axis=1)
+            lines[:, 0, index - 2] = maxmin[index - 2]
+            lines[:, 2, index - 1] = maxmin[index - 1]
             self.gridlines.set_segments(lines)
             self.gridlines.set_color(info['grid']['color'])
             self.gridlines.set_linewidth(info['grid']['linewidth'])


### PR DESCRIPTION
At least the comment helps me, and whole thing is shorter :)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
