### PR TITLE
FIX: un-break nightly wheels on py37

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -697,10 +697,13 @@ class BboxBase(TransformNode):
         """Return a `Bbox` that contains all of the given *bboxes*."""
         if not len(bboxes):
             raise ValueError("'bboxes' cannot be empty")
-        x0 = np.min([bbox.xmin for bbox in bboxes])
-        x1 = np.max([bbox.xmax for bbox in bboxes])
-        y0 = np.min([bbox.ymin for bbox in bboxes])
-        y1 = np.max([bbox.ymax for bbox in bboxes])
+        # needed for 1.14.4 < numpy_version < 1.15
+        # can remove once we are at numpy >= 1.15
+        with np.errstate(invalid='ignore'):
+            x0 = np.min([bbox.xmin for bbox in bboxes])
+            x1 = np.max([bbox.xmax for bbox in bboxes])
+            y0 = np.min([bbox.ymin for bbox in bboxes])
+            y1 = np.max([bbox.ymax for bbox in bboxes])
         return Bbox([[x0, y0], [x1, y1]])
 
     @staticmethod


### PR DESCRIPTION
The issue is that https://github.com/matplotlib/matplotlib/pull/14131
made our test suite fail on any warnings (good!), however we do not
test all versions of numpy and `np.min([np.nan])` seems to warn for
1.14.4 < version < 1.15.0 which is not a range we test on travis.
However, the version of numpy that the wheels pin to for py37 in
1.14.6 which does warn.

This is likely related to https://github.com/numpy/numpy/issues/10370


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->