### PR TITLE
Resize canvas when changing figure size

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -631,7 +631,8 @@ class FigureManagerQT(FigureManagerBase):
         # so we do not need to worry about dpi scaling here.
         extra_width = self.window.width() - self.canvas.width()
         extra_height = self.window.height() - self.canvas.height()
-        self.window.resize(width+extra_width, height+extra_height)
+        self.canvas.resize(width, height)
+        self.window.resize(width + extra_width, height + extra_height)
 
     def show(self):
         self.window.show()

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -272,3 +272,19 @@ def test_figureoptions():
             "matplotlib.backends.qt_editor._formlayout.FormDialog.exec_",
             lambda self: None):
         fig.canvas.manager.toolbar.edit_parameters()
+
+
+@pytest.mark.backend('Qt5Agg')
+def test_double_resize():
+    # Check that resizing a figure twice keeps the same window size
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    window = fig.canvas.manager.window
+
+    fig.set_size_inches(2, 2)
+    old_width = window.width()
+    old_height = window.height()
+
+    fig.set_size_inches(2, 2)
+    assert window.width() == old_width
+    assert window.height() == old_height

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import matplotlib
 from matplotlib import pyplot as plt
+from matplotlib import rcParams
 from matplotlib._pylab_helpers import Gcf
 
 import pytest
@@ -281,10 +282,14 @@ def test_double_resize():
     fig.canvas.draw()
     window = fig.canvas.manager.window
 
-    fig.set_size_inches(2, 2)
+    w, h = 3, 2
+    fig.set_size_inches(w, h)
+    assert fig.canvas.width() == w * rcParams['figure.dpi']
+    assert fig.canvas.height() == h * rcParams['figure.dpi']
+
     old_width = window.width()
     old_height = window.height()
 
-    fig.set_size_inches(2, 2)
+    fig.set_size_inches(w, h)
     assert window.width() == old_width
     assert window.height() == old_height


### PR DESCRIPTION
When the figure size is resized, as well as the window being manually resized the canvas needs to be resized too. Usually the canvas is resized automatically to the window at draw time, but this handles the case where the figure size is changed more than once before drawing (ie. #15040).

This might not be the right thing to do though, maybe others know better?

Fixes #15040