### PR TITLE
Fix cross-references in tutorials and FAQ

### DIFF
--- a/doc/faq/environment_variables_faq.rst
+++ b/doc/faq/environment_variables_faq.rst
@@ -12,14 +12,10 @@ Environment Variables
 
   The user's home directory. On linux, :envvar:`~ <HOME>` is shorthand for :envvar:`HOME`.
 
-.. envvar:: PATH
+.. envvar:: MPLBACKEND
 
-  The list of directories searched to find executable programs
-
-.. envvar:: PYTHONPATH
-
-  The list of directories that is added to Python's standard search list when
-  importing packages and modules
+  This optional variable can be set to choose the Matplotlib backend. See
+  :ref:`what-is-a-backend`.
 
 .. envvar:: MPLCONFIGDIR
 
@@ -31,10 +27,14 @@ Environment Variables
   is used to find a base directory in which the :file:`matplotlib` subdirectory 
   is created.
 
-.. envvar:: MPLBACKEND
+.. envvar:: PATH
 
-  This optional variable can be set to choose the matplotlib backend.  See
-  :ref:`what-is-a-backend`.
+  The list of directories searched to find executable programs.
+
+.. envvar:: PYTHONPATH
+
+  The list of directories that are added to Python's standard search list when
+  importing packages and modules.
 
 .. _setting-linux-osx-environment-variables:
 

--- a/doc/faq/environment_variables_faq.rst
+++ b/doc/faq/environment_variables_faq.rst
@@ -8,6 +8,13 @@ Environment Variables
    :backlinks: none
 
 
+.. envvar:: DISPLAY
+
+  The server and screen on which to place windows. This is interpreted by GUI
+  toolkits in a backend-specific manner, but generally refers to an `X.org
+  display name
+  <https://www.x.org/releases/X11R7.7/doc/man/man7/X.7.xhtml#heading5>`_.
+
 .. envvar:: HOME
 
   The user's home directory. On linux, :envvar:`~ <HOME>` is shorthand for :envvar:`HOME`.
@@ -35,6 +42,11 @@ Environment Variables
 
   The list of directories that are added to Python's standard search list when
   importing packages and modules.
+
+.. envvar:: QT_API
+
+   The Python Qt wrapper to prefer when using Qt-based backends. See :ref:`the
+   entry in the usage guide <QT_API-usage>` for more information.
 
 .. _setting-linux-osx-environment-variables:
 

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -27,7 +27,7 @@ converter with the `matplotlib.units` module::
   from pandas.tseries import converter as pdtc
   pdtc.register()
 
-If you only want to use the `pandas` converter for `datetime64` values ::
+If you only want to use the `pandas` converter for `numpy.datetime64` values ::
 
   from pandas.tseries import converter as pdtc
   import matplotlib.units as munits
@@ -48,7 +48,7 @@ recursively search the artist for any artists it may contain that meet
 some criteria (e.g., match all :class:`~matplotlib.lines.Line2D`
 instances or match some arbitrary filter function).  For example, the
 following snippet finds every object in the figure which has a
-`set_color` property and makes the object blue::
+``set_color`` property and makes the object blue::
 
     def myfunc(x):
         return hasattr(x, 'set_color')
@@ -246,8 +246,8 @@ over so that the tick labels fit in the figure:
 Configure the tick widths
 -------------------------
 
-Wherever possible, it is recommended to use the :meth:`~Axes.tick_params` or
-:meth:`~Axis.set_tick_params` methods to modify tick properties::
+Wherever possible, it is recommended to use the :meth:`~.axes.Axes.tick_params`
+or :meth:`~.axis.Axis.set_tick_params` methods to modify tick properties::
 
     import matplotlib.pyplot as plt
 
@@ -648,7 +648,7 @@ In general, the simplest solution when using Matplotlib in a web server is
 to completely avoid using pyplot (pyplot maintains references to the opened
 figures to make `~.matplotlib.pyplot.show` work, but this will cause memory
 leaks unless the figures are properly closed).  Since Matplotlib 3.1, one
-can directly create figures using the `Figure` constructor and save them to
+can directly create figures using the `.Figure` constructor and save them to
 in-memory buffers.  The following example uses Flask_, but other frameworks
 work similarly::
 

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -1380,7 +1380,6 @@
       "lib/matplotlib/colors.py:docstring of matplotlib.colors:30"
     ],
     "'C'": [
-      "doc/tutorials/colors/colors.rst:32",
       "lib/matplotlib/colors.py:docstring of matplotlib.colors:54"
     ],
     "LineCollection": [
@@ -1522,8 +1521,7 @@
       "doc/api/next_api_changes/2019-04-17-AL.rst:14"
     ],
     "figure": [
-      "doc/api/next_api_changes/2019-04-23-TH.rst:4",
-      "doc/tutorials/advanced/transforms_tutorial.rst:14"
+      "doc/api/next_api_changes/2019-04-23-TH.rst:4"
     ],
     "backend_bases.GraphicsContextBase.set_clip_path": [
       "doc/api/next_api_changes/2019-06-07-AL.rst:4"
@@ -1975,7 +1973,6 @@
     ],
     "matplotlibrc": [
       "doc/api/prev_api_changes/api_changes_1.3.x.rst:204",
-      "doc/tutorials/intermediate/constrainedlayout_guide.rst:568",
       "doc/users/prev_whats_new/whats_new_1.3.rst:332",
       "doc/users/prev_whats_new/whats_new_1.3.rst:385",
       "doc/users/prev_whats_new/whats_new_2.2.rst:260",
@@ -1993,11 +1990,7 @@
     ],
     "axes": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:12",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:16",
-      "doc/tutorials/advanced/transforms_tutorial.rst:14",
-      "doc/tutorials/advanced/transforms_tutorial.rst:244",
-      "doc/tutorials/advanced/transforms_tutorial.rst:315",
-      "doc/tutorials/advanced/transforms_tutorial.rst:633"
+      "doc/api/prev_api_changes/api_changes_1.4.x.rst:16"
     ],
     "_subplot": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:14"
@@ -2231,8 +2224,7 @@
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:181"
     ],
     "GridSpec": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:181",
-      "doc/tutorials/intermediate/constrainedlayout_guide.rst:821"
+      "doc/api/prev_api_changes/api_changes_1.4.x.rst:181"
     ],
     "matplotlib.cbook.ls_mapper": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11",
@@ -2499,12 +2491,10 @@
       "doc/users/prev_whats_new/whats_new_2.2.rst:254"
     ],
     "GTK3Agg": [
-      "doc/api/prev_api_changes/api_changes_2.2.0.rst:285",
-      "doc/tutorials/introductory/usage.rst:582"
+      "doc/api/prev_api_changes/api_changes_2.2.0.rst:285"
     ],
     "GTK3Cairo": [
-      "doc/api/prev_api_changes/api_changes_2.2.0.rst:285",
-      "doc/tutorials/introductory/usage.rst:582"
+      "doc/api/prev_api_changes/api_changes_2.2.0.rst:285"
     ],
     "Text.set_text": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:64",
@@ -2991,7 +2981,6 @@
     ],
     "GTK3": [
       "doc/devel/MEP/MEP23.rst:54",
-      "doc/tutorials/introductory/usage.rst:582",
       "doc/users/prev_whats_new/whats_new_1.5.rst:620"
     ],
     "add_canvas": [
@@ -3229,9 +3218,6 @@
       "doc/users/prev_whats_new/whats_new_1.5.rst:321",
       "doc/users/prev_whats_new/whats_new_1.5.rst:324"
     ],
-    "LinearSegmentedColormap": [
-      "doc/tutorials/colors/colormap-manipulation.rst:181"
-    ],
     "Figure.align_xlabels": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:70"
     ],
@@ -3254,8 +3240,7 @@
       "doc/index.rst:44"
     ],
     "mplot3d": [
-      "doc/index.rst:145",
-      "doc/tutorials/introductory/sample_plots.rst:128"
+      "doc/index.rst:145"
     ],
     "axes_grid1": [
       "doc/index.rst:145",
@@ -3265,154 +3250,8 @@
       "doc/index.rst:145",
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:160"
     ],
-    "data": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:122",
-      "doc/tutorials/advanced/transforms_tutorial.rst:14",
-      "doc/tutorials/advanced/transforms_tutorial.rst:203",
-      "doc/tutorials/advanced/transforms_tutorial.rst:244",
-      "doc/tutorials/advanced/transforms_tutorial.rst:276",
-      "doc/tutorials/advanced/transforms_tutorial.rst:315",
-      "doc/tutorials/advanced/transforms_tutorial.rst:580",
-      "doc/tutorials/advanced/transforms_tutorial.rst:633",
-      "doc/tutorials/advanced/transforms_tutorial.rst:87"
-    ],
-    "display": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:122",
-      "doc/tutorials/advanced/transforms_tutorial.rst:14",
-      "doc/tutorials/advanced/transforms_tutorial.rst:203",
-      "doc/tutorials/advanced/transforms_tutorial.rst:580",
-      "doc/tutorials/advanced/transforms_tutorial.rst:601"
-    ],
-    "Transformation Object": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:14"
-    ],
-    "Axes.axes.add_artist": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:73"
-    ],
-    "blended": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:315"
-    ],
-    "xt": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:451"
-    ],
-    "yt": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:451"
-    ],
-    "scale_trans": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:451"
-    ],
-    "xdata[0]": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:455"
-    ],
-    "ydata[0]": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:455"
-    ],
-    "fig.dpi_scale_trans": [
-      "doc/tutorials/advanced/transforms_tutorial.rst:521"
-    ],
-    "ListedColormap": [
-      "doc/tutorials/colors/colormap-manipulation.rst:93"
-    ],
-    "LinearSegmentedColormap.from_list": [
-      "doc/tutorials/colors/colormap-manipulation.rst:474"
-    ],
-    "vmin=-vmax": [
-      "doc/tutorials/colors/colormapnorms.rst:95"
-    ],
-    "subplot": [
-      "doc/tutorials/intermediate/constrainedlayout_guide.rst:821"
-    ],
-    "matplotlib.Figure.subplots": [
-      "doc/tutorials/intermediate/gridspec.rst:17"
-    ],
-    "extent=None": [
-      "doc/tutorials/intermediate/imshow_extent.rst:190"
-    ],
-    "set_xlim": [
-      "doc/tutorials/intermediate/imshow_extent.rst:280"
-    ],
     "set_ylim": [
-      "doc/tutorials/intermediate/imshow_extent.rst:280",
       "doc/users/prev_whats_new/whats_new_2.2.rst:230"
-    ],
-    "rc settings": [
-      "doc/tutorials/introductory/customizing.rst:202"
-    ],
-    "rc parameters": [
-      "doc/tutorials/introductory/customizing.rst:202"
-    ],
-    "$XDG_CONFIG_HOME/matplotlib/matplotlibrc": [
-      "doc/tutorials/introductory/customizing.rst:216"
-    ],
-    "http://www.xkcd.com/": [
-      "doc/tutorials/introductory/sample_plots.rst:416"
-    ],
-    "np.array": [
-      "doc/tutorials/introductory/usage.rst:166"
-    ],
-    "np.ma.masked_array": [
-      "doc/tutorials/introductory/usage.rst:166"
-    ],
-    "np.matrix": [
-      "doc/tutorials/introductory/usage.rst:166",
-      "doc/tutorials/introductory/usage.rst:176"
-    ],
-    "QT_API": [
-      "doc/tutorials/introductory/usage.rst:588"
-    ],
-    "pyqt": [
-      "doc/tutorials/introductory/usage.rst:588"
-    ],
-    "pyside": [
-      "doc/tutorials/introductory/usage.rst:588"
-    ],
-    "PyQt4": [
-      "doc/tutorials/introductory/usage.rst:588",
-      "doc/tutorials/introductory/usage.rst:591"
-    ],
-    "PySide": [
-      "doc/tutorials/introductory/usage.rst:588",
-      "doc/tutorials/introductory/usage.rst:591"
-    ],
-    "macosx": [
-      "doc/tutorials/introductory/usage.rst:666"
-    ],
-    "loc='best'": [
-      "doc/tutorials/introductory/usage.rst:872"
-    ],
-    "matplotlib.Axes.annotate": [
-      "doc/tutorials/text/annotations.rst:88"
-    ],
-    "http://www.w3.org/": [
-      "doc/tutorials/text/text_intro.rst:21"
-    ],
-    "matplotlib.xaxis.set_major_locator": [
-      "doc/tutorials/text/text_intro.rst:357"
-    ],
-    "matplotlib.xaxis.set_minor_locator": [
-      "doc/tutorials/text/text_intro.rst:357"
-    ],
-    "matplotlib.xaxis.set_major_formatter": [
-      "doc/tutorials/text/text_intro.rst:357"
-    ],
-    "matplotlib.xaxis.set_minor_formatter": [
-      "doc/tutorials/text/text_intro.rst:357"
-    ],
-    "dates.DayLocator": [
-      "doc/tutorials/text/text_intro.rst:598"
-    ],
-    "tex_demo.py": [
-      "doc/tutorials/text/usetex.rst:62",
-      "doc/tutorials/text/usetex.rst:71",
-      "doc/tutorials/text/usetex.rst:88"
-    ],
-    "Axes3D": [
-      "doc/tutorials/toolkits/mplot3d.rst:25",
-      "doc/tutorials/toolkits/mplot3d.rst:33"
-    ],
-    "Figure.add_subplot": [
-      "doc/tutorials/toolkits/mplot3d.rst:25",
-      "doc/tutorials/toolkits/mplot3d.rst:37"
     ],
     "'viridis'": [
       "doc/users/dflt_style_changes.rst:121"
@@ -4172,15 +4011,6 @@
     "Axis.set_tick_params": [
       "doc/faq/howto_faq.rst:249"
     ],
-    "matplotlib.image.Image.set_cmap": [
-      "doc/tutorials/introductory/images.rst:268"
-    ],
-    "matplotlib.image.Image.set_clim": [
-      "doc/tutorials/introductory/images.rst:355"
-    ],
-    "mpl_toolkits.axes_grid1.axes_size.Divider.new_locator": [
-      "doc/tutorials/toolkits/axes_grid.rst:409"
-    ],
     "matplotlib.patches.Rectangle.contains": [
       "doc/users/event_handling.rst:163"
     ],
@@ -4366,7 +4196,6 @@
       "doc/api/_as_gen/mpl_toolkits.axisartist.floating_axes.rst:31:<autosummary>:1"
     ],
     "Patch": [
-      "doc/tutorials/introductory/usage.rst:153",
       "lib/matplotlib/spines.py:docstring of matplotlib.spines.Spine.draw:2",
       "lib/matplotlib/table.py:docstring of matplotlib.table.Cell.draw:2",
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Patch3D.get_facecolor:2"
@@ -4616,9 +4445,6 @@
     "numpy.datetime64": [
       "doc/gallery/text_labels_and_annotations/date.rst:18"
     ],
-    "matplotlib.patch.PathPatch": [
-      "doc/tutorials/advanced/path_tutorial.rst:202"
-    ],
     "matplotlib.backend_bases.FigureCanvas": [
       "doc/tutorials/intermediate/artists.rst:18",
       "doc/tutorials/intermediate/artists.rst:20",
@@ -4631,35 +4457,6 @@
     "matplotlib.axes.Subplot": [
       "doc/tutorials/intermediate/artists.rst:34",
       "doc/tutorials/intermediate/artists.rst:57"
-    ],
-    "Axes": [
-      "doc/tutorials/introductory/usage.rst:120",
-      "doc/tutorials/introductory/usage.rst:135",
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "Locator": [
-      "doc/tutorials/introductory/usage.rst:141"
-    ],
-    "Formatter": [
-      "doc/tutorials/introductory/usage.rst:141"
-    ],
-    "Figure": [
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "Axis": [
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "Text": [
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "Line2D": [
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "collection": [
-      "doc/tutorials/introductory/usage.rst:153"
-    ],
-    "mpl_toolkits.axes_grid1.axes_size.Divider": [
-      "doc/tutorials/toolkits/axes_grid.rst:409"
     ],
     "matplotlib.patches.AxesImage": [
       "doc/users/event_handling.rst:414"
@@ -4807,16 +4604,16 @@
     ],
     "matplotlib.figure.Figure.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:171",
-      "doc/tutorials/intermediate/artists.rst:284"
+      "doc/tutorials/intermediate/artists.rst:172",
+      "doc/tutorials/intermediate/artists.rst:285"
     ],
     "matplotlib.axes.Axes.axesPatch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
     ],
     "matplotlib.axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:171",
-      "doc/tutorials/intermediate/artists.rst:382"
+      "doc/tutorials/intermediate/artists.rst:172",
+      "doc/tutorials/intermediate/artists.rst:384"
     ],
     "matplotlib.axes.Axes.axesFrame": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
@@ -4901,23 +4698,23 @@
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.RadioButtons.set_active:4"
     ],
     "matplotlib.axes.Axes.lines": [
-      "doc/tutorials/intermediate/artists.rst:398",
+      "doc/tutorials/intermediate/artists.rst:400",
       "doc/tutorials/intermediate/artists.rst:90"
     ],
     "matplotlib.figure.Figure.transFigure": [
-      "doc/tutorials/intermediate/artists.rst:333"
+      "doc/tutorials/intermediate/artists.rst:334"
     ],
     "matplotlib.axes.Axes.patches": [
-      "doc/tutorials/intermediate/artists.rst:421"
+      "doc/tutorials/intermediate/artists.rst:423"
     ],
     "matplotlib.axes.Axes.xaxis": [
-      "doc/tutorials/intermediate/artists.rst:520"
+      "doc/tutorials/intermediate/artists.rst:522"
     ],
     "matplotlib.axes.Axes.yaxis": [
-      "doc/tutorials/intermediate/artists.rst:520"
+      "doc/tutorials/intermediate/artists.rst:522"
     ],
     "matplotlib.axis.Axis.label": [
-      "doc/tutorials/intermediate/artists.rst:567"
+      "doc/tutorials/intermediate/artists.rst:569"
     ],
     "button": [
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:338"
@@ -5031,30 +4828,8 @@
     "matplotlib.get_cachedir": [
       "doc/faq/troubleshooting_faq.rst:52"
     ],
-    "colors.BoundaryNorm": [
-      "doc/tutorials/colors/colorbar_only.rst:65",
-      "doc/tutorials/colors/colormapnorms.rst:188"
-    ],
-    "colors.LogNorm": [
-      "doc/tutorials/colors/colormapnorms.rst:46"
-    ],
-    "colors.PowerNorm": [
-      "doc/tutorials/colors/colormapnorms.rst:144"
-    ],
     "matplotlib.pyplot.getp": [
-      "doc/tutorials/intermediate/artists.rst:219"
-    ],
-    "show": [
-      "doc/tutorials/introductory/usage.rst:690"
-    ],
-    "matplotlib.Axes.annotate": [
-      "doc/tutorials/text/annotations.rst:23"
-    ],
-    "zoomed_inset_axes": [
-      "doc/tutorials/toolkits/axes_grid.rst:359"
-    ],
-    "mark_inset": [
-      "doc/tutorials/toolkits/axes_grid.rst:359"
+      "doc/tutorials/intermediate/artists.rst:220"
     ],
     "contourf": [
       "doc/users/prev_whats_new/whats_new_1.3.rst:211"
@@ -5199,32 +4974,15 @@
     ],
     "matplotlib.tests.test_basic": [
       "doc/devel/testing.rst:99"
-    ],
-    "matplotlib": [
-      "doc/tutorials/introductory/usage.rst:591"
-    ],
-    "matplotlib.patch": [
-      "doc/tutorials/advanced/path_tutorial.rst:16"
-    ],
-    "pyplot": [
-      "doc/tutorials/introductory/lifecycle.rst:34"
-    ],
-    "pyplot.style": [
-      "doc/tutorials/introductory/lifecycle.rst:140"
-    ],
-    "pylab": [
-      "doc/tutorials/introductory/usage.rst:260"
-    ],
-    "mpl_toolkits/axes_grid/inset_locator": [
-      "doc/tutorials/toolkits/axes_grid.rst:359"
     ]
   },
   "std:envvar": {
     "QT_API": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:453"
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:453",
+      "doc/tutorials/introductory/usage.rst:592"
     ],
     "DISPLAY": [
-      "doc/tutorials/introductory/usage.rst:403"
+      "doc/tutorials/introductory/usage.rst:411"
     ],
     "CC": [
       "INSTALL.rst:93",

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -728,7 +728,6 @@
     ],
     "Figure": [
       "doc/devel/testing.rst:161",
-      "doc/faq/howto_faq.rst:647",
       "doc/users/prev_whats_new/whats_new_1.5.rst:22",
       "doc/users/prev_whats_new/whats_new_2.2.rst:70",
       "lib/matplotlib/backend_managers.py:docstring of matplotlib.backend_managers.ToolManager:21",
@@ -1407,8 +1406,9 @@
     "numpy.datetime64": [
       "doc/faq/howto_faq.rst:18",
       "doc/faq/howto_faq.rst:21",
+      "doc/faq/howto_faq.rst:30",
       "doc/gallery/recipes/common_date_problems.rst:34",
-      "doc/tutorials/text/text_intro.rst:581",
+      "doc/tutorials/text/text_intro.rst:580",
       "doc/users/prev_whats_new/whats_new_2.2.rst:155",
       "lib/matplotlib/dates.py:docstring of matplotlib.dates.date2num:8"
     ],
@@ -3199,12 +3199,6 @@
       "doc/devel/testing.rst:50",
       "doc/users/prev_whats_new/whats_new_2.1.0.rst:581"
     ],
-    "datetime64": [
-      "doc/faq/howto_faq.rst:30"
-    ],
-    "set_color": [
-      "doc/faq/howto_faq.rst:45"
-    ],
     "floating_axes.FloatingSubplot": [
       "doc/gallery/axisartist/demo_floating_axes.rst:20"
     ],
@@ -4004,12 +3998,6 @@
     "matplotlib.text.Text.__init__": [
       "doc/devel/contributing.rst:425",
       "doc/devel/contributing.rst:433"
-    ],
-    "Axes.tick_params": [
-      "doc/faq/howto_faq.rst:249"
-    ],
-    "Axis.set_tick_params": [
-      "doc/faq/howto_faq.rst:249"
     ],
     "matplotlib.patches.Rectangle.contains": [
       "doc/users/event_handling.rst:163"

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -4977,13 +4977,6 @@
     ]
   },
   "std:envvar": {
-    "QT_API": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:453",
-      "doc/tutorials/introductory/usage.rst:592"
-    ],
-    "DISPLAY": [
-      "doc/tutorials/introductory/usage.rst:411"
-    ],
     "CC": [
       "INSTALL.rst:93",
       "doc/users/prev_whats_new/whats_new_1.5.rst:737"

--- a/tutorials/advanced/path_tutorial.py
+++ b/tutorials/advanced/path_tutorial.py
@@ -5,7 +5,7 @@ Path Tutorial
 
 Defining paths in your Matplotlib visualization.
 
-The object underlying all of the :mod:`matplotlib.patch` objects is
+The object underlying all of the :mod:`matplotlib.patches` objects is
 the :class:`~matplotlib.path.Path`, which supports the standard set of
 moveto, lineto, curveto commands to draw simple and compound outlines
 consisting of line segments and splines.  The ``Path`` is instantiated
@@ -169,7 +169,7 @@ plt.show()
 #     verts[3::5, 1] = bottom
 #
 # All that remains is to create the path, attach it to a
-# :class:`~matplotlib.patch.PathPatch`, and add it to our axes::
+# :class:`~matplotlib.patches.PathPatch`, and add it to our axes::
 #
 #     barpath = path.Path(verts, codes)
 #     patch = patches.PathPatch(barpath, facecolor='green',

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -5,8 +5,8 @@ Transformations Tutorial
 
 Like any graphics packages, Matplotlib is built on top of a
 transformation framework to easily move between coordinate systems,
-the userland `data` coordinate system, the `axes` coordinate system,
-the `figure` coordinate system, and the `display` coordinate system.
+the userland *data* coordinate system, the *axes* coordinate system,
+the *figure* coordinate system, and the *display* coordinate system.
 In 95% of your plotting, you won't need to think about this, as it
 happens under the hood, but as you push the limits of custom figure
 generation, it helps to have an understanding of these objects so you
@@ -14,7 +14,7 @@ can reuse the existing transformations Matplotlib makes available to
 you, or create your own (see :mod:`matplotlib.transforms`).  The table
 below summarizes the some useful coordinate systems, the transformation
 object you should use to work in that coordinate system, and the
-description of that system. In the `Transformation Object` column,
+description of that system. In the ``Transformation Object`` column,
 ``ax`` is a :class:`~matplotlib.axes.Axes` instance, and ``fig`` is a
 :class:`~matplotlib.figure.Figure` instance.
 
@@ -52,23 +52,23 @@ description of that system. In the `Transformation Object` column,
 +----------------+-----------------------------+-----------------------------------+
 
 All of the transformation objects in the table above take inputs in
-their coordinate system, and transform the input to the ``display``
-coordinate system.  That is why the ``display`` coordinate system has
+their coordinate system, and transform the input to the *display*
+coordinate system.  That is why the *display* coordinate system has
 ``None`` for the ``Transformation Object`` column -- it already is in
-display coordinates.  The transformations also know how to invert
-themselves, to go from ``display`` back to the native coordinate system.
+*display* coordinates.  The transformations also know how to invert
+themselves, to go from *display* back to the native coordinate system.
 This is particularly useful when processing events from the user
 interface, which typically occur in display space, and you want to
-know where the mouse click or key-press occurred in your data
+know where the mouse click or key-press occurred in your *data*
 coordinate system.
 
-Note that specifying objects in ``display`` coordinates will change their
+Note that specifying objects in *display* coordinates will change their
 location if the ``dpi`` of the figure changes.  This can cause confusion when
 printing or changing screen resolution, because the object can change location
 and size.  Therefore it is most common
 for artists placed in an axes or figure to have their transform set to
 something *other* than the `~.transforms.IdentityTransform()`; the default when
-an artist is placed on an axes using `~.Axes.axes.add_artist` is for the
+an artist is placed on an axes using `~.axes.Axes.add_artist` is for the
 transform to be ``ax.transData``.
 
 .. _data-coords:
@@ -76,13 +76,12 @@ transform to be ``ax.transData``.
 Data coordinates
 ================
 
-Let's start with the most commonly used coordinate, the `data`
-coordinate system.  Whenever you add data to the axes, Matplotlib
-updates the datalimits, most commonly updated with the
-:meth:`~matplotlib.axes.Axes.set_xlim` and
-:meth:`~matplotlib.axes.Axes.set_ylim` methods.  For example, in the
-figure below, the data limits stretch from 0 to 10 on the x-axis, and
--1 to 1 on the y-axis.
+Let's start with the most commonly used coordinate, the *data* coordinate
+system.  Whenever you add data to the axes, Matplotlib updates the datalimits,
+most commonly updated with the :meth:`~matplotlib.axes.Axes.set_xlim` and
+:meth:`~matplotlib.axes.Axes.set_ylim` methods.  For example, in the figure
+below, the data limits stretch from 0 to 10 on the x-axis, and -1 to 1 on the
+y-axis.
 """
 
 import numpy as np
@@ -101,7 +100,7 @@ plt.show()
 
 ###############################################################################
 # You can use the ``ax.transData`` instance to transform from your
-# `data` to your `display` coordinate system, either a single point or a
+# *data* to your *display* coordinate system, either a single point or a
 # sequence of points as shown below:
 #
 # .. sourcecode:: ipython
@@ -118,7 +117,7 @@ plt.show()
 #            [ 132.435,  642.2  ]])
 #
 # You can use the :meth:`~matplotlib.transforms.Transform.inverted`
-# method to create a transform which will take you from display to data
+# method to create a transform which will take you from *display* to *data*
 # coordinates:
 #
 # .. sourcecode:: ipython
@@ -132,7 +131,7 @@ plt.show()
 #     Out[43]: array([ 5.,  0.])
 #
 # If your are typing along with this tutorial, the exact values of the
-# display coordinates may differ if you have a different window size or
+# *display* coordinates may differ if you have a different window size or
 # dpi setting.  Likewise, in the figure below, the display labeled
 # points are probably not the same as in the ipython session because the
 # documentation figure size defaults are different.
@@ -170,14 +169,14 @@ plt.show()
 # .. note::
 #
 #   If you run the source code in the example above in a GUI backend,
-#   you may also find that the two arrows for the `data` and `display`
+#   you may also find that the two arrows for the *data* and *display*
 #   annotations do not point to exactly the same point.  This is because
 #   the display point was computed before the figure was displayed, and
 #   the GUI backend may slightly resize the figure when it is created.
 #   The effect is more pronounced if you resize the figure yourself.
-#   This is one good reason why you rarely want to work in display
+#   This is one good reason why you rarely want to work in *display*
 #   space, but you can connect to the ``'on_draw'``
-#   :class:`~matplotlib.backend_bases.Event` to update figure
+#   :class:`~matplotlib.backend_bases.Event` to update *figure*
 #   coordinates on figure draws; see :ref:`event-handling-tutorial`.
 #
 # When you change the x or y limits of your axes, the data limits are
@@ -210,7 +209,7 @@ plt.show()
 # Axes coordinates
 # ================
 #
-# After the `data` coordinate system, `axes` is probably the second most
+# After the *data* coordinate system, *axes* is probably the second most
 # useful coordinate system.  Here the point (0, 0) is the bottom left of
 # your axes or subplot, (0.5, 0.5) is the center, and (1.0, 1.0) is the
 # top right.  You can also refer to points outside the range, so (-0.1,
@@ -230,16 +229,16 @@ for i, label in enumerate(('A', 'B', 'C', 'D')):
 plt.show()
 
 ###############################################################################
-# You can also make lines or patches in the axes coordinate system, but
+# You can also make lines or patches in the *axes* coordinate system, but
 # this is less useful in my experience than using ``ax.transAxes`` for
 # placing text.  Nonetheless, here is a silly example which plots some
-# random dots in `data` space, and overlays a semi-transparent
+# random dots in data space, and overlays a semi-transparent
 # :class:`~matplotlib.patches.Circle` centered in the middle of the axes
 # with a radius one quarter of the axes -- if your axes does not
 # preserve aspect ratio (see :meth:`~matplotlib.axes.Axes.set_aspect`),
 # this will look like an ellipse.  Use the pan/zoom tool to move around,
 # or manually change the data xlim and ylim, and you will see the data
-# move, but the circle will remain fixed because it is not in `data`
+# move, but the circle will remain fixed because it is not in *data*
 # coordinates and will always remain at the center of the axes.
 
 fig, ax = plt.subplots()
@@ -257,7 +256,7 @@ plt.show()
 # Blended transformations
 # =======================
 #
-# Drawing in `blended` coordinate spaces which mix `axes` with `data`
+# Drawing in *blended* coordinate spaces which mix *axes* with *data*
 # coordinates is extremely useful, for example to create a horizontal
 # span which highlights some region of the y-data but spans across the
 # x-axis regardless of the data limits, pan or zoom level, etc.  In fact
@@ -300,7 +299,7 @@ plt.show()
 ###############################################################################
 # .. note::
 #
-#   The blended transformations where x is in data coords and y in axes
+#   The blended transformations where x is in *data* coords and y in *axes*
 #   coordinates is so useful that we have helper methods to return the
 #   versions Matplotlib uses internally for drawing ticks, ticklabels, etc.
 #   The methods are :meth:`matplotlib.axes.Axes.get_xaxis_transform` and
@@ -357,14 +356,14 @@ plt.show()
 #
 #   trans = ScaledTranslation(xt, yt, scale_trans)
 #
-# where `xt` and `yt` are the translation offsets, and `scale_trans` is
-# a transformation which scales `xt` and `yt` at transformation time
+# where *xt* and *yt* are the translation offsets, and *scale_trans* is
+# a transformation which scales *xt* and *yt* at transformation time
 # before applying the offsets.
 #
 # Note the use of the plus operator on the transforms below.
 # This code says: first apply the scale transformation ``fig.dpi_scale_trans``
 # to make the ellipse the proper size, but still centered at (0, 0),
-# and then translate the data to `xdata[0]` and `ydata[0]` in data space.
+# and then translate the data to ``xdata[0]`` and ``ydata[0]`` in data space.
 #
 # In interactive use, the ellipse stays the same size even if the
 # axes limits are changed via zoom.
@@ -392,7 +391,7 @@ plt.show()
 #   in data space to the correct spot.
 #   If we had done the ``ScaledTranslation`` first, then
 #   ``xdata[0]`` and ``ydata[0]`` would
-#   first be transformed to ``display`` coordinates (``[ 358.4  475.2]`` on
+#   first be transformed to *display* coordinates (``[ 358.4  475.2]`` on
 #   a 200-dpi monitor) and then those coordinates
 #   would be scaled by ``fig.dpi_scale_trans`` pushing the center of
 #   the ellipse well off the screen (i.e. ``[ 71680.  95040.]``).
@@ -406,7 +405,7 @@ plt.show()
 # a new transformation that is
 # offset from another transformation, e.g., to place one object shifted a
 # bit relative to another object.  Typically you want the shift to be in
-# some physical dimension, like points or inches rather than in data
+# some physical dimension, like points or inches rather than in *data*
 # coordinates, so that the shift effect is constant at different zoom
 # levels and dpi settings.
 #
@@ -418,8 +417,8 @@ plt.show()
 # Here we apply the transforms in the *opposite* order to the use of
 # :class:`~matplotlib.transforms.ScaledTranslation` above. The plot is
 # first made in data units (``ax.transData``) and then shifted by
-# ``dx`` and ``dy`` points using `fig.dpi_scale_trans`.  (In typography,
-# a`point <https://en.wikipedia.org/wiki/Point_%28typography%29>`_ is
+# ``dx`` and ``dy`` points using ``fig.dpi_scale_trans``.  (In typography,
+# a `point <https://en.wikipedia.org/wiki/Point_%28typography%29>`_ is
 # 1/72 inches, and by specifying your offsets in points, your figure
 # will look the same regardless of the dpi resolution it is saved in.)
 
@@ -464,7 +463,7 @@ plt.show()
 #
 # The ``ax.transData`` transform we have been working with in this
 # tutorial is a composite of three different transformations that
-# comprise the transformation pipeline from `data` -> `display`
+# comprise the transformation pipeline from *data* -> *display*
 # coordinates.  Michael Droettboom implemented the transformations
 # framework, taking care to provide a clean API that segregated the
 # nonlinear projections and scales that happen in polar and logarithmic
@@ -485,11 +484,11 @@ plt.show()
 #
 # We've been introduced to the ``transAxes`` instance above in
 # :ref:`axes-coords`, which maps the (0, 0), (1, 1) corners of the
-# axes or subplot bounding box to `display` space, so let's look at
+# axes or subplot bounding box to *display* space, so let's look at
 # these other two pieces.
 #
 # ``self.transLimits`` is the transformation that takes you from
-# ``data`` to ``axes`` coordinates; i.e., it maps your view xlim and ylim
+# *data* to *axes* coordinates; i.e., it maps your view xlim and ylim
 # to the unit space of the axes (and ``transAxes`` then takes that unit
 # space to display space).  We can see this in action here
 #
@@ -516,7 +515,7 @@ plt.show()
 #     Out[87]: array([ 0.5,  0.5])
 #
 # and we can use this same inverted transformation to go from the unit
-# `axes` coordinates back to `data` coordinates.
+# *axes* coordinates back to *data* coordinates.
 #
 # .. sourcecode:: ipython
 #

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -45,7 +45,7 @@ fig.show()
 #
 # The second example illustrates the use of a
 # :class:`~matplotlib.colors.ListedColormap` which generates a colormap from a
-# set of listed colors, :func:`colors.BoundaryNorm` which generates a colormap
+# set of listed colors, `.colors.BoundaryNorm` which generates a colormap
 # index based on discrete intervals and extended ends to show the "over" and
 # "under" value colors. Over and under are used to display data outside of the
 # normalized [0, 1] range. Here we pass colors as gray shades as a string

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -49,7 +49,7 @@ print(viridis(0.56))
 # ListedColormap
 # --------------
 #
-# `ListedColormap` s store their color values in a ``.colors`` attribute.
+# `.ListedColormap` s store their color values in a ``.colors`` attribute.
 # The list of colors that comprise the colormap can be directly accessed using
 # the ``colors`` property,
 # or it can be accessed indirectly by calling  ``viridis`` with an array
@@ -69,7 +69,7 @@ print('viridis(np.linspace(0, 1, 12))', viridis(np.linspace(0, 1, 12)))
 ##############################################################################
 # LinearSegmentedColormap
 # -----------------------
-# `LinearSegmentedColormap` s do not have a ``.colors`` attribute.
+# `.LinearSegmentedColormap` s do not have a ``.colors`` attribute.
 # However, one may still call the colormap with an integer array, or with a
 # float array between 0 and 1.
 
@@ -238,7 +238,7 @@ plot_linearmap(cdict)
 #
 # The above described is a very versatile approach, but admitedly a bit
 # cumbersome to implement. For some basic cases, the use of
-# `LinearSegmentedColormap.from_list` may be easier. This creates a segmented
+# `.LinearSegmentedColormap.from_list` may be easier. This creates a segmented
 # colormap with equal spacings from a supplied list of colors.
 
 colors = ["darkorange", "gold", "lawngreen", "lightseagreen"]

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -35,13 +35,12 @@ colormaps in a non-linear fashion.
 Logarithmic
 -----------
 
-One of the most common transformations is to plot data by taking
-its logarithm (to the base-10).  This transformation is useful to
-display changes across disparate scales.  Using :func:`colors.LogNorm`
-normalizes the data via :math:`log_{10}`.  In the example below,
-there are two bumps, one much smaller than the other. Using
-:func:`colors.LogNorm`, the shape and location of each bump can clearly
-be seen:
+One of the most common transformations is to plot data by taking its logarithm
+(to the base-10).  This transformation is useful to display changes across
+disparate scales.  Using `.colors.LogNorm` normalizes the data via
+:math:`log_{10}`.  In the example below, there are two bumps, one much smaller
+than the other. Using `.colors.LogNorm`, the shape and location of each bump
+can clearly be seen:
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -76,7 +75,7 @@ plt.show()
 # Similarly, it sometimes happens that there is data that is positive
 # and negative, but we would still like a logarithmic scaling applied to
 # both.  In this case, the negative numbers are also scaled
-# logarithmically, and mapped to smaller numbers; e.g., if `vmin=-vmax`,
+# logarithmically, and mapped to smaller numbers; e.g., if ``vmin=-vmax``,
 # then they the negative numbers are mapped from 0 to 0.5 and the
 # positive from 0.5 to 1.
 #
@@ -112,7 +111,7 @@ plt.show()
 #
 # Sometimes it is useful to remap the colors onto a power-law
 # relationship (i.e. :math:`y=x^{\gamma}`, where :math:`\gamma` is the
-# power).  For this we use the :func:`colors.PowerNorm`.  It takes as an
+# power).  For this we use the `.colors.PowerNorm`.  It takes as an
 # argument *gamma* (*gamma* == 1.0 will just yield the default linear
 # normalization):
 #
@@ -142,11 +141,10 @@ plt.show()
 # Discrete bounds
 # ---------------
 #
-# Another normaization that comes with Matplotlib is
-# :func:`colors.BoundaryNorm`.  In addition to *vmin* and *vmax*, this
-# takes as arguments boundaries between which data is to be mapped.  The
-# colors are then linearly distributed between these "bounds".  For
-# instance:
+# Another normalization that comes with Matplotlib is `.colors.BoundaryNorm`.
+# In addition to *vmin* and *vmax*, this takes as arguments boundaries between
+# which data is to be mapped.  The colors are then linearly distributed between
+# these "bounds".  For instance:
 #
 # .. ipython::
 #

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -21,7 +21,7 @@ Matplotlib recognizes the following formats to specify a color:
   color cycle): ``{'tab:blue', 'tab:orange', 'tab:green', 'tab:red',
   'tab:purple', 'tab:brown', 'tab:pink', 'tab:gray', 'tab:olive', 'tab:cyan'}``
   (case-insensitive);
-* a "CN" color spec, i.e. `'C'` followed by a number, which is an index into
+* a "CN" color spec, i.e. ``'C'`` followed by a number, which is an index into
   the default property cycle (``matplotlib.rcParams['axes.prop_cycle']``); the
   indexing is intended to occur at rendering time, and defaults to black if the
   cycle does not include color.

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -335,7 +335,7 @@ fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
 # ========
 #
 # There are five :ref:`rcParams<matplotlib-rcparams>` that can be set,
-# either in a script or in the `matplotlibrc` file.
+# either in a script or in the :file:`matplotlibrc` file.
 # They all have the prefix ``figure.constrained_layout``:
 #
 # - ``use``: Whether to use constrained_layout. Default is False
@@ -504,8 +504,8 @@ ax2 = fig.add_axes(bb_ax2)
 # ----------------------
 #
 # ``constrained_layout`` will not work on subplots
-# created via the `subplot` command.  The reason is that each of these
-# commands creates a separate `GridSpec` instance and ``constrained_layout``
+# created via the `.pyplot.subplot` command.  The reason is that each of these
+# commands creates a separate `.GridSpec` instance and ``constrained_layout``
 # uses (nested) gridspecs to carry out the layout.  So the following fails
 # to yield a nice layout:
 

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -9,7 +9,7 @@ How to create grid-shaped combinations of axes.
         Perhaps the primary function used to create figures and axes.
         It's also similar to :func:`.matplotlib.pyplot.subplot`,
         but creates and places all axes on the figure at once.  See also
-        `matplotlib.Figure.subplots`.
+        `matplotlib.figure.Figure.subplots`.
 
     :class:`~matplotlib.gridspec.GridSpec`
         Specifies the geometry of the grid that a subplot will be

--- a/tutorials/intermediate/imshow_extent.py
+++ b/tutorials/intermediate/imshow_extent.py
@@ -172,7 +172,7 @@ def generate_imshow_demo_grid(extents, xlim=None, ylim=None):
 # Default extent
 # --------------
 #
-# First, let's have a look at the default `extent=None`
+# First, let's have a look at the default ``extent=None``
 
 generate_imshow_demo_grid(extents=[None])
 
@@ -240,8 +240,8 @@ set_extent_None_text(columns['lower'][0])
 # Explicit extent and axes limits
 # -------------------------------
 #
-# If we fix the axes limits by explicitly setting `set_xlim` / `set_ylim`, we
-# force a certain size and orientation of the axes.
+# If we fix the axes limits by explicitly setting `~.axes.Axes.set_xlim` /
+# `~.axes.Axes.set_ylim`, we force a certain size and orientation of the axes.
 # This can decouple the 'left-right' and 'top-bottom' sense of the image from
 # the orientation on the screen.
 #

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -130,11 +130,11 @@ plt.plot(data)
 # The :file:`matplotlibrc` file
 # -----------------------------
 #
-# matplotlib uses :file:`matplotlibrc` configuration files to customize all kinds
-# of properties, which we call `rc settings` or `rc parameters`. You can control
-# the defaults of almost every property in matplotlib: figure size and dpi, line
-# width, color and style, axes, axis and grid properties, text and font
-# properties and so on. matplotlib looks for :file:`matplotlibrc` in four
+# Matplotlib uses :file:`matplotlibrc` configuration files to customize all
+# kinds of properties, which we call 'rc settings' or 'rc parameters'. You can
+# control the defaults of almost every property in Matplotlib: figure size and
+# DPI, line width, color and style, axes, axis and grid properties, text and
+# font properties and so on. Matplotlib looks for :file:`matplotlibrc` in four
 # locations, in the following order:
 #
 # 1. :file:`matplotlibrc` in the current working directory, usually used for
@@ -144,8 +144,9 @@ plt.plot(data)
 #
 # 3. It next looks in a user-specific place, depending on your platform:
 #
-#    - On Linux and FreeBSD, it looks in :file:`.config/matplotlib/matplotlibrc`
-#      (or `$XDG_CONFIG_HOME/matplotlib/matplotlibrc`) if you've customized
+#    - On Linux and FreeBSD, it looks in
+#      :file:`.config/matplotlib/matplotlibrc` (or
+#      :file:`$XDG_CONFIG_HOME/matplotlib/matplotlibrc`) if you've customized
 #      your environment.
 #
 #    - On other platforms, it looks in :file:`.matplotlib/matplotlibrc`.

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -149,7 +149,7 @@ plt.imshow(lum_img, cmap="hot")
 
 ###############################################################################
 # Note that you can also change colormaps on existing plot objects using the
-# :meth:`~matplotlib.image.Image.set_cmap` method:
+# :meth:`~matplotlib.cm.ScalarMappable.set_cmap` method:
 
 imgplot = plt.imshow(lum_img)
 imgplot.set_cmap('nipy_spectral')
@@ -207,7 +207,7 @@ plt.hist(lum_img.ravel(), bins=256, range=(0.0, 1.0), fc='k', ec='k')
 # image).  Let's adjust the upper limit, so that we effectively "zoom in
 # on" part of the histogram.  We do this by passing the clim argument to
 # imshow.  You could also do this by calling the
-# :meth:`~matplotlib.image.Image.set_clim` method of the image plot
+# :meth:`~matplotlib.cm.ScalarMappable.set_clim` method of the image plot
 # object, but make sure that you do so in the same cell as your plot
 # command when working with the Jupyter Notebook - it will not change
 # plots from earlier cells.

--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -24,7 +24,7 @@ interface. In this case, we utilize an instance of :class:`axes.Axes`
 in order to render visualizations on an instance of :class:`figure.Figure`.
 
 The second is based on MATLAB and uses a state-based interface. This is
-encapsulated in the :mod:`pyplot` module. See the :doc:`pyplot tutorials
+encapsulated in the :mod:`.pyplot` module. See the :doc:`pyplot tutorials
 </tutorials/introductory/pyplot>` for a more in-depth look at the pyplot
 interface.
 
@@ -99,7 +99,7 @@ ax.barh(group_names, group_data)
 #
 # There are many styles available in Matplotlib in order to let you tailor
 # your visualization to your needs. To see a list of styles, we can use
-# :mod:`pyplot.style`.
+# :mod:`.style`.
 
 print(plt.style.available)
 

--- a/tutorials/introductory/sample_plots.py
+++ b/tutorials/introductory/sample_plots.py
@@ -118,7 +118,7 @@ including surface, wireframe, scatter, and bar charts.
    Surface3d
 
 Thanks to John Porter, Jonathon Taylor, Reinier Heeres, and Ben Root for
-the `mplot3d` toolkit. This toolkit is included with all standard Matplotlib
+the `.mplot3d` toolkit. This toolkit is included with all standard Matplotlib
 installs.
 
 .. _screenshots_ellipse_demo:
@@ -406,7 +406,7 @@ XKCD-style sketch plots
 =======================
 
 Just for fun, Matplotlib supports plotting in the style of `xkcd
-<http://www.xkcd.com/>`.
+<https://www.xkcd.com/>`_.
 
 .. figure:: ../../gallery/showcase/images/sphx_glr_xkcd_001.png
    :target: ../../gallery/showcase/xkcd.html

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -85,15 +85,13 @@ plt.plot([1, 2, 3, 4], [1, 4, 2, 3])  # Matplotlib plot.
 # Axes contains two (or three in the case of 3D)
 # :class:`~matplotlib.axis.Axis` objects (be aware of the difference
 # between **Axes** and **Axis**) which take care of the data limits (the
-# data limits can also be controlled via the
-# :meth:`~matplotlib.axes.Axes.set_xlim` and
-# :meth:`~matplotlib.axes.Axes.set_ylim` :class:`Axes` methods).  Each
-# :class:`Axes` has a title (set via
-# :meth:`~matplotlib.axes.Axes.set_title`), an x-label (set via
+# data limits can also be controlled via the :meth:`.axes.Axes.set_xlim` and
+# :meth:`.axes.Axes.set_ylim` methods).  Each :class:`~.axes.Axes` has a title
+# (set via :meth:`~matplotlib.axes.Axes.set_title`), an x-label (set via
 # :meth:`~matplotlib.axes.Axes.set_xlabel`), and a y-label set via
 # :meth:`~matplotlib.axes.Axes.set_ylabel`).
 #
-# The :class:`Axes` class and its member functions are the primary entry
+# The :class:`~.axes.Axes` class and its member functions are the primary entry
 # point to working with the OO interface.
 #
 # :class:`~matplotlib.axis.Axis`
@@ -101,40 +99,38 @@ plt.plot([1, 2, 3, 4], [1, 4, 2, 3])  # Matplotlib plot.
 #
 # These are the number-line-like objects. They take
 # care of setting the graph limits and generating the ticks (the marks
-# on the axis) and ticklabels (strings labeling the ticks).  The
-# location of the ticks is determined by a
-# :class:`~matplotlib.ticker.Locator` object and the ticklabel strings
-# are formatted by a :class:`~matplotlib.ticker.Formatter`.  The
-# combination of the correct :class:`Locator` and :class:`Formatter` gives
-# very fine control over the tick locations and labels.
+# on the axis) and ticklabels (strings labeling the ticks).  The location of
+# the ticks is determined by a `~matplotlib.ticker.Locator` object and the
+# ticklabel strings are formatted by a `~matplotlib.ticker.Formatter`.  The
+# combination of the correct `.Locator` and `.Formatter` gives very fine
+# control over the tick locations and labels.
 #
 # :class:`~matplotlib.artist.Artist`
 # ----------------------------------
 #
 # Basically everything you can see on the figure is an artist (even the
-# :class:`Figure`, :class:`Axes`, and :class:`Axis` objects).  This
-# includes :class:`Text` objects, :class:`Line2D` objects,
-# :class:`collection` objects, :class:`Patch` objects ... (you get the
-# idea).  When the figure is rendered, all of the artists are drawn to
-# the **canvas**.  Most Artists are tied to an Axes; such an Artist
-# cannot be shared by multiple Axes, or moved from one to another.
+# `.Figure`, `Axes <.axes.Axes>`, and `~.axis.Axis` objects).  This includes
+# `.Text` objects, `.Line2D` objects, :mod:`.collections` objects, `.Patch`
+# objects ... (you get the idea).  When the figure is rendered, all of the
+# artists are drawn to the **canvas**.  Most Artists are tied to an Axes; such
+# an Artist cannot be shared by multiple Axes, or moved from one to another.
 #
 # .. _input_types:
 #
 # Types of inputs to plotting functions
 # =====================================
 #
-# All of plotting functions expect `np.array` or `np.ma.masked_array` as
+# All of plotting functions expect `numpy.array` or `numpy.ma.masked_array` as
 # input.  Classes that are 'array-like' such as `pandas` data objects
-# and `np.matrix` may or may not work as intended.  It is best to
-# convert these to `np.array` objects prior to plotting.
+# and `numpy.matrix` may or may not work as intended.  It is best to
+# convert these to `numpy.array` objects prior to plotting.
 #
 # For example, to convert a `pandas.DataFrame` ::
 #
 #   a = pandas.DataFrame(np.random.rand(4,5), columns = list('abcde'))
 #   a_asarray = a.values
 #
-# and to convert a `np.matrix` ::
+# and to convert a `numpy.matrix` ::
 #
 #   b = np.matrix([[1, 2], [3, 4]])
 #   b_asarray = np.asarray(b)
@@ -195,7 +191,7 @@ plt.legend()
 # .. note::
 #
 #    In older examples, you may find examples that instead used the so-called
-#    :mod:`pylab` interface, via ``from pylab import *``. This star-import
+#    ``pylab`` interface, via ``from pylab import *``. This star-import
 #    imports everything both from pyplot and from :mod:`numpy`, so that one
 #    could do ::
 #
@@ -483,18 +479,17 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # GTK and Cairo
 # ^^^^^^^^^^^^^
 #
-# `GTK3` backends (*both* `GTK3Agg` and `GTK3Cairo`) depend on Cairo
+# ``GTK3`` backends (*both* ``GTK3Agg`` and ``GTK3Cairo``) depend on Cairo
 # (pycairo>=1.11.0 or cairocffi).
 #
 # How do I select PyQt4 or PySide?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# The `QT_API` environment variable can be set to either `pyqt` or `pyside`
-# to use `PyQt4` or `PySide`, respectively.
+# The :envvar:`QT_API` environment variable can be set to either ``pyqt`` or
+# ``pyside`` to use ``PyQt4`` or ``PySide``, respectively.
 #
-# Since the default value for the bindings to be used is `PyQt4`,
-# :mod:`matplotlib` first tries to import it, if the import fails, it tries to
-# import `PySide`.
+# Since the default value for the bindings to be used is ``PyQt4``, Matplotlib
+# first tries to import it, if the import fails, it tries to import ``PySide``.
 #
 # Using non-builtin backends
 # --------------------------
@@ -567,7 +562,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #     ax = plt.gca()
 #     ax.plot([3.1, 2.2])
 #
-# If you are using certain backends (like `macosx`), or an older version
+# If you are using certain backends (like ``macosx``), or an older version
 # of matplotlib, you may not see the new line added to the plot immediately.
 # In this case, you need to explicitly call :func:`~matplotlib.pyplot.draw`
 # in order to update the plot::
@@ -592,22 +587,22 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #     plt.show()
 #
 # Now you see the plot, but your terminal command line is
-# unresponsive; the :func:`show()` command *blocks* the input
+# unresponsive; the :func:`.pyplot.show()` command *blocks* the input
 # of additional commands until you manually kill the plot
 # window.
 #
 # What good is this--being forced to use a blocking function?
 # Suppose you need a script that plots the contents of a file
 # to the screen.  You want to look at that plot, and then end
-# the script.  Without some blocking command such as show(), the
+# the script.  Without some blocking command such as ``show()``, the
 # script would flash up the plot and then end immediately,
 # leaving nothing on the screen.
 #
 # In addition, non-interactive mode delays all drawing until
-# show() is called; this is more efficient than redrawing
+# ``show()`` is called; this is more efficient than redrawing
 # the plot each time a line in the script adds a new feature.
 #
-# Prior to version 1.0, show() generally could not be called
+# Prior to version 1.0, ``show()`` generally could not be called
 # more than once in a single script (although sometimes one
 # could get away with it); for version 1.0.1 and above, this
 # restriction is lifted, so one can write a script like this::
@@ -774,7 +769,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # -------
 #
 # The default legend behavior for axes attempts to find the location
-# that covers the fewest data points (`loc='best'`). This can be a
+# that covers the fewest data points (``loc='best'``). This can be a
 # very expensive computation if there are lots of data points. In
 # this case, you may want to provide a specific location.
 #

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -482,6 +482,8 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # ``GTK3`` backends (*both* ``GTK3Agg`` and ``GTK3Cairo``) depend on Cairo
 # (pycairo>=1.11.0 or cairocffi).
 #
+# .. _QT_API-usage:
+#
 # How do I select PyQt4 or PySide?
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -18,7 +18,7 @@ annotate some feature of the plot, and the
 :func:`~matplotlib.axes.Axes.annotate` method provides helper functionality
 to make annotations easy.  In an annotation, there are two points to
 consider: the location being annotated represented by the argument
-``xy`` and the location of the text ``xytext``.  Both of these
+*xy* and the location of the text *xytext*.  Both of these
 arguments are ``(x, y)`` tuples.
 
 .. figure:: ../../gallery/pyplots/images/sphx_glr_annotation_basic_001.png
@@ -28,11 +28,11 @@ arguments are ``(x, y)`` tuples.
 
    Annotation Basic
 
-In this example, both the ``xy`` (arrow tip) and ``xytext`` locations
+In this example, both the *xy* (arrow tip) and *xytext* locations
 (text location) are in data coordinates.  There are a variety of other
 coordinate systems one can choose -- you can specify the coordinate
-system of ``xy`` and ``xytext`` with one of the following strings for
-``xycoords`` and ``textcoords`` (default is 'data')
+system of *xy* and *xytext* with one of the following strings for
+*xycoords* and *textcoords* (default is 'data')
 
 ==================  ========================================================
 argument            coordinate system
@@ -60,11 +60,11 @@ bottom-left of the figure or axes.
 
 Optionally, you can enable drawing of an arrow from the text to the annotated
 point by giving a dictionary of arrow properties in the optional keyword
-argument ``arrowprops``.
+argument *arrowprops*.
 
 
 ==================== =====================================================
-``arrowprops`` key   description
+*arrowprops* key     description
 ==================== =====================================================
 width                the width of the arrow in points
 frac                 the fraction of the arrow length occupied by the head
@@ -77,12 +77,12 @@ shrink               move the tip and base some percent away from
 ==================== =====================================================
 
 
-In the example below, the ``xy`` point is in native coordinates
-(``xycoords`` defaults to 'data').  For a polar axes, this is in
+In the example below, the *xy* point is in native coordinates
+(*xycoords* defaults to 'data').  For a polar axes, this is in
 (theta, radius) space.  The text in this example is placed in the
 fractional figure coordinate system. :class:`matplotlib.text.Text`
-keyword args like ``horizontalalignment``, ``verticalalignment`` and
-``fontsize`` are passed from `~matplotlib.axes.Axes.annotate` to the
+keyword arguments like *horizontalalignment*, *verticalalignment* and
+*fontsize* are passed from `~matplotlib.axes.Axes.annotate` to the
 ``Text`` instance.
 
 .. figure:: ../../gallery/pyplots/images/sphx_glr_annotation_polar_001.png
@@ -120,7 +120,7 @@ Let's start with a simple example.
 
 
 The :func:`~matplotlib.pyplot.text` function in the pyplot module (or
-`~.axes.Axes.text` method of the Axes class) takes bbox keyword argument, and
+`~.axes.Axes.text` method of the Axes class) takes *bbox* keyword argument, and
 when given, a box around the text is drawn. ::
 
     bbox_props = dict(boxstyle="rarrow,pad=0.3", fc="cyan", ec="b", lw=2)
@@ -184,14 +184,14 @@ connecting two points on the plot. ::
                 xytext=(x2, y2), textcoords='offset points',
                 )
 
-This annotates a point at ``xy`` in the given coordinate (``xycoords``)
-with the text at ``xytext`` given in ``textcoords``. Often, the
+This annotates a point at *xy* in the given coordinate (*xycoords*)
+with the text at *xytext* given in *textcoords*. Often, the
 annotated point is specified in the *data* coordinate and the annotating
 text in *offset points*.
 See :func:`~matplotlib.pyplot.annotate` for available coordinate systems.
 
-An arrow connecting two points (xy & xytext) can be optionally drawn by
-specifying the ``arrowprops`` argument. To draw only an arrow, use
+An arrow connecting two points (*xy* & *xytext*) can be optionally drawn by
+specifying the *arrowprops* argument. To draw only an arrow, use
 empty string as the first argument. ::
 
     ax.annotate("",
@@ -444,8 +444,8 @@ more control, it supports a few other options.
                    xytext=(0.5, 0.5), textcoords=ax2.transData,
                    arrowprops=dict(arrowstyle="->"))
 
- 2. :class:`~matplotlib.artist.Artist` instance. The xy value (or
-    xytext) is interpreted as a fractional coordinate of the bbox
+ 2. :class:`~matplotlib.artist.Artist` instance. The *xy* value (or
+    *xytext*) is interpreted as a fractional coordinate of the bbox
     (return value of *get_window_extent*) of the artist. ::
 
       an1 = ax.annotate("Test 1", xy=(0.5, 0.5), xycoords="data",
@@ -526,8 +526,8 @@ you want to connect points in different axes. ::
                         axesA=ax1, axesB=ax2)
   ax2.add_artist(con)
 
-The above code connects point xy in the data coordinates of ``ax1`` to
-point xy in the data coordinates of ``ax2``. Here is a simple example.
+The above code connects point *xy* in the data coordinates of ``ax1`` to
+point *xy* in the data coordinates of ``ax2``. Here is a simple example.
 
 .. figure:: ../../gallery/userdemo/images/sphx_glr_connect_simple01_001.png
    :target: ../../gallery/userdemo/connect_simple01.html

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -15,7 +15,7 @@ Basic annotation
 The uses of the basic :func:`~matplotlib.pyplot.text` will place text
 at an arbitrary position on the Axes.  A common use case of text is to
 annotate some feature of the plot, and the
-:func:`~matplotlib.Axes.annotate` method provides helper functionality
+:func:`~matplotlib.axes.Axes.annotate` method provides helper functionality
 to make annotations easy.  In an annotation, there are two points to
 consider: the location being annotated represented by the argument
 ``xy`` and the location of the text ``xytext``.  Both of these
@@ -82,7 +82,7 @@ In the example below, the ``xy`` point is in native coordinates
 (theta, radius) space.  The text in this example is placed in the
 fractional figure coordinate system. :class:`matplotlib.text.Text`
 keyword args like ``horizontalalignment``, ``verticalalignment`` and
-``fontsize`` are passed from `~matplotlib.Axes.annotate` to the
+``fontsize`` are passed from `~matplotlib.axes.Axes.annotate` to the
 ``Text`` instance.
 
 .. figure:: ../../gallery/pyplots/images/sphx_glr_annotation_polar_001.png
@@ -120,8 +120,8 @@ Let's start with a simple example.
 
 
 The :func:`~matplotlib.pyplot.text` function in the pyplot module (or
-text method of the Axes class) takes bbox keyword argument, and when
-given, a box around the text is drawn. ::
+`~.axes.Axes.text` method of the Axes class) takes bbox keyword argument, and
+when given, a box around the text is drawn. ::
 
     bbox_props = dict(boxstyle="rarrow,pad=0.3", fc="cyan", ec="b", lw=2)
     t = ax.text(0, 0, "Direction", ha="center", va="center", rotation=45,
@@ -135,8 +135,8 @@ The patch object associated with the text can be accessed by::
 
 The return value is an instance of FancyBboxPatch and the patch
 properties like facecolor, edgewidth, etc. can be accessed and
-modified as usual. To change the shape of the box, use the *set_boxstyle*
-method. ::
+modified as usual. To change the shape of the box, use the
+`~.FancyBboxPatch.set_boxstyle` method. ::
 
   bb.set_boxstyle("rarrow", pad=0.6)
 
@@ -176,7 +176,7 @@ Annotating with Arrow
 ~~~~~~~~~~~~~~~~~~~~~
 
 The :func:`~matplotlib.pyplot.annotate` function in the pyplot module
-(or annotate method of the Axes class) is used to draw an arrow
+(or `~.axes.Axes.annotate` method of the Axes class) is used to draw an arrow
 connecting two points on the plot. ::
 
     ax.annotate("Annotation",

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -16,7 +16,7 @@ or PDF, what you see on the screen is what you get in the hardcopy.
 produces very nice, antialiased fonts, that look good even at small
 raster sizes.  Matplotlib includes its own
 :mod:`matplotlib.font_manager` (thanks to Paul Barrett), which
-implements a cross platform, `W3C <http://www.w3.org/>`
+implements a cross platform, `W3C <https://www.w3.org/>`_
 compliant font finding algorithm.
 
 The user has a great deal of control over text properties (font size, font
@@ -233,19 +233,18 @@ plt.show()
 # Terminology
 # ~~~~~~~~~~~
 #
-# *Axes* have a `matplotlib.axis` object for the ``ax.xaxis`` and ``ax.yaxis``
-# that contain the information about how the labels in the axis are laid out.
+# *Axes* have an `matplotlib.axis.Axis` object for the ``ax.xaxis`` and
+# ``ax.yaxis`` that contain the information about how the labels in the axis
+# are laid out.
 #
 # The axis API is explained in detail in the documentation to
 # `~matplotlib.axis`.
 #
 # An Axis object has major and minor ticks.  The Axis has
-# `matplotlib.xaxis.set_major_locator` and
-# `matplotlib.xaxis.set_minor_locator` methods that use the data being plotted
-# to determine
-# the location of major and minor ticks.  There are also
-# `matplotlib.xaxis.set_major_formatter` and
-# `matplotlib.xaxis.set_minor_formatter` methods that format the tick labels.
+# `.Axis.set_major_locator` and `.Axis.set_minor_locator` methods that use the
+# data being plotted to determine the location of major and minor ticks.  There
+# are also `.Axis.set_major_formatter` and `.Axis.set_minor_formatter` methods
+# that format the tick labels.
 #
 # Simple ticks
 # ~~~~~~~~~~~~
@@ -396,11 +395,11 @@ ax.tick_params(axis='x', rotation=70)
 plt.show()
 
 ##############################################################################
-# We can pass a format
-# to `matplotlib.dates.DateFormatter`.  Also note that the 29th and the
-# next month are very close together.  We can fix this by using the
-# `dates.DayLocator` class, which allows us to specify a list of days of the
-# month to use. Similar formatters are listed in the `matplotlib.dates` module.
+# We can pass a format to `matplotlib.dates.DateFormatter`.  Also note that the
+# 29th and the next month are very close together.  We can fix this by using
+# the `.dates.DayLocator` class, which allows us to specify a list of days of
+# the month to use. Similar formatters are listed in the `matplotlib.dates`
+# module.
 
 import matplotlib.dates as mdates
 

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -51,7 +51,8 @@ matplotlibrc use::
   #rc('font',**{'family':'serif','serif':['Palatino']})
   rc('text', usetex=True)
 
-Here is the standard example, `tex_demo.py`:
+Here is the standard example,
+:file:`/gallery/text_labels_and_annotations/tex_demo`:
 
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_tex_demo_001.png
    :target: ../../gallery/text_labels_and_annotations/tex_demo.html
@@ -61,8 +62,7 @@ Here is the standard example, `tex_demo.py`:
    TeX Demo
 
 Note that display math mode (``$$ e=mc^2 $$``) is not supported, but adding the
-command ``\displaystyle``, as in `tex_demo.py`, will produce the same
-results.
+command ``\displaystyle``, as in the above demo, will produce the same results.
 
 .. note::
    Certain characters require special escaping in TeX, such as::
@@ -78,7 +78,8 @@ usetex with unicode
 ===================
 
 It is also possible to use unicode strings with the LaTeX text manager, here is
-an example taken from `tex_demo.py`. The axis labels include Unicode text:
+an example taken from :file:`/gallery/text_labels_and_annotations/tex_demo`.
+The axis labels include Unicode text:
 
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_tex_demo_001.png
    :target: ../../gallery/text_labels_and_annotations/tex_demo.html

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -348,10 +348,10 @@ Here is complete examples.
 
    Inset Locator Demo
 
-For example, :func:`zoomed_inset_axes` can be used when you want the
+For example, :func:`.zoomed_inset_axes` can be used when you want the
 inset represents the zoom-up of the small portion in the parent axes.
-And :mod:`~mpl_toolkits/axes_grid/inset_locator` provides a helper
-function :func:`mark_inset` to mark the location of the area
+And :mod:`~mpl_toolkits.axes_grid1.inset_locator` provides a helper
+function :func:`.mark_inset` to mark the location of the area
 represented by the inset axes.
 
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_inset_locator_demo2_001.png
@@ -391,21 +391,20 @@ yaxis of each axes are shared. ::
 AxesDivider
 ===========
 
-The axes_divider module provides helper classes to adjust the axes
-positions of a set of images at drawing time.
+The `~.axes_grid1.axes_divider` module provides helper classes to adjust the
+axes positions of a set of images at drawing time.
 
 * :mod:`~mpl_toolkits.axes_grid1.axes_size` provides a class of
   units that are used to determine the size of each axes. For example,
   you can specify a fixed size.
 
-* :class:`~mpl_toolkits.axes_grid1.axes_size.Divider` is the class
-  that calculates the axes position. It divides the given
-  rectangular area into several areas. The divider is initialized by
-  setting the lists of horizontal and vertical sizes on which the division
-  will be based. Then use
-  :meth:`~mpl_toolkits.axes_grid1.axes_size.Divider.new_locator`,
-  which returns a callable object that can be used to set the
-  axes_locator of the axes.
+* :class:`~mpl_toolkits.axes_grid1.axes_divider.Divider` is the class that
+  calculates the axes position. It divides the given rectangular area into
+  several areas. The divider is initialized by setting the lists of horizontal
+  and vertical sizes on which the division will be based. Then use
+  :meth:`~mpl_toolkits.axes_grid1.axes_divider.Divider.new_locator`, which
+  returns a callable object that can be used to set the axes_locator of the
+  axes.
 
 
 First, initialize the divider by specifying its grids, i.e.,

--- a/tutorials/toolkits/mplot3d.py
+++ b/tutorials/toolkits/mplot3d.py
@@ -14,21 +14,21 @@ Generating 3D plots using the mplot3d toolkit.
 
 Getting started
 ---------------
-3D Axes (of class `Axes3D`) are created by passing the ``projection="3d"``
-keyword argument to `Figure.add_subplot`::
+3D Axes (of class `.Axes3D`) are created by passing the ``projection="3d"``
+keyword argument to `.Figure.add_subplot`::
 
    import matplotlib.pyplot as plt
    fig = plt.figure()
    ax = fig.add_subplot(111, projection='3d')
 
 .. versionchanged:: 1.0.0
-   Prior to Matplotlib 1.0.0, `Axes3D` needed to be directly instantiated with
+   Prior to Matplotlib 1.0.0, `.Axes3D` needed to be directly instantiated with
    ``from mpl_toolkits.mplot3d import Axes3D; ax = Axes3D(fig)``.
 
 .. versionchanged:: 3.2.0
    Prior to Matplotlib 3.2.0, it was necessary to explicitly import the
    :mod:`mpl_toolkits.mplot3d` module to make the '3d' projection to
-   `Figure.add_subplot`.
+   `.Figure.add_subplot`.
 
 See the :ref:`toolkit_mplot3d-faq` for more information about the mplot3d
 toolkit.


### PR DESCRIPTION
## PR Summary

This is not perfect, since some things cannot be fixed just yet. For example, the links to attributes in the artists tutorial don't work, and I don't see anything wrong with them. Sphinx just doesn't know where to find them (possibly has to do with how numpydoc lays it out?)

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way