### PR TITLE
Fix cross-references in API changes < 1.0

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.91.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.91.0.rst
@@ -57,8 +57,7 @@ Changes for 0.91.0
   extent of a line of ordinary text.  The default is 1.2;
   ``linespacing=2`` would be like ordinary double spacing, for example.
 
-* Changed default kwarg in
-  :meth:`matplotlib.colors.Normalize.__init__`` to ``clip=False``;
+* Changed default kwarg in `matplotlib.colors.Normalize` to ``clip=False``;
   clipping silently defeats the purpose of the special over, under,
   and bad values in the colormap, thereby leading to unexpected
   behavior.  The new default should reduce such surprises.

--- a/doc/api/prev_api_changes/api_changes_0.91.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.91.0.rst
@@ -2,20 +2,19 @@
 Changes for 0.91.0
 ==================
 
-* Changed :func:`cbook.is_file_like` to
-  :func:`cbook.is_writable_file_like` and corrected behavior.
+* Changed ``cbook.is_file_like`` to ``cbook.is_writable_file_like`` and
+  corrected behavior.
 
-* Added ax kwarg to :func:`pyplot.colorbar` and
-  :meth:`Figure.colorbar` so that one can specify the axes object from
+* Added *ax* keyword argument to :func:`.pyplot.colorbar` and
+  :meth:`.Figure.colorbar` so that one can specify the axes object from
   which space for the colorbar is to be taken, if one does not want to
   make the colorbar axes manually.
 
-* Changed :func:`cbook.reversed` so it yields a tuple rather than a
-  (index, tuple). This agrees with the python reversed builtin,
-  and cbook only defines reversed if python doesn't provide the
-  builtin.
+* Changed ``cbook.reversed`` so it yields a tuple rather than a (index, tuple).
+  This agrees with the Python reversed builtin, and cbook only defines reversed
+  if Python doesn't provide the builtin.
 
-* Made skiprows=1 the default on :func:`csv2rec`
+* Made skiprows=1 the default on ``csv2rec``
 
 * The gd and paint backends have been deleted.
 
@@ -32,17 +31,18 @@ Changes for 0.91.0
   files. In the future the class might actually parse the font to
   allow e.g.,  subsetting.
 
-* :mod:`matplotlib.FT2Font` now supports :meth:`FT_Attach_File`. In
+* :mod:`matplotlib.ft2font` now supports ``FT_Attach_File``. In
   practice this can be used to read an afm file in addition to a
   pfa/pfb file, to get metrics and kerning information for a Type 1
   font.
 
-* The :class:`AFM` class now supports querying CapHeight and stem
+* The :class:`.AFM` class now supports querying CapHeight and stem
   widths. The get_name_char method now has an isord kwarg like
   get_width_char.
 
-* Changed :func:`pcolor` default to shading='flat'; but as noted now in the
-  docstring, it is preferable to simply use the edgecolor kwarg.
+* Changed :func:`.pcolor` default to ``shading='flat'``; but as noted now in
+  the docstring, it is preferable to simply use the *edgecolor* keyword
+  argument.
 
 * The mathtext font commands (``\cal``, ``\rm``, ``\it``, ``\tt``) now
   behave as TeX does: they are in effect until the next font change

--- a/doc/api/prev_api_changes/api_changes_0.91.2.rst
+++ b/doc/api/prev_api_changes/api_changes_0.91.2.rst
@@ -2,15 +2,15 @@
 Changes for 0.91.2
 ==================
 
-* For :func:`csv2rec`, checkrows=0 is the new default indicating all rows
+* For ``csv2rec``, checkrows=0 is the new default indicating all rows
   will be checked for type inference
 
 * A warning is issued when an image is drawn on log-scaled axes, since
   it will not log-scale the image data.
 
-* Moved :func:`rec2gtk` to :mod:`matplotlib.toolkits.gtktools`
+* Moved ``rec2gtk`` to ``matplotlib.toolkits.gtktools``
 
-* Moved :func:`rec2excel` to :mod:`matplotlib.toolkits.exceltools`
+* Moved ``rec2excel`` to ``matplotlib.toolkits.exceltools``
 
 * Removed, dead/experimental ExampleInfo, Namespace and Importer
-  code from :mod:`matplotlib.__init__`
+  code from :mod:`matplotlib`

--- a/doc/api/prev_api_changes/api_changes_0.98.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.0.rst
@@ -10,18 +10,18 @@ Changes for 0.98.0
 * Rewrote the :class:`matplotlib.cm.ScalarMappable` callback
   infrastructure to use :class:`matplotlib.cbook.CallbackRegistry`
   rather than custom callback handling.  Any users of
-  :meth:`matplotlib.cm.ScalarMappable.add_observer` of the
+  ``matplotlib.cm.ScalarMappable.add_observer`` of the
   :class:`~matplotlib.cm.ScalarMappable` should use the
-  :attr:`matplotlib.cm.ScalarMappable.callbacks`
+  :attr:`matplotlib.cm.ScalarMappable.callbacksSM`
   :class:`~matplotlib.cbook.CallbackRegistry` instead.
 
 * New axes function and Axes method provide control over the plot
-  color cycle: :func:`matplotlib.axes.set_default_color_cycle` and
-  :meth:`matplotlib.axes.Axes.set_color_cycle`.
+  color cycle: ``matplotlib.axes.set_default_color_cycle`` and
+  ``matplotlib.axes.Axes.set_color_cycle``.
 
 * Matplotlib now requires Python 2.4, so :mod:`matplotlib.cbook` will
   no longer provide :class:`set`, :func:`enumerate`, :func:`reversed`
-  or :func:`izip` compatibility functions.
+  or ``izip`` compatibility functions.
 
 * In Numpy 1.0, bins are specified by the left edges only.  The axes
   method :meth:`matplotlib.axes.Axes.hist` now uses future Numpy 1.3
@@ -68,10 +68,10 @@ as well.  This means locators must get their limits from their
 the :class:`~matplotlib.axes.Axes`.  If a locator is used temporarily
 and not assigned to an Axis or Axes, (e.g., in
 :mod:`matplotlib.contour`), a dummy axis must be created to store its
-bounds.  Call :meth:`matplotlib.ticker.Locator.create_dummy_axis` to
+bounds.  Call :meth:`matplotlib.ticker.TickHelper.create_dummy_axis` to
 do so.
 
-The functionality of :class:`Pbox` has been merged with
+The functionality of ``Pbox`` has been merged with
 :class:`~matplotlib.transforms.Bbox`.  Its methods now all return
 copies rather than modifying in place.
 
@@ -84,84 +84,95 @@ with a verb in the present tense.
 :mod:`matplotlib.transforms`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-:meth:`Bbox.get_bounds`                                      :attr:`transforms.Bbox.bounds`
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.width`                                           :attr:`transforms.Bbox.width`
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.height`                                          :attr:`transforms.Bbox.height`
------------------------------------------------------------- ------------------------------------------------------------
-`Bbox.intervalx().get_bounds()`                              :attr:`transforms.Bbox.intervalx`
-`Bbox.intervalx().set_bounds()`                              [:attr:`Bbox.intervalx` is now a property.]
------------------------------------------------------------- ------------------------------------------------------------
-`Bbox.intervaly().get_bounds()`                              :attr:`transforms.Bbox.intervaly`
-`Bbox.intervaly().set_bounds()`                              [:attr:`Bbox.intervaly` is now a property.]
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.xmin`                                            :attr:`transforms.Bbox.x0` or
-                                                             :attr:`transforms.Bbox.xmin` [1]_
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.ymin`                                            :attr:`transforms.Bbox.y0` or
-                                                             :attr:`transforms.Bbox.ymin` [1]_
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.xmax`                                            :attr:`transforms.Bbox.x1` or
-                                                             :attr:`transforms.Bbox.xmax` [1]_
------------------------------------------------------------- ------------------------------------------------------------
-:meth:`Bbox.ymax`                                            :attr:`transforms.Bbox.y1` or
-                                                             :attr:`transforms.Bbox.ymax` [1]_
------------------------------------------------------------- ------------------------------------------------------------
-`Bbox.overlaps(bboxes)`                                      `Bbox.count_overlaps(bboxes)`
------------------------------------------------------------- ------------------------------------------------------------
-`bbox_all(bboxes)`                                           `Bbox.union(bboxes)`
-                                                             [:meth:`transforms.Bbox.union` is a staticmethod.]
------------------------------------------------------------- ------------------------------------------------------------
-`lbwh_to_bbox(l, b, w, h)`                                   `Bbox.from_bounds(x0, y0, w, h)`
-                                                             [:meth:`transforms.Bbox.from_bounds` is a staticmethod.]
------------------------------------------------------------- ------------------------------------------------------------
-`inverse_transform_bbox(trans, bbox)`                        `Bbox.inverse_transformed(trans)`
------------------------------------------------------------- ------------------------------------------------------------
-`Interval.contains_open(v)`                                  `interval_contains_open(tuple, v)`
------------------------------------------------------------- ------------------------------------------------------------
-`Interval.contains(v)`                                       `interval_contains(tuple, v)`
------------------------------------------------------------- ------------------------------------------------------------
-`identity_transform()`                                       :class:`matplotlib.transforms.IdentityTransform`
------------------------------------------------------------- ------------------------------------------------------------
-`blend_xy_sep_transform(xtrans, ytrans)`                     `blended_transform_factory(xtrans, ytrans)`
------------------------------------------------------------- ------------------------------------------------------------
-`scale_transform(xs, ys)`                                    `Affine2D().scale(xs[, ys])`
------------------------------------------------------------- ------------------------------------------------------------
-`get_bbox_transform(boxin, boxout)`                          `BboxTransform(boxin, boxout)` or
-                                                             `BboxTransformFrom(boxin)` or
-                                                             `BboxTransformTo(boxout)`
------------------------------------------------------------- ------------------------------------------------------------
-`Transform.seq_xy_tup(points)`                               `Transform.transform(points)`
------------------------------------------------------------- ------------------------------------------------------------
-`Transform.inverse_xy_tup(points)`                           `Transform.inverted().transform(points)`
-============================================================ ============================================================
++--------------------------------------------+------------------------------------------------------+
+| Old method                                 | New method                                           |
++============================================+======================================================+
+| ``Bbox.get_bounds``                        | :attr:`.transforms.Bbox.bounds`                      |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.width``                             | :attr:`transforms.Bbox.width                         |
+|                                            | <.transforms.BboxBase.width>`                        |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.height``                            | :attr:`transforms.Bbox.height                        |
+|                                            | <.transforms.BboxBase.height>`                       |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.intervalx().get_bounds()``          | :attr:`.transforms.Bbox.intervalx`                   |
+| ``Bbox.intervalx().set_bounds()``          | [It is now a property.]                              |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.intervaly().get_bounds()``          | :attr:`.transforms.Bbox.intervaly`                   |
+| ``Bbox.intervaly().set_bounds()``          | [It is now a property.]                              |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.xmin``                              | :attr:`.transforms.Bbox.x0` or                       |
+|                                            | :attr:`transforms.Bbox.xmin                          |
+|                                            | <.transforms.BboxBase.xmin>` [1]_                    |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.ymin``                              | :attr:`.transforms.Bbox.y0` or                       |
+|                                            | :attr:`transforms.Bbox.ymin                          |
+|                                            | <.transforms.BboxBase.ymin>` [1]_                    |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.xmax``                              | :attr:`.transforms.Bbox.x1` or                       |
+|                                            | :attr:`transforms.Bbox.xmax                          |
+|                                            | <.transforms.BboxBase.xmax>` [1]_                    |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.ymax``                              | :attr:`.transforms.Bbox.y1` or                       |
+|                                            | :attr:`transforms.Bbox.ymax                          |
+|                                            | <.transforms.BboxBase.ymax>` [1]_                    |
++--------------------------------------------+------------------------------------------------------+
+| ``Bbox.overlaps(bboxes)``                  | `Bbox.count_overlaps(bboxes)                         |
+|                                            | <.BboxBase.count_overlaps>`                          |
++--------------------------------------------+------------------------------------------------------+
+| ``bbox_all(bboxes)``                       | `Bbox.union(bboxes) <.BboxBase.union>`               |
+|                                            | [It is a staticmethod.]                              |
++--------------------------------------------+------------------------------------------------------+
+| ``lbwh_to_bbox(l, b, w, h)``               | `Bbox.from_bounds(x0, y0, w, h) <.Bbox.from_bounds>` |
+|                                            | [It is a staticmethod.]                              |
++--------------------------------------------+------------------------------------------------------+
+| ``inverse_transform_bbox(trans, bbox)``    | `Bbox.inverse_transformed(trans)                     |
+|                                            | <.BboxBase.inverse_transformed>`                     |
++--------------------------------------------+------------------------------------------------------+
+| ``Interval.contains_open(v)``              | `interval_contains_open(tuple, v)                    |
+|                                            | <.interval_contains_open>`                           |
++--------------------------------------------+------------------------------------------------------+
+| ``Interval.contains(v)``                   | `interval_contains(tuple, v) <.interval_contains>`   |
++--------------------------------------------+------------------------------------------------------+
+| ``identity_transform()``                   | :class:`.transforms.IdentityTransform`               |
++--------------------------------------------+------------------------------------------------------+
+| ``blend_xy_sep_transform(xtrans, ytrans)`` | `blended_transform_factory(xtrans, ytrans)           |
+|                                            | <.blended_transform_factory>`                        |
++--------------------------------------------+------------------------------------------------------+
+| ``scale_transform(xs, ys)``                | `Affine2D().scale(xs[, ys]) <.Affine2D.scale>`       |
++--------------------------------------------+------------------------------------------------------+
+| ``get_bbox_transform(boxin, boxout)``      | `BboxTransform(boxin, boxout) <.BboxTransform>` or   |
+|                                            | `BboxTransformFrom(boxin) <.BboxTransformFrom>` or   |
+|                                            | `BboxTransformTo(boxout) <.BboxTransformTo>`         |
++--------------------------------------------+------------------------------------------------------+
+| ``Transform.seq_xy_tup(points)``           | `Transform.transform(points) <.Transform.transform>` |
++--------------------------------------------+------------------------------------------------------+
+| ``Transform.inverse_xy_tup(points)``       | `Transform.inverted()                                |
+|                                            | <.Transform.inverted>`.transform(points)             |
++--------------------------------------------+------------------------------------------------------+
 
 .. [1] The :class:`~matplotlib.transforms.Bbox` is bound by the points
    (x0, y0) to (x1, y1) and there is no defined order to these points,
    that is, x0 is not necessarily the left edge of the box.  To get
-   the left edge of the :class:`Bbox`, use the read-only property
-   :attr:`~matplotlib.transforms.Bbox.xmin`.
+   the left edge of the :class:`.Bbox`, use the read-only property
+   :attr:`xmin <matplotlib.transforms.BboxBase.xmin>`.
 
 :mod:`matplotlib.axes`
 ~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`Axes.get_position()`                                        :meth:`matplotlib.axes.Axes.get_position` [2]_
------------------------------------------------------------- ------------------------------------------------------------
-`Axes.set_position()`                                        :meth:`matplotlib.axes.Axes.set_position` [3]_
------------------------------------------------------------- ------------------------------------------------------------
-`Axes.toggle_log_lineary()`                                  :meth:`matplotlib.axes.Axes.set_yscale` [4]_
------------------------------------------------------------- ------------------------------------------------------------
-`Subplot` class                                              removed.
-============================================================ ============================================================
+============================= ==============================================
+Old method                    New method
+============================= ==============================================
+``Axes.get_position()``       :meth:`matplotlib.axes.Axes.get_position` [2]_
+----------------------------- ----------------------------------------------
+``Axes.set_position()``       :meth:`matplotlib.axes.Axes.set_position` [3]_
+----------------------------- ----------------------------------------------
+``Axes.toggle_log_lineary()`` :meth:`matplotlib.axes.Axes.set_yscale` [4]_
+----------------------------- ----------------------------------------------
+``Subplot`` class             removed
+============================= ==============================================
 
-The :class:`Polar` class has moved to :mod:`matplotlib.projections.polar`.
+The ``Polar`` class has moved to :mod:`matplotlib.projections.polar`.
 
 .. [2] :meth:`matplotlib.axes.Axes.get_position` used to return a list
    of points, now it returns a :class:`matplotlib.transforms.Bbox`
@@ -172,16 +183,16 @@ The :class:`Polar` class has moved to :mod:`matplotlib.projections.polar`.
 
 .. [4] Since the recfactoring allows for more than two scale types
    ('log' or 'linear'), it no longer makes sense to have a toggle.
-   `Axes.toggle_log_lineary()` has been removed.
+   ``Axes.toggle_log_lineary()`` has been removed.
 
 :mod:`matplotlib.artist`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`Artist.set_clip_path(path)`                                 `Artist.set_clip_path(path, transform)` [5]_
-============================================================ ============================================================
+============================== ==============================================
+Old method                     New method
+============================== ==============================================
+``Artist.set_clip_path(path)`` ``Artist.set_clip_path(path, transform)`` [5]_
+============================== ==============================================
 
 .. [5] :meth:`matplotlib.artist.Artist.set_clip_path` now accepts a
    :class:`matplotlib.path.Path` instance and a
@@ -191,11 +202,11 @@ Old method                                                   New method
 :mod:`matplotlib.collections`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`linestyle`                                                  `linestyles` [6]_
-============================================================ ============================================================
+=========== =================
+Old method  New method
+=========== =================
+*linestyle* *linestyles* [6]_
+=========== =================
 
 .. [6] Linestyles are now treated like all other collection
    attributes, i.e.  a single value or multiple values may be
@@ -204,55 +215,67 @@ Old method                                                   New method
 :mod:`matplotlib.colors`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`ColorConvertor.to_rgba_list(c)`                             `ColorConvertor.to_rgba_array(c)`
-                                                             [:meth:`matplotlib.colors.ColorConvertor.to_rgba_array`
-                                                             returns an Nx4 Numpy array of RGBA color quadruples.]
-============================================================ ============================================================
+================================== =====================================================
+Old method                         New method
+================================== =====================================================
+``ColorConvertor.to_rgba_list(c)`` ``colors.to_rgba_array(c)``
+                                   [:meth:`matplotlib.colors.to_rgba_array`
+                                   returns an Nx4 NumPy array of RGBA color quadruples.]
+================================== =====================================================
 
 :mod:`matplotlib.contour`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`Contour._segments`                                          :meth:`matplotlib.contour.Contour.get_paths` [Returns a
-                                                             list of :class:`matplotlib.path.Path` instances.]
-============================================================ ============================================================
+===================== ===================================================
+Old method            New method
+===================== ===================================================
+``Contour._segments`` ``matplotlib.contour.Contour.get_paths`` [Returns a
+                      list of :class:`matplotlib.path.Path` instances.]
+===================== ===================================================
 
 :mod:`matplotlib.figure`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`Figure.dpi.get()` / `Figure.dpi.set()`                      :attr:`matplotlib.figure.Figure.dpi` *(a property)*
-============================================================ ============================================================
++----------------------+--------------------------------------+
+| Old method           | New method                           |
++======================+======================================+
+| ``Figure.dpi.get()`` | :attr:`matplotlib.figure.Figure.dpi` |
+| ``Figure.dpi.set()`` | *(a property)*                       |
++----------------------+--------------------------------------+
 
 :mod:`matplotlib.patches`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`Patch.get_verts()`                                          :meth:`matplotlib.patches.Patch.get_path` [Returns a
-                                                             :class:`matplotlib.path.Path` instance]
-============================================================ ============================================================
+===================== ====================================================
+Old method            New method
+===================== ====================================================
+``Patch.get_verts()`` :meth:`matplotlib.patches.Patch.get_path` [Returns a
+                      :class:`matplotlib.path.Path` instance]
+===================== ====================================================
 
 :mod:`matplotlib.backend_bases`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-============================================================ ============================================================
-Old method                                                   New method
-============================================================ ============================================================
-`GraphicsContext.set_clip_rectangle(tuple)`                  `GraphicsContext.set_clip_rectangle(bbox)`
------------------------------------------------------------- ------------------------------------------------------------
-`GraphicsContext.get_clip_path()`                            `GraphicsContext.get_clip_path()` [7]_
------------------------------------------------------------- ------------------------------------------------------------
-`GraphicsContext.set_clip_path()`                            `GraphicsContext.set_clip_path()` [8]_
-============================================================ ============================================================
+============================================= ==========================================
+Old method                                    New method
+============================================= ==========================================
+``GraphicsContext.set_clip_rectangle(tuple)`` `GraphicsContext.set_clip_rectangle(bbox)
+                                              <.GraphicsContextBase.set_clip_rectangle>`
+--------------------------------------------- ------------------------------------------
+``GraphicsContext.get_clip_path()``           `GraphicsContext.get_clip_path()
+                                              <.GraphicsContextBase.get_clip_path>` [7]_
+--------------------------------------------- ------------------------------------------
+``GraphicsContext.set_clip_path()``           `GraphicsContext.set_clip_path()
+                                              <.GraphicsContextBase.set_clip_path>` [8]_
+============================================= ==========================================
+
+.. [7] :meth:`matplotlib.backend_bases.GraphicsContextBase.get_clip_path`
+   returns a tuple of the form (*path*, *affine_transform*), where *path* is a
+   :class:`matplotlib.path.Path` instance and *affine_transform* is a
+   :class:`matplotlib.transforms.Affine2D` instance.
+
+.. [8] :meth:`matplotlib.backend_bases.GraphicsContextBase.set_clip_path` now
+   only accepts a :class:`matplotlib.transforms.TransformedPath` instance.
 
 :class:`~matplotlib.backend_bases.RendererBase`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -275,38 +298,28 @@ New methods:
 
 Changed methods:
 
-  * `draw_image(self, x, y, im, bbox)` is now
+  * ``draw_image(self, x, y, im, bbox)`` is now
     :meth:`draw_image(self, x, y, im, bbox, clippath, clippath_trans)
     <matplotlib.backend_bases.RendererBase.draw_image>`
 
 Removed methods:
 
-  * `draw_arc`
+  * ``draw_arc``
 
-  * `draw_line_collection`
+  * ``draw_line_collection``
 
-  * `draw_line`
+  * ``draw_line``
 
-  * `draw_lines`
+  * ``draw_lines``
 
-  * `draw_point`
+  * ``draw_point``
 
-  * `draw_quad_mesh`
+  * ``draw_quad_mesh``
 
-  * `draw_poly_collection`
+  * ``draw_poly_collection``
 
-  * `draw_polygon`
+  * ``draw_polygon``
 
-  * `draw_rectangle`
+  * ``draw_rectangle``
 
-  * `draw_regpoly_collection`
-
-.. [7] :meth:`matplotlib.backend_bases.GraphicsContext.get_clip_path`
-   returns a tuple of the form (*path*, *affine_transform*), where
-   *path* is a :class:`matplotlib.path.Path` instance and
-   *affine_transform* is a :class:`matplotlib.transforms.Affine2D`
-   instance.
-
-.. [8] :meth:`matplotlib.backend_bases.GraphicsContext.set_clip_path`
-   now only accepts a :class:`matplotlib.transforms.TransformedPath`
-   instance.
+  * ``draw_regpoly_collection``

--- a/doc/api/prev_api_changes/api_changes_0.98.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.0.rst
@@ -218,7 +218,7 @@ Old method                                                   New method
 ============================================================ ============================================================
 Old method                                                   New method
 ============================================================ ============================================================
-`Contour._segments`                                          :meth:`matplotlib.contour.Contour.get_paths`` [Returns a
+`Contour._segments`                                          :meth:`matplotlib.contour.Contour.get_paths` [Returns a
                                                              list of :class:`matplotlib.path.Path` instances.]
 ============================================================ ============================================================
 

--- a/doc/api/prev_api_changes/api_changes_0.98.1.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.1.rst
@@ -1,5 +1,5 @@
 Changes for 0.98.1
 ==================
 
-* Removed broken :mod:`matplotlib.axes3d` support and replaced it with
-  a non-implemented error pointing to 0.91.x
+* Removed broken ``matplotlib.axes3d`` support and replaced it with a
+  non-implemented error pointing to 0.91.x

--- a/doc/api/prev_api_changes/api_changes_0.98.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.x.rst
@@ -1,10 +1,10 @@
 
 Changes for 0.98.x
 ==================
-* psd(), csd(), and cohere() will now automatically wrap negative
+* ``psd()``, ``csd()``, and ``cohere()`` will now automatically wrap negative
   frequency components to the beginning of the returned arrays.
   This is much more sensible behavior and makes them consistent
-  with specgram().  The previous behavior was more of an oversight
+  with ``specgram()``.  The previous behavior was more of an oversight
   than a design decision.
 
 * Added new keyword parameters *nonposx*, *nonposy* to
@@ -15,7 +15,7 @@ Changes for 0.98.x
 
 * Added new :func:`matplotlib.pyplot.fignum_exists` and
   :func:`matplotlib.pyplot.get_fignums`; they merely expose
-  information that had been hidden in :mod:`matplotlib._pylab_helpers`.
+  information that had been hidden in ``matplotlib._pylab_helpers``.
 
 * Deprecated numerix package.
 
@@ -28,7 +28,7 @@ Changes for 0.98.x
 * Changed the defaults of acorr and xcorr to use usevlines=True,
   maxlags=10 and normed=True since these are the best defaults
 
-* Following keyword parameters for :class:`matplotlib.label.Label` are now
+* Following keyword parameters for :class:`matplotlib.legend.Legend` are now
   deprecated and new set of parameters are introduced. The new parameters
   are given as a fraction of the font-size. Also, *scatteryoffsets*,
   *fancybox* and *columnspacing* are added as keyword parameters.
@@ -61,7 +61,7 @@ Changes for 0.98.x
 
 * :meth:`matplotlib.axes.Axes.set_xlim`,
   :meth:`matplotlib.axes.Axes.set_ylim` now return a copy of the
-  :attr:`viewlim` array to avoid modify-in-place surprises.
+  ``viewlim`` array to avoid modify-in-place surprises.
 
 * :meth:`matplotlib.afm.AFM.get_fullname` and
   :meth:`matplotlib.afm.AFM.get_familyname` no longer raise an
@@ -86,13 +86,13 @@ Changes for 0.98.x
   :meth:`matplotlib.collections.Collection.set_offsets` added to
   :class:`~matplotlib.collections.Collection` base class.
 
-* :attr:`matplotlib.figure.Figure.figurePatch` renamed
+* ``matplotlib.figure.Figure.figurePatch`` renamed
   :attr:`matplotlib.figure.Figure.patch`;
-  :attr:`matplotlib.axes.Axes.axesPatch` renamed
+  ``matplotlib.axes.Axes.axesPatch`` renamed
   :attr:`matplotlib.axes.Axes.patch`;
-  :attr:`matplotlib.axes.Axes.axesFrame` renamed
+  ``matplotlib.axes.Axes.axesFrame`` renamed
   :attr:`matplotlib.axes.Axes.frame`.
-  :meth:`matplotlib.axes.Axes.get_frame`, which returns
+  ``matplotlib.axes.Axes.get_frame``, which returns
   :attr:`matplotlib.axes.Axes.patch`, is deprecated.
 
 * Changes in the :class:`matplotlib.contour.ContourLabeler` attributes
@@ -105,6 +105,6 @@ Changes for 0.98.x
 
 * Moved several functions in :mod:`matplotlib.mlab` and
   :mod:`matplotlib.cbook` into a separate module
-  :mod:`matplotlib.numerical_methods` because they were unrelated to
+  ``matplotlib.numerical_methods`` because they were unrelated to
   the initial purpose of mlab or cbook and appeared more coherent
   elsewhere.

--- a/doc/api/prev_api_changes/api_changes_0.99.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.99.x.rst
@@ -56,7 +56,7 @@ Changes beyond 0.99.x
 
 * There is a new rc parameter ``axes.color_cycle``, and the color
   cycle is now independent of the rc parameter ``lines.color``.
-  :func:`matplotlib.Axes.set_default_color_cycle` is deprecated.
+  ``matplotlib.Axes.set_default_color_cycle`` is deprecated.
 
 * You can now print several figures to one pdf file and modify the
   document information dictionary of a pdf file. See the docstrings

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -46,7 +46,7 @@ original location:
   the upper and lower limits (*lolims*, *uplims*, *xlolims*, *xuplims*) now
   point in the correct direction.
 
-* The *fmt* kwarg for :func:`~matplotlib.pyplot.errorbar now supports
+* The *fmt* kwarg for :func:`~matplotlib.pyplot.errorbar` now supports
   the string 'none' to suppress drawing of a line and markers; use
   of the *None* object for this is deprecated. The default *fmt*
   value is changed to the empty string (''), so the line and markers
@@ -72,7 +72,7 @@ original location:
 * For consistency the ``face_alpha`` keyword to
   :class:`matplotlib.patheffects.SimplePatchShadow` has been deprecated in
   favour of the ``alpha`` keyword. Similarly, the keyword ``offset_xy`` is now
-  named ``offset`` across all :class:`~matplotlib.patheffects.AbstractPathEffect`s.
+  named ``offset`` across all :class:`~matplotlib.patheffects.AbstractPathEffect`\ s.
   ``matplotlib.patheffects._Base`` has
   been renamed to :class:`matplotlib.patheffects.AbstractPathEffect`.
   ``matplotlib.patheffect.ProxyRenderer`` has been renamed to

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -865,8 +865,8 @@ future version.
 
 - `.projections.process_projection_requirements`
 
-- `.backend_ps.PsBackendHelper``
-- `.backend_ps.ps_backend_helper``,
+- ``backend_ps.PsBackendHelper``
+- ``backend_ps.ps_backend_helper``,
 
 - `.cbook.iterable`
 - `.cbook.get_label`
@@ -938,7 +938,8 @@ Axes3D
 - `.axes3d.Axes3D.w_yaxis`
 - `.axes3d.Axes3D.w_zaxis`
 
-Use `.axes3d.Axes3D.xaxis`, `.axes3d.Axes3D.and `.axes3d.Axes3D.zaxis` instead.
+Use `.axes3d.Axes3D.xaxis`, `.axes3d.Axes3D.yaxis` and `.axes3d.Axes3D.zaxis`
+instead.
 
 Testing
 ~~~~~~~
@@ -960,8 +961,8 @@ whereas calling ``set_facecolor`` does.
 GUI / backend details
 ~~~~~~~~~~~~~~~~~~~~~
 
-- `.get_py2exe_datafiles``
-- `.tk_window_focus``
+- ``.get_py2exe_datafiles``
+- ``.tk_window_focus``
 - `.backend_gtk3.FileChooserDialog`
 - `.backend_gtk3.NavigationToolbar2GTK3.get_filechooser`
 - `.backend_gtk3.SaveFigureGTK3.get_filechooser`

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -1569,181 +1569,8 @@
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:39",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:40"
     ],
-    "Bbox.intervalx().get_bounds()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:97"
-    ],
-    "Bbox.intervalx().set_bounds()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:98"
-    ],
-    "Bbox.intervaly().get_bounds()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:100"
-    ],
-    "Bbox.intervaly().set_bounds()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:101"
-    ],
-    "Bbox.overlaps(bboxes)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:115"
-    ],
-    "Bbox.count_overlaps(bboxes)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:115"
-    ],
-    "bbox_all(bboxes)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
-    ],
-    "Bbox.union(bboxes)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
-    ],
-    "lbwh_to_bbox(l, b, w, h)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:120"
-    ],
-    "Bbox.from_bounds(x0, y0, w, h)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:120"
-    ],
-    "inverse_transform_bbox(trans, bbox)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:123"
-    ],
-    "Bbox.inverse_transformed(trans)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:123"
-    ],
-    "Interval.contains_open(v)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:125"
-    ],
-    "interval_contains_open(tuple, v)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:125"
-    ],
-    "Interval.contains(v)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:127"
-    ],
-    "interval_contains(tuple, v)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:127"
-    ],
-    "identity_transform()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:129"
-    ],
-    "blend_xy_sep_transform(xtrans, ytrans)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:131"
-    ],
-    "blended_transform_factory(xtrans, ytrans)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:131"
-    ],
-    "scale_transform(xs, ys)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:133"
-    ],
-    "Affine2D().scale(xs[, ys])": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:133"
-    ],
-    "get_bbox_transform(boxin, boxout)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:135"
-    ],
-    "BboxTransform(boxin, boxout)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:135"
-    ],
-    "BboxTransformFrom(boxin)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:135"
-    ],
-    "BboxTransformTo(boxout)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:135"
-    ],
-    "Transform.seq_xy_tup(points)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:139"
-    ],
-    "Transform.transform(points)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:139"
-    ],
-    "Transform.inverse_xy_tup(points)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:141"
-    ],
-    "Transform.inverted().transform(points)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:141"
-    ],
-    "Axes.get_position()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:156"
-    ],
-    "Axes.set_position()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:158"
-    ],
-    "Axes.toggle_log_lineary()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:160",
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:173"
-    ],
-    "Subplot": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:162"
-    ],
-    "Artist.set_clip_path(path)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:184"
-    ],
-    "Artist.set_clip_path(path, transform)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:184"
-    ],
     "linestyle": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:198",
       "doc/users/prev_whats_new/changelog.rst:232"
-    ],
-    "linestyles": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:198"
-    ],
-    "ColorConvertor.to_rgba_list(c)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:211"
-    ],
-    "ColorConvertor.to_rgba_array(c)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:211"
-    ],
-    "Contour._segments": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:222"
-    ],
-    "Figure.dpi.get()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:232"
-    ],
-    "Figure.dpi.set()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:232"
-    ],
-    "Patch.get_verts()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:241"
-    ],
-    "GraphicsContext.set_clip_rectangle(tuple)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:251"
-    ],
-    "GraphicsContext.set_clip_rectangle(bbox)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:251"
-    ],
-    "GraphicsContext.get_clip_path()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:253"
-    ],
-    "GraphicsContext.set_clip_path()": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:255"
-    ],
-    "draw_image(self, x, y, im, bbox)": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:278"
-    ],
-    "draw_arc": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:284"
-    ],
-    "draw_line_collection": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:286"
-    ],
-    "draw_line": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:288"
-    ],
-    "draw_lines": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:290"
-    ],
-    "draw_point": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:292"
-    ],
-    "draw_quad_mesh": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:294"
-    ],
-    "draw_poly_collection": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:296"
-    ],
-    "draw_polygon": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:298"
-    ],
-    "draw_rectangle": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:300"
-    ],
-    "draw_regpoly_collection": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:302"
     ],
     "rasterization_zorder": [
       "doc/api/prev_api_changes/api_changes_1.2.x.rst:10"
@@ -3869,63 +3696,6 @@
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:43",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:44"
     ],
-    "Figure.colorbar": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:8"
-    ],
-    "FT_Attach_File": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:35"
-    ],
-    "matplotlib.cm.ScalarMappable.add_observer": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
-    ],
-    "matplotlib.axes.Axes.set_color_cycle": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:18"
-    ],
-    "matplotlib.ticker.Locator.create_dummy_axis": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:64"
-    ],
-    "Bbox.get_bounds": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:91"
-    ],
-    "Bbox.width": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:93"
-    ],
-    "Bbox.height": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:95"
-    ],
-    "Bbox.xmin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:103"
-    ],
-    "Bbox.ymin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:106"
-    ],
-    "Bbox.xmax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
-    ],
-    "Bbox.ymax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:112"
-    ],
-    "transforms.Bbox.union": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
-    ],
-    "transforms.Bbox.from_bounds": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:120"
-    ],
-    "matplotlib.colors.ColorConvertor.to_rgba_array": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:211"
-    ],
-    "matplotlib.contour.Contour.get_paths": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:222"
-    ],
-    "matplotlib.backend_bases.GraphicsContext.get_clip_path": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:304"
-    ],
-    "matplotlib.backend_bases.GraphicsContext.set_clip_path": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:310"
-    ],
-    "matplotlib.axes.Axes.get_frame": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
-    ],
     "matplotlib.cbook.isvector": [
       "doc/api/prev_api_changes/api_changes_1.2.x.rst:7"
     ],
@@ -4304,21 +4074,6 @@
     "numpy.uint8": [
       "<unknown>:1"
     ],
-    "AFM": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:40"
-    ],
-    "Pbox": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:74"
-    ],
-    "Bbox": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:143"
-    ],
-    "Polar": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:164"
-    ],
-    "matplotlib.label.Label": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:31"
-    ],
     "matplotlib.colors.ColorConverter": [
       "doc/api/prev_api_changes/api_changes_1.2.x.rst:140"
     ],
@@ -4518,78 +4273,18 @@
     "matplotlib.colors.Colormap.name": [
       "lib/matplotlib/cm.py:docstring of matplotlib.cm.register_cmap:10"
     ],
-    "matplotlib.cm.ScalarMappable.callbacks": [
+    "matplotlib.cm.ScalarMappable.callbacksSM": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
-    ],
-    "transforms.Bbox.bounds": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:91"
-    ],
-    "transforms.Bbox.width": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:93"
-    ],
-    "transforms.Bbox.height": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:95"
-    ],
-    "transforms.Bbox.intervalx": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:97"
-    ],
-    "Bbox.intervalx": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:98"
-    ],
-    "transforms.Bbox.intervaly": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:100"
-    ],
-    "Bbox.intervaly": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:101"
-    ],
-    "transforms.Bbox.x0": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:103"
-    ],
-    "transforms.Bbox.xmin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:103"
-    ],
-    "transforms.Bbox.y0": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:106"
-    ],
-    "transforms.Bbox.ymin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:106"
-    ],
-    "transforms.Bbox.x1": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
-    ],
-    "transforms.Bbox.xmax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
-    ],
-    "transforms.Bbox.y1": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:112"
-    ],
-    "transforms.Bbox.ymax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:112"
-    ],
-    "matplotlib.transforms.Bbox.xmin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:143"
-    ],
-    "viewlim": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:62"
-    ],
-    "matplotlib.figure.Figure.figurePatch": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
     ],
     "matplotlib.figure.Figure.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
       "doc/tutorials/intermediate/artists.rst:172",
       "doc/tutorials/intermediate/artists.rst:285"
     ],
-    "matplotlib.axes.Axes.axesPatch": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
-    ],
     "matplotlib.axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
       "doc/tutorials/intermediate/artists.rst:172",
       "doc/tutorials/intermediate/artists.rst:384"
-    ],
-    "matplotlib.axes.Axes.axesFrame": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
     ],
     "matplotlib.axes.Axes.frame": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
@@ -4712,40 +4407,6 @@
     ],
     "findfont": [
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager:3"
-    ],
-    "cbook.is_file_like": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:5"
-    ],
-    "cbook.is_writable_file_like": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:5"
-    ],
-    "pyplot.colorbar": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:8"
-    ],
-    "cbook.reversed": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:13"
-    ],
-    "csv2rec": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:18",
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:5"
-    ],
-    "pcolor": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:44"
-    ],
-    "rec2gtk": [
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:11"
-    ],
-    "rec2excel": [
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:13"
-    ],
-    "matplotlib.axes.set_default_color_cycle": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:18"
-    ],
-    "izip": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:22"
-    ],
-    "matplotlib.Axes.set_default_color_cycle": [
-      "doc/api/prev_api_changes/api_changes_0.99.x.rst:57"
     ],
     "matplotlib.projections.projection_factory": [
       "doc/api/prev_api_changes/api_changes_1.2.x.rst:42"
@@ -4903,26 +4564,11 @@
     "matplotlib._png": [
       "doc/api/next_api_changes/2019-01-02-AL.rst:4"
     ],
-    "matplotlib.FT2Font": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:35"
+    "matplotlib.ft2font": [
+      "doc/api/prev_api_changes/api_changes_0.91.0.rst:34"
     ],
-    "matplotlib.toolkits.gtktools": [
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:11"
-    ],
-    "matplotlib.toolkits.exceltools": [
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:13"
-    ],
-    "matplotlib.__init__": [
+    "matplotlib": [
       "doc/api/prev_api_changes/api_changes_0.91.2.rst:15"
-    ],
-    "matplotlib.axes3d": [
-      "doc/api/prev_api_changes/api_changes_0.98.1.rst:4"
-    ],
-    "matplotlib._pylab_helpers": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:16"
-    ],
-    "matplotlib.numerical_methods": [
-      "doc/api/prev_api_changes/api_changes_0.98.x.rst:106"
     ],
     "matplotlib.compat.subprocess": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:352"

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -1060,12 +1060,6 @@
     "matplotlib.pyplot.get_scale_docs()": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:861"
     ],
-    "backend_ps.PsBackendHelper`": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:868"
-    ],
-    "backend_ps.ps_backend_helper`": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:869"
-    ],
     "dates.strpdate2num": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:926"
     ],
@@ -1075,7 +1069,10 @@
     "axes3d.Axes3D.xaxis": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
     ],
-    "axes3d.Axes3D.and `.axes3d.Axes3D.zaxis": [
+    "axes3d.Axes3D.yaxis": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
+    ],
+    "axes3d.Axes3D.zaxis": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
     ],
     "pytest.mark.backend(...)": [
@@ -1093,12 +1090,6 @@
       "doc/users/prev_whats_new/whats_new_1.5.rst:321",
       "doc/users/prev_whats_new/whats_new_2.2.rst:198",
       "doc/users/prev_whats_new/whats_new_2.2.rst:201"
-    ],
-    "get_py2exe_datafiles`": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:963"
-    ],
-    "tk_window_focus`": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:964"
     ],
     "backend_gtk3.FileChooserDialog": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:965"
@@ -3884,9 +3875,6 @@
     "FT_Attach_File": [
       "doc/api/prev_api_changes/api_changes_0.91.0.rst:35"
     ],
-    "matplotlib.colors.Normalize.__init__`": [
-      "doc/api/prev_api_changes/api_changes_0.91.0.rst:60"
-    ],
     "matplotlib.cm.ScalarMappable.add_observer": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
     ],
@@ -3926,7 +3914,7 @@
     "matplotlib.colors.ColorConvertor.to_rgba_array": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:211"
     ],
-    "matplotlib.contour.Contour.get_paths`": [
+    "matplotlib.contour.Contour.get_paths": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:222"
     ],
     "matplotlib.backend_bases.GraphicsContext.get_clip_path": [
@@ -4010,6 +3998,9 @@
     ],
     "fig.patch.get_alpha": [
       "doc/users/prev_whats_new/whats_new_1.3.rst:219"
+    ],
+    "matplotlib.dates.DateFormatter.__call__": [
+      "doc/users/prev_whats_new/whats_new_1.5.rst:496"
     ],
     "matplotlib.tickers.Locator.tick_values": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:542"
@@ -4331,9 +4322,6 @@
     "matplotlib.colors.ColorConverter": [
       "doc/api/prev_api_changes/api_changes_1.2.x.rst:140"
     ],
-    "matplotlib.patheffects.AbstractPathEffect`s.\n``matplotlib.patheffects._Base`": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:72"
-    ],
     "matplotlib.backqend_pdf.PdfFile": [
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:435"
     ],
@@ -4466,9 +4454,6 @@
     ],
     "matplotilb.mpl_toolkits.axes_grid.anchored_artists.AnchoredSizeBar": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:398"
-    ],
-    "matplotlib.dates.DateFormatter`s'\n:meth:`~matplotlib.dates.DateFormatter.strftime": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:496"
     ],
     "matplotlib.tickers.Locator": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:542"
@@ -4773,9 +4758,6 @@
     ],
     "matplotlib.compat.subprocess": [
       "doc/api/prev_api_changes/api_changes_1.3.x.rst:198"
-    ],
-    "matplotlib.pyplot.errorbar now supports\nthe string 'none' to suppress drawing of a line and markers; use\nof the *None* object for this is deprecated. The default *fmt*\nvalue is changed to the empty string (''), so the line and markers\nare governed by the :func:`~matplotlib.pyplot.plot": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:49"
     ],
     "matplotlib.axes.Axes._get_legend_handles": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:93"

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -493,8 +493,8 @@ backends.
 
 DateFormatter strftime
 ``````````````````````
-:class:`~matplotlib.dates.DateFormatter`s'
-:meth:`~matplotlib.dates.DateFormatter.strftime` method will format
+:class:`~matplotlib.dates.DateFormatter`\ 's
+:meth:`~matplotlib.dates.DateFormatter.__call__` method will format
 a :class:`datetime.datetime` object with the format string passed to
 the formatter's constructor. This method accepts datetimes with years
 before 1900, unlike :meth:`datetime.datetime.strftime`.


### PR DESCRIPTION
Plus a few others since I also fixed unbalanced backticks.

## PR Summary

Actually, I've done all of them, but that'd be a huge PR... Do not backport since this removes cross-referencing for things which were removed.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way