### PR TITLE
Add FontManager.addfont to register fonts at specific paths.

### DIFF
--- a/doc/api/next_api_changes/2019-08-16-AL.rst
+++ b/doc/api/next_api_changes/2019-08-16-AL.rst
@@ -1,0 +1,5 @@
+API changes
+```````````
+
+``font_manager.createFontList`` is deprecated.  `.font_manager.FontManager.addfont`
+is now available to register a font at a given path.


### PR DESCRIPTION
The naming (without underscore) is similar to findfont.

I chose to provide an API adding a single path rather than also wrap
findSystemFonts given that the later is basically just a recursive glob
(``Path(...).glob("**/*.ttf")``).

addfont has no deduplication logic but I think that's fine (really
ttflist should be ttfset, but that's a bigger API change).

findSystemFonts already assumes that the font extension gives the font
type so assuming the same in addfont seems fine.

See discussion starting at https://gitter.im/matplotlib/matplotlib?at=5d54195ea4efe3718dff8b64, attn @andrzejnovak @tacaswell 

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
