### PR TITLE
Fix cross-references in API changes < 2.0.0.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_1.2.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.2.x.rst
@@ -4,16 +4,16 @@ Changes in 1.2.x
 * The ``classic`` option of the rc parameter ``toolbar`` is deprecated
   and will be removed in the next release.
 
-* The :meth:`~matplotlib.cbook.isvector` method has been removed since it
+* The ``matplotlib.cbook.isvector`` method has been removed since it
   is no longer functional.
 
-* The `rasterization_zorder` property on `~matplotlib.axes.Axes` a
+* The ``rasterization_zorder`` property on `~matplotlib.axes.Axes` sets a
   zorder below which artists are rasterized.  This has defaulted to
-  -30000.0, but it now defaults to `None`, meaning no artists will be
+  -30000.0, but it now defaults to *None*, meaning no artists will be
   rasterized.  In order to rasterize artists below a given zorder
-  value, `set_rasterization_zorder` must be explicitly called.
+  value, `.set_rasterization_zorder` must be explicitly called.
 
-* In :meth:`~matplotlib.axes.Axes.scatter`, and `~pyplot.scatter`,
+* In :meth:`~matplotlib.axes.Axes.scatter`, and `~.pyplot.scatter`,
   when specifying a marker using a tuple, the angle is now specified
   in degrees, not radians.
 
@@ -35,11 +35,11 @@ Changes in 1.2.x
   ``savefig.extension``, and sets the default file format used by
   :meth:`matplotlib.figure.Figure.savefig`.
 
-* In :meth:`~matplotlib.pyplot.pie` and :meth:`~matplotlib.Axes.pie`, one can
-  now set the radius of the pie; setting the *radius* to 'None' (the default
-  value), will result in a pie with a radius of 1 as before.
+* In :func:`.pyplot.pie` and :meth:`.axes.Axes.pie`, one can now set the radius
+  of the pie; setting the *radius* to 'None' (the default value), will result
+  in a pie with a radius of 1 as before.
 
-* Use of :func:`~matplotlib.projections.projection_factory` is now deprecated
+* Use of ``matplotlib.projections.projection_factory`` is now deprecated
   in favour of axes class identification using
   :func:`~matplotlib.projections.process_projection_requirements` followed by
   direct axes class invocation (at the time of writing, functions which do this
@@ -137,7 +137,7 @@ Changes in 1.2.x
   and py2.7. It is anticipated that the Qt3 support will be completely
   removed for the next release.
 
-* :class:`~matplotlib.colors.ColorConverter`,
+* ``matplotlib.colors.ColorConverter``,
   :class:`~matplotlib.colors.Colormap` and
   :class:`~matplotlib.colors.Normalize` now subclasses ``object``
 

--- a/doc/api/prev_api_changes/api_changes_1.3.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.3.x.rst
@@ -10,7 +10,7 @@ Changes in 1.3.1
 It is rare that we make an API change in a bugfix release, however,
 for 1.3.1 since 1.3.0 the following change was made:
 
-- `text.Text.cached` (used to cache font objects) has been made into a
+- ``text.Text.cached`` (used to cache font objects) has been made into a
   private variable.  Among the obvious encapsulation benefit, this
   removes this confusing-looking member from the documentation.
 
@@ -24,49 +24,52 @@ Code removal
 * The following items that were deprecated in version 1.2 or earlier
   have now been removed completely.
 
-    - The Qt 3.x backends (`qt` and `qtagg`) have been removed in
-      favor of the Qt 4.x backends (`qt4` and `qt4agg`).
+    - The Qt 3.x backends (``qt`` and ``qtagg``) have been removed in
+      favor of the Qt 4.x backends (``qt4`` and ``qt4agg``).
 
     - The FltkAgg and Emf backends have been removed.
 
-    - The `matplotlib.nxutils` module has been removed.  Use the
+    - The ``matplotlib.nxutils`` module has been removed.  Use the
       functionality on `matplotlib.path.Path.contains_point` and
       friends instead.
 
-    - Instead of `axes.Axes.get_frame`, use `axes.Axes.patch`.
+    - Instead of ``axes.Axes.get_frame``, use `.axes.Axes.patch`.
 
-    - The following `kwargs` to the `legend` function have been
-      renamed:
+    - The following keyword arguments to the `~.axes.Axes.legend` function have
+      been renamed:
 
-      - `pad` -> `borderpad`
-      - `labelsep` -> `labelspacing`
-      - `handlelen` -> `handlelength`
-      - `handletextsep` -> `handletextpad`
-      - `axespad` -> `borderaxespad`
+      - *pad* -> *borderpad*
+      - *labelsep* -> *labelspacing*
+      - *handlelen* -> *handlelength*
+      - *handletextsep* -> *handletextpad*
+      - *axespad* -> *borderaxespad*
 
       Related to this, the following rcParams have been removed:
 
-      - `legend.pad`, `legend.labelsep`, `legend.handlelen`,
-        `legend.handletextsep` and `legend.axespad`
+      - ``legend.pad``,
+      - ``legend.labelsep``,
+      - ``legend.handlelen``,
+      - ``legend.handletextsep`` and
+      - ``legend.axespad``
 
-    - For the `hist` function, instead of `width`, use `rwidth`
+    - For the `~.axes.Axes.hist` function, instead of *width*, use *rwidth*
       (relative width).
 
-    - On `patches.Circle`, the `resolution` kwarg has been removed.
+    - On `.patches.Circle`, the *resolution* keyword argument has been removed.
       For a circle made up of line segments, use
-      `patches.CirclePolygon`.
+      `.patches.CirclePolygon`.
 
     - The printing functions in the Wx backend have been removed due
       to the burden of keeping them up-to-date.
 
-    - `mlab.liaupunov` has been removed.
+    - ``mlab.liaupunov`` has been removed.
 
-    - `mlab.save`, `mlab.load`, `pylab.save` and `pylab.load` have
+    - ``mlab.save``, ``mlab.load``, ``pylab.save`` and ``pylab.load`` have
       been removed.  We recommend using `numpy.savetxt` and
       `numpy.loadtxt` instead.
 
-    - `widgets.HorizontalSpanSelector` has been removed.  Use
-      `widgets.SpanSelector` instead.
+    - ``widgets.HorizontalSpanSelector`` has been removed.  Use
+      `.widgets.SpanSelector` instead.
 
 Code deprecation
 ----------------
@@ -76,35 +79,33 @@ Code deprecation
 
 * The top-level functions in `matplotlib.path` that are implemented in
   C++ were never meant to be public.  Instead, users should use the
-  Pythonic wrappers for them in the `path.Path` and
-  `collections.Collection` classes.  Use the following mapping to update
+  Pythonic wrappers for them in the `.path.Path` and
+  `.collections.Collection` classes.  Use the following mapping to update
   your code:
 
-    - `point_in_path` -> `path.Path.contains_point`
-    - `get_path_extents` -> `path.Path.get_extents`
-    - `point_in_path_collection` -> `collection.Collection.contains`
-    - `path_in_path` -> `path.Path.contains_path`
-    - `path_intersects_path` -> `path.Path.intersects_path`
-    - `convert_path_to_polygons` -> `path.Path.to_polygons`
-    - `cleanup_path` -> `path.Path.cleaned`
-    - `points_in_path` -> `path.Path.contains_points`
-    - `clip_path_to_rect` -> `path.Path.clip_to_bbox`
+    - ``point_in_path`` -> `.path.Path.contains_point`
+    - ``get_path_extents`` -> `.path.Path.get_extents`
+    - ``point_in_path_collection`` -> `.collections.Collection.contains`
+    - ``path_in_path`` -> `.path.Path.contains_path`
+    - ``path_intersects_path`` -> `.path.Path.intersects_path`
+    - ``convert_path_to_polygons`` -> `.path.Path.to_polygons`
+    - ``cleanup_path`` -> `.path.Path.cleaned`
+    - ``points_in_path`` -> `.path.Path.contains_points`
+    - ``clip_path_to_rect`` -> `.path.Path.clip_to_bbox`
 
-* `matplotlib.colors.normalize` and `matplotlib.colors.no_norm` have
+* ``matplotlib.colors.normalize`` and ``matplotlib.colors.no_norm`` have
   been deprecated in favour of `matplotlib.colors.Normalize` and
   `matplotlib.colors.NoNorm` respectively.
 
-* The `ScalarMappable` class' `set_colorbar` is now
-  deprecated. Instead, the
-  :attr:`matplotlib.cm.ScalarMappable.colorbar` attribute should be
-  used.  In previous Matplotlib versions this attribute was an
-  undocumented tuple of ``(colorbar_instance, colorbar_axes)`` but is
-  now just ``colorbar_instance``. To get the colorbar axes it is
-  possible to just use the
-  :attr:`~matplotlib.colorbar.ColorbarBase.ax` attribute on a colorbar
+* The `.ScalarMappable` class' ``set_colorbar`` method is now deprecated.
+  Instead, the :attr:`matplotlib.cm.ScalarMappable.colorbar` attribute should
+  be used.  In previous Matplotlib versions this attribute was an undocumented
+  tuple of ``(colorbar_instance, colorbar_axes)`` but is now just
+  ``colorbar_instance``.  To get the colorbar axes it is possible to just use
+  the :attr:`~matplotlib.colorbar.ColorbarBase.ax` attribute on a colorbar
   instance.
 
-* The `~matplotlib.mpl` module is now deprecated. Those who relied on this
+* The ``matplotlib.mpl`` module is now deprecated.  Those who relied on this
   module should transition to simply using ``import matplotlib as mpl``.
 
 Code changes
@@ -131,9 +132,9 @@ Code changes
   large ``linewidth``. Previously, :class:`~matplotlib.patches.Patch` used
   ``capstyle='projecting'``.
 
-* `Path` objects can now be marked as `readonly` by passing
-  `readonly=True` to its constructor.  The built-in path singletons,
-  obtained through `Path.unit*` class methods return readonly paths.
+* `.Path` objects can now be marked as *readonly* by passing
+  ``readonly=True`` to its constructor.  The built-in path singletons,
+  obtained through ``Path.unit*`` class methods return readonly paths.
   If you have code that modified these, you will need to make a
   deepcopy first, using either::
 
@@ -144,23 +145,23 @@ Code changes
 
     path = Path.unit_circle().deepcopy()
 
-  Deep copying a `Path` always creates an editable (i.e. non-readonly)
-  `Path`.
+  Deep copying a `.Path` always creates an editable (i.e. non-readonly)
+  `.Path`.
 
 * The list at ``Path.NUM_VERTICES`` was replaced by a dictionary mapping
   Path codes to the number of expected vertices at
   :attr:`~matplotlib.path.Path.NUM_VERTICES_FOR_CODE`.
 
-* To support XKCD style plots, the :func:`matplotlib.path.cleanup_path`
+* To support XKCD style plots, the ``matplotlib.path.cleanup_path``
   method's signature was updated to require a sketch argument. Users of
-  :func:`matplotlib.path.cleanup_path` are encouraged to use the new
+  ``matplotlib.path.cleanup_path`` are encouraged to use the new
   :meth:`~matplotlib.path.Path.cleaned` Path method.
 
 * Data limits on a plot now start from a state of having "null"
   limits, rather than limits in the range (0, 1).  This has an effect
   on artists that only control limits in one direction, such as
-  `axvline` and `axhline`, since their limits will not longer also
-  include the range (0, 1).  This fixes some problems where the
+  `.axes.Axes.axvline` and `.axes.Axes.axhline`, since their limits will no
+  longer also include the range (0, 1).  This fixes some problems where the
   computed limits would be dependent on the order in which artists
   were added to the axes.
 
@@ -174,7 +175,7 @@ Code changes
   width``.
 
 * It is now possible to provide ``number of levels + 1`` colors in the case of
-  `extend='both'` for contourf (or just ``number of levels`` colors for an
+  ``extend='both'`` for contourf (or just ``number of levels`` colors for an
   extend value ``min`` or ``max``) such that the resulting colormap's
   ``set_under`` and ``set_over`` are defined appropriately. Any other number
   of colors will continue to behave as before (if more colors are provided
@@ -195,18 +196,18 @@ Code changes
   raises :class:`NotImplementedError` instead of :class:`OSError` if the
   :command:`ps` command cannot be run.
 
-* The :func:`matplotlib.cbook.check_output` function has been moved to
-  :func:`matplotlib.compat.subprocess`.
+* The ``matplotlib.cbook.check_output`` function has been moved to
+  ``matplotlib.compat.subprocess``.
 
 Configuration and rcParams
 --------------------------
 
-* On Linux, the user-specific `matplotlibrc` configuration file is now
-  located in `~/.config/matplotlib/matplotlibrc` to conform to the
+* On Linux, the user-specific :file:`matplotlibrc` configuration file is now
+  located in :file:`~/.config/matplotlib/matplotlibrc` to conform to the
   `XDG Base Directory Specification
   <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>`_.
 
-* The `font.*` rcParams now affect only text objects created after the
+* The ``font.*`` rcParams now affect only text objects created after the
   rcParam has been set, and will not retroactively affect already
   existing text objects.  This brings their behavior in line with most
   other rcParams.

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -7,39 +7,40 @@ Code changes
 * A major refactoring of the axes module was made. The axes module has been
   split into smaller modules:
 
-    - the `_base` module, which contains a new private _AxesBase class. This
-      class contains all methods except plotting and labelling methods.
-    - the `axes` module, which contains the Axes class. This class inherits
-      from _AxesBase, and contains all plotting and labelling methods.
-    - the `_subplot` module, with all the classes concerning subplotting.
+    - the ``_base`` module, which contains a new private ``_AxesBase`` class.
+      This class contains all methods except plotting and labelling methods.
+    - the `~matplotlib.axes` module, which contains the `.axes.Axes` class.
+      This class inherits from ``_AxesBase``, and contains all plotting and
+      labelling methods.
+    - the ``_subplot`` module, with all the classes concerning subplotting.
 
-There are a couple of things that do not exists in the `axes` module's
-namespace anymore. If you use them, you need to import them from their
+There are a couple of things that do not exists in the `~matplotlib.axes`
+module's namespace anymore. If you use them, you need to import them from their
 original location:
 
-  - math -> `import math`
-  - ma -> `from numpy import ma`
-  - cbook -> `from matplotlib import cbook`
-  - docstring -> `from matplotlib import docstring`
-  - is_sequence_of_strings -> `from matplotlib.cbook import is_sequence_of_strings`
-  - is_string_like -> `from matplotlib.cbook import is_string_like`
-  - iterable -> `from matplotlib.cbook import iterable`
-  - itertools -> `import itertools`
-  - martist -> `from matplotlib import artist as martist`
-  - matplotlib -> `import matplotlib`
-  - mcoll -> `from matplotlib import collections as mcoll`
-  - mcolors -> `from matplotlib import colors as mcolors`
-  - mcontour -> `from matplotlib import contour as mcontour`
-  - mpatches -> `from matplotlib import patches as mpatches`
-  - mpath -> `from matplotlib import path as mpath`
-  - mquiver -> `from matplotlib import quiver as mquiver`
-  - mstack -> `from matplotlib import stack as mstack`
-  - mstream -> `from matplotlib import stream as mstream`
-  - mtable -> `from matplotlib import table as mtable`
+  - ``math`` -> ``import math``
+  - ``ma`` -> ``from numpy import ma``
+  - ``cbook`` -> ``from matplotlib import cbook``
+  - ``docstring`` -> ``from matplotlib import docstring``
+  - ``is_sequence_of_strings`` -> ``from matplotlib.cbook import is_sequence_of_strings``
+  - ``is_string_like`` -> ``from matplotlib.cbook import is_string_like``
+  - ``iterable`` -> ``from matplotlib.cbook import iterable``
+  - ``itertools`` -> ``import itertools``
+  - ``martist`` -> ``from matplotlib import artist as martist``
+  - ``matplotlib`` -> ``import matplotlib``
+  - ``mcoll`` -> ``from matplotlib import collections as mcoll``
+  - ``mcolors`` -> ``from matplotlib import colors as mcolors``
+  - ``mcontour`` -> ``from matplotlib import contour as mcontour``
+  - ``mpatches`` -> ``from matplotlib import patches as mpatches``
+  - ``mpath`` -> ``from matplotlib import path as mpath``
+  - ``mquiver`` -> ``from matplotlib import quiver as mquiver``
+  - ``mstack`` -> ``from matplotlib import stack as mstack``
+  - ``mstream`` -> ``from matplotlib import stream as mstream``
+  - ``mtable`` -> ``from matplotlib import table as mtable``
 
 * As part of the refactoring to enable Qt5 support, the module
-  `matplotlib.backends.qt4_compat` was renamed to
-  `matplotlib.qt_compat`.  `qt4_compat` is deprecated in 1.4 and
+  ``matplotlib.backends.qt4_compat`` was renamed to
+  ``matplotlib.backends.qt_compat``.  ``qt4_compat`` is deprecated in 1.4 and
   will be removed in 1.5.
 
 * The :func:`~matplotlib.pyplot.errorbar` method has been changed such that
@@ -56,15 +57,15 @@ original location:
   that the font size is consistent with non-path effect fonts. See
   https://github.com/matplotlib/matplotlib/issues/2889 for more detail.
 
-* The Sphinx extensions `ipython_directive` and
-  `ipython_console_highlighting` have been moved to the IPython
+* The Sphinx extensions ``ipython_directive`` and
+  ``ipython_console_highlighting`` have been moved to the IPython
   project itself.  While they remain in Matplotlib for this release,
-  they have been deprecated.  Update your extensions in `conf.py` to
-  point to `IPython.sphinxext.ipython_directive` instead of
-  `matplotlib.sphinxext.ipython_directive`.
+  they have been deprecated.  Update your extensions in :file:`conf.py` to
+  point to ``IPython.sphinxext.ipython_directive`` instead of
+  ``matplotlib.sphinxext.ipython_directive``.
 
-* In `~matplotlib.finance`, almost all functions have been deprecated
-  and replaced with a pair of functions name `*_ochl` and `*_ohlc`.
+* In ``matplotlib.finance``, almost all functions have been deprecated
+  and replaced with a pair of functions name ``*_ochl`` and ``*_ohlc``.
   The former is the 'open-close-high-low' order of quotes used
   previously in this module, and the latter is the
   'open-high-low-close' order that is standard in finance.
@@ -79,10 +80,10 @@ original location:
   :class:`matplotlib.patheffects.PathEffectRenderer` and is now a full
   RendererBase subclass.
 
-* The artist used to draw the outline of a `colorbar` has been changed
-  from a `matplotlib.lines.Line2D` to `matplotlib.patches.Polygon`,
-  thus `colorbar.ColorbarBase.outline` is now a
-  `matplotlib.patches.Polygon` object.
+* The artist used to draw the outline of a `.Figure.colorbar` has been changed
+  from a `matplotlib.lines.Line2D` to `matplotlib.patches.Polygon`, thus
+  `.colorbar.ColorbarBase.outline` is now a `matplotlib.patches.Polygon`
+  object.
 
 * The legend handler interface has changed from a callable, to any object
   which implements the ``legend_artists`` method (a deprecation phase will
@@ -90,36 +91,36 @@ original location:
   :doc:`/tutorials/intermediate/legend_guide` for further details. Further legend changes
   include:
 
-   * :func:`matplotlib.axes.Axes._get_legend_handles` now returns a generator
-     of handles, rather than a list.
+   * ``matplotlib.axes.Axes._get_legend_handles`` now returns a generator of
+     handles, rather than a list.
 
-   * The :func:`~matplotlib.pyplot.legend` function's "loc" positional
-     argument has been deprecated. Use the "loc" keyword instead.
+   * The :func:`~matplotlib.pyplot.legend` function's *loc* positional
+     argument has been deprecated. Use the *loc* keyword argument instead.
 
-* The rcParams `savefig.transparent` has been added to control
+* The :rc:`savefig.transparent` has been added to control
   default transparency when saving figures.
 
-* Slightly refactored the `Annotation` family.  The text location in
-  `Annotation` is now handled entirely handled by the underlying `Text`
-  object so `set_position` works as expected.  The attributes `xytext` and
-  `textcoords` have been deprecated in favor of `xyann` and `anncoords` so
-  that `Annotation` and `AnnotaionBbox` can share a common sensibly named
+* Slightly refactored the `.Annotation` family.  The text location in
+  `.Annotation` is now entirely handled by the underlying `.Text`
+  object so ``.set_position`` works as expected.  The attributes *xytext* and
+  *textcoords* have been deprecated in favor of *xyann* and *anncoords* so
+  that `.Annotation` and `.AnnotationBbox` can share a common sensibly named
   api for getting/setting the location of the text or box.
 
-    - `xyann` -> set the location of the annotation
-    - `xy` -> set where the arrow points to
-    - `anncoords` -> set the units of the annotation location
-    - `xycoords` -> set the units of the point location
-    - `set_position()` -> `Annotation` only set location of annotation
+    - *xyann* -> set the location of the annotation
+    - *xy* -> set where the arrow points to
+    - *anncoords* -> set the units of the annotation location
+    - *xycoords* -> set the units of the point location
+    - ``set_position()`` -> `.Annotation` only set location of annotation
 
 * `matplotlib.mlab.specgram`, `matplotlib.mlab.psd`,  `matplotlib.mlab.csd`,
-  `matplotlib.mlab.cohere`, `matplotlib.mlab.cohere_pairs`,
+  `matplotlib.mlab.cohere`, ``matplotlib.mlab.cohere_pairs``,
   `matplotlib.pyplot.specgram`, `matplotlib.pyplot.psd`,
   `matplotlib.pyplot.csd`, and `matplotlib.pyplot.cohere` now raise
   ValueError where they previously raised AssertionError.
 
 * For `matplotlib.mlab.psd`,  `matplotlib.mlab.csd`,
-  `matplotlib.mlab.cohere`, `matplotlib.mlab.cohere_pairs`,
+  `matplotlib.mlab.cohere`, ``matplotlib.mlab.cohere_pairs``,
   `matplotlib.pyplot.specgram`, `matplotlib.pyplot.psd`,
   `matplotlib.pyplot.csd`, and `matplotlib.pyplot.cohere`, in cases
   where a shape (n, 1) array is returned, this is now converted to a (n, )
@@ -127,64 +128,67 @@ original location:
   (n, 1) arrays were returend unchanged.  This change makes the dimensions
   consistent in both cases.
 
-* Added the rcParam `axes.fromatter.useoffset` to control the default value
-  of `useOffset` in `ticker.ScalarFormatter`
+* Added the :rc:`axes.formatter.useoffset` to control the default value
+  of *useOffset* in `.ticker.ScalarFormatter`
 
-* Added `Formatter` sub-class `StrMethodFormatter` which
-  does the exact same thing as `FormatStrFormatter`, but for new-style
+* Added `.Formatter` sub-class `.StrMethodFormatter` which
+  does the exact same thing as `.FormatStrFormatter`, but for new-style
   formatting strings.
 
-* Deprecated `matplotlib.testing.image_util` and the only function within,
-  `matplotlib.testing.image_util.autocontrast`. These will be removed
+* Deprecated ``matplotlib.testing.image_util`` and the only function within,
+  ``matplotlib.testing.image_util.autocontrast``. These will be removed
   completely in v1.5.0.
 
 * The ``fmt`` argument of :meth:`~matplotlib.axes.Axes.plot_date` has been
   changed from ``bo`` to just ``o``, so color cycling can happen by default.
 
-* Removed the class `FigureManagerQTAgg` and deprecated `NavigationToolbar2QTAgg`
-  which will be removed in 1.5.
+* Removed the class ``FigureManagerQTAgg`` and deprecated
+  ``NavigationToolbar2QTAgg`` which will be removed in 1.5.
 
-* Removed formerly public (non-prefixed) attributes `rect` and
-  `drawRect` from `FigureCanvasQTAgg`; they were always an
-  implementation detail of the (preserved) `drawRectangle()` function.
+* Removed formerly public (non-prefixed) attributes ``rect`` and
+  ``drawRect`` from ``FigureCanvasQTAgg``; they were always an
+  implementation detail of the (preserved) ``drawRectangle()`` function.
 
-* The function signatures of `tight_bbox.adjust_bbox` and
-  `tight_bbox.process_figure_for_rasterizing` have been changed. A new
-  `fixed_dpi` parameter allows for overriding the `figure.dpi` setting
+* The function signatures of `.tight_bbox.adjust_bbox` and
+  `.tight_bbox.process_figure_for_rasterizing` have been changed. A new
+  *fixed_dpi* parameter allows for overriding the ``figure.dpi`` setting
   instead of trying to deduce the intended behaviour from the file format.
 
 * Added support for horizontal/vertical axes padding to
-  `mpl_toolkits.axes_grid1.ImageGrid` --- argument ``axes_pad`` can now be
-  tuple-like if separate axis padding is required.
+  `mpl_toolkits.axes_grid1.axes_grid.ImageGrid` --- argument *axes_pad* can now
+  be tuple-like if separate axis padding is required.
   The original behavior is preserved.
 
 * Added support for skewed transforms to `matplotlib.transforms.Affine2D`,
-  which can be created using the `skew` and `skew_deg` methods.
+  which can be created using the `~.Affine2D.skew` and `~.Affine2D.skew_deg`
+  methods.
 
-* Added clockwise parameter to control sectors direction in `axes.pie`
+* Added clockwise parameter to control sectors direction in `.axes.Axes.pie`
 
-* In `matplotlib.lines.Line2D` the `markevery` functionality has been extended.
+* In `matplotlib.lines.Line2D` the *markevery* functionality has been extended.
   Previously an integer start-index and stride-length could be specified using
   either a two-element-list or a two-element-tuple.  Now this can only be done
   using a two-element-tuple.  If a two-element-list is used then it will be
   treated as numpy fancy indexing and only the two markers corresponding to the
   given indexes will be shown.
 
-* removed prop kwarg from `mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar`
-  call.  It was passed through to the base-class `__init__` and is only used for
-  setting padding.  Now `fontproperties` (which is what is really used to set
-  the font properties of `AnchoredSizeBar`) is passed through in place of `prop`.
-  If `fontpropreties` is not passed in, but `prop` is, then `prop` is used inplace
-  of `fontpropreties`.  If both are passed in, `prop` is silently ignored.
+* Removed *prop* keyword argument from
+  `mpl_toolkits.axes_grid1.anchored_artists.AnchoredSizeBar` call.  It was
+  passed through to the base-class ``__init__`` and is only used for setting
+  padding.  Now *fontproperties* (which is what is really used to set the font
+  properties of `.AnchoredSizeBar`) is passed through in place of *prop*.  If
+  *fontproperties* is not passed in, but *prop* is, then *prop* is used in
+  place of *fontproperties*.  If both are passed in, *prop* is silently
+  ignored.
 
 
-* The use of the index 0 in `plt.subplot` and related commands is
-  deprecated.  Due to a lack of validation calling `plt.subplots(2, 2,
-  0)` does not raise an exception, but puts an axes in the _last_
+* The use of the index 0 in `.pyplot.subplot` and related commands is
+  deprecated.  Due to a lack of validation, calling ``plt.subplots(2, 2, 0)``
+  does not raise an exception, but puts an axes in the _last_
   position.  This is due to the indexing in subplot being 1-based (to
-  mirror MATLAB) so before indexing into the `GridSpec` object used to
+  mirror MATLAB) so before indexing into the `.GridSpec` object used to
   determine where the axes should go, 1 is subtracted off.  Passing in
-  0 results in passing -1 to `GridSpec` which results in getting the
+  0 results in passing -1 to `.GridSpec` which results in getting the
   last position back.  Even though this behavior is clearly wrong and
   not intended, we are going through a deprecation cycle in an
   abundance of caution that any users are exploiting this 'feature'.

--- a/doc/api/prev_api_changes/api_changes_1.5.0.rst
+++ b/doc/api/prev_api_changes/api_changes_1.5.0.rst
@@ -5,14 +5,14 @@ Changes in 1.5.0
 Code Changes
 ------------
 
-Reversed `matplotlib.cbook.ls_mapper`, added `ls_mapper_r`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reversed `matplotlib.cbook.ls_mapper`, added `.ls_mapper_r`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Formerly, `matplotlib.cbook.ls_mapper` was a dictionary with
-the long-form line-style names (`"solid"`) as keys and the short
-forms (`"-"`) as values.  This long-to-short mapping is now done
-by `ls_mapper_r`, and the short-to-long mapping is done by the
-`ls_mapper`.
+the long-form line-style names (``"solid"``) as keys and the short
+forms (``"-"``) as values.  This long-to-short mapping is now done
+by `.ls_mapper_r`, and the short-to-long mapping is done by the
+`.ls_mapper`.
 
 Prevent moving artists between Axes, Property-ify Artist.axes, deprecate Artist.{get,set}_axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,48 +34,48 @@ before that gets overhauled).
 Tightened input validation on 'pivot' kwarg to quiver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Tightened validation so that only {'tip', 'tail', 'mid', and 'middle'}
-(but any capitalization) are valid values for the 'pivot' kwarg in
-the `Quiver.__init__` (and hence `Axes.quiver` and
-`plt.quiver` which both fully delegate to `Quiver`).  Previously any
-input matching 'mid.*' would be interpreted as 'middle', 'tip.*' as
-'tip' and any string not matching one of those patterns as 'tail'.
+Tightened validation so that only {'tip', 'tail', 'mid', and 'middle'} (but any
+capitalization) are valid values for the *pivot* keyword argument in the
+`.Quiver` class (and hence `.axes.Axes.quiver` and `.pyplot.quiver` which both
+fully delegate to `.Quiver`).  Previously any input matching 'mid.*' would be
+interpreted as 'middle', 'tip.*' as 'tip' and any string not matching one of
+those patterns as 'tail'.
 
-The value of `Quiver.pivot` is normalized to be in the set {'tip',
-'tail', 'middle'} in `Quiver.__init__`.
+The value of `.Quiver.pivot` is normalized to be in the set {'tip', 'tail',
+'middle'} in `.Quiver`.
 
-Reordered `Axes.get_children`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reordered ``Axes.get_children``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The artist order returned by `Axes.get_children` did not
-match the one used by `Axes.draw`.  They now use the same
-order, as `Axes.draw` now calls `Axes.get_children`.
+The artist order returned by `.axes.Axes.get_children` did not
+match the one used by `.axes.Axes.draw`.  They now use the same
+order, as `.axes.Axes.draw` now calls `.axes.Axes.get_children`.
 
 Changed behaviour of contour plots
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The default behaviour of :func:`~matplotlib.pyplot.contour` and
 :func:`~matplotlib.pyplot.contourf` when using a masked array is now determined
-by the new keyword argument `corner_mask`, or if this is not specified then
-the new rcParam `contour.corner_mask` instead.  The new default behaviour is
-equivalent to using `corner_mask=True`; the previous behaviour can be obtained
-using `corner_mask=False` or by changing the rcParam.  The example
+by the new keyword argument *corner_mask*, or if this is not specified then
+the new :rc:`contour.corner_mask` instead.  The new default behaviour is
+equivalent to using ``corner_mask=True``; the previous behaviour can be obtained
+using ``corner_mask=False`` or by changing the rcParam.  The example
 http://matplotlib.org/examples/pylab_examples/contour_corner_mask.html
 demonstrates the difference.  Use of the old contouring algorithm, which is
-obtained with `corner_mask='legacy'`, is now deprecated.
+obtained with ``corner_mask='legacy'``, is now deprecated.
 
 Contour labels may now appear in different places than in earlier versions of
 Matplotlib.
 
-In addition, the keyword argument `nchunk` now applies to
+In addition, the keyword argument *nchunk* now applies to
 :func:`~matplotlib.pyplot.contour` as well as
 :func:`~matplotlib.pyplot.contourf`, and it subdivides the domain into
-subdomains of exactly `nchunk` by `nchunk` quads, whereas previously it was
-only roughly `nchunk` by `nchunk` quads.
+subdomains of exactly *nchunk* by *nchunk* quads, whereas previously it was
+only roughly *nchunk* by *nchunk* quads.
 
 The C/C++ object that performs contour calculations used to be stored in the
-public attribute QuadContourSet.Cntr, but is now stored in a private attribute
-and should not be accessed by end users.
+public attribute ``QuadContourSet.Cntr``, but is now stored in a private
+attribute and should not be accessed by end users.
 
 Added set_params function to all Locator types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,24 +103,24 @@ Disallow ``None`` as x or y value in ax.plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Do not allow ``None`` as a valid input for the ``x`` or ``y`` args in
-`ax.plot`.  This may break some user code, but this was never officially
-supported (ex documented) and allowing ``None`` objects through can lead
-to confusing exceptions downstream.
+`.axes.Axes.plot`.  This may break some user code, but this was never
+officially supported (ex documented) and allowing ``None`` objects through can
+lead to confusing exceptions downstream.
 
 To create an empty line use ::
 
   ln1, = ax.plot([], [], ...)
   ln2, = ax.plot([], ...)
 
-In either case to update the data in the `Line2D` object you must update
+In either case to update the data in the `.Line2D` object you must update
 both the ``x`` and ``y`` data.
 
 
-Removed `args` and `kwargs` from `MicrosecondLocator.__call__`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Removed *args* and *kwargs* from `.MicrosecondLocator.__call__`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The call signature of :meth:`~matplotlib.dates.MicrosecondLocator.__call__`
-has changed from `__call__(self, *args, **kwargs)` to `__call__(self)`.
+has changed from ``__call__(self, *args, **kwargs)`` to ``__call__(self)``.
 This is consistent with the superclass :class:`~matplotlib.ticker.Locator`
 and also all the other Locators derived from this superclass.
 
@@ -137,13 +137,13 @@ the Date Locators.
 'OffsetBox.DrawingArea' respects the 'clip' keyword argument
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The call signature was `OffsetBox.DrawingArea(..., clip=True)` but nothing
-was done with the `clip` argument. The object did not do any clipping
+The call signature was ``OffsetBox.DrawingArea(..., clip=True)`` but nothing
+was done with the *clip* argument. The object did not do any clipping
 regardless of that parameter. Now the object can and does clip the
-child `Artists` if they are set to be clipped.
+child `.Artist`\ s if they are set to be clipped.
 
 You can turn off the clipping on a per-child basis using
-`child.set_clip_on(False)`.
+``child.set_clip_on(False)``.
 
 Add salt to clipPath id
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -186,9 +186,9 @@ New API for custom Axes view changes
 
 Interactive pan and zoom were previously implemented using a Cartesian-specific
 algorithm that was not necessarily applicable to custom Axes. Three new private
-methods, :meth:`~matplotlib.axes._base._AxesBase._get_view`,
-:meth:`~matplotlib.axes._base._AxesBase._set_view`, and
-:meth:`~matplotlib.axes._base._AxesBase._set_view_from_bbox`, allow for custom
+methods, ``matplotlib.axes._base._AxesBase._get_view``,
+``matplotlib.axes._base._AxesBase._set_view``, and
+``matplotlib.axes._base._AxesBase._set_view_from_bbox``, allow for custom
 *Axes* classes to override the pan and zoom algorithms. Implementors of
 custom *Axes* who override these methods may provide suitable behaviour for
 both pan and zoom as well as the view navigation buttons on the interactive
@@ -220,35 +220,35 @@ as it was in 1.4.0-1.4.2, no wrapping for any type of coordinate.
 Deprecation
 -----------
 
-Deprecated `GraphicsContextBase.set_graylevel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Deprecated ``GraphicsContextBase.set_graylevel``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `GraphicsContextBase.set_graylevel` function has been deprecated in 1.5 and
-will be removed in 1.6.  It has been unused.  The
-`GraphicsContextBase.set_foreground` could be used instead.
+The ``GraphicsContextBase.set_graylevel`` function has been deprecated in 1.5
+and will be removed in 1.6.  It has been unused.  The
+`.GraphicsContextBase.set_foreground` could be used instead.
 
 deprecated idle_event
 ~~~~~~~~~~~~~~~~~~~~~
 
-The `idle_event` was broken or missing in most backends and causes spurious
+The ``idle_event`` was broken or missing in most backends and causes spurious
 warnings in some cases, and its use in creating animations is now obsolete due
 to the animations module. Therefore code involving it has been removed from all
 but the wx backend (where it partially works), and its use is deprecated.  The
-animations module may be used instead to create animations.
+`.animation` module may be used instead to create animations.
 
-`color_cycle` deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~
+``color_cycle`` deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In light of the new property cycling feature,
-the Axes method *set_color_cycle* is now deprecated.
+the Axes method ``set_color_cycle`` is now deprecated.
 Calling this method will replace the current property cycle with
 one that cycles just the given colors.
 
 Similarly, the rc parameter *axes.color_cycle* is also deprecated in
-lieu of the new *axes.prop_cycle* parameter. Having both parameters in
+lieu of the new :rc:`axes.prop_cycle` parameter. Having both parameters in
 the same rc file is not recommended as the result cannot be
 predicted. For compatibility, setting *axes.color_cycle* will
-replace the cycler in *axes.prop_cycle* with a color cycle.
+replace the cycler in :rc:`axes.prop_cycle` with a color cycle.
 Accessing *axes.color_cycle* will return just the color portion
 of the property cycle, if it exists.
 
@@ -271,20 +271,19 @@ with webagg you will need to update your html files as such
 Code Removed
 ------------
 
-Removed `Image` from main namespace
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Removed ``Image`` from main namespace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`Image` was imported from PIL/pillow to test if PIL is available, but
-there is no reason to keep `Image` in the namespace once the availability
+``Image`` was imported from PIL/pillow to test if PIL is available, but
+there is no reason to keep ``Image`` in the namespace once the availability
 has been determined.
 
-Removed `lod` from Artist
-~~~~~~~~~~~~~~~~~~~~~~~~~
+Removed ``lod`` from Artist
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Removed the method *set_lod* and all references to
-the attribute *_lod* as the are not used anywhere else in the
-code base.  It appears to be a feature stub that was never built
-out.
+Removed the method ``set_lod`` and all references to the attribute ``_lod`` as
+they are not used anywhere else in the code base.  It appears to be a feature
+stub that was never built out.
 
 Removed threading related classes from cbook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -292,19 +291,19 @@ The classes ``Scheduler``, ``Timeout``, and ``Idle`` were in cbook, but
 are not used internally.  They appear to be a prototype for the idle event
 system which was not working and has recently been pulled out.
 
-Removed `Lena` images from sample_data
+Removed *Lena* images from sample_data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``lena.png`` and ``lena.jpg`` images have been removed from
 Matplotlib's sample_data directory. The images are also no longer
 available from `matplotlib.cbook.get_sample_data`. We suggest using
-`matplotlib.cbook.get_sample_data('grace_hopper.png')` or
-`matplotlib.cbook.get_sample_data('grace_hopper.jpg')` instead.
+``matplotlib.cbook.get_sample_data('grace_hopper.png')`` or
+``matplotlib.cbook.get_sample_data('grace_hopper.jpg')`` instead.
 
 
 Legend
 ~~~~~~
-Removed handling of `loc` as a positional argument to `Legend`
+Removed handling of *loc* as a positional argument to `.Legend`
 
 
 Legend handlers
@@ -332,16 +331,16 @@ Annotation
 Removed ``textcoords`` and ``xytext`` proprieties from Annotation objects.
 
 
-spinxext.ipython_*.py
-~~~~~~~~~~~~~~~~~~~~~
+sphinxext.ipython_*.py
+~~~~~~~~~~~~~~~~~~~~~~
 
 Both ``ipython_console_highlighting`` and ``ipython_directive`` have been
-moved to `IPython`.
+moved to IPython.
 
-Change your import from 'matplotlib.sphinxext.ipython_directive' to
-'IPython.sphinxext.ipython_directive' and from
-'matplotlib.sphinxext.ipython_directive' to
-'IPython.sphinxext.ipython_directive'
+Change your import from ``matplotlib.sphinxext.ipython_directive`` to
+``IPython.sphinxext.ipython_directive`` and from
+``matplotlib.sphinxext.ipython_directive`` to
+``IPython.sphinxext.ipython_directive``
 
 
 LineCollection.color
@@ -350,11 +349,11 @@ LineCollection.color
 Deprecated in 2005, use ``set_color``
 
 
-remove ``'faceted'`` as a valid value for `shading` in ``tri.tripcolor``
+remove ``'faceted'`` as a valid value for *shading* in ``tri.tripcolor``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use `edgecolor` instead.  Added validation on ``shading`` to
-only be valid values.
+Use *edgecolor* instead.  Added validation on *shading* to only be valid
+values.
 
 
 Remove ``faceted`` kwarg from scatter
@@ -368,7 +367,8 @@ d48b34288e9651ff95c3b8a071ef5ac5cf50bae7 (2008-04-18!) and replaced by
 Remove ``set_colorbar`` method from ``ScalarMappable``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Remove ``set_colorbar`` method, use `colorbar` attribute directly.
+Remove ``set_colorbar`` method, use `~.cm.ScalarMappable.colorbar` attribute
+directly.
 
 
 patheffects.svg
@@ -402,5 +402,5 @@ Added no functionality over the base ``NavigationToolbar2Qt``
 mpl.py
 ~~~~~~
 
-Remove the module `matplotlib.mpl`.  Deprecated in 1.3 by
+Remove the module ``matplotlib.mpl``.  Deprecated in 1.3 by
 PR #1670 and commit 78ce67d161625833cacff23cfe5d74920248c5b2

--- a/doc/api/prev_api_changes/api_changes_1.5.3.rst
+++ b/doc/api/prev_api_changes/api_changes_1.5.3.rst
@@ -4,16 +4,16 @@ Changes in 1.5.3
 ``ax.plot(..., marker=None)`` gives default marker
 --------------------------------------------------
 
-Prior to 1.5.3 kwargs passed to `~matplotlib.Axes.plot` were handled
-in two parts -- default kwargs generated internal to
-`~matplotlib.Axes.plot` (such as the cycled styles) and user supplied
-kwargs.  The internally generated kwargs were passed to the
-`matplotlib.lines.Line2D.__init__` and the user kwargs were passed to
-``ln.set(**kwargs)`` to update the artist after it was created.  Now
-both sets of kwargs are merged and passed to
-`~matplotlib.lines.Line2D.__init__`.  This change was made to allow `None`
-to be passed in via the user kwargs to mean 'do the default thing'  as
-is the convention through out mpl rather than raising an exception.
+Prior to 1.5.3 keyword arguments passed to `~matplotlib.axes.Axes.plot` were
+handled in two parts -- default keyword arguments generated internal to
+`~matplotlib.axes.Axes.plot` (such as the cycled styles) and user supplied
+keyword arguments.  The internally generated keyword arguments were passed to
+the `matplotlib.lines.Line2D` and the user keyword arguments were passed to
+``ln.set(**kwargs)`` to update the artist after it was created.  Now both sets
+of keyword arguments are merged and passed to `~matplotlib.lines.Line2D`.  This
+change was made to allow *None* to be passed in via the user keyword arguments
+to mean 'do the default thing' as is the convention through out Matplotlib
+rather than raising an exception.
 
 Unlike most `~matplotlib.lines.Line2D` setter methods
 `~matplotlib.lines.Line2D.set_marker` did accept `None` as a valid

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -306,7 +306,6 @@
       "doc/api/_as_gen/matplotlib.animation.TimedAnimation.rst:21:<autosummary>:1"
     ],
     "Artists": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:140",
       "doc/users/prev_whats_new/whats_new_1.5.rst:22",
       "doc/users/prev_whats_new/whats_new_1.5.rst:558",
       "doc/users/prev_whats_new/whats_new_1.5.rst:563",
@@ -391,7 +390,6 @@
     ],
     "Legend": [
       "doc/api/axes_api.rst:318:<autosummary>:1",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:307",
       "doc/api/prev_api_changes/api_changes_2.0.0.rst:70",
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes.Axes.get_legend:2"
     ],
@@ -400,7 +398,6 @@
     ],
     "Line2D": [
       "doc/api/axes_api.rst:420:<autosummary>:1",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:115",
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:88",
       "doc/devel/MEP/MEP26.rst:141",
       "doc/devel/MEP/MEP26.rst:36",
@@ -559,7 +556,6 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.violinplot:46"
     ],
     "Text": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102",
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:1088",
       "doc/devel/MEP/MEP14.rst:252",
       "doc/devel/MEP/MEP26.rst:141",
@@ -604,7 +600,6 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.colorbar:16"
     ],
     "ScalarMappable": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:97",
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:298",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.colorbar:26",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.colorbar:22"
@@ -691,8 +686,6 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figure:8"
     ],
     "Image": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:274",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:277",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.gci:4"
     ],
     "Axes.legend": [
@@ -998,8 +991,6 @@
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:798"
     ],
     "Annotation": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:113",
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:799"
     ],
     "Axes.annotation": [
@@ -1082,7 +1073,6 @@
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:948"
     ],
     "Quiver": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:37",
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:954"
     ],
     "Collection": [
@@ -1163,8 +1153,6 @@
       "lib/matplotlib/blocking_input.py:docstring of matplotlib.blocking_input:9"
     ],
     "Path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:134",
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:147",
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.GraphicsContextBase.get_hatch_path:2",
       "lib/matplotlib/textpath.py:docstring of matplotlib.textpath.TextToPath.get_text_path:37"
     ],
@@ -1493,8 +1481,7 @@
       "doc/users/prev_whats_new/whats_new_1.5.rst:528"
     ],
     "Formatter": [
-      "doc/api/next_api_changes/2019-04-02-AL.rst:4",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:133"
+      "doc/api/next_api_changes/2019-04-02-AL.rst:4"
     ],
     "Axis.set_major_locator": [
       "doc/api/next_api_changes/2019-04-02-AL.rst:4"
@@ -1572,477 +1559,52 @@
     "linestyle": [
       "doc/users/prev_whats_new/changelog.rst:232"
     ],
-    "rasterization_zorder": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:10"
-    ],
-    "set_rasterization_zorder": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:10"
-    ],
-    "pyplot.scatter": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:16"
-    ],
-    "text.Text.cached": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:13"
-    ],
-    "qt": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:27"
-    ],
-    "qtagg": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:27"
-    ],
-    "qt4": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:27"
-    ],
-    "qt4agg": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:27"
-    ],
-    "matplotlib.nxutils": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:32"
-    ],
-    "axes.Axes.get_frame": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:36"
-    ],
     "axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_1.3.x.rst:36"
     ],
     "kwargs": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:38",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:119",
       "doc/users/prev_whats_new/whats_new_1.4.rst:172"
     ],
-    "legend": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:38"
-    ],
-    "pad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:41"
-    ],
-    "borderpad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:41"
-    ],
-    "labelsep": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:42"
-    ],
-    "labelspacing": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:42"
-    ],
-    "handlelen": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:43"
-    ],
-    "handlelength": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:43"
-    ],
-    "handletextsep": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:44"
-    ],
-    "handletextpad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:44"
-    ],
-    "axespad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:45"
-    ],
-    "borderaxespad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:45"
-    ],
-    "legend.pad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:49"
-    ],
-    "legend.labelsep": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:49"
-    ],
-    "legend.handlelen": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:49"
-    ],
-    "legend.handletextsep": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:49"
-    ],
-    "legend.axespad": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:49"
-    ],
-    "hist": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:52"
-    ],
     "width": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:52",
       "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
     ],
-    "rwidth": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:52"
-    ],
-    "patches.Circle": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:55"
-    ],
-    "resolution": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:55"
-    ],
-    "patches.CirclePolygon": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:55"
-    ],
-    "mlab.liaupunov": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:62"
-    ],
-    "mlab.save": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:64"
-    ],
-    "mlab.load": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:64"
-    ],
-    "pylab.save": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:64"
-    ],
-    "pylab.load": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:64"
-    ],
-    "widgets.HorizontalSpanSelector": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:68"
-    ],
-    "widgets.SpanSelector": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:68"
-    ],
-    "path.Path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:77"
-    ],
-    "collections.Collection": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:77"
-    ],
-    "point_in_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:83"
-    ],
-    "path.Path.contains_point": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:83"
-    ],
-    "get_path_extents": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:84"
-    ],
-    "path.Path.get_extents": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:84"
-    ],
-    "point_in_path_collection": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:85"
-    ],
-    "collection.Collection.contains": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:85"
-    ],
-    "path_in_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:86"
-    ],
-    "path.Path.contains_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:86"
-    ],
-    "path_intersects_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:87"
-    ],
-    "path.Path.intersects_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:87"
-    ],
-    "convert_path_to_polygons": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:88"
-    ],
-    "path.Path.to_polygons": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:88"
-    ],
-    "cleanup_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:89"
-    ],
-    "path.Path.cleaned": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:89"
-    ],
-    "points_in_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:90"
-    ],
-    "path.Path.contains_points": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:90"
-    ],
-    "clip_path_to_rect": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:91"
-    ],
-    "path.Path.clip_to_bbox": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:91"
-    ],
-    "matplotlib.colors.normalize": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:93"
-    ],
-    "matplotlib.colors.no_norm": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:93"
-    ],
-    "set_colorbar": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:97"
-    ],
-    "matplotlib.mpl": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:107",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:405"
-    ],
-    "readonly": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:134"
-    ],
-    "readonly=True": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:134"
-    ],
-    "Path.unit*": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:134"
-    ],
-    "axvline": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:159"
-    ],
-    "axhline": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:159"
-    ],
-    "extend='both'": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:176"
-    ],
     "matplotlibrc": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:204",
       "doc/users/prev_whats_new/whats_new_1.3.rst:332",
       "doc/users/prev_whats_new/whats_new_1.3.rst:385",
       "doc/users/prev_whats_new/whats_new_2.2.rst:260",
       "doc/users/prev_whats_new/whats_new_2.2.rst:263"
     ],
-    "/.config/matplotlib/matplotlibrc": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:204"
-    ],
     "font.*": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:209",
       "doc/users/prev_whats_new/whats_new_1.3.rst:302"
     ],
-    "_base": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:10"
-    ],
-    "axes": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:12",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:16"
-    ],
-    "_subplot": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:14"
-    ],
-    "import math": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:20"
-    ],
-    "from numpy import ma": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:21"
-    ],
-    "from matplotlib import cbook": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:22"
-    ],
-    "from matplotlib import docstring": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:23"
-    ],
-    "from matplotlib.cbook import is_sequence_of_strings": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:24"
-    ],
-    "from matplotlib.cbook import is_string_like": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:25"
-    ],
-    "from matplotlib.cbook import iterable": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:26"
-    ],
-    "import itertools": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:27"
-    ],
-    "from matplotlib import artist as martist": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:28"
-    ],
-    "import matplotlib": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:29"
-    ],
-    "from matplotlib import collections as mcoll": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:30"
-    ],
-    "from matplotlib import colors as mcolors": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:31"
-    ],
-    "from matplotlib import contour as mcontour": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:32"
-    ],
-    "from matplotlib import patches as mpatches": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:33"
-    ],
-    "from matplotlib import path as mpath": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:34"
-    ],
-    "from matplotlib import quiver as mquiver": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:35"
-    ],
-    "from matplotlib import stack as mstack": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:36"
-    ],
-    "from matplotlib import stream as mstream": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:37"
-    ],
-    "from matplotlib import table as mtable": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:38"
-    ],
-    "matplotlib.backends.qt4_compat": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:40"
-    ],
-    "matplotlib.qt_compat": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:40"
-    ],
-    "qt4_compat": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:40"
-    ],
-    "ipython_directive": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:59"
-    ],
-    "ipython_console_highlighting": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:59"
-    ],
-    "conf.py": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:59"
-    ],
-    "IPython.sphinxext.ipython_directive": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:59"
-    ],
-    "matplotlib.sphinxext.ipython_directive": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:59"
-    ],
-    "matplotlib.finance": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:66"
-    ],
-    "*_ochl": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:66"
-    ],
-    "*_ohlc": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:66"
-    ],
-    "colorbar": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:82",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:371"
-    ],
     "colorbar.ColorbarBase.outline": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:82"
-    ],
-    "savefig.transparent": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:99"
-    ],
-    "set_position": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102"
-    ],
-    "xytext": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102"
-    ],
-    "textcoords": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102"
-    ],
-    "xyann": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:109"
-    ],
-    "anncoords": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:111"
-    ],
-    "AnnotaionBbox": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:102"
+      "doc/api/prev_api_changes/api_changes_1.4.x.rst:83"
     ],
     "xy": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:110",
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Lasso:8"
     ],
-    "xycoords": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:112"
-    ],
-    "set_position()": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:113"
-    ],
-    "matplotlib.mlab.cohere_pairs": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:115",
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:121"
-    ],
-    "axes.fromatter.useoffset": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:130"
-    ],
     "useOffset": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:130",
       "doc/users/prev_whats_new/whats_new_1.4.rst:293"
     ],
-    "ticker.ScalarFormatter": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:130"
-    ],
-    "StrMethodFormatter": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:133"
-    ],
     "FormatStrFormatter": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:133",
       "doc/users/prev_whats_new/whats_new_1.4.rst:129"
     ],
-    "matplotlib.testing.image_util": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:137"
-    ],
-    "matplotlib.testing.image_util.autocontrast": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:137"
-    ],
-    "FigureManagerQTAgg": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:144"
-    ],
-    "NavigationToolbar2QTAgg": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:144"
-    ],
-    "rect": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:147"
-    ],
-    "drawRect": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:147"
-    ],
-    "FigureCanvasQTAgg": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:147"
-    ],
-    "drawRectangle()": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:147"
-    ],
     "tight_bbox.adjust_bbox": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:151"
+      "doc/api/prev_api_changes/api_changes_1.4.x.rst:152"
     ],
     "tight_bbox.process_figure_for_rasterizing": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:151"
-    ],
-    "fixed_dpi": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:151"
-    ],
-    "figure.dpi": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:151"
-    ],
-    "mpl_toolkits.axes_grid1.ImageGrid": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:156"
+      "doc/api/prev_api_changes/api_changes_1.4.x.rst:152"
     ],
     "skew": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:161",
       "doc/users/prev_whats_new/whats_new_1.4.rst:157"
     ],
     "skew_deg": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:161",
       "doc/users/prev_whats_new/whats_new_1.4.rst:157"
     ],
-    "axes.pie": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:164"
-    ],
     "markevery": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:166",
       "doc/users/prev_whats_new/whats_new_1.4.rst:212",
       "doc/users/prev_whats_new/whats_new_1.4.rst:214",
       "doc/users/prev_whats_new/whats_new_3.0.rst:111"
-    ],
-    "__init__": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:173"
-    ],
-    "fontproperties": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:173"
-    ],
-    "AnchoredSizeBar": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:173"
-    ],
-    "prop": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:173"
-    ],
-    "fontpropreties": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:173"
-    ],
-    "plt.subplot": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:181"
-    ],
-    "plt.subplots(2, 2,\n0)": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:181"
-    ],
-    "GridSpec": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:181"
     ],
     "matplotlib.cbook.ls_mapper": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11",
@@ -2052,122 +1614,21 @@
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11",
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:8"
     ],
-    "\"solid\"": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:11"
-    ],
-    "\"-\"": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:11"
-    ],
     "ls_mapper": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11"
-    ],
-    "Quiver.__init__": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:37",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:44"
-    ],
-    "Axes.quiver": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:37"
-    ],
-    "plt.quiver": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:37"
     ],
     "Quiver.pivot": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:44"
     ],
-    "Axes.get_children": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:47",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:50"
-    ],
-    "Axes.draw": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:50"
-    ],
-    "corner_mask": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:57"
-    ],
-    "contour.corner_mask": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:57"
-    ],
-    "corner_mask=True": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:57"
-    ],
-    "corner_mask=False": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:57"
-    ],
-    "corner_mask='legacy'": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:57"
-    ],
-    "nchunk": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:70"
-    ],
-    "ax.plot": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:105"
-    ],
-    "args": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:119"
-    ],
     "MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:119"
     ],
-    "__call__(self, *args, **kwargs)": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:122"
-    ],
-    "__call__(self)": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:122"
-    ],
-    "OffsetBox.DrawingArea(..., clip=True)": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:140"
-    ],
-    "clip": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:140"
-    ],
-    "child.set_clip_on(False)": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:145"
-    ],
-    "GraphicsContextBase.set_graylevel": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:223",
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:226"
-    ],
-    "GraphicsContextBase.set_foreground": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:226"
-    ],
-    "idle_event": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:233"
-    ],
-    "color_cycle": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:239"
-    ],
-    "lod": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:281"
-    ],
-    "Lena": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:295"
-    ],
-    "matplotlib.cbook.get_sample_data('grace_hopper.png')": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:298"
-    ],
-    "matplotlib.cbook.get_sample_data('grace_hopper.jpg')": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:298"
-    ],
     "loc": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:307",
       "doc/users/prev_whats_new/whats_new_1.3.rst:263",
       "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes.set_theta_zero_location:9"
     ],
-    "IPython": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:338"
-    ],
-    "shading": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:353"
-    ],
     "edgecolor": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:356",
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Slider:85"
-    ],
-    "matplotlib.Axes.plot": [
-      "doc/api/prev_api_changes/api_changes_1.5.3.rst:7"
-    ],
-    "matplotlib.lines.Line2D.__init__": [
-      "doc/api/prev_api_changes/api_changes_1.5.3.rst:7"
     ],
     "GTKAgg": [
       "doc/api/prev_api_changes/api_changes_2.0.0.rst:15"
@@ -3696,23 +3157,8 @@
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:43",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:44"
     ],
-    "matplotlib.cbook.isvector": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:7"
-    ],
-    "matplotlib.Axes.pie": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:38"
-    ],
     "matplotlib.dates.MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:122"
-    ],
-    "matplotlib.axes._base._AxesBase._get_view": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:187"
-    ],
-    "matplotlib.axes._base._AxesBase._set_view": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:187"
-    ],
-    "matplotlib.axes._base._AxesBase._set_view_from_bbox": [
-      "doc/api/prev_api_changes/api_changes_1.5.0.rst:187"
     ],
     "draw_idle": [
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:298"
@@ -4074,9 +3520,6 @@
     "numpy.uint8": [
       "<unknown>:1"
     ],
-    "matplotlib.colors.ColorConverter": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:140"
-    ],
     "matplotlib.backqend_pdf.PdfFile": [
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:435"
     ],
@@ -4296,7 +3739,7 @@
       "doc/api/prev_api_changes/api_changes_0.99.x.rst:23"
     ],
     "matplotlib.colorbar.ColorbarBase.ax": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:97"
+      "doc/api/prev_api_changes/api_changes_1.3.x.rst:100"
     ],
     "name": [
       "lib/matplotlib/scale.py:docstring of matplotlib.scale.ScaleBase:8"
@@ -4407,21 +3850,6 @@
     ],
     "findfont": [
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager:3"
-    ],
-    "matplotlib.projections.projection_factory": [
-      "doc/api/prev_api_changes/api_changes_1.2.x.rst:42"
-    ],
-    "matplotlib.path.cleanup_path": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:154"
-    ],
-    "matplotlib.cbook.check_output": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:198"
-    ],
-    "matplotlib.compat.subprocess": [
-      "doc/api/prev_api_changes/api_changes_1.3.x.rst:198"
-    ],
-    "matplotlib.axes.Axes._get_legend_handles": [
-      "doc/api/prev_api_changes/api_changes_1.4.x.rst:93"
     ],
     "matplotlib.axis.Tick.label1On": [
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:65",


### PR DESCRIPTION
## PR Summary

More of the same. No backport since it changes references to code-style for deleted targets.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way