### PR TITLE
Cleanup offsetbox.py.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -608,12 +608,9 @@ class PaddedBox(OffsetBox):
         # docstring inherited.
         dpicor = renderer.points_to_pixels(1.)
         pad = self.pad * dpicor
-
         w, h, xd, yd = self._children[0].get_extent(renderer)
-
-        return w + 2 * pad, h + 2 * pad, \
-               xd + pad, yd + pad, \
-               [(0, 0)]
+        return (w + 2 * pad, h + 2 * pad, xd + pad, yd + pad,
+                [(0, 0)])
 
     def draw(self, renderer):
         """
@@ -668,19 +665,13 @@ class DrawingArea(OffsetBox):
         *xdescent*, *ydescent* : descent of the box in x- and y-direction.
         *clip* : Whether to clip the children
         """
-
         super().__init__()
-
         self.width = width
         self.height = height
         self.xdescent = xdescent
         self.ydescent = ydescent
         self._clip_children = clip
-
         self.offset_transform = mtransforms.Affine2D()
-        self.offset_transform.clear()
-        self.offset_transform.translate(0, 0)
-
         self.dpi_transform = mtransforms.Affine2D()
 
     @property
@@ -698,8 +689,7 @@ class DrawingArea(OffsetBox):
 
     def get_transform(self):
         """
-        Return the :class:`~matplotlib.transforms.Transform` applied
-        to the children
+        Return the `~matplotlib.transforms.Transform` applied to the children.
         """
         return self.dpi_transform + self.offset_transform
 
@@ -707,7 +697,6 @@ class DrawingArea(OffsetBox):
         """
         set_transform is ignored.
         """
-        pass
 
     def set_offset(self, xy):
         """
@@ -719,7 +708,6 @@ class DrawingArea(OffsetBox):
             The (x, y) coordinates of the offset in display units.
         """
         self._offset = xy
-
         self.offset_transform.clear()
         self.offset_transform.translate(xy[0], xy[1])
         self.stale = True
@@ -745,8 +733,8 @@ class DrawingArea(OffsetBox):
         """
 
         dpi_cor = renderer.points_to_pixels(1.)
-        return self.width * dpi_cor, self.height * dpi_cor, \
-               self.xdescent * dpi_cor, self.ydescent * dpi_cor
+        return (self.width * dpi_cor, self.height * dpi_cor,
+                self.xdescent * dpi_cor, self.ydescent * dpi_cor)
 
     def add_artist(self, a):
         'Add any :class:`~matplotlib.artist.Artist` to the container box'
@@ -816,23 +804,14 @@ class TextArea(OffsetBox):
         """
         if textprops is None:
             textprops = {}
-
-        if "va" not in textprops:
-            textprops["va"] = "baseline"
-
+        textprops.setdefault("va", "baseline")
         self._text = mtext.Text(0, 0, s, **textprops)
-
         OffsetBox.__init__(self)
-
         self._children = [self._text]
-
         self.offset_transform = mtransforms.Affine2D()
-        self.offset_transform.clear()
-        self.offset_transform.translate(0, 0)
         self._baseline_transform = mtransforms.Affine2D()
         self._text.set_transform(self.offset_transform +
                                  self._baseline_transform)
-
         self._multilinebaseline = multilinebaseline
         self._minimumdescent = minimumdescent
 
@@ -881,7 +860,6 @@ class TextArea(OffsetBox):
         """
         set_transform is ignored.
         """
-        pass
 
     def set_offset(self, xy):
         """
@@ -893,7 +871,6 @@ class TextArea(OffsetBox):
             The (x, y) coordinates of the offset in display units.
         """
         self._offset = xy
-
         self.offset_transform.clear()
         self.offset_transform.translate(xy[0], xy[1])
         self.stale = True
@@ -969,16 +946,10 @@ class AuxTransformBox(OffsetBox):
     def __init__(self, aux_transform):
         self.aux_transform = aux_transform
         OffsetBox.__init__(self)
-
         self.offset_transform = mtransforms.Affine2D()
-        self.offset_transform.clear()
-        self.offset_transform.translate(0, 0)
-
-        # ref_offset_transform is used to make the offset_transform is
-        # always reference to the lower-left corner of the bbox of its
-        # children.
+        # ref_offset_transform makes offset_transform always relative to the
+        # lower-left corner of the bbox of its children.
         self.ref_offset_transform = mtransforms.Affine2D()
-        self.ref_offset_transform.clear()
 
     def add_artist(self, a):
         'Add any :class:`~matplotlib.artist.Artist` to the container box'
@@ -991,15 +962,14 @@ class AuxTransformBox(OffsetBox):
         Return the :class:`~matplotlib.transforms.Transform` applied
         to the children
         """
-        return self.aux_transform + \
-               self.ref_offset_transform + \
-               self.offset_transform
+        return (self.aux_transform
+                + self.ref_offset_transform
+                + self.offset_transform)
 
     def set_transform(self, t):
         """
         set_transform is ignored.
         """
-        pass
 
     def set_offset(self, xy):
         """
@@ -1011,7 +981,6 @@ class AuxTransformBox(OffsetBox):
             The (x, y) coordinates of the offset in display units.
         """
         self._offset = xy
-
         self.offset_transform.clear()
         self.offset_transform.translate(xy[0], xy[1])
         self.stale = True


### PR DESCRIPTION
Mostly, newly created Affine2D()'s don't need to be clear()ed and set to
a null translation -- that's what they are to start with.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
