### PR TITLE
Cleanup patheffects.

### DIFF
--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -97,17 +97,14 @@ def test_patheffects_stroked_text():
     ax.axis('off')
 
 
-@pytest.mark.xfail
 def test_PathEffect_points_to_pixels():
     fig = plt.figure(dpi=150)
     p1, = plt.plot(range(10))
     p1.set_path_effects([path_effects.SimpleLineShadow(),
                          path_effects.Normal()])
-
     renderer = fig.canvas.get_renderer()
-    pe_renderer = path_effects.SimpleLineShadow().get_proxy_renderer(renderer)
-
-    assert isinstance(pe_renderer, path_effects.PathEffectRenderer)
+    pe_renderer = path_effects.PathEffectRenderer(
+        p1.get_path_effects(), renderer)
     # Confirm that using a path effects renderer maintains point sizes
     # appropriately. Otherwise rendered font would be the wrong size.
     assert renderer.points_to_pixels(15) == pe_renderer.points_to_pixels(15)


### PR DESCRIPTION
- Simplify offset_transform to just return the additional translation
  that needs to be applied, creating a new transform as needed.
- SimpleLineShadow does not need to specify fill_color -- draw_path
  defaults to None.
- Fix an xfailing test: get_proxy_renderer was removed in 1.5; directly
  constructing the PathEffectRenderer is the replacement.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
