### PR TITLE
Write all ACCEPTS markers in docstrings as comments.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -660,11 +660,9 @@ class Artist:
             The amplitude of the wiggle perpendicular to the source
             line, in pixels.  If scale is `None`, or not provided, no
             sketch filter will be provided.
-
         length : float, optional
              The length of the wiggle along the line, in pixels
              (default 128.0)
-
         randomness : float, optional
             The scale factor by which the length is shrunken or
             expanded (default 16.0)
@@ -732,20 +730,28 @@ class Artist:
 
     def set_clip_path(self, path, transform=None):
         """
-        Set the artist's clip path, which may be:
+        Set the artist's clip path.
 
-        - a :class:`~matplotlib.patches.Patch` (or subclass) instance; or
-        - a :class:`~matplotlib.path.Path` instance, in which case a
-          :class:`~matplotlib.transforms.Transform` instance, which will be
-          applied to the path before using it for clipping, must be provided;
-          or
-        - ``None``, to remove a previously set clipping path.
+        Parameters
+        ----------
+        path : `.Patch` or `.Path` or `.TransformedPath` or None
+            The clip path. If given a `.Path`, *transform* must be provided as
+            well. If *None*, a previously set clip path is removed.
+        transform : `~matplotlib.transforms.Transform`, optional
+            Only used if *path* is a `.Path`, in which case the given `.Path`
+            is converted to a `.TransformedPath` using *transform*.
 
-        For efficiency, if the path happens to be an axis-aligned rectangle,
-        this method will set the clipping box to the corresponding rectangle
-        and set the clipping path to ``None``.
+        Notes
+        -----
+        For efficiency, if *path* is a `.Rectangle` this method will set the
+        clipping box to the corresponding rectangle and set the clipping path
+        to ``None``.
 
-        ACCEPTS: [(`~matplotlib.path.Path`, `.Transform`) | `.Patch` | None]
+        For technical reasons (support of ``setp``), a tuple
+        (*path*, *transform*) is also accepted as a single positional
+        parameter.
+
+        .. ACCEPTS: Patch or (Path, Transform) or None
         """
         from matplotlib.patches import Patch, Rectangle
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3103,11 +3103,9 @@ class _AxesBase(martist.Artist):
         """
         Set the x-axis view limits.
 
-        .. ACCEPTS: (left: float, right: float)
-
         Parameters
         ----------
-        left : scalar, optional
+        left : float, optional
             The left xlim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
@@ -3115,7 +3113,9 @@ class _AxesBase(martist.Artist):
             (*left*, *right*) as the first positional argument (or as
             the *left* keyword argument).
 
-        right : scalar, optional
+            .. ACCEPTS: (bottom: float, top: float)
+
+        right : float, optional
             The right xlim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
@@ -3487,11 +3487,9 @@ class _AxesBase(martist.Artist):
         """
         Set the y-axis view limits.
 
-        .. ACCEPTS: (bottom: float, top: float)
-
         Parameters
         ----------
-        bottom : scalar, optional
+        bottom : float, optional
             The bottom ylim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
@@ -3499,7 +3497,9 @@ class _AxesBase(martist.Artist):
             (*bottom*, *top*) as the first positional argument (or as
             the *bottom* keyword argument).
 
-        top : scalar, optional
+            .. ACCEPTS: (bottom: float, top: float)
+
+        top : float, optional
             The top ylim in data coordinates. Passing *None* leaves the
             limit unchanged.
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -269,12 +269,17 @@ class ScalarMappable:
 
     def set_clim(self, vmin=None, vmax=None):
         """
-        set the norm limits for image scaling; if *vmin* is a length2
-        sequence, interpret it as ``(vmin, vmax)`` which is used to
-        support setp
+        Set the norm limits for image scaling.
 
-        ACCEPTS: a length 2 sequence of floats; may be overridden in methods
-        that have ``vmin`` and ``vmax`` kwargs.
+        Parameters
+        ----------
+        vmin, vmax : float
+             The limits.
+
+             The limits may also be passed as a tuple (*vmin*, *vmax*) as a
+             single positional argument.
+
+             .. ACCEPTS: (vmin: float, vmax: float)
         """
         if vmax is None:
             try:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -791,22 +791,27 @@ class Rectangle(Patch):
         self.stale = True
 
     def set_width(self, w):
-        "Set the width of the rectangle."
+        """Set the width of the rectangle."""
         self._width = w
         self._update_x1()
         self.stale = True
 
     def set_height(self, h):
-        "Set the height of the rectangle."
+        """Set the height of the rectangle."""
         self._height = h
         self._update_y1()
         self.stale = True
 
     def set_bounds(self, *args):
         """
-        Set the bounds of the rectangle.
+        Set the bounds of the rectangle as *left*, *bottom*, *width*, *height*.
 
-        ACCEPTS: (left, bottom, width, height)
+        The values may be passed as separate parameters or as a tuple::
+
+            set_bounds(left, bottom, width, height)
+            set_bounds((left, bottom, width, height))
+
+        .. ACCEPTS: (left, bottom, width, height)
         """
         if len(args) == 1:
             l, b, w, h = args[0]
@@ -2403,26 +2408,40 @@ class FancyBboxPatch(Patch):
         self.stale = True
 
     @docstring.dedent_interpd
-    def set_boxstyle(self, boxstyle=None, **kw):
+    def set_boxstyle(self, boxstyle=None, **kwargs):
         """
         Set the box style.
 
-        *boxstyle* can be a string with boxstyle name with optional
-        comma-separated attributes. Alternatively, the attrs can
-        be provided as keywords::
+        Most box styles can be further configured using attributes.
+        Attributes from the previous box style are not reused.
+
+        Without argument (or with ``boxstyle=None``), the available box styles
+        are returned as a human-readable string.
+
+        Parameters
+        ----------
+        boxstyle : str
+            The name of the box style. Optionally, followed by a comma and a
+            comma-separated list of attributes. The attributes may
+            alternatively be passed separately as keyword arguments.
+
+            The following box styles are available:
+
+            %(AvailableBoxstyles)s
+
+            .. ACCEPTS: %(ListBoxstyles)s
+
+        **kwargs
+            Additional attributes for the box style. See the table above for
+            supported parameters.
+
+        Examples
+        --------
+        ::
 
             set_boxstyle("round,pad=0.2")
             set_boxstyle("round", pad=0.2)
 
-        Old attrs simply are forgotten.
-
-        Without argument (or with *boxstyle* = None), it returns
-        available box styles.
-
-        The following boxstyles are available:
-        %(AvailableBoxstyles)s
-
-        ACCEPTS: %(ListBoxstyles)s
         """
         if boxstyle is None:
             return BoxStyle.pprint_styles()
@@ -2430,7 +2449,7 @@ class FancyBboxPatch(Patch):
         if isinstance(boxstyle, BoxStyle._Base) or callable(boxstyle):
             self._bbox_transmuter = boxstyle
         else:
-            self._bbox_transmuter = BoxStyle(boxstyle, **kw)
+            self._bbox_transmuter = BoxStyle(boxstyle, **kwargs)
         self.stale = True
 
     def set_mutation_scale(self, scale):

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -538,17 +538,17 @@ class Spine(mpatches.Patch):
         """
         Set the spine bounds.
 
-        .. ACCEPTS: (low: float, high: float)
-
         Parameters
         ----------
-        low : scalar, optional
+        low : float or None, optional
             The lower spine bound. Passing *None* leaves the limit unchanged.
 
             The bounds may also be passed as the tuple (*low*, *high*) as the
             first positional argument.
 
-        high : scalar, optional
+            .. ACCEPTS: (low: float, high: float)
+
+        high : float or None, optional
             The higher spine bound. Passing *None* leaves the limit unchanged.
         """
         if self.spine_type == 'circle':


### PR DESCRIPTION
## PR Summary

<s>They are not needed anymore because he information can nowadays be read from numpydoc-style docstrings.

This PR does not remove the parser logic nor the tests of the ACCEPTS mechanism (may be done separately).</s>

### Need for accepts (current state)

As @anntzer pointed out https://github.com/matplotlib/matplotlib/pull/15074#pullrequestreview-276270884 the info from ACCEPTS is still needed in some cases.

In particular, we need ACCEPTS if more than one parameter needs to be set for a property. The current implementation for it goes like this:

- The first argument accepts a tuple as well, which will be expanded to the following paramters. Therefore `set_foo((a, b, c))` is equivalent to `set_foo(a, b, c)` and `setp('foo', (a, b, c))` works.
- To announce this behavior for documentation purposes, we have to define `.. ACCEPTS: (a, b, c)` in the docstring. This allows `setp` to provide a proper parameter description and also shows up in property lists.

### Docstring cleanup in this PR

This PR moves plain `ACCEPTS` to comments `.. ACCEPTS`. Thus, these lines do not show up in the rendered HTML docs. This is preferable as the plain ACCEPTS statements are more confusing than helpful for a regular reader of the docs.

Additionally, some docstrings have been improved.

### Possible future improvements

Handling the tuple unpacking and parameter assignment inside the function is quite cumbersome and mixes concerns. I'm considering to move this to a decorator. The decorator could also take the data information so that the docstring can be cleaned from this `.. ACCEPTS` cruft. But that's for another PR (this one could still go in 3.2.0, the decorator stuff would be for 3.3).


