### PR TITLE
Privatize font_manager.JSONEncoder.

### DIFF
--- a/doc/api/next_api_changes/2019-08-18-AL.rst
+++ b/doc/api/next_api_changes/2019-08-18-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+``font_manager.JSONEncoder`` is deprecated.  Use `.font_manager.json_dump` to
+dump a `.FontManager` instance.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -3504,7 +3504,7 @@
     "matplotlib.dviread.Font": [
       "<unknown>:1"
     ],
-    "json.encoder.JSONEncoder": [
+    "matplotlib.font_manager._JSONEncoder": [
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager.JSONEncoder:1"
     ],
     "font_manager.FontProperties": [

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -858,7 +858,7 @@ class FontProperties:
         return new
 
 
-class JSONEncoder(json.JSONEncoder):
+class _JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, FontManager):
             return dict(o.__dict__, __class__='FontManager')
@@ -874,6 +874,11 @@ class JSONEncoder(json.JSONEncoder):
             return d
         else:
             return super().default(o)
+
+
+@cbook.deprecated("3.2", alternative="json_dump")
+class JSONEncoder(_JSONEncoder):
+    pass
 
 
 def _json_decode(o):
@@ -896,26 +901,32 @@ def _json_decode(o):
 
 def json_dump(data, filename):
     """
-    Dumps a data structure as JSON in the named file.
+    Dump `FontManager` *data* as JSON to the file named *filename*.
 
-    Handles FontManager and its fields.  File paths that are children of the
-    Matplotlib data path (typically, fonts shipped with Matplotlib) are stored
-    relative to that data path (to remain valid across virtualenvs).
+    Notes
+    -----
+    File paths that are children of the Matplotlib data path (typically, fonts
+    shipped with Matplotlib) are stored relative to that data path (to remain
+    valid across virtualenvs).
+
+    See Also
+    --------
+    json_load
     """
     with open(filename, 'w') as fh:
         try:
-            json.dump(data, fh, cls=JSONEncoder, indent=2)
+            json.dump(data, fh, cls=_JSONEncoder, indent=2)
         except OSError as e:
             _log.warning('Could not save font_manager cache {}'.format(e))
 
 
 def json_load(filename):
     """
-    Loads a data structure as JSON from the named file.
+    Load a `FontManager` from the JSON file named *filename*.
 
-    Handles FontManager and its fields.  Relative file paths are interpreted
-    as being relative to the Matplotlib data path, and transformed into
-    absolute paths.
+    See Also
+    --------
+    json_dump
     """
     with open(filename, 'r') as fh:
         return json.load(fh, object_hook=_json_decode)


### PR DESCRIPTION
... with the usual deprecation dance.

End users can still use json_dump, which provides the necessary
functionality (the docstring was slightly updated at the same time); the
point is to hide the (lengthy) docs of JSONEncoder from the docs
(https://matplotlib.org/devdocs/api/font_manager_api.html#matplotlib.font_manager.JSONEncoder), where they are basically irrelevant.

---

I guess this picks up another "interesting" issue with missing_references.json: we get missing references when a class (here, the deprecated version of JSONEncoder) has private bases (another prominent case in matplotlib is Axes/_AxesBase), because sphinx tries to link to the base class when generating the inheritance diagram.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
