### PR TITLE
Pass gid to renderer

### DIFF
--- a/doc/api/next_api_changes/2019-08-19-pass_gid.rst
+++ b/doc/api/next_api_changes/2019-08-19-pass_gid.rst
@@ -1,0 +1,10 @@
+The ``gid`` is now correctly passed to svg output
+`````````````````````````````````````````````````
+
+Previously, if a figure, axis, legend or some other artists had a custom
+``gid`` set (e.g. via ``.set_gid()``), this would not be reflected in
+the svg output. Instead a default gid, like ``figure_1`` would be shown.
+This is now fixed, such that e.g. ``fig.set_gid("myfigure")`` correctly
+shows up as ``<g id="myfigure">`` in the svg file. If you relied on the
+gid having the default format, you now need to make sure not to set the
+``gid`` parameter of the artists.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2560,7 +2560,7 @@ class _AxesBase(martist.Artist):
             return
         self._unstale_viewLim()
 
-        renderer.open_group('axes')
+        renderer.open_group('axes', gid=self.get_gid())
 
         # prevent triggering call backs during the draw process
         self._stale = True

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -291,7 +291,7 @@ class Tick(martist.Artist):
         if not self.get_visible():
             self.stale = False
             return
-        renderer.open_group(self.__name__)
+        renderer.open_group(self.__name__, gid=self.get_gid())
         for artist in [self.gridline, self.tick1line, self.tick2line,
                        self.label1, self.label2]:
             artist.draw(renderer)
@@ -1222,7 +1222,7 @@ class Axis(martist.Artist):
 
         if not self.get_visible():
             return
-        renderer.open_group(__name__)
+        renderer.open_group(__name__, gid=self.get_gid())
 
         ticks_to_draw = self._update_ticks()
         ticklabelBoxes, ticklabelBoxes2 = self._get_tick_bboxes(ticks_to_draw,

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1882,7 +1882,7 @@ class TriMesh(Collection):
     def draw(self, renderer):
         if not self.get_visible():
             return
-        renderer.open_group(self.__class__.__name__)
+        renderer.open_group(self.__class__.__name__, gid=self.get_gid())
         transform = self.get_transform()
 
         # Get a list of triangles and the color at each vertex.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1724,7 +1724,7 @@ default: 'top'
                         child.apply_aspect()
 
         try:
-            renderer.open_group('figure')
+            renderer.open_group('figure', gid=self.get_gid())
             if self.get_constrained_layout() and self.axes:
                 self.execute_constrained_layout(renderer)
             if self.get_tight_layout() and self.axes:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -633,7 +633,7 @@ class Legend(Artist):
         if not self.get_visible():
             return
 
-        renderer.open_group('legend')
+        renderer.open_group('legend', gid=self.get_gid())
 
         fontsize = renderer.points_to_pixels(self._fontsize)
 

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -411,7 +411,7 @@ class Table(Artist):
 
         if not self.get_visible():
             return
-        renderer.open_group('table')
+        renderer.open_group('table', gid=self.get_gid())
         self._update_positions(renderer)
 
         for key in sorted(self._cells):

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -189,7 +189,7 @@ def test_gid():
         if isinstance(obj, plt.Text):
             if obj.get_text() == "":
                 return False
-            elif not hasattr(obj, "axes") or obj.axes is None:
+            elif obj.axes is None:
                 return False
         if isinstance(obj, plt.Line2D):
             if np.array(obj.get_data()).shape == (2, 1):

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -127,7 +127,7 @@ class BezierPath(Line2D):
 
         if not self._visible:
             return
-        renderer.open_group('line2d')
+        renderer.open_group('line2d', gid=self.get_gid())
 
         gc = renderer.new_gc()
         self._set_gc_clip(gc)
@@ -1230,7 +1230,7 @@ class AxisArtist(martist.Artist):
         if not self.get_visible():
             return
 
-        renderer.open_group(__name__)
+        renderer.open_group(__name__, gid=self.get_gid())
 
         self._axis_artist_helper.update_lim(self.axes)
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -190,7 +190,7 @@ class Axis(maxis.XAxis):
         return mins, maxs, centers, deltas, tc, highs
 
     def draw_pane(self, renderer):
-        renderer.open_group('pane3d')
+        renderer.open_group('pane3d', gid=self.get_gid())
 
         mins, maxs, centers, deltas, tc, highs = self._get_coord_info(renderer)
 
@@ -209,7 +209,7 @@ class Axis(maxis.XAxis):
     @artist.allow_rasterization
     def draw(self, renderer):
         self.label._transform = self.axes.transData
-        renderer.open_group('axis3d')
+        renderer.open_group('axis3d', gid=self.get_gid())
 
         ticks = self._update_ticks()
 


### PR DESCRIPTION
## PR Summary

Previously the figure's `gid` would not be passed to the renderer.   
Fixes the issue brought up in https://stackoverflow.com/questions/57563180/fail-to-set-figure-gid-in-python-matplotlib

```
import matplotlib.pyplot as plt

fig = plt.figure()
fig.set_gid("myfigure")

fig.savefig("test.svg")
```

Previously:

```
<svg ....>
<g id="figure_1">
```

With this PR:

```
<svg ....>
<g id="myfigure">

```

Also, do the same with axis, ticks and legend and all other artists.   
<strike>I did not perform a complete search on whereelse it might be missing.</strike>


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
