### PR TITLE
Fix more doc references.

### DIFF
--- a/doc/api/next_api_changes/2018-02-10-AL.rst
+++ b/doc/api/next_api_changes/2018-02-10-AL.rst
@@ -16,10 +16,10 @@ The main differences are:
   ``colorbar.yaxis`` depending on the orientation, rather than
   ``colorbar.cbar_axis``.
 - Overdrawing multiple colorbars on top of one another in a single Axes (e.g.
-  when using the ``cax`` attribute of `ImageGrid` elements) is not supported;
-  if you previously relied on the second colorbar being drawn over the first,
-  you can call ``cax.cla()`` to clear the axes before drawing the second
-  colorbar.
+  when using the ``cax`` attribute of `~.axes_grid1.axes_grid.ImageGrid`
+  elements) is not supported; if you previously relied on the second colorbar
+  being drawn over the first, you can call ``cax.cla()`` to clear the axes
+  before drawing the second colorbar.
 
 During the deprecation period, the ``mpl_toolkits.legacy_colorbar``
 rcParam can be set to True to use ``mpl_toolkits.axes_grid1.colorbar`` in

--- a/doc/api/toolkits/axes_grid1.rst
+++ b/doc/api/toolkits/axes_grid1.rst
@@ -1,9 +1,9 @@
-.. _toolkit_axesgrid1-index:
+.. module:: mpl_toolkits.axes_grid1
 
 Matplotlib axes_grid1 Toolkit
 =============================
 
-The matplotlib :class:`mpl_toolkits.axes_grid1` toolkit is a collection of
+The matplotlib :mod:`mpl_toolkits.axes_grid1` toolkit is a collection of
 helper classes to ease displaying multiple images in matplotlib.  While the
 aspect parameter in matplotlib adjust the position of the single axes,
 axes_grid1 toolkit provides a framework to adjust the position of
@@ -15,8 +15,6 @@ See :ref:`axes_grid1_users-guide-index` for a guide on the usage of axes_grid1.
    :target: ../../gallery/axes_grid1/demo_axes_grid.html
    :align: center
    :scale: 50
-
-
 
 .. currentmodule:: mpl_toolkits
 

--- a/doc/api/toolkits/axisartist.rst
+++ b/doc/api/toolkits/axisartist.rst
@@ -1,4 +1,4 @@
-.. _toolkit_axisartist-index:
+.. module:: mpl_toolkits.axisartist
 
 Matplotlib axisartist Toolkit
 =============================

--- a/doc/api/toolkits/index.rst
+++ b/doc/api/toolkits/index.rst
@@ -6,11 +6,8 @@
 Toolkits
 ########
 
-
-
 Toolkits are collections of application-specific functions that extend
 Matplotlib.
-
 
 .. _toolkit_mplot3d:
 
@@ -41,20 +38,11 @@ Links
 -----
 * mpl3d API: :ref:`toolkit_mplot3d-api`
 
-.. _toolkit_axes_grid1_incl:
-
 .. include:: axes_grid1.rst
    :start-line: 1
 
-.. _toolkit_axisartist_incl:
-   
 .. include:: axisartist.rst
    :start-line: 1
 
-.. _toolkit_axes_grid_incl:
-   
 .. include:: axes_grid.rst
    :start-line: 1
-
-
-

--- a/examples/axes_grid1/simple_anchored_artists.py
+++ b/examples/axes_grid1/simple_anchored_artists.py
@@ -4,7 +4,7 @@ Simple Anchored Artists
 =======================
 
 This example illustrates the use of the anchored helper classes found in
-:py:mod:`~matplotlib.offsetbox` and in the :ref:`toolkit_axesgrid1-index`.
+:mod:`matplotlib.offsetbox` and in :mod:`mpl_toolkits.axes_grid1`.
 An implementation of a similar figure, but without use of the toolkit,
 can be found in :doc:`/gallery/misc/anchored_artists`.
 """

--- a/examples/axisartist/demo_parasite_axes.py
+++ b/examples/axisartist/demo_parasite_axes.py
@@ -12,8 +12,8 @@ This approach uses `mpl_toolkits.axes_grid1.parasite_axes.HostAxes` and
 An alternative approach using standard Matplotlib subplots is shown in the
 :doc:`/gallery/ticks_and_spines/multiple_yaxis_with_spines` example.
 
-An alternative approach using the :ref:`toolkit_axesgrid1-index`
-and :ref:`toolkit_axisartist-index` is found in the
+An alternative approach using :mod:`mpl_toolkits.axes_grid1`
+and :mod:`mpl_toolkits.axisartist` is found in the
 :doc:`/gallery/axisartist/demo_parasite_axes2` example.
 """
 

--- a/examples/misc/anchored_artists.py
+++ b/examples/misc/anchored_artists.py
@@ -4,7 +4,7 @@ Anchored Artists
 ================
 
 This example illustrates the use of the anchored objects without the
-helper classes found in the :ref:`toolkit_axesgrid1-index`. This version
+helper classes found in :mod:`mpl_toolkits.axes_grid1`. This version
 of the figure is similar to the one found in
 :doc:`/gallery/axes_grid1/simple_anchored_artists`, but it is
 implemented using only the matplotlib namespace, without the help

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -316,7 +316,7 @@ plt.show()
 # Use with AxesGrid1
 # ==================
 #
-# While limited, the axes_grid1 toolkit is also supported.
+# While limited, :mod:`mpl_toolkits.axes_grid1` is also supported.
 
 from mpl_toolkits.axes_grid1 import Grid
 


### PR DESCRIPTION
Again fixing some broken some references from a PR that was CI'd before
the missing-references.json PR.  Here I just added proper reference
targets for the mpl_toolkits.{axes_grid1,axisartis} modules.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
