### PR TITLE
Coerce MxNx1 images into MxN images for imshow

### DIFF
--- a/doc/users/next_whats_new/imshow_m_n_1.rst
+++ b/doc/users/next_whats_new/imshow_m_n_1.rst
@@ -1,0 +1,6 @@
+Imshow now coerces 3D arrays with depth 1 to 2D
+------------------------------------------------
+The number of ticks on colorbars was appropriate for a large colorbar, but
+Starting from this version arrays of size MxNx1 will be coerced into MxN 
+for displaying. This means commands like ``plt.imshow(np.ones((3, 3, 1)))`` 
+will no longer return an error message that the image shape is invalid.

--- a/doc/users/next_whats_new/imshow_m_n_1.rst
+++ b/doc/users/next_whats_new/imshow_m_n_1.rst
@@ -1,6 +1,5 @@
 Imshow now coerces 3D arrays with depth 1 to 2D
 ------------------------------------------------
-The number of ticks on colorbars was appropriate for a large colorbar, but
 Starting from this version arrays of size MxNx1 will be coerced into MxN 
-for displaying. This means commands like ``plt.imshow(np.ones((3, 3, 1)))`` 
+for displaying. This means commands like ``plt.imshow(np.random.rand(3, 3, 1))`` 
 will no longer return an error message that the image shape is invalid.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -674,7 +674,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         if (self._A.ndim == 3 and self._A.shape[-1] == 1):
             # If just one dimension assume grayscale
             self._A = self._A[:, :, 0]
-        
+
         if not (self._A.ndim == 2
                 or self._A.ndim == 3 and self._A.shape[-1] in [3, 4]):
             raise TypeError("Invalid shape {} for image data"

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -672,7 +672,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                             "float".format(self._A.dtype))
 
         if (self._A.ndim == 3 and self._A.shape[-1] == 1):
-            # If just one dimension assume grayscale
+            # If just one dimension assume scalar and apply colormap
             self._A = self._A[:, :, 0]
 
         if not (self._A.ndim == 2

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -671,7 +671,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             raise TypeError("Image data of dtype {} cannot be converted to "
                             "float".format(self._A.dtype))
 
-        if not (self._A.ndim == 3 and self._A.shape[-1]==1):
+        if (self._A.ndim == 3 and self._A.shape[-1] == 1):
             # If just one dimension assume grayscale
             self._A = self._A[:, :, 0]
         

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -671,6 +671,10 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             raise TypeError("Image data of dtype {} cannot be converted to "
                             "float".format(self._A.dtype))
 
+        if not (self._A.ndim == 3 and self._A.shape[-1]==1):
+            # If just one dimension assume grayscale
+            self._A = self._A[:, :, 0]
+        
         if not (self._A.ndim == 2
                 or self._A.ndim == 3 and self._A.shape[-1] in [3, 4]):
             raise TypeError("Invalid shape {} for image data"

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -458,13 +458,33 @@ def test_imshow():
     ax.set_ylim(0, 3)
 
 
-@image_comparison(['imshow'], remove_text=True, style='mpl20')
-def test_imshow_10_10_1():
-    fig, ax = plt.subplots()
+@check_figures_equal(extensions=['png'])
+def test_imshow_10_10_1(fig_test, fig_ref):
+    # 10x10x1 should be the same as 10x10
     arr = np.arange(100).reshape((10, 10, 1))
+    ax = fig_ref.subplots()
+    ax.imshow(arr[:, :, 0], interpolation="bilinear", extent=(1, 2, 1, 2))
+    ax.set_xlim(0, 3)
+    ax.set_ylim(0, 3)
+    
+    ax = fig_test.subplots()
     ax.imshow(arr, interpolation="bilinear", extent=(1, 2, 1, 2))
     ax.set_xlim(0, 3)
     ax.set_ylim(0, 3)
+
+
+def test_imshow_10_10_2():
+    fig, ax = plt.subplots()
+    arr = np.arange(200).reshape((10, 10, 2))
+    with pytest.raises(TypeError):
+        ax.imshow(arr)
+
+
+def test_imshow_10_10_5():
+    fig, ax = plt.subplots()
+    arr = np.arange(500).reshape((10, 10, 5))
+    with pytest.raises(TypeError):
+        ax.imshow(arr)
 
 
 @image_comparison(['no_interpolation_origin'], remove_text=True)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -458,6 +458,15 @@ def test_imshow():
     ax.set_ylim(0, 3)
 
 
+@image_comparison(['imshow'], remove_text=True, style='mpl20')
+def test_imshow_10_10_1():
+    fig, ax = plt.subplots()
+    arr = np.arange(100).reshape((10, 10, 1))
+    ax.imshow(arr, interpolation="bilinear", extent=(1, 2, 1, 2))
+    ax.set_xlim(0, 3)
+    ax.set_ylim(0, 3)
+
+
 @image_comparison(['no_interpolation_origin'], remove_text=True)
 def test_no_interpolation_origin():
     fig, axs = plt.subplots(2)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -466,7 +466,7 @@ def test_imshow_10_10_1(fig_test, fig_ref):
     ax.imshow(arr[:, :, 0], interpolation="bilinear", extent=(1, 2, 1, 2))
     ax.set_xlim(0, 3)
     ax.set_ylim(0, 3)
-    
+
     ax = fig_test.subplots()
     ax.imshow(arr, interpolation="bilinear", extent=(1, 2, 1, 2))
     ax.set_xlim(0, 3)


### PR DESCRIPTION
## PR Summary
Causes `matplotlib.pyplot.imshow` to work with depth=1 images (common in deep learning and segmentation) as if they were grayscale rather than throwing an error message (so it should be backward compatible, unless someone expected it to throw an error)
- closes #15089
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

## Specific Tests

- [x] shape (n,m) -> colormapping
- [x] shape(n,m,1) -> colormapping, same as (n,m), newly introduced here.
- [x] shape(n,m,2) -> Error
- [x] shape(n,m,3) -> RGB image
- [x] shape(n,m,4) -> RGBA image
- [x] shape(n,m,5) -> Error
