### PR TITLE
Simplify _png extension by handling file open/close in Python.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -639,7 +639,8 @@ class RendererPgf(RendererBase):
         fname = os.path.splitext(os.path.basename(self.fh.name))[0]
         fname_img = "%s-img%d.png" % (fname, self.image_counter)
         self.image_counter += 1
-        _png.write_png(im[::-1], os.path.join(path, fname_img))
+        with pathlib.Path(path, fname_img).open("wb") as file:
+            _png.write_png(im[::-1], file)
 
         # reference the image in the pgf picture
         writeln(self.fh, r"\begin{pgfscope}")

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -821,12 +821,11 @@ class RendererSVG(RendererBase):
         if url is not None:
             self.writer.start('a', attrib={'xlink:href': url})
         if rcParams['svg.image_inline']:
-            bytesio = io.BytesIO()
-            _png.write_png(im, bytesio)
-            oid = oid or self._make_id('image', bytesio.getvalue())
+            buf = _png.write_png(im, None)
+            oid = oid or self._make_id('image', buf)
             attrib['xlink:href'] = (
                 "data:image/png;base64,\n" +
-                base64.b64encode(bytesio.getvalue()).decode('ascii'))
+                base64.b64encode(buf).decode('ascii'))
         else:
             if self.basename is None:
                 raise ValueError("Cannot save image data to filesystem when "
@@ -834,7 +833,8 @@ class RendererSVG(RendererBase):
             filename = '{}.image{}.png'.format(
                 self.basename, next(self._image_counter))
             _log.info('Writing image file for inclusion: %s', filename)
-            _png.write_png(im, filename)
+            with open(filename, 'wb') as file:
+                _png.write_png(im, file)
             oid = oid or 'Im_' + self._make_id('image', filename)
             attrib['xlink:href'] = filename
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -3433,7 +3433,8 @@ class MathTextParser:
         from matplotlib import _png
         rgba, depth = self.to_rgba(
             texstr, color=color, dpi=dpi, fontsize=fontsize)
-        _png.write_png(rgba, filename)
+        with open(filename, "wb") as file:
+            _png.write_png(rgba, file)
         return depth
 
     def get_depth(self, texstr, dpi=120, fontsize=14):

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -384,10 +384,10 @@ def compare_images(expected, actual, tol, in_decorator=False):
         expected = convert(expected, True)
 
     # open the image files and remove the alpha channel (if it exists)
-    expected_image = _png.read_png_int(expected)
-    actual_image = _png.read_png_int(actual)
-    expected_image = expected_image[:, :, :3]
-    actual_image = actual_image[:, :, :3]
+    with open(expected, "rb") as expected_file:
+        expected_image = _png.read_png_int(expected_file)[:, :, :3]
+    with open(actual, "rb") as actual_file:
+        actual_image = _png.read_png_int(actual_file)[:, :, :3]
 
     actual_image, expected_image = crop_to_same(
         actual, actual_image, expected, expected_image)
@@ -438,8 +438,10 @@ def save_diff_image(expected, actual, output):
     '''
     # Drop alpha channels, similarly to compare_images.
     from matplotlib import _png
-    expected_image = _png.read_png(expected)[..., :3]
-    actual_image = _png.read_png(actual)[..., :3]
+    with open(expected, "rb") as expected_file:
+        expected_image = _png.read_png(expected_file)[..., :3]
+    with open(actual, "rb") as actual_file:
+        actual_image = _png.read_png(actual_file)[..., :3]
     actual_image, expected_image = crop_to_same(
         actual, actual_image, expected, expected_image)
     expected_image = np.array(expected_image).astype(float)
@@ -465,4 +467,5 @@ def save_diff_image(expected, actual, output):
     # Hard-code the alpha channel to fully solid
     save_image_np[:, :, 3] = 255
 
-    _png.write_png(save_image_np, output)
+    with open(output, "wb") as output_file:
+        _png.write_png(save_image_np, output_file)

--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -1,6 +1,8 @@
 from io import BytesIO
 import glob
 import os
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -33,9 +35,9 @@ def test_pngsuite():
 
 def test_imread_png_uint16():
     from matplotlib import _png
-    img = _png.read_png_int(os.path.join(os.path.dirname(__file__),
-                                     'baseline_images/test_png/uint16.png'))
-
+    with (Path(__file__).parent
+          / 'baseline_images/test_png/uint16.png').open('rb') as file:
+        img = _png.read_png_int(file)
     assert (img.dtype == np.uint16)
     assert np.sum(img.flatten()) == 134184960
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -403,7 +403,8 @@ class TexManager:
         alpha = self.grey_arrayd.get(key)
         if alpha is None:
             pngfile = self.make_png(tex, fontsize, dpi)
-            X = _png.read_png(os.path.join(self.texcache, pngfile))
+            with open(os.path.join(self.texcache, pngfile), "rb") as file:
+                X = _png.read_png(file)
             self.grey_arrayd[key] = alpha = X[:, :, -1]
         return alpha
 


### PR DESCRIPTION
Make functions in the (private) _png extension only take file-like
objects as arguments, rather than "filename or file-like".  Filenames
were anyways handled by calling the python C-API to open/close the
files, so we may as well just do this from Python where a simple
`with open(...):` does the job.  The public API is not changed.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
