### PR TITLE
Clip annotations if annotation_clip is not False and clip_on is not set

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -773,6 +773,10 @@ class Axes(_AxesBase):
 
     @docstring.dedent_interpd
     def annotate(self, s, xy, *args, **kwargs):
+        if kwargs.get('annotation_clip', None) is not False:
+            if 'clip_on' not in kwargs:
+                kwargs['clip_on'] = True
+
         a = mtext.Annotation(s, xy, *args, **kwargs)
         a.set_transform(mtransforms.IdentityTransform())
         if 'clip_on' in kwargs:


### PR DESCRIPTION
## PR Summary

If an annotation is created using e.g. `plt.annotate(xy=(3, 3), s='test')`, then this annotation is clipped on the scene as a default, but still virtually occupies space that leads to a larger bounding box. This goes also for `annotation_clip=True`. Currently, the parameter `clip_on` defaults to `None`, which leads to this exact situation. With this PR, it defaults to `True`, if `annotation_clip` is not `False`. This fixes the original issue while preserving both the ability to change `clip_on` if wished and leaving the API unchanged, so the result of `annotation_clip=False` is unchanged.

Fixes #14354.

## PR Checklist

*Disclamer: This PR is created as bug fix. Therefore, most of the following checklist does not apply. If a unit test for this is desired, I can create one. I am just not sure how a good test would be applied here.*

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
