### PR TITLE
Add lightsource parameter to bar3d

### DIFF
--- a/doc/users/next_whats_new/bar3d_lightsource.rst
+++ b/doc/users/next_whats_new/bar3d_lightsource.rst
@@ -1,4 +1,4 @@
-bar3d gained support for the `lightsource` parameter
+bar3d gained support for the ``lightsource`` parameter
 ----------------------------------------------------
 
 bar3d now supports lighting from different angles when the *shade* parameter is

--- a/doc/users/next_whats_new/bar3d_lightsource.rst
+++ b/doc/users/next_whats_new/bar3d_lightsource.rst
@@ -1,0 +1,5 @@
+bar3d gained support for the `lightsource` parameter
+----------------------------------------------------
+
+bar3d now supports lighting from different angles when 
+the *shade* parameter is True.

--- a/doc/users/next_whats_new/bar3d_lightsource.rst
+++ b/doc/users/next_whats_new/bar3d_lightsource.rst
@@ -1,5 +1,5 @@
 bar3d gained support for the `lightsource` parameter
 ----------------------------------------------------
 
-bar3d now supports lighting from different angles when 
-the *shade* parameter is True.
+bar3d now supports lighting from different angles when the *shade* parameter is
+True.

--- a/doc/users/next_whats_new/bar3d_lightsource.rst
+++ b/doc/users/next_whats_new/bar3d_lightsource.rst
@@ -1,5 +1,5 @@
 bar3d gained support for the ``lightsource`` parameter
-----------------------------------------------------
+------------------------------------------------------
 
 bar3d now supports lighting from different angles when the *shade* parameter is
 True.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2375,7 +2375,7 @@ class Axes3D(Axes):
         shade : bool, optional (default = True)
             When true, this shades the dark sides of the bars (relative
             to the plot's source of light).
-            
+
         lightsource : `~matplotlib.colors.LightSource`
             The lightsource to use when *shade* is True.
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1241,7 +1241,7 @@ class Axes3D(Axes):
         label = self.zaxis.get_label()
         return label.get_text()
 
-    #### Axes rectangle characteristics
+    # Axes rectangle characteristics
 
     def get_frame_on(self):
         """
@@ -1344,7 +1344,7 @@ class Axes3D(Axes):
             zkw.pop('labelbottom', None)
             self.zaxis.set_tick_params(**zkw)
 
-    ### data limits, ticks, tick labels, and formatting
+    # data limits, ticks, tick labels, and formatting
 
     def invert_zaxis(self):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2376,8 +2376,8 @@ class Axes3D(Axes):
             When true, this shades the dark sides of the bars (relative
             to the plot's source of light).
             
-        lightsource : matplotlib.color.LightSource, optional (default = None)
-            The lightsource defines the plot's source of light.
+        lightsource : `~matplotlib.colors.LightSource`
+            The lightsource to use when *shade* is True.
 
         **kwargs
             Any additional keyword arguments are passed onto

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2333,7 +2333,7 @@ class Axes3D(Axes):
         return patches
 
     def bar3d(self, x, y, z, dx, dy, dz, color=None,
-              zsort='average', shade=True, *args, **kwargs):
+              zsort='average', shade=True, lightsource=None, *args, **kwargs):
         """Generate a 3D barplot.
 
         This method creates three dimensional barplot where the width,
@@ -2375,6 +2375,9 @@ class Axes3D(Axes):
         shade : bool, optional (default = True)
             When true, this shades the dark sides of the bars (relative
             to the plot's source of light).
+            
+        lightsource : matplotlib.color.LightSource, optional (default = None)
+            The lightsource defines the plot's source of light.
 
         **kwargs
             Any additional keyword arguments are passed onto
@@ -2474,7 +2477,7 @@ class Axes3D(Axes):
 
         if shade:
             normals = self._generate_normals(polys)
-            sfacecolors = self._shade_colors(facecolors, normals)
+            sfacecolors = self._shade_colors(facecolors, normals, lightsource)
         else:
             sfacecolors = facecolors
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -488,7 +488,7 @@ class Axes3D(Axes):
             else:
                 scalez = False
         self.autoscale_view(tight=tight, scalex=scalex, scaley=scaley,
-                                         scalez=scalez)
+                            scalez=scalez)
 
     def auto_scale_xyz(self, X, Y, Z=None, had_data=None):
         # This updates the bounding boxes as to keep a record as to what the
@@ -505,7 +505,7 @@ class Axes3D(Axes):
         self.autoscale_view()
 
     def autoscale_view(self, tight=None, scalex=True, scaley=True,
-                             scalez=True):
+                       scalez=True):
         """
         Autoscale the view limits using the data limits.
         See :meth:`matplotlib.axes.Axes.autoscale_view` for documentation.
@@ -631,7 +631,7 @@ class Axes3D(Axes):
             for other in self._shared_x_axes.get_siblings(self):
                 if other is not self:
                     other.set_xlim(self.xy_viewLim.intervalx,
-                                            emit=False, auto=auto)
+                                   emit=False, auto=auto)
                     if other.figure != self.figure:
                         other.figure.canvas.draw_idle()
         self.stale = True
@@ -692,7 +692,7 @@ class Axes3D(Axes):
             for other in self._shared_y_axes.get_siblings(self):
                 if other is not self:
                     other.set_ylim(self.xy_viewLim.intervaly,
-                                            emit=False, auto=auto)
+                                   emit=False, auto=auto)
                     if other.figure != self.figure:
                         other.figure.canvas.draw_idle()
         self.stale = True
@@ -753,7 +753,7 @@ class Axes3D(Axes):
             for other in self._shared_z_axes.get_siblings(self):
                 if other is not self:
                     other.set_zlim(self.zz_viewLim.intervalx,
-                                            emit=False, auto=auto)
+                                   emit=False, auto=auto)
                     if other.figure != self.figure:
                         other.figure.canvas.draw_idle()
         self.stale = True
@@ -1820,9 +1820,9 @@ class Axes3D(Axes):
         tzlines = [tZ[i] for i in cii]
 
         lines = ([list(zip(xl, yl, zl))
-                  for xl, yl, zl in zip(xlines, ylines, zlines)]
-                + [list(zip(xl, yl, zl))
-                   for xl, yl, zl in zip(txlines, tylines, tzlines)])
+                 for xl, yl, zl in zip(xlines, ylines, zlines)]
+                 + [list(zip(xl, yl, zl))
+                 for xl, yl, zl in zip(txlines, tylines, tzlines)])
 
         linec = art3d.Line3DCollection(lines, *args, **kwargs)
         self.add_collection(linec)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -85,6 +85,7 @@ def test_bar3d_lightsource():
                           dx=1, dy=1, dz=dz,
                           color=color, shade=True, lightsource=ls)
 
+    # Asserts that the bar top colors are unchanged with light from above
     np.testing.assert_array_equal(color, collection._facecolors3d[1::6])
 
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -85,7 +85,10 @@ def test_bar3d_lightsource():
                           dx=1, dy=1, dz=dz,
                           color=color, shade=True, lightsource=ls)
 
-    # Asserts that the bar top colors are unchanged with light from above
+    # Testing that the custom 90° lightsource produces different shading on
+    # the top facecolors then to the default, and that those colors are
+    # precisely the colors from the colormap, due to the illumination parallel
+    # to the z-axis.
     np.testing.assert_array_equal(color, collection._facecolors3d[1::6])
 
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -4,6 +4,7 @@ from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 import matplotlib as mpl
 from matplotlib import cm
 from matplotlib import path as mpath
+from matplotlib import colors as mcolors
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
 from matplotlib.collections import LineCollection, PolyCollection
@@ -62,6 +63,29 @@ def test_bar3d_notshaded():
     z = x2d + y2d
     ax.bar3d(x2d, y2d, x2d * 0, 1, 1, z, shade=False)
     fig.canvas.draw()
+
+
+def test_bar3d_lightsource():
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1, projection="3d")
+
+    ls = mcolors.LightSource(azdeg=0, altdeg=90)
+
+    length, width = 3, 4
+    area = length * width
+
+    x, y = np.meshgrid(np.arange(length), np.arange(width))
+    x = x.ravel()
+    y = y.ravel()
+    dz = x + y
+
+    color = [cm.coolwarm(i/area) for i in range(area)]
+
+    collection = ax.bar3d(x=x, y=y, z=0,
+                          dx=1, dy=1, dz=dz,
+                          color=color, shade=True, lightsource=ls)
+
+    np.testing.assert_array_equal(color, collection._facecolors3d[1::6])
 
 
 @image_comparison(['contour3d.png'], remove_text=True, style='mpl20')

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -86,7 +86,7 @@ def test_bar3d_lightsource():
                           color=color, shade=True, lightsource=ls)
 
     # Testing that the custom 90° lightsource produces different shading on
-    # the top facecolors then to the default, and that those colors are
+    # the top facecolors compared to the default, and that those colors are
     # precisely the colors from the colormap, due to the illumination parallel
     # to the z-axis.
     np.testing.assert_array_equal(color, collection._facecolors3d[1::6])


### PR DESCRIPTION
Bar3d now allows the user to define the user to define the origin of the lightsource.

## PR Summary

Note: I have little experience with pull requests, and I have not thouroughly checked the correctness of the code (even though it is two lines of code, anything can go wrong), so I cannot advise a merge just yet. I would like to hear if this change is even needed (is this even the best way to go about it?). I will make the proper adjustments if needed, any advice is appreciated.

This adds a `lightsource` parameter to `bar3d`. This is already a documented feature without any implementation (AFAIK). The documentation for the `shade` parameter says:

> When true, this shades the dark sides of the bars (relative to the plot's source of light).

However, there is currently no apparent way to set this, as `bar3d` calls `self._shade_colors(facecolors, normals)` without a lightsource parameter, which by default uses `LightSource(azdeg=225, altdeg=19.4712)` if no `lightsource` parameter is set.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] ~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
