### PR TITLE
Add a SymmetricalLogFormatter

### DIFF
--- a/doc/api/next_api_changes/2019-08-22-DS.rst
+++ b/doc/api/next_api_changes/2019-08-22-DS.rst
@@ -1,0 +1,5 @@
+``linthresh`` paramter to `LogFormatter` is deprecated
+------------------------------------------------------
+Handing the ``linthresh`` parameter to `LogFormatter` is deprecated, and
+code for handling `SymmetricalLogScale` formattng has been moved to the new
+`SymmetricalLogFormatter` class, which takes the ``linthresh`` parameter.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -16,6 +16,7 @@ from numpy import ma
 from matplotlib import cbook, docstring, rcParams
 from matplotlib.ticker import (
     NullFormatter, ScalarFormatter, LogFormatterSciNotation, LogitFormatter,
+    SymmetricalLogFormatter,
     NullLocator, LogLocator, AutoLocator, AutoMinorLocator,
     SymmetricalLogLocator, LogitLocator)
 from matplotlib.transforms import Transform, IdentityTransform
@@ -578,7 +579,8 @@ class SymmetricalLogScale(ScaleBase):
     def set_default_locators_and_formatters(self, axis):
         # docstring inherited
         axis.set_major_locator(SymmetricalLogLocator(self.get_transform()))
-        axis.set_major_formatter(LogFormatterSciNotation(self.base))
+        axis.set_major_formatter(SymmetricalLogFormatter(self.linthresh,
+                                                         base=self.base))
         axis.set_minor_locator(SymmetricalLogLocator(self.get_transform(),
                                                      self.subs))
         axis.set_minor_formatter(NullFormatter())

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -180,6 +180,7 @@ __all__ = ('TickHelper', 'Formatter', 'FixedFormatter',
            'StrMethodFormatter', 'ScalarFormatter', 'LogFormatter',
            'LogFormatterExponent', 'LogFormatterMathtext',
            'IndexFormatter', 'LogFormatterSciNotation',
+           'SymmetricalLogFormatter',
            'LogitFormatter', 'EngFormatter', 'PercentFormatter',
            'Locator', 'IndexLocator', 'FixedLocator', 'NullLocator',
            'LinearLocator', 'LogLocator', 'AutoLocator',
@@ -894,6 +895,7 @@ class LogFormatter(Formatter):
     decades, use ``minor_thresholds=(1.5, 1.5)``.
 
     """
+    @cbook._delete_parameter('3.2', 'linthresh')
     def __init__(self, base=10.0, labelOnlyBase=False,
                  minor_thresholds=None,
                  linthresh=None):
@@ -1159,11 +1161,18 @@ class LogFormatterSciNotation(LogFormatterMathtext):
         if is_close_to_int(coeff):
             coeff = round(coeff)
         if usetex:
-            return (r'$%s%g\times%s^{%d}$') % \
-                                        (sign_string, coeff, base, exponent)
+            return ((r'$%s%g\times%s^{%d}$') %
+                    (sign_string, coeff, base, exponent))
         else:
             return ('$%s$' % _mathdefault(r'%s%g\times%s^{%d}' %
-                                        (sign_string, coeff, base, exponent)))
+                    (sign_string, coeff, base, exponent)))
+
+
+class SymmetricalLogFormatter(LogFormatterSciNotation):
+    def __init__(self, linthresh, base=10.0, labelOnlyBase=False,
+                 minor_thresholds=None):
+        super().__init__(base, labelOnlyBase, minor_thresholds)
+        self._linthresh = linthresh
 
 
 class LogitFormatter(Formatter):


### PR DESCRIPTION
This extracts the logic inside `LogFormatter` that is designed for `SymmetricalLogScale` and puts it into a new `SymmetricalLogFormatter` class. This doesn't change any of the scale formatting behaviour, but provides better code for doing so in the future.

I've added inline comments on the changes.