### PR TITLE
Fix doc build and resync matplotlibrc.template with actual defaults.

### DIFF
--- a/doc/api/next_api_changes/2019-07-18-SL.rst
+++ b/doc/api/next_api_changes/2019-07-18-SL.rst
@@ -1,4 +1,4 @@
-Reduced default value of `axes.formatter.limits`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reduced default value of :rc:`axes.formatter.limits`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Changed the default value of `axes.formatter.limits` from -7, 7 to -5, 6 for better readability.
+Changed the default value of :rc:`axes.formatter.limits` from -7, 7 to -5, 6 for better readability.

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -368,7 +368,7 @@
                               ##     - above patches but below lines ('line')
                               ##     - above all (False)
 
-#axes.formatter.limits : -7, 7  ## use scientific notation if log10
+#axes.formatter.limits : -5, 6  ## use scientific notation if log10
                                 ## of the axis range is smaller than the
                                 ## first or larger than the second
 #axes.formatter.use_locale : False  ## When True, format tick labels


### PR DESCRIPTION
## PR Summary

(note that https://github.com/matplotlib/matplotlib/pull/15029 would have made the resync unnecessary :))
intending to self-merge once ci passes.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
