### PR TITLE
Add inheritance diagram to mpl.ticker docs

### DIFF
--- a/doc/api/ticker_api.rst
+++ b/doc/api/ticker_api.rst
@@ -6,3 +6,7 @@
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+.. inheritance-diagram:: matplotlib.ticker
+   :parts: 1

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -181,10 +181,11 @@ __all__ = ('TickHelper', 'Formatter', 'FixedFormatter',
            'LogFormatterExponent', 'LogFormatterMathtext',
            'IndexFormatter', 'LogFormatterSciNotation',
            'LogitFormatter', 'EngFormatter', 'PercentFormatter',
+           'OldScalarFormatter',
            'Locator', 'IndexLocator', 'FixedLocator', 'NullLocator',
            'LinearLocator', 'LogLocator', 'AutoLocator',
            'MultipleLocator', 'MaxNLocator', 'AutoMinorLocator',
-           'SymmetricalLogLocator', 'LogitLocator')
+           'SymmetricalLogLocator', 'LogitLocator', 'OldAutoLocator')
 
 
 def _mathdefault(s):


### PR DESCRIPTION
Does what it says on the tin, it's a bit of a high inheritance diagram so I've put it under the main docs. Also adds a couple of missing entries to `__all__`.