### PR TITLE
By default, don't change the figure face/edgecolor on savefig().

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -234,3 +234,10 @@ This also means there is a new keyword argument for `.axes.Axes.get_tightbbox`:
 bounding box using the rules above.  `.axis.Axis.get_tightbbox` gets an
 ``ignore_label`` keyword argument, which is *None* by default, but which can
 also be 'x' or 'y'. 
+
+:rc:`savefig.facecolor` and :rc:`savefig.edgecolor` now default to "auto"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This newly allowed value for :rc:`savefig.facecolor` and :rc:`savefig.edgecolor`,
+as well as the *facecolor* and *edgecolor* parameters to `.Figure.savefig`, means
+"use whatever facecolor and edgecolor the figure current has".

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2008,11 +2008,13 @@ class FigureCanvasBase:
         dpi : float, default: :rc:`savefig.dpi`
             The dots per inch to save the figure in.
 
-        facecolor : color, default: :rc:`savefig.facecolor`
-            The facecolor of the figure.
+        facecolor : color or 'auto', default: :rc:`savefig.facecolor`
+            The facecolor of the figure.  If 'auto', use the current figure
+            facecolor.
 
-        edgecolor : color, default: :rc:`savefig.edgecolor`
-            The edgecolor of the figure.
+        edgecolor : color or 'auto', default: :rc:`savefig.edgecolor`
+            The edgecolor of the figure.  If 'auto', use the current figure
+            edgecolor.
 
         orientation : {'landscape', 'portrait'}, default: 'portrait'
             Only currently applies to PostScript printing.
@@ -2068,21 +2070,23 @@ class FigureCanvasBase:
         # but this should be fine.
         with cbook._setattr_cm(self, _is_saving=True, manager=None), \
                 cbook._setattr_cm(self.figure, dpi=dpi):
+            origfacecolor = self.figure.get_facecolor()
+            origedgecolor = self.figure.get_edgecolor()
 
             if facecolor is None:
                 facecolor = rcParams['savefig.facecolor']
+            if cbook._str_equal(facecolor, 'auto'):
+                facecolor = origfacecolor
             if edgecolor is None:
                 edgecolor = rcParams['savefig.edgecolor']
-
-            origfacecolor = self.figure.get_facecolor()
-            origedgecolor = self.figure.get_edgecolor()
+            if cbook._str_equal(edgecolor, 'auto'):
+                edgecolor = origedgecolor
 
             self.figure.set_facecolor(facecolor)
             self.figure.set_edgecolor(edgecolor)
 
             if bbox_inches is None:
                 bbox_inches = rcParams['savefig.bbox']
-
             if bbox_inches:
                 if bbox_inches == "tight":
                     renderer = _get_renderer(

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2097,11 +2097,13 @@ default: 'top'
 
             This parameter is deprecated.
 
-        facecolor : color, default: :rc:`savefig.facecolor`
-            The facecolor of the figure.
+        facecolor : color or 'auto', default: :rc:`savefig.facecolor`
+            The facecolor of the figure.  If 'auto', use the current figure
+            facecolor.
 
-        edgecolor : color, default: :rc:`savefig.edgecolor`
-            The edgecolor of the figure.
+        edgecolor : color or 'auto', default: :rc:`savefig.edgecolor`
+            The edgecolor of the figure.  If 'auto', use the current figure
+            edgecolor.
 
         orientation : {'landscape', 'portrait'}
             Currently only supported by the postscript backend.
@@ -2172,9 +2174,6 @@ default: 'top'
                                              patch.get_edgecolor()))
                 patch.set_facecolor('none')
                 patch.set_edgecolor('none')
-        else:
-            kwargs.setdefault('facecolor', mpl.rcParams['savefig.facecolor'])
-            kwargs.setdefault('edgecolor', mpl.rcParams['savefig.edgecolor'])
 
         self.canvas.print_figure(fname, **kwargs)
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1529,9 +1529,10 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
             pil_kwargs["pnginfo"] = pnginfo
         if format in ["jpg", "jpeg"]:
             format = "jpeg"  # Pillow doesn't recognize "jpg".
-            color = tuple(
-                int(x * 255)
-                for x in mcolors.to_rgb(mpl.rcParams["savefig.facecolor"]))
+            facecolor = mpl.rcParams["savefig.facecolor"]
+            if cbook._str_equal(facecolor, "auto"):
+                facecolor = mpl.rcParams["figure.facecolor"]
+            color = tuple(int(x * 255) for x in mcolors.to_rgb(facecolor))
             background = PIL.Image.new("RGB", pil_shape, color)
             background.paste(image, image)
             image = background

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -324,13 +324,13 @@ validate_nseq_int = partial(_make_nseq_validator, int)
 
 def validate_color_or_inherit(s):
     """Return a valid color arg."""
-    if s == 'inherit':
+    if cbook._str_equal(s, 'inherit'):
         return s
     return validate_color(s)
 
 
 def validate_color_or_auto(s):
-    if s == 'auto':
+    if cbook._str_equal(s, 'auto'):
         return s
     return validate_color(s)
 
@@ -1411,8 +1411,8 @@ defaultParams = {
 
     ## Saving figure's properties
     'savefig.dpi':         ['figure', validate_dpi],  # DPI
-    'savefig.facecolor':   ['white', validate_color],
-    'savefig.edgecolor':   ['white', validate_color],
+    'savefig.facecolor':   ['auto', validate_color_or_auto],
+    'savefig.edgecolor':   ['auto', validate_color_or_auto],
     'savefig.orientation': ['portrait', ['landscape', 'portrait']],
     'savefig.jpeg_quality': [95, validate_int],
     # value checked by backend at runtime

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -641,8 +641,8 @@
 ## e.g., you may want a higher resolution, or to make the figure
 ## background white
 #savefig.dpi:       figure      # figure dots per inch or 'figure'
-#savefig.facecolor: white       # figure facecolor when saving
-#savefig.edgecolor: white       # figure edgecolor when saving
+#savefig.facecolor: auto        # figure facecolor when saving
+#savefig.edgecolor: auto        # figure edgecolor when saving
 #savefig.format:    png         # {png, ps, pdf, svg}
 #savefig.bbox:      standard    # {tight, standard}
                                 # 'tight' is incompatible with pipe-based animation


### PR DESCRIPTION
This seems to repeatedly confuse users.

Closes #7619; fixes https://gitter.im/matplotlib/matplotlib?at=5d5faff768406739f96b2673; alternate for #10023.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
