### PR TITLE
Doc: highlight rcparams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ Thumbs.db
 ###################################
 lib/matplotlib/mpl-data/matplotlib.conf
 lib/matplotlib/mpl-data/matplotlibrc
+tutorials/intermediate/CL01.png
+tutorials/intermediate/CL02.png
 
 # Documentation generated files #
 #################################

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -594,6 +594,10 @@ span.linkdescr {
     font-size: 90%;
 }
 
+.highlight span.c1 span.highlighted {
+    background-color: #fce5a6;
+}
+
 ul.search {
     margin: 10px 0 0 20px;
     padding: 0;

--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -2,14 +2,10 @@ from docutils import nodes
 from os.path import sep
 from matplotlib import rcParamsDefault
 
+
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    
     param = rcParamsDefault.get(text)
-    if isinstance(param, str):
-        txt = f' : "{param}"'
-    else:
-        txt = f' : {param}'
-    rendered = nodes.Text(f'rcParams["{text}"]' + txt)
+    rendered = nodes.Text(f'rcParams["{text}"] = {param!r}')
 
     source = inliner.document.attributes['source'].replace(sep, '/')
     rel_source = source.split('/doc/', 1)[1]

--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -1,9 +1,15 @@
 from docutils import nodes
 from os.path import sep
-
+from matplotlib import rcParamsDefault
 
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    rendered = nodes.Text(f'rcParams["{text}"]')
+    
+    param = rcParamsDefault.get(text)
+    if isinstance(param, str):
+        txt = f' : "{param}"'
+    else:
+        txt = f' : {param}'
+    rendered = nodes.Text(f'rcParams["{text}"]' + txt)
 
     source = inliner.document.attributes['source'].replace(sep, '/')
     rel_source = source.split('/doc/', 1)[1]

--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -3,14 +3,15 @@ from os.path import sep
 
 
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    rendered = nodes.Text('rcParams["{}"]'.format(text))
+    rendered = nodes.Text(f'rcParams["{text}"]')
 
     source = inliner.document.attributes['source'].replace(sep, '/')
     rel_source = source.split('/doc/', 1)[1]
 
     levels = rel_source.count('/')
     refuri = ('../' * levels +
-              'tutorials/introductory/customizing.html#matplotlib-rcparams')
+              'tutorials/introductory/customizing.html' +
+              f"?highlight={text}#a-sample-matplotlibrc-file")
 
     ref = nodes.reference(rawtext, rendered, refuri=refuri)
     return [nodes.literal('', '', ref)], []


### PR DESCRIPTION
## PR Summary

Many of the function parameters default to `None`, in which case the value from an rc parameter is taken. The custom `:rc:` role allows to link to the template, but it's always been bothering me that you then have to scroll through that complete file to locate the parameter you want to know the default of. 

This PR will highlight the parameter in question, such that it is easier to locate. 

I.e. if you click on a parameter, eg.

![image](https://user-images.githubusercontent.com/23121882/63607046-cfffdf00-c5d1-11e9-9412-03f893d4a6f9.png)

you will now be directed to 

    /tutorials/introductory/customizing.html?highlight=legend.numpoints#a-sample-matplotlibrc-file

and then scrolling down the file, the parameter in question is highlighted like this:

![image](https://user-images.githubusercontent.com/23121882/63607128-09384f00-c5d2-11e9-8bc4-4c192d509570.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
