### PR TITLE
Deprecate a validator for a deprecated rcParam value.

### DIFF
--- a/doc/api/next_api_changes/2019-07-30-AL.rst
+++ b/doc/api/next_api_changes/2019-07-30-AL.rst
@@ -5,3 +5,5 @@ Setting :rc:`savefig.format` to "auto" is deprecated; use its synonym "png" inst
 
 Setting :rc:`text.hinting` to True or False is deprecated; use their synonyms
 "auto" or "none" instead.
+
+``rcsetup.update_savefig_format`` is deprecated.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -458,7 +458,22 @@ def validate_whiskers(s):
                                  "(float, float)]")
 
 
+@cbook.deprecated("3.2")
 def update_savefig_format(value):
+    # The old savefig.extension could also have a value of "auto", but
+    # the new savefig.format does not.  We need to fix this here.
+    value = validate_string(value)
+    if value == 'auto':
+        cbook.warn_deprecated(
+            "3.2", message="Support for setting the 'savefig.format' rcParam "
+            "to 'auto' is deprecated since %(since)s and will be removed "
+            "%(removal)s; set it to 'png' instead.")
+        value = 'png'
+    return value
+
+
+# Replace by validate_string once deprecation period passes.
+def _update_savefig_format(value):
     # The old savefig.extension could also have a value of "auto", but
     # the new savefig.format does not.  We need to fix this here.
     value = validate_string(value)
@@ -1344,7 +1359,7 @@ defaultParams = {
     'savefig.orientation': ['portrait', validate_orientation],
     'savefig.jpeg_quality': [95, validate_int],
     # value checked by backend at runtime
-    'savefig.format':     ['png', update_savefig_format],
+    'savefig.format':     ['png', _update_savefig_format],
     # options are 'tight', or 'standard'. 'standard' validates to None.
     'savefig.bbox':       ['standard', validate_bbox],
     'savefig.pad_inches': [0.1, validate_float],


### PR DESCRIPTION
By doing so we'll be able to get rid of update_savefig_format at the
same time as we get rid of "auto" as a synonym for "png" in
:rc:savefig.format.
This should have been done at the same time as #14931, sorry I missed that.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
