### PR TITLE
Fix Stacked bar graph example

### DIFF
--- a/examples/lines_bars_and_markers/bar_stacked.py
+++ b/examples/lines_bars_and_markers/bar_stacked.py
@@ -1,6 +1,6 @@
 """
 =================
-Stacked Bar Graph
+Stacked bar chart
 =================
 
 This is an example of creating a stacked bar plot with error bars
@@ -13,24 +13,21 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-N = 5
+labels = ['G1', 'G2', 'G3', 'G4', 'G5']
 men_means = [20, 35, 30, 35, 27]
 women_means = [25, 32, 34, 20, 25]
 men_std = [2, 3, 4, 1, 2]
 women_std = [3, 5, 2, 3, 3]
-ind = np.arange(N)    # the x locations for the groups
 width = 0.35       # the width of the bars: can also be len(x) sequence
 
 fig, ax = plt.subplots()
 
-ax.bar(ind, men_means, width, yerr=men_std, label='Men')
-ax.bar(ind, women_means, width, yerr=women_std, bottom=men_means,
+ax.bar(labels, men_means, width, yerr=men_std, label='Men')
+ax.bar(labels, women_means, width, yerr=women_std, bottom=men_means,
        label='Women')
 
 ax.set_ylabel('Scores')
 ax.set_title('Scores by group and gender')
-ax.set_xticks(ind, ('G1', 'G2', 'G3', 'G4', 'G5'))
-ax.set_yticks(np.arange(0, 81, 10))
 ax.legend()
 
 plt.show()


### PR DESCRIPTION
## PR Summary

The example got broken in the rewrite from pyplot to the OOP interface (#14868).

![grafik](https://user-images.githubusercontent.com/2836374/63653496-c7441000-c76d-11e9-8a44-a69a54b65036.png)

Unfortunately, `plt.xticks` and `Axes.set_xticks` have different interfaces; see also #15005.

Anyway, the x labels can be directly set in the `bar()` call nowadays. So, we don't need `set_xticks` in the example.

Also changed the title "Bar graph" -> "Bar chart". The latter is more common (google has twice as many results).