### PR TITLE
Fixed app creation in qt5 backend (see #15100)

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -123,7 +123,7 @@ def _create_qApp():
                     QtCore.Qt.AA_EnableHighDpiScaling)
             except AttributeError:  # Attribute only exists for Qt>=5.6.
                 pass
-            qApp = QtWidgets.QApplication([b"matplotlib"])
+            qApp = QtWidgets.QApplication(["matplotlib"])
             qApp.lastWindowClosed.connect(qApp.quit)
         else:
             qApp = app


### PR DESCRIPTION
This PR changes type of argument of QApplication to `str` from `bytes`. See #15100 for discussion.
