### PR TITLE
Improve categorical example

### DIFF
--- a/examples/lines_bars_and_markers/categorical_variables.py
+++ b/examples/lines_bars_and_markers/categorical_variables.py
@@ -11,7 +11,7 @@ many plotting functions, which we demonstrate below.
 """
 import matplotlib.pyplot as plt
 
-data = {'apples': 10, 'oranges': 15, 'lemons': 5, 'limes': 20}
+data = {'apple': 10, 'orange': 15, 'lemon': 5, 'lime': 20}
 names = list(data.keys())
 values = list(data.values())
 


### PR DESCRIPTION
## PR Summary

This is a purely aesthetic change. The fruit names were a bit long so that they overlap in the bar plot: https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/categorical_variables.html#sphx-glr-gallery-lines-bars-and-markers-categorical-variables-py.

While there are many ways to clean that up, I did not want to introduce additional parameters or commands to keep the example code as simple as possible. So just switching to shorter food names (and making it more pythonesque).
