### PR TITLE
Fix ScalarFormatter formatting of masked values

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -629,6 +629,8 @@ class ScalarFormatter(Formatter):
         """
         if self._useLocale:
             return locale.format_string('%-12g', (value,))
+        elif isinstance(value, np.ma.MaskedArray) and value.mask:
+            return ''
         else:
             return '%-12g' % value
 


### PR DESCRIPTION
Fixes #15103. Could probably do with a test. Possibly an API change since previously a masked value would be formatted as `nan`?