### PR TITLE
Restore doc references.

### DIFF
--- a/doc/api/next_api_changes/2018-02-18-AL.rst
+++ b/doc/api/next_api_changes/2018-02-18-AL.rst
@@ -1,9 +1,9 @@
 Deprecations
 ````````````
 
-For the ``mpl_toolkits.axistartist.axis_artist.AttributeCopier`` class, the
+For the `mpl_toolkits.axisartist.axis_artist.AttributeCopier` class, the
 constructor and the ``set_ref_artist`` method, and the *default_value*
 parameter of ``get_attribute_from_ref_artist``, are deprecated.
 
 Deprecation of the constructor means that classes inheriting from
-``AttributeCopier`` should no longer call its constructor.
+`.AttributeCopier` should no longer call its constructor.


### PR DESCRIPTION
## PR Summary

followup to #15134, especially https://github.com/matplotlib/matplotlib/pull/15134#issuecomment-525076861.  Sorry @ImportanceOfBeingErnest, I completely missed that there's already an API entry for AttributeCopier and that it was a typo on my side.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
