### PR TITLE
pyplot.style.use() to accept pathlib.Path objects as arguments

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -948,7 +948,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
 
     Parameters
     ----------
-    fname : str
+    fname : str, Path
         Name of file parsed for Matplotlib settings.
     fail_on_error : bool
         If True, raise an error when the parser fails to convert a parameter.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -948,7 +948,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
 
     Parameters
     ----------
-    fname : str, Path
+    fname : str, pathlib.Path
         Name of file parsed for Matplotlib settings.
     fail_on_error : bool
         If True, raise an error when the parser fails to convert a parameter.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -948,7 +948,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
 
     Parameters
     ----------
-    fname : str, path-like
+    fname : str or path-like
         Name of file parsed for Matplotlib settings.
     fail_on_error : bool
         If True, raise an error when the parser fails to convert a parameter.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -948,7 +948,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
 
     Parameters
     ----------
-    fname : str, pathlib.Path
+    fname : str, path-like
         Name of file parsed for Matplotlib settings.
     fail_on_error : bool
         If True, raise an error when the parser fails to convert a parameter.

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -94,7 +94,8 @@ def use(style):
         # If name is a single str or dict, make it a single element list.
         styles = [style]
     elif isinstance(style, Path):
-        # If the style is pathlib.Path object make a single element list of string
+        # If the style is pathlib.Path object cast to string.
+        # and make it a single element list.
         styles = [str(style)]
     else:
         styles = style

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -72,7 +72,7 @@ def use(style):
 
     Parameters
     ----------
-    style : str, dict, or list
+    style : str, dict, list or Path object
         A style specification. Valid options are:
 
         +------+-------------------------------------------------------------+
@@ -85,12 +85,17 @@ def use(style):
         | list | A list of style specifiers (str or dict) applied from first |
         |      | to last in the list.                                        |
         +------+-------------------------------------------------------------+
+        | Path | A Path object which is a path to a style file.              |
+        +------+-------------------------------------------------------------+
     """
     style_alias = {'mpl20': 'default',
                    'mpl15': 'classic'}
     if isinstance(style, str) or hasattr(style, 'keys'):
         # If name is a single str or dict, make it a single element list.
         styles = [style]
+    elif isinstance(style, Path):
+        # If the style is pathlib.Path object make a single element list of string
+        styles = [str(style)]
     else:
         styles = style
 

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -82,28 +82,26 @@ def use(style):
         | dict | Dictionary with valid key/value pairs for                   |
         |      | `matplotlib.rcParams`.                                      |
         +------+-------------------------------------------------------------+
-        | list | A list of style specifiers (str or dict) applied from first |
-        |      | to last in the list.                                        |
-        +------+-------------------------------------------------------------+
         | Path | A Path object which is a path to a style file.              |
         +------+-------------------------------------------------------------+
+        | list | A list of style specifiers (str, Path or dict) applied from |
+        |      | first to last in the list.                                  |
+        +------+-------------------------------------------------------------+
+
     """
     style_alias = {'mpl20': 'default',
                    'mpl15': 'classic'}
-    if isinstance(style, str) or hasattr(style, 'keys'):
-        # If name is a single str or dict, make it a single element list.
+    if isinstance(style, str) or hasattr(style, 'keys') or \
+            isinstance(style, Path):
+        # If name is a single str, Path or dict, make it a single element list.
         styles = [style]
-    elif isinstance(style, Path):
-        # If the style is pathlib.Path object cast to string.
-        # and make it a single element list.
-        styles = [str(style)]
     else:
         styles = style
 
     styles = (style_alias.get(s, s) if isinstance(s, str) else s
               for s in styles)
     for style in styles:
-        if not isinstance(style, str):
+        if not isinstance(style, str) and not isinstance(style, Path):
             _apply_style(style)
         elif style == 'default':
             # Deprecation warnings were already handled when creating
@@ -113,6 +111,8 @@ def use(style):
         elif style in library:
             _apply_style(library[style])
         else:
+            if isinstance(style, Path):
+                style = str(style)
             try:
                 rc = rc_params_from_file(style, use_default_template=False)
                 _apply_style(rc)

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -72,7 +72,7 @@ def use(style):
 
     Parameters
     ----------
-    style : str, dict, list or Path object
+    style : str, dict, Path or list object
         A style specification. Valid options are:
 
         +------+-------------------------------------------------------------+
@@ -91,8 +91,7 @@ def use(style):
     """
     style_alias = {'mpl20': 'default',
                    'mpl15': 'classic'}
-    if isinstance(style, str) or hasattr(style, 'keys') or \
-            isinstance(style, Path):
+    if isinstance(style, (str, Path)) or hasattr(style, 'keys'):
         # If name is a single str, Path or dict, make it a single element list.
         styles = [style]
     else:
@@ -101,7 +100,7 @@ def use(style):
     styles = (style_alias.get(s, s) if isinstance(s, str) else s
               for s in styles)
     for style in styles:
-        if not isinstance(style, str) and not isinstance(style, Path):
+        if not isinstance(style, (str, Path)):
             _apply_style(style)
         elif style == 'default':
             # Deprecation warnings were already handled when creating
@@ -111,8 +110,6 @@ def use(style):
         elif style in library:
             _apply_style(library[style])
         else:
-            if isinstance(style, Path):
-                style = str(style)
             try:
                 rc = rc_params_from_file(style, use_default_template=False)
                 _apply_style(rc)
@@ -129,7 +126,7 @@ def context(style, after_reset=False):
 
     Parameters
     ----------
-    style : str, dict, or list
+    style : str, dict, Path or list
         A style specification. Valid options are:
 
         +------+-------------------------------------------------------------+
@@ -139,8 +136,10 @@ def context(style, after_reset=False):
         | dict | Dictionary with valid key/value pairs for                   |
         |      | `matplotlib.rcParams`.                                      |
         +------+-------------------------------------------------------------+
-        | list | A list of style specifiers (str or dict) applied from first |
-        |      | to last in the list.                                        |
+        | Path | A Path object which is a path to a style file.              |
+        +------+-------------------------------------------------------------+
+        | list | A list of style specifiers (str, Path or dict) applied from |
+        |      | first to last in the list.                                  |
         +------+-------------------------------------------------------------+
 
     after_reset : bool

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -72,7 +72,7 @@ def use(style):
 
     Parameters
     ----------
-    style : str, dict, pathlib.Path or list
+    style : str, dict, Path or list
         A style specification. Valid options are:
 
         +------+-------------------------------------------------------------+
@@ -82,7 +82,7 @@ def use(style):
         | dict | Dictionary with valid key/value pairs for                   |
         |      | `matplotlib.rcParams`.                                      |
         +------+-------------------------------------------------------------+
-        | Path | A Path object which is a path to a style file.              |
+        | Path | A path-like object which is a path to a style file.         |
         +------+-------------------------------------------------------------+
         | list | A list of style specifiers (str, Path or dict) applied from |
         |      | first to last in the list.                                  |
@@ -136,7 +136,7 @@ def context(style, after_reset=False):
         | dict | Dictionary with valid key/value pairs for                   |
         |      | `matplotlib.rcParams`.                                      |
         +------+-------------------------------------------------------------+
-        | Path | A Path object which is a path to a style file.              |
+        | Path | A path-like object which is a path to a style file.         |
         +------+-------------------------------------------------------------+
         | list | A list of style specifiers (str, Path or dict) applied from |
         |      | first to last in the list.                                  |

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -72,7 +72,7 @@ def use(style):
 
     Parameters
     ----------
-    style : str, dict, Path or list object
+    style : str, dict, pathlib.Path or list
         A style specification. Valid options are:
 
         +------+-------------------------------------------------------------+

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -67,11 +67,12 @@ def test_use_url(tmpdir):
         with style.context(url):
             assert mpl.rcParams['axes.facecolor'] == "#adeade"
 
+
 def test_single_path(tmpdir):
     mpl.rcParams[PARAM] = 'gray'
     temp_file = '%s.%s' % ('test', STYLE_EXTENSION)
     path = Path(tmpdir, temp_file)
-    path.write_text("{} : {}".format(PARAM,VALUE))
+    path.write_text("{} : {}".format(PARAM, VALUE))
     with style.context(path):
         assert mpl.rcParams[PARAM] == VALUE
     assert mpl.rcParams[PARAM] == 'gray'

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -70,7 +70,7 @@ def test_use_url(tmpdir):
 
 def test_single_path(tmpdir):
     mpl.rcParams[PARAM] = 'gray'
-    temp_file = '%s.%s' % ('test', STYLE_EXTENSION)
+    temp_file = f'text.{STYLE_EXTENSION}'
     path = Path(tmpdir, temp_file)
     path.write_text("{} : {}".format(PARAM, VALUE))
     with style.context(path):

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -72,7 +72,7 @@ def test_single_path(tmpdir):
     mpl.rcParams[PARAM] = 'gray'
     temp_file = f'text.{STYLE_EXTENSION}'
     path = Path(tmpdir, temp_file)
-    path.write_text("{} : {}".format(PARAM, VALUE))
+    path.write_text(f'{PARAM} : {VALUE}')
     with style.context(path):
         assert mpl.rcParams[PARAM] == VALUE
     assert mpl.rcParams[PARAM] == 'gray'

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -67,6 +67,15 @@ def test_use_url(tmpdir):
         with style.context(url):
             assert mpl.rcParams['axes.facecolor'] == "#adeade"
 
+def test_single_path(tmpdir):
+    mpl.rcParams[PARAM] = 'gray'
+    temp_file = '%s.%s' % ('test', STYLE_EXTENSION)
+    path = Path(tmpdir, temp_file)
+    path.write_text("{} : {}".format(PARAM,VALUE))
+    with style.context(path):
+        assert mpl.rcParams[PARAM] == VALUE
+    assert mpl.rcParams[PARAM] == 'gray'
+
 
 def test_context():
     mpl.rcParams[PARAM] = 'gray'


### PR DESCRIPTION
## PR Summary
Currently the pyplot.style.use() supports strings, list, and dic as function arguments where string can be  a library style or path/URL to style file. Added the code to leverage the function to use pathlib.Path object as an argument.   
Fixes #15138 
## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
