### PR TITLE
Autodetect whether pgf can use \includegraphics[interpolate].

### DIFF
--- a/doc/api/next_api_changes/2019-08-28-AL.rst
+++ b/doc/api/next_api_changes/2019-08-28-AL.rst
@@ -1,0 +1,8 @@
+PGF backend changes
+```````````````````
+
+The pgf backend now includes images using ``\includegraphics`` instead of
+``\pgfimage`` if the version of ``graphicx`` is recent enough to support the
+``interpolate`` option (this is detected automatically).
+
+``RendererPgf.latexManager`` is deprecated.


### PR DESCRIPTION
Closes #10963 (see discussion there); replaces #10973.

This is done by reusing the same LatexManager instance as the one used
for measuring text extents.

As an aside, this exposes an awkwardness in the implementation of
LatexManager -- after an error occurs, the instance needs to be
discarded (ideally, the instance would auto-create a new subprocess).
This is why _get_image_inclusion_command manually discards the cached
instance in such a case.

For recent setups where \includegraphics[interpolate=true] is available,
the cost of this PR is essentially just an additional
\usepackage{graphicx} executed once; for older setups, an additional
instantiation of a latex subprocess (only once).

This can't be tested on CI because Travis' version of latex is too old,
but can be manually tested by inspecting a resulting pgf output, and
possibly changing `interpolate=true` by a nonexistent option (e.g.
`foobar` and checking that there's fallback to \pgfimage in that case.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
