### PR TITLE
FIX: indexed pandas bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2138,33 +2138,14 @@ class Axes(_AxesBase):
             # removes the units from unit packages like `pint` that
             # wrap numpy arrays.
             try:
-                x0 = x0[0]
+                x0 = cbook.safe_first_element(x0)
             except (TypeError, IndexError, KeyError):
-                try:
-                    xx = np.atleast_1d(np.asarray(x0))
-                    if len(xx) == 1:
-                        # this keeps units for singletons...
-                        x0 = x0
-                    else:
-                        # fallback for objects with length, but strange
-                        # ways of indexing (i.e. pandas)
-                        x0 = xx[0]
-                except:
-                    # generic except.  Think this should never happen, but...
-                    x0 = x0
+                x0 = x0
 
             try:
-                x = xconv[0]
+                x = cbook.safe_first_element(xconv)
             except (TypeError, IndexError, KeyError):
-                try:
-                    xx = np.atleast_1d(np.asarray(xconv))
-                    if len(xx) == 1:
-                        x = xconv
-                    else:
-                        x = xx[0]
-                except:
-                    # generic except.  Think this should never happen, but...
-                    x = xconv
+                x = xconv
 
             delist = False
             if not np.iterable(dx):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2140,12 +2140,31 @@ class Axes(_AxesBase):
             try:
                 x0 = x0[0]
             except (TypeError, IndexError, KeyError):
-                x0 = x0
+                try:
+                    xx = np.atleast_1d(np.asarray(x0))
+                    if len(xx) == 1:
+                        # this keeps units for singletons...
+                        x0 = x0
+                    else:
+                        # fallback for objects with length, but strange
+                        # ways of indexing (i.e. pandas)
+                        x0 = xx[0]
+                except:
+                    # generic except.  Think this should never happen, but...
+                    x0 = x0
 
             try:
                 x = xconv[0]
             except (TypeError, IndexError, KeyError):
-                x = xconv
+                try:
+                    xx = np.atleast_1d(np.asarray(xconv))
+                    if len(xx) == 1:
+                        x = xconv
+                    else:
+                        x = xx[0]
+                except:
+                    # generic except.  Think this should never happen, but...
+                    x = xconv
 
             delist = False
             if not np.iterable(dx):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1647,6 +1647,14 @@ def test_bar_pandas(pd):
     ax.plot(dates, baseline, color='orange', lw=4)
 
 
+def test_bar_pandas_indexed(pd):
+    # Smoke test for indexed pandas
+    df = pd.DataFrame({"x": [1., 2., 3.], "width": [.2, .4, .6]},
+                       index=[1, 2, 3])
+    fig, ax = plt.subplots()
+    ax.bar(df.x, 1., width=df.width)
+
+
 @image_comparison(['hist_log'], remove_text=True)
 def test_hist_log():
     data0 = np.linspace(0, 1, 200)**3


### PR DESCRIPTION
## PR Summary

Closes #15162

basically if you do `df = pd.DataFrame({"x":[1,2,3],"width":[.2,.4,.6]},index=[1,2,3])`, then `df.x[0]` errors because that index doesn't exist, which breaks `bar`.

While I appreciate this is a bit *more* code than trying to call `iat(0)`, which is what we did before, this solution doesn't presuppose `iat` exists.  

```python
import pandas as pd
from matplotlib import pyplot as plt
import numpy as np

df = pd.DataFrame({"x":[1.,2.,3.],"width":[.2,.4,.6]}, index=[1, 2, 3])
plt.figure()
plt.bar(df.x, 1., width=df.width)
plt.savefig('/Users/jklymak/downloads/Test1.png')

df = pd.DataFrame({"x":[1,3,10]},index=[1000,2000,3000])

plt.figure()
plt.bar(df.x, 1, width=.2)
plt.savefig('/Users/jklymak/downloads/Test2.png')
```

Now yields the expected (and pre 3.1.0):

![Test1](https://user-images.githubusercontent.com/1562854/64070032-8421eb00-cc0c-11e9-8967-cd933a66ac48.png)
![Test2](https://user-images.githubusercontent.com/1562854/64070034-86844500-cc0c-11e9-94d4-04607d82602e.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->