### PR TITLE
MNT: explicitly cast np.bool_ -> bool to prevent deprecation warning

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3213,7 +3213,8 @@ class _AxesBase(martist.Artist):
         reverse = left > right
         left, right = self.xaxis.get_major_locator().nonsingular(left, right)
         left, right = self.xaxis.limit_range_for_scale(left, right)
-        left, right = sorted([left, right], reverse=reverse)
+        # cast to bool to avoid bad interaction between python 3.8 and np.bool_
+        left, right = sorted([left, right], reverse=bool(reverse))
 
         self._viewLim.intervalx = (left, right)
         if auto is not None:
@@ -3597,7 +3598,8 @@ class _AxesBase(martist.Artist):
         reverse = bottom > top
         bottom, top = self.yaxis.get_major_locator().nonsingular(bottom, top)
         bottom, top = self.yaxis.limit_range_for_scale(bottom, top)
-        bottom, top = sorted([bottom, top], reverse=reverse)
+        # cast to bool to avoid bad interaction between python 3.8 and np.bool_
+        bottom, top = sorted([bottom, top], reverse=bool(reverse))
 
         self._viewLim.intervaly = (bottom, top)
         if auto is not None:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2169,7 +2169,8 @@ class XAxis(Axis):
     def set_inverted(self, inverted):
         # docstring inherited
         a, b = self.get_view_interval()
-        self.axes.set_xlim(sorted((a, b), reverse=inverted), auto=None)
+        # cast to bool to avoid bad interaction between python 3.8 and np.bool_
+        self.axes.set_xlim(sorted((a, b), reverse=bool(inverted)), auto=None)
 
     def set_default_intervals(self):
         # docstring inherited
@@ -2468,7 +2469,8 @@ class YAxis(Axis):
     def set_inverted(self, inverted):
         # docstring inherited
         a, b = self.get_view_interval()
-        self.axes.set_ylim(sorted((a, b), reverse=inverted), auto=None)
+        # cast to bool to avoid bad interaction between python 3.8 and np.bool_
+        self.axes.set_ylim(sorted((a, b), reverse=bool(inverted)), auto=None)
 
     def set_default_intervals(self):
         # docstring inherited

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -619,7 +619,8 @@ class Axes3D(Axes):
         reverse = left > right
         left, right = self.xaxis.get_major_locator().nonsingular(left, right)
         left, right = self.xaxis.limit_range_for_scale(left, right)
-        left, right = sorted([left, right], reverse=reverse)
+        # cast to bool to avoid bad interaction between python 3.8 and np.bool_
+        left, right = sorted([left, right], reverse=bool(reverse))
         self.xy_viewLim.intervalx = (left, right)
 
         if auto is not None:


### PR DESCRIPTION
This is a workaround to https://bugs.python.org/issue37980

- np.bool raises a warning if you try to use it as an index (by
  warning in its `__index__` method
- in py38 https://github.com/python/cpython/pull/11952 python changes
  the code path used to convert `np.bool_` -> int for as it is used in
  `sorted` so it now goes through the `__index__` code path
- this causes a bunch of spurious warnings to come out of Matplotlib.

I see failures on this locally, but we do not see these failures on the azure pre-release, not sure why.

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
