### PR TITLE
TST: verify warnings fail the test suite

### DIFF
--- a/lib/matplotlib/tests/test_testing.py
+++ b/lib/matplotlib/tests/test_testing.py
@@ -1,0 +1,7 @@
+import warnings
+import pytest
+
+@pytest.mark.xfail(strict=True,
+                   reason="testing that warnings fail tests")
+def test_warn_to_fail():
+    warnings.warn("This should fail the test")


### PR DESCRIPTION
## PR Summary

I expected the tests on azure on preview python to be failing without #15168 so adding a test the will fail if it does not fail on warnings :face_with_head_bandage: 

The other explanation for it passing is I am confused about if b4 should have the upstream changes that are causing the warnings. 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
