### PR TITLE
Add useful error message when trying to add Slider to 3DAxes

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -320,6 +320,9 @@ class Slider(AxesWidget):
         knob.  See the :class:`~matplotlib.patches.Rectangle` documentation for
         valid property names (e.g., `facecolor`, `edgecolor`, `alpha`).
         """
+        if ax.name == '3d':
+            raise ValueError('Sliders cannot be added to 3D Axes')
+
         AxesWidget.__init__(self, ax)
 
         if slidermin is not None and not hasattr(slidermin, 'val'):


### PR DESCRIPTION
Before the error message would have been:
```python
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    valk = Slider(ax, 'kparam', 0, 30.0, valinit=1.0)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/widgets.py", line 381, in __init__
    horizontalalignment='right')
TypeError: text() missing 1 required positional argument: 's'
```
Now it is
```python
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    valk = Slider(ax, 'kparam', 0, 30.0, valinit=1.0)
  File "/Users/dstansby/github/matplotlib/lib/matplotlib/widgets.py", line 324, in __init__
    raise ValueError('Sliders cannot be added to 3D Axes')
ValueError: Sliders cannot be added to 3D Axes
```

I was wondering if this should be a more strict test for `ax.name != 'rectilinear'` instead, but sliders with at least a polar projection do seem to work (modulo some drawing issues).

Closes #15156