### PR TITLE
Mark missing_references extension as parallel read safe

### DIFF
--- a/doc/sphinxext/missing_references.py
+++ b/doc/sphinxext/missing_references.py
@@ -292,3 +292,5 @@ def setup(app):
     app.connect("builder-inited", prepare_missing_references_handler)
     app.connect("missing-reference", record_missing_reference_handler)
     app.connect("build-finished", save_missing_references_handler)
+
+    return {'parallel_read_safe': True}


### PR DESCRIPTION
In theory this should be fine, and in practice also works fine locally for me. Fixes #15075