### PR TITLE
Trivial style fixes.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import sys
 import tempfile
-import warnings
 
 import numpy as np
 import pytest
@@ -14,11 +13,9 @@ from matplotlib.testing.compare import compare_images
 from matplotlib.testing.decorators import image_comparison
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    needs_usetex = pytest.mark.skipif(
-        not checkdep_usetex(True),
-        reason="This test needs a TeX installation")
+needs_usetex = pytest.mark.skipif(
+    not checkdep_usetex(True),
+    reason="This test needs a TeX installation")
 
 
 @image_comparison(['pdf_use14corefonts.pdf'])

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import re
 import tempfile
-import warnings
 
 import pytest
 
@@ -13,14 +12,12 @@ from matplotlib import cbook, patheffects
 from matplotlib.testing.decorators import image_comparison
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    needs_ghostscript = pytest.mark.skipif(
-        "eps" not in mpl.testing.compare.converter,
-        reason="This test needs a ghostscript installation")
-    needs_usetex = pytest.mark.skipif(
-        not mpl.checkdep_usetex(True),
-        reason="This test needs a TeX installation")
+needs_ghostscript = pytest.mark.skipif(
+    "eps" not in mpl.testing.compare.converter,
+    reason="This test needs a ghostscript installation")
+needs_usetex = pytest.mark.skipif(
+    not mpl.checkdep_usetex(True),
+    reason="This test needs a TeX installation")
 
 
 # This tests tends to hit a TeX cache lock on AppVeyor.

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -2,7 +2,6 @@ import numpy as np
 from io import BytesIO
 import re
 import tempfile
-import warnings
 import xml.parsers.expat
 
 import pytest
@@ -14,11 +13,9 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    needs_usetex = pytest.mark.skipif(
-        not mpl.checkdep_usetex(True),
-        reason="This test needs a TeX installation")
+needs_usetex = pytest.mark.skipif(
+    not mpl.checkdep_usetex(True),
+    reason="This test needs a TeX installation")
 
 
 def test_visibility():

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -434,7 +434,7 @@ def test_step_fails(args):
 
 
 def test_grouper():
-    class dummy():
+    class dummy:
         pass
     a, b, c, d, e = objs = [dummy() for j in range(5)]
     g = cbook.Grouper()
@@ -454,7 +454,7 @@ def test_grouper():
 
 
 def test_grouper_private():
-    class dummy():
+    class dummy:
         pass
     objs = [dummy() for j in range(5)]
     g = cbook.Grouper()
@@ -484,7 +484,7 @@ def test_flatiter():
 
 def test_reshape2d():
 
-    class dummy():
+    class dummy:
         pass
 
     xnew = cbook._reshape_2D([], 'x')

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -12,11 +12,9 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore')
-    needs_usetex = pytest.mark.skipif(
-        not matplotlib.checkdep_usetex(True),
-        reason="This test needs a TeX installation")
+needs_usetex = pytest.mark.skipif(
+    not matplotlib.checkdep_usetex(True),
+    reason="This test needs a TeX installation")
 
 
 @image_comparison(['font_styles'])

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -228,7 +228,7 @@ class NonAffineForTest(mtransforms.Transform):
         return self.real_trans.transform_path(path)
 
 
-class TestBasicTransform():
+class TestBasicTransform:
     def setup_method(self):
 
         self.ta1 = mtransforms.Affine2D(shorthand_name='ta1').rotate(np.pi / 2)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -220,9 +220,8 @@ def get_renderer(fig):
 
         if canvas and hasattr(canvas, "get_renderer"):
             renderer = canvas.get_renderer()
-        else:
-            # not sure if this can happen
-            cbook._warn_external("tight_layout : falling back to Agg renderer")
+        else:  # Some noninteractive backends have no renderer until draw time.
+            cbook._warn_external("tight_layout: falling back to Agg renderer")
             from matplotlib.backends.backend_agg import FigureCanvasAgg
             canvas = FigureCanvasAgg(fig)
             renderer = canvas.get_renderer()

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -588,7 +588,7 @@ class CubicTriInterpolator(TriInterpolator):
 
 # FEM element used for interpolation and for solving minimisation
 # problem (Reduced HCT element)
-class _ReducedHCT_Element():
+class _ReducedHCT_Element:
     """
     Implementation of reduced HCT triangular element with explicit shape
     functions.
@@ -1006,7 +1006,7 @@ class _ReducedHCT_Element():
 # _DOF_estimator_min_E
 # Private classes used to compute the degree of freedom of each triangular
 # element for the TriCubicInterpolator.
-class _DOF_estimator():
+class _DOF_estimator:
     """
     Abstract base class for classes used to perform estimation of a function
     first derivatives, and deduce the dofs for a CubicTriInterpolator using a


### PR DESCRIPTION
In the various test files, there is no point of wrapping checkdep_usetex
in catch_warnings because checkdep_usetex uses logging.warning, not
warnings.warn.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
