### PR TITLE
Fix integers being passed as length to quiver3d.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2607,7 +2607,7 @@ pivot='tail', normalize=False, **kwargs)
             self.add_collection(linec)
             return linec
 
-        shaft_dt = np.array([0., length])
+        shaft_dt = np.array([0., length], dtype=float)
         arrow_dt = shaft_dt * arrow_length_ratio
 
         cbook._check_in_list(['tail', 'middle', 'tip'], pivot=pivot)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2607,14 +2607,14 @@ pivot='tail', normalize=False, **kwargs)
             self.add_collection(linec)
             return linec
 
-        shaft_dt = np.array([0, length])
+        shaft_dt = np.array([0., length])
         arrow_dt = shaft_dt * arrow_length_ratio
 
         cbook._check_in_list(['tail', 'middle', 'tip'], pivot=pivot)
         if pivot == 'tail':
             shaft_dt -= length
         elif pivot == 'middle':
-            shaft_dt -= length/2.
+            shaft_dt -= length / 2
 
         XYZ = np.column_stack(input_args[:3])
         UVW = np.column_stack(input_args[3:argi]).astype(float)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -970,3 +970,19 @@ def test_ticklabel_format(fig_test, fig_ref):
         for fmt in get_formatters(row[4], names):
             fmt.set_useMathText(
                 not mpl.rcParams["axes.formatter.use_mathtext"])
+
+
+@check_figures_equal(extensions=["png"])
+def test_quiver3D_smoke(fig_test, fig_ref):
+    pivot = "middle"
+    # Make the grid
+    x, y, z = np.meshgrid(
+        np.arange(-0.8, 1, 0.2),
+        np.arange(-0.8, 1, 0.2),
+        np.arange(-0.8, 1, 0.8)
+    )
+    u = v = w = np.ones_like(x)
+
+    for fig, length in zip((fig_ref, fig_test), (1, 1.0)):
+        ax = fig.gca(projection="3d")
+        ax.quiver(x, y, z, u, v, w, length=length, pivot=pivot)


### PR DESCRIPTION
## PR Summary

closes https://github.com/matplotlib/matplotlib/issues/15186.

As it turns out there was a subtle difference between `linspace(0, length, num=2)` and `np.asarray([0, length])`: the former always returns a float array...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
