### PR TITLE
Force html4 writer for sphinx 2

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -676,6 +676,11 @@ dl.class p.rubric + table.docutils td:first-of-type > strong {
     font-weight: normal;
 }
 
+.classifier:before {
+    font-style: normal;
+    margin: 0.2em;
+    content: ":";
+}
 
 /* module summary table */
 .longtable.docutils {

--- a/doc/_templates/search.html
+++ b/doc/_templates/search.html
@@ -1,6 +1,9 @@
 {% extends "layout.html" %}
 {% set title = _('Search') %}
-{% set script_files = script_files + ['_static/searchtools.js'] %}
+{%- block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+{%- endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>
   <p>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -362,6 +362,8 @@ latex_elements = {
     'fontpkg': r'\setmainfont{DejaVu Serif}',
 }
 
+html4_writer = True
+
 
 def setup(app):
     if any(st in version for st in ('post', 'alpha', 'beta')):

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -322,7 +322,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.xcorr:19"
     ],
     "AxesBase": [
-      "doc/api/axes_api.rst:451:<autosummary>:1",
+      "doc/api/axes_api.rst:448:<autosummary>:1",
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes.Axes.add_child_axes:2"
     ],
     "window_hanning": [
@@ -396,7 +396,7 @@
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes.Axes.get_window_extent:24"
     ],
     "Line2D": [
-      "doc/api/axes_api.rst:420:<autosummary>:1",
+      "doc/api/axes_api.rst:417:<autosummary>:1",
       "doc/devel/MEP/MEP26.rst:141",
       "doc/devel/MEP/MEP26.rst:36",
       "doc/users/prev_whats_new/whats_new_1.5.rst:321",
@@ -455,23 +455,23 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:133"
     ],
     "bbox_to_anchor": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:230",
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:235",
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:194",
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:199",
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:189",
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:194",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:194",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:199",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:230",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:235"
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:219",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:224",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:183",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:188",
+      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:178",
+      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:183",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:183",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:188",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:219",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:224"
     ],
     "handler_map": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:282",
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:246",
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:241",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:246",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:282"
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:259",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:223",
+      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:218",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:223",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:259"
     ],
     "pandas.DataFame": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.plot:39",
@@ -533,7 +533,7 @@
     "Axes.dataLim": [
       "doc/api/axes_api.rst:299:<autosummary>:1",
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes.Axes.update_datalim:2",
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.view_init:22"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.update_datalim:2"
     ],
     "Axes.datalim": [
       "doc/api/axes_api.rst:299:<autosummary>:1",
@@ -554,7 +554,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.violinplot:46"
     ],
     "Text": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1088",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1089",
       "doc/devel/MEP/MEP14.rst:252",
       "doc/devel/MEP/MEP26.rst:141",
       "lib/matplotlib/axis.py:docstring of matplotlib.axis.Axis.set_ticklabels:33",
@@ -631,7 +631,7 @@
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.set_constrained_layout:5"
     ],
     "matplotlib.Figure.get_size_inches": [
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.set_size_inches:26"
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.set_size_inches:32"
     ],
     "sharex": [
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.subplots:13",
@@ -643,7 +643,6 @@
     ],
     "FontProperties": [
       "doc/devel/MEP/MEP14.rst:110",
-      "doc/users/next_whats_new/2019-05-31-AL.rst:1",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.suptitle:40",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.suptitle:40"
     ],
@@ -731,7 +730,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.subplot2grid:25"
     ],
     "quiverkey": [
-      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Quiver:242"
+      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Quiver:247"
     ],
     "set_contains": [
       "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend.contains:29",
@@ -764,8 +763,8 @@
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size:1"
     ],
     "axes_class": [
-      "lib/mpl_toolkits/axes_grid1/inset_locator.py:docstring of mpl_toolkits.axes_grid1.inset_locator.inset_axes:148",
-      "lib/mpl_toolkits/axes_grid1/inset_locator.py:docstring of mpl_toolkits.axes_grid1.inset_locator.zoomed_inset_axes:140"
+      "lib/mpl_toolkits/axes_grid1/inset_locator.py:docstring of mpl_toolkits.axes_grid1.inset_locator.inset_axes:147",
+      "lib/mpl_toolkits/axes_grid1/inset_locator.py:docstring of mpl_toolkits.axes_grid1.inset_locator.zoomed_inset_axes:139"
     ],
     "pyplot.gcf()": [
       "lib/mpl_toolkits/axes_grid1/parasite_axes.py:docstring of mpl_toolkits.axes_grid1.parasite_axes.host_axes:8",
@@ -780,15 +779,15 @@
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.CircleCollection.get_tightbbox:2",
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.Collection.get_tightbbox:2",
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.EllipseCollection.get_tightbbox:2",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EventCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PatchCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.StarPolygonCollection.get_transform:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_transform:1",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EventCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PatchCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.StarPolygonCollection.get_tightbbox:2",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_tightbbox:2",
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisArtist.get_tightbbox:2",
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Text3D.get_tightbbox:2"
     ],
@@ -800,15 +799,15 @@
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.CircleCollection.get_tightbbox:26",
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.Collection.get_tightbbox:26",
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.EllipseCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EventCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PatchCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.StarPolygonCollection.get_transformed_clip_path_and_affine:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_transformed_clip_path_and_affine:1",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EventCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PatchCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.StarPolygonCollection.get_tightbbox:26",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_tightbbox:26",
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisArtist.get_tightbbox:26",
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Text3D.get_tightbbox:26"
     ],
@@ -817,6 +816,14 @@
       "lib/matplotlib/text.py:docstring of matplotlib.text.Text.get_window_extent:2",
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisLabel.get_window_extent:2",
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.LabelBase.get_window_extent:2"
+    ],
+    "'auto'": [
+      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator:28",
+      "lib/mpl_toolkits/axisartist/grid_finder.py:docstring of mpl_toolkits.axisartist.grid_finder.MaxNLocator:8"
+    ],
+    "min_n_ticks": [
+      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator:41",
+      "lib/mpl_toolkits/axisartist/grid_finder.py:docstring of mpl_toolkits.axisartist.grid_finder.MaxNLocator:21"
     ],
     "set_xbound": [
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.get_xlim3d:22",
@@ -860,259 +867,102 @@
     ],
     "zdir": [
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.Axes3D.text:2",
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.text2D:32",
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.tick_params:32"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.text3D:2",
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.text:2"
     ],
     "filled": [
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.voxels:73"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.voxels:17"
     ],
     "Poly3DCollection": [
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.w_yaxis:4"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.voxels:58"
     ],
     "MovieWriter.saving": [
       "doc/api/animation_api.rst:213"
     ],
-    "Locator.nonsingular": [
-      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
+    "MovieWriterRegistry": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:49",
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:51",
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:118"
     ],
-    "LogLocator": [
-      "doc/api/prev_api_changes/api_changes_3.0.0.rst:207",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:59",
-      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
+    "Axes.add_line": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:65"
     ],
-    "LogitLocator": [
-      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
+    "Axes.add_patch": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:65"
     ],
-    "PathCollection.get_offsets": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    "Axes.autoscale_view": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:65"
     ],
-    "PathCollection": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    "fig.canvas.draw": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:69"
     ],
-    "PathCollection.get_array": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    "Axes.transData": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:89",
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:91",
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:93",
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:96"
     ],
-    "AutoLocator": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:59"
+    "Axes.streamplot": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:139"
     ],
-    "Axis.remove_overlaping_locs": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:79"
+    "matplotlib.color.is_colorlike()": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:169"
     ],
-    "TextPath": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:127"
+    "imshow(A, interpolation='antialiased')": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:180"
     ],
-    "backend_bases.Timer.remove_callback": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:247"
+    "RendererSVG": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:198"
     ],
-    "backend_bases.Timer.remove_callback(func, *args,\n**kwargs)": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:250"
+    "figure": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:211"
     ],
-    "backend_bases.Timer.add_callback(func, *args, **kwargs)": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:250"
+    "backend_bases.GraphicsContextBase.set_clip_path": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "backend_bases.Timer.add_callback": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:267"
+    "blocking_input.BlockingInput.__call__": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "collections.StemContainer": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:273",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:276"
+    "cm.register_cmap": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "Axes.stem": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:276"
+    "dviread.DviFont": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "collections.LineCollection.get_segements()": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:288"
+    "rcsetup.validate_hatch": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "matplotlib.colorbar.ColorbarBase.set_norm": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    "rcsetup.validate_animation_writer_path": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "matplotlib.colorbar.ColorbarBase.set_cmap": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    "spines.Spine": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst:254"
     ],
-    "matplotlib.colorbar.ColorbarBase.set_clim": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    "Locator": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:20",
+      "doc/users/prev_whats_new/whats_new_1.5.rst:522",
+      "doc/users/prev_whats_new/whats_new_1.5.rst:528"
     ],
-    "Installing": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:319"
+    "Formatter": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:20"
     ],
-    "Axes.spy(..., origin='lower')": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:367"
+    "Axis.set_major_locator": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:20"
     ],
-    "str()": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:386"
+    "Axis.set_minor_locator": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:20"
     ],
-    "Axes.fmt_xdata": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:405",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:408"
+    "GridFinder": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:88"
     ],
-    "Axes.fmt_ydata": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:405",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:408"
+    "Locator.autoscale()": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:113"
     ],
-    "Tick": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:414",
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:409",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:244"
+    "Locator.view_limits()": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:113"
     ],
-    "streamplot.Grid": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:487"
-    ],
-    "legend.Legend.set_draggable()": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:507"
-    ],
-    "scipy.stats.norm.pdf": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:573",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:659"
-    ],
-    "matplotlib.pylab": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:626"
-    ],
-    "ImageComparisonTest": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:710"
-    ],
-    "mathcircled": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:737"
-    ],
-    "cbook.deprecated": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1080",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:774"
-    ],
-    "cbook.warn_deprecated": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:774"
-    ],
-    "matplotlib.testing.compare.calculate_rms": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:779"
-    ],
-    "Axes.hist2d": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:798"
-    ],
-    "Annotation": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:799"
-    ],
-    "Axes.annotation": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:799"
-    ],
-    "bezier.find_bezier_t_intersecting_with_closedpath": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
-    ],
-    "bezier.split_bezier_intersecting_with_closedpath": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
-    ],
-    "bezier.find_r_to_boundary_of_closedpath": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1025",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
-    ],
-    "bezier.split_path_inout": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
-    ],
-    "bezier.check_if_parallel": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
-    ],
-    "spine.Spine.is_frame_like": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:823"
-    ],
-    "axis.Axis.get_ticks_position": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:829"
-    ],
-    "mpl_toolkits.Axes.AxisDict": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:835"
-    ],
-    "checkdep_dvipng": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:840"
-    ],
-    "checkdep_ghostscript": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:841"
-    ],
-    "checkdep_pdftops": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:842"
-    ],
-    "checkdep_inkscape": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:843"
-    ],
-    "ticker.decade_up": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:846"
-    ],
-    "ticker.decade_down": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:847"
-    ],
-    "docstring.Appender": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:851"
-    ],
-    "docstring.dedent": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:852"
-    ],
-    "docstring.copy_dedent": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:853"
-    ],
-    "matplotlib.pyplot.get_scale_docs()": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:861"
-    ],
-    "dates.strpdate2num": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:926"
-    ],
-    "dates.bytespdate2num": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:927"
-    ],
-    "axes3d.Axes3D.xaxis": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
-    ],
-    "axes3d.Axes3D.yaxis": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
-    ],
-    "axes3d.Axes3D.zaxis": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
-    ],
-    "pytest.mark.backend(...)": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:948"
-    ],
-    "matplotlib.testing.conftest.mpl_test_settings": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:948"
-    ],
-    "Quiver": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:954"
-    ],
-    "Collection": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:956",
-      "doc/users/prev_whats_new/whats_new_1.5.rst:321",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:198",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:201"
-    ],
-    "backend_gtk3.FileChooserDialog": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:965"
-    ],
-    "backend_gtk3.NavigationToolbar2GTK3.get_filechooser": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:966"
-    ],
-    "backend_gtk3.SaveFigureGTK3.get_filechooser": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:967"
-    ],
-    "NavigationToolbar2QT.adj_window": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:968"
-    ],
-    "backend_wx.IDLE_DELAY": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:969"
-    ],
-    "LogTransform": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1000"
-    ],
-    "InvertedLogTransform": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1000"
-    ],
-    "NavigationToolbar2QT.buttons": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1040"
-    ],
-    "Axis.iter_ticks": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1071"
-    ],
-    "Axis._update_ticks": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1073"
-    ],
-    "Formatter.__call__": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1122",
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1128"
-    ],
-    "ticker..MaxNLocator": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1155"
+    "SymLogScale": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:224"
     ],
     "GraphicsContextBase": [
       "lib/matplotlib/backends/backend_agg.py:docstring of matplotlib.backends.backend_agg.RendererAgg.draw_text:8",
@@ -1345,7 +1195,7 @@
       "lib/matplotlib/cm.py:docstring of matplotlib.cm.get_cmap:10"
     ],
     "draw_gouraud_triangle": [
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.convert_xunits:4"
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.convert_mesh_to_triangles:2"
     ],
     "#rrggbb": [
       "lib/matplotlib/colors.py:docstring of matplotlib.colors:30"
@@ -1354,7 +1204,7 @@
       "lib/matplotlib/colors.py:docstring of matplotlib.colors:30"
     ],
     "'C'": [
-      "lib/matplotlib/colors.py:docstring of matplotlib.colors:54"
+      "lib/matplotlib/colors.py:docstring of matplotlib.colors:58"
     ],
     "LineCollection": [
       "lib/matplotlib/container.py:docstring of matplotlib.container.StemContainer:40"
@@ -1443,94 +1293,6 @@
     "kde.covariance_factor": [
       "lib/matplotlib/mlab.py:docstring of matplotlib.mlab.GaussianKDE:41"
     ],
-    "Locator.autoscale()": [
-      "doc/api/next_api_changes/2019-02-19-AL.rst:4"
-    ],
-    "Locator.view_limits()": [
-      "doc/api/next_api_changes/2019-02-19-AL.rst:4"
-    ],
-    "MovieWriterRegistry": [
-      "doc/api/next_api_changes/2019-03-03-AL.rst:10",
-      "doc/api/next_api_changes/2019-03-03-AL.rst:4"
-    ],
-    "Axes.add_line": [
-      "doc/api/next_api_changes/2019-03-04-AL.rst:9"
-    ],
-    "Axes.add_patch": [
-      "doc/api/next_api_changes/2019-03-04-AL.rst:9"
-    ],
-    "Axes.autoscale_view": [
-      "doc/api/next_api_changes/2019-03-04-AL.rst:9"
-    ],
-    "fig.canvas.draw": [
-      "doc/api/next_api_changes/2019-03-04-AL.rst:13"
-    ],
-    "Axes.transData": [
-      "doc/api/next_api_changes/2019-03-04-AL.rst:36",
-      "doc/api/next_api_changes/2019-03-04-AL.rst:38",
-      "doc/api/next_api_changes/2019-03-04-AL.rst:40",
-      "doc/api/next_api_changes/2019-03-04-AL.rst:43"
-    ],
-    "Locator": [
-      "doc/api/next_api_changes/2019-04-02-AL.rst:4",
-      "doc/users/prev_whats_new/whats_new_1.5.rst:522",
-      "doc/users/prev_whats_new/whats_new_1.5.rst:528"
-    ],
-    "Formatter": [
-      "doc/api/next_api_changes/2019-04-02-AL.rst:4"
-    ],
-    "Axis.set_major_locator": [
-      "doc/api/next_api_changes/2019-04-02-AL.rst:4"
-    ],
-    "Axis.set_minor_locator": [
-      "doc/api/next_api_changes/2019-04-02-AL.rst:4"
-    ],
-    "GridFinder": [
-      "doc/api/next_api_changes/2019-04-04-AL.rst:4"
-    ],
-    "matplotlib.color.is_colorlike()": [
-      "doc/api/next_api_changes/2019-04-13-TH.rst:4"
-    ],
-    "Axes.streamplot": [
-      "doc/api/next_api_changes/2019-04-17-AL.rst:14"
-    ],
-    "figure": [
-      "doc/api/next_api_changes/2019-04-23-TH.rst:4"
-    ],
-    "backend_bases.GraphicsContextBase.set_clip_path": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "blocking_input.BlockingInput.__call__": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "cm.register_cmap": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "dviread.DviFont": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "rcsetup.validate_hatch": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "rcsetup.validate_animation_writer_path": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "spines.Spine": [
-      "doc/api/next_api_changes/2019-06-07-AL.rst:4"
-    ],
-    "RendererSVG": [
-      "doc/api/next_api_changes/2019-06-10-AL.rst:4"
-    ],
-    "image": [
-      "doc/api/next_api_changes/2019-07-17-JMK.rst:1",
-      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
-    ],
-    "imshow(A, interpolation='antialiased')": [
-      "doc/api/next_api_changes/2019-07-17-JMK.rst:8"
-    ],
-    "SymLogScale": [
-      "doc/api/next_api_changes/2019-07-24-AL.rst:4"
-    ],
     "api_changes.rst": [
       "doc/api/next_api_changes/README.rst:6"
     ],
@@ -1551,55 +1313,17 @@
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:39",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:40"
     ],
-    "linestyle": [
-      "doc/users/prev_whats_new/changelog.rst:232"
-    ],
     "axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_1.3.x.rst:36"
     ],
-    "kwargs": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:172"
-    ],
-    "width": [
-      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
-    ],
-    "matplotlibrc": [
-      "doc/users/prev_whats_new/whats_new_1.3.rst:332",
-      "doc/users/prev_whats_new/whats_new_1.3.rst:385",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:260",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:263"
-    ],
-    "font.*": [
-      "doc/users/prev_whats_new/whats_new_1.3.rst:302"
-    ],
     "colorbar.ColorbarBase.outline": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:83"
-    ],
-    "xy": [
-      "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Lasso:8"
-    ],
-    "useOffset": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:293"
-    ],
-    "FormatStrFormatter": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:129"
     ],
     "tight_bbox.adjust_bbox": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:152"
     ],
     "tight_bbox.process_figure_for_rasterizing": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:152"
-    ],
-    "skew": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:157"
-    ],
-    "skew_deg": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:157"
-    ],
-    "markevery": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:212",
-      "doc/users/prev_whats_new/whats_new_1.4.rst:214",
-      "doc/users/prev_whats_new/whats_new_3.0.rst:111"
     ],
     "matplotlib.cbook.ls_mapper": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11",
@@ -1618,32 +1342,8 @@
     "MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:119"
     ],
-    "loc": [
-      "doc/users/prev_whats_new/whats_new_1.3.rst:263",
-      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes.set_theta_zero_location:9"
-    ],
-    "edgecolor": [
-      "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Slider:85"
-    ],
     "numpy.round": [
       "doc/api/prev_api_changes/api_changes_2.0.0.rst:33"
-    ],
-    "rcParams": [
-      "doc/devel/MEP/MEP14.rst:110",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:244"
-    ],
-    "bar": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:457"
-    ],
-    "mpl_toolkits.axes_grid1": [
-      "doc/api/prev_api_changes/api_changes_2.1.0.rst:318"
-    ],
-    "mpl_toolkits.axisartist": [
-      "doc/api/prev_api_changes/api_changes_2.1.0.rst:318"
-    ],
-    "Axes.imshow": [
-      "doc/users/prev_whats_new/whats_new_2.2.rst:251",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:254"
     ],
     "Axis.units": [
       "doc/api/prev_api_changes/api_changes_2.2.0.rst:77"
@@ -1680,6 +1380,11 @@
     ],
     "LogNorm": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:207"
+    ],
+    "LogLocator": [
+      "doc/api/prev_api_changes/api_changes_3.0.0.rst:207",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:59",
+      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
     ],
     "Axes.axes.streamplot": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:215"
@@ -1757,6 +1462,247 @@
     "matplotlib.tri.trifinder._tri": [
       "doc/api/prev_api_changes/api_changes_3.0.1.rst:21"
     ],
+    "PathCollection.get_offsets": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    ],
+    "PathCollection": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    ],
+    "PathCollection.get_array": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:30"
+    ],
+    "AutoLocator": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:59"
+    ],
+    "Axis.remove_overlaping_locs": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:79"
+    ],
+    "TextPath": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:127"
+    ],
+    "backend_bases.Timer.remove_callback": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:247"
+    ],
+    "backend_bases.Timer.remove_callback(func, *args,\n**kwargs)": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:250"
+    ],
+    "backend_bases.Timer.add_callback(func, *args, **kwargs)": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:250"
+    ],
+    "backend_bases.Timer.add_callback": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:267"
+    ],
+    "collections.StemContainer": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:273",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:276"
+    ],
+    "Axes.stem": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:276"
+    ],
+    "collections.LineCollection.get_segements()": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:288"
+    ],
+    "matplotlib.colorbar.ColorbarBase.set_norm": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    ],
+    "matplotlib.colorbar.ColorbarBase.set_cmap": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    ],
+    "matplotlib.colorbar.ColorbarBase.set_clim": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:298"
+    ],
+    "Installing": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:319"
+    ],
+    "Axes.spy(..., origin='lower')": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:367"
+    ],
+    "str()": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:386"
+    ],
+    "Axes.fmt_xdata": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:405",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:408"
+    ],
+    "Axes.fmt_ydata": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:405",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:408"
+    ],
+    "Tick": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:414",
+      "doc/users/prev_whats_new/whats_new_2.1.0.rst:409",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:244"
+    ],
+    "streamplot.Grid": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:487"
+    ],
+    "legend.Legend.set_draggable()": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:507"
+    ],
+    "scipy.stats.norm.pdf": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:573",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:659"
+    ],
+    "matplotlib.pylab": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:626"
+    ],
+    "ImageComparisonTest": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:710"
+    ],
+    "mathcircled": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:737"
+    ],
+    "cbook.deprecated": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1081",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:774"
+    ],
+    "cbook.warn_deprecated": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:774"
+    ],
+    "matplotlib.testing.compare.calculate_rms": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:779"
+    ],
+    "Axes.hist2d": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:798"
+    ],
+    "Annotation": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:799"
+    ],
+    "Axes.annotation": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:799"
+    ],
+    "bezier.find_bezier_t_intersecting_with_closedpath": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
+    ],
+    "bezier.split_bezier_intersecting_with_closedpath": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
+    ],
+    "bezier.find_r_to_boundary_of_closedpath": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1026",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
+    ],
+    "bezier.split_path_inout": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
+    ],
+    "bezier.check_if_parallel": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:801"
+    ],
+    "spine.Spine.is_frame_like": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:823"
+    ],
+    "axis.Axis.get_ticks_position": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:829"
+    ],
+    "mpl_toolkits.Axes.AxisDict": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:835"
+    ],
+    "checkdep_dvipng": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:840"
+    ],
+    "checkdep_ghostscript": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:841"
+    ],
+    "checkdep_pdftops": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:842"
+    ],
+    "checkdep_inkscape": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:843"
+    ],
+    "ticker.decade_up": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:846"
+    ],
+    "ticker.decade_down": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:847"
+    ],
+    "docstring.Appender": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:851"
+    ],
+    "docstring.dedent": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:852"
+    ],
+    "docstring.copy_dedent": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:853"
+    ],
+    "matplotlib.pyplot.get_scale_docs()": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:861"
+    ],
+    "dates.strpdate2num": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:926"
+    ],
+    "dates.bytespdate2num": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:927"
+    ],
+    "axes3d.Axes3D.xaxis": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
+    ],
+    "axes3d.Axes3D.yaxis": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
+    ],
+    "axes3d.Axes3D.zaxis": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:941"
+    ],
+    "pytest.mark.backend(...)": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:949"
+    ],
+    "matplotlib.testing.conftest.mpl_test_settings": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:949"
+    ],
+    "Quiver": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:955"
+    ],
+    "Collection": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:957",
+      "doc/users/prev_whats_new/whats_new_1.5.rst:321",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:198",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:201"
+    ],
+    "backend_gtk3.FileChooserDialog": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:966"
+    ],
+    "backend_gtk3.NavigationToolbar2GTK3.get_filechooser": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:967"
+    ],
+    "backend_gtk3.SaveFigureGTK3.get_filechooser": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:968"
+    ],
+    "NavigationToolbar2QT.adj_window": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:969"
+    ],
+    "backend_wx.IDLE_DELAY": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:970"
+    ],
+    "LogTransform": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1001"
+    ],
+    "InvertedLogTransform": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1001"
+    ],
+    "NavigationToolbar2QT.buttons": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1041"
+    ],
+    "Axis.iter_ticks": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1072"
+    ],
+    "Axis._update_ticks": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1074"
+    ],
+    "Formatter.__call__": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1123",
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1129"
+    ],
+    "ticker..MaxNLocator": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1156"
+    ],
+    "Locator.nonsingular": [
+      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
+    ],
+    "LogitLocator": [
+      "doc/api/prev_api_changes/api_changes_3.1.1.rst:14"
+    ],
+    "loc": [
+      "doc/users/prev_whats_new/whats_new_1.3.rst:263",
+      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes.set_theta_zero_location:9"
+    ],
     "YAxis": [
       "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.RadialAxis:4"
     ],
@@ -1782,10 +1728,16 @@
     ":context:": [
       "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:60"
     ],
+    "image": [
+      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
+    ],
     "alt": [
       "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
     ],
     "height": [
+      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
+    ],
+    "width": [
       "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
     ],
     "scale": [
@@ -1846,12 +1798,6 @@
     "display_range": [
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.PercentFormatter.format_pct:5"
     ],
-    "'auto'": [
-      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator:28"
-    ],
-    "min_n_ticks": [
-      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator:41"
-    ],
     "patch.Patch": [
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.TransformedPatchPath:2"
     ],
@@ -1864,6 +1810,9 @@
     ],
     "figure.canvas.mpl_connect": [
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.AxesWidget.connect_event:4"
+    ],
+    "xy": [
+      "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Lasso:8"
     ],
     "callback": [
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Lasso:20"
@@ -1890,6 +1839,9 @@
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Slider:70"
     ],
     "facecolor": [
+      "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Slider:85"
+    ],
+    "edgecolor": [
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.Slider:85"
     ],
     "alpha": [
@@ -2021,6 +1973,10 @@
     ],
     "harfbuzz": [
       "doc/devel/MEP/MEP14.rst:85"
+    ],
+    "rcParams": [
+      "doc/devel/MEP/MEP14.rst:110",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:244"
     ],
     "font.family": [
       "doc/devel/MEP/MEP14.rst:110"
@@ -2270,16 +2226,16 @@
       "doc/devel/coding_guide.rst:26"
     ],
     "tox": [
-      "doc/devel/coding_guide.rst:69"
+      "doc/devel/coding_guide.rst:81"
     ],
     "git status": [
-      "doc/devel/coding_guide.rst:175"
+      "doc/devel/coding_guide.rst:185"
     ],
     "v2.2.x": [
-      "doc/devel/coding_guide.rst:184"
+      "doc/devel/coding_guide.rst:194"
     ],
     "master": [
-      "doc/devel/coding_guide.rst:184"
+      "doc/devel/coding_guide.rst:194"
     ],
     "doc/api/api_changes": [
       "doc/devel/contributing.rst:269"
@@ -2326,26 +2282,23 @@
     ":doc:": [
       "doc/devel/documenting_mpl.rst:161"
     ],
-    "= [default-val]": [
-      "doc/devel/documenting_mpl.rst:503"
-    ],
     "pyplot.getp": [
-      "doc/devel/documenting_mpl.rst:523"
+      "doc/devel/documenting_mpl.rst:520"
     ],
     "matplotlib.docstring.dedent_interpd": [
-      "doc/devel/documenting_mpl.rst:591"
+      "doc/devel/documenting_mpl.rst:588"
     ],
     "matplotlib.patches.Patch.__init__": [
-      "doc/devel/documenting_mpl.rst:624"
+      "doc/devel/documenting_mpl.rst:621"
     ],
     "# docstring inherited": [
-      "doc/devel/documenting_mpl.rst:640"
+      "doc/devel/documenting_mpl.rst:637"
     ],
     ":plot:": [
-      "doc/devel/documenting_mpl.rst:660"
+      "doc/devel/documenting_mpl.rst:657"
     ],
     "###": [
-      "doc/devel/documenting_mpl.rst:747"
+      "doc/devel/documenting_mpl.rst:744"
     ],
     "pytest": [
       "doc/devel/testing.rst:50",
@@ -2360,27 +2313,8 @@
     "load_char": [
       "doc/gallery/misc/ftface_props.rst:14"
     ],
-    "Patch": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:321",
-      "doc/users/prev_whats_new/whats_new_1.5.rst:324"
-    ],
-    "Figure.align_xlabels": [
-      "doc/users/prev_whats_new/whats_new_2.2.rst:70"
-    ],
-    "Figure.align_ylabels": [
-      "doc/users/prev_whats_new/whats_new_2.2.rst:70"
-    ],
-    "Figure.align_labels": [
-      "doc/users/prev_whats_new/whats_new_2.2.rst:84"
-    ],
     "ConciseDateConverter": [
       "doc/gallery/ticks_and_spines/date_concise_formatter.rst:215"
-    ],
-    "ScalarFormatter": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:293"
-    ],
-    "ConnectionPatch": [
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:178"
     ],
     "pyplot": [
       "doc/index.rst:44"
@@ -2389,15 +2323,10 @@
       "doc/index.rst:145"
     ],
     "axes_grid1": [
-      "doc/index.rst:145",
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:160"
+      "doc/index.rst:145"
     ],
     "axisartist": [
-      "doc/index.rst:145",
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:160"
-    ],
-    "set_ylim": [
-      "doc/users/prev_whats_new/whats_new_2.2.rst:230"
+      "doc/index.rst:145"
     ],
     "'viridis'": [
       "doc/users/dflt_style_changes.rst:121"
@@ -2420,43 +2349,11 @@
     "numticks": [
       "doc/users/dflt_style_changes.rst:1083"
     ],
-    "pyplot.imsave": [
-      "doc/users/next_whats_new/2019-04-05-AL.rst:1"
-    ],
-    "Figure.savefig()": [
-      "doc/users/next_whats_new/2019-04-05-AL.rst:4"
-    ],
-    "cbook.normalize_kwargs": [
-      "doc/users/next_whats_new/2019-04-17-AL.rst:1",
-      "doc/users/next_whats_new/2019-04-17-AL.rst:4"
-    ],
     "whats_new.rst": [
       "doc/users/next_whats_new/README.rst:6"
     ],
     "next_whats_new": [
       "doc/users/next_whats_new/README.rst:6"
-    ],
-    "plt.errorbar()": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:4"
-    ],
-    "errorevery": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:4",
-      "doc/users/next_whats_new/errorbar_offsets.rst:8"
-    ],
-    "plt.errorbar(x, y, yerr, errorevery=6)": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:4"
-    ],
-    "x[::6], y[::6]": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:4"
-    ],
-    "errorbar()": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:8"
-    ],
-    "plt.errorbar(x, y, yerr, errorevery=(start, N))": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:8"
-    ],
-    "x[start::N], y[start::N]": [
-      "doc/users/next_whats_new/errorbar_offsets.rst:8"
     ],
     "MPLBACKEND": [
       "doc/users/prev_whats_new/changelog.rst:32"
@@ -2504,6 +2401,9 @@
     "cbook.boxplot_stats": [
       "doc/users/prev_whats_new/changelog.rst:148"
     ],
+    "linestyle": [
+      "doc/users/prev_whats_new/changelog.rst:232"
+    ],
     "step": [
       "doc/users/prev_whats_new/changelog.rst:232"
     ],
@@ -2547,8 +2447,17 @@
     "draw_text": [
       "doc/users/prev_whats_new/whats_new_1.3.rst:254"
     ],
+    "font.*": [
+      "doc/users/prev_whats_new/whats_new_1.3.rst:302"
+    ],
     "savefig.directory": [
       "doc/users/prev_whats_new/whats_new_1.3.rst:332"
+    ],
+    "matplotlibrc": [
+      "doc/users/prev_whats_new/whats_new_1.3.rst:332",
+      "doc/users/prev_whats_new/whats_new_1.3.rst:385",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:260",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:263"
     ],
     "setup.cfg.template": [
       "doc/users/prev_whats_new/whats_new_1.3.rst:374"
@@ -2571,6 +2480,9 @@
     "FormatStrFormatterNewStyle": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:129"
     ],
+    "FormatStrFormatter": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:129"
+    ],
     "density=1": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:135"
     ],
@@ -2585,11 +2497,31 @@
     "minor": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:141"
     ],
+    "skew": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:157"
+    ],
+    "skew_deg": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:157"
+    ],
+    "kwargs": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:172"
+    ],
+    "markevery": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:212",
+      "doc/users/prev_whats_new/whats_new_1.4.rst:214",
+      "doc/users/prev_whats_new/whats_new_3.0.rst:111"
+    ],
     "Collections": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:220"
     ],
     "set_size": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:223"
+    ],
+    "useOffset": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:293"
+    ],
+    "ScalarFormatter": [
+      "doc/users/prev_whats_new/whats_new_1.4.rst:293"
     ],
     "zip()": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:96"
@@ -2652,6 +2584,10 @@
     "format_pixel_data": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:274"
     ],
+    "Patch": [
+      "doc/users/prev_whats_new/whats_new_1.5.rst:321",
+      "doc/users/prev_whats_new/whats_new_1.5.rst:324"
+    ],
     "\"--\"": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:324"
     ],
@@ -2669,6 +2605,9 @@
     ],
     "dpi='figure'": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:412"
+    ],
+    "bar": [
+      "doc/users/prev_whats_new/whats_new_1.5.rst:457"
     ],
     "barh": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:457"
@@ -2857,6 +2796,15 @@
     "figure.suptitle": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:30"
     ],
+    "Figure.align_xlabels": [
+      "doc/users/prev_whats_new/whats_new_2.2.rst:70"
+    ],
+    "Figure.align_ylabels": [
+      "doc/users/prev_whats_new/whats_new_2.2.rst:70"
+    ],
+    "Figure.align_labels": [
+      "doc/users/prev_whats_new/whats_new_2.2.rst:84"
+    ],
     "dateime.datetime": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:155"
     ],
@@ -2866,12 +2814,19 @@
     "matplotlib.colors.same_color": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:218"
     ],
+    "set_ylim": [
+      "doc/users/prev_whats_new/whats_new_2.2.rst:230"
+    ],
     "Axes.tick_params": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:241",
       "doc/users/prev_whats_new/whats_new_2.2.rst:244"
     ],
     "pyplot.tick_params": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:244"
+    ],
+    "Axes.imshow": [
+      "doc/users/prev_whats_new/whats_new_2.2.rst:251",
+      "doc/users/prev_whats_new/whats_new_2.2.rst:254"
     ],
     "xtick.labeltop": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:263"
@@ -2918,6 +2873,9 @@
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:131",
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:135"
     ],
+    "ConnectionPatch": [
+      "doc/users/prev_whats_new/whats_new_3.1.0.rst:178"
+    ],
     "Axes..set_inverted": [
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:247"
     ],
@@ -2942,17 +2900,27 @@
     "pyplot.set_loglevel": [
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:377"
     ],
+    "cbook.normalize_kwargs": [
+      "doc/users/prev_whats_new/whats_new_3.2.0.rst:26"
+    ],
+    "plt.errorbar()": [
+      "doc/users/prev_whats_new/whats_new_3.2.0.rst:92",
+      "doc/users/prev_whats_new/whats_new_3.2.0.rst:96"
+    ],
+    "errorevery": [
+      "doc/users/prev_whats_new/whats_new_3.2.0.rst:96"
+    ],
     "%matplotlib": [
       "doc/users/shell.rst:32"
     ]
   },
   "py:data": {
     "matplotlib.axes.Axes.transAxes": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:235",
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:199",
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:194",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:199",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:235"
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:224",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:188",
+      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:183",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:188",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:224"
     ]
   },
   "py:meth": {
@@ -2990,7 +2958,7 @@
       "lib/mpl_toolkits/axes_grid1/colorbar.py:docstring of mpl_toolkits.axes_grid1.colorbar.ColorbarBase:31"
     ],
     "set_ylabel": [
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.set_zlim3d:9"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.set_zlabel:2"
     ],
     "draw_image": [
       "lib/matplotlib/backends/backend_agg.py:docstring of matplotlib.backends.backend_agg.RendererAgg.option_scale_image:2"
@@ -3205,7 +3173,7 @@
     ],
     "matplotlib.axes._axes.Axes": [
       "doc/api/artist_api.rst:189",
-      "doc/api/axes_api.rst:688",
+      "doc/api/axes_api.rst:685",
       "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes:1",
       "lib/mpl_toolkits/axes_grid1/mpl_axes.py:docstring of mpl_toolkits.axes_grid1.mpl_axes.Axes:1",
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.Axes:1",
@@ -3257,22 +3225,23 @@
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Patch3D.get_facecolor:2"
     ],
     "tzinfo": [
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.AutoDateLocator:64",
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.DateLocator.datalim_to_dt:6",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.AutoDateLocator:36",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.DateLocator:24",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.RRuleLocator:2",
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.zaxis_date:4"
     ],
     "matplotlib.axes._base._AxesBase": [
       "doc/api/artist_api.rst:189",
-      "doc/api/axes_api.rst:688",
+      "doc/api/axes_api.rst:685",
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes:1"
     ],
     "matplotlib.collections._CollectionWithSizes": [
       "doc/api/artist_api.rst:189",
       "doc/api/collections_api.rst:13",
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.CircleCollection:1",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection:27",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection:27",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection:27"
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection:1",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection:1",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection:1"
     ],
     "matplotlib.image._ImageBase": [
       "doc/api/artist_api.rst:189",
@@ -3333,9 +3302,6 @@
     "matplotlib.colorbar._ColorbarMappableDummy": [
       "lib/matplotlib/colorbar.py:docstring of matplotlib.colorbar.ColorbarBase:1"
     ],
-    "Artist": [
-      "lib/matplotlib/container.py:docstring of matplotlib.container.Container.add_callback:2"
-    ],
     "matplotlib.dates.strpdate2num": [
       "doc/api/dates_api.rst:11"
     ],
@@ -3357,7 +3323,7 @@
       "lib/matplotlib/dates.py:docstring of matplotlib.dates.num2date:19"
     ],
     "dateutil.rrule.rrulebase": [
-      "<external>/rrule.py:docstring of matplotlib.dates.rrule:27"
+      "<external>/rrule.py:docstring of matplotlib.dates.rrule:1"
     ],
     "dviread.PsfontsMap": [
       "lib/matplotlib/dviread.py:docstring of matplotlib.dviread.DviFont:20"
@@ -3373,7 +3339,16 @@
       "lib/matplotlib/fontconfig_pattern.py:docstring of matplotlib.fontconfig_pattern.parse_fontconfig_pattern:2"
     ],
     "MathTextBackend": [
-      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.Fonts:30"
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.BakomaFonts:29",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.DejaVuFonts:7",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.DejaVuSansFonts:28",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.DejaVuSerifFonts:28",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.Fonts:30",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.StandardPsFonts:29",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.StixFonts:34",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.StixSansFonts:28",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.TruetypeFonts:28",
+      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.UnicodeFonts:33"
     ],
     "Annotation": [
       "lib/matplotlib/offsetbox.py:docstring of matplotlib.offsetbox.AnnotationBbox.draw:2"
@@ -3411,6 +3386,22 @@
     "matplotlib.cbook.MatplotlibDeprecationWarning": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:405"
     ],
+    "TransformNode": [
+      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.InvertedPolarTransform:23",
+      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes.InvertedPolarTransform:23",
+      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes.PolarTransform:25",
+      "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarTransform:25",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.InvertedLogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.InvertedSymmetricalLogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.LogScale.InvertedLogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.LogScale.LogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.LogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.LogisticTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.LogitTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.SymmetricalLogScale.InvertedSymmetricalLogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.SymmetricalLogScale.SymmetricalLogTransform:2",
+      "lib/matplotlib/scale.py:docstring of matplotlib.scale.SymmetricalLogTransform:2"
+    ],
     "ListedColormap": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.colormaps:98"
     ],
@@ -3419,13 +3410,6 @@
     ],
     "unittest.case.TestCase": [
       "lib/matplotlib/testing/decorators.py:docstring of matplotlib.testing.decorators.CleanupTestCase:1"
-    ],
-    "OldAutoLocator": [
-      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker:73"
-    ],
-    "mpl_toolkits.axes_grid1": [
-      "doc/api/toolkits/axes_grid1.rst:5",
-      "doc/api/toolkits/axes_grid1.rst:6"
     ],
     "mpl_toolkits.axisartist.Axes": [
       "doc/api/toolkits/axisartist.rst:5",
@@ -3529,21 +3513,21 @@
       "lib/mpl_toolkits/axes_grid1/colorbar.py:docstring of mpl_toolkits.axes_grid1.colorbar.ColorbarBase:29"
     ],
     "matplotlib.cm.ScalarMappable._A": [
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.add_callback:13",
+      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection:101",
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Line3DCollection:95"
     ],
     "fmt_zdata": [
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.format_zdata:2"
     ],
     "_autoscaleZon": [
-      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.set_zlim:7"
+      "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.set_zbound:2"
     ],
     "axis": [
-      "<external>/rrule.py:docstring of matplotlib.dates.rrule:1",
       "lib/matplotlib/category.py:docstring of matplotlib.category.StrCategoryLocator.tick_values:5",
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.AutoDateLocator:1",
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.MonthLocator:1",
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.YearLocator:1",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.AutoDateLocator.tick_values:5",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.MicrosecondLocator.tick_values:5",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.RRuleLocator.tick_values:5",
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.YearLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.AutoMinorLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.IndexLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.LinearLocator.tick_values:5",
@@ -3552,6 +3536,7 @@
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.LogitLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MultipleLocator.tick_values:5",
+      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.OldAutoLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.SymmetricalLogLocator.tick_values:5"
     ],
     "matplotlib.colors.Colormap.name": [
@@ -3559,6 +3544,45 @@
     ],
     "matplotlib.cm.ScalarMappable.callbacksSM": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
+    ],
+    "transforms.Bbox.bounds": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:91"
+    ],
+    "transforms.BboxBase.width": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:93"
+    ],
+    "transforms.BboxBase.height": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:96"
+    ],
+    "transforms.Bbox.intervalx": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:99"
+    ],
+    "transforms.Bbox.intervaly": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:102"
+    ],
+    "transforms.Bbox.x0": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:105"
+    ],
+    "transforms.BboxBase.xmin": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:105"
+    ],
+    "transforms.Bbox.y0": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
+    ],
+    "transforms.BboxBase.ymin": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
+    ],
+    "transforms.Bbox.x1": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:113"
+    ],
+    "transforms.BboxBase.xmax": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:113"
+    ],
+    "transforms.Bbox.y1": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
+    ],
+    "transforms.BboxBase.ymax": [
+      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
     ],
     "matplotlib.figure.Figure.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
@@ -3687,13 +3711,7 @@
       "lib/matplotlib/dates.py:docstring of matplotlib.dates:28:<autosummary>:1"
     ],
     "strftime": [
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates.AutoDateFormatter:3"
-    ],
-    "findfont": [
-      "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager:3"
-    ],
-    "matplotlib.axis.Tick.label1On": [
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:409"
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates.IndexDateFormatter:23"
     ],
     "matplotlib.pylab.plot": [
       "doc/devel/add_new_projection.rst:18"
@@ -3774,6 +3792,9 @@
     ],
     "streamplot": [
       "doc/users/prev_whats_new/whats_new_2.0.0.rst:299"
+    ],
+    "matplotlib.axis.Tick.label1On": [
+      "doc/users/prev_whats_new/whats_new_2.1.0.rst:409"
     ]
   },
   "py:mod": {
@@ -3788,12 +3809,8 @@
       "lib/mpl_toolkits/axes_grid1/axes_divider.py:docstring of mpl_toolkits.axes_grid1.axes_divider.Divider:41",
       "lib/mpl_toolkits/axes_grid1/axes_divider.py:docstring of mpl_toolkits.axes_grid1.axes_divider.Divider:44"
     ],
-    "matplotlib.pylab": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:624",
-      "doc/users/history.rst:63"
-    ],
-    "matplotlib.scales": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1000"
+    "matplotlib._png": [
+      "doc/api/prev_api_changes/api_changes_3.2.0/development.rst:6"
     ],
     "matplotlib.backends.backend_gtk3agg": [
       "doc/api/backend_gtk3agg_api.rst:2"
@@ -3822,9 +3839,6 @@
     "dateutil": [
       "lib/matplotlib/dates.py:docstring of matplotlib.dates:1"
     ],
-    "matplotlib._png": [
-      "doc/api/next_api_changes/2019-01-02-AL.rst:4"
-    ],
     "matplotlib.ft2font": [
       "doc/api/prev_api_changes/api_changes_0.91.0.rst:34"
     ],
@@ -3836,6 +3850,13 @@
     ],
     "matplotlib.backends.wx_compat": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:355"
+    ],
+    "matplotlib.pylab": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:624",
+      "doc/users/history.rst:63"
+    ],
+    "matplotlib.scales": [
+      "doc/api/prev_api_changes/api_changes_3.1.0.rst:1001"
     ],
     "mpl_toolkits.mplot3d.axes3d": [
       "doc/api/toolkits/mplot3d.rst:19"

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.8.1,<2.0.0
+sphinx>=1.8.1,!=2.0.0
 colorspacious
 ipython
 ipywidgets


### PR DESCRIPTION
Sphinx 2 by default uses a `html5` writer, that changes the outputted html, causing the issues mentioned in #13591. In order to allow the use of sphinx 2, without having to change our CSS,  makes sphinx 2 use the `html4` writer that sphinx 1 also uses.

Possibly we will want to migrate/upgrade to the `html5` writer, but changing the CSS to match is a pain (see #14105  for my aborted attempt to do this) so this provides a solution to use sphinx 2 in the medium term.

Fixes #13591