### PR TITLE
MNT/TST: generalize check_figures_equal to work with pytest.marks

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -381,8 +381,7 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             fig_test.subplots().plot([1, 3, 5])
             fig_ref.subplots().plot([0, 1, 2], [1, 3, 5])
     """
-    POK = inspect.Parameter.POSITIONAL_OR_KEYWORD
-
+    POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
     def decorator(func):
         import pytest
 
@@ -405,14 +404,10 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         sig = inspect.signature(func)
         new_sig = sig.replace(
-            parameters=(
-                [
-                    param
-                    for param in sig.parameters.values()
-                    if param.name not in {"fig_test", "fig_ref"}
-                ]
-                + [inspect.Parameter("ext", POK)]
-            )
+            parameters=([param
+                         for param in sig.parameters.values()
+                         if param.name not in {"fig_test", "fig_ref"}]
+                        + [inspect.Parameter("ext", POSITIONAL_OR_KEYWORD)])
         )
         wrapper.__signature__ = new_sig
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -381,6 +381,7 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             fig_test.subplots().plot([1, 3, 5])
             fig_ref.subplots().plot([0, 1, 2], [1, 3, 5])
     """
+    POK = inspect.Parameter.POSITIONAL_OR_KEYWORD
 
     def decorator(func):
         import pytest
@@ -410,18 +411,14 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
                     for param in sig.parameters.values()
                     if param.name not in {"fig_test", "fig_ref"}
                 ]
-                + [
-                    inspect.Parameter(
-                        "ext", inspect.Parameter.POSITIONAL_OR_KEYWORD
-                    )
-                ]
+                + [inspect.Parameter("ext", POK)]
             )
         )
         wrapper.__signature__ = new_sig
 
         # reach a bit into pytest internals to hoist the marks from
         # our wrapped function
-        new_marks = getattr(func, 'pytestmark', []) + wrapper.pytestmark
+        new_marks = getattr(func, "pytestmark", []) + wrapper.pytestmark
         wrapper.pytestmark = new_marks
 
         return wrapper

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -421,11 +421,8 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         # reach a bit into pytest internals to hoist the marks from
         # our wrapped function
-        from _pytest.mark.structures import get_unpacked_marks
-
-        wrapper.pytestmark = get_unpacked_marks(
-            wrapper
-        ) + get_unpacked_marks(func)
+        new_marks = getattr(func, 'pytestmark', []) + wrapper.pytestmark
+        wrapper.pytestmark = new_marks
 
         return wrapper
 

--- a/lib/matplotlib/tests/test_testing.py
+++ b/lib/matplotlib/tests/test_testing.py
@@ -1,7 +1,19 @@
 import warnings
 import pytest
+from matplotlib.testing.decorators import check_figures_equal
 
-@pytest.mark.xfail(strict=True,
-                   reason="testing that warnings fail tests")
+
+@pytest.mark.xfail(
+    strict=True, reason="testing that warnings fail tests"
+)
 def test_warn_to_fail():
     warnings.warn("This should fail the test")
+
+
+@pytest.mark.parametrize("a", [1])
+@check_figures_equal(extensions=["png"])
+@pytest.mark.parametrize("b", [1])
+def test_paramatirize_with_check_figure_equal(
+    a, fig_ref, b, fig_test
+):
+    assert a == b

--- a/lib/matplotlib/tests/test_testing.py
+++ b/lib/matplotlib/tests/test_testing.py
@@ -13,7 +13,5 @@ def test_warn_to_fail():
 @pytest.mark.parametrize("a", [1])
 @check_figures_equal(extensions=["png"])
 @pytest.mark.parametrize("b", [1])
-def test_paramatirize_with_check_figure_equal(
-    a, fig_ref, b, fig_test
-):
+def test_parametrize_with_check_figure_equal(a, fig_ref, b, fig_test):
     assert a == b


### PR DESCRIPTION
## PR Summary

Generalize (at the cost of reaching a little bit into pytest
internals) the check_figures_equal decorator so it works as
expected with `pytest.mark.paramatarize`

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
