### PR TITLE
Deprecate the renderer parameter to Figure.tight_layout.

### DIFF
--- a/doc/api/next_api_changes/2018-09-06-AL.rst
+++ b/doc/api/next_api_changes/2018-09-06-AL.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+The ``renderer`` parameter to `.Figure.tight_layout` is deprecated; this method
+now always uses the renderer instance cached on the `.Figure`.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1695,6 +1695,7 @@ default: 'top'
         Render the figure using :class:`matplotlib.backend_bases.RendererBase`
         instance *renderer*.
         """
+        self._cachedRenderer = renderer
 
         # draw the figure bounding box, perhaps none for white figure
         if not self.get_visible():
@@ -1729,8 +1730,7 @@ default: 'top'
                 self.execute_constrained_layout(renderer)
             if self.get_tight_layout() and self.axes:
                 try:
-                    self.tight_layout(renderer,
-                                      **self._tight_parameters)
+                    self.tight_layout(**self._tight_parameters)
                 except ValueError:
                     pass
                     # ValueError can occur when resizing a window.
@@ -1743,7 +1743,6 @@ default: 'top'
         finally:
             self.stale = False
 
-        self._cachedRenderer = renderer
         self.canvas.draw_event(renderer)
 
     def draw_artist(self, a):
@@ -2450,6 +2449,7 @@ default: 'top'
             renderer = layoutbox.get_renderer(fig)
         do_constrained_layout(fig, renderer, h_pad, w_pad, hspace, wspace)
 
+    @cbook._delete_parameter("3.2", "renderer")
     def tight_layout(self, renderer=None, pad=1.08, h_pad=None, w_pad=None,
                      rect=None):
         """
@@ -2462,8 +2462,7 @@ default: 'top'
         Parameters
         ----------
         renderer : subclass of `~.backend_bases.RendererBase`, optional
-            Defaults to the renderer for the figure.
-
+            Defaults to the renderer for the figure.  Deprecated.
         pad : float, optional
             Padding between the figure edge and the edges of subplots,
             as a fraction of the font size.


### PR DESCRIPTION
We only ever use the renderer instance cached on the Figure anyways
(except that in `Figure.draw` we need to cache it earlier).

After the parameter is removed, the signature of Figure.tight_layout
will match the one of pyplot.tight_layout and we'll be able to dedupe
the latter by just adding tight_layout to the list of functions
autogenerated by boilerplate.py.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
