### PR TITLE
PEP8ify some variable names.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5634,12 +5634,11 @@ optional.
 
         if len(args) == 1:
             C = np.asanyarray(args[0])
-            numRows, numCols = C.shape
+            nrows, ncols = C.shape
             if allmatch:
-                X, Y = np.meshgrid(np.arange(numCols), np.arange(numRows))
+                X, Y = np.meshgrid(np.arange(ncols), np.arange(nrows))
             else:
-                X, Y = np.meshgrid(np.arange(numCols + 1),
-                                   np.arange(numRows + 1))
+                X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
             C = cbook.safe_masked_invalid(C)
             return X, Y, C
 
@@ -5659,7 +5658,7 @@ optional.
                     X = X.data  # strip mask as downstream doesn't like it...
                 if isinstance(Y, np.ma.core.MaskedArray):
                     Y = Y.data
-            numRows, numCols = C.shape
+            nrows, ncols = C.shape
         else:
             raise TypeError(
                 'Illegal arguments to %s; see help(%s)' % (funcname, funcname))
@@ -5677,12 +5676,12 @@ optional.
                 'Incompatible X, Y inputs to %s; see help(%s)' % (
                 funcname, funcname))
         if allmatch:
-            if (Nx, Ny) != (numCols, numRows):
+            if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
         else:
-            if not (numCols in (Nx, Nx - 1) and numRows in (Ny, Ny - 1)):
+            if not (ncols in (Nx, Nx - 1) and nrows in (Ny, Ny - 1)):
                 raise TypeError('Dimensions of C %s are incompatible with'
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -17,16 +17,19 @@ class SubplotBase:
 
     def __init__(self, fig, *args, **kwargs):
         """
-        *fig* is a :class:`matplotlib.figure.Figure` instance.
+        Parameters
+        ----------
+        fig : `matplotlib.figure.Figure`
 
-        *args* is the tuple (*numRows*, *numCols*, *plotNum*), where
-        the array of subplots in the figure has dimensions *numRows*,
-        *numCols*, and where *plotNum* is the number of the subplot
-        being created.  *plotNum* starts at 1 in the upper left
-        corner and increases to the right.
+        *args : tuple (*nrows*, *ncols*, *index*) or int
+            The array of subplots in the figure has dimensions ``(nrows,
+            ncols)``, and *index* is the index of the subplot being created.
+            *index* starts at 1 in the upper left corner and increases to the
+            right.
 
-        If *numRows* <= *numCols* <= *plotNum* < 10, *args* can be the
-        decimal integer *numRows* * 100 + *numCols* * 10 + *plotNum*.
+            If *nrows*, *ncols*, and *index* are all single digit numbers, then
+            *args* can be passed as a single 3-digit number (e.g. 234 for
+            (2, 3, 4)).
         """
 
         self.figure = fig

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -350,15 +350,17 @@ class SubplotDivider(Divider):
         """
         Parameters
         ----------
-        fig : :class:`matplotlib.figure.Figure`
-        *args : tuple (*numRows*, *numCols*, *plotNum*)
-            The array of subplots in the figure has dimensions *numRows*,
-            *numCols*, and *plotNum* is the number of the subplot
-            being created.  *plotNum* starts at 1 in the upper left
-            corner and increases to the right.
+        fig : `matplotlib.figure.Figure`
 
-            If *numRows* <= *numCols* <= *plotNum* < 10, *args* can be the
-            decimal integer *numRows* * 100 + *numCols* * 10 + *plotNum*.
+        *args : tuple (*nrows*, *ncols*, *index*) or int
+            The array of subplots in the figure has dimensions ``(nrows,
+            ncols)``, and *index* is the index of the subplot being created.
+            *index* starts at 1 in the upper left corner and increases to the
+            right.
+
+            If *nrows*, *ncols*, and *index* are all single digit numbers, then
+            *args* can be passed as a single 3-digit number (e.g. 234 for
+            (2, 3, 4)).
         """
 
         self.figure = fig


### PR DESCRIPTION
nrows/ncols is already used as parameter names in subplots() so
standardizing on them seems good enough.

Note that the docstring of SubplotBase was previously incorrect:
one didn't need `numRows <= numCols <= plotNum < 10`, just that all
three be single-digit.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
