### PR TITLE
Various backend cleanups.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2498,14 +2498,9 @@ class FigureCanvasPdf(FigureCanvasBase):
     ----------
     figure : `matplotlib.figure.Figure`
         A high-level Figure instance
-
     """
 
     fixed_dpi = 72
-
-    def draw(self):
-        pass
-
     filetypes = {'pdf': 'Portable Document Format'}
 
     def get_default_filetype(self):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -952,14 +952,12 @@ class FigureCanvasPgf(FigureCanvasBase):
         return RendererPgf(self.figure, None, dummy=True)
 
 
-class FigureManagerPgf(FigureManagerBase):
-    pass
+FigureManagerPgf = FigureManagerBase
 
 
 @_Backend.export
 class _BackendPgf(_Backend):
     FigureCanvas = FigureCanvasPgf
-    FigureManager = FigureManagerPgf
 
 
 def _cleanup_all():

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -748,10 +748,6 @@ class _Orientation(Enum):
 
 class FigureCanvasPS(FigureCanvasBase):
     fixed_dpi = 72
-
-    def draw(self):
-        pass
-
     filetypes = {'ps': 'Postscript',
                  'eps': 'Encapsulated Postscript'}
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -222,7 +222,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         _create_qApp()
         super().__init__(figure=figure)
 
-        self.figure = figure
         # We don't want to scale up the figure DPI more than once.
         # Note, we don't handle a signal for changing DPI yet.
         figure._original_dpi = figure.dpi

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -200,8 +200,7 @@ class FigureCanvasTemplate(FigureCanvasBase):
 
     # If the file type is not in the base set of filetypes,
     # you should add it to the class-scope filetypes dictionary as follows:
-    filetypes = FigureCanvasBase.filetypes.copy()
-    filetypes['foo'] = 'My magic Foo format'
+    filetypes = {**FigureCanvasBase.filetypes, 'foo': 'My magic Foo format'}
 
     def print_foo(self, filename, *args, **kwargs):
         """

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -512,12 +512,11 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
 
     def __init__(self, parent, id, figure):
         """
-        Initialise a FigureWx instance.
+        Initialize a FigureWx instance.
 
-        - Initialise the FigureCanvasBase and wxPanel parents.
-        - Set event handlers for:
-          EVT_SIZE  (Resize event)
-          EVT_PAINT (Paint event)
+        - Initialize the FigureCanvasBase and wxPanel parents.
+        - Set event handlers for resize, paint, and keyboard and mouse
+          interaction.
         """
 
         FigureCanvasBase.__init__(self, figure)


### PR DESCRIPTION
- Noninteractive backends don't need to redefine `draw()` as a
  do-nothing: that's already the default in the base class.
- FigureCanvasQT doesn't need to assign `self.figure = figure`:
  that's already done in the super() init.
- Use star-unpack in backend_template.
- The list of event handlers set up by backend_wx is much bigger than
  previously documented.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
