### PR TITLE
Inline wx icon loading.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1079,25 +1079,16 @@ class FigureManagerWx(FigureManagerBase):
 
 def _load_bitmap(filename):
     """
-    Load a bitmap file from the backends/images subdirectory in which the
-    matplotlib library is installed. The filename parameter should not
-    contain any path information as this is determined automatically.
-
-    Returns a wx.Bitmap object.
+    Load a wx.Bitmap from a file in the "images" directory of the Matplotlib
+    data.
     """
-    path = cbook._get_data_path('images', filename)
-    if not path.exists():
-        raise IOError(f"Could not find bitmap file '{path}'; dying")
-    return wx.Bitmap(str(path))
+    return wx.Bitmap(str(cbook._get_data_path('images', filename)))
 
 
 def _set_frame_icon(frame):
     bundle = wx.IconBundle()
     for image in ('matplotlib.png', 'matplotlib_large.png'):
-        try:
-            icon = wx.Icon(_load_bitmap(image))
-        except IOError:
-            continue
+        icon = wx.Icon(_load_bitmap(image))
         if not icon.IsOk():
             return
         bundle.AddIcon(icon)
@@ -1142,7 +1133,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             self.wx_ids[text] = (
                 self.AddTool(
                     -1,
-                    bitmap=_load_bitmap(image_file + ".png"),
+                    bitmap=_load_bitmap(f"{image_file}.png"),
                     bmpDisabled=wx.NullBitmap,
                     label=text, shortHelp=text, longHelp=tooltip_text,
                     kind=(wx.ITEM_CHECK if text in ["Pan", "Zoom"]
@@ -1323,8 +1314,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 class StatusBarWx(wx.StatusBar):
     """
     A status bar is added to _FigureFrame to allow measurements and the
-    previously selected scroll function to be displayed as a user
-    convenience.
+    previously selected scroll function to be displayed as a user convenience.
     """
 
     def __init__(self, parent, *args, **kwargs):
@@ -1354,7 +1344,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
             tool = self.InsertTool(idx, -1, name, bmp, wx.NullBitmap, kind,
                                    description or "")
         else:
-            size = (self.GetTextExtent(name)[0]+10, -1)
+            size = (self.GetTextExtent(name)[0] + 10, -1)
             if toggle:
                 control = wx.ToggleButton(self, -1, name, size=size)
             else:


### PR DESCRIPTION
No other backend bothers checking that the icons actually exist -- them
not being present would be a packaging bug anyways.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
