### PR TITLE
Correctly format floats passed to pgf backend.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -25,7 +25,9 @@ from matplotlib._pylab_helpers import Gcf
 _log = logging.getLogger(__name__)
 
 
-###############################################################################
+# Note: When formatting floating point values, it is important to use the
+# %f/{:f} format rather than %s/{} to avoid triggering scientific notation,
+# which is not recognized by TeX.
 
 
 def get_fontspec():
@@ -724,14 +726,14 @@ class RendererPgf(RendererBase):
             valign = {"top": "top", "bottom": "bottom",
                       "baseline": "base", "center": ""}
             text_args.extend([
-                f"x={x/dpi}in",
-                f"y={y/dpi}in",
+                f"x={x/dpi:f}in",
+                f"y={y/dpi:f}in",
                 halign[mtext.get_horizontalalignment()],
                 valign[mtext.get_verticalalignment()],
             ])
         else:
             # if not, use the text layout provided by Matplotlib.
-            text_args.append(f"x={x/dpi}in, y={y/dpi}in, left, base")
+            text_args.append(f"x={x/dpi:f}in, y={y/dpi:f}in, left, base")
 
         if angle != 0:
             text_args.append("rotate=%f" % angle)


### PR DESCRIPTION
Using scientific notation (implicitly via "{}".format) results in e.g.
`use("pgf"); figtext(1e-6, 1e-6, "foo"); savefig("/tmp/test.pdf")` lead
to tex failing with
`! Package PGF Math Error: Unknown operator `i' or `in' (in '6.4e-06in').`

regression from #14750.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
