### PR TITLE
Don't fallback to agg in tight_layout.get_renderer.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1501,7 +1501,7 @@ class KeyEvent(LocationEvent):
         self.key = key
 
 
-def _get_renderer(figure, print_method, *, draw_disabled=False):
+def _get_renderer(figure, print_method=None, *, draw_disabled=False):
     """
     Get the renderer that would be used to save a `~.Figure`, and cache it on
     the figure.
@@ -1520,8 +1520,11 @@ def _get_renderer(figure, print_method, *, draw_disabled=False):
     def _draw(renderer): raise Done(renderer)
 
     with cbook._setattr_cm(figure, draw=_draw):
+        if print_method is None:
+            fmt = figure.canvas.get_default_filetype()
+            print_method = getattr(figure.canvas, f"print_{fmt}")
         try:
-            print_method(io.BytesIO())
+            print_method(io.BytesIO(), dpi=figure.dpi)
         except Done as exc:
             renderer, = figure._cachedRenderer, = exc.args
 
@@ -2089,7 +2092,7 @@ class FigureCanvasBase:
                     renderer = _get_renderer(
                         self.figure,
                         functools.partial(
-                            print_method, dpi=dpi, orientation=orientation),
+                            print_method, orientation=orientation),
                         draw_disabled=True)
                     self.figure.draw(renderer)
                     bbox_inches = self.figure.get_tightbbox(

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -310,3 +310,18 @@ def test_suptitle():
     t = ax.set_title("bar")
     fig.canvas.draw()
     assert st.get_window_extent().y0 > t.get_window_extent().y1
+
+
+@pytest.mark.backend("pdf")
+def test_non_agg_renderer(monkeypatch, recwarn):
+    unpatched_init = mpl.backend_bases.RendererBase.__init__
+
+    def __init__(self, *args, **kwargs):
+        # Check that we don't instantiate any other renderer than a pdf
+        # renderer to perform pdf tight layout.
+        assert isinstance(self, mpl.backends.backend_pdf.RendererPdf)
+        unpatched_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(mpl.backend_bases.RendererBase, "__init__", __init__)
+    fig, ax = plt.subplots()
+    fig.tight_layout()

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -166,19 +166,14 @@ def auto_adjust_subplotpars(
 
 def get_renderer(fig):
     if fig._cachedRenderer:
-        renderer = fig._cachedRenderer
+        return fig._cachedRenderer
     else:
         canvas = fig.canvas
-
         if canvas and hasattr(canvas, "get_renderer"):
-            renderer = canvas.get_renderer()
-        else:  # Some noninteractive backends have no renderer until draw time.
-            cbook._warn_external("tight_layout: falling back to Agg renderer")
-            from matplotlib.backends.backend_agg import FigureCanvasAgg
-            canvas = FigureCanvasAgg(fig)
-            renderer = canvas.get_renderer()
-
-    return renderer
+            return canvas.get_renderer()
+        else:
+            from . import backend_bases
+            return backend_bases._get_renderer(fig, draw_disabled=True)
 
 
 def get_subplotspec_list(axes_list, grid_spec=None):


### PR DESCRIPTION
tight_layout.get_renderer currently falls back to agg if it is unable to
get a renderer for the current canvas, but we actually have a way to
coerce the canvas to produce a renderer, via
backend_bases._get_renderer.

This renderer gets used by the tight_layout machinery to estimate text
size.  Falling back to Agg would produce bad results in the (admittedly
rare) cases where text size estimation yields very different results
depending on the renderer -- the easiest way to trigger this is to use
a "thin" font, e.g. Tex Gyre Chorus, while using the pdf backend with
the "pdf.use14corefonts" rcParam set to True, which effectively forces
Helvetica. e.g.
```
from pylab import *
matplotlib.use("pdf")
rcdefaults()
rcParams.update({"pdf.use14corefonts": True, "font.family": "TeX Gyre Chorus"})
plot()
margins(0)
tight_layout(0)
savefig("/tmp/test.pdf")
```
would crop the tick labels before this PR.

(The real point is not to fix an obscure edge case, but actually to have
fewer places that fall back to Agg as "favorited" backend.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
