### PR TITLE
Avoid infinite loop when switching actions in qt backend.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -753,8 +753,10 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
     def _update_buttons_checked(self):
         # sync button checkstates to match active mode
-        self._actions['pan'].setChecked(self._active == 'PAN')
-        self._actions['zoom'].setChecked(self._active == 'ZOOM')
+        if 'pan' in self._actions:
+            self._actions['pan'].setChecked(self._active == 'PAN')
+        if 'zoom' in self._actions:
+            self._actions['zoom'].setChecked(self._active == 'ZOOM')
 
     def pan(self, *args):
         super().pan(*args)

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -678,8 +678,6 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
     def _init_toolbar(self):
         self.basedir = str(cbook._get_data_path('images'))
-        # Ensure that zoom and pan are mutually exclusive.
-        self._button_group = QtWidgets.QButtonGroup()
 
         background_color = self.palette().color(self.backgroundRole())
         foreground_color = self.palette().color(self.foregroundRole())
@@ -695,7 +693,6 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                 self._actions[callback] = a
                 if callback in ['zoom', 'pan']:
                     a.setCheckable(True)
-                    self._button_group.addButton(self.widgetForAction(a))
                 if tooltip_text is not None:
                     a.setToolTip(tooltip_text)
                 if text == 'Subplots':
@@ -754,13 +751,18 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             ax = axes[titles.index(item)]
         figureoptions.figure_edit(ax, self)
 
+    def _update_buttons_checked(self):
+        # sync button checkstates to match active mode
+        self._actions['pan'].setChecked(self._active == 'PAN')
+        self._actions['zoom'].setChecked(self._active == 'ZOOM')
+
     def pan(self, *args):
         super().pan(*args)
-        self._actions['pan'].setChecked(self._active == 'PAN')
+        self._update_buttons_checked()
 
     def zoom(self, *args):
         super().zoom(*args)
-        self._actions['zoom'].setChecked(self._active == 'ZOOM')
+        self._update_buttons_checked()
 
     def set_message(self, s):
         self.message.emit(s)


### PR DESCRIPTION
Currently, in the qt backend
1) When switching from pan to zoom by the keyboard ("p" then "o"), one
   gets a recursion error as the buttons try to update their states.  To
   avoid this, block signals from disabling the other button.  (This is
   really due to the base class' pan() and zoom() being two-state
   toggles which get confused when both get called, one for activating
   an action and the other for disactivating an action.)
2) When toggling an action twice with the same key press ("pp" or "oo"),
   the button widget doesn't get unchecked.  To allow unchecking all
   buttons, the QButtonGroup must temporarily be set to "not exclusive".

Fixes a regression from #14719 

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
