### PR TITLE
Doc: Fix Bbox and BboxBase links

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -91,8 +91,6 @@
     "Artist": [
       "doc/api/animation_api.rst:27:<autosummary>:1",
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.ArtistAnimation:2",
-      "lib/matplotlib/text.py:docstring of matplotlib.text.OffsetFrom:28",
-      "lib/matplotlib/text.py:docstring of matplotlib.text.OffsetFrom:31",
       "lib/mpl_toolkits/axisartist/axisline_style.py:docstring of mpl_toolkits.axisartist.axisline_style.AxislineStyle:9"
     ],
     "matplotlib.animation.ArtistAnimation.new_frame_seq": [
@@ -790,32 +788,6 @@
       "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_tightbbox:2",
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisArtist.get_tightbbox:2",
       "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Text3D.get_tightbbox:2"
-    ],
-    "BBox": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes:26",
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes:30",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.AsteriskPolygonCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.BrokenBarHCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.CircleCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.Collection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EllipseCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.EventCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PatchCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PathCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.PolyCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.QuadMesh.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.RegularPolyCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.StarPolygonCollection.get_tightbbox:26",
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.TriMesh.get_tightbbox:26",
-      "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisArtist.get_tightbbox:26",
-      "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Text3D.get_tightbbox:26"
-    ],
-    "Bbox": [
-      "lib/matplotlib/text.py:docstring of matplotlib.text.Annotation.get_window_extent:2",
-      "lib/matplotlib/text.py:docstring of matplotlib.text.Text.get_window_extent:2",
-      "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.AxisLabel.get_window_extent:2",
-      "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist.LabelBase.get_window_extent:2"
     ],
     "'auto'": [
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator:28",
@@ -1774,14 +1746,9 @@
     "pytest.mark.usefixtures": [
       "lib/matplotlib/testing/decorators.py:docstring of matplotlib.testing.decorators.image_comparison:13"
     ],
-    "BboxBase": [
-      "lib/matplotlib/text.py:docstring of matplotlib.text.OffsetFrom:28",
-      "lib/matplotlib/text.py:docstring of matplotlib.text.OffsetFrom:31"
-    ],
     "Transform": [
       "doc/users/prev_whats_new/whats_new_2.2.rst:357",
-      "doc/users/prev_whats_new/whats_new_2.2.rst:360",
-      "lib/matplotlib/text.py:docstring of matplotlib.text.OffsetFrom:28"
+      "doc/users/prev_whats_new/whats_new_2.2.rst:360"
     ],
     "texmanager.TexManager": [
       "lib/matplotlib/textpath.py:docstring of matplotlib.textpath.TextToPath.get_texmanager:2"

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -276,7 +276,7 @@ class Artist:
 
         Returns
         -------
-        bbox : `.BBox`
+        bbox : `.Bbox`
             The enclosing bounding box (in figure pixel co-ordinates).
         """
         bbox = self.get_window_extent(renderer)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -106,9 +106,9 @@ class Axes(_AxesBase):
 
     Attributes
     ----------
-    dataLim : `.BBox`
+    dataLim : `.Bbox`
         The bounding box enclosing all data displayed in the Axes.
-    viewLim : `.BBox`
+    viewLim : `.Bbox`
         The view limits in data coordinates.
 
     """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2008,9 +2008,9 @@ class _AxesBase(martist.Artist):
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """
-        Extend the `~.Axes.dataLim` BBox to include the given points.
+        Extend the `~.Axes.dataLim` Bbox to include the given points.
 
-        If no data is set currently, the BBox will ignore its limits and set
+        If no data is set currently, the Bbox will ignore its limits and set
         the bound to be the bounds of the xydata (*xys*). Otherwise, it will
         compute the bounds of the union of its current data and the data in
         *xys*.
@@ -2018,7 +2018,7 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         xys : 2D array-like
-            The points to include in the data limits BBox. This can be either
+            The points to include in the data limits Bbox. This can be either
             a list of (x, y) tuples or a Nx2 array.
 
         updatex, updatey : bool, optional, default *True*
@@ -2033,7 +2033,7 @@ class _AxesBase(martist.Artist):
 
     def update_datalim_bounds(self, bounds):
         """
-        Extend the `~.Axes.datalim` BBox to include the given
+        Extend the `~.Axes.datalim` Bbox to include the given
         `~matplotlib.transforms.Bbox`.
 
         Parameters

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -367,8 +367,8 @@ class Legend(Artist):
         Notes
         -----
         Users can specify any arbitrary location for the legend using the
-        *bbox_to_anchor* keyword argument. bbox_to_anchor can be an instance
-        of BboxBase(or its derivatives) or a tuple of 2 or 4 floats.
+        *bbox_to_anchor* keyword argument. *bbox_to_anchor* can be a
+        `.BboxBase` (or derived therefrom) or a tuple of 2 or 4 floats.
         See :meth:`set_bbox_to_anchor` for more detail.
 
         The legend location can be specified by setting *loc* with a tuple of

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -866,7 +866,7 @@ class Text(Artist):
 
     def get_window_extent(self, renderer=None, dpi=None):
         """
-        Return the `Bbox` bounding the text, in display units.
+        Return the `.Bbox` bounding the text, in display units.
 
         In addition to being used internally, this is useful for specifying
         clickable regions in a png file on a web page.
@@ -1671,11 +1671,11 @@ class OffsetFrom:
         '''
         Parameters
         ----------
-        artist : `Artist`, `BboxBase`, or `Transform`
+        artist : `.Artist`, `.BboxBase`, or `.Transform`
             The object to compute the offset from.
 
         ref_coord : length 2 sequence
-            If *artist* is an `Artist` or `BboxBase`, this values is
+            If *artist* is an `.Artist` or `.BboxBase`, this values is
             the location to of the offset origin in fractions of the
             *artist* bounding box.
 
@@ -2379,7 +2379,7 @@ class Annotation(Text, _AnnotationBase):
 
     def get_window_extent(self, renderer=None):
         """
-        Return the `Bbox` bounding the text and arrow, in display units.
+        Return the `.Bbox` bounding the text and arrow, in display units.
 
         Parameters
         ----------

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -449,7 +449,7 @@ class BboxBase(TransformNode):
 
         Parameters
         ----------
-        other : BboxBase
+        other : `.BboxBase`
         """
         ax1, ay1, ax2, ay2 = self.extents
         bx1, by1, bx2, by2 = other.extents
@@ -490,7 +490,7 @@ class BboxBase(TransformNode):
 
         Parameters
         ----------
-        other : BboxBase
+        other : `.BboxBase`
         """
         ax1, ay1, ax2, ay2 = self.extents
         bx1, by1, bx2, by2 = other.extents
@@ -644,7 +644,7 @@ class BboxBase(TransformNode):
 
         Parameters
         ----------
-        bboxes : sequence of :class:`BboxBase` objects
+        bboxes : sequence of `.BboxBase`
         """
         return count_bboxes_overlapping_bbox(
             self, np.atleast_3d([np.array(x) for x in bboxes]))

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -514,7 +514,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
         if len(bbox_to_anchor) != 4:
             raise ValueError("Using relative units for width or height "
                              "requires to provide a 4-tuple or a "
-                             "`BBox` instance to `bbox_to_anchor.")
+                             "`Bbox` instance to `bbox_to_anchor.")
 
     axes_locator = AnchoredSizeLocator(bbox_to_anchor,
                                        width, height,


### PR DESCRIPTION
## PR Summary

It's `Bbox` not `BBox`. Also needed `` `Bbox` -> `.Bbox` `` in some places.