### PR TITLE
Doc: Remove hard-documented rcParams defaults

### DIFF
--- a/examples/images_contours_and_fields/interpolation_methods.py
+++ b/examples/images_contours_and_fields/interpolation_methods.py
@@ -6,10 +6,9 @@ Interpolations for imshow
 This example displays the difference between interpolation methods for
 :meth:`~.axes.Axes.imshow`.
 
-If *interpolation* is None, it defaults to the :rc:`image.interpolation`
-(default: ``'nearest'``). If the interpolation is ``'none'``, then no
-interpolation is performed for the Agg, ps and pdf backends. Other backends
-will default to ``'antialiased'``.
+If *interpolation* is None, it defaults to the :rc:`image.interpolation`.
+If the interpolation is ``'none'``, then no interpolation is performed for the
+Agg, ps and pdf backends. Other backends will default to ``'antialiased'``.
 
 For the Agg, ps and pdf backends, ``interpolation = 'none'`` works well when a
 big image is scaled down, while ``interpolation = 'nearest'`` works well when

--- a/examples/text_labels_and_annotations/unicode_minus.py
+++ b/examples/text_labels_and_annotations/unicode_minus.py
@@ -5,7 +5,7 @@ Unicode minus
 
 By default, tick labels at negative values are rendered using a `Unicode
 minus`__ (U+2212) rather than an ASCII hyphen (U+002D).  This can be controlled
-by setting :rc:`axes.unicode_minus` (which defaults to True).
+by setting :rc:`axes.unicode_minus`.
 
 __ https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
 

--- a/examples/ticks_and_spines/tick_xlabel_top.py
+++ b/examples/ticks_and_spines/tick_xlabel_top.py
@@ -3,10 +3,9 @@
 Set default x-axis tick labels on the top
 ==========================================
 
-We can use :rc:`xtick.labeltop` (default False) and :rc:`xtick.top`
-(default False) and :rc:`xtick.labelbottom` (default True) and
-:rc:`xtick.bottom` (default True) to control where on the axes ticks and
-their labels appear.
+We can use :rc:`xtick.labeltop` and :rc:`xtick.top` and :rc:`xtick.labelbottom`
+and :rc:`xtick.bottom` to control where on the axes ticks and their labels
+appear.
 
 These properties can also be set in ``.matplotlib/matplotlibrc``.
 """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5469,11 +5469,11 @@ optional.
               that the data fit in the axes. In general, this will result in
               non-square pixels.
 
-            If not given, use :rc:`image.aspect` (default: 'equal').
+            If not given, use :rc:`image.aspect`.
 
         interpolation : str, optional
-            The interpolation method used. If *None*
-            :rc:`image.interpolation` is used, which defaults to 'nearest'.
+            The interpolation method used. If *None*, :rc:`image.interpolation`
+            is used.
 
             Supported values are 'none', 'antialiased', 'nearest', 'bilinear',
             'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
@@ -5782,7 +5782,7 @@ optional.
             *edgecolors*\ ="none" is used.  This eliminates artificial lines
             at patch boundaries, and works regardless of the value of alpha.
             If *edgecolors* is not "none", then the default *antialiaseds*
-            is taken from :rc:`patch.antialiased`, which defaults to True.
+            is taken from :rc:`patch.antialiased`.
             Stroking the edges may be preferred if *alpha* is 1, but will
             cause artifacts otherwise.
 
@@ -7650,7 +7650,7 @@ optional.
             - 'auto': The axes is kept fixed and the aspect is adjusted so
               that the data fit in the axes. In general, this will result in
               non-square pixels.
-            - *None*: Use :rc:`image.aspect` (default: 'equal').
+            - *None*: Use :rc:`image.aspect`.
 
             Default: 'equal'
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1626,7 +1626,7 @@ class QuadContourSet(ContourSet):
             nearest those points are always masked out, other triangular
             corners comprising three unmasked points are contoured as usual.
 
-            Defaults to :rc:`contour.corner_mask`, which defaults to ``True``.
+            Defaults to :rc:`contour.corner_mask`.
 
         colors : color string or sequence of colors, optional
             The colors of the levels, i.e. the lines for `.contour` and the

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2100,7 +2100,7 @@ default: 'top'
         quality : [ *None* | 1 <= scalar <= 100 ]
             The image quality, on a scale from 1 (worst) to 95 (best).
             Applicable only if *format* is jpg or jpeg, ignored otherwise.
-            If *None*, defaults to :rc:`savefig.jpeg_quality` (95 by default).
+            If *None*, defaults to :rc:`savefig.jpeg_quality`.
             Values above 95 should be avoided; 100 completely disables the
             JPEG quantization stage.
 


### PR DESCRIPTION
## PR Summary

#15115 introduced automatic documentation of rcParams defaults. Therefore, we should remove hard-coded defaults, which are now just duplicates such as 

![image](https://user-images.githubusercontent.com/2836374/64495715-b6cb8380-d29d-11e9-88be-102ec9c6201b.png)

or were even incorrect:

![image](https://user-images.githubusercontent.com/2836374/64495721-cd71da80-d29d-11e9-90e4-c59e9a44db7a.png)