### PR TITLE
Doc: Do not write default for non-existing rcParams

### DIFF
--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -4,8 +4,12 @@ from matplotlib import rcParamsDefault
 
 
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
-    param = rcParamsDefault.get(text)
-    rendered = nodes.Text(f'rcParams["{text}"] = {param!r}')
+    try:
+        default_str = f' = {rcParamsDefault[text]!r}'
+    except KeyError:
+        # handling of generic references such as rcParams["figure.subplot.*"]
+        default_str = ''
+    rendered = nodes.Text(f'rcParams["{text}"]' + default_str)
 
     source = inliner.document.attributes['source'].replace(sep, '/')
     rel_source = source.split('/doc/', 1)[1]


### PR DESCRIPTION
## PR Summary

#15115 introduced automatic documentation of rcParams defaults. We have some special-named references such as wildcards. They were documented as defaulting to `None`:

![image](https://user-images.githubusercontent.com/2836374/64496151-38251500-d2a2-11e9-9b18-da3906735398.png)

This PR changes the behavior to simply not show any default in such a case.

*Note*: If one wanted to be more strict, one could alternatively exclude wildcard references and error out/warn if other references are encountered.