### PR TITLE
Drop mention of msinttypes in Windows build.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,9 +20,9 @@ environment:
                  --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:
-    # theoretically the CONDA_INSTALL_LOCN could be only two: one for 32bit,
-    # one for 64bit because we construct envs anyway. But using one for the
-    # right python version is hopefully making it fast due to package caching.
+    # In theory we could use a single CONDA_INSTALL_LOCN because we construct
+    # the envs anyway. But using one for the right python version hopefully
+    # making things faster due to package caching.
     - PYTHON_VERSION: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
@@ -48,7 +48,6 @@ init:
 install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
   - set PYTHONUNBUFFERED=1
-  # for msinttypes and newer stuff
   - conda config --set always_yes true
   - conda update --all
   - conda config --set show_channel_urls yes
@@ -58,16 +57,13 @@ install:
   - conda info -a
 
   # For building, use a new environment which only includes the requirements for mpl
-  # same things as the requirements in ci/conda_recipe/meta.yaml
   # if conda-forge gets a new pyqt, it might be nice to install it as well to have more backends
   # https://github.com/conda-forge/conda-forge.github.io/issues/157#issuecomment-223536381
-  #
   - conda create -q -n test-environment python=%PYTHON_VERSION%
-    msinttypes freetype=2.6 "libpng>=1.6.21,<1.7" zlib=1.2 tk=8.5
+    freetype=2.6 "libpng>=1.6.21,<1.7" zlib=1.2 tk=8.5
     pip setuptools numpy sphinx tornado
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
-  # pytest-cov>=2.3.1 due to https://github.com/pytest-dev/pytest-cov/issues/124
   - pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis36.txt
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -298,7 +298,7 @@ the list of conda packages.
 
 ::
 
-  conda create -n "matplotlib_build" python=3.7 numpy python-dateutil pyparsing tornado cycler tk libpng zlib freetype msinttypes
+  conda create -n "matplotlib_build" python=3.7 numpy python-dateutil pyparsing tornado cycler tk libpng zlib freetype
   conda activate matplotlib_build
   # force the build against static libpng and zlib libraries
   set MPLSTATICBUILD=True


### PR DESCRIPTION
It provides stdint.h/inttypes.h but that's unneeded since MSVC 2013;
building for Py3.6 requires MSVC 2015 anyways.  See
https://github.com/conda-forge/msinttypes-feedstock
https://devblogs.microsoft.com/cppblog/c99-library-support-in-visual-studio-2013/
https://packaging.python.org/guides/packaging-binary-extensions/#binary-extensions-for-windows

Also misc. cleanups to .appveyor.yml.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
