### PR TITLE
Composite against white, not the savefig.facecolor rc, in print_jpeg.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -584,12 +584,10 @@ class FigureCanvasAgg(FigureCanvasBase):
             FigureCanvasAgg.draw(self)
             if dryrun:
                 return
-            # The image is "pasted" onto a white background image to safely
-            # handle any transparency
+            # The image is pasted onto a white background image to handle
+            # transparency.
             image = Image.fromarray(np.asarray(self.buffer_rgba()))
-            rgba = mcolors.to_rgba(rcParams['savefig.facecolor'])
-            color = tuple([int(x * 255) for x in rgba[:3]])
-            background = Image.new('RGB', image.size, color)
+            background = Image.new('RGB', image.size, "white")
             background.paste(image, image)
             if pil_kwargs is None:
                 pil_kwargs = {}

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -674,8 +674,7 @@ def test_jpeg_alpha():
     plt.figimage(im)
 
     buff = io.BytesIO()
-    with rc_context({'savefig.facecolor': 'red'}):
-        plt.savefig(buff, transparent=True, format='jpg', dpi=300)
+    plt.savefig(buff, facecolor="red", format='jpg', dpi=300)
 
     buff.seek(0)
     image = Image.open(buff)


### PR DESCRIPTION
jpeg doesn't support alpha transparency, so we need to paste the image
against some solid background before saving it.  Pasting against the
savefig.facecolor rc, as the code did before, is just wrong: it makes
e.g.
```
plot([1, 2])
rcParams["savefig.facecolor"] = "blue"
savefig("/tmp/foo.jpg", facecolor=(1, 0, 0, .5))
```
result in a purple background (blue + 0.5 red), instead of a red one (as
for png -- the facecolor kwarg should just override the rcParam).
Likewise the test_jpeg_alpha test was just wrong (indeed, trying to run
the same code but saving as png shows that transparent=True should
override the savefig.facecolor rcParam).

Instead, paste the image against a white background, which fixes the
issues (and is tested by the fixed test_jpeg_alpha).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
