### PR TITLE
Fix incorrect calls to warn_deprecated.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1167,11 +1167,11 @@ class TimerBase:
         """
         if args or kwargs:
             cbook.warn_deprecated(
-                "3.1", "In a future version, Timer.remove_callback will not "
-                "take *args, **kwargs anymore, but remove all callbacks where "
-                "the callable matches; to keep a specific callback removable "
-                "by itself, pass it to add_callback as a functools.partial "
-                "object.")
+                "3.1", message="In a future version, Timer.remove_callback "
+                "will not take *args, **kwargs anymore, but remove all "
+                "callbacks where the callable matches; to keep a specific "
+                "callback removable by itself, pass it to add_callback as a "
+                "functools.partial object.")
             self.callbacks.remove((func, args, kwargs))
         else:
             funcs = [c[0] for c in self.callbacks]

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1308,7 +1308,7 @@ class AnchoredText(AnchoredOffsetbox):
             cbook.warn_deprecated(
                 "3.1", message="Mixing horizontalalignment or "
                 "verticalalignment with AnchoredText is not supported, "
-                "deprecated since %(version)s, and will raise an exception "
+                "deprecated since %(since)s, and will raise an exception "
                 "%(removal)s.")
 
         self.txt = TextArea(s, textprops=prop, minimumdescent=False)

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -10,7 +10,8 @@ def _deprecate_factor_none(factor):
     # removed.
     if factor is None:
         cbook.warn_deprecated(
-            "3.2", "factor=None is deprecated; use/return factor=1 instead")
+            "3.2",
+            message="factor=None is deprecated; use/return factor=1 instead")
         factor = 1
     return factor
 


### PR DESCRIPTION
1) `message` is keyword-only.
2) it's `%(since)s`, not `%(version)s`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
