### PR TITLE
Automatic API deprecations generator.

### DIFF
--- a/tools/api_changes_generator.py
+++ b/tools/api_changes_generator.py
@@ -1,0 +1,124 @@
+import ast
+import inspect
+import logging
+from pathlib import Path
+import tokenize
+
+import matplotlib
+from matplotlib import cbook
+
+_log = logging.getLogger(__name__)
+
+
+def node_match(node, name, **kwargs):
+    return (type(node).__name__ == name
+            and all(getattr(node, k) == v for k, v in kwargs.items()))
+
+
+def bind_arguments(func, node, qualname):
+    ba = inspect.signature(func).bind(
+        *node.args, **{k.arg: k.value for k in node.keywords})
+    for k, v in [*ba.arguments.items()]:
+        if node_match(v, "NameConstant"):
+            ba.arguments[k] = v.value
+        if node_match(v, "Num"):
+            ba.arguments[k] = v.n
+        elif node_match(v, "Str"):
+            ba.arguments[k] = v.s
+        else:
+            _log.warning(f"In {qualname} line {node.lineno}, "
+                         f"unsupported argument: {v}")
+    return ba
+
+
+def generate_apichanges_deprecated(name, arguments):
+    obj_type = arguments["obj_type"]
+    s = [f"The {name} {obj_type} is deprecated."]
+    if arguments["alternative"]:
+        s += [f"Use {arguments['alternative']} instead."]
+    return "  ".join(s)
+
+
+def generate_apichanges_warn_deprecated(name, arguments):
+    try:
+        return cbook.deprecation._generate_deprecation_warning(**arguments)
+    except TypeError:
+        return "FIXME"
+
+
+class DeprecationDetector(ast.NodeVisitor):
+    def __init__(self, module_name):
+        super().__init__()
+        self._qualname_parts = [module_name]
+        self.deprecateds = []
+        self.warn_deprecateds = []
+
+    current_qualname = property(lambda self: ".".join(self._qualname_parts))
+
+    def _visit_class_or_function(self, node):
+        self._qualname_parts.append(node.name)
+        obj_type = {"ClassDef": "class", "FunctionDef": "function"}[
+            type(node).__name__]
+        for decorator in node.decorator_list[::-1]:
+            if node_match(decorator, "Name", id="property"):
+                obj_type = "property"
+            if node_match(decorator, "Call"):
+                func = decorator.func
+                if (node_match(func, "Name", id="deprecated")
+                        or node_match(func, "Attribute", attr="deprecated")):
+                    ba = bind_arguments(cbook.deprecated, decorator,
+                                        self.current_qualname)
+                    ba.arguments.setdefault("obj_type", obj_type)
+                    ba.apply_defaults()
+                    self.deprecateds.append(
+                        (self.current_qualname, ba.arguments))
+        super().generic_visit(node)
+        self._qualname_parts.pop()
+
+    visit_ClassDef = visit_FunctionDef = _visit_class_or_function
+
+    def visit_Call(self, node):
+        if (node_match(node.func, "Name", id="warn_deprecated")
+                or node_match(node.func, "Attribute", attr="warn_deprecated")):
+            ba = bind_arguments(cbook.warn_deprecated, node,
+                                self.current_qualname)
+            self.warn_deprecateds.append((self.current_qualname, ba.arguments))
+
+
+def main():
+    root = Path(matplotlib.__file__).parent.parent
+    deprecateds = []
+    warn_deprecateds = []
+    for path in sorted(root.glob("**/*.py")):
+        parts = path.relative_to(root).with_suffix("").parts
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        module_name = "".join(f".{part}" for part in parts[1:])  # Drop pkg name.
+        with tokenize.open(path) as file:
+            source = file.read()
+        tree = ast.parse(source)
+        dd = DeprecationDetector(module_name)
+        dd.visit(tree)
+        deprecateds.extend(dd.deprecateds)
+        warn_deprecateds.extend(dd.warn_deprecateds)
+    by_version = {}
+    for name, arguments in deprecateds:
+        by_version.setdefault(arguments["since"], []).append((name, arguments))
+    for version, deprecateds in sorted(by_version.items()):
+        print()
+        print(f"Since {version}:")
+        for name, arguments in deprecateds:
+            print(generate_apichanges_deprecated(name, arguments))
+    by_version = {}
+    for name, arguments in warn_deprecateds:
+        by_version.setdefault(arguments["since"], []).append((name, arguments))
+    # for version, warn_deprecateds in sorted(by_version.items()):
+    for version, warn_deprecateds in by_version.items():
+        print()
+        print(f"Since {version}:")
+        for name, arguments in warn_deprecateds:
+            print(generate_apichanges_warn_deprecated(name, arguments))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## PR Summary

Just a prototype (proposed during the dev call), written to perhaps alleviate the problems in #15158 (documentation of api changes is a pain).  Perhaps not to be taken too seriously... dunno.

Run tools/api_changes_generator.py.

Collection of `@deprecated` basically works.
Collection of `warn_deprecated` has some rough spots.
Collection of `@_delete_parameter`, `@_rename_parameter`,
`@_make_keyword_only` is not implemented yet but should be easy to do.

Goes on top of #15245, which were caught by this...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
