### PR TITLE
Change layout of test_triager to avoid cropping images.

### DIFF
--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -68,7 +68,7 @@ class Thumbnail(QtWidgets.QFrame):
         self.image = QtWidgets.QLabel()
         self.image.setAlignment(QtCore.Qt.AlignHCenter |
                                 QtCore.Qt.AlignVCenter)
-        self.image.setMinimumSize(800/3, 500/3)
+        self.image.setMinimumSize(800/3, 600/3)
         layout.addWidget(self.image)
         self.setLayout(layout)
 
@@ -124,21 +124,21 @@ class Dialog(QtWidgets.QDialog):
         for entry in entries:
             self.filelist.addItem(entry.display)
 
-        images_box = QtWidgets.QWidget()
-        images_layout = QtWidgets.QVBoxLayout()
         thumbnails_box = QtWidgets.QWidget()
-        thumbnails_layout = QtWidgets.QHBoxLayout()
+        thumbnails_layout = QtWidgets.QVBoxLayout()
         self.thumbnails = []
         for i, name in enumerate(('test', 'expected', 'diff')):
             thumbnail = Thumbnail(self, i, name)
             thumbnails_layout.addWidget(thumbnail)
             self.thumbnails.append(thumbnail)
         thumbnails_box.setLayout(thumbnails_layout)
+
+        images_layout = QtWidgets.QVBoxLayout()
+        images_box = QtWidgets.QWidget()
         self.image_display = QtWidgets.QLabel()
         self.image_display.setAlignment(QtCore.Qt.AlignHCenter |
                                         QtCore.Qt.AlignVCenter)
-        self.image_display.setMinimumSize(800, 500)
-        images_layout.addWidget(thumbnails_box, 3)
+        self.image_display.setMinimumSize(800, 600)
         images_layout.addWidget(self.image_display, 6)
         images_box.setLayout(images_layout)
 
@@ -154,8 +154,9 @@ class Dialog(QtWidgets.QDialog):
         images_layout.addWidget(buttons_box)
 
         main_layout = QtWidgets.QHBoxLayout()
-        main_layout.addWidget(self.filelist, 3)
-        main_layout.addWidget(images_box, 6)
+        main_layout.addWidget(self.filelist, 1)
+        main_layout.addWidget(thumbnails_box, 1)
+        main_layout.addWidget(images_box, 3)
 
         self.setLayout(main_layout)
 


### PR DESCRIPTION
The previous test triager would crop test images because the 800/500
aspect ratio of the main widget does not match the 6.4:4.8 aspect ratio
of the test images.  Change the main widget to have size 800x600, and
move the thumbnails to the side so that the whole thing still fits in a
1600x900 display.

before
![old](https://user-images.githubusercontent.com/1322974/64820181-24cebe00-d5b0-11e9-9c20-418beda271fa.png)
after
![new](https://user-images.githubusercontent.com/1322974/64820185-25ffeb00-d5b0-11e9-82bd-083b39c1d1a5.png)
(yes, this is the whole test image, the ylabels are actually cropped)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
