### PR TITLE
Correctly setup comparisons in test_compare_images.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -380,8 +380,8 @@ def compare_images(expected, actual, tol, in_decorator=False):
         raise IOError('Baseline image %r does not exist.' % expected)
     extension = expected.split('.')[-1]
     if extension != 'png':
-        actual = convert(actual, False)
-        expected = convert(expected, True)
+        actual = convert(actual, cache=False)
+        expected = convert(expected, cache=True)
 
     # open the image files and remove the alpha channel (if it exists)
     with open(expected, "rb") as expected_file:

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -1,14 +1,12 @@
 import os
+from pathlib import Path
 import shutil
 
 import pytest
 from pytest import approx
 
-from matplotlib.testing.compare import compare_images
+from matplotlib.testing.compare import compare_images, make_test_filename
 from matplotlib.testing.decorators import _image_directories
-
-
-baseline_dir, result_dir = _image_directories(lambda: 'dummy func')
 
 
 # Tests of the image comparison algorithm.
@@ -56,14 +54,16 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms):
     succeed if compare_images succeeds. Otherwise, the test will succeed if
     compare_images fails and returns an RMS error almost equal to this value.
     """
-    im1 = os.path.join(baseline_dir, im1)
-    im2_src = os.path.join(baseline_dir, im2)
-    im2 = os.path.join(result_dir, im2)
-    # Move im2 from baseline_dir to result_dir. This will ensure that
-    # compare_images writes the diff file to result_dir, instead of trying to
-    # write to the (possibly read-only) baseline_dir.
-    shutil.copyfile(im2_src, im2)
-    results = compare_images(im1, im2, tol=tol, in_decorator=True)
+    baseline_dir, result_dir = map(Path, _image_directories(lambda: "dummy"))
+    # Copy both "baseline" and "test" image to result_dir, so that 1)
+    # compare_images writes the diff to result_dir, rather than to the source
+    # tree and 2) the baseline image doesn't appear missing to triage_tests.py.
+    result_im1 = make_test_filename(result_dir / im1, "expected")
+    shutil.copyfile(baseline_dir / im1, result_im1)
+    result_im2 = result_dir / im1
+    shutil.copyfile(baseline_dir / im2, result_im2)
+    results = compare_images(
+        result_im1, result_im2, tol=tol, in_decorator=True)
 
     if expect_rms is None:
         assert results is None


### PR DESCRIPTION
Copy the baseline images to the results directory, to avoid the
"QPixmap::scaled: Pixmap is a null pixmap" error from triage_tests.py.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
