### PR TITLE
Embedding in Tk example: Fix toolbar being clipped.

### DIFF
--- a/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -25,11 +25,9 @@ fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
 
 canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
 canvas.draw()
-canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
 
 toolbar = NavigationToolbar2Tk(canvas, root)
 toolbar.update()
-canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
 
 
 def on_key_press(event):
@@ -40,6 +38,12 @@ def on_key_press(event):
 canvas.mpl_connect("key_press_event", on_key_press)
 
 button = tkinter.Button(master=root, text="Quit", command=root.quit)
+
+# Packing order is important. Widgets are processed sequentially and if there
+# is no space left, because the window is too small, they are not displayed.
+# The canvas is rather flexible in its size, so we pack it last which makes
+# sure the UI controls are displayed as long as possible.
 button.pack(side=tkinter.BOTTOM)
+canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
 
 tkinter.mainloop()


### PR DESCRIPTION
Fixes #13485.

This was driving me crazy, but #13485 pointed me to the right code in mpl where it actually works, and it has [this helpful comment](https://github.com/matplotlib/matplotlib/blob/2aba5aa77e8e53dd83ccfb0a3652146c3049f478/lib/matplotlib/backends/_backend_tk.py#L431) there:

```
 # packing toolbar first, because if space is getting low, last packed
 # widget is getting shrunk first (-> the canvas)
```
So, the solution is to pack the canvas after the toolbar got initialized, because initializing the toolbar will call `pack` on the root window.

Flake 8 passes, the other points don't apply, but correct me if I'm wrong :)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
