### PR TITLE
DOC: don't use term units in transform tutorial

### DIFF
--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -312,11 +312,11 @@ plt.show()
 #
 # .. _transforms-fig-scale-dpi:
 #
-# Plotting in physical units
-# ==========================
+# Plotting in physical coordinates
+# ================================
 #
 # Sometimes we want an object to be a certain physical size on the plot.
-# Here we draw the same circle as above, but in physical units.  If done
+# Here we draw the same circle as above, but in physical coordinates.  If done
 # interactively, you can see that changing the size of the figure does
 # not change the offset of the circle from the lower-left corner,
 # does not change its size, and the circle remains a circle regardless of
@@ -325,7 +325,7 @@ plt.show()
 fig, ax = plt.subplots(figsize=(5, 4))
 x, y = 10*np.random.rand(2, 1000)
 ax.plot(x, y*10., 'go', alpha=0.2)  # plot some data in data coordinates
-# add a circle in fixed-units
+# add a circle in fixed-coordinates
 circ = mpatches.Circle((2.5, 2), 1.0, transform=fig.dpi_scale_trans,
                        facecolor='blue', alpha=0.75)
 ax.add_patch(circ)
@@ -338,7 +338,7 @@ plt.show()
 fig, ax = plt.subplots(figsize=(7, 2))
 x, y = 10*np.random.rand(2, 1000)
 ax.plot(x, y*10., 'go', alpha=0.2)  # plot some data in data coordinates
-# add a circle in fixed-units
+# add a circle in fixed-coordinates
 circ = mpatches.Circle((2.5, 2), 1.0, transform=fig.dpi_scale_trans,
                        facecolor='blue', alpha=0.75)
 ax.add_patch(circ)
@@ -416,7 +416,7 @@ plt.show()
 #
 # Here we apply the transforms in the *opposite* order to the use of
 # :class:`~matplotlib.transforms.ScaledTranslation` above. The plot is
-# first made in data units (``ax.transData``) and then shifted by
+# first made in data coordinates (``ax.transData``) and then shifted by
 # ``dx`` and ``dy`` points using ``fig.dpi_scale_trans``.  (In typography,
 # a `point <https://en.wikipedia.org/wiki/Point_%28typography%29>`_ is
 # 1/72 inches, and by specifying your offsets in points, your figure


### PR DESCRIPTION
## PR Summary

The transform tutorial refers to "physical units" and "data units" in a few places.  While colloquially correct, it is confusing because this has nothing to do with "units" as meant by matplotlib units handling.  I'd argue its better to just call everything here "coordinates" and leave "units" in matplotlib for things that run through `units.py`, otherwise confusion ensues. 



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->