### PR TITLE
NavigationToolbar2Tk: make packing optional.

### DIFF
--- a/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -26,7 +26,8 @@ fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
 canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
 canvas.draw()
 
-toolbar = NavigationToolbar2Tk(canvas, root)
+# pack_toolbar=False will make it easier to use a layout manager later on.
+toolbar = NavigationToolbar2Tk(canvas, root, pack_toolbar=False)
 toolbar.update()
 
 
@@ -44,6 +45,7 @@ button = tkinter.Button(master=root, text="Quit", command=root.quit)
 # The canvas is rather flexible in its size, so we pack it last which makes
 # sure the UI controls are displayed as long as possible.
 button.pack(side=tkinter.BOTTOM)
+toolbar.pack(side=tkinter.BOTTOM, fill=tkinter.X)
 canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
 
 tkinter.mainloop()

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -507,17 +507,23 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
     Attributes
     ----------
     canvas : `FigureCanvas`
-        the figure canvas on which to operate
+        The figure canvas on which to operate.
     win : tk.Window
-        the tk.Window which owns this toolbar
-
+        The tk.Window which owns this toolbar.
+    pack_toolbar : bool, default: True
+        If True, add the toolbar to the parent's pack manager's packing list
+        during initialization with *side='bottom'* and *fill='x'*.
+        If you want to use the toolbar with a different layout manager, use
+        *pack_toolbar=False*.
     """
-    def __init__(self, canvas, window):
+    def __init__(self, canvas, window, *, pack_toolbar=True):
         self.canvas = canvas
         # Avoid using self.window (prefer self.canvas.get_tk_widget().master),
         # so that Tool implementations can reuse the methods.
         self.window = window
         NavigationToolbar2.__init__(self, canvas)
+        if pack_toolbar:
+            self.pack(side=tk.BOTTOM, fill=tk.X)
 
     def destroy(self, *args):
         del self.message
@@ -582,7 +588,6 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, textvariable=self.message)
         self._message_label.pack(side=tk.RIGHT)
-        self.pack(side=tk.BOTTOM, fill=tk.X)
 
     def configure_subplots(self):
         toolfig = Figure(figsize=(6, 3))

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -512,9 +512,9 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         The tk.Window which owns this toolbar.
     pack_toolbar : bool, default: True
         If True, add the toolbar to the parent's pack manager's packing list
-        during initialization with *side='bottom'* and *fill='x'*.
+        during initialization with ``side='bottom'`` and ``fill='x'``.
         If you want to use the toolbar with a different layout manager, use
-        *pack_toolbar=False*.
+        ``pack_toolbar=False``.
     """
     def __init__(self, canvas, window, *, pack_toolbar=True):
         self.canvas = canvas


### PR DESCRIPTION
## PR Summary

Currently, `NavigationToolbar2Tk` cannot be easily used with the grid layout manager.
When initalizing the toolbar, it is immediately [packed](https://github.com/matplotlib/matplotlib/blob/70c8a4fad05a9fd964fc4db283b97940246f302b/lib/matplotlib/backends/_backend_tk.py#L585): `self.pack(side=tk.BOTTOM, fill=tk.X)`

I think this is unfortunate behavior, because:

- It is unexpected.
Usually, you initialize a widget and afterwards it must be added to one of the layout managers.
- It makes it hard to use the toolbar with the grid layout manager.
You need to call `pack_forget()` on the toolbar first, before you can add it to the grid layout manager.
- When resizing a window that contains the canvas and the toolbar in the same frame: how do you make sure, that the toolbar is *not* resized first and thus disappears before the canvas widget?
  You need to initialize it *before* the canvas, which again, is not super obvious.
  But then, how do you place the toolbar on top of the canvas - it is packed with `side=tk.BOTTOM`, so basically you have to call `pack_forget` and repack it with `side=tk.TOP`.
  Or, you initialize the canvas before the toolbar, but then you get the resizing problem again.

I assume we cannot change the default behavior for backwards compatibility, so this PR makes packing optional.

No idea how to write a test for this. Couldn't get the tests to run locally on master, so I'm relying on the CI tests.
## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
