### PR TITLE
Don't use ImageGrid in demo_text_rotation_mode.

### DIFF
--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -17,62 +17,69 @@ The actual positioning depends on the additional parameters
   the bounding box of the rotated text.
 - ``rotation_mode='anchor'`` aligns the unrotated text and then rotates the
   text around the point of alignment.
-
 """
+
 import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.axes_grid import ImageGrid
+import numpy as np
 
 
 def test_rotation_mode(fig, mode, subplot_location):
     ha_list = ["left", "center", "right"]
     va_list = ["top", "center", "baseline", "bottom"]
-    grid = ImageGrid(fig, subplot_location,
-                     nrows_ncols=(len(va_list), len(ha_list)),
-                     share_all=True, aspect=True, cbar_mode=None)
+    axs = np.empty((len(va_list), len(ha_list)), object)
+    gs = subplot_location.subgridspec(*axs.shape, hspace=0, wspace=0)
+    axs[0, 0] = fig.add_subplot(gs[0, 0])
+    for i in range(len(va_list)):
+        for j in range(len(ha_list)):
+            if (i, j) == (0, 0):
+                continue  # Already set.
+            axs[i, j] = fig.add_subplot(
+                gs[i, j], sharex=axs[0, 0], sharey=axs[0, 0])
+    for ax in axs.flat:
+        ax.set(aspect=1)
 
     # labels and title
-    for ha, ax in zip(ha_list, grid.axes_row[-1]):
-        ax.axis["bottom"].label.set_text(ha)
-    for va, ax in zip(va_list, grid.axes_column[0]):
-        ax.axis["left"].label.set_text(va)
-    grid.axes_row[0][1].set_title(f"rotation_mode='{mode}'", size="large")
+    for ha, ax in zip(ha_list, axs[-1, :]):
+        ax.set_xlabel(ha)
+    for va, ax in zip(va_list, axs[:, 0]):
+        ax.set_ylabel(va)
+    axs[0, 1].set_title(f"rotation_mode='{mode}'", size="large")
 
-    if mode == "default":
-        kw = dict()
-    else:
-        kw = dict(
-            bbox=dict(boxstyle="square,pad=0.", ec="none", fc="C1", alpha=0.3))
+    kw = (
+        {} if mode == "default" else
+        {"bbox": dict(boxstyle="square,pad=0.", ec="none", fc="C1", alpha=0.3)}
+    )
 
     # use a different text alignment in each axes
-    texts = []
-    for (va, ha), ax in zip([(x, y) for x in va_list for y in ha_list], grid):
-        # prepare axes layout
-        for axis in ax.axis.values():
-            axis.toggle(ticks=False, ticklabels=False)
-        ax.axvline(0.5, color="skyblue", zorder=0)
-        ax.axhline(0.5, color="skyblue", zorder=0)
-        ax.plot(0.5, 0.5, color="C0", marker="o", zorder=1)
-
-        # add text with rotation and alignment settings
-        tx = ax.text(0.5, 0.5, "Tpg",
-                     size="x-large", rotation=40,
-                     horizontalalignment=ha, verticalalignment=va,
-                     rotation_mode=mode, **kw)
-        texts.append(tx)
+    for i, va in enumerate(va_list):
+        for j, ha in enumerate(ha_list):
+            ax = axs[i, j]
+            # prepare axes layout
+            ax.set(xticks=[], yticks=[])
+            ax.axvline(0.5, color="skyblue", zorder=0)
+            ax.axhline(0.5, color="skyblue", zorder=0)
+            ax.plot(0.5, 0.5, color="C0", marker="o", zorder=1)
+            # add text with rotation and alignment settings
+            tx = ax.text(0.5, 0.5, "Tpg",
+                         size="x-large", rotation=40,
+                         horizontalalignment=ha, verticalalignment=va,
+                         rotation_mode=mode, **kw)
 
     if mode == "default":
         # highlight bbox
         fig.canvas.draw()
-        for ax, tx in zip(grid, texts):
-            bb = tx.get_window_extent().transformed(ax.transData.inverted())
+        for ax in axs.flat:
+            text, = ax.texts
+            bb = text.get_window_extent().transformed(ax.transData.inverted())
             rect = plt.Rectangle((bb.x0, bb.y0), bb.width, bb.height,
                                  facecolor="C1", alpha=0.3, zorder=2)
             ax.add_patch(rect)
 
 
-fig = plt.figure(figsize=(8, 6))
-test_rotation_mode(fig, "default", 121)
-test_rotation_mode(fig, "anchor", 122)
+fig = plt.figure(figsize=(8, 5))
+gs = fig.add_gridspec(1, 2)
+test_rotation_mode(fig, "default", gs[0])
+test_rotation_mode(fig, "anchor", gs[1])
 plt.show()
 
 


### PR DESCRIPTION
The example can be written without involving axes_grid.

old: https://matplotlib.org/gallery/text_labels_and_annotations/demo_text_rotation_mode.html#sphx-glr-gallery-text-labels-and-annotations-demo-text-rotation-mode-py
new:
![new](https://user-images.githubusercontent.com/1322974/65056767-c28c0980-d971-11e9-9c15-4f4f3160ec37.png)
(admittedly the inability to set the absolute spacing between subplots is mildly annoying)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
