### PR TITLE
Don't default axes_grid colorbar locator to MaxNLocator.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -45,10 +45,14 @@ The main differences are:
 
 - Setting the ticks on the colorbar is done by calling ``colorbar.set_ticks``
   rather than ``colorbar.cbar_axis.set_xticks`` or
-  ``colorbar.cbar_axis.set_yticks``.
+  ``colorbar.cbar_axis.set_yticks``; the ``locator`` parameter to ``colorbar()``
+  is deprecated in favor of its synonym ``ticks`` (which already existed
+  previously, and is consistent with :mod:`matplotlib.colorbar`).
 - The colorbar's long axis is accessed with ``colorbar.xaxis`` or
   ``colorbar.yaxis`` depending on the orientation, rather than
   ``colorbar.cbar_axis``.
+- The default ticker is no longer ``MaxNLocator(5)``, but a
+  ``_ColorbarAutoLocator``.
 - Overdrawing multiple colorbars on top of one another in a single Axes (e.g.
   when using the ``cax`` attribute of `~.axes_grid1.axes_grid.ImageGrid`
   elements) is not supported; if you previously relied on the second colorbar

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -31,17 +31,8 @@ def _tick_only(ax, bottom_on, left_on):
 
 class CbarAxesBase:
 
-    def colorbar(self, mappable, *, locator=None, **kwargs):
-
-        if locator is None:
-            if "ticks" not in kwargs:
-                kwargs["ticks"] = ticker.MaxNLocator(5)
-        if locator is not None:
-            if "ticks" in kwargs:
-                raise ValueError("Either *locator* or *ticks* need" +
-                                 " to be given, not both")
-            else:
-                kwargs["ticks"] = locator
+    @cbook._rename_parameter("3.2", "locator", "ticks")
+    def colorbar(self, mappable, *, ticks=None, **kwargs):
 
         if self.orientation in ["top", "bottom"]:
             orientation = "horizontal"
@@ -55,10 +46,13 @@ class CbarAxesBase:
                 "%(removal)s.  Set the 'mpl_toolkits.legacy_colorbar' rcParam "
                 "to False to use Matplotlib's default colorbar implementation "
                 "and suppress this deprecation warning.")
+            if ticks is None:
+                ticks = ticker.MaxNLocator(5)  # For backcompat.
             from .colorbar import Colorbar
         else:
             from matplotlib.colorbar import Colorbar
-        cb = Colorbar(self, mappable, orientation=orientation, **kwargs)
+        cb = Colorbar(
+            self, mappable, orientation=orientation, ticks=ticks, **kwargs)
         self._config_axes()
 
         def on_changed(m):

--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -48,4 +48,16 @@ def test_imagegrid_cbar_mode_edge(legacy_colorbar):
             # the "second" ones.  To achieve this, clear out the axes first.
             for ax in grid:
                 ax.cax.cla()
-                ax.cax.colorbar(ax.images[0])
+                cb = ax.cax.colorbar(
+                    ax.images[0],
+                    ticks=mpl.ticker.MaxNLocator(5))  # old default locator.
+
+
+def test_imagegrid():
+    mpl.rcParams["mpl_toolkits.legacy_colorbar"] = False
+    fig = plt.figure()
+    grid = ImageGrid(fig, 111, nrows_ncols=(1, 1))
+    ax = grid[0]
+    im = ax.imshow([[1, 2]], norm=mpl.colors.LogNorm())
+    cb = ax.cax.colorbar(im)
+    assert isinstance(cb.locator, mpl.colorbar._ColorbarLogLocator)


### PR DESCRIPTION
Closes #15247.  Would be nice to have in 3.2 as this is technically a default change, but we can just lump it into the already ongoing default change...  So tagging as release critical for 3.2, but feel free to untag if this doesn't work out.

By not providing a default locator, this allows axes_grid's colorbar to
correctly switch to LogLocator when the image is log-normed (basically, use the logic already in matplotlib.colorbar to determine the default locator).

Lumped this together with the mpl_toolkits.legacy_colorbar API change as
that avoids having two overlapping API deprecations on the same thing.

edit: added tests.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
