### PR TITLE
throw deprecation warning on empty call to fig.add_axes()

### DIFF
--- a/doc/api/next_api_changes/deprecated_empty_add_axes.rst
+++ b/doc/api/next_api_changes/deprecated_empty_add_axes.rst
@@ -1,0 +1,5 @@
+Deprecations
+````````````
+
+Calling ``fig.add_axes()`` with no arguments currently return None,
+will raise an error in the future

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1221,6 +1221,11 @@ default: 'top'
         """
 
         if not len(args):
+            cbook.warn_deprecated(
+                "3.3",
+                message="Calling add_axes() without argument is "
+                "deprecated. You may want to use add_suplot() "
+                "instead.")
             return
 
         # shortcut the projection "key" modifications later on, if an axes

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -141,6 +141,10 @@ def test_figure_legend():
 def test_gca():
     fig = plt.figure()
 
+    with pytest.warns(UserWarning):
+        # empty call to add_axes() will throw deprecation warning
+        assert fig.add_axes() is None
+
     ax1 = fig.add_axes([0, 0, 1, 1])
     assert fig.gca(projection='rectilinear') is ax1
     assert fig.gca() is ax1


### PR DESCRIPTION
## PR Summary
Deprecate call to fig.add_axes() with no arguments as discussed in #15059

My first contribution, feedback is welcome. Unsure about adding API change to doc/api/next_api_changes.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
