### PR TITLE
Allow sharex/y after axes creation.

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -447,8 +447,8 @@ Adding Artists
    Axes.add_table
 
 
-Twinning
-========
+Twinning and sharing
+====================
 
 .. autosummary::
    :toctree: _as_gen
@@ -457,6 +457,9 @@ Twinning
 
    Axes.twinx
    Axes.twiny
+
+   Axes.sharex
+   Axes.sharey
 
    Axes.get_shared_x_axes
    Axes.get_shared_y_axes

--- a/doc/users/next_whats_new/2020-01-24-lateshare.rst
+++ b/doc/users/next_whats_new/2020-01-24-lateshare.rst
@@ -1,0 +1,8 @@
+`.Axes.sharex`, `.Axes.sharey`
+------------------------------
+These new methods allow sharing axes *immediately* after creating them.  For
+example, they can be used to selectively link some axes created all together
+using `~.Figure.subplots`.
+
+Note that they may *not* be used to share axes after any operation (e.g.,
+drawing) has occurred on them.

--- a/examples/subplots_axes_and_figures/subplots_demo.py
+++ b/examples/subplots_axes_and_figures/subplots_demo.py
@@ -177,6 +177,23 @@ for ax in axs.flat:
     ax.label_outer()
 
 ###############################################################################
+# If you want a more complex sharing structure, you can first create the
+# grid of axes with no sharing, and then call `.axes.Axes.sharex` or
+# `.axes.Axes.sharey` to add sharing info a posteriori.
+
+fig, axs = plt.subplots(2, 2)
+axs[0, 0].plot(x, y)
+axs[0, 0].set_title("main")
+axs[1, 0].plot(x, y**2)
+axs[1, 0].set_title("shares x with main")
+axs[1, 0].sharex(axs[0, 0])
+axs[0, 1].plot(x + 1, y + 1)
+axs[0, 1].set_title("unrelated")
+axs[1, 1].plot(x + 2, y + 2)
+axs[1, 1].set_title("also unrelated")
+fig.tight_layout()
+
+###############################################################################
 # Polar axes
 # """"""""""
 #


### PR DESCRIPTION
This intentionally does not allow unsharing or changing the shared axes,
as there are bigger questions on the API there (#9923 and issues linked there).

The API is named `Axes.sharex()` to allow for a later `Axes.unsharex()`,
though (`set_sharex()` would be fine, but `set_unsharex()`? or perhaps
`set_sharex(None)`, though).  Happy to hear suggestions.

An example use case is creating a grid with `subplots()`, but with
custom sharing relationships between the subplots -- e.g., sharex/sharey
across all, except the first row of axes which only shares x with their
column and the first column which only shares y with their lines.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
