### PR TITLE
Unify fig.delaxes(ax) and ax.remove().

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1163,11 +1163,8 @@ class ColorbarBase(_ColorbarMappableDummy):
         self.alpha = alpha
 
     def remove(self):
-        """
-        Remove this colorbar from the figure.
-        """
-        fig = self.ax.figure
-        fig.delaxes(self.ax)
+        """Remove this colorbar from the figure."""
+        self.ax.remove()
 
 
 class Colorbar(ColorbarBase):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1021,16 +1021,6 @@ default: 'top'
 
     frameon = property(get_frameon, set_frameon)
 
-    def delaxes(self, ax):
-        """
-        Remove the `~matplotlib.axes.Axes` *ax* from the figure and update the
-        current axes.
-        """
-        self._axstack.remove(ax)
-        for func in self._axobservers:
-            func(self)
-        self.stale = True
-
     def add_artist(self, artist, clip=False):
         """
         Add any :class:`~matplotlib.artist.Artist` to the figure.
@@ -1366,10 +1356,10 @@ default: 'top'
             # add a red subplot that share the x-axis with ax1
             fig.add_subplot(224, sharex=ax1, facecolor='red')
 
-            #delete x2 from the figure
+            # delete x2 from the figure
             fig.delaxes(ax2)
 
-            #add x2 to the figure again
+            # add x2 to the figure again
             fig.add_subplot(ax2)
         """
         if not len(args):
@@ -1424,7 +1414,7 @@ default: 'top'
         """Private helper for `add_axes` and `add_subplot`."""
         self._axstack.add(key, ax)
         self.sca(ax)
-        ax._remove_method = self._remove_ax
+        ax._remove_method = self.delaxes
         self.stale = True
         ax.stale_callback = _stale_figure_callback
         return ax
@@ -1597,7 +1587,11 @@ default: 'top'
             # Returned axis array will be always 2-d, even if nrows=ncols=1.
             return axarr
 
-    def _remove_ax(self, ax):
+    def delaxes(self, ax):
+        """
+        Remove the `~.axes.Axes` *ax* from the figure; update the current axes.
+        """
+
         def _reset_locators_and_formatters(axis):
             # Set the formatters and locators to be associated with axis
             # (where previously they may have been associated with another
@@ -1639,7 +1633,11 @@ default: 'top'
                         return last_ax
             return None
 
-        self.delaxes(ax)
+        self._axstack.remove(ax)
+        for func in self._axobservers:
+            func(self)
+        self.stale = True
+
         last_ax = _break_share_link(ax, ax._shared_y_axes)
         if last_ax is not None:
             _reset_locators_and_formatters(last_ax.yaxis)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1342,25 +1342,17 @@ default: 'top'
         ::
 
             fig = plt.figure()
-            fig.add_subplot(221)
 
-            # equivalent but more general
-            ax1 = fig.add_subplot(2, 2, 1)
+            fig.add_subplot(231)
+            ax1 = fig.add_subplot(2, 3, 1)  # equivalent but more general
 
-            # add a subplot with no frame
-            ax2 = fig.add_subplot(222, frameon=False)
+            fig.add_subplot(232, frameon=False)  # subplot with no frame
+            fig.add_subplot(233, projection='polar')  # polar subplot
+            fig.add_subplot(234, sharex=ax1)  # subplot sharing x-axis with ax1
+            fig.add_subplot(235, facecolor="red")  # red subplot
 
-            # add a polar subplot
-            fig.add_subplot(223, projection='polar')
-
-            # add a red subplot that share the x-axis with ax1
-            fig.add_subplot(224, sharex=ax1, facecolor='red')
-
-            # delete x2 from the figure
-            fig.delaxes(ax2)
-
-            # add x2 to the figure again
-            fig.add_subplot(ax2)
+            ax1.remove()  # delete ax1 from the figure
+            fig.add_subplot(ax1)  # add ax1 back to the figure
         """
         if not len(args):
             args = (1, 1, 1)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -828,12 +828,10 @@ def axes(arg=None, **kwargs):
 def delaxes(ax=None):
     """
     Remove the `Axes` *ax* (defaulting to the current axes) from its figure.
-
-    A KeyError is raised if the axes doesn't exist.
     """
     if ax is None:
         ax = gca()
-    ax.figure.delaxes(ax)
+    ax.remove()
 
 
 def sca(ax):


### PR DESCRIPTION
fig.delaxes(ax) and ax.remove() are subtly different because the former
fails to correctly reset locators and formatters when removing shared
axes.  Fix that by putting the logic in delaxes and making ax.remove()
just map to it.

(We could even consider deprecating delaxes as Artist.remove() is the standard, generic way to remove any artist -- but let's not get into that discussion here :p)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
