### PR TITLE
fix warning used by cbook.warn_deprecated()

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -108,7 +108,7 @@ def warn_deprecated(
         since, message, name, alternative, pending, obj_type, addendum,
         removal=removal)
     from . import _warn_external
-    _warn_external(warning)
+    _warn_external(warning, category=MatplotlibDeprecationWarning)
 
 
 def deprecated(since, *, message='', name='', alternative='', pending=False,


### PR DESCRIPTION
change warning class from UserWarning to MatplotlibDeprecationWarning

closes #15289
