### PR TITLE
Deprecate unused rcParams["animation.html_args"].

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -381,3 +381,8 @@ Path helpers in :mod:`.bezier`
 
 ``bezier.concatenate_paths`` is deprecated.  Use ``Path.make_compound_path()``
 instead.
+
+``animation.html_args`` rcParam
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The unused ``animation.html_args`` rcParam and ``animation.HTMLWriter.args_key``
+attribute are deprecated.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -619,6 +619,7 @@ _deprecated_remain_as_none = {
     'datapath': ('3.2.1',),
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
+    'animation.html_args': ('3.3',),
     'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
     'savefig.jpeg_quality': ('3.3',),

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -784,7 +784,11 @@ class HTMLWriter(FileMovieWriter):
     """Writer for JavaScript-based HTML movies."""
 
     supported_formats = ['png', 'jpeg', 'tiff', 'svg']
-    _args_key = 'animation.html_args'
+
+    @cbook.deprecated("3.3")
+    @property
+    def args_key(self):
+        return 'animation.html_args'
 
     @classmethod
     def isAvailable(cls):
@@ -793,20 +797,22 @@ class HTMLWriter(FileMovieWriter):
     def __init__(self, fps=30, codec=None, bitrate=None, extra_args=None,
                  metadata=None, embed_frames=False, default_mode='loop',
                  embed_limit=None):
+
+        if extra_args:
+            _log.warning("HTMLWriter ignores 'extra_args'")
+        extra_args = ()  # Don't lookup nonexistent rcParam[args_key].
         self.embed_frames = embed_frames
         self.default_mode = default_mode.lower()
+        cbook._check_in_list(['loop', 'once', 'reflect'],
+                             default_mode=self.default_mode)
 
         # Save embed limit, which is given in MB
         if embed_limit is None:
             self._bytes_limit = mpl.rcParams['animation.embed_limit']
         else:
             self._bytes_limit = embed_limit
-
         # Convert from MB to bytes
         self._bytes_limit *= 1024 * 1024
-
-        cbook._check_in_list(['loop', 'once', 'reflect'],
-                             default_mode=self.default_mode)
 
         super().__init__(fps, codec, bitrate, extra_args, metadata)
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -728,7 +728,6 @@
 #animation.bitrate: -1            # Controls size/quality tradeoff for movie.
                                   # -1 implies let utility auto-determine
 #animation.frame_format: png      # Controls frame format used by temp files
-#animation.html_args:             # Additional arguments to pass to html writer
 #animation.ffmpeg_path:  ffmpeg   # Path to ffmpeg binary. Without full path
                                   # $PATH is searched
 #animation.ffmpeg_args:           # Additional arguments to pass to ffmpeg


### PR DESCRIPTION
I guess it was intended as a parallel for e.g. `animation.ffmpeg_args`
-- a list of command-line arguments additionally passed to ffmpeg -- but
no external program is used by the html animation writer.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
