### PR TITLE
Simplify and unify character tracking in pdf and ps backends.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -41,3 +41,9 @@ Flags containing "U" passed to `.cbook.to_filehandle` and `.cbook.open_file_cm`
 Please remove "U" from flags passed to `.cbook.to_filehandle` and
 `.cbook.open_file_cm`.  This is consistent with their removal from `open` in
 Python 3.9.
+
+PDF and PS character tracking internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``used_characters`` attribute and ``track_characters`` and
+``merge_used_characters`` methods of `.RendererPdf`, `.PdfFile`, and
+`.RendererPS` are deprecated.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -357,6 +357,10 @@
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolGrid:1",
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolMinorGrid:1"
     ],
+    "matplotlib.backends._backend_pdf_ps.CharacterTracker": [
+      "lib/matplotlib/backends/backend_pdf.py:docstring of matplotlib.backends.backend_pdf.PdfFile:1",
+      "lib/matplotlib/backends/backend_ps.py:docstring of matplotlib.backends.backend_ps.RendererPS:1"
+    ],
     "matplotlib.backends._backend_pdf_ps.RendererPDFPSBase": [
       "lib/matplotlib/backends/backend_pdf.py:docstring of matplotlib.backends.backend_pdf.RendererPdf:1",
       "lib/matplotlib/backends/backend_ps.py:docstring of matplotlib.backends.backend_ps.RendererPS:1"

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -142,6 +142,7 @@ class RendererBase:
     """
 
     def __init__(self):
+        super().__init__()
         self._texmanager = None
         self._text2path = textpath.TextToPath()
 

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -16,10 +16,50 @@ def _cached_get_afm_from_fname(fname):
         return AFM(fh)
 
 
+class CharacterTracker:
+    """
+    Helper for font subsetting by the pdf and ps backends.
+
+    Maintains a mapping of font paths to the set of character codepoints that
+    are being used from that font.
+    """
+
+    def __init__(self):
+        self.used = {}
+
+    @mpl.cbook.deprecated("3.3")
+    @property
+    def used_characters(self):
+        d = {}
+        for fname, chars in self.used.items():
+            realpath, stat_key = mpl.cbook.get_realpath_and_stat(fname)
+            d[stat_key] = (realpath, chars)
+        return d
+
+    def track(self, font, s):
+        """Record that string *s* is being typeset using font *font*."""
+        if isinstance(font, str):
+            # Unused, can be removed after removal of track_characters.
+            fname = font
+        else:
+            fname = font.fname
+        self.used.setdefault(fname, set()).update(map(ord, s))
+
+    def merge(self, other):
+        """Update self with a font path to character codepoints."""
+        for fname, charset in other.items():
+            self.used.setdefault(fname, set()).update(charset)
+
+
 class RendererPDFPSBase(RendererBase):
     # The following attributes must be defined by the subclasses:
     # - _afm_font_dir
     # - _use_afm_rc_name
+
+    def __init__(self, width, height):
+        super().__init__()
+        self.width = width
+        self.height = height
 
     def flipy(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -451,6 +451,8 @@ class PdfFile:
             for `'Creator'`, `'Producer'` and `'CreationDate'`. They
             can be removed by setting them to `None`.
         """
+        super().__init__()
+
         self._object_seq = itertools.count(1)  # consumed by reserveObject
         self.xrefTable = [[0, 65535, 'the zero object']]
         self.passed_in_file_object = False
@@ -513,7 +515,7 @@ class PdfFile:
         self.dviFontInfo = {}   # maps dvi font names to embedding information
         # differently encoded Type-1 fonts may share the same descriptor
         self.type1Descriptors = {}
-        self.used_characters = {}
+        self._character_tracker = _backend_pdf_ps.CharacterTracker()
 
         self.alphaStates = {}   # maps alpha values to graphics state objects
         self._alpha_state_seq = (Name(f'A{i}') for i in itertools.count(1))
@@ -549,6 +551,11 @@ class PdfFile:
                      'Shading': self.gouraudObject,
                      'ProcSet': procsets}
         self.writeObject(self.resourceObject, resources)
+
+    @cbook.deprecated("3.3")
+    @property
+    def used_characters(self):
+        return self.file._character_tracker.used_characters
 
     def newPage(self, width, height):
         self.endStream()
@@ -724,10 +731,9 @@ class PdfFile:
             else:
                 # a normal TrueType font
                 _log.debug('Writing TrueType font.')
-                realpath, stat_key = cbook.get_realpath_and_stat(filename)
-                chars = self.used_characters.get(stat_key)
-                if chars is not None and len(chars[1]):
-                    fonts[Fx] = self.embedTTF(realpath, chars[1])
+                chars = self._character_tracker.used.get(filename)
+                if chars:
+                    fonts[Fx] = self.embedTTF(filename, chars)
         self.writeObject(self.fontObject, fonts)
 
     def _write_afm_font(self, filename):
@@ -1675,9 +1681,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
     _use_afm_rc_name = "pdf.use14corefonts"
 
     def __init__(self, file, image_dpi, height, width):
-        RendererBase.__init__(self)
-        self.height = height
-        self.width = width
+        super().__init__(width, height)
         self.file = file
         self.gc = self.new_gc()
         self.mathtext_parser = MathTextParser("Pdf")
@@ -1713,22 +1717,14 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         gc._fillcolor = orig_fill
         gc._effective_alphas = orig_alphas
 
-    def track_characters(self, font, s):
+    @cbook.deprecated("3.3")
+    def track_characters(self, *args, **kwargs):
         """Keeps track of which characters are required from each font."""
-        if isinstance(font, str):
-            fname = font
-        else:
-            fname = font.fname
-        realpath, stat_key = cbook.get_realpath_and_stat(fname)
-        used_characters = self.file.used_characters.setdefault(
-            stat_key, (realpath, set()))
-        used_characters[1].update(map(ord, s))
+        self.file._character_tracker.track(*args, **kwargs)
 
-    def merge_used_characters(self, other):
-        for stat_key, (realpath, charset) in other.items():
-            used_characters = self.file.used_characters.setdefault(
-                stat_key, (realpath, set()))
-            used_characters[1].update(charset)
+    @cbook.deprecated("3.3")
+    def merge_used_characters(self, *args, **kwargs):
+        self.file._character_tracker.merge(*args, **kwargs)
 
     def get_image_magnification(self):
         return self.image_dpi/72.0
@@ -1938,7 +1934,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         # TODO: fix positioning and encoding
         width, height, descent, glyphs, rects, used_characters = \
             self.mathtext_parser.parse(s, 72, prop)
-        self.merge_used_characters(used_characters)
+        self.file._character_tracker.merge(used_characters)
 
         # When using Type 3 fonts, we can't use character codes higher
         # than 255, so we use the "Do" command to render those
@@ -2101,7 +2097,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             fonttype = 1
         else:
             font = self._get_font_ttf(prop)
-            self.track_characters(font, s)
+            self.file._character_tracker.track(font, s)
             fonttype = rcParams['pdf.fonttype']
             # We can't subset all OpenType fonts, so switch to Type 42
             # in that case.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -524,6 +524,7 @@ def flatten(seq, scalarp=is_scalar_or_string):
             yield from flatten(item, scalarp)
 
 
+@deprecated("3.3", alternative="os.path.realpath and os.stat")
 @functools.lru_cache()
 def get_realpath_and_stat(path):
     realpath = os.path.realpath(path)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1339,6 +1339,9 @@ if hasattr(os, "register_at_fork"):
 
 
 def get_font(filename, hinting_factor=None):
+    # Resolving the path avoids embedding the font twice in pdf/ps output if a
+    # single font is selected using two different relative paths.
+    filename = os.path.realpath(filename)
     if hinting_factor is None:
         hinting_factor = rcParams['text.hinting_factor']
     return _get_font(os.fspath(filename), hinting_factor,

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -32,7 +32,6 @@ from pyparsing import (
 
 from matplotlib import cbook, colors as mcolors, rcParams
 from matplotlib.afm import AFM
-from matplotlib.cbook import get_realpath_and_stat
 from matplotlib.ft2font import FT2Image, KERNING_DEFAULT, LOAD_NO_HINTING
 from matplotlib.font_manager import findfont, FontProperties, get_font
 from matplotlib._mathtext_data import (latex_to_bakoma, latex_to_standard,
@@ -485,10 +484,7 @@ class Fonts:
           - *dpi*: The dpi to draw at.
         """
         info = self._get_info(facename, font_class, sym, fontsize, dpi)
-        realpath, stat_key = get_realpath_and_stat(info.font.fname)
-        used_characters = self.used_characters.setdefault(
-            stat_key, (realpath, set()))
-        used_characters[1].add(info.num)
+        self.used_characters.setdefault(info.font.fname, set()).add(info.num)
         self.mathtext_backend.render_glyph(ox, oy, info)
 
     def render_rect_filled(self, x1, y1, x2, y2):


### PR DESCRIPTION
Instead of trying to resolve font paths to absolute files and key off by
inode(!), just track fonts using whatever names they use, and simplify
used_characters to be a straight mapping of filenames to character ids
(making the attribute private -- with a backcompat shim) at the same
time).

The previous approach would avoid embedding the same file twice if it is
given under two different filenames (hardlinks to the same file...), but
it would fail if the user passes a relative path, chdir()s to another
directory, and passes another different font with the same filename,
because of the lru_cache().  None of these seem likely to happen in
practice, and in any case we can cover most of it by making the font
paths absolute before passing them to FreeType (which is going to open
the file anyways, so the cost of making them absolute doesn't matter).

---

missing_references.json needs to be regenerated due to the missing reference to the private CharacterTracker class; to avoid changes in order in missing_references.json creating needless diffs, this goes on top of #15321 

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
