### PR TITLE
Add appnope to avoid AppNap after displaying a figure

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -128,6 +128,7 @@ Matplotlib requires the following dependencies:
 * `dateutil <https://pypi.org/project/python-dateutil>`_ (>= 2.1)
 * `kiwisolver <https://github.com/nucleic/kiwi>`_ (>= 1.0.0)
 * `pyparsing <https://pyparsing.wikispaces.com/>`_
+* `appnope <https://github.com/minrk/appnope>`_ (macOS only)
 
 Optionally, you can also install a number of packages to enable better user
 interface toolkits. See :ref:`what-is-a-backend` for more details on the

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -53,6 +53,9 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.transforms import Affine2D
 from matplotlib.path import Path
 
+if sys.platform == 'darwin':
+    import appnope
+
 try:
     from PIL import PILLOW_VERSION
     from distutils.version import LooseVersion
@@ -1623,6 +1626,13 @@ class FigureCanvasBase:
 
     def __init__(self, figure):
         self._fix_ipython_backend2gui()
+        if sys.platform == 'darwin':
+            # This disables AppNap for macOS
+            # AppNap uses gui windows usage to decide to put an app in "Nap"
+            # If a terminal shows a window and then hides it, macOS will
+            # reclassify this process as "GUI" that should be slowed down if
+            # no window is active. To avoid this:
+            appnope.nope()
         self._is_idle_drawing = True
         self._is_saving = False
         figure.set_canvas(self)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -42,6 +42,8 @@ import os
 import sys
 import time
 from weakref import WeakKeyDictionary
+from distutils.version import LooseVersion
+import platform
 
 import numpy as np
 
@@ -53,7 +55,8 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.transforms import Affine2D
 from matplotlib.path import Path
 
-if sys.platform == 'darwin':
+if (sys.platform == 'darwin'
+        and LooseVersion(platform.mac_ver()[0]) >= LooseVersion('10.9')):
     import appnope
 
 try:
@@ -1626,7 +1629,10 @@ class FigureCanvasBase:
 
     def __init__(self, figure):
         self._fix_ipython_backend2gui()
-        if sys.platform == 'darwin':
+        use_appnope = (
+            sys.platform == 'darwin'
+            and LooseVersion(platform.mac_ver()[0]) >= LooseVersion('10.9'))
+        if use_appnope:
             # This disables AppNap for macOS
             # AppNap uses gui windows usage to decide to put an app in "Nap"
             # If a terminal shows a window and then hides it, macOS will

--- a/setup.py
+++ b/setup.py
@@ -264,6 +264,7 @@ if __name__ == '__main__':
             "numpy>=1.11",
             "pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6",
             "python-dateutil>=2.1",
+            'appnope;platform_system=="Darwin"',
         ],
 
         cmdclass=cmdclass,


### PR DESCRIPTION
## PR Summary
AppNap is a macOS feature that slows down gui processes that are in the background to save energy.

Usually, a python interpreter is not a gui appliaction. For example, invoking `python` in a terminal to get a command line prompt or using qtconsole (python runs in a kernel that doesn't have a gui, even if there is a gui for the console.)

If matplotlib uses a gui backend to display a figure (`qt5`, `macOSX`), the process will be reclassified by the os as a gui process. Some time after closing the figure or the figure not being in focus, the interpreter will start to slow down. (30 seconds on my mac)

Therefore, this PR disables AppNap on macOS using appnope (https://github.com/minrk/appnope)

fixes https://github.com/matplotlib/matplotlib/issues/15314

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
