### PR TITLE
Simplify the rcparams deprecation machinery.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -648,14 +648,17 @@ class RcParams(MutableMapping, dict):
                 f"a list of valid parameters)")
 
     def __getitem__(self, key):
+        if key in _deprecated_rcs:
+            cbook.warn_deprecated(
+                **{"name": key, "obj_type": "rcparam", **_deprecated_rcs[key]})
+        return self._getitem_skip_deprecation(key)
+
+    def _getitem_skip_deprecation(self, key):
         if key == "backend":
             val = dict.__getitem__(self, key)
             if val is rcsetup._auto_backend_sentinel:
                 from matplotlib import pyplot as plt
                 plt.switch_backend(rcsetup._auto_backend_sentinel)
-        if key in _deprecated_rcs:
-            cbook.warn_deprecated(
-                **{"name": key, "obj_type": "rcparam", **_deprecated_rcs[key]})
         return dict.__getitem__(self, key)
 
     def __repr__(self):

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -465,14 +465,13 @@ def test_rcparams_reset_after_fail():
 
 def test_if_rctemplate_is_up_to_date():
     # This tests if the matplotlibrc.template file contains all valid rcParams.
-    deprecated = {*mpl._all_deprecated, *mpl._deprecated_remain_as_none}
     with cbook._get_data_path('matplotlibrc').open() as file:
         rclines = file.readlines()
     missing = {}
     for k, v in mpl.defaultParams.items():
         if k[0] == "_":
             continue
-        if k in deprecated:
+        if k in mpl._deprecated_rcs:
             continue
         found = False
         for line in rclines:

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -160,15 +160,17 @@ class TexManager:
         if self._rc_cache is None:
             self._rc_cache = dict.fromkeys(self._rc_cache_keys)
         changed = [par for par in self._rc_cache_keys
-                   if dict.__getitem__(rcParams, par) != self._rc_cache[par]]
+                   if (rcParams._getitem_skip_deprecation(par)
+                       != self._rc_cache[par])]
         if changed:
             _log.debug('following keys changed: %s', changed)
             for k in changed:
                 _log.debug('%-20s: %-10s -> %-10s',
-                           k, self._rc_cache[k], dict.__getitem__(rcParams, k))
+                           k, self._rc_cache[k],
+                           rcParams._getitem_skip_deprecation(k))
                 # deepcopy may not be necessary, but feels more future-proof
                 self._rc_cache[k] = copy.deepcopy(
-                    dict.__getitem__(rcParams, k))
+                    rcParams._getitem_skip_deprecation(k))
             _log.debug('RE-INIT\nold fontconfig: %s', self._fontconfig)
             self._reinit()
         _log.debug('fontconfig: %s', self._fontconfig)

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -160,14 +160,15 @@ class TexManager:
         if self._rc_cache is None:
             self._rc_cache = dict.fromkeys(self._rc_cache_keys)
         changed = [par for par in self._rc_cache_keys
-                   if rcParams[par] != self._rc_cache[par]]
+                   if dict.__getitem__(rcParams, par) != self._rc_cache[par]]
         if changed:
             _log.debug('following keys changed: %s', changed)
             for k in changed:
                 _log.debug('%-20s: %-10s -> %-10s',
-                           k, self._rc_cache[k], rcParams[k])
+                           k, self._rc_cache[k], dict.__getitem__(rcParams, k))
                 # deepcopy may not be necessary, but feels more future-proof
-                self._rc_cache[k] = copy.deepcopy(rcParams[k])
+                self._rc_cache[k] = copy.deepcopy(
+                    dict.__getitem__(rcParams, k))
             _log.debug('RE-INIT\nold fontconfig: %s', self._fontconfig)
             self._reinit()
         _log.debug('fontconfig: %s', self._fontconfig)


### PR DESCRIPTION
Just have a single kind of deprecated rcParams, which emit a
DeprecationWarning on get and on set.

... which caught the fact that we were previously *not* warning on
access to text.latex.unicode, now we do but need to avoid triggering the
warnings internally.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
