### PR TITLE
Enh: DivergingNorm Fair

### DIFF
--- a/doc/users/next_whats_new/2019-09-24_divergingnorm_fair.rst
+++ b/doc/users/next_whats_new/2019-09-24_divergingnorm_fair.rst
@@ -1,0 +1,27 @@
+Fair DivergingNorm
+------------------
+`~.DivergingNorm` now has an argument ``fair``, which can be set to ``True``
+in order to create an off-centered normalization with equally spaced colors.
+
+..plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import DivergingNorm
+
+    np.random.seed(19680801)
+    data = np.random.rand(4, 11)
+
+    fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(7, 2))
+
+    norm1 = DivergingNorm(0.25, vmin=0, vmax=1, fair=False)
+    im = ax1.imshow(data, cmap='RdBu', norm=norm1)
+    cbar = fig.colorbar(im, ax=ax1, orientation="horizontal", aspect=15)
+
+    norm2 = DivergingNorm(0.25, vmin=0, vmax=1, fair=True)
+    im = ax2.imshow(data, cmap='RdBu', norm=norm2)
+    cbar = fig.colorbar(im, ax=ax2, orientation="horizontal", aspect=15)
+
+    ax1.set_title("DivergingNorm(.., fair=False)")
+    ax2.set_title("DivergingNorm(.., fair=True)")
+    plt.show()

--- a/examples/userdemo/colormap_normalizations_diverging.py
+++ b/examples/userdemo/colormap_normalizations_diverging.py
@@ -2,14 +2,22 @@
 =====================================
 DivergingNorm colormap normalization
 =====================================
-
-Sometimes we want to have a different colormap on either side of a
-conceptual center point, and we want those two colormaps to have
-different linear scales.  An example is a topographic map where the land
-and ocean have a center at zero, but land typically has a greater
-elevation range than the water has depth range, and they are often
-represented by a different colormap.
 """
+
+##############################################################################
+# .. _divergingnorm-diffmap:
+#
+# Different mapping on either side of a center
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Sometimes we want to have a different colormap on either side of a
+# conceptual center point, and we want those two colormaps to have
+# different linear scales.  An example is a topographic map where the land
+# and ocean have a center at zero, but land typically has a greater
+# elevation range than the water has depth range, and they are often
+# represented by a different colormap.
+# This achieved with a `~.DivergingNorm` and by setting its ``vcenter``
+# argument to zero.
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -29,16 +37,45 @@ colors_undersea = plt.cm.terrain(np.linspace(0, 0.17, 256))
 colors_land = plt.cm.terrain(np.linspace(0.25, 1, 256))
 all_colors = np.vstack((colors_undersea, colors_land))
 terrain_map = colors.LinearSegmentedColormap.from_list('terrain_map',
-    all_colors)
+                                                       all_colors)
 
 # make the norm:  Note the center is offset so that the land has more
 # dynamic range:
 divnorm = colors.DivergingNorm(vmin=-500, vcenter=0, vmax=4000)
 
 pcm = ax.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
-    cmap=terrain_map,)
+                    cmap=terrain_map)
 ax.set_xlabel('Lon $[^o E]$')
 ax.set_ylabel('Lat $[^o N]$')
 ax.set_aspect(1 / np.cos(np.deg2rad(49)))
 fig.colorbar(pcm, shrink=0.6, extend='both', label='Elevation [m]')
+plt.show()
+
+
+##############################################################################
+# .. _divergingnorm-fairmap:
+#
+# Fair mapping on either side of a center
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# On other occasions it may be useful to preserve the linear mapping to colors,
+# but still define a center point, such that the colormap extends to both sides
+# of the center equally. This can be achieved by using the ``fair=True``
+# argument of the `~.DivergingNorm`.
+
+np.random.seed(19680801)
+data = np.random.rand(11, 11)
+
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 3.5))
+
+norm1 = colors.DivergingNorm(0.25, vmin=0, vmax=1, fair=False)
+im = ax1.imshow(data, cmap='RdBu', norm=norm1)
+cbar = fig.colorbar(im, ax=ax1, ticks=[0, 0.25, 0.5, 0.75, 1])
+
+norm2 = colors.DivergingNorm(0.25, vmin=0, vmax=1, fair=True)
+im = ax2.imshow(data, cmap='RdBu', norm=norm2)
+cbar = fig.colorbar(im, ax=ax2, ticks=[0, 0.25, 0.5, 0.75, 1])
+
+ax1.set_title("DivergingNorm(.., fair=False)")
+ax2.set_title("DivergingNorm(.., fair=True)")
 plt.show()

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -186,16 +186,23 @@ fig.colorbar(pcm, ax=ax[2], extend='both', orientation='vertical')
 plt.show()
 
 
-###############################################################################
-# DivergingNorm: Different mapping on either side of a center
-# -----------------------------------------------------------
+##############################################################################
+# .. _colormapnorms-diffmap:
+#
+# DivergingNorm
+# -------------
+#
+# Different mapping on either side of a center
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Sometimes we want to have a different colormap on either side of a
 # conceptual center point, and we want those two colormaps to have
 # different linear scales.  An example is a topographic map where the land
 # and ocean have a center at zero, but land typically has a greater
 # elevation range than the water has depth range, and they are often
-# represented by a different colormap.
+# represented by a different colormap. This achieved with a `~.DivergingNorm`
+# and by setting its ``vcenter`` argument to zero.
+
 
 filename = cbook.get_sample_data('topobathy.npz', asfileobj=False)
 with np.load(filename) as dem:
@@ -203,7 +210,7 @@ with np.load(filename) as dem:
     longitude = dem['longitude']
     latitude = dem['latitude']
 
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(constrained_layout=True)
 # make a colormap that has land and ocean clearly delineated and of the
 # same length (256 + 256)
 colors_undersea = plt.cm.terrain(np.linspace(0, 0.17, 256))
@@ -214,14 +221,44 @@ terrain_map = colors.LinearSegmentedColormap.from_list('terrain_map',
 
 # make the norm:  Note the center is offset so that the land has more
 # dynamic range:
-divnorm = colors.DivergingNorm(vmin=-500., vcenter=0, vmax=4000)
+divnorm = colors.DivergingNorm(vmin=-500, vcenter=0, vmax=4000)
 
 pcm = ax.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
     cmap=terrain_map,)
-# Simple geographic plot, set aspect ratio beecause distance between lines of
-# longitude depends on latitude.
+ax.set_xlabel('Lon $[^o E]$')
+ax.set_ylabel('Lat $[^o N]$')
 ax.set_aspect(1 / np.cos(np.deg2rad(49)))
-fig.colorbar(pcm, shrink=0.6)
+fig.colorbar(pcm, shrink=0.6, extend='both', label='Elevation [m]')
+plt.show()
+
+
+##############################################################################
+# .. _colormapnorms-fairmap:
+#
+# Fair mapping on either side of a center
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# On other occasions it may be useful to preserve the linear mapping to colors,
+# but still define a center point, such that the colormap extends to both sides
+# of the center equally. This can be achieved by using the ``fair=True``
+# argument of the `~.DivergingNorm`.
+
+
+np.random.seed(19680801)
+data = np.random.rand(11, 11)
+
+fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 3.5))
+
+norm1 = colors.DivergingNorm(0.25, vmin=0, vmax=1, fair=False)
+im = ax1.imshow(data, cmap='RdBu', norm=norm1)
+cbar = fig.colorbar(im, ax=ax1, ticks=[0, 0.25, 0.5, 0.75, 1])
+
+norm2 = colors.DivergingNorm(0.25, vmin=0, vmax=1, fair=True)
+im = ax2.imshow(data, cmap='RdBu', norm=norm2)
+cbar = fig.colorbar(im, ax=ax2, ticks=[0, 0.25, 0.5, 0.75, 1])
+
+ax1.set_title("DivergingNorm(.., fair=False)")
+ax2.set_title("DivergingNorm(.., fair=True)")
 plt.show()
 
 
@@ -231,6 +268,7 @@ plt.show()
 #
 # The `.DivergingNorm` described above makes a useful example for
 # defining your own norm.
+
 
 class MidpointNormalize(colors.Normalize):
     def __init__(self, vmin=None, vmax=None, vcenter=None, clip=False):
@@ -248,7 +286,7 @@ fig, ax = plt.subplots()
 midnorm = MidpointNormalize(vmin=-500., vcenter=0, vmax=4000)
 
 pcm = ax.pcolormesh(longitude, latitude, topo, rasterized=True, norm=midnorm,
-    cmap=terrain_map)
+                    cmap=terrain_map)
 ax.set_aspect(1 / np.cos(np.deg2rad(49)))
 fig.colorbar(pcm, shrink=0.6, extend='both')
 plt.show()


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/13948

Adds a new argument `fair`  to the `DiverginNorm` to be able to create off-centered colormapping with equally spaced colors. 

![image](https://user-images.githubusercontent.com/23121882/65471056-09946600-de6e-11e9-860f-ebb35464ace0.png)

While doing this, also removes the restriction `vmin <= vcenter <= vmax` in `DiverginNorm` and replace it by ``vmin <=  vmax``, such that the center can be outside the interval `[vmin, vmax]`. This is useful when wanting to show only a partial colormap.


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
