### PR TITLE
Add discourse link to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,13 +70,14 @@ or your package manager of choice.
 
 Contact
 =======
-matplotlib's communication channels include active mailing lists:
+* `Discourse <https://discourse.matplotlib.org/>`_ is the discussion forum for general questions and discussions and our recommended starting point. 
+
+Our active active mailing lists (which are mirrored on the discourse) are:
 
 * `Users <https://mail.python.org/mailman/listinfo/matplotlib-users>`_ mailing list: matplotlib-users@python.org
 * `Announcement  <https://mail.python.org/mailman/listinfo/matplotlib-announce>`_ mailing list: matplotlib-announce@python.org
 * `Development <https://mail.python.org/mailman/listinfo/matplotlib-devel>`_ mailing list: matplotlib-devel@python.org
 
-The first is a good starting point for general questions and discussions.
 
 Gitter_ is for coordinating development and asking questions directly related
 to contributing to matplotlib.

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Contact
 =======
 * `Discourse <https://discourse.matplotlib.org/>`_ is the discussion forum for general questions and discussions and our recommended starting point. 
 
-Our active active mailing lists (which are mirrored on the discourse) are:
+Our active active mailing lists (which are mirrored on discourse) are:
 
 * `Users <https://mail.python.org/mailman/listinfo/matplotlib-users>`_ mailing list: matplotlib-users@python.org
 * `Announcement  <https://mail.python.org/mailman/listinfo/matplotlib-announce>`_ mailing list: matplotlib-announce@python.org

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ or your package manager of choice.
 
 Contact
 =======
-* `Discourse <https://discourse.matplotlib.org/>`_ is the discussion forum for general questions and discussions and our recommended starting point. 
+`Discourse <https://discourse.matplotlib.org/>`_ is the discussion forum for general questions and discussions and our recommended starting point. 
 
 Our active active mailing lists (which are mirrored on discourse) are:
 

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Contact
 =======
 `Discourse <https://discourse.matplotlib.org/>`_ is the discussion forum for general questions and discussions and our recommended starting point. 
 
-Our active active mailing lists (which are mirrored on discourse) are:
+Our active mailing lists (which are mirrored on Discourse) are:
 
 * `Users <https://mail.python.org/mailman/listinfo/matplotlib-users>`_ mailing list: matplotlib-users@python.org
 * `Announcement  <https://mail.python.org/mailman/listinfo/matplotlib-announce>`_ mailing list: matplotlib-announce@python.org


### PR DESCRIPTION
From this week's call, starting the soft launch of the discourse by adding a link to the discourse.
