### PR TITLE
Always attach a manager attribute (possibly None) on canvas.

### DIFF
--- a/doc/api/next_api_changes/2018-09-25-AL.rst
+++ b/doc/api/next_api_changes/2018-09-25-AL.rst
@@ -1,0 +1,7 @@
+``FigureCanvasBase`` now always has a ``manager`` attribute, which may be None
+``````````````````````````````````````````````````````````````````````````````
+
+Previously, it did not necessarily have such an attribute.  A check for
+``hasattr(figure.canvas, "manager")`` should now be replaced by
+``figure.canvas.manager is not None`` (or ``getattr(figure.canvas, "manager", None) is not None``
+for back-compatibility).

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1627,6 +1627,7 @@ class FigureCanvasBase:
         self._is_saving = False
         figure.set_canvas(self)
         self.figure = figure
+        self.manager = None
         # a dictionary from event name to a dictionary that maps cid->func
         self.callbacks = cbook.CallbackRegistry()
         self.widgetlock = widgets.LockDraw()
@@ -2127,7 +2128,7 @@ class FigureCanvasBase:
         Get the title text of the window containing the figure.
         Return None if there is no window (e.g., a PS backend).
         """
-        if hasattr(self, "manager"):
+        if self.manager:
             return self.manager.get_window_title()
 
     def set_window_title(self, title):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -430,25 +430,18 @@ class Figure(Artist):
             If ``True`` and we are not running headless (i.e. on Linux with an
             unset DISPLAY), issue warning when called on a non-GUI backend.
         """
+        if self.canvas.manager is None:
+            raise AttributeError(
+                "Figure.show works only for figures managed by pyplot, "
+                "normally created by pyplot.figure()")
         try:
-            manager = getattr(self.canvas, 'manager')
-        except AttributeError as err:
-            raise AttributeError("%s\n"
-                                 "Figure.show works only "
-                                 "for figures managed by pyplot, normally "
-                                 "created by pyplot.figure()." % err)
-
-        if manager is not None:
-            try:
-                manager.show()
-                return
-            except NonGuiException:
-                pass
-        if (backends._get_running_interactive_framework() != "headless"
-                and warn):
-            cbook._warn_external('Matplotlib is currently using %s, which is '
-                                 'a non-GUI backend, so cannot show the '
-                                 'figure.' % get_backend())
+            self.canvas.manager.show()
+        except NonGuiException:
+            if (backends._get_running_interactive_framework() != "headless"
+                    and warn):
+                cbook._warn_external(
+                    f"Matplotlib is currently using {get_backend()}, which is "
+                    f"a non-GUI backend, so cannot show the figure.")
 
     def _get_axes(self):
         return self._axstack.as_list()


### PR DESCRIPTION
This avoids the confusion in the earlier implementation of Figure.show,
which checked separately for whether the attribute existed and whether
it is None, and (wrongly, I believe) handled the two cases differently.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
