### PR TITLE
Move non-gui warning message to backend_bases.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -436,12 +436,8 @@ class Figure(Artist):
                 "normally created by pyplot.figure()")
         try:
             self.canvas.manager.show()
-        except NonGuiException:
-            if (backends._get_running_interactive_framework() != "headless"
-                    and warn):
-                cbook._warn_external(
-                    f"Matplotlib is currently using {get_backend()}, which is "
-                    f"a non-GUI backend, so cannot show the figure.")
+        except NonGuiException as exc:
+            cbook._warn_external(str(exc))
 
     def _get_axes(self):
         return self._axstack.as_list()


### PR DESCRIPTION
This avoids 1) splitting the emission of the NonGuiException and the
generation of the actual message in two places, and 2) allows replacing
the rather roundabout `manager.canvas.figure.show()` by just
`manager.show()` in `plt.show()`  (previously, the two only differed by
the fact that the former would convert the NonGuiException thrown by the
latter into an exception.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
