### PR TITLE
Fix axes.hist bins units

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6575,6 +6575,9 @@ optional.
         if bin_range is not None:
             bin_range = self.convert_xunits(bin_range)
 
+        if not cbook.is_scalar_or_string(bins):
+            bins = self.convert_xunits(bins)
+
         # We need to do to 'weights' what was done to 'x'
         if weights is not None:
             w = cbook._reshape_2D(weights, 'weights')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1752,20 +1752,27 @@ def test_hist_datetime_datasets():
     ax.hist(data, stacked=True)
     ax.hist(data, stacked=False)
 
-@pytest.mark.parametrize("bins_preprocess", [lambda bins: None, mpl.dates.date2num, lambda bins: bins], 
-                         ids=['None', 'date2num', 'datetime.datetime'])
+
+@pytest.mark.parametrize("bins_preprocess",
+                         [lambda bins: None,
+                          mpl.dates.date2num,
+                          lambda bins: bins,
+                          lambda bins: np.asarray(bins).astype('datetime64')],
+                         ids=['None', 'date2num', 'datetime.datetime',
+                              'np.datetime64'])
 def test_hist_datetime_datasets_bins(bins_preprocess):
-    data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11), 
+    data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11),
              datetime.datetime(2019, 2, 1), datetime.datetime(2019, 3, 1)],
-            [datetime.datetime(2019, 1, 11), datetime.datetime(2019, 2, 5), 
+            [datetime.datetime(2019, 1, 11), datetime.datetime(2019, 2, 5),
              datetime.datetime(2019, 2, 18), datetime.datetime(2019, 3, 1)]]
 
-    date_edges = [datetime.datetime(2019, 1, 1), datetime.datetime(2019, 2, 1), 
-                  datetime.datetime(2019, 3, 1),] 
-    
+    date_edges = [datetime.datetime(2019, 1, 1), datetime.datetime(2019, 2, 1),
+                  datetime.datetime(2019, 3, 1)]
+
     fig, ax = plt.subplots()
     ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
     ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
+
 
 @pytest.mark.parametrize('data, expected_number_of_hists',
                          [([], 1),

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1754,11 +1754,10 @@ def test_hist_datetime_datasets():
 
 
 @pytest.mark.parametrize("bins_preprocess",
-                         [lambda bins: None,
-                          mpl.dates.date2num,
+                         [mpl.dates.date2num,
                           lambda bins: bins,
                           lambda bins: np.asarray(bins).astype('datetime64')],
-                         ids=['None', 'date2num', 'datetime.datetime',
+                         ids=['date2num', 'datetime.datetime',
                               'np.datetime64'])
 def test_hist_datetime_datasets_bins(bins_preprocess):
     data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11),
@@ -1770,8 +1769,11 @@ def test_hist_datetime_datasets_bins(bins_preprocess):
                   datetime.datetime(2019, 3, 1)]
 
     fig, ax = plt.subplots()
-    ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
-    ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
+    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
+    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
+
+    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
+    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
 
 
 @pytest.mark.parametrize('data, expected_number_of_hists',

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1752,6 +1752,20 @@ def test_hist_datetime_datasets():
     ax.hist(data, stacked=True)
     ax.hist(data, stacked=False)
 
+@pytest.mark.parametrize("bins_preprocess", [lambda bins: None, mpl.dates.date2num, lambda bins: bins], 
+                         ids=['None', 'date2num', 'datetime.datetime'])
+def test_hist_datetime_datasets_bins(bins_preprocess):
+    data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11), 
+             datetime.datetime(2019, 2, 1), datetime.datetime(2019, 3, 1)],
+            [datetime.datetime(2019, 1, 11), datetime.datetime(2019, 2, 5), 
+             datetime.datetime(2019, 2, 18), datetime.datetime(2019, 3, 1)]]
+
+    date_edges = [datetime.datetime(2019, 1, 1), datetime.datetime(2019, 2, 1), 
+                  datetime.datetime(2019, 3, 1),] 
+    
+    fig, ax = plt.subplots()
+    ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
+    ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
 
 @pytest.mark.parametrize('data, expected_number_of_hists',
                          [([], 1),


### PR DESCRIPTION
## PR Summary

Issue #15332 raised a problem with the `bins=` argument to `axes.hist`, where it would fail if the bins are `datetime.datetime` objects (although the data can be `datetime.datetime` objects).

In `axes.hist` we call `convert_xunits` on `x` and `bin_range`. This PR also calls `convert_xunits` on `bins` if it is a sequence (and not a scalar or string).

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
