### PR TITLE
Use checkboxes as bullet points for the PR review checklists

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -1,5 +1,14 @@
 .. _pr-guidelines:
 
+.. raw:: html
+
+   <style>
+   .checklist { list-style: none; padding: 0; margin: 0; }
+   .checklist li { margin-left: 24px; padding-left: 23px;  margin-right: 6px; }
+   .checklist li:before { content: "\2610\2001"; margin-left: -24px; }
+   .checklist li p {display: inline; }
+   </style>
+
 ***********************
 Pull request guidelines
 ***********************
@@ -22,6 +31,8 @@ Summary for PR authors
      please ping us by posting a comment to your PR.
 
 When making a PR, pay attention to:
+
+.. rst-class:: checklist
 
 * :ref:`Target the master branch <pr-branch-selection>`.
 * Adhere to the :ref:`coding_guidelines`.
@@ -53,12 +64,16 @@ Summary for PR reviewers
 
 Content topics:
 
+.. rst-class:: checklist
+
 * Is the feature / bugfix reasonable?
 * Does the PR conform with the :ref:`coding_guidelines`?
 * Is the :ref:`documentation <pr-documentation>` (docstrings, examples,
   what's new, API changes) updated?
 
 Organizational topics:
+
+.. rst-class:: checklist
 
 * Make sure all :ref:`automated tests <pr-automated-tests>` pass.
 * The PR should :ref:`target the master branch <pr-branch-selection>`.


### PR DESCRIPTION
## PR Summary

This is intended as a visual aid as proposed in https://github.com/matplotlib/matplotlib/pull/15324#discussion_r326911425. Ping @story645 

There are other ways to achieve similar behavior, but the proposed solution seems best to me.

Just for reference here are the other alternatives:

### rst-class with .css file
Essentially the same as this one but the CSS is not defined inline via `<style>` but in a .css file. 
*Advantage:* Less clutter in the .rst file. *Disadvantage:* The CSS styling is far away from it's usage future changes may not be aware of this relation and accidentially break it.

### Faking a box using square brackets
`* [ ] Is the feature / bugfix reasonable?`
*Advantage:* No extra formatting. *Disadvantage:* Doesn't look good.

### Adding a checkbox to the list
~~~
* |checkbox| Is the feature / bugfix reasonable?
* |checkbox| ...

.. |checkbox| unicode:: U+02751
~~~
*Advantage:* No no style changes necessary. *Disadvantage:* The checkbox does not replace the bullet point but is placed after it.
