### PR TITLE
Don't generate double-reversed cmaps ("viridis_r_r", ...).

### DIFF
--- a/lib/matplotlib/_cm_listed.py
+++ b/lib/matplotlib/_cm_listed.py
@@ -1801,16 +1801,13 @@ _twilight_shifted_data = (_twilight_data[len(_twilight_data)//2:] +
                           _twilight_data[:len(_twilight_data)//2])
 _twilight_shifted_data.reverse()
 
-cmaps = {}
-for (name, data) in (('magma', _magma_data),
-                     ('inferno', _inferno_data),
-                     ('plasma', _plasma_data),
-                     ('viridis', _viridis_data),
-                     ('cividis', _cividis_data),
-                     ('twilight', _twilight_data),
-                     ('twilight_shifted', _twilight_shifted_data)):
-
-    cmaps[name] = ListedColormap(data, name=name)
-    # generate reversed colormap
-    name = name + '_r'
-    cmaps[name] = ListedColormap(list(reversed(data)), name=name)
+cmaps = {
+    name: ListedColormap(data, name=name) for name, data in [
+        ('magma', _magma_data),
+        ('inferno', _inferno_data),
+        ('plasma', _plasma_data),
+        ('viridis', _viridis_data),
+        ('cividis', _cividis_data),
+        ('twilight', _twilight_data),
+        ('twilight_shifted', _twilight_shifted_data),
+    ]}


### PR DESCRIPTION
_gen_cmap_d handles reversal of all colormaps, so _cm_listed doesn't
need to generate reversed colormaps anymore -- otherwise, one gets the
"double-reversed" colormaps `viridis_r_r`, etc.

Not really release critical, but does fix a regression from #14679.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
