### PR TITLE
DOC: fix typo in colormap docs

### DIFF
--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -12,10 +12,10 @@ give a color at the center of the colormap *RdBu_r* (white in this
 case).
 
 Matplotlib does this mapping in two steps, with a normalization from
-[0, 1] occurring first, and then mapping onto the indices in the
-colormap.  Normalizations are classes defined in the
-:func:`matplotlib.colors` module.  The default, linear normalization is
-:func:`matplotlib.colors.Normalize`.
+the input data to [0, 1] occurring first, and then mapping onto the
+indices in the colormap.  Normalizations are classes defined in the
+:func:`matplotlib.colors` module.  The default, linear normalization
+is :func:`matplotlib.colors.Normalize`.
 
 Artists that map data to color pass the arguments *vmin* and *vmax* to
 construct a :func:`matplotlib.colors.Normalize` instance, then call it:
@@ -41,6 +41,7 @@ disparate scales.  Using `.colors.LogNorm` normalizes the data via
 :math:`log_{10}`.  In the example below, there are two bumps, one much smaller
 than the other. Using `.colors.LogNorm`, the shape and location of each bump
 can clearly be seen:
+
 """
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

The meaning was inverted!