### PR TITLE
Deprecate Colorbar.config_axis()

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -12,3 +12,7 @@ instead.
 ~~~~~~~~~~~~~~~~~~~~~~~~
 ``backend_wx.DEBUG_MSG`` is deprecated.  The wx backends now use regular
 logging.
+
+``Colorbar.config_axis()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``Colorbar.config_axis()`` is considered internal. Its use is deprecated.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -541,12 +541,17 @@ class ColorbarBase(_ColorbarMappableDummy):
         X, Y = self._mesh()
         C = self._values[:, np.newaxis]
         # decide minor/major axis
-        self.config_axis()
+        self._config_axis()
         self._config_axes(X, Y)
         if self.filled:
             self._add_solids(X, Y, C)
 
+    @cbook.deprecated("3.3")
     def config_axis(self):
+        self._config_axis()
+
+    def _config_axis(self):
+        """Configure the ticks, ticklabels and label of the underlying Axes."""
         ax = self.ax
 
         if self.orientation == 'vertical':


### PR DESCRIPTION
## PR Summary

There is no need for a user to call this. It's only used internally in `draw_all()`. So let's remove it from the public API.
