### PR TITLE
Increase fontsize in inheritance graphs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -366,6 +366,8 @@ latex_elements = {
 
 html4_writer = True
 
+inheritance_node_attrs = dict(fontsize=16)
+
 
 def setup(app):
     if any(st in version for st in ('post', 'alpha', 'beta')):


### PR DESCRIPTION
This closes #15109.

The diagram in question goes from (click on images to see actual size in sphinx, the Github PR view rescales them)
![inheritance-baace9733e25a3aea26ce118da06767ea5ea372e](https://user-images.githubusercontent.com/1187292/66326310-064ab100-e929-11e9-8926-0fa2d48e3863.png)
to
![inheritance-84ea9a23f67b6f8091bb1887c23eb7780337cb16](https://user-images.githubusercontent.com/1187292/66326351-195d8100-e929-11e9-8e86-eeeff72cce78.png)
which isn't ideal, but the best I achieved given the width constraints.