### PR TITLE
Autoscale for ax.arrow()

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -129,3 +129,7 @@ Shortcuts for closing all figures now also work for the classic toolbar.
 There is no default shortcut any more because unintentionally closing all figures by a key press
 might happen too easily. You can configure the shortcut yourself
 using :rc:`keymap.quit_all`.
+
+Autoscale for arrow
+~~~~~~~~~~~~~~~~~~~
+Calling ax.arrow() will now autoscale the axes.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4959,7 +4959,8 @@ default: :rc:`scatter.edgecolors`
         dy = self.convert_yunits(dy)
 
         a = mpatches.FancyArrow(x, y, dx, dy, **kwargs)
-        self.add_artist(a)
+        self.add_patch(a)
+        self._request_autoscale_view()
         return a
 
     @docstring.copy(mquiver.QuiverKey.__init__)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -468,6 +468,13 @@ def test_arrow_empty():
     ax.arrow(0, 0, 0, 0, head_length=0)
 
 
+def test_arrow_in_view():
+    _, ax = plt.subplots()
+    ax.arrow(1, 1, 1, 1)
+    assert ax.get_xlim() == (0.8, 2.2)
+    assert ax.get_ylim() == (0.8, 2.2)
+
+
 def test_annotate_default_arrow():
     # Check that we can make an annotation arrow with only default properties.
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary
When ax.arrow() is called, a FancyArrow object is being added to the current axes as an artist and not a patch. So when autoscale_view is called, which loops through all Patches and scales the view based on the minimum and maximum of those, the FancyArrow isn't being considered.
The solution is a two-step process. First, we have to add the arrow as a Patch, and second, we have to lazily call autoscale_view() after adding it on the axes.

Part of a course at University of Toronto with @atafliovich.

Resolves #12712
Takes over #13788
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
