### PR TITLE
Deprecate {NonUniformImage,PcolorImage}.is_grayscale.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -16,3 +16,9 @@ logging.
 ``Colorbar.config_axis()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``Colorbar.config_axis()`` is considered internal. Its use is deprecated.
+
+``NonUniformImage.is_grayscale`` and ``PcolorImage.is_grayscale``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These attributes are deprecated, for consistency with ``AxesImage.is_grayscale``,
+which was removed back in Matplotlib 2.0.0.  (Note that previously, these
+attributes were only available *after rendering the image*).

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -982,6 +982,11 @@ class NonUniformImage(AxesImage):
         """Return False. Do not use unsampled image."""
         return False
 
+    @cbook.deprecated("3.3")
+    @property
+    def is_grayscale(self):
+        return self._is_grayscale
+
     def make_image(self, renderer, magnification=1.0, unsampled=False):
         # docstring inherited
         if self._A is None:
@@ -992,11 +997,11 @@ class NonUniformImage(AxesImage):
         if A.ndim == 2:
             if A.dtype != np.uint8:
                 A = self.to_rgba(A, bytes=True)
-                self.is_grayscale = self.cmap.is_gray()
+                self._is_grayscale = self.cmap.is_gray()
             else:
                 A = np.repeat(A[:, :, np.newaxis], 4, 2)
                 A[:, :, 3] = 255
-                self.is_grayscale = True
+                self._is_grayscale = True
         else:
             if A.dtype != np.uint8:
                 A = (255*A).astype(np.uint8)
@@ -1005,7 +1010,7 @@ class NonUniformImage(AxesImage):
                 B[:, :, 0:3] = A
                 B[:, :, 3] = 255
                 A = B
-            self.is_grayscale = False
+            self._is_grayscale = False
         x0, y0, v_width, v_height = self.axes.viewLim.bounds
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
@@ -1115,6 +1120,11 @@ class PcolorImage(AxesImage):
         if A is not None:
             self.set_data(x, y, A)
 
+    @cbook.deprecated("3.3")
+    @property
+    def is_grayscale(self):
+        return self._is_grayscale
+
     def make_image(self, renderer, magnification=1.0, unsampled=False):
         # docstring inherited
         if self._A is None:
@@ -1134,7 +1144,7 @@ class PcolorImage(AxesImage):
             A = self.to_rgba(self._A, bytes=True)
             self._rgbacache = A
             if self._A.ndim == 2:
-                self.is_grayscale = self.cmap.is_gray()
+                self._is_grayscale = self.cmap.is_gray()
         else:
             A = self._rgbacache
         vl = self.axes.viewLim
@@ -1180,12 +1190,12 @@ class PcolorImage(AxesImage):
             raise ValueError("A must be 2D or 3D")
         if A.ndim == 3 and A.shape[2] == 1:
             A.shape = A.shape[:2]
-        self.is_grayscale = False
+        self._is_grayscale = False
         if A.ndim == 3:
             if A.shape[2] in [3, 4]:
                 if ((A[:, :, 0] == A[:, :, 1]).all() and
                         (A[:, :, 0] == A[:, :, 2]).all()):
-                    self.is_grayscale = True
+                    self._is_grayscale = True
             else:
                 raise ValueError("3D arrays must have RGB or RGBA as last dim")
 


### PR DESCRIPTION
See changelog.

(AxesImage.is_grayscale was removed without deprecation in #5718, strongly suggesting that it was intended for internal use in the old image infrastructure; now it's not used at all anymore.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
