### PR TITLE
Added arrowhead positioning options to quiver.

### DIFF
--- a/galleries/examples/images_contours_and_fields/gallery_order.txt
+++ b/galleries/examples/images_contours_and_fields/gallery_order.txt
@@ -47,6 +47,7 @@ contours_in_optimization_demo
 # quiver
 quiver_simple_demo
 quiver_demo
+quiver_head_pos_demo
 
 # barbs and streamlines
 barb_demo

--- a/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
+++ b/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
@@ -1,0 +1,39 @@
+"""
+==============================
+Quiver Arrowhead Position Demo
+==============================
+
+An example of how to add positioning of arrowheads to
+a `~.axes.Axes.quiver` plot, with a `~.axes.Axes.quiverkey`.
+
+For more advanced options refer to
+:doc:`/gallery/images_contours_and_fields/quiver_demo`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+X = np.arange(-10, 10, 2)
+Y = np.arange(-10, 10, 2)
+U, V = np.meshgrid(X, Y)
+
+fig, ax = plt.subplots()
+q = ax.quiver(X, Y, U, V, head_pos=0.5)
+ax.quiverkey(q, X=0.3, Y=1.1, U=10,
+             label='Quiver key, length = 10', labelpos='E')
+
+plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions and methods is shown in this example:
+
+import matplotlib
+matplotlib.axes.Axes.quiver
+matplotlib.pyplot.quiver
+matplotlib.axes.Axes.quiverkey
+matplotlib.pyplot.quiverkey

--- a/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
+++ b/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
@@ -23,17 +23,12 @@ ax.quiverkey(q, X=0.3, Y=1.1, U=10,
 
 plt.show()
 
-#############################################################################
+# %%
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.quiver
-matplotlib.pyplot.quiver
-matplotlib.axes.Axes.quiverkey
-matplotlib.pyplot.quiverkey
+#    - `matplotlib.axes.Axes.quiver` / `matplotlib.pyplot.quiver`
+#    - `matplotlib.axes.Axes.quiverkey` / `matplotlib.pyplot.quiverkey`

--- a/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
+++ b/galleries/examples/images_contours_and_fields/quiver_head_pos_demo.py
@@ -32,3 +32,10 @@ plt.show()
 #
 #    - `matplotlib.axes.Axes.quiver` / `matplotlib.pyplot.quiver`
 #    - `matplotlib.axes.Axes.quiverkey` / `matplotlib.pyplot.quiverkey`
+#
+# .. tags::
+#
+#    component: axes
+#    component: quiver
+#    styling: position
+#    level: beginner

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -48,6 +48,15 @@ To change this behavior see the *scale* and *scale_units* parameters.
 The arrow shape is determined by *width*, *headwidth*, *headlength* and
 *headaxislength*. See the notes below.
 
+The defaults give a slightly swept-back arrow; to make the head a
+triangle, make *headaxislength* the same as *headlength*. To make the
+arrow more pointed, reduce *headwidth* or increase *headlength* and
+*headaxislength*. To make the head smaller relative to the shaft,
+scale down all the head parameters. You will probably do best to leave
+minshaft alone. To set the position of the arrowhead use *head_pos*.
+
+# TODO MELISSA and to exactly position the head on the shaft use *mid_scale*.
+
 **Arrow styling**
 
 Each arrow is internally represented by a filled polygon with a default edge
@@ -220,6 +229,18 @@ minshaft : float, default: 1
 minlength : float, default: 1
     Minimum length as a multiple of shaft width; if an arrow length
     is less than this, plot a dot (hexagon) of this diameter instead.
+
+pivot : {'tail', 'mid', 'middle', 'tip'}, default: 'tail'
+    The part of the arrow that is anchored to the *X*, *Y* grid. The arrow
+    rotates about this point.
+
+    'mid' is a synonym for 'middle'.
+
+head_pos : {'tip', 'mid', 'middle', 'tail'}, or float, default: 'tip'
+    The position of the arrowhead along the shaft.
+    'tail' gives value 0.0, 'tip' gives value 1.0,
+    'mid' synonymous to 'middle' gives value 0.5.
+    If a float is specified, it must be between 0.0 and 1.0.
 
 color : :mpltype:`color` or list :mpltype:`color`, optional
     Explicit color(s) for the arrows. If *C* has been set, *color* has no
@@ -517,7 +538,8 @@ class Quiver(mcollections.PolyCollection):
     def __init__(self, ax, *args,
                  scale=None, headwidth=3, headlength=5, headaxislength=4.5,
                  minshaft=1, minlength=1, units='width', scale_units=None,
-                 angles='uv', width=None, color='k', pivot='tail', **kwargs):
+                 angles='uv', width=None, color='k', pivot='tail',
+                 head_pos='tip', **kw):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -540,6 +562,25 @@ class Quiver(mcollections.PolyCollection):
         self.scale_units = scale_units
         self.angles = angles
         self.width = width
+
+        # Checks the boundaries of head_pos if outside range default of 0.5
+        if (head_pos == 0.0) or (head_pos == "tail"):
+            self.head_pos = 0.0
+        elif (head_pos == 1.0) or (head_pos == "tip"):
+            self.head_pos = 1.0
+        elif (head_pos == "mid") or (head_pos == "middle"):
+            self.head_pos = 0.5
+        elif type(head_pos) == float:
+            if 0.0 < head_pos < 1.0:
+                self.head_pos = head_pos
+            else:
+                raise ValueError("'head_pos' must be "
+                                 "a value in the bounds 0<head_pos<1,"
+                                 "or a string in {'tail', 'middle', 'tip'}")
+        else:
+            raise ValueError("'head_pos' must be "
+                             "a value in the bounds 0head_pos<1,"
+                             "or a string in {'tail', 'middle', 'tip'}")
 
         if pivot.lower() == 'mid':
             pivot = 'middle'
@@ -732,26 +773,54 @@ class Quiver(mcollections.PolyCollection):
         np.clip(length, 0, 2 ** 16, out=length)
         # x, y: normal horizontal arrow
         x = np.array([0, -self.headaxislength,
-                      -self.headlength, 0],
+                      -self.headlength, 0, 0],
                      np.float64)
-        x = x + np.array([0, 1, 1, 1]) * length
-        y = 0.5 * np.array([1, 1, self.headwidth, 0], np.float64)
+        x = x + np.array([0, 1, 1, 1, 1]) * length
+        y = 0.5 * np.array([1, 1, self.headwidth, 0, 1], np.float64)
         y = np.repeat(y[np.newaxis, :], N, axis=0)
         # x0, y0: arrow without shaft, for short vectors
         x0 = np.array([0, minsh - self.headaxislength,
                        minsh - self.headlength, minsh], np.float64)
         y0 = 0.5 * np.array([1, 1, self.headwidth, 0], np.float64)
-        ii = [0, 1, 2, 3, 2, 1, 0, 0]
-        X = x[:, ii]
-        Y = y[:, ii]
-        Y[:, 3:-1] *= -1
-        X0 = x0[ii]
-        Y0 = y0[ii]
+        if self.head_pos == 1.0:
+            ii = [0, 1, 2, 3, 2, 1, 0, 0]
+            ii_min = [0, 1, 2, 3, 2, 1, 0, 0]
+            X = x[:, ii]
+            Y = y[:, ii]
+            Y[:, 3:-1] *= -1
+        elif self.head_pos == 0.0:
+            ii = [0, 2, 3, 4, 4, 3, 2, 0, 0]
+            ii_min = [0, 1, 2, 3, 2, 1, 0, 0, 0]
+            X = x[:, ii]
+            Y = y[:, ii]
+            X[:, 1:3] -= (length-self.headlength)
+            X[:, 5:-2] -= (length-self.headlength)
+            Y[:, 2] = np.ones(np.shape(Y[:, 2])) * 0.5
+            Y[:, 5] = np.ones(np.shape(Y[:, 5])) * 0.5
+            Y[:, 4:-1] *= -1
+        elif 0.0 < self.head_pos < 1.0:
+            ii = [0, 1, 2, 3, 4, 4, 3, 2, 1, 0, 0]
+            ii_min = [0, 1, 2, 3, 2, 1, 0, 0, 0, 0, 0]
+            X = x[:, ii]
+            Y = y[:, ii]
+            X[:, 1:4] *= self.head_pos
+            X[:, 6:-2] *= self.head_pos
+            X[:, 1:4] += self.headlength / 4
+            X[:, 6:-2] += self.headlength / 4
+            Y[:, 3] = np.ones(np.shape(Y[:, 3])) * 0.5
+            Y[:, 6] = np.ones(np.shape(Y[:, 6])) * 0.5
+            Y[:, 5:-1] *= -1
+        else:
+            raise ValueError("'head_pos' must be "
+                             "a value in the bounds 0<head_pos<1,"
+                             "or a string in {'tail', 'middle', 'tip'}")
+        X0 = x0[ii_min]
+        Y0 = y0[ii_min]
         Y0[3:-1] *= -1
         shrink = length / minsh if minsh != 0. else 0.
         X0 = shrink * X0[np.newaxis, :]
         Y0 = shrink * Y0[np.newaxis, :]
-        short = np.repeat(length < minsh, 8, axis=1)
+        short = np.repeat(length < minsh, len(ii_min), axis=1)
         # Now select X0, Y0 if short, otherwise X, Y
         np.copyto(X, X0, where=short)
         np.copyto(Y, Y0, where=short)
@@ -767,12 +836,12 @@ class Quiver(mcollections.PolyCollection):
         tooshort = length < self.minlength
         if tooshort.any():
             # Use a heptagonal dot:
-            th = np.arange(0, 8, 1, np.float64) * (np.pi / 3.0)
+            th = np.arange(0, len(ii_min), 1, np.float64) * (np.pi / 3.0)
             x1 = np.cos(th) * self.minlength * 0.5
             y1 = np.sin(th) * self.minlength * 0.5
             X1 = np.repeat(x1[np.newaxis, :], N, axis=0)
             Y1 = np.repeat(y1[np.newaxis, :], N, axis=0)
-            tooshort = np.repeat(tooshort, 8, 1)
+            tooshort = np.repeat(tooshort, len(ii_min), 1)
             np.copyto(X, X1, where=tooshort)
             np.copyto(Y, Y1, where=tooshort)
         # Mask handling is deferred to the caller, _make_verts.

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -55,8 +55,6 @@ arrow more pointed, reduce *headwidth* or increase *headlength* and
 scale down all the head parameters. You will probably do best to leave
 minshaft alone. To set the position of the arrowhead use *head_pos*.
 
-# TODO MELISSA and to exactly position the head on the shaft use *mid_scale*.
-
 **Arrow styling**
 
 Each arrow is internally represented by a filled polygon with a default edge
@@ -96,7 +94,7 @@ C : 1D or 2D array-like, optional
 angles : {'uv', 'xy'} or array-like, default: 'uv'
     Method for determining the angle of the arrows.
 
-    - 'uv':  Arrow directions are based on
+    - 'uv': Arrow directions are based on
       :ref:`display coordinates <coordinate-systems>`; i.e. a 45° angle will
       always show up as diagonal on the screen, irrespective of figure or Axes
       aspect ratio or Axes data ranges. This is useful when the arrows represent
@@ -539,7 +537,7 @@ class Quiver(mcollections.PolyCollection):
                  scale=None, headwidth=3, headlength=5, headaxislength=4.5,
                  minshaft=1, minlength=1, units='width', scale_units=None,
                  angles='uv', width=None, color='k', pivot='tail',
-                 head_pos='tip', **kw):
+                 head_pos='tip', **kwargs):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -564,22 +562,17 @@ class Quiver(mcollections.PolyCollection):
         self.width = width
 
         # Checks the boundaries of head_pos if outside range default of 0.5
-        if (head_pos == 0.0) or (head_pos == "tail"):
+        if (head_pos == "tail"):
             self.head_pos = 0.0
-        elif (head_pos == 1.0) or (head_pos == "tip"):
+        elif (head_pos == "tip"):
             self.head_pos = 1.0
         elif (head_pos == "mid") or (head_pos == "middle"):
             self.head_pos = 0.5
-        elif type(head_pos) == float:
-            if 0.0 < head_pos < 1.0:
-                self.head_pos = head_pos
-            else:
-                raise ValueError("'head_pos' must be "
-                                 "a value in the bounds 0<head_pos<1,"
-                                 "or a string in {'tail', 'middle', 'tip'}")
+        elif isinstance(head_pos, float) and (0.0 < head_pos < 1.0):
+            self.head_pos = head_pos
         else:
             raise ValueError("'head_pos' must be "
-                             "a value in the bounds 0head_pos<1,"
+                             "a value in the bounds 0<head_pos<1,"
                              "or a string in {'tail', 'middle', 'tip'}")
 
         if pivot.lower() == 'mid':
@@ -810,10 +803,7 @@ class Quiver(mcollections.PolyCollection):
             Y[:, 3] = np.ones(np.shape(Y[:, 3])) * 0.5
             Y[:, 6] = np.ones(np.shape(Y[:, 6])) * 0.5
             Y[:, 5:-1] *= -1
-        else:
-            raise ValueError("'head_pos' must be "
-                             "a value in the bounds 0<head_pos<1,"
-                             "or a string in {'tail', 'middle', 'tip'}")
+
         X0 = x0[ii_min]
         Y0 = y0[ii_min]
         Y0[3:-1] *= -1

--- a/lib/matplotlib/quiver.pyi
+++ b/lib/matplotlib/quiver.pyi
@@ -100,6 +100,7 @@ class Quiver(mcollections.PolyCollection):
         width: float | None = ...,
         color: ColorType | Sequence[ColorType] = ...,
         pivot: Literal["tail", "mid", "middle", "tip"] = ...,
+        head_pos: Literal["tail", "mid", "middle", "tip"] | float = ...,
         **kwargs
     ) -> None: ...
     @overload
@@ -125,7 +126,8 @@ class Quiver(mcollections.PolyCollection):
         width: float | None = ...,
         color: ColorType | Sequence[ColorType] = ...,
         pivot: Literal["tail", "mid", "middle", "tip"] = ...,
-        **kwargs
+        head_pos: Literal["tail", "mid", "middle", "tip"] | float = ...,
+        **kwargs,
     ) -> None: ...
     def get_datalim(self, transData: Transform) -> Bbox: ...
     def set_UVC(


### PR DESCRIPTION
## PR Summary

the optional keywords 'head_pos' has been added to quiver. 'head_pos' can put the arrowhead at the tip tail or middle of the arrow shaft dictated by keywords matching 'pivot', or be passed a float in range 0-1 to specify the exact location on the arrow shaft.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
