### PR TITLE
Fix DeprecationWarning in nightly testing

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3112,7 +3112,8 @@ class _AxesBase(martist.Artist):
         if upper is None:
             upper = old_upper
 
-        self.set_xlim(sorted((lower, upper), reverse=self.xaxis_inverted()),
+        self.set_xlim(sorted((lower, upper),
+                             reverse=bool(self.xaxis_inverted())),
                       auto=None)
 
     def get_xlim(self):
@@ -3511,7 +3512,8 @@ class _AxesBase(martist.Artist):
         if upper is None:
             upper = old_upper
 
-        self.set_ylim(sorted((lower, upper), reverse=self.yaxis_inverted()),
+        self.set_ylim(sorted((lower, upper),
+                             reverse=bool(self.yaxis_inverted())),
                       auto=None)
 
     def get_ylim(self):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1389,7 +1389,8 @@ class Axes3D(Axes):
         if upper is None:
             upper = old_upper
 
-        self.set_zlim(sorted((lower, upper), reverse=self.zaxis_inverted()),
+        self.set_zlim(sorted((lower, upper),
+                             reverse=bool(self.zaxis_inverted())),
                       auto=None)
 
     def text(self, x, y, z, s, zdir=None, **kwargs):


### PR DESCRIPTION
Carrying on from https://github.com/matplotlib/matplotlib/pull/15168, there's a couple of other places where `np.bool_` needs casting to `bool` to prevent a DeprecationWarning.