### PR TITLE
catch OSError instead of FileNotFoundError in _get_executable_info to resolve #15399

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -337,8 +337,8 @@ def _get_executable_info(name):
                 output = _cpe.output
             else:
                 raise ExecutableNotFoundError(str(_cpe)) from _cpe
-        except FileNotFoundError as _fnf:
-            raise ExecutableNotFoundError(str(_fnf)) from _fnf
+        except OSError as _ose:
+            raise ExecutableNotFoundError(str(_ose)) from _ose
         match = re.search(regex, output)
         if match:
             version = LooseVersion(match.group(1))

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -723,8 +723,9 @@ class ImageMagickBase:
     def isAvailable(cls):
         try:
             return super().isAvailable()
-        except mpl.ExecutableNotFoundError:
+        except mpl.ExecutableNotFoundError as _enf:
             # May be raised by get_executable_info.
+            _log.debug('ImageMagick unavailable due to: %s', _enf)
             return False
 
 


### PR DESCRIPTION
## PR Summary

While finding available movie writers, if the executable is presented but
cannot be run, the import process will fail upon calling '_get_executable_info'
since it only handled CalledProcessError and FileNotFoundError.

In this commit, we catch OSError instead of FileNotFoundError in '\_\_init__.py'
and log the error message in 'animation.py' to improve the import robustness.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
