### PR TITLE
Separate plots using #### in demo_fixed_size_axes.py

### DIFF
--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -11,6 +11,7 @@ from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
 ###############################################################################
 
+
 def demo_fixed_size_axes():
     fig = plt.figure(figsize=(6, 6))
 
@@ -32,6 +33,7 @@ def demo_fixed_size_axes():
 demo_fixed_size_axes()
 
 ###############################################################################
+
 
 def demo_fixed_pad_axes():
     fig = plt.figure(figsize=(6, 6))

--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import Divider, Size
 from mpl_toolkits.axes_grid1.mpl_axes import Axes
 
+###############################################################################
 
 def demo_fixed_size_axes():
     fig = plt.figure(figsize=(6, 6))
@@ -28,6 +29,9 @@ def demo_fixed_size_axes():
 
     ax.plot([1, 2, 3])
 
+demo_fixed_size_axes()
+
+###############################################################################
 
 def demo_fixed_pad_axes():
     fig = plt.figure(figsize=(6, 6))
@@ -47,9 +51,4 @@ def demo_fixed_pad_axes():
 
     ax.plot([1, 2, 3])
 
-
-if __name__ == "__main__":
-    demo_fixed_size_axes()
-    demo_fixed_pad_axes()
-
-    plt.show()
+demo_fixed_pad_axes()

--- a/examples/axes_grid1/demo_fixed_size_axes.py
+++ b/examples/axes_grid1/demo_fixed_size_axes.py
@@ -12,45 +12,39 @@ from mpl_toolkits.axes_grid1.mpl_axes import Axes
 ###############################################################################
 
 
-def demo_fixed_size_axes():
-    fig = plt.figure(figsize=(6, 6))
+fig = plt.figure(figsize=(6, 6))
 
-    # The first items are for padding and the second items are for the axes.
-    # sizes are in inch.
-    h = [Size.Fixed(1.0), Size.Fixed(4.5)]
-    v = [Size.Fixed(0.7), Size.Fixed(5.)]
+# The first items are for padding and the second items are for the axes.
+# sizes are in inch.
+h = [Size.Fixed(1.0), Size.Fixed(4.5)]
+v = [Size.Fixed(0.7), Size.Fixed(5.)]
 
-    divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
-    # the width and height of the rectangle is ignored.
+divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
+# the width and height of the rectangle is ignored.
 
-    ax = Axes(fig, divider.get_position())
-    ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
+ax = Axes(fig, divider.get_position())
+ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
 
-    fig.add_axes(ax)
+fig.add_axes(ax)
 
-    ax.plot([1, 2, 3])
-
-demo_fixed_size_axes()
+ax.plot([1, 2, 3])
 
 ###############################################################################
 
 
-def demo_fixed_pad_axes():
-    fig = plt.figure(figsize=(6, 6))
+fig = plt.figure(figsize=(6, 6))
 
-    # The first & third items are for padding and the second items are for the
-    # axes. Sizes are in inches.
-    h = [Size.Fixed(1.0), Size.Scaled(1.), Size.Fixed(.2)]
-    v = [Size.Fixed(0.7), Size.Scaled(1.), Size.Fixed(.5)]
+# The first & third items are for padding and the second items are for the
+# axes. Sizes are in inches.
+h = [Size.Fixed(1.0), Size.Scaled(1.), Size.Fixed(.2)]
+v = [Size.Fixed(0.7), Size.Scaled(1.), Size.Fixed(.5)]
 
-    divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
-    # the width and height of the rectangle is ignored.
+divider = Divider(fig, (0.0, 0.0, 1., 1.), h, v, aspect=False)
+# the width and height of the rectangle is ignored.
 
-    ax = Axes(fig, divider.get_position())
-    ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
+ax = Axes(fig, divider.get_position())
+ax.set_axes_locator(divider.new_locator(nx=1, ny=1))
 
-    fig.add_axes(ax)
+fig.add_axes(ax)
 
-    ax.plot([1, 2, 3])
-
-demo_fixed_pad_axes()
+ax.plot([1, 2, 3])


### PR DESCRIPTION
## PR Summary

Separate plots using `#########` lines for Sphinx-gallery to render plots in sections.
Part of #8922.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
