### PR TITLE
Fix OSX build on azure

### DIFF
--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -28,7 +28,8 @@ steps:
 
 - ${{ if eq(parameters.installer, 'brew') }}:
   - script: |
-      brew install pkg-config ffmpeg imagemagick mplayer ccache xquartz
+      brew cask install xquartz
+      brew install pkg-config ffmpeg imagemagick mplayer ccache
     displayName: 'Install dependencies with brew'
 
 - ${{ if eq(parameters.installer, 'apt') }}:

--- a/ci/azure-pipelines-steps.yml
+++ b/ci/azure-pipelines-steps.yml
@@ -28,7 +28,7 @@ steps:
 
 - ${{ if eq(parameters.installer, 'brew') }}:
   - script: |
-      brew install pkg-config ffmpeg imagemagick mplayer ccache
+      brew install pkg-config ffmpeg imagemagick mplayer ccache xquartz
     displayName: 'Install dependencies with brew'
 
 - ${{ if eq(parameters.installer, 'apt') }}:


### PR DESCRIPTION
## PR Summary

Current OSX pipeline fails with

~~~
🍺  /usr/local/Cellar/imagemagick/7.0.8-68: 1,479 files, 23.5MB
imlib2: XQuartz 2.7.11 (or newer) is required to install this formula. X11Requirement unsatisfied!
You can install with Homebrew Cask:
  brew cask install xquartz
You can download from:
  https://xquartz.macosforge.org
Error: An unsatisfied requirement failed this build.
##[error]Bash exited with code '1'.
~~~

This is an attempt to fix that. Not sure it will work, but let's see what Azure thinks.