### PR TITLE
Change the description of Rectangle's xy parameter

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -707,7 +707,7 @@ class Rectangle(Patch):
         Parameters
         ----------
         xy : (float, float)
-            The starting coordinates. For most data plotting functions, it is (left, bottom). For imshow(), it is (left, top).
+            The starting coordinates
         width : float
             Rectangle width
         height : float

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -707,7 +707,7 @@ class Rectangle(Patch):
         Parameters
         ----------
         xy : (float, float)
-            The bottom and left rectangle coordinates
+            The starting coordinates. For most data plotting functions, it is (left, bottom). For imshow(), it is (left, top).
         width : float
             Rectangle width
         height : float


### PR DESCRIPTION
matplotlib.patches.Rectangle's first parameter, xy, is previously only documented for data plotting functions in which xy means left and bottom coordinates. However, in imshow(), the vertical axis's direction is inverted, and xy means left and top coordinates. See https://github.com/matplotlib/matplotlib/issues/15401.

In this PR, a fix is made to explain xy as starting coordinates so as to make it suitable for both cases.