### PR TITLE
In imsave, let pnginfo have precedence over metadata.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1539,13 +1539,16 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
             pil_shape = (rgba.shape[1], rgba.shape[0])
             image = Image.frombuffer(
                 "RGBA", pil_shape, rgba, "raw", "RGBA", 0, 1)
-            if (format == "png"
-                    and metadata is not None and "pnginfo" not in pil_kwargs):
+            if format == "png" and metadata:
                 # cf. backend_agg's print_png.
-                pnginfo = PngInfo()
-                for k, v in metadata.items():
-                    pnginfo.add_text(k, v)
-                pil_kwargs["pnginfo"] = pnginfo
+                if "pnginfo" in pil_kwargs:
+                    cbook._warn_external("'metadata' is overridden by the "
+                                         "'pnginfo' entry in 'pil_kwargs'.")
+                else:
+                    pnginfo = PngInfo()
+                    for k, v in metadata.items():
+                        pnginfo.add_text(k, v)
+                    pil_kwargs["pnginfo"] = pnginfo
             if format in ["jpg", "jpeg"]:
                 format = "jpeg"  # Pillow doesn't recognize "jpg".
                 color = tuple(

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1539,7 +1539,8 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
             pil_shape = (rgba.shape[1], rgba.shape[0])
             image = Image.frombuffer(
                 "RGBA", pil_shape, rgba, "raw", "RGBA", 0, 1)
-            if format == "png" and metadata is not None:
+            if (format == "png"
+                    and metadata is not None and "pnginfo" not in pil_kwargs):
                 # cf. backend_agg's print_png.
                 pnginfo = PngInfo()
                 for k, v in metadata.items():


### PR DESCRIPTION
This is consistent with the documented behavior ("If the 'pnginfo' key
is present, it completely overrides *metadata*, including the default
'Software' key.") and also with the behavior of
FigureCanvasAgg.print_png, cf https://github.com/matplotlib/matplotlib/blob/c9f292f650f3a72d3c1a68e5d183b28f8985d6e2/lib/matplotlib/backends/backend_agg.py#L522-L524

The feature came in in #13902 which is not in any released version so far, so it would be nice if this was fixed before the final 3.2 release.  I will prepare a separate PR for master.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
