### PR TITLE
Allow imshow from float16 data

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -425,8 +425,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                         # cast float16 up into float32
                         if A.dtype == np.float16:
                             scaled_dtype = np.float32
-                        # cast float128 down into float64
-                        elif A.dtype == np.float128:
+                        # cast large floats down into float64
+                        else:
                             scaled_dtype = np.float64
 
                         # warn when casting floats

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -420,7 +420,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     a_min, a_max = np.int32(0), np.int32(1)
                 if inp_dtype.kind == 'f':
                     scaled_dtype = A.dtype
-                    # Cast usupported dtypes to nearest supported float depth
+                    # Cast unsupported dtypes to nearest supported float depth
                     if A.dtype not in (np.float64, np.float32):
                         # cast float16 up into float32
                         if A.dtype == np.float16:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -420,13 +420,19 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                     a_min, a_max = np.int32(0), np.int32(1)
                 if inp_dtype.kind == 'f':
                     scaled_dtype = A.dtype
-                    # Cast to float64
-                    if A.dtype not in (np.float64, np.float32, np.float16):
-                        # warn if decreasing float precision
+                    # Cast usupported dtypes to nearest supported float depth
+                    if A.dtype not in (np.float64, np.float32):
+                        # cast float16 up into float32
+                        if A.dtype == np.float16:
+                            scaled_dtype = np.float32
+                        # cast float128 down into float64
+                        elif A.dtype == np.float128:
+                            scaled_dtype = np.float64
+
+                        # warn when casting floats
                         cbook._warn_external(
                             f"Casting input data from '{A.dtype}' to "
-                            f"'float64' for imshow")
-                    scaled_dtype = np.float64
+                            f"'{scaled_dtype.__name__}' for imshow")
                 else:
                     # probably an integer of some type.
                     da = a_max.astype(np.float64) - a_min.astype(np.float64)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -421,12 +421,12 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 if inp_dtype.kind == 'f':
                     scaled_dtype = A.dtype
                     # Cast to float64
-                    if A.dtype not in (np.float32, np.float16):
-                        if A.dtype != np.float64:
-                            cbook._warn_external(
-                                f"Casting input data from '{A.dtype}' to "
-                                f"'float64' for imshow")
-                        scaled_dtype = np.float64
+                    if A.dtype not in (np.float64, np.float32, np.float16):
+                        # warn if decreasing float precision
+                        cbook._warn_external(
+                            f"Casting input data from '{A.dtype}' to "
+                            f"'float64' for imshow")
+                    scaled_dtype = np.float64
                 else:
                     # probably an integer of some type.
                     da = a_max.astype(np.float64) - a_min.astype(np.float64)


### PR DESCRIPTION
Removes ValueError "dtype not supported" error when plotting data with dtype float16 ( Fixes #15432 ). This casts everything into dtype float64. Casting is done silently when upscaling precision and with a warning when precision will be decreased. 