### PR TITLE
Use rcParams to control default "raise window" behavior (Qt,Gtk,Tk,Wx)

### DIFF
--- a/doc/users/next_whats_new/2019-10-18_rcParams-for-raise-window-behavior.rst
+++ b/doc/users/next_whats_new/2019-10-18_rcParams-for-raise-window-behavior.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+rcParams for controlling default "raise window" behavior
+--------------------------------------------------------
+The new config option ``rcParams['figure.raise_window']`` allows to disable
+raising the plot window when calling ``plt.show`` or ``plt.pause`` methods.
+

--- a/doc/users/next_whats_new/2019-10-18_rcParams-for-raise-window-behavior.rst
+++ b/doc/users/next_whats_new/2019-10-18_rcParams-for-raise-window-behavior.rst
@@ -4,4 +4,5 @@ rcParams for controlling default "raise window" behavior
 --------------------------------------------------------
 The new config option ``rcParams['figure.raise_window']`` allows to disable
 raising the plot window when calling ``plt.show`` or ``plt.pause`` methods.
+``MacOSX`` backend is currently not supported.
 

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -475,9 +475,9 @@ class FigureManagerTk(FigureManagerBase):
                 self.window.deiconify()
             else:
                 self.canvas.draw_idle()
-            # Raise the new window.
-            self.canvas.manager.window.attributes('-topmost', 1)
-            self.canvas.manager.window.attributes('-topmost', 0)
+            if matplotlib.rcParams['figure.raise_window']:
+                self.canvas.manager.window.attributes('-topmost', 1)
+                self.canvas.manager.window.attributes('-topmost', 0)
             self._shown = True
 
     def destroy(self, *args):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -411,7 +411,9 @@ class FigureManagerGTK3(FigureManagerBase):
     def show(self):
         # show the figure window
         self.window.show()
-        self.window.present()
+        self.canvas.draw()
+        if matplotlib.rcParams['figure.raise_window']:
+            self.window.present()
 
     def full_screen_toggle(self):
         self._full_screen_flag = not self._full_screen_flag

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -628,8 +628,9 @@ class FigureManagerQT(FigureManagerBase):
 
     def show(self):
         self.window.show()
-        self.window.activateWindow()
-        self.window.raise_()
+        if matplotlib.rcParams['figure.raise_window']:
+            self.window.activateWindow()
+            self.window.raise_()
 
     def destroy(self, *args):
         # check for qApp first, as PySide deletes it in its atexit handler

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1139,6 +1139,8 @@ class FigureManagerWx(FigureManagerBase):
     def show(self):
         self.frame.Show()
         self.canvas.draw()
+        if matplotlib.rcParams['figure.raise_window']:
+            self.frame.Raise()
 
     def destroy(self, *args):
         _log.debug("%s - destroy()", type(self))

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1348,6 +1348,7 @@ defaultParams = {
     'figure.frameon':    [True, validate_bool],
     'figure.autolayout': [False, validate_bool],
     'figure.max_open_warning': [20, validate_int],
+    'figure.raise_window': [True, validate_bool],
 
     'figure.subplot.left': [0.125, _range_validators["0 <= x <= 1"]],
     'figure.subplot.right': [0.9, _range_validators["0 <= x <= 1"]],

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -38,7 +38,8 @@ STYLE_BLACKLIST = {
     'interactive', 'backend', 'backend.qt4', 'webagg.port', 'webagg.address',
     'webagg.port_retries', 'webagg.open_in_browser', 'backend_fallback',
     'toolbar', 'timezone', 'datapath', 'figure.max_open_warning',
-    'savefig.directory', 'tk.window_focus', 'docstring.hardcopy'}
+    'figure.raise_window', 'savefig.directory', 'tk.window_focus',
+    'docstring.hardcopy'}
 
 
 def _remove_blacklisted_style_params(d, warn=True):

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -533,6 +533,7 @@
 #figure.max_open_warning : 20   ## The maximum number of figures to open through
                                 ## the pyplot interface before emitting a warning.
                                 ## If less than one this feature is disabled.
+#figure.raise_window : True     ## Raise the GUI window to front when show() is called
 
 ## The figure subplot parameters.  All dimensions are a fraction of the figure width and height.
 #figure.subplot.left   : 0.125  ## the left side of the subplots of the figure


### PR DESCRIPTION
## PR Summary

Address Issue #8692

A new rcParms entry have been added: "figure.raise_window"
Now it is possible to disable the default "raise GUI window" behavior
This change apply to & tested on Qt4, Qt5, Gtk3, Tk and Wx backends (OS: CentOS7, Win7)
Has document it in the 'whats new' section

Known Issue:
~~Gtk3 have to use a small trick to force the screen update, better solutions welcome~~
Qt4 "raise window" pop-out "Figure is ready", have to click the notification manually

Side Note:
Wx backend didn't implement the "raise window" behavior before
Don't have a Mac to work on macosx backend
Manually tested with the attached python script

[test_raise_window.txt](https://github.com/matplotlib/matplotlib/files/3744821/test_raise_window.txt)

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way



<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
