### PR TITLE
Improve example for tick formatters

### DIFF
--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -3,52 +3,51 @@
 Tick formatters
 ===============
 
-Show the different tick formatters.
+Tick formatters define how the numeric value associated with a tick on an axis
+is formatted as a string.
+
+This example illustrates the usage and effect of the most common formatters.
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 
 
-# Setup a plot such that only the bottom spine is shown
-def setup(ax):
+def setup(ax, title):
+    """Set up common parameters for the Axes in the example."""
+    # only show the bottom spine
+    ax.yaxis.set_major_locator(ticker.NullLocator())
     ax.spines['right'].set_color('none')
     ax.spines['left'].set_color('none')
-    ax.yaxis.set_major_locator(ticker.NullLocator())
     ax.spines['top'].set_color('none')
+
+    # define tick positions
+    ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
+    ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
+
     ax.xaxis.set_ticks_position('bottom')
     ax.tick_params(which='major', width=1.00, length=5)
     ax.tick_params(which='minor', width=0.75, length=2.5, labelsize=10)
     ax.set_xlim(0, 5)
     ax.set_ylim(0, 1)
-    ax.patch.set_alpha(0.0)
+    ax.text(0.0, 0.2, title, transform=ax.transAxes,
+            fontsize=14, fontname='Monospace', color='tab:blue')
 
 
-fig = plt.figure(figsize=(8, 6))
-n = 7
+fig, axs = plt.subplots(7, 1, figsize=(8, 6))
 
 # Null formatter
-ax = fig.add_subplot(n, 1, 1)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(ticker.NullFormatter())
-ax.xaxis.set_minor_formatter(ticker.NullFormatter())
-ax.text(0.0, 0.1, "NullFormatter()", fontsize=16, transform=ax.transAxes)
+setup(axs[0], title="NullFormatter()")
+axs[0].xaxis.set_major_formatter(ticker.NullFormatter())
 
 # Fixed formatter
-ax = fig.add_subplot(n, 1, 2)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.0))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-majors = ["", "0", "1", "2", "3", "4", "5"]
-ax.xaxis.set_major_formatter(ticker.FixedFormatter(majors))
-minors = [""] + ["%.2f" % (x-int(x)) if (x-int(x))
-                 else "" for x in np.arange(0, 5, 0.25)]
-ax.xaxis.set_minor_formatter(ticker.FixedFormatter(minors))
-ax.text(0.0, 0.1, "FixedFormatter(['', '0', '1', ...])",
-        fontsize=15, transform=ax.transAxes)
+setup(axs[1], title="FixedFormatter(['A', 'B', 'C', ...])")
+# FixedFormatter should only be used together with FixedLocator.
+# Otherwise, one cannot be sure where the labels will end up.
+positions = [0, 1, 2, 3, 4, 5]
+labels = ['A', 'B', 'C', 'D', 'E', 'F']
+axs[1].xaxis.set_major_locator(ticker.FixedLocator(positions))
+axs[1].xaxis.set_major_formatter(ticker.FixedFormatter(labels))
 
 
 # FuncFormatter can be used as a decorator
@@ -57,52 +56,24 @@ def major_formatter(x, pos):
     return "[%.2f]" % x
 
 
-ax = fig.add_subplot(n, 1, 3)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(major_formatter)
-ax.text(0.0, 0.1, 'FuncFormatter(lambda x, pos: "[%.2f]" % x)',
-        fontsize=15, transform=ax.transAxes)
-
+setup(axs[2], title='FuncFormatter(lambda x, pos: "[%.2f]" % x)')
+axs[2].xaxis.set_major_formatter(major_formatter)
 
 # FormatStr formatter
-ax = fig.add_subplot(n, 1, 4)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(ticker.FormatStrFormatter(">%d<"))
-ax.text(0.0, 0.1, "FormatStrFormatter('>%d<')",
-        fontsize=15, transform=ax.transAxes)
+setup(axs[3], title="FormatStrFormatter('#%d')")
+axs[3].xaxis.set_major_formatter(ticker.FormatStrFormatter("#%d"))
 
 # Scalar formatter
-ax = fig.add_subplot(n, 1, 5)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.AutoLocator())
-ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
-ax.xaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
-ax.text(0.0, 0.1, "ScalarFormatter()", fontsize=15, transform=ax.transAxes)
+setup(axs[4], title="ScalarFormatter()")
+axs[4].xaxis.set_major_formatter(ticker.ScalarFormatter(useMathText=True))
 
 # StrMethod formatter
-ax = fig.add_subplot(n, 1, 6)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(ticker.StrMethodFormatter("{x}"))
-ax.text(0.0, 0.1, "StrMethodFormatter('{x}')",
-        fontsize=15, transform=ax.transAxes)
+setup(axs[5], title="StrMethodFormatter('{x:.3f}')")
+axs[5].xaxis.set_major_formatter(ticker.StrMethodFormatter("{x:.3f}"))
 
 # Percent formatter
-ax = fig.add_subplot(n, 1, 7)
-setup(ax)
-ax.xaxis.set_major_locator(ticker.MultipleLocator(1.00))
-ax.xaxis.set_minor_locator(ticker.MultipleLocator(0.25))
-ax.xaxis.set_major_formatter(ticker.PercentFormatter(xmax=5))
-ax.text(0.0, 0.1, "PercentFormatter(xmax=5)",
-        fontsize=15, transform=ax.transAxes)
+setup(axs[6], title="PercentFormatter(xmax=5)")
+axs[6].xaxis.set_major_formatter(ticker.PercentFormatter(xmax=5))
 
-# Push the top of the top axes outside the figure because we only show the
-# bottom spine.
-fig.subplots_adjust(left=0.05, right=0.95, bottom=0.05, top=1.05)
-
+plt.tight_layout()
 plt.show()


### PR DESCRIPTION
## PR Summary

- Cleanup to make the code more compact and readable.
- Nicer formatting of the titles (color and monospaced font).
- Meaningful summary at the top.
- Changed the strings for  `FormatStrFormatter` and `StrMethodFormatter`.

For comparison:
- [current version](https://matplotlib.org/devdocs/gallery/ticks_and_spines/tick-formatters.html)
- [new version](https://25768-1385122-gh.circle-artifacts.com/0/home/circleci/project/doc/build/html/gallery/ticks_and_spines/tick-formatters.html#sphx-glr-gallery-ticks-and-spines-tick-formatters-py)