### PR TITLE
Fix incorrect value check in axes_grid.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -499,7 +499,7 @@ default: None
         if ngrids is None:
             ngrids = self._nrows * self._ncols
         else:
-            if not 0 <= ngrids < self._nrows * self._ncols:
+            if not 0 < ngrids <= self._nrows * self._ncols:
                 raise Exception
 
         self.ngrids = ngrids

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -102,6 +102,7 @@ def test_axesgrid_colorbar_log_smoketest(legacy_colorbar):
     fig = plt.figure()
     grid = AxesGrid(fig, 111,  # modified to be only subplot
                     nrows_ncols=(1, 1),
+                    ngrids=1,
                     label_mode="L",
                     cbar_location="top",
                     cbar_mode="single",


### PR DESCRIPTION
## PR Summary

The mistake came in at https://github.com/matplotlib/matplotlib/pull/10091/files#diff-3ddd29752271f4c2798bdf132a2b4673L491, sorry about that.
This patch is necessary to make the example at #9778 runnable.
On the other hand I think the fact that this was in in mpl2.2 and 3.0 and 3.1 and no one has complained about it so far says something about the extent to which axes_grid is (un)used...
I guess it would be nice to backport this to 2.2.5 and 3.1.x as well, but again, no one has complained :)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
