### PR TITLE
Fix invalid checks for axes_class parameter in ImageGrid.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -2,7 +2,6 @@ from numbers import Number
 
 import matplotlib as mpl
 from matplotlib import cbook
-import matplotlib.axes as maxes
 import matplotlib.ticker as ticker
 from matplotlib.gridspec import SubplotSpec
 
@@ -191,14 +190,6 @@ default: None
 
         if axes_class is None:
             axes_class = self._defaultAxesClass
-            axes_class_args = {}
-        else:
-            if (isinstance(axes_class, type)
-                    and issubclass(axes_class,
-                                   self._defaultAxesClass.Axes)):
-                axes_class_args = {}
-            else:
-                axes_class, axes_class_args = axes_class
 
         self.axes_all = []
         self.axes_column = [[] for _ in range(self._ncols)]
@@ -246,8 +237,7 @@ default: None
                 else:
                     sharey = None
 
-            ax = axes_class(fig, rect, sharex=sharex, sharey=sharey,
-                            **axes_class_args)
+            ax = axes_class(fig, rect, sharex=sharex, sharey=sharey)
 
             if share_all:
                 if self._refax is None:
@@ -529,12 +519,6 @@ default: None
 
         if axes_class is None:
             axes_class = self._defaultAxesClass
-            axes_class_args = {}
-        else:
-            if isinstance(axes_class, maxes.Axes):
-                axes_class_args = {}
-            else:
-                axes_class, axes_class_args = axes_class
 
         self.axes_all = []
         self.axes_column = [[] for _ in range(self._ncols)]
@@ -581,8 +565,7 @@ default: None
                 sharex = self._column_refax[col]
                 sharey = self._row_refax[row]
 
-            ax = axes_class(fig, rect, sharex=sharex, sharey=sharey,
-                            **axes_class_args)
+            ax = axes_class(fig, rect, sharex=sharex, sharey=sharey)
 
             self.axes_all.append(ax)
             self.axes_column[col].append(ax)


### PR DESCRIPTION
The validation of the axes_class parameter in the Grid and ImageGrid
class have been wrong ever since they were merged in in f44235e
(relevant followup commits: 7482fdc, a5e67b9).

- In Grid, self._defaultAxesClass has never been a class with its own
  .Axes attribute, so the subclass check would fail with an
  AttributeError.
- In ImageGrid, the `isinstance(axes_class, Axes)` check should be
  `issubclass(...)` instead.  (The code later calls `axes_class(...)`
  to build an axes instance so if one really passed an axes instance,
  the call would raise an exception as axes are not callable.)

Fix these checks.  As a consequence, there was no previously valid
path where axes_class_args would have been set, and passing a
`(class, args)` pair is not documented anyways, so drop that
"functionality" (which never worked).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
