### PR TITLE
Validate and simplify set_tick_params(which=...)

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -30,3 +30,9 @@ in that case.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `.axes.Axes.locator_params` used to accept any value for ``axis`` and silently
 did nothing, when passed an unsupported value. It now raises a ``ValueError``.
+
+``Axis.set_tick_params()`` validates ``which`` parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.Axis.set_tick_params` (and the higher level `.axes.Axes.tick_params` and
+`.pyplot.tick_params`) used to accept any value for ``which`` and silently
+did nothing, when passed an unsupported value. It now raises a ``ValueError``.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -888,33 +888,29 @@ class Axis(martist.Artist):
         For documentation of keyword arguments, see
         :meth:`matplotlib.axes.Axes.tick_params`.
         """
-        dicts = []
         cbook._check_in_list(['major', 'minor', 'both'], which=which)
-        if which in ['major', 'both']:
-            dicts.append(self._major_tick_kw)
-        if which in ['minor', 'both']:
-            dicts.append(self._minor_tick_kw)
         kwtrans = self._translate_tick_kw(kw)
 
-        # this stashes the parameter changes so any new ticks will
-        # automatically get them
-        for d in dicts:
-            if reset:
-                d.clear()
-            d.update(kwtrans)
-
+        # the kwargs are stored in self._major/minor_tick_kw so that any
+        # future new ticks will automatically get them
         if reset:
+            if which in ['major', 'both']:
+                self._major_tick_kw.clear()
+                self._major_tick_kw.update(kwtrans)
+            if which in ['minor', 'both']:
+                self._minor_tick_kw.clear()
+                self._minor_tick_kw.update(kwtrans)
             self.reset_ticks()
         else:
-            # apply the new kwargs to the existing ticks
             if which in ['major', 'both']:
+                self._major_tick_kw.update(kwtrans)
                 for tick in self.majorTicks:
                     tick._apply_params(**kwtrans)
             if which in ['minor', 'both']:
+                self._minor_tick_kw.update(kwtrans)
                 for tick in self.minorTicks:
                     tick._apply_params(**kwtrans)
-            # special-case label color to also apply to the offset
-            # text
+            # special-case label color to also apply to the offset text
             if 'labelcolor' in kwtrans:
                 self.offsetText.set_color(kwtrans['labelcolor'])
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -889,9 +889,10 @@ class Axis(martist.Artist):
         :meth:`matplotlib.axes.Axes.tick_params`.
         """
         dicts = []
-        if which == 'major' or which == 'both':
+        cbook._check_in_list(['major', 'minor', 'both'], which=which)
+        if which in ['major', 'both']:
             dicts.append(self._major_tick_kw)
-        if which == 'minor' or which == 'both':
+        if which in ['minor', 'both']:
             dicts.append(self._minor_tick_kw)
         kwtrans = self._translate_tick_kw(kw)
 
@@ -906,10 +907,10 @@ class Axis(martist.Artist):
             self.reset_ticks()
         else:
             # apply the new kwargs to the existing ticks
-            if which == 'major' or which == 'both':
+            if which in ['major', 'both']:
                 for tick in self.majorTicks:
                     tick._apply_params(**kwtrans)
-            if which == 'minor' or which == 'both':
+            if which in ['minor', 'both']:
                 for tick in self.minorTicks:
                     tick._apply_params(**kwtrans)
             # special-case label color to also apply to the offset


### PR DESCRIPTION
## PR Summary

- The first commit adds validation to the the parameter `which` (was accepting any argument and silently doing nothing if it was not in "major", "minor" or "both").
- The second commit reorders the logic so that code paths with and without reset are separated. IMHO this is simpler to understand than before.