### PR TITLE
Validate locator_params(axis=...)

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -5,7 +5,7 @@ Behaviour changes
 ~~~~~~~~~~~~~~~~~~~~~~~
 `.Formatter.fix_minus` now performs hyphen-to-unicode-minus replacement
 whenever :rc:`axes.unicode_minus` is True; i.e. its behavior matches the one
-of ``.ScalarFormatter.fix_minus`` (`.ScalarFormatter` now just inherits that
+of ``ScalarFormatter.fix_minus`` (`.ScalarFormatter` now just inherits that
 implementation).
 
 This replacement is now used by the ``format_data_short`` method of the various
@@ -25,3 +25,8 @@ callbacks when no interactive GUI event loop is running.  If a GUI event loop
 *is* running, `.cbook.CallbackRegistry` still defaults to just printing a
 traceback, as unhandled exceptions can make the program completely ``abort()``
 in that case.
+
+``Axes.locator_params()`` validates ``axis`` parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.axes.Axes.locator_params` used to accept any value for ``axis`` and silently
+did nothing, when passed an unsupported value. It now raises a ``ValueError``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2912,7 +2912,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        axis : {'both', 'x', 'y'}, optional
+        axis : {'both', 'x', 'y'}, default: 'both'
             The axis on which to operate.
 
         tight : bool or None, optional
@@ -2936,13 +2936,15 @@ class _AxesBase(martist.Artist):
             ax.locator_params(tight=True, nbins=4)
 
         """
-        _x = axis in ['x', 'both']
-        _y = axis in ['y', 'both']
-        if _x:
+        cbook._check_in_list(['x', 'y', 'both'], axis=axis)
+        update_x = axis in ['x', 'both']
+        update_y = axis in ['y', 'both']
+        if update_x:
             self.xaxis.get_major_locator().set_params(**kwargs)
-        if _y:
+        if update_y:
             self.yaxis.get_major_locator().set_params(**kwargs)
-        self._request_autoscale_view(tight=tight, scalex=_x, scaley=_y)
+        self._request_autoscale_view(tight=tight,
+                                     scalex=update_x, scaley=update_y)
 
     def tick_params(self, axis='both', **kwargs):
         """Change the appearance of ticks, tick labels, and gridlines.


### PR DESCRIPTION
## PR Summary

*axis* accepted any value and silently did nothing if it was not in 'x', 'y', 'both'.

Also renamed the internal variables `_x -> update_x` for clarity.