### PR TITLE
Make ConciseDateFormatter obey timezone

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -752,7 +752,7 @@ class ConciseDateFormatter(ticker.Formatter):
         return formatter(x, pos=pos)
 
     def format_ticks(self, values):
-        tickdatetime = [num2date(value) for value in values]
+        tickdatetime = [num2date(value, tz=self._tz) for value in values]
         tickdate = np.array([tdt.timetuple()[:6] for tdt in tickdatetime])
 
         # basic algorithm:
@@ -818,7 +818,7 @@ class ConciseDateFormatter(ticker.Formatter):
         return self.offset_string
 
     def format_data_short(self, value):
-        return num2date(value).strftime('%Y-%m-%d %H:%M:%S')
+        return num2date(value, tz=self._tz).strftime('%Y-%m-%d %H:%M:%S')
 
 
 class AutoDateFormatter(ticker.Formatter):

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -527,26 +527,7 @@ def test_concise_formatter_tz():
         return sts, ax.yaxis.get_offset_text().get_text()
 
     d1 = datetime.datetime(1997, 1, 1).replace(tzinfo=datetime.timezone.utc)
-    results = ([datetime.timedelta(weeks=52 * 200),
-                [str(t) for t in range(1980, 2201, 20)],
-                ""
-                ],
-               [datetime.timedelta(weeks=52),
-                ['1997', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
-                'Sep', 'Oct', 'Nov', 'Dec'],
-                "1997"
-                ],
-               [datetime.timedelta(days=141),
-                ['Jan', '22', 'Feb', '22', 'Mar', '22', 'Apr', '22',
-                 'May', '22'],
-                "1997-May"
-                ],
-               [datetime.timedelta(days=40),
-                ['Jan', '05', '09', '13', '17', '21', '25', '29', 'Feb',
-                 '05', '09'],
-                "1997-Feb"
-                ],
-               [datetime.timedelta(hours=40),
+    results = ([datetime.timedelta(hours=40),
                 ['03:00', '07:00', '11:00', '15:00', '19:00', '23:00',
                  '03:00', '07:00', '11:00', '15:00', '19:00'],
                 "1997-Jan-02"

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -511,6 +511,68 @@ def test_concise_formatter():
         assert strings == expected
 
 
+def test_concise_formatter_tz():
+    def _create_auto_date_locator(date1, date2, tz):
+        fig, ax = plt.subplots()
+
+        locator = mdates.AutoDateLocator(interval_multiples=True)
+        formatter = mdates.ConciseDateFormatter(locator, tz=tz)
+        ax.yaxis.set_major_locator(locator)
+        ax.yaxis.set_major_formatter(formatter)
+        ax.set_ylim(date1, date2)
+        fig.canvas.draw()
+        sts = []
+        for st in ax.get_yticklabels():
+            sts += [st.get_text()]
+        return sts, ax.yaxis.get_offset_text().get_text()
+
+    d1 = datetime.datetime(1997, 1, 1).replace(tzinfo=datetime.timezone.utc)
+    results = ([datetime.timedelta(weeks=52 * 200),
+                [str(t) for t in range(1980, 2201, 20)],
+                ""
+                ],
+               [datetime.timedelta(weeks=52),
+                ['1997', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
+                'Sep', 'Oct', 'Nov', 'Dec'],
+                "1997"
+                ],
+               [datetime.timedelta(days=141),
+                ['Jan', '22', 'Feb', '22', 'Mar', '22', 'Apr', '22',
+                 'May', '22'],
+                "1997-May"
+                ],
+               [datetime.timedelta(days=40),
+                ['Jan', '05', '09', '13', '17', '21', '25', '29', 'Feb',
+                 '05', '09'],
+                "1997-Feb"
+                ],
+               [datetime.timedelta(hours=40),
+                ['03:00', '07:00', '11:00', '15:00', '19:00', '23:00',
+                 '03:00', '07:00', '11:00', '15:00', '19:00'],
+                "1997-Jan-02"
+                ],
+               [datetime.timedelta(minutes=20),
+                ['03:00', '03:05', '03:10', '03:15', '03:20'],
+                "1997-Jan-01"
+                ],
+               [datetime.timedelta(seconds=40),
+                ['03:00', '05', '10', '15', '20', '25', '30', '35', '40'],
+                "1997-Jan-01 03:00"
+                ],
+               [datetime.timedelta(seconds=2),
+                ['59.5', '03:00', '00.5', '01.0', '01.5', '02.0', '02.5'],
+                "1997-Jan-01 03:00"
+                ],
+               )
+
+    new_tz = datetime.timezone(datetime.timedelta(hours=3))
+    for t_delta, expected_strings, expected_offset in results:
+        d2 = d1 + t_delta
+        strings, offset = _create_auto_date_locator(d1, d2, new_tz)
+        assert strings == expected_strings
+        assert offset == expected_offset
+
+
 def test_auto_date_locator_intmult_tz():
     def _create_auto_date_locator(date1, date2, tz):
         locator = mdates.AutoDateLocator(interval_multiples=True, tz=tz)


### PR DESCRIPTION
## PR Summary

This is a bugfix PR that addresses #15468 by making `dates.ConciseDateFormatter` obey its given 
timezone inside of `ConciseDateFormatter.format_ticks` and `ConciseDateFormatter.format_data_short`. Prior to this PR, the timezone given to this class' constructor was ignored when formatting the x-axis.

Does this need a test? I haven't looked at the pytest infrastructure.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
