### PR TITLE
Cleanup axes_rgb.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -326,3 +326,10 @@ Support for passing ``None`` as base class to `.axes.subplot_class_factory`,
 ``axes_grid1.parasite_axes.parasite_axes_class_factory``, and
 ``axes_grid1.parasite_axes.parasite_axes_auxtrans_class_factory`` is deprecated.
 Explicitly pass the correct base ``Axes`` class instead.
+
+``axes_rgb``
+~~~~~~~~~~~~
+In :mod:`mpl_toolkits.axes_grid1.axes_rgb`, ``imshow_rgb`` is deprecated (use
+``ax.imshow(np.dstack([r, g, b]))`` instead); ``RGBAxesBase`` is deprecated
+(use ``RGBAxes`` instead); ``RGBAxes.add_RGB_to_figure`` is deprecated (it was
+an internal helper).

--- a/lib/mpl_toolkits/axes_grid/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid/axes_rgb.py
@@ -1,7 +1,1 @@
-from mpl_toolkits.axes_grid1.axes_rgb import (
-    make_rgb_axes, imshow_rgb, RGBAxesBase)
-from mpl_toolkits.axisartist.axislines import Axes
-
-
-class RGBAxes(RGBAxesBase):
-    _defaultAxesClass = Axes
+from mpl_toolkits.axisartist.axes_rgb import *

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -1,10 +1,11 @@
 import numpy as np
 
+from matplotlib import cbook
 from .axes_divider import make_axes_locatable, Size
 from .mpl_axes import Axes
 
 
-def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True):
+def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True, **kwargs):
     """
     Parameters
     ----------
@@ -32,9 +33,8 @@ def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True):
             axes_class = type(ax)
 
     for ny in [4, 2, 0]:
-        ax1 = axes_class(ax.get_figure(),
-                         ax.get_position(original=True),
-                         sharex=ax, sharey=ax)
+        ax1 = axes_class(ax.get_figure(), ax.get_position(original=True),
+                         sharex=ax, sharey=ax, **kwargs)
         locator = divider.new_locator(nx=2, ny=ny)
         ax1.set_axes_locator(locator)
         for t in ax1.yaxis.get_ticklabels() + ax1.xaxis.get_ticklabels():
@@ -55,24 +55,14 @@ def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True):
     return ax_rgb
 
 
+@cbook.deprecated("3.3", alternative="ax.imshow(np.dstack([r, g, b]))")
 def imshow_rgb(ax, r, g, b, **kwargs):
-    ny, nx = r.shape
-    R = np.zeros((ny, nx, 3))
-    R[:, :, 0] = r
-    G = np.zeros_like(R)
-    G[:, :, 1] = g
-    B = np.zeros_like(R)
-    B[:, :, 2] = b
-
-    RGB = R + G + B
-
-    im_rgb = ax.imshow(RGB, **kwargs)
-
-    return im_rgb
+    return ax.imshow(np.dstack([r, g, b]), **kwargs)
 
 
-class RGBAxesBase:
-    """base class for a 4-panel imshow (RGB, R, G, B)
+class RGBAxes:
+    """
+    4-panel imshow (RGB, R, G, B).
 
     Layout:
     +---------------+-----+
@@ -83,20 +73,22 @@ class RGBAxesBase:
     |               |  B  |
     +---------------+-----+
 
+    Subclasses can override the ``_defaultAxesClass`` attribute.
+
     Attributes
     ----------
-    _defaultAxesClass : matplotlib.axes.Axes
-        defaults to 'Axes' in RGBAxes child class.
-        No default in abstract base class
-    RGB : _defaultAxesClass
-        The axes object for the three-channel imshow
-    R : _defaultAxesClass
-        The axes object for the red channel imshow
-    G : _defaultAxesClass
-        The axes object for the green channel imshow
-    B : _defaultAxesClass
-        The axes object for the blue channel imshow
+    RGB : ``_defaultAxesClass``
+        The axes object for the three-channel imshow.
+    R : ``_defaultAxesClass``
+        The axes object for the red channel imshow.
+    G : ``_defaultAxesClass``
+        The axes object for the green channel imshow.
+    B : ``_defaultAxesClass``
+        The axes object for the blue channel imshow.
     """
+
+    _defaultAxesClass = Axes
+
     def __init__(self, *args, pad=0, add_all=True, **kwargs):
         """
         Parameters
@@ -112,47 +104,12 @@ class RGBAxesBase:
         **kwargs
             Unpacked into axes_class() init for RGB, R, G, B axes
         """
-        try:
-            axes_class = kwargs.pop("axes_class", self._defaultAxesClass)
-        except AttributeError as err:
-            raise AttributeError(
-                'A subclass of RGBAxesBase must have a _defaultAxesClass '
-                'attribute. If you are not sure which axes class to use, '
-                'consider using mpl_toolkits.axes_grid1.mpl_axes.Axes.'
-            ) from err
-
-        ax = axes_class(*args, **kwargs)
-
-        divider = make_axes_locatable(ax)
-
-        pad_size = pad * Size.AxesY(ax)
-
-        xsize = ((1-2*pad)/3) * Size.AxesX(ax)
-        ysize = ((1-2*pad)/3) * Size.AxesY(ax)
-
-        divider.set_horizontal([Size.AxesX(ax), pad_size, xsize])
-        divider.set_vertical([ysize, pad_size, ysize, pad_size, ysize])
-
-        ax.set_axes_locator(divider.new_locator(0, 0, ny1=-1))
-
-        ax_rgb = []
-        for ny in [4, 2, 0]:
-            ax1 = axes_class(ax.get_figure(),
-                             ax.get_position(original=True),
-                             sharex=ax, sharey=ax, **kwargs)
-            locator = divider.new_locator(nx=2, ny=ny)
-            ax1.set_axes_locator(locator)
-            ax1.axis[:].toggle(ticklabels=False)
-            ax_rgb.append(ax1)
-
-        self.RGB = ax
-        self.R, self.G, self.B = ax_rgb
-
+        axes_class = kwargs.pop("axes_class", self._defaultAxesClass)
+        self.RGB = ax = axes_class(*args, **kwargs)
         if add_all:
-            fig = ax.get_figure()
-            fig.add_axes(ax)
-            self.add_RGB_to_figure()
-
+            ax.get_figure().add_axes(ax)
+        self.R, self.G, self.B = make_rgb_axes(
+            ax, pad=pad, axes_class=axes_class, add_all=add_all, **kwargs)
         self._config_axes()
 
     def _config_axes(self, line_color='w', marker_edge_color='w'):
@@ -167,6 +124,7 @@ class RGBAxesBase:
             ax1.axis[:].line.set_color(line_color)
             ax1.axis[:].major_ticks.set_markeredgecolor(marker_edge_color)
 
+    @cbook.deprecated("3.3")
     def add_RGB_to_figure(self):
         """Add the red, green and blue axes to the RGB composite's axes figure
         """
@@ -196,11 +154,8 @@ class RGBAxesBase:
         b : matplotlib.image.AxesImage
         """
         if not (r.shape == g.shape == b.shape):
-            raise ValueError('Input shapes do not match.'
-                             '\nr.shape = {}'
-                             '\ng.shape = {}'
-                             '\nb.shape = {}'
-                             .format(r.shape, g.shape, b.shape))
+            raise ValueError(
+                f'Input shapes ({r.shape}, {g.shape}, {b.shape}) do not match')
         RGB = np.dstack([r, g, b])
         R = np.zeros_like(RGB)
         R[:, :, 0] = r
@@ -208,14 +163,13 @@ class RGBAxesBase:
         G[:, :, 1] = g
         B = np.zeros_like(RGB)
         B[:, :, 2] = b
-
         im_rgb = self.RGB.imshow(RGB, **kwargs)
         im_r = self.R.imshow(R, **kwargs)
         im_g = self.G.imshow(G, **kwargs)
         im_b = self.B.imshow(B, **kwargs)
-
         return im_rgb, im_r, im_g, im_b
 
 
-class RGBAxes(RGBAxesBase):
-    _defaultAxesClass = Axes
+@cbook.deprecated("3.3", alternative="RGBAxes")
+class RGBAxesBase(RGBAxes):
+    pass

--- a/lib/mpl_toolkits/axisartist/axes_rgb.py
+++ b/lib/mpl_toolkits/axisartist/axes_rgb.py
@@ -1,8 +1,7 @@
 from mpl_toolkits.axes_grid1.axes_rgb import (
-    make_rgb_axes, imshow_rgb, RGBAxesBase)
-
+    make_rgb_axes, imshow_rgb, RGBAxes as _RGBAxes)
 from .axislines import Axes
 
 
-class RGBAxes(RGBAxesBase):
+class RGBAxes(_RGBAxes):
     _defaultAxesClass = Axes


### PR DESCRIPTION
- `imshow_rgb` is just `imshow` after stacking the r, g, and b channels
  (the docstring of `np.dstack` even explicitly mentions this use).
- RGBAxesBase only differs from RGBAxes by not having a _defaultAxesClass,
  and thus requiring specific handling for catching that case in the
  constructor; simplify this by getting rid of the base class (other
  subclasses of RGBAxes can still override _defaultAxesClass as needed).
- The constructor of `RGBAxes` is duplicated from make_axes_rgb; just
  call the latter instead; this makes add_RGB_to_figure unused so
  deprecate it as well (it's clearly just an internal helper).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
