### PR TITLE
Fix wording in [packages] section of setup.cfg

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -12,8 +12,8 @@
 
 [packages]
 # There are a number of data subpackages from Matplotlib that are
-# considered optional. All except tests data are installed by default,
-# but that can be changed here.
+# considered optional. All except 'tests' data (meaning the baseline
+# image files) are installed by default, but that can be changed here.
 #tests = False
 #sample_data = True
 

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -11,10 +11,9 @@
 #local_freetype = False
 
 [packages]
-# There are a number of subpackages of Matplotlib that are considered
-# optional. All except tests are installed by default, but that can
-# be changed here.
-#
+# There are a number of data subpackages from Matplotlib that are
+# considered optional. All except tests data are installed by default,
+# but that can be changed here.
 #tests = False
 #sample_data = True
 


### PR DESCRIPTION
Nowadays, this is just about some data files, those from the tests (baseline images) and the sample ones. Tests files themselves are always installed since https://github.com/matplotlib/matplotlib/pull/14170.