### PR TITLE
Cleanup docs regarding compilers.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -238,16 +238,11 @@ and on Windows:
   - ``qhull``: to compute Delaunay triangulation;
   - ``ttconv``: a TrueType font utility.
 
-.. _build_windows:
-
 Building on Windows
 -------------------
 
-The Python shipped from https://www.python.org is compiled with Visual Studio
-2015 for 3.5+.  Python extensions should be compiled with the same
-compiler, see e.g.
-https://packaging.python.org/guides/packaging-binary-extensions/#binary-extensions-for-windows
-for how to set up a build environment.
+Compiling Matplotlib (or any other extension module, for that matter) requires
+Visual Studio 2015 or later.
 
 If you are building your own Matplotlib wheels (or sdists), note that any DLLs
 that you copy into the source tree will be packaged too.

--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -127,15 +127,6 @@ from the Terminal.app command line::
 You might also want to install IPython or the Jupyter notebook (``python3 -mpip
 install ipython notebook``).
 
-pip problems
-^^^^^^^^^^^^
-
-If you get errors with pip trying to run a compiler like ``gcc`` or ``clang``,
-then the first thing to try is to `install xcode
-<https://guide.macports.org/chunked/installing.html#installing.xcode>`_ and
-retry the install.  If that does not work, then check
-:ref:`reporting-problems`.
-
 Checking your installation
 --------------------------
 
@@ -174,6 +165,12 @@ picked up by other Pythons.  If all these fail, please :ref:`let us know
 Install from source
 ===================
 
+A C compiler is required.  Typically, on Linux, you will need ``gcc``, which
+should be installed using your distribution's package manager; on macOS, you
+will need xcode_; on Windows, you will need Visual Studio 2015 or later.
+
+.. _xcode: https://guide.macports.org/chunked/installing.html#installing.xcode
+
 Clone the main source using one of::
 
    git clone git@github.com:matplotlib/matplotlib.git
@@ -196,9 +193,6 @@ just replace the last step with::
 
 This creates links and installs the command line script in the appropriate
 places.
-
-.. note::
-   Windows users please see the :ref:`build_windows` guide.
 
 Then, if you want to update your Matplotlib at any time, just do::
 


### PR DESCRIPTION
- On Windows, with py>=3.5, it's just "use VS>=2015". https://packaging.python.org/guides/packaging-binary-extensions/#binary-extensions-for-windows excerpt:
> For Python 3.5
> 1. Install Visual Studio 2015 Community Edition (or any later version, when these are released).
> 2. Done.
- On macOS (or anywhere else), a compiler is only needed when building
  from source.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
