### PR TITLE
Fixes an error in the documentation of Ellipse

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1420,7 +1420,7 @@ class Ellipse(Patch):
 
     def get_path(self):
         """
-        Return the vertices of the ellipse
+        Return the path of the ellipse
         """
         return self._path
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1420,7 +1420,7 @@ class Ellipse(Patch):
 
     def get_path(self):
         """
-        Return the vertices of the rectangle
+        Return the vertices of the ellipse
         """
         return self._path
 


### PR DESCRIPTION
## PR Summary
This fixes a very minor error in the documentation of a function in the Ellipse class. The function returns the vertices of an _ellipse_, not a _rectangle_. 
