### PR TITLE
Fix window not always raised in Qt example

### DIFF
--- a/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -69,4 +69,6 @@ if __name__ == "__main__":
 
     app = ApplicationWindow()
     app.show()
+    app.activateWindow()
+    app.raise_()
     qapp.exec_()


### PR DESCRIPTION
## PR Summary

Closes #13400 (last part thereof). See https://github.com/matplotlib/matplotlib/issues/13400#issuecomment-543068906.
