### PR TITLE
DOC: adding main nav to site

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1118,3 +1118,28 @@ div.viewcode-block:target {
 .sidebar-announcement p {
     margin: 0.4em 0.4em 0.6em 0.4em;
 }
+
+/* new main nav */
+nav.main-nav{
+    background-color: #002b47;
+    font-family: Calibri, 'Gill Sans', 'Gill Sans MT', 'Trebuchet MS', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    font-size: 11px;
+  }
+  
+  nav.main-nav ul{
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: row;
+  }
+  
+  nav.main-nav li{
+    margin: 8px 15px;
+    list-style-type: none;
+  }
+  
+  nav.main-nav a{
+    color: white;
+  }

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1122,10 +1122,10 @@ div.viewcode-block:target {
 /* new main nav */
 nav.main-nav{
     background-color: #002b47;
-    font-family: Calibri, 'Gill Sans', 'Gill Sans MT', 'Trebuchet MS', sans-serif;
+    font-family: Calibri, 'Carlito', 'Gill Sans', 'Gill Sans MT', 'Trebuchet MS', sans-serif;
     text-transform: uppercase;
     letter-spacing: 2px;
-    font-size: 11px;
+    font-size: 12px;
   }
   
   nav.main-nav ul{
@@ -1141,5 +1141,11 @@ nav.main-nav{
   }
   
   nav.main-nav a{
+    color: rgba(256, 256, 256, .8);
+    transform: color .2s ease-in-out;
+  }
+  
+  nav.main-nav a:hover{
     color: white;
+    text-decoration: underline;
   }

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,10 +1,6 @@
 {% extends "!layout.html" %}
 
 {%- block rootrellink %}
-        <li><a href="{{ pathto('index') }}">home</a>|&nbsp;</li>
-        <li><a href="{{ pathto('gallery/index') }}">examples</a>|&nbsp;</li>
-        <li><a href="{{ pathto('tutorials/index') }}">tutorials</a>|&nbsp;</li>
-        <li><a href="{{ pathto('api/index') }}">API</a>|&nbsp;</li>
         <li><a href="{{ pathto('contents') }}">contents</a> &raquo;</li>
 {%- endblock %}
 
@@ -45,6 +41,16 @@
     <!-- The "Fork me on github" ribbon -->
     <div id="forkongithub"><a href="https://github.com/matplotlib/matplotlib">Fork me on GitHub</a></div>
     </div>
+
+    <nav class="main-nav">
+        <ul>
+           <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
+           <li><a href="{{ pathto('gallery/index') }}">Sample Plots</a></li>
+           <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
+           <li><a href="{{ pathto('contents') }}">Documentation</a></li>
+           <li><a href="{{ pathto('users/installing') }}">Installation</a></li>
+        </ul>
+     </nav>
 {%- endblock %}
 
 {%- block sidebar1 %}{{ sidebar() }}{% endblock %}

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -1,6 +1,7 @@
 {% extends "!layout.html" %}
 
 {%- block rootrellink %}
+        <li><a href="{{ pathto('index') }}">home</a>|&nbsp;</li>
         <li><a href="{{ pathto('contents') }}">contents</a> &raquo;</li>
 {%- endblock %}
 

--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -45,11 +45,11 @@
 
     <nav class="main-nav">
         <ul>
-           <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
-           <li><a href="{{ pathto('gallery/index') }}">Sample Plots</a></li>
-           <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
-           <li><a href="{{ pathto('contents') }}">Documentation</a></li>
-           <li><a href="{{ pathto('users/installing') }}">Installation</a></li>
+            <li><a href="{{ pathto('users/installing') }}">Installation</a></li>
+            <li><a href="{{ pathto('contents') }}">Documentation</a></li>
+            <li><a href="{{ pathto('gallery/index') }}">Examples</a></li>
+            <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
+            <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
         </ul>
      </nav>
 {%- endblock %}


### PR DESCRIPTION
## PR SUMMARY
Added a main nav to separate nav links from breadcrumb links
This should make navigating matplotlib.org easier
<img width="1205" alt="Matplotlib__Python_plotting_—_Matplotlib_3_1_1_post2348_dev0_g03bc3c116_documentation" src="https://user-images.githubusercontent.com/8163534/67356034-f2a56a00-f526-11e9-8604-53fa59783669.png">

Questions

1. Are these the correct links to appear in the nav?
2. I tried something clever with the font to look like the logo font, and it may not appear the same on all machines. Can someone let me know if it looks bad on their machines?

Next step will be to replace the "fork me on GitHub" ribbon. I figure this is better handled in a separate PR.

@story645 @efiring @timhoffm @tacaswell 