### PR TITLE
Do not show path in font table example

### DIFF
--- a/examples/text_labels_and_annotations/font_table.py
+++ b/examples/text_labels_and_annotations/font_table.py
@@ -14,6 +14,7 @@ investigate a font by running ::
     python font_table.py /path/to/font/file
 """
 
+import os
 import unicodedata
 
 import matplotlib.font_manager as fm
@@ -84,7 +85,7 @@ def draw_font_table(path):
         chars[row][col] = chr(char_code)
 
     fig, ax = plt.subplots(figsize=(8, 4))
-    ax.set_title(path)
+    ax.set_title(os.path.basename(path))
     ax.set_axis_off()
 
     table = ax.table(


### PR DESCRIPTION
## PR Summary

I don't think we want full paths in the rendered docs like this:
https://matplotlib.org/gallery/text_labels_and_annotations/font_table.html

So let's just show the font filename.
