### PR TITLE
Get rid of trivial compiler warning.

### DIFF
--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -63,9 +63,9 @@ class exception : public std::exception
         return (errorcode);                                                  \
     }
 
-#define CALL_CPP_CLEANUP(name, a, cleanup) CALL_CPP_FULL(name, a, cleanup, NULL)
+#define CALL_CPP_CLEANUP(name, a, cleanup) CALL_CPP_FULL(name, a, cleanup, 0)
 
-#define CALL_CPP(name, a) CALL_CPP_FULL(name, a, , NULL)
+#define CALL_CPP(name, a) CALL_CPP_FULL(name, a, , 0)
 
 #define CALL_CPP_INIT(name, a) CALL_CPP_FULL(name, a, , -1)
 


### PR DESCRIPTION
Namely

    In file included from src/numpy_cpp.h:17,
                     from src/py_converters.h:17,
                     from src/ft2font_wrapper.cpp:4:
    src/ft2font_wrapper.cpp: In function ‘int PyFT2Font_init(PyFT2Font*, PyObject*, PyObject*)’:
    src/py_exceptions.h:31:26: warning: converting to non-pointer type ‘int’ from NULL [-Wconversion-null]
       31 |         return (errorcode);                                                  \
          |                          ^
    src/py_exceptions.h:68:27: note: in expansion of macro ‘CALL_CPP_FULL’
       68 | #define CALL_CPP(name, a) CALL_CPP_FULL(name, a, , NULL)
          |                           ^~~~~~~~~~~~~
    src/ft2font_wrapper.cpp:572:5: note: in expansion of macro ‘CALL_CPP’
      572 |     CALL_CPP("FT2Font->set_kerning_factor", (self->x->set_kerning_factor(kerning_factor)));
          |

(multiple times).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
