### PR TITLE
Warn when trying to start a GUI event loop out of the main thread.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -221,6 +221,11 @@ def switch_backend(newbackend):
             rcParamsOrig["backend"] = "agg"
             return
 
+    # Backends are implemented as modules, but "inherit" default method
+    # implementations from backend_bases._Backend.  This is achieved by
+    # creating a "class" that inherits from backend_bases._Backend and whose
+    # body is filled with the module's globals.
+
     backend_name = cbook._backend_module_name(newbackend)
 
     class backend_mod(matplotlib.backend_bases._Backend):
@@ -258,16 +263,19 @@ def _warn_if_gui_out_of_main_thread():
             "fail.")
 
 
+# This function's signature is rewritten upon backend-load by switch_backend.
 def new_figure_manager(*args, **kwargs):
     """Create a new figure manager instance."""
     _warn_if_gui_out_of_main_thread()
     return _backend_mod.new_figure_manager(*args, **kwargs)
 
 
+# This function's signature is rewritten upon backend-load by switch_backend.
 def draw_if_interactive(*args, **kwargs):
     return _backend_mod.draw_if_interactive(*args, **kwargs)
 
 
+# This function's signature is rewritten upon backend-load by switch_backend.
 def show(*args, **kwargs):
     """
     Display all figures.


### PR DESCRIPTION
## PR Summary

The first commit rearchitects a bit pyplot to make it possible to further wrap the backend-provided new_figure_manager().
The second commit uses that to emit a warning when new_figure_manager() (and thus figure()) is called for an GUI backend when not in the main loop.  Note that the text of the warning is a placeholder, suggestions for the wording would be welcome.
Closes #12085, closes #14304.

For the record the main thread requirement is documented at
https://developer.gnome.org/gdk3/stable/gdk3-Threads.html
https://doc.qt.io/qt-5/thread-basics.html#gui-thread-and-worker-thread
http://effbot.org/zone/tkinter-threads.htm
https://docs.wxwidgets.org/3.0/overview_thread.html#overview_thread_notes

I chose to only emit a warning because 1) it looks like things actually work with gtk if you are extra careful? ("You should only use GTK+ and GDK from the thread gtk_init() and gtk_main() were called on. This is usually referred to as the “main thread”." -- I guess the "gtk main thread" is not necessarily the python main thread, and indeed things don't appear to crash immediately.), and 2) if things are going to crash anyways you'll have a traceback and it's not as if catching the exception would really help, as it's a program logic error.

Test e.g. with
```python
from threading import Thread
from matplotlib.pyplot import show
Thread(target=lambda: show()).start()
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
