### PR TITLE
Use FixedFormatter only with FixedLocator

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3412,10 +3412,15 @@ class _AxesBase(martist.Artist):
         """
         Set the x-tick labels with list of string labels.
 
+        .. warning::
+            This method should only be used after fixing the tick positions
+            using `~.axes.Axes.set_xticks`. Otherwise, the labels may end up
+            in unexpected positions.
+
         Parameters
         ----------
-        labels : List[str]
-            List of string labels.
+        labels : list of str
+            The label texts.
 
         fontdict : dict, optional
             A dictionary controlling the appearance of the ticklabels.
@@ -3426,12 +3431,13 @@ class _AxesBase(martist.Artist):
                 'verticalalignment': 'baseline',
                 'horizontalalignment': loc}
 
-        minor : bool, optional
+        minor : bool, default: False
             Whether to set the minor ticklabels rather than the major ones.
 
         Returns
         -------
-        A list of `~.text.Text` instances.
+        labels : list of `~.Text`
+            The labels.
 
         Other Parameters
         -----------------
@@ -3792,12 +3798,17 @@ class _AxesBase(martist.Artist):
 
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
-        Set the y-tick labels with list of strings labels.
+        Set the y-tick labels with list of string labels.
+
+        .. warning::
+            This method should only be used after fixing the tick positions
+            using `~.axes.Axes.set_yticks`. Otherwise, the labels may end up
+            in unexpected positions.
 
         Parameters
         ----------
-        labels : List[str]
-            list of string labels
+        labels : list of str
+            The label texts.
 
         fontdict : dict, optional
             A dictionary controlling the appearance of the ticklabels.
@@ -3808,12 +3819,13 @@ class _AxesBase(martist.Artist):
                 'verticalalignment': 'baseline',
                 'horizontalalignment': loc}
 
-        minor : bool, optional
+        minor : bool, default: False
             Whether to set the minor ticklabels rather than the major ones.
 
         Returns
         -------
-        A list of `~.text.Text` instances.
+        labels
+            A list of `~.text.Text` instances.
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1632,6 +1632,11 @@ class Axis(martist.Artist):
         formatter : `~matplotlib.ticker.Formatter`
         """
         cbook._check_isinstance(mticker.Formatter, formatter=formatter)
+        if (isinstance(formatter, mticker.FixedFormatter)
+                and len(formatter.seq) > 0
+                and not isinstance(self.major.locator, mticker.FixedLocator)):
+            cbook._warn_external('FixedFormatter should only be used together '
+                                 'with FixedLocator')
         self.isDefault_majfmt = False
         self.major.formatter = formatter
         formatter.set_axis(self)
@@ -1646,6 +1651,11 @@ class Axis(martist.Artist):
         formatter : `~matplotlib.ticker.Formatter`
         """
         cbook._check_isinstance(mticker.Formatter, formatter=formatter)
+        if (isinstance(formatter, mticker.FixedFormatter)
+                and len(formatter.seq) > 0
+                and not isinstance(self.minor.locator, mticker.FixedLocator)):
+            cbook._warn_external('FixedFormatter should only be used together '
+                                 'with FixedLocator')
         self.isDefault_minfmt = False
         self.minor.formatter = formatter
         formatter.set_axis(self)
@@ -1697,6 +1707,11 @@ class Axis(martist.Artist):
         r"""
         Set the text values of the tick labels.
 
+        .. warning::
+            This method should only be used after fixing the tick positions
+            using `.Axis.set_ticks`. Otherwise, the labels may end up in
+            unexpected positions.
+
         Parameters
         ----------
         ticklabels : sequence of str or of `Text`\s
@@ -1718,18 +1733,8 @@ class Axis(martist.Artist):
                 "3.1", message="Additional positional arguments to "
                 "set_ticklabels are ignored, and deprecated since Matplotlib "
                 "3.1; passing them will raise a TypeError in Matplotlib 3.3.")
-        get_labels = []
-        for t in ticklabels:
-            # try calling get_text() to check whether it is Text object
-            # if it is Text, get label content
-            try:
-                get_labels.append(t.get_text())
-            # otherwise add the label to the list directly
-            except AttributeError:
-                get_labels.append(t)
-        # replace the ticklabels list with the processed one
-        ticklabels = get_labels
-
+        ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
+                      for t in ticklabels]
         if minor:
             self.set_minor_formatter(mticker.FixedFormatter(ticklabels))
             ticks = self.get_minor_ticks()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5064,11 +5064,15 @@ def test_set_get_ticklabels():
     ax[1].set_title(ha[1])
 
     # set ticklabel to 1 plot in normal way
-    ax[0].set_xticklabels(('a', 'b', 'c', 'd'))
-    ax[0].set_yticklabels(('11', '12', '13', '14'))
+    ax[0].set_xticks(range(10))
+    ax[0].set_yticks(range(10))
+    ax[0].set_xticklabels(['a', 'b', 'c', 'd'])
+    ax[0].set_yticklabels(['11', '12', '13', '14'])
 
     # set ticklabel to the other plot, expect the 2 plots have same label
     # setting pass get_ticklabels return value as ticklabels argument
+    ax[1].set_xticks(ax[0].get_xticks())
+    ax[1].set_yticks(ax[0].get_yticks())
     ax[1].set_xticklabels(ax[0].get_xticklabels())
     ax[1].set_yticklabels(ax[0].get_yticklabels())
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 import platform
+import warnings
 
 from matplotlib import rcParams
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -317,7 +318,11 @@ def test_autofmt_xdate(which):
     ax.xaxis_date()
 
     ax.xaxis.set_minor_locator(AutoMinorLocator(2))
-    ax.xaxis.set_minor_formatter(FixedFormatter(minors))
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            'FixedFormatter should only be used together with FixedLocator')
+        ax.xaxis.set_minor_formatter(FixedFormatter(minors))
 
     fig.autofmt_xdate(0.2, angle, 'right', which)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -345,6 +345,11 @@ class NullFormatter(Formatter):
 class FixedFormatter(Formatter):
     """
     Return fixed strings for tick labels based only on position, not value.
+
+    .. note::
+        `.FixedFormatter` should only be used together with `.FixedLocator`.
+        Otherwise, the labels may end up in unexpected positions.
+
     """
     def __init__(self, seq):
         """


### PR DESCRIPTION
## PR Summary

This PR prevents users from stumbling into #7122, #8779, #15501.
It does not technically fix them, `FixedFormatter` has a one-off bug with locators other than `FixedLocator`. But setting fixed labels at unknown positions is anyway not a good idea. So even if the one-off bug was fixed `FixedFormatter` should only used with `FixedLocator`.


- This PR mostly documents that `FixedFormatter` should not be used without a `FixedLocator` (along the hierarchy of tick label setter methods).
- Additionally it warns on the lowest level `set_major/minor_formatter()` if a `FixedFormatter` is set without a `FixedLocator`. This may be debatable.
  One could set the formatter first and the locator afterwards, which would technically yield the correct result. However, I feel that setting the position first and the labels second is the natural way, and is actually done throughout the library.
  No alternative: Since Formatters don't know about Locators `FixedFormatter` itself cannot check at runtime and we have to resort to this somewhat clumsy approach.
  And I strongly want some feedback on this potential problem from running code, because nobody reads the docs :smile:.
- One could consider captureing and re-emitting warnings on the higher levels with more appropriate messages, but I felt this was too much fuss.
