### PR TITLE
DOC: fix nav location

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -197,6 +197,17 @@ parents[-1].link|e }}" />
 <div id="forkongithub"><a href="https://github.com/matplotlib/matplotlib">Fork me on GitHub</a></div>
 </div>
 
+
+<nav class="main-nav">
+  <ul>
+    <li><a href="{{ pathto('users/installing') }}">Installation</a></li>
+    <li><a href="{{ pathto('contents') }}">Documentation</a></li>
+    <li><a href="{{ pathto('gallery/index') }}">Examples</a></li>
+    <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
+    <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
+  </ul>
+</nav>
+
 {% endblock %}
 
 {%- block relbar2 %}
@@ -229,15 +240,6 @@ parents[-1].link|e }}" />
       <div class="clearer"></div>
     </div>
 
-    <nav class="main-nav">
-        <ul>
-            <li><a href="{{ pathto('users/installing') }}">Installation</a></li>
-            <li><a href="{{ pathto('contents') }}">Documentation</a></li>
-            <li><a href="{{ pathto('gallery/index') }}">Examples</a></li>
-            <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
-            <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
-        </ul>
-     </nav>
 {%- endblock %}
 
 {%- block footer %}


### PR DESCRIPTION
I was too hasty merging the backport which put the nav source in a
very wrong place.

Rather than putting this into v3.1.x and backporting, putting this in to 3.1.1-doc and will merge this branch up to 3.1.x as part of the prep for 3.1.2.

Sorry about this :sheep: 