### PR TITLE
FIX: do not consider webagg and nbagg "interactive" for fallback

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2244,8 +2244,8 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
 # requested, ignore rcParams['backend'] and force selection of a backend that
 # is compatible with the current running interactive framework.
 if (rcParams["backend_fallback"]
-        and dict.__getitem__(rcParams, "backend") in [
-            k for k in _interactive_bk if k not in ['WebAgg', 'nbAgg']]
+        and dict.__getitem__(rcParams, "backend") in (
+            set(_interactive_bk) - {'WebAgg', 'nbAgg'})
         and cbook._get_running_interactive_framework()):
     dict.__setitem__(rcParams, "backend", rcsetup._auto_backend_sentinel)
 # Set up the backend.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2244,7 +2244,8 @@ def plotfile(fname, cols=(0,), plotfuncs=None,
 # requested, ignore rcParams['backend'] and force selection of a backend that
 # is compatible with the current running interactive framework.
 if (rcParams["backend_fallback"]
-        and dict.__getitem__(rcParams, "backend") in _interactive_bk
+        and dict.__getitem__(rcParams, "backend") in [
+            k for k in _interactive_bk if k not in ['WebAgg', 'nbAgg']]
         and cbook._get_running_interactive_framework()):
     dict.__setitem__(rcParams, "backend", rcsetup._auto_backend_sentinel)
 # Set up the backend.

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+import pytest
+
+
+@pytest.mark.parametrize('backend', ['webagg', 'nbagg'])
+def test_webagg_fallback(backend):
+    test_code = ("import matplotlib.pyplot as plt; " +
+                 "print(plt.get_backend());"
+                 f"assert '{backend}' == plt.get_backend().lower();")
+    ret = subprocess.call(
+        [sys.executable, "-c", test_code],
+        env={"MPLBACKEND": backend, "DISPLAY": ""}
+    )
+
+    assert ret == 0

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -3,13 +3,17 @@ import sys
 import pytest
 
 
-@pytest.mark.parametrize('backend', ['webagg', 'nbagg'])
+@pytest.mark.parametrize("backend", ["webagg", "nbagg"])
 def test_webagg_fallback(backend):
-    test_code = ("import os;" +
-                 f"os.environ['MPLBACKEND'] = '{backend}';" +
-                 "import matplotlib.pyplot as plt; " +
-                 "print(plt.get_backend());"
-                 f"assert '{backend}' == plt.get_backend().lower();")
+    if backend == "nbagg":
+        pytest.importorskip("IPython")
+    test_code = (
+        "import os;"
+        + f"os.environ['MPLBACKEND'] = '{backend}';"
+        + "import matplotlib.pyplot as plt; "
+        + "print(plt.get_backend());"
+        f"assert '{backend}' == plt.get_backend().lower();"
+    )
     ret = subprocess.call(
         [sys.executable, "-c", test_code],
         env={"MPLBACKEND": backend, "DISPLAY": ""}

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -5,7 +5,9 @@ import pytest
 
 @pytest.mark.parametrize('backend', ['webagg', 'nbagg'])
 def test_webagg_fallback(backend):
-    test_code = ("import matplotlib.pyplot as plt; " +
+    test_code = ("import os;" +
+                 f"os.environ['MPLBACKEND'] = '{backend}';" +
+                 "import matplotlib.pyplot as plt; " +
                  "print(plt.get_backend());"
                  f"assert '{backend}' == plt.get_backend().lower();")
     ret = subprocess.call(

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 import sys
 import pytest
 
@@ -7,16 +8,21 @@ import pytest
 def test_webagg_fallback(backend):
     if backend == "nbagg":
         pytest.importorskip("IPython")
+    env = {}
+    if os.name == "nt":
+        env = dict(os.environ)
+    else:
+        env = {"DISPLAY": ""}
+
+    env["MPLBACKEND"] = backend
+
     test_code = (
         "import os;"
-        + f"os.environ['MPLBACKEND'] = '{backend}';"
+        + f"assert os.environ['MPLBACKEND'] == '{backend}';"
         + "import matplotlib.pyplot as plt; "
         + "print(plt.get_backend());"
         f"assert '{backend}' == plt.get_backend().lower();"
     )
-    ret = subprocess.call(
-        [sys.executable, "-c", test_code],
-        env={"MPLBACKEND": backend, "DISPLAY": ""}
-    )
+    ret = subprocess.call([sys.executable, "-c", test_code], env=env)
 
     assert ret == 0


### PR DESCRIPTION
## PR Summary

There is logic in pyplot to determine if the user has is some way
selected a backend which is incompatible with the interactive
framework that we detect is running.  This helps prevent issues where
the user is already using one GUI frame work (ex tk) before Matplotlib
is imported and has Matplotlib configured to use Qt.  The other place
this behavior is desired is if Matplotlib is configured to use a GUI
framework by default, but is then imported on a headless server.  By
detecting there is no DISPLAY we fall back to Agg rather than failing
to import.

From the point of view of having UI events, webagg and nbagg are
interactive backends, however from the point of view of requiring
DISPLAY they are not.

This is the minimal fix, filtering out these two backends in pyplot
rather than changing this in rcsetup, incase anyone is relying on
those lists for other purposes.

closes #14903

This will backport badly due to the change in line light below this one but :woman_shrugging: 

Will work on a test tomorrow.