### PR TITLE
Separate plots using #### in make_room_for_ylabel_using_axesgrid.py

### DIFF
--- a/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
+++ b/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
@@ -4,13 +4,15 @@ Make Room For Ylabel Using Axesgrid
 ===================================
 
 """
+
+import matplotlib.pyplot as plt
+
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_area_auto_adjustable
 
 
 plt.figure()
 ax = plt.axes([0, 0, 1, 1])
-#ax = plt.subplot(111)
 
 ax.set_yticks([0.5])
 ax.set_yticklabels(["very long label"])

--- a/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
+++ b/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
@@ -7,65 +7,54 @@ Make Room For Ylabel Using Axesgrid
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_area_auto_adjustable
 
-import matplotlib.pyplot as plt
 
-def ex1():
-    plt.figure(1)
-    ax = plt.axes([0, 0, 1, 1])
-    #ax = plt.subplot(111)
+plt.figure()
+ax = plt.axes([0, 0, 1, 1])
+#ax = plt.subplot(111)
 
-    ax.set_yticks([0.5])
-    ax.set_yticklabels(["very long label"])
+ax.set_yticks([0.5])
+ax.set_yticklabels(["very long label"])
 
-    make_axes_area_auto_adjustable(ax)
-
-ex1()
+make_axes_area_auto_adjustable(ax)
 
 ###############################################################################
 
 
-def ex2():
+plt.figure()
+ax1 = plt.axes([0, 0, 1, 0.5])
+ax2 = plt.axes([0, 0.5, 1, 0.5])
 
-    plt.figure(2)
-    ax1 = plt.axes([0, 0, 1, 0.5])
-    ax2 = plt.axes([0, 0.5, 1, 0.5])
+ax1.set_yticks([0.5])
+ax1.set_yticklabels(["very long label"])
+ax1.set_ylabel("Y label")
 
-    ax1.set_yticks([0.5])
-    ax1.set_yticklabels(["very long label"])
-    ax1.set_ylabel("Y label")
+ax2.set_title("Title")
 
-    ax2.set_title("Title")
-
-    make_axes_area_auto_adjustable(ax1, pad=0.1, use_axes=[ax1, ax2])
-    make_axes_area_auto_adjustable(ax2, pad=0.1, use_axes=[ax1, ax2])
-
-ex2()
+make_axes_area_auto_adjustable(ax1, pad=0.1, use_axes=[ax1, ax2])
+make_axes_area_auto_adjustable(ax2, pad=0.1, use_axes=[ax1, ax2])
 
 ###############################################################################
 
 
-def ex3():
+fig = plt.figure()
+ax1 = plt.axes([0, 0, 1, 1])
+divider = make_axes_locatable(ax1)
 
-    fig = plt.figure(3)
-    ax1 = plt.axes([0, 0, 1, 1])
-    divider = make_axes_locatable(ax1)
+ax2 = divider.new_horizontal("100%", pad=0.3, sharey=ax1)
+ax2.tick_params(labelleft=False)
+fig.add_axes(ax2)
 
-    ax2 = divider.new_horizontal("100%", pad=0.3, sharey=ax1)
-    ax2.tick_params(labelleft=False)
-    fig.add_axes(ax2)
+divider.add_auto_adjustable_area(use_axes=[ax1], pad=0.1,
+                                 adjust_dirs=["left"])
+divider.add_auto_adjustable_area(use_axes=[ax2], pad=0.1,
+                                 adjust_dirs=["right"])
+divider.add_auto_adjustable_area(use_axes=[ax1, ax2], pad=0.1,
+                                 adjust_dirs=["top", "bottom"])
 
-    divider.add_auto_adjustable_area(use_axes=[ax1], pad=0.1,
-                                     adjust_dirs=["left"])
-    divider.add_auto_adjustable_area(use_axes=[ax2], pad=0.1,
-                                     adjust_dirs=["right"])
-    divider.add_auto_adjustable_area(use_axes=[ax1, ax2], pad=0.1,
-                                     adjust_dirs=["top", "bottom"])
+ax1.set_yticks([0.5])
+ax1.set_yticklabels(["very long label"])
 
-    ax1.set_yticks([0.5])
-    ax1.set_yticklabels(["very long label"])
+ax2.set_title("Title")
+ax2.set_xlabel("X - Label")
 
-    ax2.set_title("Title")
-    ax2.set_xlabel("X - Label")
-
-ex3()
 plt.show()

--- a/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
+++ b/examples/axes_grid1/make_room_for_ylabel_using_axesgrid.py
@@ -7,61 +7,65 @@ Make Room For Ylabel Using Axesgrid
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.axes_divider import make_axes_area_auto_adjustable
 
+import matplotlib.pyplot as plt
 
-if __name__ == "__main__":
+def ex1():
+    plt.figure(1)
+    ax = plt.axes([0, 0, 1, 1])
+    #ax = plt.subplot(111)
 
-    import matplotlib.pyplot as plt
+    ax.set_yticks([0.5])
+    ax.set_yticklabels(["very long label"])
 
-    def ex1():
-        plt.figure(1)
-        ax = plt.axes([0, 0, 1, 1])
-        #ax = plt.subplot(111)
+    make_axes_area_auto_adjustable(ax)
 
-        ax.set_yticks([0.5])
-        ax.set_yticklabels(["very long label"])
+ex1()
 
-        make_axes_area_auto_adjustable(ax)
+###############################################################################
 
-    def ex2():
 
-        plt.figure(2)
-        ax1 = plt.axes([0, 0, 1, 0.5])
-        ax2 = plt.axes([0, 0.5, 1, 0.5])
+def ex2():
 
-        ax1.set_yticks([0.5])
-        ax1.set_yticklabels(["very long label"])
-        ax1.set_ylabel("Y label")
+    plt.figure(2)
+    ax1 = plt.axes([0, 0, 1, 0.5])
+    ax2 = plt.axes([0, 0.5, 1, 0.5])
 
-        ax2.set_title("Title")
+    ax1.set_yticks([0.5])
+    ax1.set_yticklabels(["very long label"])
+    ax1.set_ylabel("Y label")
 
-        make_axes_area_auto_adjustable(ax1, pad=0.1, use_axes=[ax1, ax2])
-        make_axes_area_auto_adjustable(ax2, pad=0.1, use_axes=[ax1, ax2])
+    ax2.set_title("Title")
 
-    def ex3():
+    make_axes_area_auto_adjustable(ax1, pad=0.1, use_axes=[ax1, ax2])
+    make_axes_area_auto_adjustable(ax2, pad=0.1, use_axes=[ax1, ax2])
 
-        fig = plt.figure(3)
-        ax1 = plt.axes([0, 0, 1, 1])
-        divider = make_axes_locatable(ax1)
+ex2()
 
-        ax2 = divider.new_horizontal("100%", pad=0.3, sharey=ax1)
-        ax2.tick_params(labelleft=False)
-        fig.add_axes(ax2)
+###############################################################################
 
-        divider.add_auto_adjustable_area(use_axes=[ax1], pad=0.1,
-                                         adjust_dirs=["left"])
-        divider.add_auto_adjustable_area(use_axes=[ax2], pad=0.1,
-                                         adjust_dirs=["right"])
-        divider.add_auto_adjustable_area(use_axes=[ax1, ax2], pad=0.1,
-                                         adjust_dirs=["top", "bottom"])
 
-        ax1.set_yticks([0.5])
-        ax1.set_yticklabels(["very long label"])
+def ex3():
 
-        ax2.set_title("Title")
-        ax2.set_xlabel("X - Label")
+    fig = plt.figure(3)
+    ax1 = plt.axes([0, 0, 1, 1])
+    divider = make_axes_locatable(ax1)
 
-    ex1()
-    ex2()
-    ex3()
+    ax2 = divider.new_horizontal("100%", pad=0.3, sharey=ax1)
+    ax2.tick_params(labelleft=False)
+    fig.add_axes(ax2)
 
-    plt.show()
+    divider.add_auto_adjustable_area(use_axes=[ax1], pad=0.1,
+                                     adjust_dirs=["left"])
+    divider.add_auto_adjustable_area(use_axes=[ax2], pad=0.1,
+                                     adjust_dirs=["right"])
+    divider.add_auto_adjustable_area(use_axes=[ax1, ax2], pad=0.1,
+                                     adjust_dirs=["top", "bottom"])
+
+    ax1.set_yticks([0.5])
+    ax1.set_yticklabels(["very long label"])
+
+    ax2.set_title("Title")
+    ax2.set_xlabel("X - Label")
+
+ex3()
+plt.show()


### PR DESCRIPTION
## PR Summary

Separate plots using ######### lines for Sphinx-gallery to render plots in sections.
Part of #8922.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
