### PR TITLE
FIX: fix anti-aliasing zoom bug

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -176,11 +176,10 @@ def _resample(
     if interpolation == 'antialiased':
         # don't antialias if upsampling by an integer number or
         # if zooming in more than a factor of 3
-        shape = list(data.shape)
-        if image_obj.origin == 'upper':
-            shape[0] = 0
-        dispx, dispy = transform.transform([shape[1], shape[0]])
-
+        pos = np.array([[0, 0], [data.shape[1], data.shape[0]]])
+        disp = transform.transform(pos)
+        dispx = np.abs(np.diff(disp[:, 0]))
+        dispy = np.abs(np.diff(disp[:, 1]))
         if ((dispx > 3 * data.shape[1] or
                 dispx == data.shape[1] or
                 dispx == 2 * data.shape[1]) and
@@ -190,7 +189,6 @@ def _resample(
             interpolation = 'nearest'
         else:
             interpolation = 'hanning'
-
     out = np.zeros(out_shape + data.shape[2:], data.dtype)  # 2D->2D, 3D->3D.
     if resample is None:
         resample = image_obj.get_resample()

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -198,6 +198,24 @@ def test_imshow_upsample3(fig_test, fig_ref):
     axs.imshow(A, interpolation='nearest')
 
 
+@check_figures_equal(extensions=['png'])
+def test_imshow_zoom(fig_test, fig_ref):
+    # should be less than 3 upsample, so should be nearest...
+    np.random.seed(19680801)
+    dpi = 100
+    A = np.random.rand(int(dpi * 3), int(dpi * 3))
+    for fig in [fig_test, fig_ref]:
+        fig.set_size_inches(2.9, 2.9)
+    axs = fig_test.subplots()
+    axs.imshow(A, interpolation='nearest')
+    axs.set_xlim([10, 20])
+    axs.set_ylim([10, 20])
+    axs = fig_ref.subplots()
+    axs.imshow(A, interpolation='antialiased')
+    axs.set_xlim([10, 20])
+    axs.set_ylim([10, 20])
+
+
 @check_figures_equal()
 def test_imshow_pil(fig_test, fig_ref):
     style.use("default")


### PR DESCRIPTION
## PR Summary

Closes #15517.

This failed the new test on master, and passes now.  

The test from #15517 yields:

![fix](https://user-images.githubusercontent.com/1562854/67596957-ceac7900-f71e-11e9-90da-acb0160b2c5b.png)

```python
from pylab import *
plt.rcdefaults()
fig, axs = plt.subplots(1, 2)
axs[0].imshow(np.random.rand(10, 10))  # now defaults to interpolation="antialiased"
axs[1].imshow(np.random.rand(1000, 1000))
axs[1].set(xlim=(-.5, 9.5), ylim=(-.5, 9.5))
plt.show()
```

and it works under interactive use as far as I can see.



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
