### PR TITLE
Declutter home page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,11 +46,6 @@ particularly when combined with IPython.  For the power user, you have full
 control of line styles, font properties, axes properties, etc, via an object
 oriented interface or via a set of functions familiar to MATLAB users.
 
-Installation
-------------
-
-Visit the :doc:`Matplotlib installation instructions <users/installing>`.
-
 Documentation
 -------------
 
@@ -226,8 +221,3 @@ and `Pull requests`_ are tracked at GitHub too.
 .. _source code: https://github.com/matplotlib/matplotlib
 .. _issue tracker: https://github.com/matplotlib/matplotlib/issues
 .. _pull requests: https://github.com/matplotlib/matplotlib/pulls
-
-For contributers
-================
-
-Visit :doc:`/devel/index`.


### PR DESCRIPTION
## PR Summary

A tiny step towards decluttering the home page.

These two sections do not contain any info except for the links, but the links are now already prominently present in the main nav bar.
