### PR TITLE
Resolve 'text ignores rotational part of transformation' (#698)

### DIFF
--- a/doc/users/next_whats_new/2019-12-22_transform-rotates-text-direction.rst
+++ b/doc/users/next_whats_new/2019-12-22_transform-rotates-text-direction.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+Transform can rotates text direction
+------------------------------------
+The new `.Text` parameter ``transform_rotates_text`` now allows to enable
+rotations of the transform affect the text direction.
+

--- a/doc/users/next_whats_new/2019-12-22_transform-rotates-text-direction.rst
+++ b/doc/users/next_whats_new/2019-12-22_transform-rotates-text-direction.rst
@@ -1,7 +1,7 @@
 :orphan:
 
-Transform can rotates text direction
-------------------------------------
-The new `.Text` parameter ``transform_rotates_text`` now allows to enable
+Transform can rotate text direction
+-----------------------------------
+The new `.Text` parameter ``transform_rotates_text`` now sets whether
 rotations of the transform affect the text direction.
 

--- a/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
+++ b/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
@@ -10,8 +10,8 @@ are changed).  However, at times one wants to rotate text with respect
 to something on the plot.  In this case, the correct angle won't be
 the angle of that object in the plot coordinate system, but the angle
 that that object APPEARS in the screen coordinate system.  This angle
-can be provided by the helper parameter *transform_rotates_text*, as
-shown in the example below.
+can be determined automatically by setting the parameter
+*transform_rotates_text*, as shown in the example below.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
+++ b/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
@@ -10,7 +10,7 @@ are changed).  However, at times one wants to rotate text with respect
 to something on the plot.  In this case, the correct angle won't be
 the angle of that object in the plot coordinate system, but the angle
 that that object APPEARS in the screen coordinate system.  This angle
-can be provided by the helper parameter `transform_rotates_text`, as
+can be provided by the helper parameter *transform_rotates_text*, as
 shown in the example below.
 """
 

--- a/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
+++ b/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
@@ -10,8 +10,8 @@ are changed).  However, at times one wants to rotate text with respect
 to something on the plot.  In this case, the correct angle won't be
 the angle of that object in the plot coordinate system, but the angle
 that that object APPEARS in the screen coordinate system.  This angle
-is found by transforming the angle from the plot to the screen
-coordinate system, as shown in the example below.
+can be provided by the helper parameter `transform_rotates_text`, as
+shown in the example below.
 """
 
 import matplotlib.pyplot as plt
@@ -31,12 +31,12 @@ l2 = np.array((5, 5))
 
 # Rotate angle
 angle = 45
-trans_angle = ax.transData.transform_angles([45], l2.reshape((1, 2)))[0]
 
 # Plot text
 th1 = ax.text(*l1, 'text not rotated correctly', fontsize=16,
               rotation=angle, rotation_mode='anchor')
 th2 = ax.text(*l2, 'text rotated correctly', fontsize=16,
-              rotation=trans_angle, rotation_mode='anchor')
+              rotation=angle, rotation_mode='anchor',
+              transform_rotates_text=True)
 
 plt.show()

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -696,5 +696,5 @@ def test_transform_rotates_text():
     transform = mtransforms.Affine2D().rotate_deg(30)
     text = ax.text(0, 0, 'test', transform=transform,
                    transform_rotates_text=True)
-    result = text.get_rotation()[0]
+    result = text.get_rotation()
     assert_almost_equal(result, 30)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -3,15 +3,14 @@ import io
 import warnings
 
 import numpy as np
-import pytest
 from numpy.testing import assert_almost_equal
+import pytest
 
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
-from matplotlib.backend_bases import MouseEvent
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 needs_usetex = pytest.mark.skipif(

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -3,15 +3,16 @@ import io
 import warnings
 
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pytest
+from numpy.testing import assert_almost_equal
 
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
+from matplotlib.backend_bases import MouseEvent
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
-
 
 needs_usetex = pytest.mark.skipif(
     not mpl.checkdep_usetex(True),
@@ -689,3 +690,12 @@ def test_fontproperties_kwarg_precedence():
     text2 = plt.ylabel("counts", size=40.0, fontproperties='Times New Roman')
     assert text1.get_size() == 40.0
     assert text2.get_size() == 40.0
+
+
+def test_transform_rotates_text():
+    ax = plt.gca()
+    transform = mtransforms.Affine2D().rotate_deg(30)
+    text = ax.text(0, 0, 'test', transform=transform,
+                   transform_rotates_text=True)
+    result = text.get_rotation()[0]
+    assert_almost_equal(result, 30)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -13,6 +13,7 @@ import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
+
 needs_usetex = pytest.mark.skipif(
     not mpl.checkdep_usetex(True),
     reason="This test needs a TeX installation")

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -136,7 +136,7 @@ class Text(Artist):
                  rotation_mode=None,
                  usetex=None,          # defaults to rcParams['text.usetex']
                  wrap=False,
-                 rotation_transformed=False,
+                 transform_rotates_text=False,
                  **kwargs
                  ):
         """
@@ -158,7 +158,7 @@ class Text(Artist):
         self.set_horizontalalignment(horizontalalignment)
         self._multialignment = multialignment
         self._rotation = rotation
-        self._rotation_transformed = rotation_transformed
+        self._transform_rotates_text = transform_rotates_text
         self._bbox_patch = None  # a FancyBboxPatch instance
         self._renderer = None
         if linespacing is None:
@@ -230,16 +230,18 @@ class Text(Artist):
 
     def get_rotation(self):
         """Return the text angle in degrees between 0 and 360."""
-        if self.get_rotation_transformed():
+        if self.get_transform_rotates_text():
             angle = get_rotation(self._rotation)
             x, y = self.get_unitless_position()
             return self.get_transform().transform_angles([angle, ], [[x, y]])
         else:
             return get_rotation(self._rotation)  # string_or_number -> number
 
-    def get_rotation_transformed(self):
-        """Return if the text rotation get transformed or not."""
-        return self._rotation_transformed
+    def get_transform_rotates_text(self):
+        """
+        Return whether rotations of the transform affect the text direction.
+        """
+        return self._transform_rotates_text
 
     def set_rotation_mode(self, m):
         """
@@ -270,7 +272,7 @@ class Text(Artist):
         self._fontproperties = other._fontproperties.copy()
         self._usetex = other._usetex
         self._rotation = other._rotation
-        self._rotation_transformed = other._rotation_transformed
+        self._transform_rotates_text = other._transform_rotates_text
         self._picker = other._picker
         self._linespacing = other._linespacing
         self.stale = True
@@ -855,7 +857,7 @@ class Text(Artist):
                 self._verticalalignment, self._horizontalalignment,
                 hash(self._fontproperties),
                 self._rotation, self._rotation_mode,
-                self._rotation_transformed,
+                self._transform_rotates_text,
                 self.figure.dpi, weakref.ref(renderer),
                 self._linespacing
                 )
@@ -1145,15 +1147,15 @@ class Text(Artist):
         self._rotation = s
         self.stale = True
 
-    def set_rotation_transformed(self, t):
+    def set_transform_rotates_text(self, t):
         """
-        Set if the text rotation get transformed or not.
+        Whether rotations of the transform affect the text direction.
 
         Parameters
         ----------
         t : bool
         """
-        self._rotation_transformed = t
+        self._transform_rotates_text = t
         self.stale = True
 
     def set_verticalalignment(self, align):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -233,7 +233,9 @@ class Text(Artist):
         if self.get_transform_rotates_text():
             angle = get_rotation(self._rotation)
             x, y = self.get_unitless_position()
-            return self.get_transform().transform_angles([angle, ], [[x, y]])
+            angles = [angle, ]
+            pts = [[x, y]]
+            return self.get_transform().transform_angles(angles, pts).item(0)
         else:
             return get_rotation(self._rotation)  # string_or_number -> number
 


### PR DESCRIPTION
## PR Summary

Considering the text rotation don't get transformed may be a desired behavior
(such as text for annotation to some data point). Here made it as an option to
control whether or not the text rotation get transformed.

- original behavior described in #698:
```python
text = plt.text(0, 0, 'hello', size=50, transform=R + ax.transData)
```
![Screenshot from 2019-10-27 00-02-16-small](https://user-images.githubusercontent.com/26521816/67622490-2943f300-f84d-11e9-8985-abc1955e7e56.png)

- behavior in this patch:
```python
text = plt.text(0, 0, 'hello', size=50, transform=R + ax.transData, 
                rotation_mode='anchor', rotation_transformed=True)
```
![Screenshot from 2019-10-26 23-57-37-small](https://user-images.githubusercontent.com/26521816/67622453-dd914980-f84c-11e9-8ef5-41096b1e98fe.png)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
