### PR TITLE
DOC: add cache-buster query string to css path

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -229,7 +229,7 @@ github_project_url = "https://github.com/matplotlib/matplotlib/"
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
 #html_style = 'matplotlib.css'
-html_style = 'mpl.css'
+html_style = f'mpl.css?{SHA}'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
This is to make sure when we re-build the docs users get the
new css rather than using a cached version.

The query string is enough to make (most) browsers and cloudflare
treat the get request as a new file.

See the first suggestion at https://css-tricks.com/strategies-for-cache-busting-css/  