### PR TITLE
Use True instead of 1 as filternorm default

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5481,7 +5481,7 @@ optional.
     @cbook._delete_parameter("3.1", "imlim")
     def imshow(self, X, cmap=None, norm=None, aspect=None,
                interpolation=None, alpha=None, vmin=None, vmax=None,
-               origin=None, extent=None, shape=None, filternorm=1,
+               origin=None, extent=None, shape=None, filternorm=True,
                filterrad=4.0, imlim=None, resample=None, url=None, **kwargs):
         """
         Display data as an image; i.e. on a 2D regular raster.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -871,7 +871,7 @@ class AxesImage(_ImageBase):
                  interpolation=None,
                  origin=None,
                  extent=None,
-                 filternorm=1,
+                 filternorm=True,
                  filterrad=4.0,
                  resample=False,
                  **kwargs
@@ -1327,7 +1327,7 @@ class BboxImage(_ImageBase):
                  norm=None,
                  interpolation=None,
                  origin=None,
-                 filternorm=1,
+                 filternorm=True,
                  filterrad=4.0,
                  resample=False,
                  interp_at_native=True,

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1325,7 +1325,7 @@ class OffsetImage(OffsetBox):
                  norm=None,
                  interpolation=None,
                  origin=None,
-                 filternorm=1,
+                 filternorm=True,
                  filterrad=4.0,
                  resample=False,
                  dpi_cor=True,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2629,9 +2629,10 @@ def hlines(
 def imshow(
         X, cmap=None, norm=None, aspect=None, interpolation=None,
         alpha=None, vmin=None, vmax=None, origin=None, extent=None,
-        shape=cbook.deprecation._deprecated_parameter, filternorm=1,
-        filterrad=4.0, imlim=cbook.deprecation._deprecated_parameter,
-        resample=None, url=None, *, data=None, **kwargs):
+        shape=cbook.deprecation._deprecated_parameter,
+        filternorm=True, filterrad=4.0,
+        imlim=cbook.deprecation._deprecated_parameter, resample=None,
+        url=None, *, data=None, **kwargs):
     __ret = gca().imshow(
         X, cmap=cmap, norm=norm, aspect=aspect,
         interpolation=interpolation, alpha=alpha, vmin=vmin,


### PR DESCRIPTION
## PR Summary

*filternorm* is actually a bool, so the default should be *True* instead of *1*.

Since this is a code change, it won't be backported.