### PR TITLE
Cleanup following using Pillow as universal image reader

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -46,7 +46,7 @@ To run the test suite:
 * extract the :file:`lib/matplotlib/tests` or :file:`lib/mpl_toolkits/tests`
   directories from the source distribution;
 * install test dependencies: `pytest <https://pypi.org/project/pytest>`_,
-  Pillow, MiKTeX, GhostScript, ffmpeg, avconv, ImageMagick, and `Inkscape
+  MiKTeX, GhostScript, ffmpeg, avconv, ImageMagick, and `Inkscape
   <https://inkscape.org/>`_;
 * run ``python -mpytest``.
 
@@ -126,6 +126,7 @@ Matplotlib requires the following dependencies:
 * `cycler <http://matplotlib.org/cycler/>`_ (>= 0.10.0)
 * `dateutil <https://pypi.org/project/python-dateutil>`_ (>= 2.1)
 * `kiwisolver <https://github.com/nucleic/kiwi>`_ (>= 1.0.0)
+* `Pillow <https://pillow.readthedocs.io/en/latest/>`_ (>= 6.2)
 * `pyparsing <https://pyparsing.wikispaces.com/>`_
 
 Optionally, you can also install a number of packages to enable better user
@@ -160,8 +161,6 @@ etc., you can install the following:
   <https://libav.org/avconv.html>`_: for saving movies;
 * `ImageMagick <https://www.imagemagick.org/script/index.php>`_: for saving
   animated gifs;
-* `Pillow <https://pillow.readthedocs.io/en/latest/>`_ (>= 3.4): for a larger
-  selection of image file formats: JPEG, BMP, and TIFF image files;
 * `LaTeX <https://miktex.org/>`_ and `GhostScript (>=9.0)
   <https://ghostscript.com/download/>`_ : for rendering text with LaTeX.
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2143,9 +2143,7 @@ default: 'top'
 
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to `PIL.Image.save`
-            when saving the figure.  Only applicable for formats that are saved
-            using Pillow, i.e. JPEG, TIFF, and (if the keyword is set to a
-            non-None value) PNG.
+            when saving the figure.
         """
 
         kwargs.setdefault('dpi', rcParams['savefig.dpi'])

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1629,8 +1629,9 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
     Parameters
     ----------
     infile : str or file-like
-        The image file -- must be PNG, or Pillow-readable if you have Pillow_
-        installed.
+        The image file. Matplotlib relies on Pillow_ for image reading, and
+        thus supports a wide range of file formats, including PNG, JPG, TIFF
+        and others.
 
         .. _Pillow: http://python-pillow.org/
 

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -2,7 +2,9 @@ import io
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from PIL import Image, TiffTags
 import pytest
+
 
 from matplotlib import (
     collections, path, pyplot as plt, transforms as mtransforms, rcParams)
@@ -217,7 +219,6 @@ def test_chunksize():
 
 @pytest.mark.backend('Agg')
 def test_jpeg_dpi():
-    Image = pytest.importorskip("PIL.Image")
     # Check that dpi is set correctly in jpg files.
     plt.plot([0, 1, 2], [0, 1, 0])
     buf = io.BytesIO()
@@ -227,7 +228,6 @@ def test_jpeg_dpi():
 
 
 def test_pil_kwargs_png():
-    Image = pytest.importorskip("PIL.Image")
     from PIL.PngImagePlugin import PngInfo
     buf = io.BytesIO()
     pnginfo = PngInfo()
@@ -238,11 +238,9 @@ def test_pil_kwargs_png():
 
 
 def test_pil_kwargs_tiff():
-    Image = pytest.importorskip("PIL.Image")
-    from PIL.TiffTags import TAGS_V2 as TAGS
     buf = io.BytesIO()
     pil_kwargs = {"description": "test image"}
     plt.figure().savefig(buf, format="tiff", pil_kwargs=pil_kwargs)
     im = Image.open(buf)
-    tags = {TAGS[k].name: v for k, v in im.tag_v2.items()}
+    tags = {TiffTags.TAGS_V2[k].name: v for k, v in im.tag_v2.items()}
     assert tags["ImageDescription"] == "test image"

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -132,8 +132,6 @@ WRITER_OUTPUT += [
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, output', WRITER_OUTPUT)
 def test_save_animation_smoketest(tmpdir, writer, output):
-    if writer == 'pillow':
-        pytest.importorskip("PIL")
     try:
         # for ImageMagick the rcparams must be patched to account for
         # 'convert' being a built in MS tool, not the imagemagick

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -11,6 +11,7 @@ import warnings
 import numpy as np
 from numpy import ma
 from numpy.testing import assert_array_equal
+from PIL import Image
 
 from matplotlib import (
     colors, image as mimage, patches, pyplot as plt, style, rcParams)
@@ -219,19 +220,17 @@ def test_imshow_zoom(fig_test, fig_ref):
 @check_figures_equal()
 def test_imshow_pil(fig_test, fig_ref):
     style.use("default")
-    PIL = pytest.importorskip("PIL")
     png_path = Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png"
     tiff_path = Path(__file__).parent / "baseline_images/test_image/uint16.tif"
     axs = fig_test.subplots(2)
-    axs[0].imshow(PIL.Image.open(png_path))
-    axs[1].imshow(PIL.Image.open(tiff_path))
+    axs[0].imshow(Image.open(png_path))
+    axs[1].imshow(Image.open(tiff_path))
     axs = fig_ref.subplots(2)
     axs[0].imshow(plt.imread(png_path))
     axs[1].imshow(plt.imread(tiff_path))
 
 
 def test_imread_pil_uint16():
-    pytest.importorskip("PIL")
     img = plt.imread(os.path.join(os.path.dirname(__file__),
                      'baseline_images', 'test_image', 'uint16.tif'))
     assert img.dtype == np.uint16
@@ -239,7 +238,6 @@ def test_imread_pil_uint16():
 
 
 def test_imread_fspath():
-    pytest.importorskip("PIL")
     img = plt.imread(
         Path(__file__).parent / 'baseline_images/test_image/uint16.tif')
     assert img.dtype == np.uint16
@@ -248,8 +246,6 @@ def test_imread_fspath():
 
 @pytest.mark.parametrize("fmt", ["png", "jpg", "jpeg", "tiff"])
 def test_imsave(fmt):
-    if fmt in ["jpg", "jpeg", "tiff"]:
-        pytest.importorskip("PIL")
     has_alpha = fmt not in ["jpg", "jpeg"]
 
     # The goal here is that the user can specify an output logical DPI
@@ -314,7 +310,6 @@ def test_imsave_color_alpha():
 
 
 def test_imsave_pil_kwargs_png():
-    Image = pytest.importorskip("PIL.Image")
     from PIL.PngImagePlugin import PngInfo
     buf = io.BytesIO()
     pnginfo = PngInfo()
@@ -326,7 +321,6 @@ def test_imsave_pil_kwargs_png():
 
 
 def test_imsave_pil_kwargs_tiff():
-    Image = pytest.importorskip("PIL.Image")
     from PIL.TiffTags import TAGS_V2 as TAGS
     buf = io.BytesIO()
     pil_kwargs = {"description": "test image"}
@@ -664,7 +658,6 @@ def test_nonuniformimage_setnorm():
 
 
 def test_jpeg_2d():
-    Image = pytest.importorskip('PIL.Image')
     # smoke test that mode-L pillow images work.
     imd = np.ones((10, 10), dtype='uint8')
     for i in range(10):
@@ -676,8 +669,6 @@ def test_jpeg_2d():
 
 
 def test_jpeg_alpha():
-    Image = pytest.importorskip('PIL.Image')
-
     plt.figure(figsize=(1, 1), dpi=300)
     # Create an image that is all black, with a gradient from 0-1 in
     # the alpha channel from left to right.

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -220,12 +220,8 @@ def test_imshow_zoom(fig_test, fig_ref):
 def test_imshow_pil(fig_test, fig_ref):
     style.use("default")
     PIL = pytest.importorskip("PIL")
-    # Pillow<=6.0 fails to open pathlib.Paths on Windows (pillow#3823), and
-    # Matplotlib's builtin png opener doesn't handle them either.
-    png_path = str(
-        Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png")
-    tiff_path = str(
-        Path(__file__).parent / "baseline_images/test_image/uint16.tif")
+    png_path = Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png"
+    tiff_path = Path(__file__).parent / "baseline_images/test_image/uint16.tif"
     axs = fig_test.subplots(2)
     axs[0].imshow(PIL.Image.open(png_path))
     axs[1].imshow(PIL.Image.open(tiff_path))


### PR DESCRIPTION
## PR Summary

This cleans up docs and code that were outdated due to these two PRs:

- BLD: update pillow dependency #15534
- Switch to using pillow for png as well. #15193


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
