### PR TITLE
Restore `build_alllocal.cmd` 

### DIFF
--- a/build_alllocal.cmd
+++ b/build_alllocal.cmd
@@ -1,0 +1,27 @@
+:: This assumes you have installed all the dependencies via conda packages:
+:: # create a new environment with the required packages
+:: # if you want a qt backend, add "pyqt" to the list of conda packages
+:: conda create -n "matplotlib_build" python=3.7 numpy python-dateutil pyparsing tornado cycler tk libpng zlib freetype msinttypes
+:: conda activate matplotlib_build
+
+set TARGET=bdist_wheel
+IF [%1]==[] (
+    echo Using default target: %TARGET%
+) else (
+    set TARGET=%1
+    echo Using user supplied target: %TARGET%
+)
+
+IF NOT DEFINED CONDA_PREFIX (
+    echo No Conda env activated: you need to create a conda env with the right packages and activate it!
+    GOTO:eof
+)
+
+:: copy the libs which have "wrong" names
+set LIBRARY_LIB=%CONDA_PREFIX%\Library\lib
+mkdir lib || cmd /c "exit /b 0"
+copy %LIBRARY_LIB%\zlibstatic.lib lib\zlib.lib
+copy %LIBRARY_LIB%\libpng16_static.lib lib\libpng16.lib
+
+:: build the target
+python setup.py %TARGET%


### PR DESCRIPTION
The [building on windows using conda wheels](https://matplotlib.org/3.1.1/users/installing.html#building-on-windows) instructions say to run `build_alllocal.cmd` which git history suggests may have accidentally been deleted?

```cmd
(matplotlib_build) C:\Users\story\Projects\matplotlib>git log --full-history -1 -- build_alllocal.cmd
commit 4906876f57bafa8a242c18d75ddcf6033e5f7c61
Merge: ce334d46c 0bec9e623
Author: Thomas A Caswell <tcaswell@gmail.com>
Date:   Fri Oct 18 16:20:46 2019 -0400

    Merge pull request #15439 from jklymak/doc-mention-discourse

    DOC: mention discourse main page
```
[commit 490687](https://github.com/matplotlib/matplotlib/tree/4906876f57bafa8a242c18d75ddcf6033e5f7c61)

I'm just adding the file back here in case it was accidental, otherwise this needs a doc fix that I don't know how to resolve. 

ALso realizing now there's probably a git revert/cherry pick that's probably a better way of approaching this since it'll retain the file history. 
xref w/ #15512 'cause that's how I ran into this. 