### PR TITLE
BLD: set the max line length on the flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
+max-line-length = 79
 ignore =
     # Normal default
     E121,E123,E126,E226,E24,E704,W503,W504,


### PR DESCRIPTION
This is to make sure that if developers have a global config for the
max line length we over-ride that setting in the mpl code.