### PR TITLE
Remove matplotlib.sphinxext.tests from __init__.py

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1302,7 +1302,6 @@ def tk_window_focus():
 
 default_test_modules = [
     'matplotlib.tests',
-    'matplotlib.sphinxext.tests',
     'mpl_toolkits.tests',
 ]
 


### PR DESCRIPTION
## PR Summary
Commit: https://github.com/matplotlib/matplotlib/commit/291599d4b3ea5e00f922820b1e9b79e4e009a2ac
moved tests in `sphinxext` to `matplotlib/tests` but missed removing
`matplotlib.sphinxext.tests` from `matplotlib/__init__.py`.  This does not
seem to affect testing using pytest directly, but fails when invoked
using tests.py.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way