### PR TITLE
Make sure that figures are closed when check_figures_equal finishes

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -389,18 +389,22 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         @pytest.mark.parametrize("ext", extensions)
         def wrapper(*args, ext, **kwargs):
-            fig_test = plt.figure("test")
-            fig_ref = plt.figure("reference")
-            func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
-            test_image_path = result_dir / (func.__name__ + "." + ext)
-            ref_image_path = result_dir / (
-                func.__name__ + "-expected." + ext
-            )
-            fig_test.savefig(test_image_path)
-            fig_ref.savefig(ref_image_path)
-            _raise_on_image_difference(
-                ref_image_path, test_image_path, tol=tol
-            )
+            try:
+                fig_test = plt.figure("test")
+                fig_ref = plt.figure("reference")
+                func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
+                test_image_path = result_dir / (func.__name__ + "." + ext)
+                ref_image_path = result_dir / (
+                    func.__name__ + "-expected." + ext
+                )
+                fig_test.savefig(test_image_path)
+                fig_ref.savefig(ref_image_path)
+                _raise_on_image_difference(
+                    ref_image_path, test_image_path, tol=tol
+                )
+            finally:
+                plt.close(fig_test)
+                plt.close(fig_ref)
 
         sig = inspect.signature(func)
         new_sig = sig.replace(


### PR DESCRIPTION
## PR Summary
fixes #15079. Closes figures after `check_figures_equal` has finished so that different tests don't overwrite each others' figures.
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
