### PR TITLE
Rename numpy to NumPy in docs.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.99.rst
+++ b/doc/api/prev_api_changes/api_changes_0.99.rst
@@ -4,7 +4,7 @@ Changes in 0.99
 * pylab no longer provides a load and save function.  These are
   available in matplotlib.mlab, or you can use numpy.loadtxt and
   numpy.savetxt for text files, or np.save and np.load for binary
-  numpy arrays.
+  NumPy arrays.
 
 * User-generated colormaps can now be added to the set recognized
   by :func:`matplotlib.cm.get_cmap`.  Colormaps can be made the

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -169,7 +169,7 @@ original location:
   Previously an integer start-index and stride-length could be specified using
   either a two-element-list or a two-element-tuple.  Now this can only be done
   using a two-element-tuple.  If a two-element-list is used then it will be
-  treated as numpy fancy indexing and only the two markers corresponding to the
+  treated as NumPy fancy indexing and only the two markers corresponding to the
   given indexes will be shown.
 
 * Removed *prop* keyword argument from
@@ -207,6 +207,6 @@ original location:
 Code removal
 ------------
 
-* Removed ``mlab.levypdf``.  The code raised a numpy error (and has for
+* Removed ``mlab.levypdf``.  The code raised a NumPy error (and has for
   a long time) and was not the standard form of the Levy distribution.
   ``scipy.stats.levy`` should be used instead

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -715,9 +715,9 @@ likewise changed.
 Dependency changes
 ------------------
 
-numpy
+NumPy
 ~~~~~
-Matplotlib 3.1 now requires numpy>=1.11.
+Matplotlib 3.1 now requires NumPy>=1.11.
 
 ghostscript
 ~~~~~~~~~~~
@@ -871,7 +871,7 @@ future version.
 - `.cbook.iterable`
 - `.cbook.get_label`
 - `.cbook.safezip`
-  Manually check the lengths of the inputs instead, or rely on numpy to do it.
+  Manually check the lengths of the inputs instead, or rely on NumPy to do it.
 - `.cbook.is_hashable`
   Use ``isinstance(..., collections.abc.Hashable)`` instead.
 

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -12,7 +12,7 @@ plotfile
 ~~~~~~~~
 `.pyplot.plotfile` is deprecated in favor of separately loading and plotting
 the data.  See :doc:`/gallery/misc/plotfile_demo_sgskip` for various ways to
-use pandas or numpy to load data, and pandas or matplotlib to plot the
+use pandas or NumPy to load data, and pandas or matplotlib to plot the
 resulting data.
 
 axes and axis
@@ -220,7 +220,7 @@ is now available to register a font at a given path.
 
 The ``as_str``, ``as_rgba_str``, ``as_array``, ``get_width`` and ``get_height``
 methods of ``matplotlib.ft2font.FT2Image`` are deprecated.  Convert the ``FT2Image``
-to a numpy array with ``np.asarray`` before processing it.
+to a NumPy array with ``np.asarray`` before processing it.
 
 Colors
 ~~~~~~

--- a/doc/devel/MEP/MEP28.rst
+++ b/doc/devel/MEP/MEP28.rst
@@ -17,7 +17,7 @@ The following lists any open PRs or branches related to this MEP:
 
 #. Deprecate redundant statistical kwargs in ``Axes.boxplot``: https://github.com/phobson/matplotlib/tree/MEP28-initial-deprecations
 #. Deprecate redundant style options in ``Axes.boxplot``: https://github.com/phobson/matplotlib/tree/MEP28-initial-deprecations
-#. Deprecate passings 2D numpy arrays as input: None
+#. Deprecate passings 2D NumPy arrays as input: None
 #. Add pre- & post-processing options to ``cbook.boxplot_stats``: https://github.com/phobson/matplotlib/tree/boxplot-stat-transforms
 #. Exposing ``cbook.boxplot_stats`` through ``Axes.boxplot`` kwargs: None
 #. Remove redundant statistical kwargs in ``Axes.boxplot``: None
@@ -197,9 +197,9 @@ Schedule
 An accelerated timeline could look like the following:
 
 #. v2.0.1 add transforms to ``cbook.boxplots_stats``, expose in ``Axes.boxplot``
-#. v2.1.0 Initial Deprecations , and using 2D numpy arrays as input
+#. v2.1.0 Initial Deprecations , and using 2D NumPy arrays as input
 
-    a. Using 2D numpy arrays as input. The semantics around 2D arrays are generally confusing.
+    a. Using 2D NumPy arrays as input. The semantics around 2D arrays are generally confusing.
     b. ``usermedians``, ``conf_intervals``, ``sym`` parameters
 
 #. v2.2.0

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -10,7 +10,7 @@ releases. For projects that use date-based versioning, every release
 is a 'minor version'.
 
 
-Python and numpy
+Python and NumPy
 ================
 
 - support minor versions of ``Python`` initially released

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -519,7 +519,7 @@ Picking exercise
 
 Create a data set of 100 arrays of 1000 Gaussian random numbers and
 compute the sample mean and standard deviation of each of them (hint:
-numpy arrays have a mean and std method) and make a xy marker plot of
+NumPy arrays have a mean and std method) and make a xy marker plot of
 the 100 means vs. the 100 standard deviations.  Connect the line
 created by the plot command to the pick event, and plot the original
 time series of the data that generated the clicked on points.  If more

--- a/doc/users/prev_whats_new/github_stats_3.0.2.rst
+++ b/doc/users/prev_whats_new/github_stats_3.0.2.rst
@@ -161,7 +161,7 @@ Pull Requests (224):
 * :ghpull:`12507`: FIX: make minor ticks formatted with science formatter as well
 * :ghpull:`12500`: Adjust the widths of the messages during the build.
 * :ghpull:`12492`: Simplify radar_chart example.
-* :ghpull:`12478`: MAINT: numpy deprecates asscalar in 1.16
+* :ghpull:`12478`: MAINT: NumPy deprecates asscalar in 1.16
 * :ghpull:`12363`: FIX: errors in get_position changes
 * :ghpull:`12495`: Fix duplicate condition in pathpatch3d example
 * :ghpull:`11984`: Strip out pkg-config machinery for agg and libqhull.


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Documentation is sphinx and numpydoc compliant
