### PR TITLE
Offset text position

### DIFF
--- a/doc/users/next_whats_new/2019-11-13-offset-text-position.rst
+++ b/doc/users/next_whats_new/2019-11-13-offset-text-position.rst
@@ -1,0 +1,4 @@
+Offset text is now set to the top when using axis.tick_top()
+------------------------------------------------------------
+
+Solves the issue that the power indicator (e.g. 1e4) stayed on the bottom, even if the ticks were on the top.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2068,7 +2068,6 @@ class XAxis(Axis):
             else:
                 bbox = mtransforms.Bbox.union(bboxes)
                 bottom = bbox.y0
-            self.offsetText.set_va('bottom')
             self.offsetText.set_position(
                 (x, bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72)
             )

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1975,7 +1975,7 @@ class XAxis(Axis):
             self.axes.transAxes, mtransforms.IdentityTransform())
         )
         self._set_artist_props(offsetText)
-        self.offset_text_position = 'bottom'
+        self._offset_text_position = 'bottom'
         return offsetText
 
     def set_label_position(self, position):
@@ -2059,15 +2059,44 @@ class XAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        x, y = self.offsetText.get_position()
-        if not len(bboxes):
-            bottom = self.axes.bbox.ymin
+        x, _ = self.offsetText.get_position()
+        offsetpad = self.OFFSETTEXTPAD * self.figure.dpi / 72.0
+        if self.offset_text_position == 'bottom':
+            if not len(bboxes):
+                y = self.axes.bbox.ymin
+            else:
+                bbox = mtransforms.Bbox.union(bboxes)
+                y = bbox.y0
+            y -= offsetpad
         else:
-            bbox = mtransforms.Bbox.union(bboxes)
-            bottom = bbox.y0
-        self.offsetText.set_position(
-            (x, bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72)
-        )
+            if not len(bboxes2):
+                y = self.axes.bbox.ymax
+            else:
+                bbox = mtransforms.Bbox.union(bboxes2)
+                y = bbox.y1
+            y += offsetpad
+        self.offsetText.set_position((x, y))
+
+    @property
+    def offset_text_position(self):
+        '''
+        The offset text position for exponent and offsets to labels
+
+        ACCEPTS: [ 'top' | 'bottom' ]
+        '''
+        return self._offset_text_position
+
+    @offset_text_position.setter
+    def offset_text_position(self, position):
+        valid_values = ('bottom', 'top')
+        if position not in valid_values:
+            raise ValueError("Position accepts only [ '{}' ]".format(
+                             "' | '".join(valid_values)))
+        self._offset_text_position = position
+        # For some reason vertical alignment bottom is actually top and top is
+        # bottom so swap what was selected
+        self.offsetText.set_va({'bottom': 'top', 'top': 'bottom'}[position])
+        self.stale = True
 
     def get_text_heights(self, renderer):
         """
@@ -2107,9 +2136,11 @@ class XAxis(Axis):
         if position == 'top':
             self.set_tick_params(which='both', top=True, labeltop=True,
                                  bottom=False, labelbottom=False)
+            self.offset_text_position = position
         elif position == 'bottom':
             self.set_tick_params(which='both', top=False, labeltop=False,
                                  bottom=True, labelbottom=True)
+            self.offset_text_position = position
         elif position == 'both':
             self.set_tick_params(which='both', top=True,
                                  bottom=True)
@@ -2119,6 +2150,7 @@ class XAxis(Axis):
         elif position == 'default':
             self.set_tick_params(which='both', top=True, labeltop=False,
                                  bottom=True, labelbottom=True)
+            self.offset_text_position = 'bottom'
         else:
             raise ValueError("invalid position: %s" % position)
         self.stale = True
@@ -2265,7 +2297,7 @@ class YAxis(Axis):
             self.axes.transAxes, mtransforms.IdentityTransform())
         )
         self._set_artist_props(offsetText)
-        self.offset_text_position = 'left'
+        self._offset_text_position = 'left'
         return offsetText
 
     def set_label_position(self, position):
@@ -2350,24 +2382,35 @@ class YAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        x, y = self.offsetText.get_position()
+        _, y = self.offsetText.get_position()
+        x = {'left': 0, 'right': 1}[self.offset_text_position]
         top = self.axes.bbox.ymax
         self.offsetText.set_position(
             (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
         )
 
-    def set_offset_position(self, position):
-        """
-        Parameters
-        ----------
-        position : {'left', 'right'}
-        """
-        x, y = self.offsetText.get_position()
-        x = cbook._check_getitem({'left': 0, 'right': 1}, position=position)
+    @property
+    def offset_text_position(self):
+        '''
+        The offset text position for exponent and offsets to labels
 
+        ACCEPTS: [ 'left' | 'right' ]
+        '''
+        return self._offset_text_position
+
+    @offset_text_position.setter
+    def offset_text_position(self, position):
+        valid_values = ('left', 'right')
+        if position not in valid_values:
+            raise ValueError("Position accepts only [ '{}' ]".format(
+                             "' | '".join(valid_values)))
+        self._offset_text_position = position
         self.offsetText.set_ha(position)
-        self.offsetText.set_position((x, y))
         self.stale = True
+
+    def set_offset_position(self, position):
+        ''' Deprecated '''
+        self.offset_text_position = position
 
     def get_text_widths(self, renderer):
         bbox, bbox2 = self.get_ticklabel_extents(renderer)
@@ -2403,11 +2446,11 @@ class YAxis(Axis):
         if position == 'right':
             self.set_tick_params(which='both', right=True, labelright=True,
                                  left=False, labelleft=False)
-            self.set_offset_position(position)
+            self.offset_text_position = position
         elif position == 'left':
             self.set_tick_params(which='both', right=False, labelright=False,
                                  left=True, labelleft=True)
-            self.set_offset_position(position)
+            self.offset_text_position = position
         elif position == 'both':
             self.set_tick_params(which='both', right=True,
                                  left=True)
@@ -2417,6 +2460,7 @@ class YAxis(Axis):
         elif position == 'default':
             self.set_tick_params(which='both', right=True, labelright=False,
                                  left=True, labelleft=True)
+            self.offset_text_position = 'left'
         else:
             raise ValueError("invalid position: %s" % position)
         self.stale = True

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2060,9 +2060,9 @@ class XAxis(Axis):
         boxes of all the ticklabels
         """
         x, y = self.offsetText.get_position()
-        if not hasattr(self, '_text_offset_position'):
-            self._text_offset_position = 'bottom'
-        if self._text_offset_position == 'bottom':
+        if not hasattr(self, '_tick_position'):
+            self._tick_position = 'bottom'
+        if self._tick_position == 'bottom':
             if not len(bboxes):
                 bottom = self.axes.bbox.ymin
             else:
@@ -2071,16 +2071,16 @@ class XAxis(Axis):
             self.offsetText.set_position(
                 (x, bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72)
             )
-            return
-        if not len(bboxes2):
-            top = self.axes.bbox.ymax
         else:
-            bbox = mtransforms.Bbox.union(bboxes2)
-            top = bbox.y1
-        self.offsetText.set_va('top')
-        self.offsetText.set_position(
-            (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
-        )
+            if not len(bboxes2):
+                top = self.axes.bbox.ymax
+            else:
+                bbox = mtransforms.Bbox.union(bboxes2)
+                top = bbox.y1
+            self.offsetText.set_va('top')
+            self.offsetText.set_position(
+                (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
+            )
 
     def get_text_heights(self, renderer):
         """
@@ -2120,11 +2120,11 @@ class XAxis(Axis):
         if position == 'top':
             self.set_tick_params(which='both', top=True, labeltop=True,
                                  bottom=False, labelbottom=False)
-            self._text_offset_position = 'top'
+            self._tick_position = 'top'
         elif position == 'bottom':
             self.set_tick_params(which='both', top=False, labeltop=False,
                                  bottom=True, labelbottom=True)
-            self._text_offset_position = 'bottom'
+            self._tick_position = 'bottom'
         elif position == 'both':
             self.set_tick_params(which='both', top=True,
                                  bottom=True)
@@ -2134,6 +2134,7 @@ class XAxis(Axis):
         elif position == 'default':
             self.set_tick_params(which='both', top=True, labeltop=False,
                                  bottom=True, labelbottom=True)
+            self._tick_position = 'bottom'
         else:
             raise ValueError("invalid position: %s" % position)
         self.stale = True

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1975,7 +1975,7 @@ class XAxis(Axis):
             self.axes.transAxes, mtransforms.IdentityTransform())
         )
         self._set_artist_props(offsetText)
-        self._offset_text_position = 'bottom'
+        self.offset_text_position = 'bottom'
         return offsetText
 
     def set_label_position(self, position):
@@ -2059,44 +2059,29 @@ class XAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        x, _ = self.offsetText.get_position()
-        offsetpad = self.OFFSETTEXTPAD * self.figure.dpi / 72.0
-        if self.offset_text_position == 'bottom':
+        x, y = self.offsetText.get_position()
+        if not hasattr(self, '_text_offset_position'):
+            self._text_offset_position = 'bottom'
+        if self._text_offset_position == 'bottom':
             if not len(bboxes):
-                y = self.axes.bbox.ymin
+                bottom = self.axes.bbox.ymin
             else:
                 bbox = mtransforms.Bbox.union(bboxes)
-                y = bbox.y0
-            y -= offsetpad
+                bottom = bbox.y0
+            self.offsetText.set_va('bottom')
+            self.offsetText.set_position(
+                (x, bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72)
+            )
+            return
+        if not len(bboxes2):
+            top = self.axes.bbox.ymax
         else:
-            if not len(bboxes2):
-                y = self.axes.bbox.ymax
-            else:
-                bbox = mtransforms.Bbox.union(bboxes2)
-                y = bbox.y1
-            y += offsetpad
-        self.offsetText.set_position((x, y))
-
-    @property
-    def offset_text_position(self):
-        '''
-        The offset text position for exponent and offsets to labels
-
-        ACCEPTS: [ 'top' | 'bottom' ]
-        '''
-        return self._offset_text_position
-
-    @offset_text_position.setter
-    def offset_text_position(self, position):
-        valid_values = ('bottom', 'top')
-        if position not in valid_values:
-            raise ValueError("Position accepts only [ '{}' ]".format(
-                             "' | '".join(valid_values)))
-        self._offset_text_position = position
-        # For some reason vertical alignment bottom is actually top and top is
-        # bottom so swap what was selected
-        self.offsetText.set_va({'bottom': 'top', 'top': 'bottom'}[position])
-        self.stale = True
+            bbox = mtransforms.Bbox.union(bboxes2)
+            top = bbox.y1
+        self.offsetText.set_va('top')
+        self.offsetText.set_position(
+            (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
+        )
 
     def get_text_heights(self, renderer):
         """
@@ -2136,11 +2121,11 @@ class XAxis(Axis):
         if position == 'top':
             self.set_tick_params(which='both', top=True, labeltop=True,
                                  bottom=False, labelbottom=False)
-            self.offset_text_position = position
+            self._text_offset_position = 'top'
         elif position == 'bottom':
             self.set_tick_params(which='both', top=False, labeltop=False,
                                  bottom=True, labelbottom=True)
-            self.offset_text_position = position
+            self._text_offset_position = 'bottom'
         elif position == 'both':
             self.set_tick_params(which='both', top=True,
                                  bottom=True)
@@ -2150,7 +2135,6 @@ class XAxis(Axis):
         elif position == 'default':
             self.set_tick_params(which='both', top=True, labeltop=False,
                                  bottom=True, labelbottom=True)
-            self.offset_text_position = 'bottom'
         else:
             raise ValueError("invalid position: %s" % position)
         self.stale = True
@@ -2297,7 +2281,7 @@ class YAxis(Axis):
             self.axes.transAxes, mtransforms.IdentityTransform())
         )
         self._set_artist_props(offsetText)
-        self._offset_text_position = 'left'
+        self.offset_text_position = 'left'
         return offsetText
 
     def set_label_position(self, position):
@@ -2382,35 +2366,24 @@ class YAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        _, y = self.offsetText.get_position()
-        x = {'left': 0, 'right': 1}[self.offset_text_position]
+        x, y = self.offsetText.get_position()
         top = self.axes.bbox.ymax
         self.offsetText.set_position(
             (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
         )
 
-    @property
-    def offset_text_position(self):
-        '''
-        The offset text position for exponent and offsets to labels
-
-        ACCEPTS: [ 'left' | 'right' ]
-        '''
-        return self._offset_text_position
-
-    @offset_text_position.setter
-    def offset_text_position(self, position):
-        valid_values = ('left', 'right')
-        if position not in valid_values:
-            raise ValueError("Position accepts only [ '{}' ]".format(
-                             "' | '".join(valid_values)))
-        self._offset_text_position = position
-        self.offsetText.set_ha(position)
-        self.stale = True
-
     def set_offset_position(self, position):
-        ''' Deprecated '''
-        self.offset_text_position = position
+        """
+        Parameters
+        ----------
+        position : {'left', 'right'}
+        """
+        x, y = self.offsetText.get_position()
+        x = cbook._check_getitem({'left': 0, 'right': 1}, position=position)
+
+        self.offsetText.set_ha(position)
+        self.offsetText.set_position((x, y))
+        self.stale = True
 
     def get_text_widths(self, renderer):
         bbox, bbox2 = self.get_ticklabel_extents(renderer)
@@ -2446,11 +2419,11 @@ class YAxis(Axis):
         if position == 'right':
             self.set_tick_params(which='both', right=True, labelright=True,
                                  left=False, labelleft=False)
-            self.offset_text_position = position
+            self.set_offset_position(position)
         elif position == 'left':
             self.set_tick_params(which='both', right=False, labelright=False,
                                  left=True, labelleft=True)
-            self.offset_text_position = position
+            self.set_offset_position(position)
         elif position == 'both':
             self.set_tick_params(which='both', right=True,
                                  left=True)
@@ -2460,7 +2433,6 @@ class YAxis(Axis):
         elif position == 'default':
             self.set_tick_params(which='both', right=True, labelright=False,
                                  left=True, labelleft=True)
-            self.offset_text_position = 'left'
         else:
             raise ValueError("invalid position: %s" % position)
         self.stale = True

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5201,10 +5201,24 @@ def test_unicode_hist_label():
 
 def test_move_offsetlabel():
     data = np.random.random(10) * 1e-22
+
     fig, ax = plt.subplots()
     ax.plot(data)
+    fig.canvas.draw()
+    before = ax.yaxis.offsetText.get_position()
     ax.yaxis.tick_right()
-    assert (1, 0.5) == ax.yaxis.offsetText.get_position()
+    fig.canvas.draw()
+    after = ax.yaxis.offsetText.get_position()
+    assert after[0] > before[0] and after[1] == before[1]
+
+    fig, ax = plt.subplots()
+    ax.plot(data)
+    fig.canvas.draw()
+    before = ax.xaxis.offsetText.get_position()
+    ax.xaxis.tick_top()
+    fig.canvas.draw()
+    after = ax.xaxis.offsetText.get_position()
+    assert after[0] == before[0] and after[1] > before[1]
 
 
 @image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})


### PR DESCRIPTION
## PR Summary
fixes #5238 (sets offset text to top when using axis.tick_top())
Solves the issue that the power indicator (e.g. ``1e4``) stays on the bottom, even if the ticks are on the top.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->