### PR TITLE
Add in autoscale

### DIFF
--- a/doc/users/next_whats_new/2019-11-02-in_autoscale.rst
+++ b/doc/users/next_whats_new/2019-11-02-in_autoscale.rst
@@ -1,0 +1,5 @@
+``Artist`` gained an ``set_in_autoscale()`` method
+---------------------------------------------------
+
+The ``Artist`` class gained an ``set_in_autoscale()`` method which
+is used to determine if the instance is used in the autoscale calculation.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -107,6 +107,7 @@ class Artist:
         self._path_effects = rcParams['path.effects']
         self._sticky_edges = _XYPair([], [])
         self._in_layout = True
+        self._in_autoscale = True
 
     def __getstate__(self):
         d = self.__dict__.copy()
@@ -816,6 +817,13 @@ class Artist:
         """
         return self._in_layout
 
+    def get_in_autoscale(self):
+        """
+        Return boolean flag, ``True`` if artist is included in autoscale
+        calculations.    
+        """
+        return self._in_autoscale
+
     def get_clip_on(self):
         """Return whether the artist uses clipping."""
         return self._clipon
@@ -970,6 +978,16 @@ class Artist:
         in_layout : bool
         """
         self._in_layout = in_layout
+
+    def set_in_autoscale(self, in_autoscale):
+        """
+        Set if artist is to be included in autoscale calculations.
+
+        Parameters
+        ----------
+        in_autoscale : bool
+        """
+        self._in_autoscale = in_autoscale
 
     def update(self, props):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1910,6 +1910,8 @@ class _AxesBase(martist.Artist):
         return image
 
     def _update_image_limits(self, image):
+        if not image.get_in_autoscale():
+            return
         xmin, xmax, ymin, ymax = image.get_extent()
         self.axes.update_datalim(((xmin, ymin), (xmax, ymax)))
 
@@ -1943,6 +1945,9 @@ class _AxesBase(martist.Artist):
         """
         Figures out the data limit of the given line, updating self.dataLim.
         """
+        if not line.get_in_autoscale():
+            return
+
         path = line.get_path()
         if path.vertices.size == 0:
             return
@@ -2005,6 +2010,9 @@ class _AxesBase(martist.Artist):
         # cannot check for '==0' since unitized data may not compare to zero
         # issue #2150 - we update the limits if patch has non zero width
         # or height.
+        if not patch.get_in_autoscale():
+            return
+
         if (isinstance(patch, mpatches.Rectangle) and
                 ((not patch.get_width()) and (not patch.get_height()))):
             return

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -285,3 +285,23 @@ def test_artist_inspector_get_aliases():
     ai = martist.ArtistInspector(mlines.Line2D)
     aliases = ai.get_aliases()
     assert aliases["linewidth"] == {"lw"}
+
+
+def test_in_autoscale_true():
+    # test autoscale is performed when in_autoscale=True.
+    fig, ax = plt.subplots()
+    ax.plot([0, 1])
+    ax.plot([0, 1, 2, 3], in_autoscale=True)
+    ax.margins(0)
+    ax.autoscale_view()
+    assert ax.get_xlim() == ax.get_ylim() == (0, 3)
+
+
+def test_in_autoscale_false():
+    # test autoscale is not performed when in_autoscale=False.
+    fig, ax = plt.subplots()
+    ax.plot([0, 1])
+    ax.plot([0, 1, 2, 3], in_autoscale=False)
+    ax.margins(0)
+    ax.autoscale_view()
+    assert ax.get_xlim() == ax.get_ylim() == (0, 1) # The default limits.

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -287,8 +287,8 @@ def test_artist_inspector_get_aliases():
     assert aliases["linewidth"] == {"lw"}
 
 
-def test_in_autoscale_true():
-    # test autoscale is performed when in_autoscale=True.
+def test_line_in_autoscale_true():
+    # test autoscale is performed when in_autoscale=True for a line.
     fig, ax = plt.subplots()
     ax.plot([0, 1])
     ax.plot([0, 1, 2, 3], in_autoscale=True)
@@ -297,11 +297,33 @@ def test_in_autoscale_true():
     assert ax.get_xlim() == ax.get_ylim() == (0, 3)
 
 
-def test_in_autoscale_false():
-    # test autoscale is not performed when in_autoscale=False.
+def test_line_in_autoscale_false():
+    # test autoscale is not performed when in_autoscale=False for a line.
     fig, ax = plt.subplots()
     ax.plot([0, 1])
     ax.plot([0, 1, 2, 3], in_autoscale=False)
     ax.margins(0)
     ax.autoscale_view()
     assert ax.get_xlim() == ax.get_ylim() == (0, 1) # The default limits.
+
+
+def test_patch_in_autoscale_true():
+    # test autoscale is performed when in_autoscale=True for a patch.
+    fig, ax = plt.subplots()
+    ax.plot([0, 1])
+    ax.bar([0, 1, 2, 3], [0, 10, 20, 30], width=0.5, in_autoscale=True)
+    ax.margins(0)
+    ax.autoscale_view()
+    assert ax.get_xlim() == (-.25, 3.25)
+    assert ax.get_ylim() == (0, 30)
+
+
+def test_patch_in_autoscale_false():
+    # test autoscale is not performed when in_autoscale=False for a patch.
+    fig, ax = plt.subplots()
+    ax.plot([0, 1])
+    ax.bar([0, 1, 2, 3], [0, 10, 20, 30], width=0.5, in_autoscale=False)
+    ax.margins(0)
+    ax.autoscale_view()
+    assert ax.get_xlim() == (0, 1)
+    assert ax.get_ylim() == (0, 1)


### PR DESCRIPTION
## PR Summary
The ``Artist`` class gained an ``set_in_autoscale()`` method which
is used to determine if the instance is used in the autoscale calculation.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
