### PR TITLE
Simplify OldAutoLocator and AutoDateLocator.

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1220,7 +1220,6 @@ class AutoDateLocator(DateLocator):
             at 6 hour intervals.
         """
         DateLocator.__init__(self, tz)
-        self._locator = YearLocator(tz=tz)
         self._freq = YEARLY
         self._freqs = [YEARLY, MONTHLY, DAILY, HOURLY, MINUTELY,
                        SECONDLY, MICROSECONDLY]
@@ -1258,9 +1257,10 @@ class AutoDateLocator(DateLocator):
                           range(0, 24), range(0, 60), range(0, 60), None]
 
     def __call__(self):
-        """Return the locations of the ticks."""
-        self.refresh()
-        return self._locator()
+        # docstring inherited
+        dmin, dmax = self.viewlim_to_dt()
+        locator = self.get_locator(dmin, dmax)
+        return locator()
 
     def tick_values(self, vmin, vmax):
         return self.get_locator(vmin, vmax).tick_values(vmin, vmax)
@@ -1279,15 +1279,6 @@ class AutoDateLocator(DateLocator):
             vmax = vmax + DAYS_PER_YEAR * 2
         return vmin, vmax
 
-    def set_axis(self, axis):
-        DateLocator.set_axis(self, axis)
-        self._locator.set_axis(axis)
-
-    def refresh(self):
-        # docstring inherited
-        dmin, dmax = self.viewlim_to_dt()
-        self._locator = self.get_locator(dmin, dmax)
-
     def _get_unit(self):
         if self._freq in [MICROSECONDLY]:
             return 1. / MUSECONDS_PER_DAY
@@ -1298,8 +1289,7 @@ class AutoDateLocator(DateLocator):
     def autoscale(self):
         """Try to choose the view limits intelligently."""
         dmin, dmax = self.datalim_to_dt()
-        self._locator = self.get_locator(dmin, dmax)
-        return self._locator.autoscale()
+        return self.get_locator(dmin, dmax).autoscale()
 
     def get_locator(self, dmin, dmax):
         """Pick the best locator based on a distance."""

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2816,33 +2816,25 @@ class OldAutoLocator(Locator):
     """
     On autoscale this class picks the best MultipleLocator to set the
     view limits and the tick locs.
-
     """
-    def __init__(self):
-        self._locator = LinearLocator()
 
     def __call__(self):
-        """Return the locations of the ticks."""
-        self.refresh()
-        return self.raise_if_exceeds(self._locator())
+        # docstring inherited
+        vmin, vmax = self.axis.get_view_interval()
+        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
+        d = abs(vmax - vmin)
+        locator = self.get_locator(d)
+        return self.raise_if_exceeds(locator())
 
     def tick_values(self, vmin, vmax):
         raise NotImplementedError('Cannot get tick locations for a '
                                   '%s type.' % type(self))
 
-    def refresh(self):
-        # docstring inherited
-        vmin, vmax = self.axis.get_view_interval()
-        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
-        d = abs(vmax - vmin)
-        self._locator = self.get_locator(d)
-
     def view_limits(self, vmin, vmax):
-        """Try to choose the view limits intelligently."""
-
+        # docstring inherited
         d = abs(vmax - vmin)
-        self._locator = self.get_locator(d)
-        return self._locator.view_limits(vmin, vmax)
+        locator = self.get_locator(d)
+        return locator.view_limits(vmin, vmax)
 
     def get_locator(self, d):
         """Pick the best locator based on a distance *d*."""


### PR DESCRIPTION
In both classes the `refresh` method only sets the `_locator` attribute,
which is only later called in `__call__` -- but `__call__` also calls
`refresh` first.  So we can instead inline the contents of `refresh`
into `__call__`, get rid of the `refresh` implementation (inheriting
the do-nothing implementation of the base class) and get rid of the
`_locator` attribute, as this has no publically observable effect.
Likewise, `AutoDateLocator.set_axis` can go.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
