### PR TITLE
Font weight warning if found font sufficiently different

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -36,3 +36,8 @@ did nothing, when passed an unsupported value. It now raises a ``ValueError``.
 `.Axis.set_tick_params` (and the higher level `.axes.Axes.tick_params` and
 `.pyplot.tick_params`) used to accept any value for ``which`` and silently
 did nothing, when passed an unsupported value. It now raises a ``ValueError``.
+
+``font_manager.findfont`` now warns of +-100 font-weight difference of selected font vs found font
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fonts are mapped from string to number. If the best-matched font is over 100 less than or
+greater than the chosen font, a warning will be logged.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1281,9 +1281,10 @@ class FontManager:
                 break
         
         if best_font is not None:
-            if abs(map_weight_name_to_score(prop.get_weight()) - map_weight_name_to_score(best_font.weight)) > 100:
-                _log.warning('findfont: Failed to find font weight %s, now using %s.',
-                            prop.get_weight(), best_font.weight)
+            if abs(map_weight_name_to_score(prop.get_weight()) 
+                - map_weight_name_to_score(best_font.weight)) > 100:
+                _log.warning('findfont: Failed to find font weight %s, '
+                + 'now using %s.', prop.get_weight(), best_font.weight)
 
         if best_font is None or best_score >= 10.0:
             if fallback_to_default:

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1279,6 +1279,11 @@ class FontManager:
                 best_font = font
             if score == 0:
                 break
+        
+        if best_font is not None:
+            if abs(map_weight_name_to_score(prop.get_weight()) - map_weight_name_to_score(best_font.weight)) > 100:
+                _log.warning('findfont: Failed to find font weight %s, now using %s.',
+                            prop.get_weight(), best_font.weight)
 
         if best_font is None or best_score >= 10.0:
             if fallback_to_default:
@@ -1296,10 +1301,6 @@ class FontManager:
             _log.debug('findfont: Matching %s to %s (%r) with score of %f.',
                        prop, best_font.name, best_font.fname, best_score)
             result = best_font.fname
-        
-        if abs(map_weight_name_to_score(prop.get_weight()) - map_weight_name_to_score(best_font.weight)) > 100:
-            _log.warning('findfont: Failed to find font weight %s, now using %s.',
-                        prop.get_weight(), best_font.weight)
 
         if not os.path.isfile(result):
             if rebuild_if_missing:

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -86,6 +86,10 @@ weight_dict = {
     'extra bold': 800,
     'black':      900,
 }
+
+def map_weight_name_to_score(weight):
+    return weight if isinstance(weight, Number) else weight_dict[weight]
+
 font_family_aliases = {
     'serif',
     'sans-serif',
@@ -1147,8 +1151,8 @@ class FontManager:
         # exact match of the weight names, e.g. weight1 == weight2 == "regular"
         if cbook._str_equal(weight1, weight2):
             return 0.0
-        w1 = weight1 if isinstance(weight1, Number) else weight_dict[weight1]
-        w2 = weight2 if isinstance(weight2, Number) else weight_dict[weight2]
+        w1 = map_weight_name_to_score(weight1)
+        w2 = map_weight_name_to_score(weight2)
         return 0.95 * (abs(w1 - w2) / 1000) + 0.05
 
     def score_size(self, size1, size2):
@@ -1292,6 +1296,10 @@ class FontManager:
             _log.debug('findfont: Matching %s to %s (%r) with score of %f.',
                        prop, best_font.name, best_font.fname, best_score)
             result = best_font.fname
+        
+        if abs(map_weight_name_to_score(prop.get_weight()) - map_weight_name_to_score(best_font.weight)) > 100:
+            _log.warning('findfont: Failed to find font weight %s, now using %s.',
+                        prop.get_weight(), best_font.weight)
 
         if not os.path.isfile(result):
             if rebuild_if_missing:

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -13,7 +13,7 @@ from matplotlib import font_manager as fm
 from matplotlib.font_manager import (
     findfont, findSystemFonts, FontProperties, fontManager, json_dump,
     json_load, get_font, get_fontconfig_fonts, is_opentype_cff_font,
-    MSUserFontDirectories, _call_fc_list)
+    MSUserFontDirectories, _call_fc_list, map_weight_name_to_score, weight_dict)
 from matplotlib import pyplot as plt, rc_context
 
 has_fclist = shutil.which('fc-list') is not None
@@ -199,3 +199,22 @@ def test_fork():
     _model_handler(0)  # Make sure the font cache is filled.
     ctx = multiprocessing.get_context("fork")
     ctx.Pool(processes=2).map(_model_handler, range(2))
+
+def test_map_weights():
+    assert map_weight_name_to_score('ultralight') == 100
+    assert map_weight_name_to_score('light') == 200
+    assert map_weight_name_to_score('normal') == 400
+    assert map_weight_name_to_score('regular') == 400
+    assert map_weight_name_to_score('book') == 400
+    assert map_weight_name_to_score('medium') == 500
+    assert map_weight_name_to_score('roman') == 500
+    assert map_weight_name_to_score('semibold') == 600
+    assert map_weight_name_to_score('demibold') == 600
+    assert map_weight_name_to_score('demi') == 600
+    assert map_weight_name_to_score('bold') == 700
+    assert map_weight_name_to_score('heavy') == 800
+    assert map_weight_name_to_score('extra bold') == 800
+    assert map_weight_name_to_score('black') == 900
+
+
+


### PR DESCRIPTION
## PR Summary
#15529 

We check if the chosen font is +-100 from the desired user outcome. If so, we log a warning documenting the desired and the actual used.

Test is added to make sure new function for string mappings are correct.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
