### PR TITLE
TST: Increase tolerance of some tests for aarch64

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -6,6 +6,7 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
+import platform
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -165,7 +166,8 @@ def test_pathclip():
 # test mixed mode rendering
 @needs_xelatex
 @pytest.mark.backend('pgf')
-@image_comparison(['pgf_mixedmode.pdf'], style='default')
+@image_comparison(['pgf_mixedmode.pdf'], style='default',
+                  tol={'aarch64': 1.086}.get(platform.machine(), 0.0))
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -40,7 +40,7 @@ def test_simple():
 
 
 @image_comparison(['multi_pickle.png'], remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.082}.get(platform.machine(), 0.0))
 def test_complete():
     fig = plt.figure('Figure with a label?', figsize=(10, 6))
 

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -1,4 +1,5 @@
 import pytest
+import platform
 
 import matplotlib as mpl
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
@@ -14,7 +15,7 @@ def usetex():
 
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
-                  tol=0.3)
+                  tol={'aarch64': 2.868}.get(platform.machine(), 0.3))
 def test_usetex():
     fig = plt.figure()
     ax = fig.add_subplot(111)

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -16,7 +16,8 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
     GridHelperCurveLinear
 
 
-@image_comparison(['custom_transform.png'], style='default', tol=0.03)
+@image_comparison(['custom_transform.png'], style='default',
+                  tol={'aarch64': 0.034}.get(platform.machine(), 0.03))
 def test_custom_transform():
     class MyTransform(Transform):
         input_dims = 2


### PR DESCRIPTION
##  PR Summary
Some tests differ from expected result on aarch64 by more than the
expected tolerance.  The generated images however remain visually
similar.

The differences appear to be at borders of colours for images,
i.e. edges of fonts, between transitions of colours, etc. and is
possibly due to FP rounding differences at those points.

Bump up tolerance of these tests by a bit so that they pass on
aarch64.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
