### PR TITLE
Cleanup mpl_toolkits locators.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -344,3 +344,8 @@ PGF backend cleanups
 The *dummy* parameter of `.RendererPgf` is deprecated.
 
 `.GraphicsContextPgf` is deprecated (use `.GraphicsContextBase` instead).
+
+``set_factor`` method of :mod:`mpl_toolkits.axisartist` locators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``set_factor`` method of :mod:`mpl_toolkits.axisartist` locators (which are
+different from "standard" Matplotlib tick locators) is deprecated.

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -238,6 +238,7 @@ class MaxNLocator(mticker.MaxNLocator):
         locs = mticker.MaxNLocator.__call__(self)
         return np.array(locs), len(locs), self._factor
 
+    @cbook.deprecated("3.3")
     def set_factor(self, f):
         self._factor = _deprecate_factor_none(f)
 
@@ -252,6 +253,7 @@ class FixedLocator:
         locs = np.array([l for l in self._locs if v1 <= l <= v2])
         return locs, len(locs), self._factor
 
+    @cbook.deprecated("3.3")
     def set_factor(self, f):
         self._factor = _deprecate_factor_none(f)
 
@@ -263,11 +265,8 @@ class FormatterPrettyPrint:
         self._fmt = mticker.ScalarFormatter(
             useMathText=useMathText, useOffset=False)
         self._fmt.create_dummy_axis()
-        self._ignore_factor = True
 
     def __call__(self, direction, factor, values):
-        if not self._ignore_factor:
-            values = [v / _deprecate_factor_none(factor) for v in values]
         return self._fmt.format_ticks(values)
 
 


### PR DESCRIPTION
mpl_toolkits locators have a separate API from "normal" Locators.  Work
towards unifying them by deprecating the unused set_factor method.

Also remove a branch for the never-unset _ignore_factor attribute of
FormatterPrettyPrint.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
