### PR TITLE
Docstring for Artist.mouseover

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1201,8 +1201,8 @@ class Artist:
     @property
     def mouseover(self):
         """
-        If this property is set to *True*, the data from the artist will be
-        displayed when the mouse cursor moves.
+        If this property is set to *True*, the artist will be queried for
+        custom context information when the mouse cursor moves over it.
 
         See also :meth:`get_cursor_data`, :class:`.ToolCursorPosition` and
         :class:`.NavigationToolbar2`.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1201,7 +1201,7 @@ class Artist:
     @property
     def mouseover(self):
         """
-        If this property is set to *True*, the data from the artist will be 
+        If this property is set to *True*, the data from the artist will be
         displayed when the mouse cursor moves.
 
         See also :meth:`get_cursor_data`, :class:`.ToolCursorPosition` and

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1200,6 +1200,13 @@ class Artist:
 
     @property
     def mouseover(self):
+        """
+        If this property is set to *True*, the data from the artist will be 
+        displayed when the mouse cursor moves.
+
+        See also :meth:`get_cursor_data`, :class:`.ToolCursorPosition` and
+        :class:`.NavigationToolbar2`.
+        """
         return self._mouseover
 
     @mouseover.setter


### PR DESCRIPTION
## PR Summary

There was no docstring for `Artist.mouseover` and the purpose of that property was not obvious, so I wrote a documentation.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] Documentation is sphinx and numpydoc compliant