### PR TITLE
Consistently use realpaths to build XObject names

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -868,8 +868,9 @@ class PdfFile:
         return fontdescObject
 
     def _get_xobject_symbol_name(self, filename, symbol_name):
+        realpath, stat_key = cbook.get_realpath_and_stat(filename)
         return "%s-%s" % (
-            os.path.splitext(os.path.basename(filename))[0],
+            os.path.splitext(os.path.basename(realpath))[0],
             symbol_name)
 
     _identityToUnicodeCMap = b"""/CIDInit /ProcSet findresource begin


### PR DESCRIPTION
##  PR Summary

This PR addresses an issue in the PDF backend which lead to invalid PDFs. The PDF backend used two inconsistent ways to build the name for XObjects required for Unicode glyphs above code point 255.

 - The first method is based on the file name of the font returned by  font_manager.findfont()`. This method is used to refer to the XObject glyphs when drawing text.
 - When the XObjects are created inside `writeFonts()` the realpath of the font returned by `cbook.get_realpath_and_stat()` is used instead.

The realpath differs from the file name of the font if the font is a symbolic link. In this case, the produced PDF contains invalid references to XObjects.

This commit adds a safe-guard in `PdfFile._get_xobject_symbol_name()`. The returned XObject names are always based on the realpath, even if the supplied path is a link.  This achieves consistent XObject names and prevents invalid PDF files.

This PR resolves #15628.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
