### PR TITLE
Fix examples claiming matplotlib can't plot np.datetime64.

### DIFF
--- a/examples/recipes/common_date_problems.py
+++ b/examples/recipes/common_date_problems.py
@@ -24,23 +24,11 @@ objects in a numpy record array::
          '2008-10-13', '2008-10-14'], dtype='datetime64[D]')
 
 The dtype of the NumPy record array for the field ``date`` is ``datetime64[D]``
-which means it is a 64-bit `numpy.datetime64` in 'day' units. While this format
-is more portable, Matplotlib cannot plot this format natively yet. We can plot
-this data by changing the dates to `datetime.date` instances instead, which can
-be achieved by converting to an object array::
-
-  In [67]: r.date.astype('O')
-  array([datetime.date(2004, 8, 19), datetime.date(2004, 8, 20),
-         datetime.date(2004, 8, 23), ..., datetime.date(2008, 10, 10),
-         datetime.date(2008, 10, 13), datetime.date(2008, 10, 14)],
-        dtype=object)
-
-The dtype of this converted array is now ``object`` and it is filled with
-datetime.date instances instead.
+which means it is a 64-bit `numpy.datetime64` in 'day' units.
 
 If you plot the data, ::
 
-  In [67]: plot(r.date.astype('O'), r.close)
+  In [67]: plot(r.date, r.close)
   Out[67]: [<matplotlib.lines.Line2D object at 0x92a6b6c>]
 
 you will see that the x tick labels are all squashed together.
@@ -53,35 +41,28 @@ import matplotlib.pyplot as plt
 with cbook.get_sample_data('goog.npz') as datafile:
     r = np.load(datafile)['price_data'].view(np.recarray)
 
-# Matplotlib prefers datetime instead of np.datetime64.
-date = r.date.astype('O')
 fig, ax = plt.subplots()
-ax.plot(date, r.close)
+ax.plot(r.date, r.close)
 ax.set_title('Default date handling can cause overlapping labels')
 
 ###############################################################################
-# Another annoyance is that if you hover the mouse over the window and
-# look in the lower right corner of the matplotlib toolbar
-# (:ref:`navigation-toolbar`) at the x and y coordinates, you see that
-# the x locations are formatted the same way the tick labels are, e.g.,
-# "Dec 2004".
+# Another annoyance is that if you hover the mouse over the window and look in
+# the lower right corner of the Matplotlib toolbar (:ref:`navigation-toolbar`)
+# at the x and y coordinates, you see that the x locations are formatted the
+# same way the tick labels are, e.g.,  "Dec 2004".
 #
-# What we'd like is for the location in the toolbar to have
-# a higher degree of precision, e.g., giving us the exact date out mouse is
-# hovering over.  To fix the first problem, we can use
-# :func:`matplotlib.figure.Figure.autofmt_xdate` and to fix the second
-# problem we can use the ``ax.fmt_xdata`` attribute which can be set to
-# any function that takes a scalar and returns a string.  matplotlib has
-# a number of date formatters built in, so we'll use one of those.
+# What we'd like is for the location in the toolbar to have a higher degree of
+# precision, e.g., giving us the exact date out mouse is hovering over.  To fix
+# the first problem, we can use `.Figure.autofmt_xdate` and to fix the second
+# problem we can use the ``ax.fmt_xdata`` attribute which can be set to any
+# function that takes a scalar and returns a string.  Matplotlib has a number
+# of date formatters built in, so we'll use one of those.
 
 fig, ax = plt.subplots()
-ax.plot(date, r.close)
-
-# rotate and align the tick labels so they look better
+ax.plot(r.date, r.close)
+# Rotate and align the tick labels so they look better.
 fig.autofmt_xdate()
-
-# use a more precise date string for the x axis locations in the
-# toolbar
+# Use a more precise date string for the x axis locations in the toolbar.
 ax.fmt_xdata = mdates.DateFormatter('%Y-%m-%d')
 ax.set_title('fig.autofmt_xdate fixes the labels')
 

--- a/examples/recipes/fill_between_alpha.py
+++ b/examples/recipes/fill_between_alpha.py
@@ -2,16 +2,14 @@
 Fill Between and Alpha
 ======================
 
-The :meth:`~matplotlib.axes.Axes.fill_between` function generates a
-shaded region between a min and max boundary that is useful for
-illustrating ranges.  It has a very handy ``where`` argument to
-combine filling with logical ranges, e.g., to just fill in a curve over
-some threshold value.
+The :meth:`~matplotlib.axes.Axes.fill_between` function generates a shaded
+region between a min and max boundary that is useful for illustrating ranges.
+It has a very handy ``where`` argument to combine filling with logical ranges,
+e.g., to just fill in a curve over some threshold value.
 
-At its most basic level, ``fill_between`` can be use to enhance a
-graphs visual appearance. Let's compare two graphs of a financial
-times with a simple line plot on the left and a filled line on the
-right.
+At its most basic level, ``fill_between`` can be use to enhance a graphs visual
+appearance. Let's compare two graphs of a financial times with a simple line
+plot on the left and a filled line on the right.
 """
 
 import matplotlib.pyplot as plt
@@ -21,15 +19,13 @@ import matplotlib.cbook as cbook
 # load up some sample financial data
 with cbook.get_sample_data('goog.npz') as datafile:
     r = np.load(datafile)['price_data'].view(np.recarray)
-# Matplotlib prefers datetime instead of np.datetime64.
-date = r.date.astype('O')
 # create two subplots with the shared x and y axes
 fig, (ax1, ax2) = plt.subplots(1, 2, sharex=True, sharey=True)
 
 pricemin = r.close.min()
 
-ax1.plot(date, r.close, lw=2)
-ax2.fill_between(date, pricemin, r.close, facecolor='blue', alpha=0.5)
+ax1.plot(r.date, r.close, lw=2)
+ax2.fill_between(r.date, pricemin, r.close, facecolor='blue', alpha=0.5)
 
 for ax in ax1, ax2:
     ax.grid(True)

--- a/examples/text_labels_and_annotations/date_index_formatter.py
+++ b/examples/text_labels_and_annotations/date_index_formatter.py
@@ -18,13 +18,10 @@ import matplotlib.ticker as ticker
 with cbook.get_sample_data('goog.npz') as datafile:
     r = np.load(datafile)['price_data'].view(np.recarray)
 r = r[-30:]  # get the last 30 days
-# Matplotlib works better with datetime.datetime than np.datetime64, but the
-# latter is more portable.
-date = r.date.astype('O')
 
 # first we'll do it the default way, with gaps on weekends
 fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4))
-ax1.plot(date, r.adj_close, 'o-')
+ax1.plot(r.date, r.adj_close, 'o-')
 ax1.set_title("Default")
 fig.autofmt_xdate()
 
@@ -35,7 +32,7 @@ ind = np.arange(N)  # the evenly spaced plot indices
 
 def format_date(x, pos=None):
     thisind = np.clip(int(x + 0.5), 0, N - 1)
-    return date[thisind].strftime('%Y-%m-%d')
+    return r.date[thisind].item().strftime('%Y-%m-%d')
 
 
 ax2.plot(ind, r.adj_close, 'o-')

--- a/examples/ticks_and_spines/centered_ticklabels.py
+++ b/examples/ticks_and_spines/centered_ticklabels.py
@@ -27,12 +27,9 @@ import matplotlib.pyplot as plt
 with cbook.get_sample_data('aapl.npz') as fh:
     r = np.load(fh)['price_data'].view(np.recarray)
 r = r[-250:]  # get the last 250 days
-# Matplotlib works better with datetime.datetime than np.datetime64, but the
-# latter is more portable.
-date = r.date.astype('O')
 
 fig, ax = plt.subplots()
-ax.plot(date, r.adj_close)
+ax.plot(r.date, r.adj_close)
 
 ax.xaxis.set_major_locator(dates.MonthLocator())
 # 16 is a slight approximation since months differ in number of days.
@@ -47,5 +44,5 @@ for tick in ax.xaxis.get_minor_ticks():
     tick.label1.set_horizontalalignment('center')
 
 imid = len(r) // 2
-ax.set_xlabel(str(date[imid].year))
+ax.set_xlabel(str(r.date[imid].item().year))
 plt.show()


### PR DESCRIPTION
This is simply not true anymore, they are natively handled.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
