### PR TITLE
Hide sphinx-gallery config comments

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -135,6 +135,7 @@ sphinx_gallery_conf = {
     'backreferences_dir': 'api/_as_gen',
     'subsection_order': gallery_order.sectionorder,
     'within_subsection_order': gallery_order.subsectionorder,
+    'remove_config_comments': True,
     'min_reported_time': 1,
 }
 

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -12,5 +12,5 @@ colorspacious
 ipython
 ipywidgets
 numpydoc>=0.8
-sphinx-gallery>=0.2
+sphinx-gallery>=0.4
 sphinx-copybutton


### PR DESCRIPTION
## PR Summary

This activates the new sphinx-gallery config option `remove_config_comments` which removes comments like `# sphinx_gallery_thumbnail_number = 2` (e.g. in the code at https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/fill_between_demo.html#example-confidence-bands). These do only controll sphinx-gallery behavior, they are not relevant for the viewer of the docs, and are rather confusing.

This requires `sphinx-gallery>=0.4` and thus bumps the minimum needed version (but that's rather uncritical because it's only needed for doc builds and not affecting the end-user).