### PR TITLE
Fix searchindex.js loading when ajax fails (because e.g. CORS in embedded iframes)

### DIFF
--- a/doc/_templates/search.html
+++ b/doc/_templates/search.html
@@ -41,8 +41,5 @@
 {% endblock %}
 {% block footer %}
   {{ super() }}
-<script type="text/javascript">
-    jQuery(function() { Search.loadIndex("searchindex.js"); });
-</script>
-<script type="text/javascript" id="searchindexloader"></script>
+  <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
 {% endblock %}

--- a/doc/_templates/search.html
+++ b/doc/_templates/search.html
@@ -44,4 +44,5 @@
 <script type="text/javascript">
     jQuery(function() { Search.loadIndex("searchindex.js"); });
 </script>
+<script type="text/javascript" id="searchindexloader"></script>
 {% endblock %}


### PR DESCRIPTION
### Summary:
Searching the documentation does not work in Jupyterlab's Matplotlib reference pane, because `searchindex.js` fails to load due to a AJAX/XHR CORS issue. The search page remains stuck on "Searching..".

This PR partially fixes the issue by restoring the backup-method of using a `<script>` tag that was missing from Matplotlib's version of the `search.html` template.

The search page now returns a list of relevant links. The preview snippets that load underneath each link still do not work because of the same CORS issue (and cannot be loaded in an alternate way).

### Context of the fix:
The `searchindex.js` is being loaded using AJAX/XHR in [search.html#L45](https://github.com/matplotlib/matplotlib/blob/c178929d9a80e4a8fec86f1096e19914006b0d81/doc/_templates/search.html#L45) calling `loadIndex` in [searchtools.js#L78](https://github.com/sphinx-doc/sphinx/blob/c2d64a9b0a7ef1fbd56c620d292e067ded462200/sphinx/themes/basic/static/searchtools.js#L78) (A file provided by Sphinx. Matplotlib docs inherits its theme from [numpy/numpydoc](https://github.com/numpy/numpydoc), which inherits from [scipy/scipy-sphinx-theme](https://github.com/scipy/scipy-sphinx-theme), which inherits from the [sphinx-doc/sphinx basic](https://github.com/sphinx-doc/sphinx/tree/master/sphinx/themes/basic) theme).

If the XHR fails, `loadIndex` resorts to loading the script through the `<script id="searchindexloader">` tag. Matplotlib's version of the `search.html` template has somehow lost this tag.

*Additionally, Sphinx has changed the way `searchindex.js` loads*:
 - In the [latest version](https://github.com/sphinx-doc/sphinx/commit/55c5168f338d6a9625c789af6c4b9ab04eb5ec93#diff-71eb2d907f122b85744ef4c3390903cb) of the `search.html` template, the AJAX method is dropped for just a simple `defer`-ed `<script>` tag. **Alternative to this PR, matplotlib could also adopt this change instead?**
- But this was then [reverted](https://github.com/sphinx-doc/sphinx/commit/a6e31708ccfa099af656cc90e525f99b0e778b50#diff-71eb2d907f122b85744ef4c3390903cb) again because of third-party themes (such as Matplotlib's) still using the old method.

### What about the original issue, that XHR fails?
The original AJAX/XHR request fails because the CORS (Cross-Origin-Resource-Sharing) preflight OPTIONS request returns a 405 Method Not Allowed response from matplotlib.org. Even though a subsequent GET would return the correct `Access-Control-Allow-Origin: *` header. The same happens for the snippets.

This issue has to be fixed in the web server configuration. For the OPTIONS request it should instead respond with a 200 OK and the headers `Access-Control-Allow-Methods: POST, GET, OPTIONS` and
`Access-Control-Allow-Origin: *`. I'll submit a request in [discourse](https://discourse.matplotlib.org/t/matplotlib-website-feedback/20648) for this, but otherwise do not know where/whom to direct this issue to. (Should this require a separate issue on the main repo?)

See also: https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request or https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests.

### What about the older docs?
I am not sure how to go about potentially getting this fix back-ported to older versions of Matplotlib documentation (Is that a thing? Or are those frozen?). The Jupyterlab reference pane only points to the latest version on matplotlib.org, so it is not an immediate concern. It's probably better to just have the CORS issue on the server fixed.