### PR TITLE
Simplify axes_pad handling in axes_grid.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -135,8 +135,7 @@ class Grid:
             - "1": Only the bottom left axes is labelled.
             - "all": all axes are labelled.
 
-        axes_class : a type that is a subclass of `matplotlib.axes.Axes`, \
-default: None
+        axes_class : subclass of `matplotlib.axes.Axes`, default: None
         """
         self._nrows, self._ncols = nrows_ncols
 
@@ -400,8 +399,7 @@ class ImageGrid(Grid):
         cbar_set_cax : bool, default: True
             If True, each axes in the grid has a *cax* attribute that is bound
             to associated *cbar_axes*.
-        axes_class : a type that is a subclass of `matplotlib.axes.Axes`, \
-default: None
+        axes_class : subclass of `matplotlib.axes.Axes`, default: None
         """
         self._nrows, self._ncols = nrows_ncols
 


### PR DESCRIPTION
- Replace _extend_axes_pad by np.broadcast_to(..., 2).
- Get rid of the unused _axes_pad attribute.

Also an unrelated small docstring fix in the same module that's not worth being a separate PR.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
