### PR TITLE
Rely on findfont autofallback-to-default in pdf/ps backends.

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -69,11 +69,8 @@ class RendererPDFPSBase(RendererBase):
             return w, h, d
 
     def _get_font_afm(self, prop):
-        fname = (
-            font_manager.findfont(
-                prop, fontext="afm", directory=self._afm_font_dir)
-            or font_manager.findfont(
-                "Helvetica", fontext="afm", directory=self._afm_font_dir))
+        fname = font_manager.findfont(
+            prop, fontext="afm", directory=self._afm_font_dir)
         return _cached_get_afm_from_fname(fname)
 
     def _get_font_ttf(self, prop):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -663,10 +663,6 @@ class PdfFile:
         elif rcParams['pdf.use14corefonts']:
             filename = findfont(
                 fontprop, fontext='afm', directory=RendererPdf._afm_font_dir)
-            if filename is None:
-                filename = findfont(
-                    "Helvetica",
-                    fontext='afm', directory=RendererPdf._afm_font_dir)
         else:
             filename = findfont(fontprop)
 


### PR DESCRIPTION
findfont(...) will never return None unless fallback_to_default=False
is passed -- the default is True and causes afm searches to fall
back to Helvetica -- so the "filename is None" branch never occurs.
(The code in the pdf/ps backends came in in af9954d (2009) whereas
fallback_to_default only came in in 94120dc (2010).)

Noted while reviewing https://github.com/matplotlib/matplotlib/pull/15629.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
