### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
-
-custom: https://numfocus.salsalabs.org/donate-to-matplotlib/index.html
+github: [numfocus]
+custom: https://numfocus.org/donate-to-matplotlib


### PR DESCRIPTION
add NumFOCUS github sponsors button (recurring donations only)

This feature is launching today at GitHub Universe!

Also suggested change to your donation link so that it's the one hosted on numfocus.org, in case that helps give potential donors a greater sense of security.

cc @story645 @tacaswell