### PR TITLE
Handle upcoming deprecation of np.float.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -719,9 +719,7 @@ class _WedgeBbox(mtransforms.Bbox):
         Bbox determining the origin for the wedge, if different from *viewLim*
     """
     def __init__(self, center, viewLim, originLim, **kwargs):
-        mtransforms.Bbox.__init__(self,
-                                  np.array([[0.0, 0.0], [1.0, 1.0]], np.float),
-                                  **kwargs)
+        mtransforms.Bbox.__init__(self, [[0, 0], [1, 1]], **kwargs)
         self._center = center
         self._viewLim = viewLim
         self._originLim = originLim

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -763,12 +763,12 @@ class Bbox(BboxBase):
     @staticmethod
     def unit():
         """Create a new unit `Bbox` from (0, 0) to (1, 1)."""
-        return Bbox(np.array([[0.0, 0.0], [1.0, 1.0]], float))
+        return Bbox([[0, 0], [1, 1]])
 
     @staticmethod
     def null():
         """Create a new null `Bbox` from (inf, inf) to (-inf, -inf)."""
-        return Bbox(np.array([[np.inf, np.inf], [-np.inf, -np.inf]], float))
+        return Bbox([[np.inf, np.inf], [-np.inf, -np.inf]])
 
     @staticmethod
     def from_bounds(x0, y0, width, height):
@@ -786,8 +786,7 @@ class Bbox(BboxBase):
 
         The *y*-axis increases upwards.
         """
-        points = np.array(args, dtype=float).reshape(2, 2)
-        return Bbox(points)
+        return Bbox(np.reshape(args, (2, 2)))
 
     def __format__(self, fmt):
         return (

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -155,9 +155,8 @@ class ConversionInterface:
 
 
 class DecimalConverter(ConversionInterface):
-    """
-    Converter for decimal.Decimal data to float.
-    """
+    """Converter for decimal.Decimal data to float."""
+
     @staticmethod
     def convert(value, unit, axis):
         """
@@ -172,13 +171,13 @@ class DecimalConverter(ConversionInterface):
         """
         # If value is a Decimal
         if isinstance(value, Decimal):
-            return np.float(value)
+            return float(value)
         else:
             # assume x is a list of Decimal
             converter = np.asarray
             if isinstance(value, ma.MaskedArray):
                 converter = ma.asarray
-            return converter(value, dtype=np.float)
+            return converter(value, dtype=float)
 
     @staticmethod
     def axisinfo(unit, axis):


### PR DESCRIPTION
numpy plans to deprecate np.float in favor of float (https://github.com/numpy/numpy/pull/14882); remove the few
remaining usages of np.float in the codebase.

Actually the Bbox constructor already converts its argument using
`np.asarray(..., dtype=float)` so we don't need to bother explicitly
casting the argument to a float array at the call site.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
