### PR TITLE
Make 3d plot accept scalars as arguments.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1438,7 +1438,7 @@ class Axes3D(Axes):
             zs = kwargs.pop('zs', 0)
 
         # Match length
-        zs = np.broadcast_to(zs, len(xs))
+        zs = np.broadcast_to(zs, np.shape(xs))
 
         lines = super().plot(xs, ys, *args, **kwargs)
         for line in lines:

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -160,6 +160,14 @@ def test_lines3d():
     ax.plot(x, y, z)
 
 
+@check_figures_equal(extensions=["png"])
+def test_plot_scalar(fig_test, fig_ref):
+    ax1 = fig_test.gca(projection='3d')
+    ax1.plot([1], [1], "o")
+    ax2 = fig_ref.gca(projection='3d')
+    ax2.plot(1, 1, "o")
+
+
 @image_comparison(['mixedsubplot.png'], remove_text=True)
 def test_mixedsubplots():
     def f(t):


### PR DESCRIPTION
... for consistency with 2d plot.

Closes #8577.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
