### PR TITLE
Don't explicitly list scalez kwarg in Axes3D constructor and docs.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -48,10 +48,9 @@ class Axes3D(Axes):
     name = '3d'
     _shared_z_axes = cbook.Grouper()
 
-    @docstring.dedent_interpd
     def __init__(
             self, fig, rect=None, *args,
-            azim=-60, elev=30, zscale=None, sharez=None, proj_type='persp',
+            azim=-60, elev=30, sharez=None, proj_type='persp',
             **kwargs):
         """
         Parameters
@@ -64,13 +63,14 @@ class Axes3D(Axes):
             Azimuthal viewing angle, defaults to -60.
         elev : float, optional
             Elevation viewing angle, defaults to 30.
-        zscale : %(scale_type)s, optional
-            The z scale.  Note that currently, only a linear scale is
-            supported.
         sharez : Axes3D, optional
             Other axes to share z-limits with.
         proj_type : {'persp', 'ortho'}
             The projection type, default 'persp'.
+        **kwargs
+            Other optional keyword arguments:
+
+            %(Axes3D)s
 
         Notes
         -----
@@ -109,9 +109,6 @@ class Axes3D(Axes):
 
         # func used to format z -- fall back on major formatters
         self.fmt_zdata = None
-
-        if zscale is not None:
-            self.set_zscale(zscale)
 
         if self.zaxis is not None:
             self._zcid = self.zaxis.callbacks.connect(
@@ -2874,6 +2871,10 @@ pivot='tail', normalize=False, **kwargs)
             polygons[coord] = poly
 
         return polygons
+
+
+docstring.interpd.update(Axes3D=artist.kwdoc(Axes3D))
+docstring.dedent_interpd(Axes3D.__init__)
 
 
 def get_test_data(delta=0.05):


### PR DESCRIPTION
1) We actually don't even support non-linear scales in Axes3D.
2) This is consistent with 2D axes, for which the scales are just listed
   in the properties table.

(note that the kwarg remains "supported" and handled via `self.update(kwargs)`).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
