### PR TITLE
Catch correct parse errror type for dateutil >= 2.8.1

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -179,7 +179,8 @@ class UnitData:
         except ValueError:
             try:
                 dateutil.parser.parse(val)
-            except ValueError:
+            except (ValueError, TypeError):
+                # TypeError if dateutil >= 2.8.1 else ValueError
                 return False
         return True
 


### PR DESCRIPTION
## PR Summary

Fixes #15726.

Backporting to 2.2.5 because dateutil 2.8.1 still supports Python 2.

Release critical because this execption is part of a standard code path (`_str_is_convertible()` returning `False`).