### PR TITLE
Fix env override in WebAgg backend test.

### DIFF
--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -8,11 +8,9 @@ import pytest
 def test_webagg_fallback(backend):
     if backend == "nbagg":
         pytest.importorskip("IPython")
-    env = {}
-    if os.name == "nt":
-        env = dict(os.environ)
-    else:
-        env = {"DISPLAY": ""}
+    env = dict(os.environ)
+    if os.name != "nt":
+        env["DISPLAY"] = ""
 
     env["MPLBACKEND"] = backend
 


### PR DESCRIPTION
It's only necessary to override `DISPLAY`, not throw away the rest of the environment. Without the other environment variables, stuff like custom `PYTHONPATH` break in this test.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way