### PR TITLE
ImageMagick animators now can use extra_args

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -696,7 +696,11 @@ class ImageMagickBase:
 
     @property
     def output_args(self):
-        return [self.outfile]
+        if self.extra_args:
+            args = list(self.extra_args)
+        else:
+            args = []
+        return args + [self.outfile]
 
     @classmethod
     def bin_path(cls):


### PR DESCRIPTION
As a general solution for passing further args
to imagemagick when generating animations,
extra_args is now actually used. Extra args are
placed after all other args, but before the
output file name.


## PR Summary

Note: This is a "general solution" to the problem I had.

My usecase: I found that if I passed a generated .gif back to Imagemagick, with the args `-layers Optimize`  (more fully just: `convert anim.gif -layers Optimize anim.gif`), My several-megabyte gifs would be reduced in size by ~10x.  In my current usage, I do this second pass via subprocess.

I then went ahead and modified my local copy of matplotlib (caveat: v1.5.1 with pyhon2.7 on ubuntu 14.04; but the code looks identical between master and 1.51).

With the fix in this PR, I can now do `anim.save(gif_path, dpi=80, writer='imagemagick', extra_args=["-layers", "Optimize"])`.  This works fine giving visually identical animations, and further reduces file size another order of magnitude (in the one case I'm dealing with, I'm getting a resulting file 1/70th the size).

A concern I have (as I am not a regular imagemagick user, let alone an expert) is whether simply dumping extra args to image magick at the end of the hardcoded args is reasonable, or if order of operations is likely to make a mess with certain additional imagemagick arguments/operations...  I might argue that any user adding imagemagick args probably knows what they're doing and would realize what's up.  (I definitely benefited from `matplotlib.debug=helpful` or something like that, which showed the `convert` command that was actually invoked.) Alternately, maybe [this is a spot](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.animation.ImageMagickWriter.html) where it's desirable to have more detailed documentation?

For reference, the code where `convert` is invoked with args looks like:
```
return ([self.bin_path(),                                  
         '-size', '%ix%i' % self.frame_size, '-depth', '8',
         '-delay', str(self.delay), '-loop', '0',          
         '%s:-' % self.frame_format]                       
        + self.output_args)                                
```

**Therefore** I am completely open to revising/redoing this PR and instead adding a `ImageMagick[File]Writer` specific arg/property e.g. `compress` that explicitly adds `-layers Optimize` to the command (and leave `extra_args` unused as it currently is).

Other notes:
- I chose to modify the output_args property with additional logic, as this is similar to what is done with FFMpegBase and MencoderBase classes
  - Alternately, I probably would have just modified the `_args()` function instead.
- I verified that both ImageMagickWriter and ImageMagickFileWriter classes use the extra args as expected

## PR Checklist

- [ ] Has Pytest style unit tests **no similar tests exist for other classes using `extra_args`**
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant  **no additional warnings generated**
- [x] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
