### PR TITLE
Small animation cleanup.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -579,12 +579,9 @@ class FFMpegBase:
         # OSX). Also fixes internet explorer. This is as of 2015/10/29.
         if self.codec == 'h264' and '-pix_fmt' not in self.extra_args:
             args.extend(['-pix_fmt', 'yuv420p'])
-        # The %dk adds 'k' as a suffix so that ffmpeg treats our bitrate as in
-        # kbps
         if self.bitrate > 0:
-            args.extend(['-b', '%dk' % self.bitrate])
-        if self.extra_args:
-            args.extend(self.extra_args)
+            args.extend(['-b', '%dk' % self.bitrate])  # %dk: bitrate in kbps.
+        args.extend(self.extra_args)
         for k, v in self.metadata.items():
             args.extend(['-metadata', '%s=%s' % (k, v)])
 
@@ -696,11 +693,7 @@ class ImageMagickBase:
 
     @property
     def output_args(self):
-        if self.extra_args:
-            args = list(self.extra_args)
-        else:
-            args = []
-        return args + [self.outfile]
+        return [*self.extra_args, self.outfile]
 
     @classmethod
     def bin_path(cls):


### PR DESCRIPTION
Animation.extra_args is always a list (we normalize None to be the rc in
the constructor) so we don't need to separately handle the empty case.

Noticed while reviewing #15739.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
