### PR TITLE
Move Text init to end of Annotation init.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1765,21 +1765,16 @@ class Annotation(Text, _AnnotationBase):
         x, y = xytext
 
         self.arrowprops = arrowprops
-
         if arrowprops is not None:
+            arrowprops = arrowprops.copy()
             if "arrowstyle" in arrowprops:
-                arrowprops = self.arrowprops.copy()
                 self._arrow_relpos = arrowprops.pop("relpos", (0.5, 0.5))
             else:
                 # modified YAArrow API to be used with FancyArrowPatch
-                shapekeys = ('width', 'headwidth', 'headlength',
-                             'shrink', 'frac')
-                arrowprops = dict()
-                for key, val in self.arrowprops.items():
-                    if key not in shapekeys:
-                        arrowprops[key] = val  # basic Patch properties
-            self.arrow_patch = FancyArrowPatch((0, 0), (1, 1),
-                                               **arrowprops)
+                for key in [
+                        'width', 'headwidth', 'headlength', 'shrink', 'frac']:
+                    arrowprops.pop(key, None)
+            self.arrow_patch = FancyArrowPatch((0, 0), (1, 1), **arrowprops)
         else:
             self.arrow_patch = None
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1764,8 +1764,6 @@ class Annotation(Text, _AnnotationBase):
             xytext = self.xy
         x, y = xytext
 
-        Text.__init__(self, x, y, text, **kwargs)
-
         self.arrowprops = arrowprops
 
         if arrowprops is not None:
@@ -1784,6 +1782,9 @@ class Annotation(Text, _AnnotationBase):
                                                **arrowprops)
         else:
             self.arrow_patch = None
+
+        # Must come last, as some kwargs may be propagated to arrow_patch.
+        Text.__init__(self, x, y, text, **kwargs)
 
     def contains(self, event):
         inside, info = self._default_contains(event)


### PR DESCRIPTION
## PR Summary

... in case some kwargs (each of which is handled by calling a set_foo)
need to refer to arrow_patch).  Closes #15745. 

I nearly told the OP of #15745 that he needed to create an annotation without setting axes and figure because add_text (like add_line) would take care of it for him... but _add_text is private, for some reason (probably should be public, like add_line and friends?)

Small neighboring cleanup in a separate commit.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
