### PR TITLE
Modernize FAQ entry for plt.show().

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -485,38 +485,25 @@ interface window, you do not need to call ``show`` (see :ref:`howto-batch`
 and :ref:`what-is-a-backend`).
 
 .. note::
-   Because closing a figure window invokes the destruction of its plotting
-   elements, you should call :func:`~matplotlib.pyplot.savefig` *before*
-   calling ``show`` if you wish to save the figure as well as view it.
+   Because closing a figure window unregisters it from pyplot, you must call
+   `~matplotlib.pyplot.savefig` *before* calling ``show`` if you wish to save
+   the figure as well as view it.
 
-.. versionadded:: v1.0.0
-   ``show`` now starts the GUI mainloop only if it isn't already running.
-   Therefore, multiple calls to ``show`` are now allowed.
-
-Having ``show`` block further execution of the script or the python
-interpreter depends on whether Matplotlib is set for interactive mode
-or not.  In non-interactive mode (the default setting), execution is paused
+Whether ``show`` blocks further execution of the script or the python
+interpreter depends on whether Matplotlib is set to use interactive mode.
+In non-interactive mode (the default setting), execution is paused
 until the last figure window is closed.  In interactive mode, the execution
 is not paused, which allows you to create additional figures (but the script
 won't finish until the last figure window is closed).
 
-.. note::
-   Support for interactive/non-interactive mode depends upon the backend.
-   Until version 1.0.0 (and subsequent fixes for 1.0.1), the behavior of
-   the interactive mode was not consistent across backends.
-   As of v1.0.1, only the macosx backend differs from other backends
-   because it does not support non-interactive mode.
-
-
 Because it is expensive to draw, you typically will not want Matplotlib
 to redraw a figure many times in a script such as the following::
 
-    plot([1,2,3])            # draw here ?
-    xlabel('time')           # and here ?
-    ylabel('volts')          # and here ?
-    title('a simple plot')   # and here ?
+    plot([1, 2, 3])          # draw here?
+    xlabel('time')           # and here?
+    ylabel('volts')          # and here?
+    title('a simple plot')   # and here?
     show()
-
 
 However, it is *possible* to force Matplotlib to draw after every command,
 which might be what you want when working interactively at the
@@ -534,26 +521,10 @@ you're all done issuing commands and you want to draw the figure now.
     If you want to force a figure draw, use
     :func:`~matplotlib.pyplot.draw` instead.
 
-Many users are frustrated by ``show`` because they want it to be a
-blocking call that raises the figure, pauses the script until they
-close the figure, and then allow the script to continue running until
-the next figure is created and the next show is made.  Something like
-this::
-
-   # WARNING : illustrating how NOT to use show
-   for i in range(10):
-       # make figure i
-       show()
-
-This is not what show does and unfortunately, because doing blocking
-calls across user interfaces can be tricky, is currently unsupported,
-though we have made significant progress towards supporting blocking events.
-
 .. versionadded:: v1.0.0
-   As noted earlier, this restriction has been relaxed to allow multiple
-   calls to ``show``.  In *most* backends, you can now expect to be
-   able to create new figures and raise them in a subsequent call to
-   ``show`` after closing the figures from a previous call to ``show``.
+   Matplotlib 1.0.0 and 1.0.1 added support for calling ``show`` multiple times
+   per script, and harmonized the behavior of interactive mode, across most
+   backends.
 
 .. _howto-boxplot_violinplot:
 


### PR DESCRIPTION
- show() can now be called multiple times (admittedly, I don't know for
  the OSX backend, all others do work fine).
- Move all references to pre-1.0 behavior together at the end.
- One can actually call savefig() after interactively closing a figure;
  the only thing is that one would need to call fig.savefig() rather
  than plt.savefig() as pyplot loses track of the figure once it is
  closed.  So slightly reword the corresponding admonition (no need to
  go into the details there).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
