### PR TITLE
Update badges in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
-|Travis|_ |AzurePipelines|_ |AppVeyor|_ |Codecov|_ |LGTM|_ |PyPi|_ |Gitter|_ |NUMFocus|_ |GitTutorial|_
+|PyPi|_ |Downloads|_ |NUMFocus|_
 
+|DiscourseBadge|_ |Gitter|_ |GitHubIssues|_ |GitTutorial|_
+
+|Travis|_ |AzurePipelines|_ |AppVeyor|_ |Codecov|_ |LGTM|_
 
 .. |Travis| image:: https://travis-ci.com/matplotlib/matplotlib.svg?branch=master
 .. _Travis: https://travis-ci.com/matplotlib/matplotlib
@@ -16,17 +19,27 @@
 .. |LGTM| image:: https://img.shields.io/lgtm/grade/python/g/matplotlib/matplotlib.svg?logo=lgtm&logoWidth=18
 .. _LGTM: https://lgtm.com/projects/g/matplotlib/matplotlib
 
+.. |DiscourseBadge| image:: https://img.shields.io/badge/help_forum-discourse-blue.svg
+.. _DiscourseBadge: https://discourse.matplotlib.org
+
+.. |Gitter| image:: https://badges.gitter.im/matplotlib/matplotlib.svg
+.. _Gitter: https://gitter.im/matplotlib/matplotlib
+
+.. |GitHubIssues| image:: https://img.shields.io/badge/issue_tracking-github-blue.svg
+.. _GitHubIssues: https://github.com/matplotlib/matplotlib/issues
+
+.. |GitTutorial| image:: https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?
+.. _GitTutorial: https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
+
 .. |PyPi| image:: https://badge.fury.io/py/matplotlib.svg
 .. _PyPi: https://badge.fury.io/py/matplotlib
 
-.. |Gitter| image:: https://badges.gitter.im/matplotlib/matplotlib.png
-.. _Gitter: https://gitter.im/matplotlib/matplotlib
+.. |Downloads| image:: https://pepy.tech/badge/matplotlib/month
+.. _Downloads: https://pepy.tech/project/matplotlib/month
 
 .. |NUMFocus| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
 .. _NUMFocus: http://www.numfocus.org
 
-.. |GitTutorial| image:: https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?
-.. _GitTutorial: https://git-scm.com/book/en/v2/GitHub-Contributing-to-a-Project
 
 ##########
 Matplotlib


### PR DESCRIPTION
## PR Summary

Update badges on GitHub entry page (README.rst):

- Added badges for Discourse, GitHub Issues, Download statistics
- Group into rows:
  - General
  - Community
  - CI

![grafik](https://user-images.githubusercontent.com/2836374/69494889-14489700-0ec1-11ea-8cf2-01c3f3a1007b.png)

Can also be viewed at https://github.com/timhoffm/matplotlib/tree/badges