### PR TITLE
scatter() should not rescale if norm is given

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -88,3 +88,11 @@ Setting :rc:`text.latex.preamble` or :rc:`pdf.preamble` to non-strings
 These rcParams should be set to string values.  Support for None (meaning the
 empty string) and lists of strings (implicitly joined with newlines) is
 deprecated.
+
+Parameters *norm* and *vmin*/*vmax* should not be used simultaneously
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing parameters *norm* and *vmin*/*vmax* simultaneously to functions using
+colormapping such as ``scatter()`` and ``imshow()`` is deprecated.
+Inestead of ``norm=LogNorm(), vmin=min_val, vmax=max_val`` pass
+``norm=LogNorm(min_val, max_val)``. *vmin* and *vmax* should only be used
+without setting *norm*.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4297,8 +4297,8 @@ class Axes(_AxesBase):
         vmin, vmax : scalar, default: None
             *vmin* and *vmax* are used in conjunction with *norm* to normalize
             luminance data. If None, the respective min and max of the color
-            array is used. *vmin* and *vmax* are ignored if you pass a *norm*
-            instance.
+            array is used.
+            It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         alpha : scalar, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
@@ -4419,11 +4419,7 @@ default: :rc:`scatter.edgecolors`
             collection.set_array(c)
             collection.set_cmap(cmap)
             collection.set_norm(norm)
-
-            if vmin is not None or vmax is not None:
-                collection.set_clim(vmin, vmax)
-            else:
-                collection.autoscale_None()
+            collection._scale_norm(norm, vmin, vmax)
 
         # Classic mode only:
         # ensure there are margins to allow for the
@@ -4529,7 +4525,8 @@ default: :rc:`scatter.edgecolors`
             The colorbar range. If *None*, suitable min/max values are
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of the bins in case of the default
-            linear scaling). This is ignored if *norm* is given.
+            linear scaling).
+            It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         alpha : float between 0 and 1, optional
             The alpha blending value, between 0 (transparent) and 1 (opaque).
@@ -4773,11 +4770,7 @@ default: :rc:`scatter.edgecolors`
         collection.set_norm(norm)
         collection.set_alpha(alpha)
         collection.update(kwargs)
-
-        if vmin is not None or vmax is not None:
-            collection.set_clim(vmin, vmax)
-        else:
-            collection.autoscale_None()
+        collection._scale_norm(norm, vmin, vmax)
 
         corners = ((xmin, ymin), (xmax, ymax))
         self.update_datalim(corners)
@@ -5493,7 +5486,7 @@ default: :rc:`scatter.edgecolors`
             When using scalar data and no explicit *norm*, *vmin* and *vmax*
             define the data range that the colormap covers. By default,
             the colormap covers the complete value range of the supplied
-            data. *vmin*, *vmax* are ignored if the *norm* parameter is used.
+            data. It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         origin : {'upper', 'lower'}, default: :rc:`image.origin`
             Place the [0, 0] index of the array in the upper left or lower
@@ -5589,10 +5582,7 @@ default: :rc:`scatter.edgecolors`
         if im.get_clip_path() is None:
             # image does not already have clipping set, clip to axes patch
             im.set_clip_path(self.patch)
-        if vmin is not None or vmax is not None:
-            im.set_clim(vmin, vmax)
-        else:
-            im.autoscale_None()
+        im._scale_norm(norm, vmin, vmax)
         im.set_url(url)
 
         # update ax.dataLim, and, if autoscaling, set viewLim
@@ -5731,6 +5721,7 @@ default: :rc:`scatter.edgecolors`
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
+            It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         edgecolors : {'none', None, 'face', color, color sequence}, optional
             The color of the edges. Defaults to 'none'. Possible values:
@@ -5867,8 +5858,7 @@ default: :rc:`scatter.edgecolors`
         collection.set_array(C)
         collection.set_cmap(cmap)
         collection.set_norm(norm)
-        collection.set_clim(vmin, vmax)
-        collection.autoscale_None()
+        collection._scale_norm(norm, vmin, vmax)
         self.grid(False)
 
         x = X.compressed()
@@ -5962,6 +5952,7 @@ default: :rc:`scatter.edgecolors`
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
+            It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         edgecolors : {'none', None, 'face', color, color sequence}, optional
             The color of the edges. Defaults to 'none'. Possible values:
@@ -6081,8 +6072,7 @@ default: :rc:`scatter.edgecolors`
         collection.set_array(C)
         collection.set_cmap(cmap)
         collection.set_norm(norm)
-        collection.set_clim(vmin, vmax)
-        collection.autoscale_None()
+        collection._scale_norm(norm, vmin, vmax)
 
         self.grid(False)
 
@@ -6196,6 +6186,7 @@ default: :rc:`scatter.edgecolors`
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
+            It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
         alpha : scalar, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
@@ -6278,10 +6269,9 @@ default: :rc:`scatter.edgecolors`
             self.add_image(im)
             ret = im
 
-        if vmin is not None or vmax is not None:
-            ret.set_clim(vmin, vmax)
-        elif np.ndim(C) == 2:  # C.ndim == 3 is RGB(A) so doesn't need scaling.
-            ret.autoscale_None()
+        if np.ndim(C) == 2:  # C.ndim == 3 is RGB(A) so doesn't need scaling.
+            ret._scale_norm(norm, vmin, vmax)
+
         if ret.get_clip_path() is None:
             # image does not already have clipping set, clip to axes patch
             ret.set_clip_path(self.patch)

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -184,6 +184,27 @@ class ScalarMappable:
         self.colorbar = None
         self.update_dict = {'array': False}
 
+    def _scale_norm(self, norm, vmin, vmax):
+        """
+        Helper for initial scaling.
+
+        Used by public functions that create a ScalarMappable and support
+        parameters *vmin*, *vmax* and *norm*. This makes sure that a *norm*
+        will take precedence over *vmin*, *vmax*.
+
+        Note that this method does not set the norm.
+        """
+        if vmin is not None or vmax is not None:
+            self.set_clim(vmin, vmax)
+            if norm is not None:
+                cbook.warn_deprecated(
+                    "3.3",
+                    message="Passing parameters norm and vmin/vmax "
+                            "simultaneously is deprecated. Please pass "
+                            "vmin/vmax directly to the norm when creating it.")
+        else:
+            self.autoscale_None()
+
     def to_rgba(self, x, alpha=None, bytes=False, norm=True):
         """
         Return a normalized rgba array corresponding to *x*.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1001,6 +1001,19 @@ def test_imshow_clip():
     ax.imshow(r, clip_path=clip_path)
 
 
+@check_figures_equal(extensions=["png"])
+def test_imshow_norm_vminvmax(fig_test, fig_ref):
+    """Parameters vmin, vmax should be ignored if norm is given."""
+    a = [[1, 2], [3, 4]]
+    ax = fig_ref.subplots()
+    ax.imshow(a, vmin=0, vmax=5)
+    ax = fig_test.subplots()
+    with pytest.warns(MatplotlibDeprecationWarning,
+                      match="Passing parameters norm and vmin/vmax "
+                            "simultaneously is deprecated."):
+        ax.imshow(a, norm=mcolors.Normalize(-10, 10), vmin=0, vmax=5)
+
+
 @image_comparison(['polycollection_joinstyle'], remove_text=True)
 def test_polycollection_joinstyle():
     # Bug #2890979 reported by Matthew West
@@ -1969,6 +1982,19 @@ class TestScatter:
                    cmap=cmap, plotnonfinite=False)
         ax = fig_ref.subplots()
         ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_norm_vminvmax(self, fig_test, fig_ref):
+        """Parameters vmin, vmax should be ignored if norm is given."""
+        x = [1, 2, 3]
+        ax = fig_ref.subplots()
+        ax.scatter(x, x, c=x, vmin=0, vmax=5)
+        ax = fig_test.subplots()
+        with pytest.warns(MatplotlibDeprecationWarning,
+                          match="Passing parameters norm and vmin/vmax "
+                                "simultaneously is deprecated."):
+            ax.scatter(x, x, c=x, norm=mcolors.Normalize(-10, 10),
+                       vmin=0, vmax=5)
 
     @check_figures_equal(extensions=["png"])
     def test_scatter_single_point(self, fig_test, fig_ref):

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -120,10 +120,7 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     cbook._check_isinstance((Normalize, None), norm=norm)
     collection.set_cmap(cmap)
     collection.set_norm(norm)
-    if vmin is not None or vmax is not None:
-        collection.set_clim(vmin, vmax)
-    else:
-        collection.autoscale_None()
+    collection._scale_norm(norm, vmin, vmax)
     ax.grid(False)
 
     minx = tri.x.min()


### PR DESCRIPTION
## PR Summary

Fixes #14603.

<s>The brings the behavior in line with the `scatter` documentation:

> *vmin* and *vmax* are ignored if you pass a *norm* instance.

Also, when a *norm* is given, we shouldn't autoscale.</s>

*Update*: After discussion, the new behavior in this PR is https://github.com/matplotlib/matplotlib/pull/15769#issuecomment-558610547. Docs are updated accordingly.