### PR TITLE
Add support for (sub-) panel labels to Axes

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -246,8 +246,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        text : :class:`~matplotlib.text.Text`
-            The matplotlib text instance representing the panel label
+        text : :class:`~matplotlib.text.Annotation`
+            The matplotlib annotation instance representing the panel label
 
         Other Parameters
         ----------------
@@ -267,12 +267,7 @@ class Axes(_AxesBase):
             self.panellabel.update(fontdict)
         self.panellabel.update(kwargs)
         self._panellabel_align = (h_align, v_align)
-        if isinstance(pad, Number):
-            pad = (pad, pad)
-        t = mtransforms.ScaledTranslation(
-            pad[0] / 72, pad[1] / 72, self.figure.dpi_scale_trans)
-        self.panellabel.set_transform(self.transAxes + t)
-        self.panellabel.set_clip_box(None)
+        self.panellabel.xyann = (pad,)*2 if isinstance(pad, Number) else pad
         return self.panellabel
 
     def get_xlabel(self):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -193,6 +193,88 @@ class Axes(_AxesBase):
         title.update(kwargs)
         return title
 
+    def get_panellabel(self):
+        """
+        Get the (sub-) panel label text.
+
+        This is typically a letter (a, b, c, …) identifying the panel for
+        reference in a figure legend.
+
+        Returns
+        -------
+        label : str
+            The panel label string.
+
+        """
+        return self.panellabel.get_text()
+
+    def set_panellabel(self, label, fontdict=None, h_align='axislabel',
+                       v_align='title', pad=0., **kwargs):
+        """
+        Set a (sub-) panel label.
+
+        This is typically a letter (a, b, c, …) identifying the panel for
+        reference in a figure legend.
+
+        Parameters
+        ----------
+        label : str
+            Text to use for the label
+        fontdict : dict, optional
+            A dictionary controlling the appearance of the label text,
+            the default `fontdict` is::
+
+               {'fontsize': rcParams['axes.panellabelsize'],
+                'fontweight' : rcParams['axes.panellabelweight'],
+                'verticalalignment': 'baseline',
+                'horizontalalignment': 'left'}
+
+        v_align : {'top', 'title', 'axislabel', 'frame'}, optional
+            Set vertical alignment of the label. If 'top', align to top
+            of the title. If 'title', align to baseline of the title. If
+            'axislabel', align to top of the x axis label (only useful if
+            x axis is on top). If 'frame', align to the frame.
+            Defaults to 'title'.
+        h_align : {'axislabel', 'frame'}, optional
+            Set vertical alignment of the label. If
+            'axislabel', align to left edge of the y axis label. If 'frame',
+            align to the frame. Defaults to 'axislabel'.
+        pad : float or pair of float, optional
+            The offset of the label from the left and top of the axes, in
+            points. If only one number is given, it will be used for both
+            dimensions. Default is 0.
+
+        Returns
+        -------
+        text : :class:`~matplotlib.text.Text`
+            The matplotlib text instance representing the panel label
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.text.Text` properties
+            Other keyword arguments are text properties, see
+            :class:`~matplotlib.text.Text` for a list of valid text
+            properties.
+        """
+        default = {
+            'fontsize': rcParams['axes.panellabelsize'],
+            'fontweight': rcParams['axes.panellabelweight'],
+            'verticalalignment': 'baseline',
+            'horizontalalignment': 'left'}
+        self.panellabel.set_text(label)
+        self.panellabel.update(default)
+        if fontdict is not None:
+            self.panellabel.update(fontdict)
+        self.panellabel.update(kwargs)
+        self._panellabel_align = (h_align, v_align)
+        if isinstance(pad, Number):
+            pad = (pad, pad)
+        t = mtransforms.ScaledTranslation(
+            pad[0] / 72, pad[1] / 72, self.figure.dpi_scale_trans)
+        self.panellabel.set_transform(self.transAxes + t)
+        self.panellabel.set_clip_box(None)
+        return self.panellabel
+
     def get_xlabel(self):
         """
         Get the xlabel text string.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1148,12 +1148,11 @@ class _AxesBase(martist.Artist):
         for _title in (self.title, self._left_title, self._right_title):
             self._set_artist_props(_title)
 
-        self.panellabel = mtext.Text(
-            x=0.0, y=1.0, text='',
-            transform=self.transAxes,
+        self.panellabel = mtext.Annotation(
+            '', (0.0, 1.0), (0.0, 0.0), xycoords=self._get_panellabel_bbox,
+            textcoords='offset points'
             )
         self._panellabel_align = ('axislabel', 'title')
-        self._autopanellabelpos = None
         self._set_artist_props(self.panellabel)
 
         # The patch draws the background of the axes.  We want this to be below
@@ -2669,56 +2668,37 @@ class _AxesBase(martist.Artist):
             x, _ = title.get_position()
             title.set_position((x, ymax))
 
-    def _update_panellabel_position(self, renderer):
+    def _get_panellabel_bbox(self, renderer):
         """
-        Update the panel label position based title and axis label positions.
+        Update bounding box for panel label based title and axis label pos.
         """
-        if self._autopanellabelpos is not None and not self._autopanellabelpos:
-            _log.debug(
-                'panel label position was updated manually, not adjusting')
-            return
+        bbox = self.get_window_extent(renderer).frozen()
+        include_xy = []
 
-        if self._autopanellabelpos is None:
-            pp = self.panellabel.get_position()
-            if not np.allclose(pp, (0.0, 1.0)):
-                self._autotitlepos = False
-                _log.debug('not adjusting title pos because a title was'
-                           ' already placed manually: (%f, %f)', *pp)
-                return
-            self._autopanellabelpos = True
-
-        panel_x = math.inf
         for axx in self.figure._align_panellabel_x_grp.get_siblings(self):
             if self._panellabel_align[0] == 'frame':
-                other_x = axx.get_window_extent(renderer).xmin
+                xmin = axx.get_window_extent(renderer).xmin
             else:
-                try:
-                    other_x = axx.yaxis.get_tightbbox(renderer).xmin
-                except AttributeError:
-                    # axx.yaxis.get_tightbbox() returned None
-                    other_x = axx.get_window_extent(renderer).xmin
-            panel_x = min(panel_x, other_x)
-        panel_y = -math.inf
+                xmin = (axx.yaxis.get_tightbbox(renderer) or
+                        axx.get_window_extent(renderer)).xmin
+            include_xy.append([xmin, bbox.ymin])
+
         for axy in self.figure._align_panellabel_y_grp.get_siblings(self):
             if self._panellabel_align[1] == 'frame':
-                other_y = axy.get_window_extent(renderer).ymax
+                ymax = axy.get_window_extent(renderer).ymax
             elif self._panellabel_align[1] == 'axislabel':
-                try:
-                    other_y = axy.xaxis.get_tightbbox(renderer).ymax
-                except AttributeError:
-                    # axy.xaxis.get_tightbbox() returned None
-                    other_y = axy.get_window_extent(renderer).ymax
+                ymax = (axy.xaxis.get_tightbbox(renderer) or
+                        axy.get_window_extent(renderer)).ymax
             elif self._panellabel_align[1] == 'top':
-                other_y = axy.title.get_tightbbox(renderer).ymax
+                ymax = axy.title.get_tightbbox(renderer).ymax
             else:
                 t = axy.title
                 tpos = t.get_position()
-                other_y = t.get_transform().transform(tpos)[1]
-            panel_y = max(panel_y, other_y)
+                ymax = t.get_transform().transform(tpos)[1]
+            include_xy.append([bbox.xmin, ymax])
 
-        inv_panel_trafo = self.transAxes.inverted()
-        self.panellabel.set_position(
-            inv_panel_trafo.transform((panel_x, panel_y)))
+        bbox.update_from_data_xy(include_xy, ignore=False)
+        return bbox
 
     # Drawing
     @martist.allow_rasterization
@@ -2764,7 +2744,6 @@ class _AxesBase(martist.Artist):
                 artists.remove(spine)
 
         self._update_title_position(renderer)
-        self._update_panellabel_position(renderer)
 
         if not self.axison or inframe:
             for _axis in self._get_axis_list():
@@ -4226,7 +4205,6 @@ class _AxesBase(martist.Artist):
                 if bb_yaxis:
                     bb.append(bb_yaxis)
         self._update_title_position(renderer)
-        self._update_panellabel_position(renderer)
         axbbox = self.get_window_extent(renderer)
         bb.append(axbbox)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2611,21 +2611,19 @@ default: 'top'
         axs = np.asarray(axs).ravel()
         for ax in axs:
             ss = ax.get_subplotspec()
-            nrows, ncols, row0, row1, col0, col1 = ss.get_rows_columns()
+            row0 = ss.rowspan.start
+            col0 = ss.colspan.start
             # loop through other axes and search ones that share the
             # appropriate column or row number.
             # Add to a list associated with each axes of siblings.
-            # This list is inspected in `Axes.draw` by
-            # `axis._update_panellabel_position`.
+            # This list used in `Axes._get_panellabel_bbox`.
             for axc in axs:
                 if axc is ax:
                     continue
-                ss = axc.get_subplotspec()
-                nrows, ncols, rowc0, rowc1, colc0, colc1 = \
-                        ss.get_rows_columns()
-                if colc0 == col0:
+                ssc = axc.get_subplotspec()
+                if ssc.colspan.start == col0:
                     self._align_panellabel_x_grp.join(ax, axc)
-                if row0 == rowc0:
+                if ssc.rowspan.start == row0:
                     self._align_panellabel_y_grp.join(ax, axc)
 
     def add_gridspec(self, nrows=1, ncols=1, **kwargs):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1234,6 +1234,8 @@ defaultParams = {
     'axes.titlecolor':       ['auto', validate_color_or_auto],  # font color of axes title
     'axes.titley':           [None, validate_float_or_None],  # title location, axes units, None means auto
     'axes.titlepad':         [6.0, validate_float],  # pad from axes top decoration to title in points
+    'axes.panellabelsize':   ['x-large', validate_fontsize],  # fontsize of the panel label
+    'axes.panellabelweight': ['bold', validate_fontweight],  # font weight of panel label
     'axes.grid':             [False, validate_bool],   # display grid or not
     'axes.grid.which':       ['major', ['minor', 'both', 'major']],  # set whether the grid is drawn on
                                                                      # 'major' 'minor' or 'both' ticks


### PR DESCRIPTION
##  PR Summary
In scientific publications, sub-panels are often enumerated (a, b, c, …), identifying them for reference in the figure legend or main text.

This adds support for such labels, plus various options for alignment.

By default, labels are aligned with the left edge of the y axis label and with the baseline of the title.

Example:
```python
fig, (ax1, ax2) = plt.subplots(1, 2)
ax1.set_title("Plot1")
ax1.plot([0, 1], [0, 1])
ax2.set_title("Plot2")
ax2.plot([0, 1], [0, 0])
ax1.set_panellabel("a")
ax2.set_panellabel("b")
fig.tight_layout()
```
![ex1](https://user-images.githubusercontent.com/13418822/69537973-82549300-0f81-11ea-91e4-70a7de777c6b.png)

However, alignment can be changed:
```python
fig, (ax1, ax2) = plt.subplots(1, 2)
ax1.set_title("Plot1")
ax1.plot([0, 1], [0, 1])
ax2.set_title("Plot2")
ax2.plot([0, 1], [0, 0])
fd = {"horizontalalignment": "right"}
ax1.set_panellabel("a", h_align="frame", fontdict=fd)
ax2.set_panellabel("b", h_align="frame", fontdict=fd)
fig.tight_layout()
```
![ex2](https://user-images.githubusercontent.com/13418822/69538258-2d654c80-0f82-11ea-8e30-2f35401b63b8.png)

It is also possible to align the labels of multiple sub-panels, even if their titles and/or axis labels are not aligned:
```python
fig, ax = plt.subplots(2, 2)
ax[0, 0].set_title("Plot1")
axt = ax[0, 0].twiny()
ax[0, 0].plot([0, 1], [0, 1])
ax[0, 1].set_title("Plot2")
ax[0, 1].plot([0, 1], [0, 0])
ax[1, 0].set_ylabel("y1")
ax[1, 1].set_ylabel("y2")
ax[0, 0].set_panellabel("a")
ax[0, 1].set_panellabel("b")
ax[1, 0].set_panellabel("c")
ax[1, 1].set_panellabel("d")
fig.align_panellabels()
fig.tight_layout()
```
![ex3](https://user-images.githubusercontent.com/13418822/69538781-52a68a80-0f83-11ea-8298-3ec778d5a0a1.png)

Default font size and font weight are controlled by the `axes.panellabelsize` and `axes.panellabelweight` rcParams, respectively.

Before I start polishing documentation, writing unit tests, etc. I would love some feedback!


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
