### PR TITLE
Directly dedent the spectral parameter docs.

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -54,7 +54,6 @@ Spectral functions
 """
 
 import csv
-import inspect
 from numbers import Number
 
 import numpy as np
@@ -613,72 +612,62 @@ def _single_spectrum_helper(x, mode, Fs=None, window=None, pad_to=None,
 
 
 # Split out these keyword docs so that they can be used elsewhere
-docstring.interpd.update(Spectral=inspect.cleandoc("""
-    Fs : scalar
-        The sampling frequency (samples per time unit).  It is used
-        to calculate the Fourier frequencies, freqs, in cycles per time
-        unit. The default value is 2.
+docstring.interpd.update(
+    Spectral="""\
+Fs : scalar, default: 2
+    The sampling frequency (samples per time unit).  It is used to calculate
+    the Fourier frequencies, *freqs*, in cycles per time unit.
 
-    window : callable or ndarray
-        A function or a vector of length *NFFT*.  To create window vectors see
-        `.window_hanning`, `.window_none`, `numpy.blackman`, `numpy.hamming`,
-        `numpy.bartlett`, `scipy.signal`, `scipy.signal.get_window`, etc.  The
-        default is `.window_hanning`.  If a function is passed as the argument,
-        it must take a data segment as an argument and return the windowed
-        version of the segment.
+window : callable or ndarray, default: `.window_hanning`
+    A function or a vector of length *NFFT*.  To create window vectors see
+    `.window_hanning`, `.window_none`, `numpy.blackman`, `numpy.hamming`,
+    `numpy.bartlett`, `scipy.signal`, `scipy.signal.get_window`, etc.  If a
+    function is passed as the argument, it must take a data segment as an
+    argument and return the windowed version of the segment.
 
-    sides : {'default', 'onesided', 'twosided'}
-        Which sides of the spectrum to return. 'default' is one-sided for real
-        data and two-sided for complex data. 'onesided' forces the return of a
-        one-sided spectrum, while 'twosided' forces two-sided.
-"""))
+sides : {'default', 'onesided', 'twosided'}, optional
+    Which sides of the spectrum to return. 'default' is one-sided for real
+    data and two-sided for complex data. 'onesided' forces the return of a
+    one-sided spectrum, while 'twosided' forces two-sided.""",
 
+    Single_Spectrum="""\
+pad_to : int, optional
+    The number of points to which the data segment is padded when performing
+    the FFT.  While not increasing the actual resolution of the spectrum (the
+    minimum distance between resolvable peaks), this can give more points in
+    the plot, allowing for more detail. This corresponds to the *n* parameter
+    in the call to fft().  The default is None, which sets *pad_to* equal to
+    the length of the input signal (i.e. no padding).""",
 
-docstring.interpd.update(Single_Spectrum=inspect.cleandoc("""
-    pad_to : int
-        The number of points to which the data segment is padded when
-        performing the FFT.  While not increasing the actual resolution of
-        the spectrum (the minimum distance between resolvable peaks),
-        this can give more points in the plot, allowing for more
-        detail. This corresponds to the *n* parameter in the call to fft().
-        The default is None, which sets *pad_to* equal to the length of the
-        input signal (i.e. no padding).
-"""))
+    PSD="""\
+pad_to : int, optional
+    The number of points to which the data segment is padded when performing
+    the FFT.  This can be different from *NFFT*, which specifies the number
+    of data points used.  While not increasing the actual resolution of the
+    spectrum (the minimum distance between resolvable peaks), this can give
+    more points in the plot, allowing for more detail. This corresponds to
+    the *n* parameter in the call to fft(). The default is None, which sets
+    *pad_to* equal to *NFFT*
 
+NFFT : int, default: 256
+    The number of data points used in each block for the FFT.  A power 2 is
+    most efficient.  This should *NOT* be used to get zero padding, or the
+    scaling of the result will be incorrect; use *pad_to* for this instead.
 
-docstring.interpd.update(PSD=inspect.cleandoc("""
-    pad_to : int
-        The number of points to which the data segment is padded when
-        performing the FFT.  This can be different from *NFFT*, which
-        specifies the number of data points used.  While not increasing
-        the actual resolution of the spectrum (the minimum distance between
-        resolvable peaks), this can give more points in the plot,
-        allowing for more detail. This corresponds to the *n* parameter
-        in the call to fft(). The default is None, which sets *pad_to*
-        equal to *NFFT*
+detrend : {'none', 'mean', 'linear'} or callable, default 'none'
+    The function applied to each segment before fft-ing, designed to remove
+    the mean or linear trend.  Unlike in MATLAB, where the *detrend* parameter
+    is a vector, in Matplotlib is it a function.  The :mod:`~matplotlib.mlab`
+    module defines `.detrend_none`, `.detrend_mean`, and `.detrend_linear`,
+    but you can use a custom function as well.  You can also use a string to
+    choose one of the functions: 'none' calls `.detrend_none`. 'mean' calls
+    `.detrend_mean`. 'linear' calls `.detrend_linear`.
 
-    NFFT : int
-        The number of data points used in each block for the FFT.
-        A power 2 is most efficient.  The default value is 256.
-        This should *NOT* be used to get zero padding, or the scaling of the
-        result will be incorrect. Use *pad_to* for this instead.
-
-    detrend : {'none', 'mean', 'linear'} or callable, default 'none'
-        The function applied to each segment before fft-ing, designed to
-        remove the mean or linear trend.  Unlike in MATLAB, where the
-        *detrend* parameter is a vector, in Matplotlib is it a function.
-        The :mod:`~matplotlib.mlab` module defines `.detrend_none`,
-        `.detrend_mean`, and `.detrend_linear`, but you can use a custom
-        function as well.  You can also use a string to choose one of the
-        functions: 'none' calls `.detrend_none`. 'mean' calls `.detrend_mean`.
-        'linear' calls `.detrend_linear`.
-
-    scale_by_freq : bool, optional
-        Whether the resulting density values should be scaled by the scaling
-        frequency, which gives density in units of Hz^-1.  This allows for
-        integration over the returned frequency values.  The default is True
-        for MATLAB compatibility.
-"""))
+scale_by_freq : bool, optional, default: True
+    Whether the resulting density values should be scaled by the scaling
+    frequency, which gives density in units of Hz^-1.  This allows for
+    integration over the returned frequency values.  The default is True for
+    MATLAB compatibility.""")
 
 
 @docstring.dedent_interpd


### PR DESCRIPTION
There's little point in sending them through inspect.cleandoc.

Also list the defaults right next to the parameters.

(As discussed at length in https://github.com/matplotlib/matplotlib/pull/15765#discussion_r349900457 there are further improvements possible to these docstrings but let's not rehash that here.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
