### PR TITLE
Don't bother disconnecting idle_draw at gtk shutdown.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -191,8 +191,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
     def destroy(self):
         #Gtk.DrawingArea.destroy(self)
         self.close_event()
-        if self._idle_draw_id != 0:
-            GLib.source_remove(self._idle_draw_id)
 
     def scroll_event(self, widget, event):
         x = event.x


### PR DESCRIPTION
If the canvas has already been destroyed this leads to a warning
("Source ID xxx was not found when attempting to remove it").

repro:
MPLBACKEND=gtk3agg python -c 'from pylab import *; fig = plt.figure(); plot(); show(); fig.savefig("/tmp/test.png")'

This may cause an additional call to idle_draw(), but idle_draw() (via
draw()) first checks `self.is_drawable()` which would return False for
destroyed (thus not visible anymore) widgets
(https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-is-drawable)
so it's just a noop.

Closes #15773.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
