### PR TITLE
Try documenting inherited class members

### DIFF
--- a/doc/_templates/autosummary.rst
+++ b/doc/_templates/autosummary.rst
@@ -3,22 +3,27 @@
 
 .. currentmodule:: {{ module }}
 
-
 {% if objtype in ['class'] %}
+{% if module in ['mpl_toolkits.axes_grid1.mpl_axes',
+                 'mpl_toolkits.axisartist.axislines',
+                 'mpl_toolkits.mplot3d.axis3d'] %}
 .. auto{{ objtype }}:: {{ objname }}
     :show-inheritance:
+    :no-inherited-members:
+{% else %}
+.. auto{{ objtype }}:: {{ objname }}
+    :show-inheritance:
+{% endif %}
 
 {% else %}
 .. auto{{ objtype }}:: {{ objname }}
 
 {% endif %}
-
 {% if objtype in ['class', 'method', 'function'] %}
 {% if objname in ['AxesGrid', 'Scalable', 'HostAxes', 'FloatingAxes',
                       'ParasiteAxesAuxTrans', 'ParasiteAxes'] %}
 .. Filter out the above aliases to other classes, as sphinx gallery
    creates no example file for those (sphinx-gallery/sphinx-gallery#365)
-
 {% else %}
 .. include:: {{module}}.{{objname}}.examples
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,9 +101,10 @@ autosummary_generate = True
 
 autodoc_docstring_signature = True
 if sphinx.version_info < (1, 8):
-    autodoc_default_flags = ['members', 'undoc-members']
+    autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
 else:
-    autodoc_default_options = {'members': None, 'undoc-members': None}
+    autodoc_default_options = {'members': None, 'undoc-members': None,
+                               'inherited-members': True}
 
 nitpicky = True
 # change this to True to update the allowed failures

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -100,11 +100,8 @@ os.environ.pop("DISPLAY", None)
 autosummary_generate = True
 
 autodoc_docstring_signature = True
-if sphinx.version_info < (1, 8):
-    autodoc_default_flags = ['members', 'undoc-members', 'inherited-members']
-else:
-    autodoc_default_options = {'members': None, 'undoc-members': None,
-                               'inherited-members': True}
+autodoc_default_options = {'members': None, 'undoc-members': None,
+                           'inherited-members': True}
 
 nitpicky = True
 # change this to True to update the allowed failures


### PR DESCRIPTION
This should solve documentation issues where a private base class contains methods etc. that are hidden (because the class is private), but should be exposed in any class that inherits from the base class.