### PR TITLE
Add ImageMagick[File]Writer compression arg

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -693,7 +693,7 @@ class ImageMagickBase:
 
     @property
     def output_args(self):
-        return [*self.extra_args, self.outfile]
+        return [*self.compress, *self.extra_args, self.outfile]
 
     @classmethod
     def bin_path(cls):
@@ -721,6 +721,17 @@ class ImageMagickWriter(ImageMagickBase, MovieWriter):
     in a single pass.
 
     '''
+    def __init__(self, compress=False, *args, **kwargs):
+        '''
+        Parameters
+        ----------
+        compress : bool, optional
+            Resulting gif will be compressed. Equivalent of passing
+            '-layers Optimize' to ImageMagick.
+        '''
+        ImageMagickWriter.__init__(self, *args, **kwargs)
+        self.compress = ['-layers', 'Optimize'] if args.compress else []
+
     def _args(self):
         return ([self.bin_path(),
                  '-size', '%ix%i' % self.frame_size, '-depth', '8',
@@ -741,6 +752,17 @@ class ImageMagickFileWriter(ImageMagickBase, FileMovieWriter):
 
     supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',
                          'pbm', 'raw', 'rgba']
+
+    def __init__(self, compress=False, *args, **kwargs):
+        '''
+        Parameters
+        ----------
+        compress : bool, optional
+            Resulting gif will be compressed. Equivalent of passing
+            '-layers Optimize' to ImageMagick.
+        '''
+        ImageMagickWriter.__init__(self, *args, **kwargs)
+        self.compress = ['-layers', 'Optimize'] if args.compress else []
 
     def _args(self):
         return ([self.bin_path(), '-delay', str(self.delay), '-loop', '0',


### PR DESCRIPTION
## PR Summary
Follow-up to my previous PR #15739. Adding a simple `compress` arg to `ImageMagickWriter` and `ImageMagickFileWriter` classes.

## Questions

I'm suspecting that the docstring is not done right. Sphinx probably doesn't combine the `MovieWriter.__init__()` docstring and child class' `__init__()` docstrings automagically.  Never dealt with child classes and shared docstrings when I more heavily used sphinx years ago. Is the correct thing to do here to just duplicate the shared args? From what I've seen looking around, I suspect not?

Also, I'm definitely curious to hear what the optimal approach to testing docstring changes/additions is? `make html` in `docs/` is awfully slow. (d'oh, I see now there is a -O j4 option I can pass; will do that next time)

Further tangents on docs:
- Is it just an artifact of Ubuntu 18.04 and/or WSL that `python` doesn't point at `python3` by default? I modified the docs Makefile to use `python3`, as the format strings in (iirc) `conf.py` didn't make 2.x happy.  I could imagine other distros that are more fully on Python3 do link `/bin/python` to `/bin/python3`.
- Has anyone else ever get the docs to build in WSL's bash? I ended up switching to my linux machine to build the docs, since somehow, (if I understood errors correctly) MSVC++ DLLs were being looked for.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
