### PR TITLE
Fixes pyplot xticks() and yticks() by allowing setting only the labels

### DIFF
--- a/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
+++ b/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
@@ -1,5 +1,5 @@
-ticks' labels can now be set without passing `locs` in pyplot
--------------------------------------------------------------
+ticks' labels can now be set without passing `ticks` in pyplot
+--------------------------------------------------------------
 
 `pyplot.xticks()` and `pyplot.yticks()` can now be used to set ticks' labels without
-requiring to pass the `locs` parameter.
+requiring to pass the `ticks` parameter.

--- a/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
+++ b/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
@@ -1,0 +1,5 @@
+ticks' labels can now be set without passing `locs` in pyplot
+-------------------------------------------------------------
+
+`pyplot.xticks()` and `pyplot.yticks()` can now be used to set ticks' labels without
+requiring to pass the `locs` parameter.

--- a/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
+++ b/doc/users/next_whats_new/2019-11-29-pyplot-ticks-labels.rst
@@ -1,5 +1,5 @@
-ticks' labels can now be set without passing `ticks` in pyplot
---------------------------------------------------------------
+ticks' labels can now be set without passing ``ticks`` in pyplot
+----------------------------------------------------------------
 
-`pyplot.xticks()` and `pyplot.yticks()` can now be used to set ticks' labels without
-requiring to pass the `ticks` parameter.
+``pyplot.xticks()`` and ``pyplot.yticks()`` can now be used to set ticks'
+labels without requiring to pass the ``ticks`` parameter.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1428,15 +1428,16 @@ def xticks(ticks=None, labels=None, **kwargs):
     """
     ax = gca()
 
-    if ticks is None and labels is None:
+    if ticks is None:
         locs = ax.get_xticks()
-        labels = ax.get_xticklabels()
-    elif labels is None:
-        locs = ax.set_xticks(ticks)
-        labels = ax.get_xticklabels()
     else:
         locs = ax.set_xticks(ticks)
+
+    if labels is None:
+        labels = ax.get_xticklabels()
+    else:
         labels = ax.set_xticklabels(labels, **kwargs)
+
     for l in labels:
         l.update(kwargs)
 
@@ -1503,15 +1504,16 @@ def yticks(ticks=None, labels=None, **kwargs):
     """
     ax = gca()
 
-    if ticks is None and labels is None:
+    if ticks is None:
         locs = ax.get_yticks()
-        labels = ax.get_yticklabels()
-    elif labels is None:
-        locs = ax.set_yticks(ticks)
-        labels = ax.get_yticklabels()
     else:
         locs = ax.set_yticks(ticks)
+
+    if labels is None:
+        labels = ax.get_yticklabels()
+    else:
         labels = ax.set_yticklabels(labels, **kwargs)
+
     for l in labels:
         l.update(kwargs)
 


### PR DESCRIPTION
## PR Summary
This PR was suggested in issue #15005 as to fix the error that is returned when xticks() or yticks() is called with only the labels as parameters. 

The changes remove the error by allowing setting only the labels. This is useful for cases where we plot multiple boxplots or bar plots in the same figure, in where we know exactly how many boxplots or bars to plot. The xticks are always range(n), where n is the number of boxplots or bars to put in the plot.

Simple test example:
```
import matplotlib.pyplot as plt
import numpy as np

data = [np.random.rand(5), np.random.rand(5)]
plt.boxplot(data)
plt.xticks(labels=['first', 'second'])   # fails on current pyplot with TypeError: object of type 'NoneType' has no len(). Fixed in this PR
plt.show()

plt.figure()
plt.boxplot(data, vert=False)
plt.yticks(labels=['first', 'second'])  # fails on current pyplot with TypeError: object of type 'NoneType' has no len(). Fixed in this PR
plt.show()
```

**Note:** I didn't add any example to the examples in the function description. Do you think it would be valuable?

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
