### PR TITLE
Remove incorrect statement re: colorbars in image tutorial.

### DIFF
--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -175,17 +175,12 @@ imgplot.set_cmap('nipy_spectral')
 # ------------------------
 #
 # It's helpful to have an idea of what value a color represents.  We can
-# do that by adding color bars.
+# do that by adding a color bar to your figure:
 
 imgplot = plt.imshow(lum_img)
 plt.colorbar()
 
 ###############################################################################
-# This adds a colorbar to your existing figure.  This won't
-# automatically change if you switch to a different
-# colormap - you have to re-create your plot, and add in the colorbar
-# again.
-#
 # .. _`Data ranges`:
 #
 # Examining a specific data range


### PR DESCRIPTION
Colorbars actually do auto-update their cmap to match the image's cmap.
I don't think it's worth mentioning that in an intro tutorial, but at
least remove the incorrect statement.

Noted while looking at https://github.com/matplotlib/matplotlib/pull/15793.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
