### PR TITLE
Closes #15796 (building PDF docs of matplotlib via LaTeX)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -304,32 +304,94 @@ latex_documents = [
 # the title page.
 latex_logo = None
 
+# Use Unicode aware LaTeX engine
+latex_engine = 'xelatex'  # or 'lualatex'
+
 latex_elements = {}
+
+# Keep babel usage also with xelatex (Sphinx default is polyglossia)
+# If this key is removed or changed, latex build directory must be cleaned
+latex_elements['babel'] = r'\usepackage{babel}'
+
+# Font configuration
+# Fix fontspec converting " into right curly quotes in PDF
+# cf https://github.com/sphinx-doc/sphinx/pull/6888/
+latex_elements['fontenc'] = r'''
+\usepackage{fontspec}
+\defaultfontfeatures[\rmfamily,\sffamily,\ttfamily]{}
+'''
+# Sphinx 2.0 adopts GNU FreeFont by default, but it does not have all
+# the Unicode codepoints needed for the section about Mathtext
+# "Writing mathematical expressions"
+latex_elements['fontpkg'] = r"""
+\setmainfont{XITS}[
+  Extension      = .otf,
+  UprightFont    = *-Regular,
+  ItalicFont     = *-Italic,
+  BoldFont       = *-Bold,
+  BoldItalicFont = *-BoldItalic,
+]
+\setsansfont{FreeSans}[
+  Extension      = .otf,
+  UprightFont    = *,
+  ItalicFont     = *Oblique,
+  BoldFont       = *Bold,
+  BoldItalicFont = *BoldOblique,
+]
+\setmonofont{FreeMono}[
+  Extension      = .otf,
+  UprightFont    = *,
+  ItalicFont     = *Oblique,
+  BoldFont       = *Bold,
+  BoldItalicFont = *BoldOblique,
+]
+% needed for \mathbb (blackboard alphabet) to actually work
+\usepackage{unicode-math}
+\setmathfont{XITS Math}
+"""
+# Sphinx <1.8.0 or >=2.0.0 does this by default, but the 1.8.x series
+# did not for latex_engine = 'xelatex' (as it used Latin Modern font).
+# We need this for code-blocks as FreeMono has wide glyphs.
+latex_elements['fvset'] = r'\fvset{fontsize=\small}'
+# Fix fancyhdr complaining about \headheight being too small
+latex_elements['passoptionstopackages'] = r"""
+    \PassOptionsToPackage{headheight=14pt}{geometry}
+"""
+
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r"""
    % One line per author on title page
    \DeclareRobustCommand{\and}%
      {\end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}}%
-   % In the parameters section, place a newline after the Parameters
-   % header.  (This is stolen directly from Numpy's conf.py, since it
-   % affects Numpy-style docstrings).
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
-
-   \usepackage{amsmath}
-   \usepackage{amsfonts}
-   \usepackage{amssymb}
-   \usepackage{txfonts}
-
-   % The enumitem package provides unlimited nesting of lists and
-   % enums.  Sphinx may use this in the future, in which case this can
-   % be removed.  See
-   % https://bitbucket.org/birkenfeld/sphinx/issue/777/latex-output-too-deeply-nested
-   \usepackage{enumitem}
-   \setlistdepth{2048}
+   % But expdlist old LaTeX package requires fixes:
+   % 1) remove extra space
+   \usepackage{etoolbox}
+   \makeatletter
+   \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+   \makeatother
+   % 2) fix bug in expdlist's way of breaking the line after long item label
+   \makeatletter
+   \def\breaklabel{%
+       \def\@breaklabel{%
+           \leavevmode\par
+           % now a hack because Sphinx inserts \leavevmode after term node
+           \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+      }%
+   }
+   \makeatother
 """
+# Sphinx 1.5 provides this to avoid "too deeply nested" LaTeX error
+# and usage of "enumitem" LaTeX package is unneeded.
+# Value can be increased but do not set it to something such as 2048
+# which needlessly would trigger creation of thousands of TeX macros
+latex_elements['maxlistdepth'] = '10'
 latex_elements['pointsize'] = '11pt'
+
+# Better looking general index in PDF
+latex_elements['printindex'] = r'\footnotesize\raggedright\printindex'
 
 # Documents to append as an appendix to all manuals.
 latex_appendices = []
@@ -357,13 +419,6 @@ texinfo_documents = [
 # numpydoc config
 
 numpydoc_show_class_members = False
-
-latex_engine = 'xelatex'  # or 'lualatex'
-
-latex_elements = {
-    'babel': r'\usepackage{babel}',
-    'fontpkg': r'\setmainfont{DejaVu Serif}',
-}
 
 html4_writer = True
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,21 +325,18 @@ latex_elements['fontenc'] = r'''
 # "Writing mathematical expressions"
 latex_elements['fontpkg'] = r"""
 \setmainfont{XITS}[
-  Extension      = .otf,
   UprightFont    = *-Regular,
   ItalicFont     = *-Italic,
   BoldFont       = *-Bold,
   BoldItalicFont = *-BoldItalic,
 ]
 \setsansfont{FreeSans}[
-  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,
   BoldItalicFont = *BoldOblique,
 ]
 \setmonofont{FreeMono}[
-  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,


### PR DESCRIPTION
## PR Summary

Make build of matplotlib documentation to PDF possible.

The #15796 issue is caused by the fact that `latex_elements` dict got redefined near end of `conf.py` hence the part about using LaTeX package enumitem and its `\setlistdepth` got lost. But anyway since Sphinx 1.5 there is `'maxlistdepth'` key, so use that.

Another problem arose related to `expdlist` very old LaTeX package. I realized it broke the build <s>with recent LaTeX</s> (when a description environment was found in a longtable cell). 

edited: this also breaks with LaTeX as old as 2012. Because I did not recall having seen the issue in 2018 when trying out building scipy's PDF documentation (but perhaps I had already patched `expdlist`), and as my laptop only has TeXLive 2018 and 2019 I erroneously thought the issue arose from LaTeX upstream change of array package. But I see now `expdlist` (not updated since 1999...) breaks LaTeX (even from 2012) when a description list ends up in a table cell. It is not recent issue.

<s>The cause is probably the upstream LaTeX changes in array package which last year invalidated tabu package. </s>

For time being I simply commented out usage of `expdlist`. Turns out that a patch of mine which got merged into scipy (also for matters of building PDF) in April 2018 fixes the <s>more recent</s> breakage caused by `expdlist`. As experimenting with builds of matplotlib (close to 3000 pages) is time costly, I did not much investigate if it would be worthwile using `expdlist` as patched in my scipy PR. (see commit message).

Finally, matplotlib documentation of "Mathtext" uses tons of Unicode math-like characters in plain text, and DejaVu Serif was lacking 134 of them. I thus configure the build to use XITS and it turns out it provided all glyphs. It comes with TeXLive TeX distributions of recent years. I used syntax which should work whether compiling on Mac OS or Linux and probably Windows.

As latex engine is xelatex, it is not easy without additional mark-up to use both OpenType fonts and traditional TeX fonts, so I removed the `\usepackage{txfonts}` and used FreeSans and FreeMono for the sans and mono famillies. This means though that the math symbols will be the Knuth Computer Modern ones. I left commented out two lines loading `unicode-math` and the OpenType Math font `XITS Math` which would fix that aspect. Perhaps they should be activated ?


## PR Checklist

*almost* None of this applies because it is simply a modification of `doc/conf.py`...

Arrgh
```
$ flake8 conf.py
conf.py:4:80: E501 line too long (80 > 79 characters)
conf.py:7:80: E501 line too long (82 > 79 characters)
conf.py:93:1: E402 module level import not at top of file
conf.py:95:1: E402 module level import not at top of file
conf.py:180:80: E501 line too long (83 > 79 characters)
conf.py:297:80: E501 line too long (81 > 79 characters)
```
but... none of this comes from my patch as it is all after line number 300 :-)

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

Tested the PDF build with Sphinx 1.8.5 and 2.2.1 and Python 3.7.5 and matplotlib at 3d1a1bcc4
