### PR TITLE
Better default behavior for boxplots when rcParams['lines.marker'] is set

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3910,10 +3910,13 @@ class Axes(_AxesBase):
 
         zdelta = 0.1
 
-        def line_props_with_rcdefaults(subkey, explicit, zdelta=0):
+        def line_props_with_rcdefaults(subkey, explicit, zdelta=0,
+                                       use_marker=True):
             d = {k.split('.')[-1]: v for k, v in rcParams.items()
                  if k.startswith(f'boxplot.{subkey}')}
             d['zorder'] = zorder + zdelta
+            if not use_marker:
+                d['marker'] = ''
             if explicit is not None:
                 d.update(
                     cbook.normalize_kwargs(explicit, mlines.Line2D._alias_map))
@@ -3934,15 +3937,16 @@ class Axes(_AxesBase):
                     cbook.normalize_kwargs(
                         boxprops, mpatches.PathPatch._alias_map))
         else:
-            final_boxprops = line_props_with_rcdefaults('boxprops', boxprops)
+            final_boxprops = line_props_with_rcdefaults('boxprops', boxprops,
+                                                        use_marker=False)
         final_whiskerprops = line_props_with_rcdefaults(
-            'whiskerprops', whiskerprops)
+            'whiskerprops', whiskerprops, use_marker=False)
         final_capprops = line_props_with_rcdefaults(
-            'capprops', capprops)
+            'capprops', capprops, use_marker=False)
         final_flierprops = line_props_with_rcdefaults(
             'flierprops', flierprops)
         final_medianprops = line_props_with_rcdefaults(
-            'medianprops', medianprops, zdelta)
+            'medianprops', medianprops, zdelta, use_marker=False)
         final_meanprops = line_props_with_rcdefaults(
             'meanprops', meanprops, zdelta)
         removed_prop = 'marker' if meanline else 'linestyle'

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2701,6 +2701,24 @@ def test_boxplot_bad_ci_2():
         ax.boxplot([x, x], conf_intervals=[[1, 2], [1]])
 
 
+def test_boxplot_marker_behavior():
+    plt.rcParams['lines.marker'] = 's'
+    plt.rcParams['boxplot.flierprops.marker'] = 'o'
+    plt.rcParams['boxplot.meanprops.marker'] = '^'
+    fig, ax = plt.subplots()
+    test_data = np.arange(100)
+    test_data[-1] = 150  # a flier point
+    bxp_handle = ax.boxplot(test_data, showmeans=True)
+    for bxp_lines in ['whiskers', 'caps', 'boxes', 'medians']:
+        for each_line in bxp_handle[bxp_lines]:
+            # Ensure that the rcParams['lines.marker'] is overridden by ''
+            assert each_line.get_marker() == ''
+
+    # Ensure that markers for fliers and means aren't overridden with ''
+    assert bxp_handle['fliers'][0].get_marker() == 'o'
+    assert bxp_handle['means'][0].get_marker() == '^'
+
+
 @image_comparison(['boxplot_mod_artists_after_plotting.png'],
                   remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
 def test_boxplot_mod_artist_after_plotting():


### PR DESCRIPTION
## PR Summary
closes #15730
avoid using rcParams['lines.marker'] for boxplots.

**Code snippet for reproducing the issue:**
```
plt.rcParams['lines.marker'] = 's'
plt.boxplot(range(100))
```
**Before this PR:**
![test](https://user-images.githubusercontent.com/15175620/69918581-ee337180-1441-11ea-9937-dfe8c5005946.png)

**After this PR:**
![test1](https://user-images.githubusercontent.com/15175620/69918585-f4295280-1441-11ea-9e35-bfc4b07c07d8.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
