### PR TITLE
Improve display of author names on PDF titlepage of matplotlib own docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -298,8 +298,8 @@ latex_paper_size = 'letter'
 
 latex_documents = [
     ('contents', 'Matplotlib.tex', 'Matplotlib',
-     'John Hunter, Darren Dale, Eric Firing, Michael Droettboom and the '
-     'matplotlib development team', 'manual'),
+     'John Hunter\\and Darren Dale\\and Eric Firing\\and Michael Droettboom'
+     '\\and and the matplotlib development team', 'manual'),
 ]
 
 
@@ -310,6 +310,9 @@ latex_logo = None
 latex_elements = {}
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r"""
+   % One line per author on title page
+   \DeclareRobustCommand{\and}%
+     {\end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}}%
    % In the parameters section, place a newline after the Parameters
    % header.  (This is stolen directly from Numpy's conf.py, since it
    % affects Numpy-style docstrings).


### PR DESCRIPTION
## PR Summary

For LaTeX PDF title page, author names need to be separated by `\and` for better rendering (else the comma separated list of names overflows to the right of the page, see https://github.com/sphinx-doc/sphinx/issues/6875).

And `\and` is given a special definition so that each author name is on one line (else see picture at https://github.com/sphinx-doc/sphinx/issues/6876 to see how it would look like).

This incorporates #15797 to allow PDF build of matplotlib documentation.

Result looks like this:

![Capture d’écran 2019-12-01 à 00 17 18](https://user-images.githubusercontent.com/2589111/69907211-1d5dca80-13d1-11ea-9c24-821cff2bf413.png)


