### PR TITLE
More cleanup defaults in docstrings

### DIFF
--- a/lib/matplotlib/_cm.py
+++ b/lib/matplotlib/_cm.py
@@ -86,16 +86,16 @@ def cubehelix(gamma=1.0, s=0.5, r=-1.5, h=1.0):
 
     Parameters
     ----------
-    gamma : float, optional, default: 1
+    gamma : float, default: 1
         Gamma factor emphasizing either low intensity values (gamma < 1), or
         high intensity values (gamma > 1).
-    s : float, optional, default: 0.5 (purple)
+    s : float, default: 0.5 (purple)
         The starting color.
-    r : float, optional, default: -1.5
+    r : float, default: -1.5
         The number of r, g, b rotations in color that are made from the start
         to the end of the color scheme.  The default of -1.5 corresponds to ->
         B -> G -> R -> B.
-    h : float, optional, default: 1
+    h : float, default: 1
         The hue, i.e. how saturated the colors are. If this parameter is zero
         then the color scheme is purely a greyscale.
     """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1771,7 +1771,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        basex, basey : scalar, optional, default 10
+        basex, basey : float, default: 10
             Base of the x/y logarithm.
 
         subsx, subsy : sequence, optional
@@ -1780,7 +1780,7 @@ class Axes(_AxesBase):
             decades in the plot.
             See `.Axes.set_xscale` / `.Axes.set_yscale` for details.
 
-        nonposx, nonposy : {'mask', 'clip'}, optional, default 'mask'
+        nonposx, nonposy : {'mask', 'clip'}, default: 'mask'
             Non-positive values in x or y can be masked as invalid, or clipped
             to a very small positive number.
 
@@ -1825,7 +1825,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        basex : scalar, optional, default 10
+        basex : float, default: 10
             Base of the x logarithm.
 
         subsx : array-like, optional
@@ -1833,7 +1833,7 @@ class Axes(_AxesBase):
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_xscale` for details.
 
-        nonposx : {'mask', 'clip'}, optional, default 'mask'
+        nonposx : {'mask', 'clip'}, default: 'mask'
             Non-positive values in x can be masked as invalid, or clipped to a
             very small positive number.
 
@@ -1874,7 +1874,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        basey : scalar, optional, default 10
+        basey : float, default: 10
             Base of the y logarithm.
 
         subsy : array-like, optional
@@ -1882,7 +1882,7 @@ class Axes(_AxesBase):
             are automatically chosen depending on the number of decades in the
             plot. See `.Axes.set_yscale` for details.
 
-        nonposy : {'mask', 'clip'}, optional, default 'mask'
+        nonposy : {'mask', 'clip'}, default: 'mask'
             Non-positive values in y can be masked as invalid, or clipped to a
             very small positive number.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1247,7 +1247,7 @@ class _AxesBase(martist.Artist):
 
             See `.set_anchor` for further details.
 
-        share : bool, optional, default: False
+        share : bool, default: False
             If ``True``, apply the settings to all shared Axes.
 
         See Also
@@ -1309,7 +1309,7 @@ class _AxesBase(martist.Artist):
             If 'box', change the physical dimensions of the Axes.
             If 'datalim', change the ``x`` or ``y`` data limits.
 
-        share : bool, optional, default: False
+        share : bool, default: False
             If ``True``, apply the settings to all shared Axes.
 
         See Also
@@ -1443,7 +1443,7 @@ class _AxesBase(martist.Artist):
               | 'SW' | 'S'  | 'SE' |
               +------+------+------+
 
-        share : bool, optional, default: False
+        share : bool, default: False
             If ``True``, apply the settings to all shared Axes.
 
         See Also
@@ -1664,7 +1664,7 @@ class _AxesBase(martist.Artist):
                      ``xmax-xmin == ymax-ymin``.
             ======== ==========================================================
 
-        emit : bool, optional, default *True*
+        emit : bool, default: True
             Whether observers are notified of the axis limit change.
             This option is passed on to `~.Axes.set_xlim` and
             `~.Axes.set_ylim`.
@@ -2092,7 +2092,7 @@ class _AxesBase(martist.Artist):
             The points to include in the data limits Bbox. This can be either
             a list of (x, y) tuples or a Nx2 array.
 
-        updatex, updatey : bool, optional, default *True*
+        updatex, updatey : bool, default: True
             Whether to update the x/y limits.
         """
         xys = np.asarray(xys)
@@ -2370,12 +2370,12 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        enable : bool or None, optional, default: True
+        enable : bool or None, default: True
             True turns autoscaling on, False turns it off.
             None leaves the autoscaling state unchanged.
-        axis : {'both', 'x', 'y'}, optional, default: 'both'
+        axis : {'both', 'x', 'y'}, default: 'both'
             Which axis to operate on.
-        tight : bool or None, optional, default: None
+        tight : bool or None, default: None
             If True, first set the margins to zero.  Then, this argument is
             forwarded to `autoscale_view` (regardless of its value); see the
             description of its behavior there.
@@ -3174,14 +3174,14 @@ class _AxesBase(martist.Artist):
             The right xlim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
-        emit : bool, optional, default: True
+        emit : bool, default: True
             Whether to notify observers of limit change.
 
-        auto : bool or None, optional, default: False
+        auto : bool or None, default: False
             Whether to turn on autoscaling of the x-axis. True turns on,
             False turns off, None leaves unchanged.
 
-        xmin, xmax : scalar, optional
+        xmin, xmax : float, optional
             They are equivalent to left and right respectively,
             and it is an error to pass both *xmin* and *left* or
             *xmax* and *right*.
@@ -3350,7 +3350,7 @@ class _AxesBase(martist.Artist):
         ----------
         ticks : list
             List of x-axis tick locations.
-        minor : bool, optional, default: False
+        minor : bool, default: False
             If ``False`` sets major ticks, if ``True`` sets minor ticks.
         """
         ret = self.xaxis.set_ticks(ticks, minor=minor)
@@ -3555,10 +3555,10 @@ class _AxesBase(martist.Artist):
             The top ylim in data coordinates. Passing *None* leaves the
             limit unchanged.
 
-        emit : bool, optional, default: True
+        emit : bool, default: True
             Whether to notify observers of limit change.
 
-        auto : bool or None, optional, default: False
+        auto : bool or None, default: False
             Whether to turn on autoscaling of the y-axis. *True* turns on,
             *False* turns off, *None* leaves unchanged.
 
@@ -3731,7 +3731,7 @@ class _AxesBase(martist.Artist):
         ----------
         ticks : list
             List of y-axis tick locations
-        minor : bool, optional, default: False
+        minor : bool, default: False
             If ``False`` sets major ticks, if ``True`` sets minor ticks.
         """
         ret = self.yaxis.set_ticks(ticks, minor=minor)

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -170,7 +170,7 @@ class SecondaryAxis(_AxesBase):
         ----------
         ticks : list
             List of x-axis tick locations.
-        minor : bool, optional, default: False
+        minor : bool, default: False
             If ``False`` sets major ticks, if ``True`` sets minor ticks.
         """
         ret = self._axis.set_ticks(ticks, minor=minor)
@@ -306,7 +306,7 @@ class SecondaryAxis(_AxesBase):
         xlabel : str
             The label text.
 
-        labelpad : scalar, optional, default: None
+        labelpad : float, default: ``self.xaxis.labelpad``
             Spacing in points between the label and the x-axis.
 
         Other Parameters
@@ -324,15 +324,15 @@ class SecondaryAxis(_AxesBase):
 
     def set_ylabel(self, ylabel, fontdict=None, labelpad=None, **kwargs):
         """
-        Set the label for the x-axis.
+        Set the label for the y-axis.
 
         Parameters
         ----------
         ylabel : str
             The label text.
 
-        labelpad : scalar, optional, default: None
-            Spacing in points between the label and the x-axis.
+        labelpad : scalar, default: ``self.yaxis.labelpad``
+            Spacing in points between the label and the y-axis.
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3170,7 +3170,7 @@ class ToolContainerBase:
             The tool to add, see `ToolManager.get_tool`.
         group : str
             The name of the group to add this tool to.
-        position : int, optional, default: -1
+        position : int, default: -1
             The position within the group to place this tool.
         """
         tool = self.toolmanager.get_tool(tool)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -932,12 +932,11 @@ class PathCollection(_CollectionWithSizes):
 
         Parameters
         ----------
-        prop : string, optional, default *"colors"*
-            Can be *"colors"* or *"sizes"*. In case of *"colors"*, the legend
-            handles will show the different colors of the collection. In case
-            of "sizes", the legend will show the different sizes.
+        prop : {"colors", "sizes"}, default: "colors"
+            If "colors", the legend handles will show the different colors of
+            the collection. If "sizes", the legend will show the different
+            sizes.
         num : int, None, "auto" (default), array-like, or `~.ticker.Locator`,
-            optional
             Target number of elements to create.
             If None, use all unique elements of the mappable array. If an
             integer, target to use *num* elements in the normed range.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1602,10 +1602,10 @@ class LightSource:
 
         Parameters
         ----------
-        azdeg : float, optional, default: 315 degrees (from the northwest)
+        azdeg : float, default: 315 degrees (from the northwest)
             The azimuth (0-360, degrees clockwise from North) of the light
             source.
-        altdeg : float, optional, default: 45 degrees
+        altdeg : float, default: 45 degrees
             The altitude (0-90, degrees up from horizontal) of the light
             source.
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -64,7 +64,7 @@ class ContourLabeler:
             A list of level values, that should be labeled. The list must be
             a subset of ``cs.levels``. If not given, all levels are labeled.
 
-        fontsize : str or float, optional
+        fontsize : str or float, default: :rc:`font.size`
             Size in points or relative size e.g., 'smaller', 'x-large'.
             See `.Text.set_size` for accepted string values.
 
@@ -80,17 +80,17 @@ class ContourLabeler:
             - If a tuple of colors (string, float, rgb, etc), different labels
               will be plotted in different colors in the order specified.
 
-        inline : bool, optional, default: True
+        inline : bool, default: True
             If ``True`` the underlying contour is removed where the label is
             placed.
 
-        inline_spacing : float, optional, default: 5
+        inline_spacing : float, default: 5
             Space in pixels to leave on each side of label when placing inline.
 
             This spacing will be exact for labels at locations where the
             contour is straight, less so for labels on curved contours.
 
-        fmt : str or dict, optional, default: '%1.3f'
+        fmt : str or dict, default: '%1.3f'
             A format string for the label.
 
             Alternatively, this can be a dictionary matching contour levels
@@ -114,11 +114,11 @@ class ContourLabeler:
             Contour labels will be created as if mouse is clicked at each
             (x, y) position.
 
-        rightside_up : bool, optional, default: True
+        rightside_up : bool, default: True
             If ``True``, label rotations will always be plus
             or minus 90 degrees from level.
 
-        use_clabeltext : bool, optional, default: False
+        use_clabeltext : bool, default: False
             If ``True``, `.ClabelText` class (instead of `.Text`) is used to
             create labels. `ClabelText` recalculates rotation angles
             of texts during the drawing time, therefore this can be used if
@@ -461,10 +461,10 @@ class ContourLabeler:
         x, y : float
             The approximate location of the label.
 
-        inline : bool, optional, default: True
+        inline : bool, default: True
             If *True* remove the segment of the contour beneath the label.
 
-        inline_spacing : int, optional, default: 5
+        inline_spacing : int, default: 5
             Space in pixels to leave on each side of label when placing
             inline. This spacing will be exact for labels at locations where
             the contour is straight, less so for labels on curved contours.
@@ -1686,8 +1686,7 @@ class QuadContourSet(ContourSet):
             are not given explicitly via *levels*.
             Defaults to `~.ticker.MaxNLocator`.
 
-        extend : {'neither', 'both', 'min', 'max'}, optional, default: \
-'neither'
+        extend : {'neither', 'both', 'min', 'max'}, default: 'neither'
             Determines the ``contourf``-coloring of values that are outside the
             *levels* range.
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1027,7 +1027,7 @@ default: 'top'
             The artist to add to the figure. If the added artist has no
             transform previously set, its transform will be set to
             ``figure.transFigure``.
-        clip : bool, optional, default: False
+        clip : bool, default: False
             Whether the added artist should be clipped by the figure patch.
 
         Returns
@@ -1414,7 +1414,7 @@ default: 'top'
 
         Parameters
         ----------
-        nrows, ncols : int, optional, default: 1
+        nrows, ncols : int, default: 1
             Number of rows/columns of the subplot grid.
 
         sharex, sharey : bool or {'none', 'all', 'row', 'col'}, default: False
@@ -1432,7 +1432,7 @@ default: 'top'
             first column subplot are created. To later turn other subplots'
             ticklabels on, use `~matplotlib.axes.Axes.tick_params`.
 
-        squeeze : bool, optional, default: True
+        squeeze : bool, default: True
             - If True, extra dimensions are squeezed out from the returned
               array of Axes:
 
@@ -1841,12 +1841,13 @@ default: 'top'
         s : str
             The text string.
 
-        fontdict : dictionary, optional, default: None
-            A dictionary to override the default text properties. If fontdict
-            is None, the defaults are determined by your rc parameters. A
-            property in *kwargs* override the same property in fontdict.
+        fontdict : dict, optional
+            A dictionary to override the default text properties. If not given,
+            the defaults are determined by your rc parameters. Properties
+            passed as *kwargs* override the corresponding ones given in
+            *fontdict*.
 
-        withdash : boolean, optional, default: False
+        withdash : bool, default: False
             Creates a `~matplotlib.text.TextWithDash` instance instead of a
             `~matplotlib.text.Text` instance.
 
@@ -2298,19 +2299,19 @@ default: 'top'
 
         Parameters
         ----------
-        n : int, optional, default: 1
+        n : int, default: 1
             Number of mouse clicks to accumulate. If negative, accumulate
             clicks until the input is terminated manually.
-        timeout : scalar, optional, default: 30
+        timeout : scalar, default: 30 seconds
             Number of seconds to wait before timing out. If zero or negative
             will never timeout.
-        show_clicks : bool, optional, default: True
+        show_clicks : bool, default: True
             If True, show a red cross at the location of each click.
-        mouse_add : {1, 2, 3, None}, optional, default: 1 (left click)
+        mouse_add : {1, 2, 3, None}, default: 1 (left click)
             Mouse button used to add points.
-        mouse_pop : {1, 2, 3, None}, optional, default: 3 (right click)
+        mouse_pop : {1, 2, 3, None}, default: 3 (right click)
             Mouse button used to remove the most recently added point.
-        mouse_stop : {1, 2, 3, None}, optional, default: 2 (middle click)
+        mouse_stop : {1, 2, 3, None}, default: 2 (middle click)
             Mouse button used to stop input.
 
         Returns

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1191,7 +1191,7 @@ class FontManager:
             `.FontProperties` object or a string defining a
             `fontconfig patterns`_.
 
-        fontext : {'ttf', 'afm'}, optional, default: 'ttf'
+        fontext : {'ttf', 'afm'}, default: 'ttf'
             The extension of the font file:
 
             - 'ttf': TrueType and OpenType fonts (.ttf, .ttc, .otf)

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -405,7 +405,7 @@ class GridSpec(GridSpecBase):
         h_pad, w_pad : float, optional
             Padding (height/width) between edges of adjacent subplots.
             Defaults to *pad*.
-        rect : tuple of 4 floats, optional, default: (0, 0, 1, 1)
+        rect : tuple of 4 floats, default: (0, 0, 1, 1), i.e. the whole figure
             (left, bottom, right, top) rectangle in normalized figure
             coordinates that the whole subplots area (including labels) will
             fit into.

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -652,12 +652,11 @@ class HandlerTuple(HandlerBase):
 
     Parameters
     ----------
-    ndivide : int, optional, default: 1
+    ndivide : int, default: 1
         The number of sections to divide the legend area into. If None,
         use the length of the input tuple.
-    pad : float, optional, default: None
-        Padding in units of fraction of font size.  If None, use
-        :rc:`legend.borderpad`.
+    pad : float, default: :rc:`legend.borderpad`
+        Padding in units of fraction of font size.
     """
 
     def __init__(self, ndivide=1, pad=None, **kwargs):

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -791,7 +791,7 @@ class TextArea(OffsetBox):
         s : str
             a string to be displayed.
 
-        textprops : dictionary, optional, default: None
+        textprops : dict, optional
             Dictionary of keyword parameters to be passed to the
             `~matplotlib.text.Text` instance contained inside TextArea.
 
@@ -1291,7 +1291,7 @@ class AnchoredText(AnchoredOffsetbox):
         borderpad : float, optional
             Pad between the frame and the axes (or *bbox_to_anchor*).
 
-        prop : dictionary, optional, default: None
+        prop : dict, optional
             Dictionary of keyword parameters to be passed to the
             `~matplotlib.text.Text` instance contained inside AnchoredText.
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1192,10 +1192,10 @@ class PolarAxes(Axes):
             The top limit (default: None, which leaves the top limit
             unchanged).
 
-        emit : bool, optional, default: True
+        emit : bool, default: True
             Whether to notify observers of limit change.
 
-        auto : bool or None, optional, default: False
+        auto : bool or None, default: False
             Whether to turn on autoscaling of the y-axis. True turns on,
             False turns off, None leaves unchanged.
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -408,7 +408,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
     Parameters
     ----------
-    num : int or str, optional, default: None
+    num : int or str, optional
         If not provided, a new figure will be created, and the figure number
         will be incremented. The figure objects holds this number in a `number`
         attribute.
@@ -418,29 +418,25 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
         If num is a string, the window title will be set to this figure's
         *num*.
 
-    figsize : (float, float), optional, default: None
-        width, height in inches. If not provided, defaults to
-        :rc:`figure.figsize` = ``[6.4, 4.8]``.
+    figsize : (float, float), default: :rc:`figure.figsize`
+        Width, height in inches.
 
-    dpi : int, optional, default: None
-        resolution of the figure. If not provided, defaults to
-        :rc:`figure.dpi` = ``100``.
+    dpi : int, default: :rc:`figure.dpi`
+        The resolution of the figure in dots-per-inch.
 
-    facecolor : color
-        the background color. If not provided, defaults to
-        :rc:`figure.facecolor` = ``'w'``.
+    facecolor : color, default: :rc:`figure.facecolor`
+        The background color.
 
-    edgecolor : color
-        the border color. If not provided, defaults to
-        :rc:`figure.edgecolor` = ``'w'``.
+    edgecolor : color, default: :rc:`figure.edgecolor`
+        The border color.
 
-    frameon : bool, optional, default: True
+    frameon : bool, default: True
         If False, suppress drawing the figure frame.
 
     FigureClass : subclass of `~matplotlib.figure.Figure`
         Optionally use a custom `.Figure` instance.
 
-    clear : bool, optional, default: False
+    clear : bool, default: False
         If True and the figure already exists, then it is cleared.
 
     Returns
@@ -985,7 +981,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
 
     Parameters
     ----------
-    nrows, ncols : int, optional, default: 1
+    nrows, ncols : int, default: 1
         Number of rows/columns of the subplot grid.
 
     sharex, sharey : bool or {'none', 'all', 'row', 'col'}, default: False
@@ -1003,7 +999,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         column subplot are created. To later turn other subplots' ticklabels
         on, use `~matplotlib.axes.Axes.tick_params`.
 
-    squeeze : bool, optional, default: True
+    squeeze : bool, default: True
         - If True, extra dimensions are squeezed out from the returned
           array of `~matplotlib.axes.Axes`:
 
@@ -1016,9 +1012,6 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         - If False, no squeezing at all is done: the returned Axes object is
           always a 2D array containing Axes instances, even if it ends up
           being 1x1.
-
-    num : int or str, optional, default: None
-        A `.pyplot.figure` keyword that sets the figure number or label.
 
     subplot_kw : dict, optional
         Dict with keywords passed to the
@@ -1263,7 +1256,7 @@ def tight_layout(pad=1.08, h_pad=None, w_pad=None, rect=None):
     h_pad, w_pad : float, optional
         Padding (height/width) between edges of adjacent subplots,
         as a fraction of the font size.  Defaults to *pad*.
-    rect : tuple (left, bottom, right, top), optional, default: (0, 0, 1, 1)
+    rect : tuple (left, bottom, right, top), default: (0, 0, 1, 1)
         A rectangle (left, bottom, right, top) in the normalized
         figure coordinate that the whole subplots area (including
         labels) will fit into.

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -101,7 +101,7 @@ units : {'width', 'height', 'dots', 'inches', 'x', 'y' 'xy'}, default: 'width'
     height of the axes, respectively, when the window is resized;
     for 'dots' or 'inches', resizing does not change the arrows.
 
-angles : {'uv', 'xy'} or array-like, optional, default: 'uv'
+angles : {'uv', 'xy'} or array-like, default: 'uv'
     Method for determining the angle of the arrows.
 
     - 'uv': The arrow axis aspect ratio is 1 so that
@@ -150,24 +150,24 @@ width : float, optional
     above, and number of vectors; a typical starting value is about
     0.005 times the width of the plot.
 
-headwidth : float, optional, default: 3
+headwidth : float, default: 3
     Head width as multiple of shaft width.
 
-headlength : float, optional, default: 5
+headlength : float, default: 5
     Head length as multiple of shaft width.
 
-headaxislength : float, optional, default: 4.5
+headaxislength : float, default: 4.5
     Head length at shaft intersection.
 
-minshaft : float, optional, default: 1
+minshaft : float, default: 1
     Length below which arrow scales, in units of head length. Do not
     set this to less than 1, or small arrows will look terrible!
 
-minlength : float, optional, default: 1
+minlength : float, default: 1
     Minimum length as a multiple of shaft width; if an arrow length
     is less than this, plot a dot (hexagon) of this diameter instead.
 
-pivot : {'tail', 'mid', 'middle', 'tip'}, optional, default: 'tail'
+pivot : {'tail', 'mid', 'middle', 'tip'}, default: 'tail'
     The part of the arrow that is anchored to the *X*, *Y* grid. The arrow
     rotates about this point.
 

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -701,7 +701,7 @@ def table(ax,
     rowColours : list of colors, optional
         The colors of the row header cells.
 
-    rowLoc : {'left', 'center', 'right'}, optional, default: 'left'
+    rowLoc : {'left', 'center', 'right'}, default: 'left'
         The text alignment of the row header cells.
 
     colLabels : list of str, optional
@@ -710,7 +710,7 @@ def table(ax,
     colColours : list of colors, optional
         The colors of the column header cells.
 
-    colLoc : {'left', 'center', 'right'}, optional, default: 'left'
+    colLoc : {'left', 'center', 'right'}, default: 'left'
         The text alignment of the column header cells.
 
     loc : str, optional

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -379,7 +379,7 @@ class TextPath(Path):
         _interpolation_steps : int, optional
             (Currently ignored)
 
-        usetex : bool, optional, default: False
+        usetex : bool, default: False
             Whether to use tex rendering.
 
         Examples

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1414,11 +1414,11 @@ class EngFormatter(Formatter):
             * ``sep="\N{NARROW NO-BREAK SPACE}"`` (``U+202F``);
             * ``sep="\N{NO-BREAK SPACE}"`` (``U+00A0``).
 
-        usetex : bool, optional, default: None
+        usetex : bool, default: :rc:`text.usetex`
             To enable/disable the use of TeX's math mode for rendering the
             numbers in the formatter.
 
-        useMathText : bool, optional, default: None
+        useMathText : bool, default: :rc:`axes.formatter.use_mathtext`
             To enable/disable the use mathtext for rendering the numbers in
             the formatter.
         """
@@ -2338,7 +2338,7 @@ class LogLocator(Locator):
 
         Parameters
         ----------
-        subs : None, str, or sequence of float, optional, default (1.0,)
+        subs : None or str or sequence of float, default: (1.0,)
             Gives the multiples of integer powers of the base at which
             to place ticks.  The default places ticks only at
             integer powers of the base.

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2781,16 +2781,16 @@ def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
     ----------
     vmin, vmax : float
         The initial endpoints.
-    expander : float, optional, default: 0.001
+    expander : float, default: 0.001
         Fractional amount by which *vmin* and *vmax* are expanded if
         the original interval is too small, based on *tiny*.
-    tiny : float, optional, default: 1e-15
+    tiny : float, default: 1e-15
         Threshold for the ratio of the interval to the maximum absolute
         value of its endpoints.  If the interval is smaller than
         this, it will be expanded.  This value should be around
         1e-15 or larger; otherwise the interval will be approaching
         the double precision resolution limit.
-    increasing : bool, optional, default: True
+    increasing : bool, default: True
         If True, swap *vmin*, *vmax* if *vmin* > *vmax*.
 
     Returns
@@ -2904,11 +2904,11 @@ def offset_copy(trans, fig=None, x=0.0, y=0.0, units='inches'):
     ----------
     trans : :class:`Transform` instance
         Any transform, to which offset will be applied.
-    fig : :class:`~matplotlib.figure.Figure`, optional, default: None
+    fig : :class:`~matplotlib.figure.Figure`, default: None
         Current figure. It can be None if *units* are 'dots'.
-    x, y : float, optional, default: 0.0
+    x, y : float, default: 0.0
         The offset to apply.
-    units : {'inches', 'points', 'dots'}, optional
+    units : {'inches', 'points', 'dots'}, default: 'inches'
         Units of the offset.
 
     Returns

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -77,10 +77,10 @@ class UniformTriRefiner(TriRefiner):
 
         Parameters
         ----------
-        return_tri_index : bool, optional, default: False
+        return_tri_index : bool, default: False
             Whether an index table indicating the father triangle index of each
             point will be returned.
-        subdiv : int, optional, default: 3
+        subdiv : int, default: 3
             Recursion level for the subdivision.
             Each triangle will be divided into ``4**subdiv`` child triangles.
 
@@ -149,7 +149,7 @@ class UniformTriRefiner(TriRefiner):
             Interpolator used for field interpolation. If not specified,
             a :class:`~matplotlib.tri.CubicTriInterpolator` will
             be used.
-        subdiv : int, optional, default: 3
+        subdiv : int, default: 3
             Recursion level for the subdivision.
             Each triangle will be divided into ``4**subdiv`` child triangles.
 

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -66,7 +66,7 @@ class TriAnalyzer:
 
         Parameters
         ----------
-        rescale : bool, optional, default: True
+        rescale : bool, default: True
             If True, a rescaling will be internally performed (based on
             :attr:`scale_factors`, so that the (unmasked) triangles fit
             exactly inside a unit square mesh.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -274,30 +274,30 @@ class Slider(AxesWidget):
         valmax : float
             The maximum value of the slider.
 
-        valinit : float, optional, default: 0.5
+        valinit : float, default: 0.5
             The slider initial position.
 
-        valfmt : str, optional, default: "%1.2f"
+        valfmt : str, default: "%1.2f"
             Used to format the slider value, fprint format string.
 
-        closedmin : bool, optional, default: True
+        closedmin : bool, default: True
             Whether the slider interval is closed on the bottom.
 
-        closedmax : bool, optional, default: True
+        closedmax : bool, default: True
             Whether the slider interval is closed on the top.
 
-        slidermin : Slider, optional, default: None
+        slidermin : Slider, default: None
             Do not allow the current slider to have a value less than
             the value of the Slider `slidermin`.
 
-        slidermax : Slider, optional, default: None
+        slidermax : Slider, default: None
             Do not allow the current slider to have a value greater than
             the value of the Slider `slidermax`.
 
-        dragging : bool, optional, default: True
+        dragging : bool, default: True
             If True the slider can be dragged by the mouse.
 
-        valstep : float, optional, default: None
+        valstep : float, default: None
             If given, the slider will snap to multiples of `valstep`.
 
         orientation : {'horizontal', 'vertical'}, default: 'horizontal'
@@ -1234,11 +1234,11 @@ class Cursor(AxesWidget):
     ----------
     ax : `matplotlib.axes.Axes`
         The `~.axes.Axes` to attach the cursor to.
-    horizOn : bool, optional, default: True
+    horizOn : bool, default: True
         Whether to draw the horizontal line.
-    vertOn : bool, optional, default: True
+    vertOn : bool, default: True
         Whether to draw the vertical line.
-    useblit : bool, optional, default: False
+    useblit : bool, default: False
         Use blitting for faster drawing if supported by the backend.
 
     Other Parameters


### PR DESCRIPTION
## PR Summary

Continuation of #15818.

> Accroding to our recent docstring conventions, use default: xxx instead of optional, default: xxx.