### PR TITLE
Fix bar3d bug with matching color string and array x lengths

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2507,13 +2507,15 @@ class Axes3D(Axes):
         if color is None:
             color = [self._get_patches_for_fill.get_next_color()]
 
+        color = list(mcolors.to_rgba_array(color))
+
         if len(color) == len(x):
             # bar colors specified, need to expand to number of faces
             for c in color:
                 facecolors.extend([c] * 6)
         else:
             # a single color specified, or face colors specified explicitly
-            facecolors = list(mcolors.to_rgba_array(color))
+            facecolors = color
             if len(facecolors) < len(x):
                 facecolors *= (6 * len(x))
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -36,6 +36,18 @@ def test_bar3d():
         ax.bar(xs, ys, zs=z, zdir='y', align='edge', color=cs, alpha=0.8)
 
 
+def test_bar3d_colors():
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    for c in ['red', 'green', 'blue', 'yellow']:
+        xs = np.arange(len(c))
+        ys = np.zeros_like(xs)
+        zs = np.zeros_like(ys)
+        # Color names with same length as xs/ys/zs should not be split into
+        # individual letters.
+        ax.bar3d(xs, ys, zs, 1, 1, 1, color=c)
+
+
 @mpl3d_image_comparison(['bar3d_shaded.png'])
 def test_bar3d_shaded():
     x = np.arange(4)


### PR DESCRIPTION
## PR Summary
Closes #15815 
The bug is caused by the line `len(color) == len(x)`, since `len(color)` is the length of string rather than the actual number of colors.

Converting color to an RBG array before comparison ensures that `len(color)` actually represents the number of colors.
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
