### PR TITLE
Fix validation of linestyle in rcparams and cycler.

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -370,18 +370,21 @@ def generate_validator_testcases(valid):
                      ('', ''), (' ', ' '),
                      ('None', 'none'), ('none', 'none'),
                      ('DoTtEd', 'dotted'),  # case-insensitive
-                     (['1.23', '4.56'], (None, [1.23, 4.56])),
+                     ('1, 3', (None, (1, 3))),
                      ([1.23, 456], (None, [1.23, 456.0])),
                      ([1, 2, 3, 4], (None, [1.0, 2.0, 3.0, 4.0])),
+                     ((None, [1, 2]), (None, [1, 2])),
+                     ((0, [1, 2]), (0, [1, 2])),
+                     ((-1, [1, 2]), (-1, [1, 2])),
                      ),
          'fail': (('aardvark', ValueError),  # not a valid string
                   (b'dotted', ValueError),
                   ('dotted'.encode('utf-16'), ValueError),
-                  ((None, [1, 2]), ValueError),  # (offset, dashes) != OK
-                  ((0, [1, 2]), ValueError),  # idem
-                  ((-1, [1, 2]), ValueError),  # idem
                   ([1, 2, 3], ValueError),  # sequence with odd length
                   (1.23, ValueError),  # not a sequence
+                  (("a", [1, 2]), ValueError),  # wrong explicit offset
+                  ((1, [1, 2, 3]), ValueError),  # odd length sequence
+                  (([1, 2], 1), ValueError),  # inverted offset/onoff
                   )
          },
     )


### PR DESCRIPTION
Correcly use _validate_linestyle instead of validate_stringlist in the
cycler linestyle validator.  For compat, support both the (on, off, on,
off, ...) and (offset, (on, off, on, off, ...)) forms.  Don't support
passing on, off, etc. as *individual* separate strings anymore as that's
not a realistic use case (unlike passing the whole thing as a single
string, which is supported for parsing the rc file).

Closes #15825 (the corresponding test is that (0, [1, 2]) no longer fails but is instead parsed as (0, [1, 2])).
Makes https://github.com/matplotlib/matplotlib/pull/8040/files#diff-2423339af6767c3b30e1882f7c8d8f54R30 actually work (it didn't before).

Note that _validate_stringlist needed to be moved up in rcsetup.py to come before the _prop_validators dict.

Edit: Also closes #9792 and supersedes #9797, from which some test cases were taken.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
