### PR TITLE
In C extensions, use FutureWarning, not DeprecationWarning.

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -109,7 +109,7 @@ const char *PyFT2Image_as_str__doc__ =
 
 static PyObject *PyFT2Image_as_str(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+    if (PyErr_WarnEx(PyExc_FutureWarning,
                      "FT2Image.as_str is deprecated since Matplotlib 3.2 and "
                      "will be removed in Matplotlib 3.4; convert the FT2Image "
                      "to a NumPy array with np.asarray instead.",
@@ -129,7 +129,7 @@ const char *PyFT2Image_as_rgba_str__doc__ =
 
 static PyObject *PyFT2Image_as_rgba_str(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+    if (PyErr_WarnEx(PyExc_FutureWarning,
                      "FT2Image.as_rgba_str is deprecated since Matplotlib 3.2 and "
                      "will be removed in Matplotlib 3.4; convert the FT2Image "
                      "to a NumPy array with np.asarray instead.",
@@ -162,7 +162,7 @@ const char *PyFT2Image_as_array__doc__ =
 
 static PyObject *PyFT2Image_as_array(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+    if (PyErr_WarnEx(PyExc_FutureWarning,
                      "FT2Image.as_array is deprecated since Matplotlib 3.2 and "
                      "will be removed in Matplotlib 3.4; convert the FT2Image "
                      "to a NumPy array with np.asarray instead.",
@@ -175,7 +175,7 @@ static PyObject *PyFT2Image_as_array(PyFT2Image *self, PyObject *args, PyObject 
 
 static PyObject *PyFT2Image_get_width(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+    if (PyErr_WarnEx(PyExc_FutureWarning,
                      "FT2Image.get_width is deprecated since Matplotlib 3.2 and "
                      "will be removed in Matplotlib 3.4; convert the FT2Image "
                      "to a NumPy array with np.asarray instead.",
@@ -187,7 +187,7 @@ static PyObject *PyFT2Image_get_width(PyFT2Image *self, PyObject *args, PyObject
 
 static PyObject *PyFT2Image_get_height(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
-    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+    if (PyErr_WarnEx(PyExc_FutureWarning,
                      "FT2Image.get_height is deprecated since Matplotlib 3.2 and "
                      "will be removed in Matplotlib 3.4; convert the FT2Image "
                      "to a NumPy array with np.asarray instead.",


### PR DESCRIPTION
DeprecationWarnings are hidden by default (that's why
MatplotlibDeprecationWarning inherits from UserWarning, not
DeprecationWarning...) and throwing a MatplotlibDeprecationWarning from
C code is too much of a pain to be worth it; also, CPython suggests
using FutureWarning for this purpose as well.
(https://docs.python.org/3/library/warnings.html#warning-categories)

Release critical so that the warnings actually show up...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
