### PR TITLE
Fix build with numpy master.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6586,8 +6586,6 @@ optional.
         if histtype == 'barstacked' and not stacked:
             stacked = True
 
-        # basic input validation
-        input_empty = np.size(x) == 0
         # Massage 'x' for processing.
         x = cbook._reshape_2D(x, 'x')
         nx = len(x)  # number of datasets
@@ -6649,13 +6647,10 @@ optional.
         # If bins are not specified either explicitly or via range,
         # we need to figure out the range required for all datasets,
         # and supply that to np.histogram.
-        if not input_empty and len(x) > 1:
-            if weights is not None:
-                _w = np.concatenate(w)
-            else:
-                _w = None
-            bins = np.histogram_bin_edges(
-                np.concatenate(x), bins, bin_range, _w)
+        all_xs = np.concatenate(x)
+        if len(all_xs):
+            all_ws = np.concatenate(w) if weights is not None else None
+            bins = np.histogram_bin_edges(all_xs, bins, bin_range, all_ws)
         else:
             hist_kwargs['range'] = bin_range
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -68,6 +68,7 @@ Matplotlib recognizes the following formats to specify a color:
 from collections.abc import Sized
 import functools
 import itertools
+from numbers import Number
 import re
 
 import numpy as np
@@ -260,14 +261,12 @@ def _to_rgba_no_colorcycle(c, alpha=None):
             return c, c, c, alpha if alpha is not None else 1.
         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")
     # tuple color.
-    c = np.array(c)
-    if not np.can_cast(c.dtype, float, "same_kind") or c.ndim != 1:
-        # Test the dtype explicitly as `map(float, ...)`, `np.array(...,
-        # float)` and `np.array(...).astype(float)` all convert "0.5" to 0.5.
-        # Test dimensionality to reject single floats.
+    if not np.iterable(c) or not all(isinstance(x, Number) for x in c):
+        # Checks that don't work: `map(float, ...)`, `np.array(..., float)` and
+        # `np.array(...).astype(float)` would all convert "0.5" to 0.5.
         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")
     # Return a tuple to prevent the cached value from being modified.
-    c = tuple(c.astype(float))
+    c = tuple(map(float, c))
     if len(c) not in [3, 4]:
         raise ValueError("RGBA sequence should have length 3 or 4")
     if len(c) == 3 and alpha is None:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -604,7 +604,9 @@ def test_shaped_data():
     plt.plot(y2)
 
     plt.subplot(413)
-    with pytest.raises(ValueError):
+    # DeprecationWarning is raised by numpy 1.19 on object array creation;
+    # later it will be a ValueError again.
+    with pytest.raises((ValueError, DeprecationWarning)):
         plt.plot((y1, y2))
 
     plt.subplot(414)
@@ -2697,7 +2699,9 @@ def test_boxplot_bad_ci_2():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
     fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
+    # DeprecationWarning is raised by numpy 1.19 on object array creation;
+    # later it will be a ValueError again.
+    with pytest.raises((ValueError, DeprecationWarning)):
         ax.boxplot([x, x], conf_intervals=[[1, 2], [1]])
 
 


### PR DESCRIPTION
Specifically, fix places where we build object arrays implicitly, as
that's deprecated on numpy master.

The change to colors.py may possibly(?) make conversion to rgba actually
slightly *faster* as we avoid the conversion to array in some cases.
(Edit: indeed, it's 2x faster in the relevant case, lifted this to its own PR: #15834.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
