### PR TITLE
Remove some references to Py2.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,9 +19,6 @@ import sphinx
 
 from datetime import datetime
 
-if sys.version_info < (3, 0, 0):
-    print("You're using python 2.x, conf.py works with python3+ only.")
-    exit()
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -97,22 +97,7 @@ developed and maintained by a host of others.
 
 Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
-
 """
-# NOTE: This file must remain Python 2 compatible for the foreseeable future,
-# to ensure that we error out properly for existing editable installs.
-
-import sys
-if sys.version_info < (3, 5):  # noqa: E402
-    raise ImportError("""
-Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
-Beginning with Matplotlib 3.0, Python 3.5 and above is required.
-
-See Matplotlib `INSTALL.rst` file for more information:
-
-    https://github.com/matplotlib/matplotlib/blob/master/INSTALL.rst
-
-""")
 
 import atexit
 from collections import namedtuple
@@ -131,6 +116,7 @@ import pprint
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 
 # cbook must import matplotlib only within function

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1167,7 +1167,6 @@ class PcolorImage(AxesImage):
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
         height = (round(t) + 0.5) - (round(b) - 0.5)
-        # The extra cast-to-int is only needed for python2
         width = int(round(width * magnification))
         height = int(round(height * magnification))
         if self._rgbacache is None:

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -6,9 +6,6 @@ from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import matplotlib.category as cat
 
-# Python2/3 text handling
-_to_str = cat.StrCategoryFormatter._text
-
 
 class TestUnitData:
     test_cases = [('single', (["hello world"], [0])),
@@ -156,14 +153,14 @@ class TestStrCategoryFormatter:
         unit = cat.UnitData(ydata)
         labels = cat.StrCategoryFormatter(unit._mapping)
         for i, d in enumerate(ydata):
-            assert labels(i, i) == _to_str(d)
+            assert labels(i, i) == d
 
     @pytest.mark.parametrize("ydata", cases, ids=ids)
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)
     def test_StrCategoryFormatterPlot(self, ax, ydata, plotter):
         plotter(ax, range(len(ydata)), ydata)
         for i, d in enumerate(ydata):
-            assert ax.yaxis.major.formatter(i, i) == _to_str(d)
+            assert ax.yaxis.major.formatter(i, i) == d
         assert ax.yaxis.major.formatter(i+1, i+1) == ""
         assert ax.yaxis.major.formatter(0, None) == ""
 
@@ -172,7 +169,8 @@ def axis_test(axis, labels):
     ticks = list(range(len(labels)))
     np.testing.assert_array_equal(axis.get_majorticklocs(), ticks)
     graph_labels = [axis.major.formatter(i, i) for i in ticks]
-    assert graph_labels == [_to_str(l) for l in labels]
+    # _text also decodes bytes as utf-8.
+    assert graph_labels == [cat.StrCategoryFormatter._text(l) for l in labels]
     assert list(axis.units._mapping.keys()) == [l for l in labels]
     assert list(axis.units._mapping.values()) == ticks
 


### PR DESCRIPTION
The checks in `conf.py` and `matplotlib/__init__.py` are not useful
because the files are in fact not Py2-compatible (this has been the case
for `__init__.py` for a while...) due to f-strings/nonlocal, so someone
trying to run the file on Py2 will get a SyntaxError instead of the
error message.

In image.py the cast to int remains necessary even on Py3 because
round(np.float) returns a np.float, not a np.int.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
