### PR TITLE
Remove some dead branches from texmanager code.

### DIFF
--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -41,9 +41,16 @@ Default values and styling
 
 .. autofunction:: rc_params_from_file
 
+.. autofunction:: get_configdir
+
 .. autofunction:: matplotlib_fname
 
 Logging
 =======
 
 .. autofunction:: set_loglevel
+
+Miscellaneous
+=============
+
+.. autofunction:: get_cachedir

--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -131,3 +131,7 @@ This method is deprecated.  Use
 ``SymmetricalScale.SymmetricalTransform`` and
 ``SymmetricalScale.InvertedSymmetricalTransform`` are deprecated.  Directly
 access the transform classes from the :mod:`.scale` module.
+
+``TexManager.cachedir``
+~~~~~~~~~~~~~~~~~~~~~~~
+Use `matplotlib.get_cachedir()` instead.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -488,19 +488,18 @@ def _get_config_or_cache_dir(xdg_base):
 @_logged_cached('CONFIGDIR=%s')
 def get_configdir():
     """
-    Return the string representing the configuration directory.
+    Return the string path of the the configuration directory.
 
     The directory is chosen as follows:
 
     1. If the MPLCONFIGDIR environment variable is supplied, choose that.
-    2a. On Linux, follow the XDG specification and look first in
-        `$XDG_CONFIG_HOME`, if defined, or `$HOME/.config`.
-    2b. On other platforms, choose `$HOME/.matplotlib`.
+    2. On Linux, follow the XDG specification and look first in
+       ``$XDG_CONFIG_HOME``, if defined, or ``$HOME/.config``.  On other
+       platforms, choose ``$HOME/.matplotlib``.
     3. If the chosen directory exists and is writable, use that as the
        configuration directory.
-    4. If possible, create a temporary directory, and use it as the
-       configuration directory.
-    5. A writable directory could not be found or created; return None.
+    4. Else, create a temporary directory, and use it as the configuration
+       directory.
     """
     return _get_config_or_cache_dir(_get_xdg_config_dir())
 
@@ -508,10 +507,10 @@ def get_configdir():
 @_logged_cached('CACHEDIR=%s')
 def get_cachedir():
     """
-    Return the location of the cache directory.
+    Return the string path of the cache directory.
 
     The procedure used to find the directory is the same as for
-    _get_config_dir, except using `$XDG_CACHE_HOME`/`~/.cache` instead.
+    _get_config_dir, except using ``$XDG_CACHE_HOME``/``$HOME/.cache`` instead.
     """
     return _get_config_or_cache_dir(_get_xdg_cache_dir())
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -53,16 +53,8 @@ class TexManager:
     Repeated calls to this constructor always return the same instance.
     """
 
-    cachedir = mpl.get_cachedir()
-    if cachedir is not None:
-        texcache = os.path.join(cachedir, 'tex.cache')
-        Path(texcache).mkdir(parents=True, exist_ok=True)
-    else:
-        # Should only happen in a restricted environment (such as Google App
-        # Engine). Deal with this gracefully by not creating a cache directory.
-        texcache = None
-
     # Caches.
+    texcache = os.path.join(mpl.get_cachedir(), 'tex.cache')
     rgba_arrayd = {}
     grey_arrayd = {}
 
@@ -99,6 +91,11 @@ class TexManager:
         ('text.latex.preamble', 'text.latex.unicode', 'text.latex.preview',
          'font.family') + tuple('font.' + n for n in font_families))
 
+    @cbook.deprecated("3.3", alternative="matplotlib.get_cachedir()")
+    @property
+    def cachedir(self):
+        return mpl.get_cachedir()
+
     @functools.lru_cache()  # Always return the same instance.
     def __new__(cls):
         self = object.__new__(cls)
@@ -106,16 +103,10 @@ class TexManager:
         return self
 
     def _reinit(self):
-        if self.texcache is None:
-            raise RuntimeError('Cannot create TexManager, as there is no '
-                               'cache directory available')
-
         Path(self.texcache).mkdir(parents=True, exist_ok=True)
         ff = rcParams['font.family']
         if len(ff) == 1 and ff[0].lower() in self.font_families:
             self.font_family = ff[0].lower()
-        elif isinstance(ff, str) and ff.lower() in self.font_families:
-            self.font_family = ff.lower()
         else:
             _log.info('font.family must be one of (%s) when text.usetex is '
                       'True. serif will be used by default.',


### PR DESCRIPTION
1) get_cachedir() never returns None (244e8d8/#8939).
2) rcParams["font.family"] is always a list of str(s), not a single str
   (its rc validator in rcsetup is validate_stringlist).

--
edit: turns out a few more docstrings need to be cleaned :)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
