### PR TITLE
np.abs -> (builtins).abs

### DIFF
--- a/examples/event_handling/resample.py
+++ b/examples/event_handling/resample.py
@@ -37,15 +37,14 @@ class DataDisplayDownsampler:
         xdata = xdata[::ratio]
         ydata = ydata[::ratio]
 
-        print("using {} of {} visible points".format(
-            len(ydata), np.sum(mask)))
+        print("using {} of {} visible points".format(len(ydata), np.sum(mask)))
 
         return xdata, ydata
 
     def update(self, ax):
         # Update the line
         lims = ax.viewLim
-        if np.abs(lims.width - self.delta) > 1e-8:
+        if abs(lims.width - self.delta) > 1e-8:
             self.delta = lims.width
             xstart, xend = lims.intervalx
             self.line.set_data(*self.downsample(xstart, xend))

--- a/examples/specialty_plots/hinton_demo.py
+++ b/examples/specialty_plots/hinton_demo.py
@@ -19,7 +19,7 @@ def hinton(matrix, max_weight=None, ax=None):
     ax = ax if ax is not None else plt.gca()
 
     if not max_weight:
-        max_weight = 2 ** np.ceil(np.log(np.abs(matrix).max()) / np.log(2))
+        max_weight = 2 ** np.ceil(np.log2(np.abs(matrix).max()))
 
     ax.patch.set_facecolor('gray')
     ax.set_aspect('equal', 'box')
@@ -28,7 +28,7 @@ def hinton(matrix, max_weight=None, ax=None):
 
     for (x, y), w in np.ndenumerate(matrix):
         color = 'white' if w > 0 else 'black'
-        size = np.sqrt(np.abs(w) / max_weight)
+        size = np.sqrt(abs(w) / max_weight)
         rect = plt.Rectangle([x - size / 2, y - size / 2], size, size,
                              facecolor=color, edgecolor=color)
         ax.add_patch(rect)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6276,8 +6276,8 @@ optional.
                 else:
                     dx = np.diff(x)
                     dy = np.diff(y)
-                    if (np.ptp(dx) < 0.01 * np.abs(dx.mean()) and
-                        np.ptp(dy) < 0.01 * np.abs(dy.mean())):
+                    if (np.ptp(dx) < 0.01 * abs(dx.mean()) and
+                        np.ptp(dy) < 0.01 * abs(dy.mean())):
                         style = "image"
                     else:
                         style = "pcolorimage"

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -34,7 +34,7 @@ def get_intersection(cx1, cy1, cos_t1, sin_t1,
     c, d = sin_t2, -cos_t2
 
     ad_bc = a * d - b * c
-    if np.abs(ad_bc) < 1.0e-12:
+    if abs(ad_bc) < 1e-12:
         raise ValueError("Given lines do not intersect. Please verify that "
                          "the angles are not equal or differ by 180 degrees.")
 
@@ -368,10 +368,10 @@ def check_if_parallel(dx1, dy1, dx2, dy2, tolerance=1.e-5):
     """
     theta1 = np.arctan2(dx1, dy1)
     theta2 = np.arctan2(dx2, dy2)
-    dtheta = np.abs(theta1 - theta2)
+    dtheta = abs(theta1 - theta2)
     if dtheta < tolerance:
         return 1
-    elif np.abs(dtheta - np.pi) < tolerance:
+    elif abs(dtheta - np.pi) < tolerance:
         return -1
     else:
         return False

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -330,9 +330,7 @@ class MarkerStyle:
         self._filled = False
 
     def _set_custom_marker(self, path):
-        verts = path.vertices
-        rescale = max(np.max(np.abs(verts[:, 0])),
-                      np.max(np.abs(verts[:, 1])))
+        rescale = np.max(np.abs(path.vertices))  # max of x's and y's.
         self._transform = Affine2D().scale(0.5 / rescale)
         self._path = path
 
@@ -340,9 +338,7 @@ class MarkerStyle:
         self._set_custom_marker(self._marker)
 
     def _set_vertices(self):
-        verts = self._marker
-        marker = Path(verts)
-        self._set_custom_marker(marker)
+        self._set_custom_marker(Path(self._marker))
 
     def _set_tuple_marker(self):
         marker = self._marker

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -463,7 +463,7 @@ class Sankey:
             raise ValueError(
                 "'trunklength' is negative, which is not allowed because it "
                 "would cause poor layout")
-        if np.abs(np.sum(flows)) > self.tolerance:
+        if abs(np.sum(flows)) > self.tolerance:
             _log.info("The sum of the flows is nonzero (%f; patchlabel=%r); "
                       "is the system not at steady state?",
                       np.sum(flows), patchlabel)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1008,7 +1008,7 @@ class TestLogitFormatter:
                 x2 = 1 - float(fx[2:])
             else:
                 x2 = float(fx)
-            assert np.abs(x - x2) < 1 / N
+            assert abs(x - x2) < 1 / N
 
 
 class TestFormatStrFormatter:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -575,7 +575,7 @@ class ScalarFormatter(Formatter):
             return ''
         else:
             xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
-            if np.abs(xp) < 1e-8:
+            if abs(xp) < 1e-8:
                 xp = 0
             if self._useLocale:
                 s = locale.format_string(self.format, (xp,))
@@ -792,7 +792,7 @@ class ScalarFormatter(Formatter):
     @cbook.deprecated("3.1")
     def pprint_val(self, x):
         xp = (x - self.offset) / (10. ** self.orderOfMagnitude)
-        if np.abs(xp) < 1e-8:
+        if abs(xp) < 1e-8:
             xp = 0
         if self._useLocale:
             return locale.format_string(self.format, (xp,))
@@ -1123,7 +1123,7 @@ class LogFormatterMathtext(LogFormatter):
         else:
             base = '%s' % b
 
-        if np.abs(fx) < min_exp:
+        if abs(fx) < min_exp:
             if usetex:
                 return r'${0}{1:g}$'.format(sign_string, x)
             else:
@@ -2269,7 +2269,7 @@ def is_decade(x, base=10, *, rtol=1e-10):
         return False
     if x == 0.0:
         return True
-    lx = np.log(np.abs(x)) / np.log(base)
+    lx = np.log(abs(x)) / np.log(base)
     return is_close_to_int(lx, atol=rtol)
 
 
@@ -2614,7 +2614,7 @@ class SymmetricalLogLocator(Locator):
         a_lo, a_hi = (0, 0)
         if has_a:
             a_upper_lim = min(-linthresh, vmax)
-            a_lo, a_hi = get_log_range(np.abs(a_upper_lim), np.abs(vmin) + 1)
+            a_lo, a_hi = get_log_range(abs(a_upper_lim), abs(vmin) + 1)
 
         c_lo, c_hi = (0, 0)
         if has_c:


### PR DESCRIPTION
On scalars (whether python or numpy scalars), builtin abs is ~10x faster
than np.abs:

    In [1]: nf = np.float64(1); pf = 1.

    In [2]: %timeit abs(nf)
    156 ns ± 1.87 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

    In [3]: %timeit abs(pf)
    63.5 ns ± 0.659 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

    In [4]: %timeit np.abs(nf)
    1.26 µs ± 9.29 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

    In [5]: %timeit np.abs(pf)
    809 ns ± 4.34 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

so replace np.abs by abs in that case.  (For arrays they have ~ the same
speed, so we could even do a global search-replace, but heh.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
