### PR TITLE
Simplify 3d axes callback setup.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -79,7 +79,6 @@ class Axes3D(Axes):
 
         if rect is None:
             rect = [0.0, 0.0, 1.0, 1.0]
-        self._cids = []
 
         self.initial_azim = azim
         self.initial_elev = elev
@@ -115,6 +114,12 @@ class Axes3D(Axes):
             self._zcid = None
 
         self.mouse_init()
+        self.figure.canvas.mpl_connect(
+            'motion_notify_event', self._on_move),
+        self.figure.canvas.mpl_connect(
+            'button_press_event', self._button_press),
+        self.figure.canvas.mpl_connect(
+            'button_release_event', self._button_release),
         self.set_top_view()
 
         self.patch.set_linewidth(0)
@@ -1004,8 +1009,7 @@ class Axes3D(Axes):
 
     def mouse_init(self, rotate_btn=1, zoom_btn=3):
         """
-        Initializes mouse button callbacks to enable 3D rotation of the axes.
-        Also optionally sets the mouse buttons for 3D rotation and zooming.
+        Set the mouse buttons for 3D rotation and zooming.
 
         Parameters
         ----------
@@ -1015,19 +1019,15 @@ class Axes3D(Axes):
             The mouse button or buttons to use to zoom the 3D axes.
         """
         self.button_pressed = None
-        self._cids = [
-            self.figure.canvas.mpl_connect(
-                'motion_notify_event', self._on_move),
-            self.figure.canvas.mpl_connect(
-                'button_press_event', self._button_press),
-            self.figure.canvas.mpl_connect(
-                'button_release_event', self._button_release),
-        ]
         # coerce scalars into array-like, then convert into
         # a regular list to avoid comparisons against None
         # which breaks in recent versions of numpy.
         self._rotate_btn = np.atleast_1d(rotate_btn).tolist()
         self._zoom_btn = np.atleast_1d(zoom_btn).tolist()
+
+    def disable_mouse_rotation(self):
+        """Disable mouse buttons for 3D rotation and zooming."""
+        self.mouse_init(rotate_btn=[], zoom_btn=[])
 
     def can_zoom(self):
         """
@@ -1068,13 +1068,6 @@ class Axes3D(Axes):
         self._zmargin = 0
 
         self.grid(rcParams['axes3d.grid'])
-
-    def disable_mouse_rotation(self):
-        """Disable mouse button callbacks."""
-        # Disconnect the various events we set.
-        for cid in self._cids:
-            self.figure.canvas.mpl_disconnect(cid)
-        self._cids = []
 
     def _button_press(self, event):
         if event.inaxes == self:


### PR DESCRIPTION
Always setup the 3d mouse rotate/zoom callbacks and don't store their
cids; instead, handle their disconnection by disabling all mouse buttons
(which has the same observable effect).

This is in preparation of restoring the pan/zoom callbacks upon
unpickling (#10843): after a pickle/unpickle cycle, even if we restore the
callbacks, we can't guarantee that the callback numeric ids will stay
the same, and so self._cids would become incorrect.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
