### PR TITLE
Avoid some uses of len-1 tuples.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -684,14 +684,11 @@ grestore
         xmax, ymax = points_max
 
         streamarr = np.empty(
-            (shape[0] * shape[1],),
-            dtype=[('flags', 'u1'),
-                   ('points', '>u4', (2,)),
-                   ('colors', 'u1', (3,))])
+            shape[0] * shape[1],
+            dtype=[('flags', 'u1'), ('points', '2>u4'), ('colors', '3u1')])
         streamarr['flags'] = 0
         streamarr['points'] = (flat_points - points_min) * factor
         streamarr['colors'] = flat_colors[:, :3] * 255.0
-
         stream = quote_ps_string(streamarr.tostring())
 
         self._pswriter.write(f"""\

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -91,8 +91,8 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
     offsets : array of float
         The left offsets of the boxes.
     """
-    w_list, d_list = zip(*wd_list)
-    # d_list is currently not used.
+    w_list, d_list = zip(*wd_list)  # d_list is currently not used.
+    cbook._check_in_list(["fixed", "expand", "equal"], mode=mode)
 
     if mode == "fixed":
         offsets_ = np.cumsum([0] + [w + sep for w in w_list])
@@ -119,15 +119,12 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
         if total is None:
             if sep is None:
                 raise ValueError("total and sep cannot both be None when "
-                                 "using layout mode 'equal'.")
+                                 "using layout mode 'equal'")
             total = (maxh + sep) * len(w_list)
         else:
             sep = total / len(w_list) - maxh
         offsets = (maxh + sep) * np.arange(len(w_list))
         return total, offsets
-
-    else:
-        raise ValueError("Unknown mode : %s" % (mode,))
 
 
 def _get_aligned_offsets(hd_list, height, align="baseline"):
@@ -146,6 +143,8 @@ def _get_aligned_offsets(hd_list, height, align="baseline"):
 
     if height is None:
         height = max(h for h, d in hd_list)
+    cbook._check_in_list(
+        ["baseline", "left", "top", "right", "bottom", "center"], align=align)
 
     if align == "baseline":
         height_descent = max(h - d for h, d in hd_list)
@@ -161,8 +160,6 @@ def _get_aligned_offsets(hd_list, height, align="baseline"):
     elif align == "center":
         descent = 0.
         offsets = [(height - h) * .5 + d for h, d in hd_list]
-    else:
-        raise ValueError("Unknown Align mode : %s" % (align,))
 
     return height, descent, offsets
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3864,14 +3864,11 @@ class FancyArrowPatch(Patch):
     _edge_default = True
 
     def __str__(self):
-
         if self._posA_posB is not None:
             (x1, y1), (x2, y2) = self._posA_posB
-            return self.__class__.__name__ \
-                + "((%g, %g)->(%g, %g))" % (x1, y1, x2, y2)
+            return f"{type(self).__name__}(({x1:g}, {y1:g})->({x2:g}, {y2:g}))"
         else:
-            return self.__class__.__name__ \
-                + "(%s)" % (str(self._path_original),)
+            return f"{type(self).__name__}({self._path_original})"
 
     @docstring.dedent_interpd
     def __init__(self, posA=None, posB=None,

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -688,8 +688,8 @@ class Path:
             theta += np.pi / 2.0
             r = np.ones(ns2 + 1)
             r[1::2] = innerCircle
-            verts = np.vstack((r*np.cos(theta), r*np.sin(theta))).transpose()
-            codes = np.empty((ns2 + 1,))
+            verts = (r * np.vstack((np.cos(theta), np.sin(theta)))).T
+            codes = np.empty(ns2 + 1)
             codes[0] = cls.MOVETO
             codes[1:-1] = cls.LINETO
             codes[-1] = cls.CLOSEPOLY


### PR DESCRIPTION
... when scalars or f-strings or other constructs would do.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
