### PR TITLE
Backport PR #15851 on branch v3.2.x (ffmpeg is available on default ubuntu packages now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ addons:
     paths:
     - result_images.tar.bz2
   apt:
-    sources:
-      - sourceline: ppa:jonathonf/ffmpeg-3
     packages:
       - cm-super
       - dvipng


### PR DESCRIPTION
## PR Summary

Backport PR #15851 on branch v3.2.x (ffmpeg is available on default ubuntu packages now)

