### PR TITLE
Standardize parameter types in docs

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2409,7 +2409,7 @@ class PdfPages:
         keep_empty : bool, optional
             If set to False, then empty pdf files will be deleted automatically
             when closed.
-        metadata : dictionary, optional
+        metadata : dict, optional
             Information dictionary object (see PDF reference section 10.2.1
             'Document Information Dictionary'), e.g.:
             ``{'Creator': 'My software', 'Author': 'Me', 'Title': 'Awesome'}``.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -1023,7 +1023,7 @@ class PdfPages:
         keep_empty : bool, optional
             If set to False, then empty pdf files will be deleted automatically
             when closed.
-        metadata : dictionary, optional
+        metadata : dict, optional
             Information dictionary object (see PDF reference section 10.2.1
             'Document Information Dictionary'), e.g.:
             ``{'Creator': 'My software', 'Author': 'Me', 'Title': 'Awesome'}``.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -98,7 +98,7 @@ def apply_window(x, window, axis=0, return_window=None):
         Either a function to generate a window or an array with length
         *x*.shape[*axis*]
 
-    axis : integer
+    axis : int
         The axis over which to do the repetition.
         Must be 0 or 1.  The default is 0
 
@@ -157,7 +157,7 @@ def detrend(x, key=None, axis=None):
         corresponding functions for more details regarding the algorithms. Can
         also be a function that carries out the detrend operation.
 
-    axis : integer
+    axis : int
         The axis along which to do the detrending.
 
     See Also
@@ -201,7 +201,7 @@ def demean(x, axis=0):
         Array or sequence containing the data
         Can have any dimensionality
 
-    axis : integer
+    axis : int
         The axis along which to take the mean.  See numpy.mean for a
         description of this argument.
 
@@ -222,7 +222,7 @@ def detrend_mean(x, axis=None):
         Array or sequence containing the data
         Can have any dimensionality
 
-    axis : integer
+    axis : int
         The axis along which to take the mean.  See numpy.mean for a
         description of this argument.
 
@@ -249,7 +249,7 @@ def detrend_none(x, axis=None):
     x : any object
         An object containing the data
 
-    axis : integer
+    axis : int
         This parameter is ignored.
         It is included for compatibility with detrend_mean
 
@@ -271,7 +271,7 @@ def detrend_linear(y):
     y : 0-D or 1-D array or sequence
         Array or sequence containing the data
 
-    axis : integer
+    axis : int
         The axis along which to take the mean.  See numpy.mean for a
         description of this argument.
 
@@ -316,14 +316,14 @@ def stride_windows(x, n, noverlap=None, axis=0):
     x : 1D array or sequence
         Array or sequence containing the data.
 
-    n : integer
+    n : int
         The number of data points in each window.
 
-    noverlap : integer
+    noverlap : int
         The overlap between adjacent windows.
         Default is 0 (no overlap)
 
-    axis : integer
+    axis : int
         The axis along which the windows will run.
 
     References
@@ -385,10 +385,10 @@ def stride_repeat(x, n, axis=0):
     x : 1D array or sequence
         Array or sequence containing the data.
 
-    n : integer
+    n : int
         The number of time to repeat the array.
 
-    axis : integer
+    axis : int
         The axis along which the data will run.
 
     References
@@ -694,7 +694,7 @@ def psd(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     %(PSD)s
 
-    noverlap : integer
+    noverlap : int
         The number of points of overlap between segments.
         The default value is 0 (no overlap).
 
@@ -754,7 +754,7 @@ def csd(x, y, NFFT=None, Fs=None, detrend=None, window=None,
 
     %(PSD)s
 
-    noverlap : integer
+    noverlap : int
         The number of points of overlap between segments.
         The default value is 0 (no overlap).
 
@@ -1059,7 +1059,7 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     %(PSD)s
 
-    noverlap : integer
+    noverlap : int
         The number of points of overlap between blocks.  The default value
         is 0 (no overlap).
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -121,7 +121,7 @@ def validate_path_exists(s):
 
 
 def validate_bool(b):
-    """Convert b to a boolean or raise"""
+    """Convert b to ``bool`` or raise."""
     if isinstance(b, str):
         b = b.lower()
     if b in ('t', 'y', 'yes', 'on', 'true', '1', 1, True):
@@ -129,11 +129,11 @@ def validate_bool(b):
     elif b in ('f', 'n', 'no', 'off', 'false', '0', 0, False):
         return False
     else:
-        raise ValueError('Could not convert "%s" to boolean' % b)
+        raise ValueError('Could not convert "%s" to bool' % b)
 
 
 def validate_bool_maybe_none(b):
-    """Convert b to a boolean or raise."""
+    """Convert b to ``bool`` or raise, passing through *None*."""
     if isinstance(b, str):
         b = b.lower()
     if b is None or b == 'none':
@@ -143,7 +143,7 @@ def validate_bool_maybe_none(b):
     elif b in ('f', 'n', 'no', 'off', 'false', '0', 0, False):
         return False
     else:
-        raise ValueError('Could not convert "%s" to boolean' % b)
+        raise ValueError('Could not convert "%s" to bool' % b)
 
 
 def _validate_tex_preamble(s):

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -164,7 +164,7 @@ def tricontour(ax, *args, **kwargs):
 
     Optional keyword arguments:
 
-        *colors*: [ *None* | string | (mpl_colors) ]
+        *colors*: [ *None* | str | (mpl_colors) ]
         If *None*, the colormap specified by cmap will be used.
 
         If a string, like 'r' or 'red', all levels will be plotted in this

--- a/tutorials/text/text_props.py
+++ b/tutorials/text/text_props.py
@@ -27,7 +27,7 @@ label                       any string
 linespacing                 `float`
 multialignment              [``'left'`` | ``'right'`` | ``'center'`` ]
 name or fontname            string e.g., [``'Sans'`` | ``'Courier'`` | ``'Helvetica'`` ...]
-picker                      [None|float|boolean|callable]
+picker                      [None|float|bool|callable]
 position                    (x, y)
 rotation                    [ angle in degrees | ``'vertical'`` | ``'horizontal'`` ]
 size or fontsize            [ size in points | relative size, e.g., ``'smaller'``, ``'x-large'`` ]


### PR DESCRIPTION
## PR Summary

Reaming in parameter type descriptions:

- `boolean` -> `bool`
- `integer` -> `int`
- `string` -> `str`

according to [numpydoc conventions](https://numpydoc.readthedocs.io/en/latest/format.html).