### PR TITLE
Deprecate implicit creation of colormaps in register_cmap()

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -52,3 +52,10 @@ Case-insensitive capstyles and joinstyles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Please pass capstyles ("miter", "round", "bevel") and joinstyles ("butt",
 "round", "projecting") as lowercase.
+
+Passing raw data to ``register_cmap()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing raw data via parameters *data* and *lut* to `.register_cmap()` is
+deprecated. Instead, explicitly create a `.LinearSegmentedColormap` and pass
+it via the *cmap* parameter:
+``register_cmap(cmap=LinearSegmentedColormap(name, data, lut))``.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -90,9 +90,11 @@ def register_cmap(name=None, cmap=None, data=None, lut=None):
     instance.  The *name* is optional; if absent, the name will
     be the :attr:`~matplotlib.colors.Colormap.name` attribute of the *cmap*.
 
-    In the second case, the three arguments are passed to
+    The second case is deprecated. Here, the three arguments are passed to
     the :class:`~matplotlib.colors.LinearSegmentedColormap` initializer,
-    and the resulting colormap is registered.
+    and the resulting colormap is registered. Instead of this implicit
+    colormap creation, create a `.LinearSegmentedColormap` and use the first
+    case: ``register_cmap(cmap=LinearSegmentedColormap(name, data, lut))``.
     """
     cbook._check_isinstance((str, None), name=name)
     if name is None:
@@ -103,6 +105,13 @@ def register_cmap(name=None, cmap=None, data=None, lut=None):
     if isinstance(cmap, colors.Colormap):
         cmap_d[name] = cmap
         return
+    if lut is not None or data is not None:
+        cbook.warn_deprecated(
+            "3.3",
+            message="Passing raw data via parameters data and lut to "
+                    "register_cmap() is deprecated. Instead use: "
+                    "register_cmap("
+                    "cmap=LinearSegmentedColormap(name, data, lut))")
     # For the remainder, let exceptions propagate.
     if lut is None:
         lut = mpl.rcParams['image.lut']


### PR DESCRIPTION
## PR Summary

[register_cmap()](https://matplotlib.org/devdocs/api/cm_api.html#matplotlib.cm.register_cmap) could be used either with a Colormap, or by passing data to implicitly create a colormap from.

This PR deprecates the second way in favor of explicitly creating colormaps via`register_cmap(cmap=LinearSementedColormap(name, data lut))`.

Having both ways is redundant, makes the function more complicated, and unnecessarily pulls colormap implementation details (like the *lut*) into the API of `register_cmap()`. Given that colormap registration is only done very rarely, the benefit of a sligtly shorter call `register_cmap(name, data=data, lut=lut)` is negligable. It's even error prone because *data* has to be passed as kwarg since the second arg is the for this case unused *cmap* parameter.


## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
