### PR TITLE
Suppress exception chaining on rc validator failure.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -767,7 +767,7 @@ class RcParams(MutableMapping, dict):
             try:
                 cval = self.validate[key](val)
             except ValueError as ve:
-                raise ValueError("Key %s: %s" % (key, str(ve)))
+                raise ValueError(f"Key {key}: {ve}") from None
             dict.__setitem__(self, key, cval)
         except KeyError:
             raise KeyError(


### PR DESCRIPTION
This changes the traceback from
```
  Traceback (most recent call last):
    File ".../matplotlib/__init__.py", line 768, in __setitem__
      cval = self.validate[key](val)
    File ".../matplotlib/rcsetup.py", line 67, in __call__
      raise ValueError('Unrecognized %s string %r: valid strings are %s'
  ValueError: Unrecognized capstyle string 'foobar': valid strings are ['butt', 'round', 'projecting']

  During handling of the above exception, another exception occurred:

  Traceback (most recent call last):
    File "<string>", line 4, in <module>
    File ".../matplotlib/__init__.py", line 770, in __setitem__
      raise ValueError("Key %s: %s" % (key, str(ve)))
  ValueError: Key lines.solid_capstyle: Unrecognized capstyle string 'foobar': valid strings are ['butt', 'round', 'projecting']
```
to
```
  Traceback (most recent call last):
    File "<string>", line 4, in <module>
    File ".../matplotlib/__init__.py", line 770, in __setitem__
      raise ValueError(f"Key {key}: {ve}") from None
  ValueError: Key lines.solid_capstyle: Unrecognized capstyle string 'foobar': valid strings are ['butt', 'round', 'projecting']
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
