### PR TITLE
Improve error when passing 0d array to scatter().

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,4 +1,3 @@
-import collections.abc
 import functools
 import itertools
 import logging
@@ -4210,7 +4209,7 @@ class Axes(_AxesBase):
                  else get_next_color_func())
         c_is_string_or_strings = (
             isinstance(c, str)
-            or (isinstance(c, collections.abc.Iterable) and len(c) > 0
+            or (np.iterable(c) and len(c) > 0
                 and isinstance(cbook.safe_first_element(c), str)))
 
         def invalid_shape_exception(csize, xsize):
@@ -4244,7 +4243,7 @@ class Axes(_AxesBase):
         if not c_is_mapped:
             try:  # Is 'c' acceptable as PathCollection facecolors?
                 colors = mcolors.to_rgba_array(c)
-            except ValueError:
+            except (TypeError, ValueError):
                 if not valid_shape:
                     raise invalid_shape_exception(c.size, xsize)
                 # Both the mapping *and* the RGBA conversion failed: pretty


### PR DESCRIPTION
With `scatter([1, 2], [3, 4], c=np.array(.5))`...

previously:

    <elided>
      File ".../matplotlib/colors.py", line 338, in to_rgba_array
        if len(c) == 0:
    TypeError: len() of unsized object

now

    <elided>
      File ".../matplotlib/axes/_axes.py", line 4249, in _parse_scatter_color_args
        raise invalid_shape_exception(c.size, xsize)
    ValueError: 'c' argument has 1 elements, which is inconsistent with 'x' and 'y' with size 2.

Essentially the problem is that np.array(.5) passes an
`isinstance(..., Iterable)` check (which only checks the type) but
np.iterable() more correctly returns False because it actually tries to
iter on it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
