### PR TITLE
Fix Annotation using different units and different coords on x/y.

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import io
 import warnings
 
@@ -577,6 +578,18 @@ def test_annotation_update():
 
     assert not np.allclose(extent1.get_points(), extent2.get_points(),
                            rtol=1e-6)
+
+
+@check_figures_equal(extensions=["png"])
+def test_annotation_units(fig_test, fig_ref):
+    ax = fig_test.add_subplot()
+    ax.plot(datetime.now(), 1, "o")  # Implicitly set axes extents.
+    ax.annotate("x", (datetime.now(), 0.5), xycoords=("data", "axes fraction"),
+                # This used to crash before.
+                xytext=(0, 0), textcoords="offset points")
+    ax = fig_ref.add_subplot()
+    ax.plot(datetime.now(), 1, "o")
+    ax.annotate("x", (datetime.now(), 0.5), xycoords=("data", "axes fraction"))
 
 
 @image_comparison(['large_subscript_title.png'], style='mpl20')

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1864,19 +1864,12 @@ class _AnnotationBase:
             return isinstance(s, str) and s.split()[0] == "offset"
 
         if isinstance(self.xycoords, tuple):
-            s1, s2 = self.xycoords
-            if is_offset(s1) or is_offset(s2):
+            if any(map(is_offset, self.xycoords)):
                 raise ValueError("xycoords should not be an offset coordinate")
-            x, y = self.xy
-            x1, y1 = self._get_xy(renderer, x, y, s1)
-            x2, y2 = self._get_xy(renderer, x, y, s2)
-            return x1, y2
         elif is_offset(self.xycoords):
             raise ValueError("xycoords should not be an offset coordinate")
-        else:
-            x, y = self.xy
-            return self._get_xy(renderer, x, y, self.xycoords)
-        #raise RuntimeError("must be defined by the derived class")
+        x, y = self.xy
+        return self._get_xy(renderer, x, y, self.xycoords)
 
     # def _get_bbox(self, renderer):
     #     if hasattr(bbox, "bounds"):


### PR DESCRIPTION
`_get_xy` always needs to be called with self.xycoord, not just the
coordinate system of either x or y, so that unitful x/y get correctly
converted as needed.

Closes #15849.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
