### PR TITLE
Fix AnnotationBbox docstring.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1421,9 +1421,8 @@ class OffsetImage(OffsetBox):
 
 
 class AnnotationBbox(martist.Artist, _AnnotationBase):
-    """
-    Annotation-like class, but with offsetbox instead of Text.
-    """
+    """`.Annotation`-like class, but with `OffsetBox` instead of `.Text`."""
+
     zorder = 3
 
     def __str__(self):
@@ -1444,12 +1443,9 @@ class AnnotationBbox(martist.Artist, _AnnotationBase):
         """
         *offsetbox* : OffsetBox instance
 
-        *xycoords* : same as Annotation but can be a tuple of two
-           strings which are interpreted as x and y coordinates.
+        *xycoords* : same as Annotation
 
-        *boxcoords* : similar to textcoords as Annotation but can be a
-           tuple of two strings which are interpreted as x and y
-           coordinates.
+        *boxcoords* : similar to Annotation's textcoords
 
         *box_alignment* : a tuple of two floats for a vertical and
            horizontal alignment of the offset box w.r.t. the *boxcoords*.


### PR DESCRIPTION
Yes, it's still not numpydoc because there's a few parameters that I
don't want to figure out (e.g. what does boxcoords really do).  The
point is solely that Annotation's xycoords/textcoords also support the
(xvalue, yvalue) tuple form and so it's not specific to AnnotationBbox.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
