### PR TITLE
rcsetup cleanups.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -82,3 +82,9 @@ Passing both singular and plural *colors*, *linewidths*, *linestyles* to `.Axes.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Passing e.g. both *linewidth* and *linewidths* will raise a TypeError in the
 future.
+
+Setting :rc:`text.latex.preamble` or :rc:`pdf.preamble` to non-strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These rcParams should be set to string values.  Support for None (meaning the
+empty string) and lists of strings (implicitly joined with newlines) is
+deprecated.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -13,8 +13,6 @@ from cycler import cycler
 from decimal import Decimal
 import pytest
 
-import warnings
-
 import matplotlib
 import matplotlib as mpl
 from matplotlib.testing.decorators import (

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -112,8 +112,8 @@ def test_pdflatex():
     rc_pdflatex = {'font.family': 'serif',
                    'pgf.rcfonts': False,
                    'pgf.texsystem': 'pdflatex',
-                   'pgf.preamble': ['\\usepackage[utf8x]{inputenc}',
-                                    '\\usepackage[T1]{fontenc}']}
+                   'pgf.preamble': ('\\usepackage[utf8x]{inputenc}'
+                                    '\\usepackage[T1]{fontenc}')}
     mpl.rcParams.update(rc_pdflatex)
     create_figure()
 
@@ -137,9 +137,9 @@ def test_rcupdate():
                 'lines.markersize': 20,
                 'pgf.rcfonts': False,
                 'pgf.texsystem': 'pdflatex',
-                'pgf.preamble': ['\\usepackage[utf8x]{inputenc}',
-                                 '\\usepackage[T1]{fontenc}',
-                                 '\\usepackage{sfmath}']}]
+                'pgf.preamble': ('\\usepackage[utf8x]{inputenc}'
+                                 '\\usepackage[T1]{fontenc}'
+                                 '\\usepackage{sfmath}')}]
     tol = [6, 0]
     for i, rc_set in enumerate(rc_sets):
         with mpl.rc_context(rc_set):

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -145,7 +145,7 @@ def test_invalid_input_forms():
     with pytest.raises((TypeError, ValueError)):
         ax.set_prop_cycle('linewidth', 1)
     with pytest.raises((TypeError, ValueError)):
-        ax.set_prop_cycle('linewidth', {'1': 1, '2': 2})
+        ax.set_prop_cycle('linewidth', {1, 2})
     with pytest.raises((TypeError, ValueError)):
         ax.set_prop_cycle(linewidth=1, color='r')
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -218,7 +218,7 @@ def generate_validator_testcases(valid):
                      ((1, 2), ['1', '2']),
                      (np.array([1, 2]), ['1', '2']),
                      ),
-         'fail': ((dict(), ValueError),
+         'fail': ((set(), ValueError),
                   (1, ValueError),
                   )
          },

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -11,7 +11,7 @@ def test_fontconfig_preamble():
     tm1 = TexManager()
     font_config1 = tm1.get_font_config()
 
-    plt.rcParams['text.latex.preamble'] = ['\\usepackage{txfonts}']
+    plt.rcParams['text.latex.preamble'] = '\\usepackage{txfonts}'
     tm2 = TexManager()
     font_config2 = tm2.get_font_config()
 


### PR DESCRIPTION
- Deprecate passing text.latex.unicode/pgf.preamble as None, "None", or
  a list of strings -- it's really just a plain string.
- In validators that take "lists", disable passing sets/frozensets,
  which are unordered, but not dicts, which have deterministic iteration
  order now -- making the code consistent with the comment immediately
  above.
- Correctly set `__name__` and `__qualname__` on some more validators,
  which helps e.g. troubleshooting test failures.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
