### PR TITLE
Deprecate passing Type1Font effects as dict

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -59,3 +59,8 @@ Passing raw data via parameters *data* and *lut* to `.register_cmap()` is
 deprecated. Instead, explicitly create a `.LinearSegmentedColormap` and pass
 it via the *cmap* parameter:
 ``register_cmap(cmap=LinearSegmentedColormap(name, data, lut))``.
+
+``Type1Font.transform`` effect parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing effect parameters to `.Type1Font.transform` as dict is deprecated.
+Use the respective keyword arguments instead.


### PR DESCRIPTION
## PR Summary

https://matplotlib.org/devdocs/api/type1font.html#matplotlib.type1font.Type1Font.transform has a peculiar API of passing two optional parameters as dict.

This PR deprecates that behavior and instead introduces two regular keyword arguments with default values.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] Documentation is sphinx and numpydoc compliant
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
