### PR TITLE
Update backend_nbagg for removal of Gcf._activeQue.

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -39,7 +39,7 @@ def connection_info():
         for manager in Gcf.get_all_fig_managers()
     ]
     if not is_interactive():
-        result.append('Figures pending show: {}'.format(len(Gcf._activeQue)))
+        result.append(f'Figures pending show: {len(Gcf.figs)}')
     return '\n'.join(result)
 
 
@@ -259,12 +259,12 @@ class _BackendNbAgg(_Backend):
         for manager in managers:
             manager.show()
 
-            # plt.figure adds an event which puts the figure in focus
-            # in the activeQue. Disable this behaviour, as it results in
+            # plt.figure adds an event which makes the figure in focus the
+            # active one. Disable this behaviour, as it results in
             # figures being put as the active figure after they have been
             # shown, even in non-interactive mode.
             if hasattr(manager, '_cidgcf'):
                 manager.canvas.mpl_disconnect(manager._cidgcf)
 
-            if not interactive and manager in Gcf._activeQue:
-                Gcf._activeQue.remove(manager)
+            if not interactive:
+                Gcf.figs.pop(manager.num, None)


### PR DESCRIPTION
Looks like nbagg was (ab)using _activeQue to have "pyplot-managed
figures that can never be gcf()" (not really sure why? this was here
ever since nbagg was first merged in #3008).  Now that _activeQue has been
merged into figs this is no longer possible, but I *guess* the patch is
the closest in semantics?

Sorry I missed that in #13581.  If that's too much of a problem we can revert #13581, but intentionally making Gcf.figs and Gcf._activeQue go out of sync is... a bit too clever?

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
