### PR TITLE
Trying to set the labels without setting ticks through pyplot now raises TypeError*

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -41,3 +41,12 @@ did nothing, when passed an unsupported value. It now raises a ``ValueError``.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``backend_pgf.LatexManager.latex`` is now created with ``encoding="utf-8"``, so
 its ``stdin``, ``stdout``, and ``stderr`` attributes are utf8-encoded.
+
+``pyplot.xticks()`` and ``pyplot.yticks()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, passing labels without passing the ticks to either `.pyplot.xticks`
+and `.pyplot.yticks` would result in
+
+    TypeError: object of type 'NoneType' has no len()
+
+It now raises a ``TypeError`` with a proper description of the error.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1394,14 +1394,17 @@ def xticks(ticks=None, labels=None, **kwargs):
     """
     ax = gca()
 
-    if ticks is None and labels is None:
+    if ticks is None:
         locs = ax.get_xticks()
-        labels = ax.get_xticklabels()
-    elif labels is None:
-        locs = ax.set_xticks(ticks)
-        labels = ax.get_xticklabels()
+        if labels is not None:
+            raise TypeError("xticks(): Parameter 'labels' can't be set "
+                            "without setting 'ticks'")
     else:
         locs = ax.set_xticks(ticks)
+
+    if labels is None:
+        labels = ax.get_xticklabels()
+    else:
         labels = ax.set_xticklabels(labels, **kwargs)
     for l in labels:
         l.update(kwargs)
@@ -1451,14 +1454,17 @@ def yticks(ticks=None, labels=None, **kwargs):
     """
     ax = gca()
 
-    if ticks is None and labels is None:
+    if ticks is None:
         locs = ax.get_yticks()
-        labels = ax.get_yticklabels()
-    elif labels is None:
-        locs = ax.set_yticks(ticks)
-        labels = ax.get_yticklabels()
+        if labels is not None:
+            raise TypeError("yticks(): Parameter 'labels' can't be set "
+                            "without setting 'ticks'")
     else:
         locs = ax.set_yticks(ticks)
+
+    if labels is None:
+        labels = ax.get_yticklabels()
+    else:
         labels = ax.set_yticklabels(labels, **kwargs)
     for l in labels:
         l.update(kwargs)


### PR DESCRIPTION
## PR Summary

This PR was suggested in issue #15005 as to fix the error that is returned when xticks() or yticks() is called with only the labels as parameters. It is also a follow up from PR #15788.

Previously, passing labels without passing the ticks to either `pyplot.xticks()` and `pyplot.yticks()` would result in `TypeError: object of type 'NoneType' has no len()`. With this PR it now returns:
`AttributeError: Labels can't be set without setting ticks`.

PS: apologies for the delay.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
