### PR TITLE
DOC: use markers as slanted breaks in broken axis example

### DIFF
--- a/examples/subplots_axes_and_figures/broken_axis.py
+++ b/examples/subplots_axes_and_figures/broken_axis.py
@@ -5,61 +5,50 @@ Broken Axis
 
 Broken axis example, where the y-axis will have a portion cut out.
 """
-import matplotlib.pyplot as plt
+
 import numpy as np
+import matplotlib.pyplot as plt
 
+np.random.seed(19680801)
 
-# 30 points between [0, 0.2) originally made using np.random.rand(30)*.2
-pts = np.array([
-    0.015, 0.166, 0.133, 0.159, 0.041, 0.024, 0.195, 0.039, 0.161, 0.018,
-    0.143, 0.056, 0.125, 0.096, 0.094, 0.051, 0.043, 0.021, 0.138, 0.075,
-    0.109, 0.195, 0.050, 0.074, 0.079, 0.155, 0.020, 0.010, 0.061, 0.008])
-
+pts = np.random.rand(30)*.2
 # Now let's make two outlier points which are far away from everything.
 pts[[3, 14]] += .8
 
 # If we were to simply plot pts, we'd lose most of the interesting
 # details due to the outliers. So let's 'break' or 'cut-out' the y-axis
-# into two portions - use the top (ax) for the outliers, and the bottom
+# into two portions - use the top (ax1) for the outliers, and the bottom
 # (ax2) for the details of the majority of our data
-f, (ax, ax2) = plt.subplots(2, 1, sharex=True)
+fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+fig.subplots_adjust(hspace=0.05)  # adjust space between axes
 
 # plot the same data on both axes
-ax.plot(pts)
+ax1.plot(pts)
 ax2.plot(pts)
 
 # zoom-in / limit the view to different portions of the data
-ax.set_ylim(.78, 1.)  # outliers only
+ax1.set_ylim(.78, 1.)  # outliers only
 ax2.set_ylim(0, .22)  # most of the data
 
 # hide the spines between ax and ax2
-ax.spines['bottom'].set_visible(False)
+ax1.spines['bottom'].set_visible(False)
 ax2.spines['top'].set_visible(False)
-ax.xaxis.tick_top()
-ax.tick_params(labeltop=False)  # don't put tick labels at the top
+ax1.xaxis.tick_top()
+ax1.tick_params(labeltop=False)  # don't put tick labels at the top
 ax2.xaxis.tick_bottom()
 
-# This looks pretty good, and was fairly painless, but you can get that
-# cut-out diagonal lines look with just a bit more work. The important
-# thing to know here is that in axes coordinates, which are always
-# between 0-1, spine endpoints are at these locations (0, 0), (0, 1),
-# (1, 0), and (1, 1).  Thus, we just need to put the diagonals in the
-# appropriate corners of each of our axes, and so long as we use the
-# right transform and disable clipping.
+# Now, let's turn towards the cut-out slanted lines.
+# We create line objects in axes coordinates, in which (0,0), (0,1),
+# (1,0), and (1,1) are the four corners of the axes.
+# The slanted lines themselves are markers at those locations, such that the
+# lines keep their angle and position, independent of the axes size or scale
+# Finally, we need to disable clipping.
 
-d = .015  # how big to make the diagonal lines in axes coordinates
-# arguments to pass to plot, just so we don't keep repeating them
-kwargs = dict(transform=ax.transAxes, color='k', clip_on=False)
-ax.plot((-d, +d), (-d, +d), **kwargs)        # top-left diagonal
-ax.plot((1 - d, 1 + d), (-d, +d), **kwargs)  # top-right diagonal
+d = .5  # proportion of vertical to horizontal extent of the slanted line
+kwargs = dict(marker=[(-1, -d), (1, d)], markersize=12,
+              linestyle="none", color='k', mec='k', mew=1, clip_on=False)
+ax1.plot([0, 1], [0, 0], transform=ax1.transAxes, **kwargs)
+ax2.plot([0, 1], [1, 1], transform=ax2.transAxes, **kwargs)
 
-kwargs.update(transform=ax2.transAxes)  # switch to the bottom axes
-ax2.plot((-d, +d), (1 - d, 1 + d), **kwargs)  # bottom-left diagonal
-ax2.plot((1 - d, 1 + d), (1 - d, 1 + d), **kwargs)  # bottom-right diagonal
-
-# What's cool about this is that now if we vary the distance between
-# ax and ax2 via f.subplots_adjust(hspace=...) or plt.subplot_tool(),
-# the diagonal lines will move accordingly, and stay right at the tips
-# of the spines they are 'breaking'
 
 plt.show()


### PR DESCRIPTION
## PR Summary

The [broken axis example](https://matplotlib.org/gallery/subplots_axes_and_figures/broken_axis.html) should use markers for the slanted lines that denote the "axis break" instead of lines. This will make the example usable independent on the actual axis size; e.g. if the break does not occur in the middle of the axis. 

(The problem was initially brought up in [this Stackoverflow issue](https://stackoverflow.com/questions/59305080/formatting-a-broken-y-axis-in-python-matplotlib))

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

