### PR TITLE
Use test cache for test result images too.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -3,7 +3,9 @@ Utilities for comparing image results.
 """
 
 import atexit
+import functools
 import hashlib
+import logging
 import os
 from pathlib import Path
 import re
@@ -18,6 +20,8 @@ from PIL import Image
 import matplotlib as mpl
 from matplotlib import cbook
 from matplotlib.testing.exceptions import ImageComparisonFailure
+
+_log = logging.getLogger(__name__)
 
 __all__ = ['compare_images', 'comparable_formats']
 
@@ -285,18 +289,48 @@ def convert(filename, cache):
         cache_dir = Path(get_cache_dir()) if cache else None
 
         if cache_dir is not None:
+            _register_conversion_cache_cleaner_once()
             hash_value = get_file_hash(path)
             cached_path = cache_dir / (hash_value + newpath.suffix)
             if cached_path.exists():
+                _log.debug("For %s: reusing cached conversion.", filename)
                 shutil.copyfile(cached_path, newpath)
                 return str(newpath)
 
+        _log.debug("For %s: converting to png.", filename)
         converter[path.suffix[1:]](path, newpath)
 
         if cache_dir is not None:
+            _log.debug("For %s: caching conversion result.", filename)
             shutil.copyfile(newpath, cached_path)
 
     return str(newpath)
+
+
+def _clean_conversion_cache():
+    # This will actually ignore mpl_toolkits baseline images, but they're
+    # relatively small.
+    baseline_images_size = sum(
+        path.stat().st_size
+        for path in Path(mpl.__file__).parent.glob("**/baseline_images/**/*"))
+    # 2x: one full copy of baselines, and one full copy of test results
+    # (actually an overestimate: we don't convert png baselines and results).
+    max_cache_size = 2 * baseline_images_size
+    # Reduce cache until it fits.
+    cache_stat = {
+        path: path.stat() for path in Path(get_cache_dir()).glob("*")}
+    cache_size = sum(stat.st_size for stat in cache_stat.values())
+    paths_by_atime = sorted(  # Oldest at the end.
+        cache_stat, key=lambda path: cache_stat[path].st_atime, reverse=True)
+    while cache_size > max_cache_size:
+        path = paths_by_atime.pop()
+        cache_size -= cache_stat[path].st_size
+        path.unlink()
+
+
+@functools.lru_cache()  # Ensure this is only registered once.
+def _register_conversion_cache_cleaner_once():
+    atexit.register(_clean_conversion_cache)
 
 
 def crop_to_same(actual_path, actual_image, expected_path, expected_image):
@@ -387,7 +421,7 @@ def compare_images(expected, actual, tol, in_decorator=False):
         raise IOError('Baseline image %r does not exist.' % expected)
     extension = expected.split('.')[-1]
     if extension != 'png':
-        actual = convert(actual, cache=False)
+        actual = convert(actual, cache=True)
         expected = convert(expected, cache=True)
 
     # open the image files and remove the alpha channel (if it exists)


### PR DESCRIPTION
For image comparison tests in svg/pdf/ps formats, the result images are
converted to png for comparison.  Previously the conversion results were
cached for the baseline images, but not for the test-generated images
(because of non-deterministic svg/pdf/etc. results, due to
hash-salting, dict ordering, etc.).

Now that the test-generated images are generally deterministic, we can
enable the cache for baseline images as well.  This speeds up
`pytest -k '[svg]'` by ~30% (81s initially -> 55s on a seeded cache) and
`pytest -k '[pdf]'` by ~10% (62s -> 55s) (there are too few (e)ps image
comparison tests to see an effect).  Also add logging regarding the
cache which may help troubleshooting determinacy problems.

~This is a much simpler version of PR#7764, which added more sophisticated
reporting of cache hits and misses, as well as cache invalidation (I
think the cache can reasonably be cleaned manually, at least for now).~

A simple cache eviction mechanism prevents the cache from growing
without bounds, limiting it to 2x the size of the baseline_images
directory.

This is a much simpler version of PR7764, which added more sophisticated
reporting of cache hits and misses and cache eviction.

Supersedes (mostly) #7764 (@jkseppan).

(Note that the gain in speed is less than reported than in https://github.com/matplotlib/matplotlib/pull/7764#issuecomment-271137953, because I have also optimized the svg and gs converters in the meantime by running a single process and interacting with it over stdin/stdout, rather that launching a new instance of inkscape/ghostscript for each image.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
