### PR TITLE
Warn if a temporary config/cache dir must be created.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -431,16 +431,6 @@ def get_home():
         return None
 
 
-def _create_tmp_config_or_cache_dir():
-    """
-    If the config or cache directory cannot be created, create a temporary one.
-    """
-    configdir = os.environ['MPLCONFIGDIR'] = (
-        tempfile.mkdtemp(prefix='matplotlib-'))
-    atexit.register(shutil.rmtree, configdir)
-    return configdir
-
-
 def _get_xdg_config_dir():
     """
     Return the XDG configuration directory, according to the `XDG
@@ -474,7 +464,19 @@ def _get_config_or_cache_dir(xdg_base):
     else:
         if os.access(str(configdir), os.W_OK) and configdir.is_dir():
             return str(configdir)
-    return _create_tmp_config_or_cache_dir()
+    # If the config or cache directory cannot be created or is not a writable
+    # directory, create a temporary one.
+    tmpdir = os.environ["MPLCONFIGDIR"] = \
+        tempfile.mkdtemp(prefix="matplotlib-")
+    atexit.register(shutil.rmtree, tmpdir)
+    _log.warning(
+        "Matplotlib created a temporary config/cache directory at %s because "
+        "the default path (%s) is not a writable directory; it is highly "
+        "recommended to set the MPLCONFIGDIR environment variable to a "
+        "writable directory, in particular to speed up the import of "
+        "Matplotlib and to better support multiprocessing.",
+        configdir, tmpdir)
+    return tmpdir
 
 
 @_logged_cached('CONFIGDIR=%s')

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -1,5 +1,26 @@
+import os
+import subprocess
+import sys
+
+import pytest
+
 import matplotlib
-import matplotlib.rcsetup
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="chmod() doesn't work as is on Windows")
+def test_tmpconfigdir_warning(tmpdir):
+    """Test that a warning is emitted if a temporary configdir must be used."""
+    mode = os.stat(tmpdir).st_mode
+    try:
+        os.chmod(tmpdir, 0)
+        proc = subprocess.run(
+            [sys.executable, "-c", "import matplotlib"],
+            env={**os.environ, "MPLCONFIGDIR": str(tmpdir)},
+            stderr=subprocess.PIPE, universal_newlines=True, check=True)
+        assert "set the MPLCONFIGDIR" in proc.stderr
+    finally:
+        os.chmod(tmpdir, mode)
 
 
 def test_use_doc_standard_backends():


### PR DESCRIPTION
Paying the cost of regen'ing the font cache on every import seems a bit
silly when one can just set MPLCONFIGDIR to a persistent directory.
Moreover the tmpdir approach is brittle against forking; this is fixable
but somewhat complex to do.

Closes #15911, see also #832 (see discussions in both of them).
Edit: also closes #16677.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
