### PR TITLE
Raise an ValueError when Axes.pie accepts negative values #15923

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2921,6 +2921,10 @@ class Axes(_AxesBase):
                 "and will be removed %(removal)s; pass a 1D array instead.")
             x = np.atleast_1d(x.squeeze())
 
+        for part in x:
+            if part < 0:
+                raise ValueError("wedge sizes must be non negative values")
+
         sx = x.sum()
         if sx > 1:
             x = x / sx

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2921,9 +2921,8 @@ class Axes(_AxesBase):
                 "and will be removed %(removal)s; pass a 1D array instead.")
             x = np.atleast_1d(x.squeeze())
 
-        for part in x:
-            if part < 0:
-                raise ValueError("wedge sizes must be non negative values")
+        if np.any(x < 0):
+            raise ValueError("wedge sizes must be non negative values")
 
         sx = x.sum()
         if sx > 1:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6849,3 +6849,10 @@ def test_bbox_aspect_axes_init():
         sizes.extend([bb.width, bb.height])
 
     assert_allclose(sizes, sizes[0])
+
+
+def test_pi_get_negative_values():
+    # Test the ValueError raised when feeding negative values into axes.pie
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.pie([5, 5, -3], explode=[0, .1, .2])


### PR DESCRIPTION
## PR Summary

Issue #15923
Axes.pie accepts negative values which outputs the wrong pie chart. This issue is caused by not checking the positive and negative of all input wedge sizes of "x" in Axes.pie.

Now it will raise a ValueError, which indicates wedge sizes should be non-negative when feeding negative values into Axes.pie. It is done by adding an if condition right before calculating the portion of all sizes in the "x" `array.

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
