### PR TITLE
Don't hide exceptions in FontManager.addfont.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -986,7 +986,13 @@ class FontManager:
         for fontext in ["afm", "ttf"]:
             for path in [*findSystemFonts(paths, fontext=fontext),
                          *findSystemFonts(fontext=fontext)]:
-                self.addfont(path)
+                try:
+                    self.addfont(path)
+                except OSError as exc:
+                    _log.info("Failed to open font file %s: %s", path, exc)
+                except Exception as exc:
+                    _log.info("Failed to extract font properties from %s: %s",
+                              path, exc)
 
     def addfont(self, path):
         """
@@ -998,36 +1004,13 @@ class FontManager:
         path : str or path-like
         """
         if Path(path).suffix.lower() == ".afm":
-            try:
-                with open(path, "rb") as fh:
-                    font = afm.AFM(fh)
-            except EnvironmentError:
-                _log.info("Could not open font file %s", path)
-                return
-            except RuntimeError:
-                _log.info("Could not parse font file %s", path)
-                return
-            try:
-                prop = afmFontProperty(path, font)
-            except KeyError as exc:
-                _log.info("Could not extract properties for %s: %s", path, exc)
-                return
+            with open(path, "rb") as fh:
+                font = afm.AFM(fh)
+            prop = afmFontProperty(path, font)
             self.afmlist.append(prop)
         else:
-            try:
-                font = ft2font.FT2Font(path)
-            except (OSError, RuntimeError) as exc:
-                _log.info("Could not open font file %s: %s", path, exc)
-                return
-            except UnicodeError:
-                _log.info("Cannot handle unicode filenames")
-                return
-            try:
-                prop = ttfFontProperty(font)
-            except (KeyError, RuntimeError, ValueError,
-                    NotImplementedError) as exc:
-                _log.info("Could not extract properties for %s: %s", path, exc)
-                return
+            font = ft2font.FT2Font(path)
+            prop = ttfFontProperty(font)
             self.ttflist.append(prop)
 
     @property


### PR DESCRIPTION
We only need to hide them when constructing the default fontManager
instance (because we don't want a single bad font in the system to
prevent Matplotlib from importing, but if the end user manually calls
addfont, errors should not pass silently).

Release critical as addfont is a new API in 3.2 (#15068).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
