### PR TITLE
Some unicode-support related cleanups.

### DIFF
--- a/examples/text_labels_and_annotations/tex_demo.py
+++ b/examples/text_labels_and_annotations/tex_demo.py
@@ -3,17 +3,16 @@
 Rendering math equation using TeX
 =================================
 
-You can use TeX to render all of your matplotlib text if the rc
-parameter ``text.usetex`` is set.  This works currently on the agg and ps
-backends, and requires that you have tex and the other dependencies
-described in the :doc:`/tutorials/text/usetex` tutorial
-properly installed on your system.  The first time you run a script
-you will see a lot of output from tex and associated tools.  The next
-time, the run may be silent, as a lot of the information is cached.
+You can use TeX to render all of your Matplotlib text by setting
+:rc:`text.usetex` to True.  This requires that you have TeX and the other
+dependencies described in the :doc:`/tutorials/text/usetex` tutorial properly
+installed on your system.  Matplotlib caches processed TeX expressions, so that
+only the first occurrence of an expression triggers a TeX compilation. Later
+occurrences reuse the rendered image from the cache and are thus faster.
 
-Notice how the label for the y axis is provided using unicode!
-
+Unicode input is supported, e.g. for the y-axis label in this example.
 """
+
 import numpy as np
 import matplotlib
 matplotlib.rcParams['text.usetex'] = True

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -72,32 +72,31 @@ class LayoutBox:
         # keep track of whether we need to match this subplot up with others.
         self.subplot = subplot
 
-        # we need the str below for Py 2 which complains the string is unicode
-        self.top = Variable(str(sn + 'top'))
-        self.bottom = Variable(str(sn + 'bottom'))
-        self.left = Variable(str(sn + 'left'))
-        self.right = Variable(str(sn + 'right'))
+        self.top = Variable(sn + 'top')
+        self.bottom = Variable(sn + 'bottom')
+        self.left = Variable(sn + 'left')
+        self.right = Variable(sn + 'right')
 
-        self.width = Variable(str(sn + 'width'))
-        self.height = Variable(str(sn + 'height'))
-        self.h_center = Variable(str(sn + 'h_center'))
-        self.v_center = Variable(str(sn + 'v_center'))
+        self.width = Variable(sn + 'width')
+        self.height = Variable(sn + 'height')
+        self.h_center = Variable(sn + 'h_center')
+        self.v_center = Variable(sn + 'v_center')
 
-        self.min_width = Variable(str(sn + 'min_width'))
-        self.min_height = Variable(str(sn + 'min_height'))
-        self.pref_width = Variable(str(sn + 'pref_width'))
-        self.pref_height = Variable(str(sn + 'pref_height'))
+        self.min_width = Variable(sn + 'min_width')
+        self.min_height = Variable(sn + 'min_height')
+        self.pref_width = Variable(sn + 'pref_width')
+        self.pref_height = Variable(sn + 'pref_height')
         # margins are only used for axes-position layout boxes.  maybe should
         # be a separate subclass:
-        self.left_margin = Variable(str(sn + 'left_margin'))
-        self.right_margin = Variable(str(sn + 'right_margin'))
-        self.bottom_margin = Variable(str(sn + 'bottom_margin'))
-        self.top_margin = Variable(str(sn + 'top_margin'))
+        self.left_margin = Variable(sn + 'left_margin')
+        self.right_margin = Variable(sn + 'right_margin')
+        self.bottom_margin = Variable(sn + 'bottom_margin')
+        self.top_margin = Variable(sn + 'top_margin')
         # mins
-        self.left_margin_min = Variable(str(sn + 'left_margin_min'))
-        self.right_margin_min = Variable(str(sn + 'right_margin_min'))
-        self.bottom_margin_min = Variable(str(sn + 'bottom_margin_min'))
-        self.top_margin_min = Variable(str(sn + 'top_margin_min'))
+        self.left_margin_min = Variable(sn + 'left_margin_min')
+        self.right_margin_min = Variable(sn + 'right_margin_min')
+        self.bottom_margin_min = Variable(sn + 'bottom_margin_min')
+        self.top_margin_min = Variable(sn + 'top_margin_min')
 
         right, top = upper_right
         left, bottom = lower_left

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1362,10 +1362,7 @@ class PolarAxes(Axes):
                 "You can not set the xscale on a polar plot.")
 
     def format_coord(self, theta, r):
-        """
-        Return a format string formatting the coordinate using Unicode
-        characters.
-        """
+        # docstring inherited
         if theta < 0:
             theta += 2 * np.pi
         theta /= np.pi

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -169,12 +169,8 @@ def test_save_animation_smoketest(tmpdir, writer, output):
     # per frame with known names.
     with tmpdir.as_cwd():
         anim = animation.FuncAnimation(fig, animate, init_func=init, frames=5)
-        try:
-            anim.save(output, fps=30, writer=writer, bitrate=500, dpi=dpi,
-                      codec=codec)
-        except UnicodeDecodeError:
-            pytest.xfail("There can be errors in the numpy import stack, "
-                         "see issues #1891 and #2679")
+        anim.save(output, fps=30, writer=writer, bitrate=500, dpi=dpi,
+                  codec=codec)
 
 
 def test_no_length_frames():


### PR DESCRIPTION
- TeX demo: the old text is pretty outdated -- all backends support
  usetex, and the output of the TeX process is now hidden.
- _layoutbox.py: we don't support Py2 anymore.
- polar.py: the inherited docstring is enough.
- test_animation.py: these refer to very old bugs, likely fixed by
  now.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
