### PR TITLE
Deprecate the TTFPATH & AFMPATH environment variables.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -163,3 +163,9 @@ This ticker is deprecated.
 *required*, *forbidden* and *allowed* parameters of `.cbook.normalize_kwargs`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These parameters are deprecated.
+
+The ``TTFPATH`` and ``AFMPATH`` environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for the (undocumented) ``TTFPATH`` and ``AFMPATH`` environment
+variables is deprecated.  Additional fonts may be registered using
+``matplotlib.font_manager.fontManager.addfont()``.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -971,6 +971,9 @@ class FontManager:
                     paths.extend(ttfpath.split(':'))
                 else:
                     paths.append(ttfpath)
+                cbook.warn_deprecated(
+                    "3.3", name=pathname, obj_type="environment variable",
+                    alternative="FontManager.addfont()")
         _log.debug('font search path %s', str(paths))
         #  Load TrueType fonts and create font dictionary.
 


### PR DESCRIPTION
These undocumented environment variables allow one to selectively add
paths to the font cache... but only if the font cache doesn't exist yet
(they don't force cache regen).  The font-cache regen API (_rebuild())
is also private (even though one can trigger it "publically" e.g. by
calling `findfont` with a nonexisting font...).

Instead, we now expose `addfont()` which is a documented API for
registering fonts with the font manager.

attn @lukelbd Your proplot package is the only one I am aware of that uses TTFPATH; how does addfont() look to you?

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
