### PR TITLE
Do not use "object" or "instance" when documenting types

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -266,7 +266,7 @@ class Artist:
 
         Parameters
         ----------
-        renderer : `.RendererBase` instance
+        renderer : `.RendererBase` subclass
             renderer that will be used to draw the figures (i.e.
             ``fig.canvas.get_renderer()``)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7485,7 +7485,7 @@ default: :rc:`scatter.edgecolors`
             The times corresponding to midpoints of segments (i.e., the columns
             in *spectrum*).
 
-        im : instance of class `.AxesImage`
+        im : `.AxesImage`
             The image created by imshow containing the spectrogram.
 
         See Also

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4309,7 +4309,7 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        renderer : `.RendererBase` instance
+        renderer : `.RendererBase` subclass
             renderer that will be used to draw the figures (i.e.
             ``fig.canvas.get_renderer()``)
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -159,12 +159,12 @@ class ScalarMappable:
 
         Parameters
         ----------
-        norm : :class:`matplotlib.colors.Normalize` instance
+        norm : `matplotlib.colors.Normalize` (or subclass thereof)
             The normalizing object which scales data, typically into the
             interval ``[0, 1]``.
             If *None*, *norm* defaults to a *colors.Normalize* object which
             initializes its scaling based on the first data processed.
-        cmap : str or :class:`~matplotlib.colors.Colormap` instance
+        cmap : str or `~matplotlib.colors.Colormap`
             The colormap used to map normalized data values to RGBA colors.
         """
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1470,7 +1470,7 @@ class EventCollection(LineCollection):
         """
         Parameters
         ----------
-        positions : 1D array-like object
+        positions : 1D array-like
             Each value is an event.
 
         orientation : {None, 'horizontal', 'vertical'}, optional

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -161,10 +161,10 @@ mappable
 
         fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
 
-cax : :class:`~matplotlib.axes.Axes` object, optional
+cax : `~matplotlib.axes.Axes`, optional
     Axes into which the colorbar will be drawn.
 
-ax : :class:`~matplotlib.axes.Axes`, list of Axes, optional
+ax : `~matplotlib.axes.Axes`, list of Axes, optional
     Parent axes from which space for a new colorbar axes will be stolen.
     If a list of axes is given they will all be resized to make room for the
     colorbar axes.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1747,7 +1747,7 @@ class LightSource:
         data : array-like
             A 2d array (or equivalent) of the height values used to generate a
             shaded map.
-        cmap : `~matplotlib.colors.Colormap` instance
+        cmap : `~matplotlib.colors.Colormap`
             The colormap used to color the *data* array. Note that this must be
             a `~matplotlib.colors.Colormap` instance.  For example, rather than
             passing in `cmap='gist_earth'`, use

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -382,7 +382,7 @@ def datestr2num(d, default=None):
     d : str or sequence of str
         The dates to convert.
 
-    default : datetime instance, optional
+    default : datetime.datetime, optional
         The default date to use when fields are missing in *d*.
     """
     if isinstance(d, str):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1454,7 +1454,7 @@ default: 'top'
 
         Returns
         -------
-        ax : `~.axes.Axes` object or array of Axes objects.
+        ax : `~.axes.Axes` or array of Axes
             *ax* can be either a single `~matplotlib.axes.Axes` object or
             an array of Axes objects if more than one subplot was created. The
             dimensions of the resulting array can be controlled with the
@@ -1792,7 +1792,7 @@ default: 'top'
 
         Returns
         -------
-        :class:`matplotlib.legend.Legend` instance
+        `~matplotlib.legend.Legend`
 
         Notes
         -----
@@ -2356,7 +2356,7 @@ default: 'top'
 
         Parameters
         ----------
-        renderer : `.RendererBase` instance
+        renderer : `.RendererBase` subclass
             renderer that will be used to draw the figures (i.e.
             ``fig.canvas.get_renderer()``)
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -69,7 +69,7 @@ def composite_images(images, renderer, magnification=1.0):
         enforced by this function.  Each image must have a purely
         affine transformation with no shear.
 
-    renderer : RendererBase instance
+    renderer : `.RendererBase`
 
     magnification : float
         The additional magnification to apply for the renderer in use.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -950,7 +950,7 @@ class Legend(Artist):
 
         Parameters
         ----------
-        renderer : `.RendererBase` instance
+        renderer : `.RendererBase` subclass
             renderer that will be used to draw the figures (i.e.
             ``fig.canvas.get_renderer()``)
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -94,14 +94,14 @@ class HandlerBase:
 
         Parameters
         ----------
-        legend : :class:`matplotlib.legend.Legend` instance
+        legend : `~matplotlib.legend.Legend`
             The legend for which these legend artists are being created.
         orig_handle : :class:`matplotlib.artist.Artist` or similar
             The object for which these legend artists are being created.
         fontsize : int
             The fontsize in pixels. The artists being created should
             be scaled according to the given fontsize.
-        handlebox : :class:`matplotlib.offsetbox.OffsetBox` instance
+        handlebox : `matplotlib.offsetbox.OffsetBox`
             The box which has been created to hold this legend entry's
             artists. Artists created in the `legend_artist` method must
             be added to this handlebox inside this method.

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -84,7 +84,7 @@ class PathEffectRenderer(RendererBase):
         ----------
         path_effects : iterable of :class:`AbstractPathEffect`
             The path effects which this renderer represents.
-        renderer : :class:`matplotlib.backend_bases.RendererBase` instance
+        renderer : `matplotlib.backend_bases.RendererBase` subclass
 
         """
         self._path_effects = path_effects

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1029,7 +1029,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     -------
     fig : `~.figure.Figure`
 
-    ax : `.axes.Axes` object or array of Axes objects.
+    ax : `.axes.Axes` or array of Axes
         *ax* can be either a single `~matplotlib.axes.Axes` object or an
         array of Axes objects if more than one subplot was created.  The
         dimensions of the resulting array can be controlled with the squeeze

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -97,7 +97,7 @@ class TextToPath:
 
         Parameters
         ----------
-        prop : `matplotlib.font_manager.FontProperties` instance
+        prop : `~matplotlib.font_manager.FontProperties`
             The font properties for the text.
 
         s : str

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2902,7 +2902,7 @@ def offset_copy(trans, fig=None, x=0.0, y=0.0, units='inches'):
 
     Parameters
     ----------
-    trans : :class:`Transform` instance
+    trans : `Transform` subclass
         Any transform, to which offset will be applied.
     fig : :class:`~matplotlib.figure.Figure`, default: None
         Current figure. It can be None if *units* are 'dots'.
@@ -2913,7 +2913,7 @@ def offset_copy(trans, fig=None, x=0.0, y=0.0, units='inches'):
 
     Returns
     -------
-    trans : :class:`Transform` instance
+    trans : `Transform` subclass
         Transform with applied offset.
     """
     if units == 'dots':

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -241,14 +241,13 @@ class LinearTriInterpolator(TriInterpolator):
 
     Parameters
     ----------
-    triangulation : :class:`~matplotlib.tri.Triangulation` object
+    triangulation : `~matplotlib.tri.Triangulation`
         The triangulation to interpolate over.
     z : array-like of shape (npoints,)
         Array of values, defined at grid points, to interpolate between.
-    trifinder : :class:`~matplotlib.tri.TriFinder` object, optional
+    trifinder : `~matplotlib.tri.TriFinder`, optional
           If this is not specified, the Triangulation's default TriFinder will
-          be used by calling
-          :func:`matplotlib.tri.Triangulation.get_trifinder`.
+          be used by calling `matplotlib.tri.Triangulation.get_trifinder`.
 
     Methods
     -------
@@ -305,7 +304,7 @@ class CubicTriInterpolator(TriInterpolator):
 
     Parameters
     ----------
-    triangulation : :class:`~matplotlib.tri.Triangulation` object
+    triangulation : `~matplotlib.tri.Triangulation`
         The triangulation to interpolate over.
     z : array-like of shape (npoints,)
         Array of values, defined at grid points, to interpolate between.
@@ -321,10 +320,9 @@ class CubicTriInterpolator(TriInterpolator):
             - if 'user': The user provides the argument *dz*, no computation
               is hence needed.
 
-    trifinder : :class:`~matplotlib.tri.TriFinder` object, optional
+    trifinder : `~matplotlib.tri.TriFinder`, optional
         If not specified, the Triangulation's default TriFinder will
-        be used by calling
-        :func:`matplotlib.tri.Triangulation.get_trifinder`.
+        be used by calling `matplotlib.tri.Triangulation.get_trifinder`.
     dz : tuple of array-likes (dzdx, dzdy), optional
         Used only if  *kind* ='user'. In this case *dz* must be provided as
         (dzdx, dzdy) where dzdx, dzdy are arrays of the same shape as *z* and

--- a/lib/matplotlib/tri/trirefine.py
+++ b/lib/matplotlib/tri/trirefine.py
@@ -155,7 +155,7 @@ class UniformTriRefiner(TriRefiner):
 
         Returns
         -------
-        refi_tri : :class:`~matplotlib.tri.Triangulation` object
+        refi_tri : `~matplotlib.tri.Triangulation`
                      The returned refined triangulation
         refi_z : 1d array of length: *refi_tri* node count.
                    The returned interpolated field (at *refi_tri* nodes)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1660,7 +1660,7 @@ class SpanSelector(_SelectorWidget):
 
     Parameters
     ----------
-    ax : `matplotlib.axes.Axes` object
+    ax : `matplotlib.axes.Axes`
 
     onselect : func(min, max), min/max are floats
 

--- a/tutorials/text/text_props.py
+++ b/tutorials/text/text_props.py
@@ -21,7 +21,7 @@ clip_on                     bool
 clip_path                   a `~matplotlib.path.Path` instance and a `~matplotlib.transforms.Transform` instance, a `~matplotlib.patches.Patch`
 color                       any matplotlib :doc:`color </tutorials/colors/colors>`
 family                      [ ``'serif'`` | ``'sans-serif'`` | ``'cursive'`` | ``'fantasy'`` | ``'monospace'`` ]
-fontproperties              a `~matplotlib.font_manager.FontProperties` instance
+fontproperties              `~matplotlib.font_manager.FontProperties`
 horizontalalignment or ha   [ ``'center'`` | ``'right'`` | ``'left'`` ]
 label                       any string
 linespacing                 `float`
@@ -33,7 +33,7 @@ rotation                    [ angle in degrees | ``'vertical'`` | ``'horizontal'
 size or fontsize            [ size in points | relative size, e.g., ``'smaller'``, ``'x-large'`` ]
 style or fontstyle          [ ``'normal'`` | ``'italic'`` | ``'oblique'`` ]
 text                        string or anything printable with '%s' conversion
-transform                   a `~matplotlib.transforms.Transform` instance
+transform                   `~matplotlib.transforms.Transform` subclass
 variant                     [ ``'normal'`` | ``'small-caps'`` ]
 verticalalignment or va     [ ``'center'`` | ``'top'`` | ``'bottom'`` | ``'baseline'`` ]
 visible                     bool


### PR DESCRIPTION
## PR Summary

Use ``param : `MyClass` `` not ``param : `MyClass` object`` or ``param : `MyClass` instance``.

In some cases "instance" was used to indicate that the type itself will be used, but some subclass thereof (e.g. for `RendererBase` and `Transform`).  Use ``renderer : `.RendererBase` subclass`` in these cases.

