### PR TITLE
FIX: check subplot kwargs

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -438,8 +438,12 @@ class _AxesBase(martist.Artist):
         self._sharex = sharex
         self._sharey = sharey
         if sharex is not None:
+            if not isinstance(sharex, _AxesBase):
+                raise TypeError('sharex must be an axes, not a bool')
             self._shared_x_axes.join(self, sharex)
         if sharey is not None:
+            if not isinstance(sharey, _AxesBase):
+                raise TypeError('sharey must be an axes, not a bool')
             self._shared_y_axes.join(self, sharey)
         self.set_label(label)
         self.set_figure(fig)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -956,8 +956,8 @@ def subplot(*args, **kwargs):
                              "subplots()?")
     # Check for nrows and ncols, which are not valid subplot args:
     if 'nrows' in kwargs or 'ncols' in kwargs:
-        cbook._warn_external("You have passed nrows and/or ncols to "
-                             "subplot(). Did you mean to use subplots()?")
+        raise TypeError("subplot() got an unexpected keyword argument 'ncols' "
+                         "and/or 'nrows'.  Did you intend to call subplots()?")
 
     fig = gcf()
     a = fig.add_subplot(*args, **kwargs)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -954,6 +954,10 @@ def subplot(*args, **kwargs):
         cbook._warn_external("The subplot index argument to subplot() appears "
                              "to be a boolean. Did you intend to use "
                              "subplots()?")
+    # Check for nrows and ncols, which are not valid subplot args:
+    if 'nrows' in kwargs or 'ncols' in kwargs:
+        cbook._warn_external("You have passed nrows and/or ncols to "
+                             "subplot(). Did you mean to use subplots()?")
 
     fig = gcf()
     a = fig.add_subplot(*args, **kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5489,6 +5489,13 @@ def test_shared_scale():
         assert ax.get_xscale() == 'linear'
 
 
+def test_shared_bool():
+    with pytest.raises(TypeError):
+        plt.subplot(sharex=True)
+    with pytest.raises(TypeError):
+        plt.subplot(sharey=True)
+
+
 def test_violin_point_mass():
     """Violin plot should handle point mass pdf gracefully."""
     plt.violinplot(np.array([0, 0]))

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -53,10 +53,8 @@ def test_stackplot_smoke():
     plt.stackplot([1, 2, 3], [1, 2, 3])
 
 
-def test_nrows_warn():
-     with pytest.raises(AttributeError):
-         with pytest.warns(UserWarning) as rec:
-             plt.subplot(nrows=1)
-     with pytest.raises(AttributeError):
-         with pytest.warns(UserWarning) as rec:
-             plt.subplot(ncols=1)
+def test_nrows_error():
+    with pytest.raises(TypeError):
+        plt.subplot(nrows=1)
+    with pytest.raises(TypeError):
+        plt.subplot(ncols=1)

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -51,3 +51,12 @@ def test_pyplot_box():
 def test_stackplot_smoke():
     # Small smoke test for stackplot (see #12405)
     plt.stackplot([1, 2, 3], [1, 2, 3])
+
+
+def test_nrows_warn():
+     with pytest.raises(AttributeError):
+         with pytest.warns(UserWarning) as rec:
+             plt.subplot(nrows=1)
+     with pytest.raises(AttributeError):
+         with pytest.warns(UserWarning) as rec:
+             plt.subplot(ncols=1)


### PR DESCRIPTION
## PR Summary

Closes #15964

A couple more guard-rails for using `plt.subplot` when you really meant `plt.subplots`.  

```python
from matplotlib import pyplot as plt
fig, (ax1, ax2) = plt.subplot(nrows=1, ncols=2, sharey=True)
```

### Old:

```
...
   ~/.virtualenvs/tcpsp/lib/python3.7/site-packages/matplotlib/cbook/__init__.py in join(self, a, *args)
        923 
        924         for arg in args:
    --> 925             set_b = mapping.get(weakref.ref(arg), [weakref.ref(arg)])
        926             if set_b is not set_a:
        927                 if len(set_b) > len(set_a):


    TypeError: cannot create weak reference to 'bool' object
```

### Now:

```
./testIt.py:2: UserWarning: You have passed nrows and/or ncols to subplot(). Did you mean to use subplots()?
  fig, (ax1, ax2) = plt.subplot(nrows=1, ncols=2, sharey=True)
Traceback (most recent call last):
  File "./testIt.py", line 2, in <module>
    fig, (ax1, ax2) = plt.subplot(nrows=1, ncols=2, sharey=True)
  File "/Users/jklymak/matplotlib/lib/matplotlib/pyplot.py", line 963, in subplot
    a = fig.add_subplot(*args, **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/figure.py", line 1390, in add_subplot
    a = subplot_class_factory(projection_class)(self, *args, **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/axes/_subplots.py", line 39, in __init__
    self._axes_class.__init__(self, fig, self.figbox, **kwargs)
  File "/Users/jklymak/matplotlib/lib/matplotlib/axes/_base.py", line 446, in __init__
    raise TypeError('sharey must be an axes, not a bool')
TypeError: sharey must be an axes, not a bool
```

Wasn't sure if passing `nrows` or `ncols` should just error out.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
