### PR TITLE
Reuse colorbar outline and patch when updating the colorbar.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -444,9 +444,19 @@ class ColorbarBase:
         self.extendfrac = extendfrac
         self.extendrect = extendrect
         self.solids = None
-        self.lines = list()
-        self.outline = None
-        self.patch = None
+        self.lines = []
+
+        self.outline = mpatches.Polygon(
+            np.empty((0, 2)),
+            edgecolor=mpl.rcParams['axes.edgecolor'], facecolor='none',
+            linewidth=mpl.rcParams['axes.linewidth'], closed=True, zorder=2)
+        ax.add_artist(self.outline)
+        self.outline.set(clip_box=None, clip_path=None)
+        self.patch = mpatches.Polygon(
+            np.empty((0, 2)),
+            color=mpl.rcParams['axes.facecolor'], linewidth=0.01, zorder=-1)
+        ax.add_artist(self.patch)
+
         self.dividers = None
         self.locator = None
         self.formatter = None
@@ -709,26 +719,8 @@ class ColorbarBase:
         ax.update_datalim(xy)
         ax.set_xlim(*ax.dataLim.intervalx)
         ax.set_ylim(*ax.dataLim.intervaly)
-        if self.outline is not None:
-            self.outline.remove()
-        self.outline = mpatches.Polygon(
-            xy, edgecolor=mpl.rcParams['axes.edgecolor'],
-            facecolor='none',
-            linewidth=mpl.rcParams['axes.linewidth'],
-            closed=True,
-            zorder=2)
-        ax.add_artist(self.outline)
-        self.outline.set_clip_box(None)
-        self.outline.set_clip_path(None)
-        c = mpl.rcParams['axes.facecolor']
-        if self.patch is not None:
-            self.patch.remove()
-        self.patch = mpatches.Polygon(xy, edgecolor=c,
-                                      facecolor=c,
-                                      linewidth=0.01,
-                                      zorder=-1)
-        ax.add_artist(self.patch)
-
+        self.outline.set_xy(xy)
+        self.patch.set_xy(xy)
         self.update_ticks()
 
     def _set_label(self):
@@ -1276,10 +1268,18 @@ class Colorbar(ColorbarBase):
         self.formatter = None
 
         # clearing the axes will delete outline, patch, solids, and lines:
-        self.outline = None
-        self.patch = None
+        self.outline = mpatches.Polygon(
+            np.empty((0, 2)),
+            edgecolor=mpl.rcParams['axes.edgecolor'], facecolor='none',
+            linewidth=mpl.rcParams['axes.linewidth'], closed=True, zorder=2)
+        self.ax.add_artist(self.outline)
+        self.outline.set(clip_box=None, clip_path=None)
+        self.patch = mpatches.Polygon(
+            np.empty((0, 2)),
+            color=mpl.rcParams['axes.facecolor'], linewidth=0.01, zorder=-1)
+        self.ax.add_artist(self.patch)
         self.solids = None
-        self.lines = list()
+        self.lines = []
         self.dividers = None
         self.update_normal(mappable)
         self.draw_all()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -497,12 +497,15 @@ def test_colorbar_scale_reset():
     fig, ax = plt.subplots()
     pcm = ax.pcolormesh(z, cmap='RdBu_r', rasterized=True)
     cbar = fig.colorbar(pcm, ax=ax)
+    cbar.outline.set_edgecolor('red')
     assert cbar.ax.yaxis.get_scale() == 'linear'
 
     pcm.set_norm(LogNorm(vmin=1, vmax=100))
     assert cbar.ax.yaxis.get_scale() == 'log'
     pcm.set_norm(Normalize(vmin=-20, vmax=20))
     assert cbar.ax.yaxis.get_scale() == 'linear'
+
+    assert cbar.outline.get_edgecolor() == mcolors.to_rgba('red')
 
 
 def test_colorbar_get_ticks_2():


### PR DESCRIPTION
... so that changes to the outline edgecolor are kept.

Closes https://github.com/matplotlib/matplotlib/issues/15980.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
