### PR TITLE
Colorbar cleanup.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -144,3 +144,9 @@ and containment checks) via `.Line2D.set_picker` is deprecated.  Use
 
 `.Line2D.set_picker` no longer sets the artist's custom-contain() check.  Use
 ``Line2D.set_contains`` instead.
+
+`~matplotlib.colorbar.Colorbar` methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``on_mappable_changed`` and ``update_bruteforce`` methods of
+`~matplotlib.colorbar.Colorbar` are deprecated; both can be replaced by calls
+to `~matplotlib.colorbar.Colorbar.update_normal`.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1209,6 +1209,7 @@ class Colorbar(ColorbarBase):
                 _add_disjoint_kwargs(kwargs, alpha=mappable.get_alpha())
             ColorbarBase.__init__(self, ax, **kwargs)
 
+    @cbook.deprecated("3.3", alternative="update_normal")
     def on_mappable_changed(self, mappable):
         """
         Update this colorbar to match the mappable's properties.
@@ -1249,9 +1250,8 @@ class Colorbar(ColorbarBase):
         """
         Update solid patches, lines, etc.
 
-        Unlike `.update_bruteforce`, this does not clear the axes.  This is
-        meant to be called when the norm of the image or contour plot to which
-        this colorbar belongs changes.
+        This is meant to be called when the norm of the image or contour plot
+        to which this colorbar belongs changes.
 
         If the norm on the mappable is different than before, this resets the
         locator and formatter for the axis, so if these have been customized,
@@ -1274,6 +1274,7 @@ class Colorbar(ColorbarBase):
                 self.add_lines(CS)
         self.stale = True
 
+    @cbook.deprecated("3.3", alternative="update_normal")
     def update_bruteforce(self, mappable):
         """
         Destroy and rebuild the colorbar.  This is
@@ -1684,7 +1685,7 @@ def colorbar_factory(cax, mappable, **kwargs):
     else:
         cb = Colorbar(cax, mappable, **kwargs)
 
-    cid = mappable.callbacksSM.connect('changed', cb.on_mappable_changed)
+    cid = mappable.callbacksSM.connect('changed', cb.update_normal)
     mappable.colorbar = cb
     mappable.colorbar_cid = cid
 

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -44,12 +44,7 @@ class CbarAxesBase:
             self, mappable, orientation=orientation, ticks=ticks, **kwargs)
         self._config_axes()
 
-        def on_changed(m):
-            cb.set_cmap(m.get_cmap())
-            cb.set_clim(m.get_clim())
-            cb.update_bruteforce(m)
-
-        self.cbid = mappable.callbacksSM.connect('changed', on_changed)
+        self.cbid = mappable.callbacksSM.connect('changed', cb.update_normal)
         mappable.colorbar = cb
 
         if mpl.rcParams["mpl_toolkits.legacy_colorbar"]:

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -703,6 +703,33 @@ class Colorbar(ColorbarBase):
         #tlinewidths = [col.get_linewidth()[0] for lw in CS.collections]
         ColorbarBase.add_lines(self, CS.levels, tcolors, tlinewidths)
 
+    def update_normal(self, mappable):
+        """
+        Update solid patches, lines, etc.
+
+        This is meant to be called when the norm of the image or contour plot
+        to which this colorbar belongs changes.
+
+        If the norm on the mappable is different than before, this resets the
+        locator and formatter for the axis, so if these have been customized,
+        they will need to be customized again.  However, if the norm only
+        changes values of *vmin*, *vmax* or *cmap* then the old formatter
+        and locator will be preserved.
+        """
+        self.mappable = mappable
+        self.set_alpha(mappable.get_alpha())
+        self.cmap = mappable.cmap
+        if mappable.norm != self.norm:
+            self.norm = mappable.norm
+            self._reset_locator_formatter_scale()
+
+        self.draw_all()
+        if isinstance(self.mappable, contour.ContourSet):
+            CS = self.mappable
+            if not CS.filled:
+                self.add_lines(CS)
+        self.stale = True
+
     def update_bruteforce(self, mappable):
         """
         Update the colorbar artists to reflect the change of the


### PR DESCRIPTION
Deprecate on_mappable_changed in favor of update_normal (they're the
same now (except for a logging call) now that colorbars just use the
norm of the mappable).

Deprecate update_bruteforce in favor of update_normal -- it's not used
anywhere except in axes_grid, but that's just because whoever introduced
update_normal forgot to update axes_grid at the same time.

axes_grid.colorbar is already deprecated but until its complete removal,
we need to backport update_normal to it...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
