### PR TITLE
Refactor Annotation properties.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1460,19 +1460,10 @@ class _AnnotationBase:
 
     def _get_ref_xy(self, renderer):
         """
-        Return x, y (in display coordinate) that is to be used for a reference
+        Return x, y (in display coordinates) that is to be used for a reference
         of any offset coordinate.
         """
-        def is_offset(s):
-            return isinstance(s, str) and s.split()[0] == "offset"
-
-        if isinstance(self.xycoords, tuple):
-            if any(map(is_offset, self.xycoords)):
-                raise ValueError("xycoords should not be an offset coordinate")
-        elif is_offset(self.xycoords):
-            raise ValueError("xycoords should not be an offset coordinate")
-        x, y = self.xy
-        return self._get_xy(renderer, x, y, self.xycoords)
+        return self._get_xy(renderer, *self.xy, self.xycoords)
 
     # def _get_bbox(self, renderer):
     #     if hasattr(bbox, "bounds"):
@@ -1796,9 +1787,23 @@ class Annotation(Text, _AnnotationBase):
         return contains, tinfo
 
     @property
+    def xycoords(self):
+        return self._xycoords
+
+    @xycoords.setter
+    def xycoords(self, xycoords):
+        def is_offset(s):
+            return isinstance(s, str) and s.startswith("offset")
+
+        if (isinstance(xycoords, tuple) and any(map(is_offset, xycoords))
+                or is_offset(xycoords)):
+            raise ValueError("xycoords cannot be an offset coordinate")
+        self._xycoords = xycoords
+
+    @property
     def xyann(self):
         """
-        The the text position.
+        The text position.
 
         See also *xytext* in `.Annotation`.
         """
@@ -1808,28 +1813,24 @@ class Annotation(Text, _AnnotationBase):
     def xyann(self, xytext):
         self.set_position(xytext)
 
-    @property
-    def anncoords(self):
-        """The coordinate system to use for `.Annotation.xyann`."""
+    def get_anncoords(self):
+        """
+        Return the coordinate system to use for `.Annotation.xyann`.
+
+        See also *xycoords* in `.Annotation`.
+        """
         return self._textcoords
 
-    @anncoords.setter
-    def anncoords(self, coords):
+    def set_anncoords(self, coords):
+        """
+        Set the coordinate system to use for `.Annotation.xyann`.
+
+        See also *xycoords* in `.Annotation`.
+        """
         self._textcoords = coords
 
-    get_anncoords = anncoords.fget
-    get_anncoords.__doc__ = """
-    Return the coordinate system to use for `.Annotation.xyann`.
-
-    See also *xycoords* in `.Annotation`.
-    """
-
-    set_anncoords = anncoords.fset
-    set_anncoords.__doc__ = """
-    Set the coordinate system to use for `.Annotation.xyann`.
-
-    See also *xycoords* in `.Annotation`.
-    """
+    anncoords = property(get_anncoords, set_anncoords, doc="""
+        The coordinate system to use for `.Annotation.xyann`.""")
 
     def set_figure(self, fig):
         # docstring inherited


### PR DESCRIPTION
- Make xycoords a property to validate inputs at set-time, rather than
  at draw time.
- First define get_anncoords and set_anncoords, and then the anncoords
  property from them (the dance is just so that anncoords and
  get_anncoords get different docstrings...) as that order avoids having
  to fiddle with fget and fset.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
