### PR TITLE
Remove deprecated support for setting single property via multiple aliases

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -50,3 +50,9 @@ and `.pyplot.yticks` would result in
     TypeError: object of type 'NoneType' has no len()
 
 It now raises a ``TypeError`` with a proper description of the error.
+
+Setting the same property under multiple aliases now raises a TypeError
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, calling e.g. ``plot(..., color=somecolor, c=othercolor)`` would
+emit a warning because ``color`` and ``c`` actually map to the same Artist
+property.  This now raises a TypeError.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1763,11 +1763,9 @@ def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
         if tmp:
             ret[canonical] = tmp[-1]
             if len(tmp) > 1:
-                warn_deprecated(
-                    "3.1", message=f"Saw kwargs {seen!r} which are all "
-                    f"aliases for {canonical!r}.  Kept value from "
-                    f"{seen[-1]!r}.  Passing multiple aliases for the same "
-                    f"property will raise a TypeError %(removal)s.")
+                raise TypeError("Got the following keyword arguments which "
+                                "are aliases of one another: {}"
+                                .format(", ".join(map(repr, seen))))
 
     # at this point we know that all keys which are aliased are removed, update
     # the return dictionary from the cleaned local copy of the input

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -301,16 +301,12 @@ def test_sanitize_sequence():
 fail_mapping = (
     ({'a': 1}, {'forbidden': ('a')}),
     ({'a': 1}, {'required': ('b')}),
-    ({'a': 1, 'b': 2}, {'required': ('a'), 'allowed': ()})
-)
-
-warn_passing_mapping = (
-    ({'a': 1, 'b': 2}, {'a': 1}, {'alias_mapping': {'a': ['b']}}, 1),
-    ({'a': 1, 'b': 2}, {'a': 1},
-     {'alias_mapping': {'a': ['b']}, 'allowed': ('a',)}, 1),
-    ({'a': 1, 'b': 2}, {'a': 2}, {'alias_mapping': {'a': ['a', 'b']}}, 1),
-    ({'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'c': 3},
-     {'alias_mapping': {'a': ['b']}, 'required': ('a', )}, 1),
+    ({'a': 1, 'b': 2}, {'required': ('a'), 'allowed': ()}),
+    ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['b']}}),
+    ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['b']}, 'allowed': ('a',)}),
+    ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['a', 'b']}}),
+    ({'a': 1, 'b': 2, 'c': 3},
+     {'alias_mapping': {'a': ['b']}, 'required': ('a', )}),
 )
 
 pass_mapping = (
@@ -335,15 +331,6 @@ pass_mapping = (
 def test_normalize_kwargs_fail(inp, kwargs_to_norm):
     with pytest.raises(TypeError):
         cbook.normalize_kwargs(inp, **kwargs_to_norm)
-
-
-@pytest.mark.parametrize('inp, expected, kwargs_to_norm, warn_count',
-                         warn_passing_mapping)
-def test_normalize_kwargs_warn(inp, expected, kwargs_to_norm, warn_count):
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert expected == cbook.normalize_kwargs(inp, **kwargs_to_norm)
-        assert len(w) == warn_count
 
 
 @pytest.mark.parametrize('inp, expected, kwargs_to_norm',


### PR DESCRIPTION
attn @timhoffm who's been doing the removal of mpl3.1 deprecations -- I'm stealing this one from you because of followup plans on normalize_kwargs (looks like you haven't covered this yet).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
