### PR TITLE
Avoid setting dtypes as strings...

### DIFF
--- a/examples/axes_grid1/demo_axes_rgb.py
+++ b/examples/axes_grid1/demo_axes_rgb.py
@@ -34,7 +34,7 @@ def get_rgb():
 
 def make_cube(r, g, b):
     ny, nx = r.shape
-    R = np.zeros([ny, nx, 3], dtype="d")
+    R = np.zeros((ny, nx, 3))
     R[:, :, 0] = r
     G = np.zeros_like(R)
     G[:, :, 1] = g

--- a/examples/axes_grid1/inset_locator_demo2.py
+++ b/examples/axes_grid1/inset_locator_demo2.py
@@ -56,9 +56,9 @@ add_sizebar(axins, 0.5)
 # Second subplot, showing an image with an inset zoom
 # and a marked inset
 Z, extent = get_demo_image()
-Z2 = np.zeros([150, 150], dtype="d")
+Z2 = np.zeros((150, 150))
 ny, nx = Z.shape
-Z2[30:30 + ny, 30:30 + nx] = Z
+Z2[30:30+ny, 30:30+nx] = Z
 
 # extent = [-3, 4, -4, 3]
 ax2.imshow(Z2, extent=extent, origin="lower")

--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -23,9 +23,9 @@ fig, ax = plt.subplots(figsize=[5, 4])
 
 # make data
 Z, extent = get_demo_image()
-Z2 = np.zeros([150, 150], dtype="d")
+Z2 = np.zeros((150, 150))
 ny, nx = Z.shape
-Z2[30:30 + ny, 30:30 + nx] = Z
+Z2[30:30+ny, 30:30+nx] = Z
 
 ax.imshow(Z2, extent=extent, origin="lower")
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -369,9 +369,9 @@ def test_to_prestep():
 
     xs, y1s, y2s = cbook.pts_to_prestep(x, y1, y2)
 
-    x_target = np.asarray([0, 0, 1, 1, 2, 2, 3], dtype='float')
-    y1_target = np.asarray([0, 1, 1, 2, 2, 3, 3], dtype='float')
-    y2_target = np.asarray([3, 2, 2, 1, 1, 0, 0], dtype='float')
+    x_target = np.asarray([0, 0, 1, 1, 2, 2, 3], dtype=float)
+    y1_target = np.asarray([0, 1, 1, 2, 2, 3, 3], dtype=float)
+    y2_target = np.asarray([3, 2, 2, 1, 1, 0, 0], dtype=float)
 
     assert_array_equal(x_target, xs)
     assert_array_equal(y1_target, y1s)
@@ -394,9 +394,9 @@ def test_to_poststep():
 
     xs, y1s, y2s = cbook.pts_to_poststep(x, y1, y2)
 
-    x_target = np.asarray([0, 1, 1, 2, 2, 3, 3], dtype='float')
-    y1_target = np.asarray([0, 0, 1, 1, 2, 2, 3], dtype='float')
-    y2_target = np.asarray([3, 3, 2, 2, 1, 1, 0], dtype='float')
+    x_target = np.asarray([0, 1, 1, 2, 2, 3, 3], dtype=float)
+    y1_target = np.asarray([0, 0, 1, 1, 2, 2, 3], dtype=float)
+    y2_target = np.asarray([3, 3, 2, 2, 1, 1, 0], dtype=float)
 
     assert_array_equal(x_target, xs)
     assert_array_equal(y1_target, y1s)
@@ -419,9 +419,9 @@ def test_to_midstep():
 
     xs, y1s, y2s = cbook.pts_to_midstep(x, y1, y2)
 
-    x_target = np.asarray([0, .5, .5, 1.5, 1.5, 2.5, 2.5, 3], dtype='float')
-    y1_target = np.asarray([0, 0, 1, 1, 2, 2, 3, 3], dtype='float')
-    y2_target = np.asarray([3, 3, 2, 2, 1, 1, 0, 0], dtype='float')
+    x_target = np.asarray([0, .5, .5, 1.5, 1.5, 2.5, 2.5, 3], dtype=float)
+    y1_target = np.asarray([0, 0, 1, 1, 2, 2, 3, 3], dtype=float)
+    y2_target = np.asarray([3, 3, 2, 2, 1, 1, 0, 0], dtype=float)
 
     assert_array_equal(x_target, xs)
     assert_array_equal(y1_target, y1s)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -955,7 +955,7 @@ def test_imshow_masked_interpolation():
     N = 20
     n = colors.Normalize(vmin=0, vmax=N*N-1)
 
-    data = np.arange(N*N, dtype='float').reshape(N, N)
+    data = np.arange(N*N, dtype=float).reshape(N, N)
 
     data[5, 5] = -1
     # This will cause crazy ringing for the higher-order

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -575,7 +575,7 @@ class TestLogFormatterExponent:
         # formatted.
         (False, 10, np.array([0.1, 0.00001, np.pi, 0.2, -0.2, -0.00001]),
          range(6), ['0.1', '1e-05', '3.14', '0.2', '-0.2', '-1e-05']),
-        (False, 50, np.array([3, 5, 12, 42], dtype='float'), range(6),
+        (False, 50, np.array([3, 5, 12, 42], dtype=float), range(6),
          ['3', '5', '12', '42']),
     ]
 

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -158,10 +158,8 @@ def test_empty_arrays():
 
 
 def test_scatter_element0_masked():
-
     times = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
-
-    y = np.arange(len(times), dtype='float')
+    y = np.arange(len(times), dtype=float)
     y[0] = np.nan
     fig, ax = plt.subplots()
     ax.scatter(times, y)

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -597,8 +597,8 @@ class HBoxDivider(SubplotDivider):
                           total_appended_size):
 
         n = len(equivalent_sizes)
-        A = np.mat(np.zeros((n+1, n+1), dtype="d"))
-        B = np.zeros((n+1), dtype="d")
+        A = np.mat(np.zeros((n + 1, n + 1)))
+        B = np.zeros(n + 1)
         # AxK = B
 
         # populated A

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -57,7 +57,7 @@ def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True):
 
 def imshow_rgb(ax, r, g, b, **kwargs):
     ny, nx = r.shape
-    R = np.zeros([ny, nx, 3], dtype="d")
+    R = np.zeros((ny, nx, 3))
     R[:, :, 0] = r
     G = np.zeros_like(R)
     G[:, :, 1] = g

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -126,9 +126,9 @@ def test_inset_locator():
     # Z is a 15x15 array
     Z = np.load(cbook.get_sample_data("axes_grid/bivariate_normal.npy"))
     extent = (-3, 4, -4, 3)
-    Z2 = np.zeros([150, 150], dtype="d")
+    Z2 = np.zeros((150, 150))
     ny, nx = Z.shape
-    Z2[30:30 + ny, 30:30 + nx] = Z
+    Z2[30:30+ny, 30:30+nx] = Z
 
     # extent = [-3, 4, -4, 3]
     ax.imshow(Z2, extent=extent, interpolation="nearest",
@@ -168,9 +168,9 @@ def test_inset_axes():
     # Z is a 15x15 array
     Z = np.load(cbook.get_sample_data("axes_grid/bivariate_normal.npy"))
     extent = (-3, 4, -4, 3)
-    Z2 = np.zeros([150, 150], dtype="d")
+    Z2 = np.zeros((150, 150))
     ny, nx = Z.shape
-    Z2[30:30 + ny, 30:30 + nx] = Z
+    Z2[30:30+ny, 30:30+nx] = Z
 
     # extent = [-3, 4, -4, 3]
     ax.imshow(Z2, extent=extent, interpolation="nearest",


### PR DESCRIPTION
... in cases where a builtin works just fine.

`dtype="d"` is the same as float, which is the default anyways.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
