### PR TITLE
Style fixes for axes_divider.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -221,8 +221,8 @@ class Divider:
             ox = self._calc_offsets(hsizes, k)
             oy = self._calc_offsets(vsizes, k)
 
-            ww = (ox[-1] - ox[0])/figW
-            hh = (oy[-1] - oy[0])/figH
+            ww = (ox[-1] - ox[0]) / figW
+            hh = (oy[-1] - oy[0]) / figH
             pb = mtransforms.Bbox.from_bounds(x, y, w, h)
             pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
             pb1_anchored = pb1.anchored(self.get_anchor(), pb)
@@ -234,12 +234,12 @@ class Divider:
             x0, y0 = x, y
 
         if nx1 is None:
-            nx1 = nx+1
+            nx1 = nx + 1
         if ny1 is None:
-            ny1 = ny+1
+            ny1 = ny + 1
 
-        x1, w1 = x0 + ox[nx]/figW, (ox[nx1] - ox[nx])/figW
-        y1, h1 = y0 + oy[ny]/figH, (oy[ny1] - oy[ny])/figH
+        x1, w1 = x0 + ox[nx] / figW, (ox[nx1] - ox[nx]) / figW
+        y1, h1 = y0 + oy[ny] / figH, (oy[ny1] - oy[ny]) / figH
 
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
 
@@ -313,9 +313,9 @@ class AxesLocator:
         self._nx, self._ny = nx - _xrefindex, ny - _yrefindex
 
         if nx1 is None:
-            nx1 = nx+1
+            nx1 = nx + 1
         if ny1 is None:
-            ny1 = ny+1
+            ny1 = ny + 1
 
         self._nx1 = nx1 - _xrefindex
         self._ny1 = ny1 - _yrefindex
@@ -380,7 +380,7 @@ class SubplotDivider(Divider):
     def get_geometry(self):
         """Get the subplot geometry, e.g., (2, 2, 3)."""
         rows, cols, num1, num2 = self.get_subplotspec().get_geometry()
-        return rows, cols, num1+1  # for compatibility
+        return rows, cols, num1 + 1  # for compatibility
 
     # COVERAGE NOTE: Never used internally or from examples
     def change_geometry(self, numrows, numcols, num):
@@ -646,33 +646,20 @@ class HBoxDivider(SubplotDivider):
     def _locate(self, x, y, w, h,
                 y_equivalent_sizes, x_appended_sizes,
                 figW, figH):
-        """
-        Parameters
-        ----------
-        x
-        y
-        w
-        h
-        y_equivalent_sizes
-        x_appended_sizes
-        figW
-        figH
-        """
-
         equivalent_sizes = y_equivalent_sizes
         appended_sizes = x_appended_sizes
 
-        max_equivalent_size = figH*h
-        total_appended_size = figW*w
+        max_equivalent_size = figH * h
+        total_appended_size = figW * w
         karray = self._determine_karray(equivalent_sizes, appended_sizes,
                                         max_equivalent_size,
                                         total_appended_size)
 
         ox = self._calc_offsets(appended_sizes, karray)
 
-        ww = (ox[-1] - ox[0])/figW
+        ww = (ox[-1] - ox[0]) / figW
         ref_h = equivalent_sizes[0]
-        hh = (karray[0]*ref_h[0] + ref_h[1])/figH
+        hh = (karray[0]*ref_h[0] + ref_h[1]) / figH
         pb = mtransforms.Bbox.from_bounds(x, y, w, h)
         pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
         pb1_anchored = pb1.anchored(self.get_anchor(), pb)
@@ -705,9 +692,9 @@ class HBoxDivider(SubplotDivider):
                                       y_equivalent_sizes, x_appended_sizes,
                                       figW, figH)
         if nx1 is None:
-            nx1 = nx+1
+            nx1 = nx + 1
 
-        x1, w1 = x0 + ox[nx]/figW, (ox[nx1] - ox[nx])/figW
+        x1, w1 = x0 + ox[nx] / figW, (ox[nx1] - ox[nx]) / figW
         y1, h1 = y0, hh
 
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
@@ -759,10 +746,10 @@ class VBoxDivider(HBoxDivider):
                                       x_equivalent_sizes, y_appended_sizes,
                                       figH, figW)
         if ny1 is None:
-            ny1 = ny+1
+            ny1 = ny + 1
 
         x1, w1 = x0, ww
-        y1, h1 = y0 + oy[ny]/figH, (oy[ny1] - oy[ny])/figH
+        y1, h1 = y0 + oy[ny] / figH, (oy[ny1] - oy[ny]) / figH
 
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
 


### PR DESCRIPTION
Plain style fixes, and getting rid of a docstring which adds no
information.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
