### PR TITLE
Remove toolkit functions deprecated in 3.1

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -71,6 +71,34 @@ Classes and methods
 
 - ``text.TextWithDash`` (use ``text.Annotation`` instead)
 
+- ``mplot3d.proj3d.line2d()`` (no replacement)
+- ``mplot3d.proj3d.line2d_dist()`` (no replacement)
+- ``mplot3d.proj3d.line2d_seg_dist()`` (no replacement)
+- ``mplot3d.proj3d.mod()`` (use `numpy.linalg.norm` instead)
+- ``mplot3d.proj3d.proj_transform_vec()`` (no replacement)
+- ``mplot3d.proj3d.proj_transform_vec_clip()`` (no replacement)
+- ``mplot3d.proj3d.vec_pad_ones()`` (no replacement)
+- ``mplot3d.proj3d.proj_trans_clip_points()`` (no replacement)
+
+- ``mplot3d.art3d.norm_angle()`` (no replacement)
+- ``mplot3d.art3d.norm_text_angle()`` (no replacement)
+- ``mplot3d.art3d.path_to_3d_segment()`` (no replacement)
+- ``mplot3d.art3d.paths_to_3d_segments()`` (no replacement)
+- ``mplot3d.art3d.path_to_3d_segment_with_codes()`` (no replacement)
+- ``mplot3d.art3d.paths_to_3d_segments_with_codes()`` (no replacement)
+- ``mplot3d.art3d.get_patch_verts()`` (no replacement)
+- ``mplot3d.art3d.get_colors()`` (no replacement)
+- ``mplot3d.art3d.zalpha()`` (no replacement)
+
+- ``mplot3d.axis3d.get_flip_min_max()`` (no replacement)
+- ``mplot3d.axis3d.Axis.get_tick_positions()`` (no replacement)
+
+- ``axisartist.axis_artist.UnimplementedException`` (no replacement)
+- ``axisartist.axislines.SimpleChainedObjects``
+  (use ``axis_grid1.mpl_axes.SimpleChainedObjects`` instead)
+- ``axisartist.axislines.Axes.AxisDict``
+  (use ``axis_grid1.mpl_axes.Axes.AxisDict`` instead)
+
 Arguments
 ~~~~~~~~~
 - ``Axes.text()`` / ``pyplot.text()`` do not support the parameter ``withdash``

--- a/doc/api/prev_api_changes/api_changes_1.2.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.2.x.rst
@@ -41,7 +41,7 @@ Changes in 1.2.x
 
 * Use of ``matplotlib.projections.projection_factory`` is now deprecated
   in favour of axes class identification using
-  :func:`~matplotlib.projections.process_projection_requirements` followed by
+  ``matplotlib.projections.process_projection_requirements`` followed by
   direct axes class invocation (at the time of writing, functions which do this
   are: :meth:`~matplotlib.figure.Figure.add_axes`,
   :meth:`~matplotlib.figure.Figure.add_subplot` and

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -824,7 +824,7 @@ required methods.
 
 This has not been used in the codebase since its addition in 2009.
 
-- `.axis3d.Axis.get_tick_positions`
+- ``axis3d.Axis.get_tick_positions``
 
   This has never been used internally, there is no equivalent method exists on
   the 2D Axis classes, and despite the similar name, it has a completely
@@ -863,7 +863,7 @@ Use the standard library's docstring manipulation tools instead, such as
 These are considered internal and will be removed from the public API in a
 future version.
 
-- `.projections.process_projection_requirements`
+- ``projections.process_projection_requirements``
 
 - ``backend_ps.PsBackendHelper``
 - ``backend_ps.ps_backend_helper``,
@@ -883,26 +883,26 @@ of `.mpl_toolkits.mplot3d` are deprecated,
 
 **mpl_toolkits.mplot3d.art3d**
 
-- :func:`mpl_toolkits.mplot3d.art3d.norm_angle`
-- :func:`mpl_toolkits.mplot3d.art3d.norm_text_angle`
-- :func:`mpl_toolkits.mplot3d.art3d.path_to_3d_segment`
-- :func:`mpl_toolkits.mplot3d.art3d.paths_to_3d_segments`
-- :func:`mpl_toolkits.mplot3d.art3d.path_to_3d_segment_with_codes`
-- :func:`mpl_toolkits.mplot3d.art3d.paths_to_3d_segments_with_codes`
-- :func:`mpl_toolkits.mplot3d.art3d.get_patch_verts`
-- :func:`mpl_toolkits.mplot3d.art3d.get_colors`
-- :func:`mpl_toolkits.mplot3d.art3d.zalpha`
+- ``mpl_toolkits.mplot3d.art3d.norm_angle``
+- ``mpl_toolkits.mplot3d.art3d.norm_text_angle``
+- ``mpl_toolkits.mplot3d.art3d.path_to_3d_segment``
+- ``mpl_toolkits.mplot3d.art3d.paths_to_3d_segments``
+- ``mpl_toolkits.mplot3d.art3d.path_to_3d_segment_with_codes``
+- ``mpl_toolkits.mplot3d.art3d.paths_to_3d_segments_with_codes``
+- ``mpl_toolkits.mplot3d.art3d.get_patch_verts``
+- ``mpl_toolkits.mplot3d.art3d.get_colors``
+- ``mpl_toolkits.mplot3d.art3d.zalpha``
 
 **mpl_toolkits.mplot3d.proj3d**
 
-- :func:`mpl_toolkits.mplot3d.proj3d.line2d`
-- :func:`mpl_toolkits.mplot3d.proj3d.line2d_dist`
-- :func:`mpl_toolkits.mplot3d.proj3d.line2d_seg_dist`
-- :func:`mpl_toolkits.mplot3d.proj3d.mod`
-- :func:`mpl_toolkits.mplot3d.proj3d.proj_transform_vec`
-- :func:`mpl_toolkits.mplot3d.proj3d.proj_transform_vec_clip`
-- :func:`mpl_toolkits.mplot3d.proj3d.vec_pad_ones`
-- :func:`mpl_toolkits.mplot3d.proj3d.proj_trans_clip_points`
+- ``mpl_toolkits.mplot3d.proj3d.line2d``
+- ``mpl_toolkits.mplot3d.proj3d.line2d_dist``
+- ``mpl_toolkits.mplot3d.proj3d.line2d_seg_dist``
+- ``mpl_toolkits.mplot3d.proj3d.mod``
+- ``mpl_toolkits.mplot3d.proj3d.proj_transform_vec``
+- ``mpl_toolkits.mplot3d.proj3d.proj_transform_vec_clip``
+- ``mpl_toolkits.mplot3d.proj3d.vec_pad_ones``
+- ``mpl_toolkits.mplot3d.proj3d.proj_trans_clip_points``
 
 If your project relies on these functions, consider vendoring them.
 
@@ -944,7 +944,7 @@ instead.
 Testing
 ~~~~~~~
 
-- `matplotlib.testing.decorators.switch_backend` decorator
+- ``matplotlib.testing.decorators.switch_backend`` decorator
 
 Test functions should use `pytest.mark.backend(...)`, and the mark will be
 picked up by the `matplotlib.testing.conftest.mpl_test_settings` fixture.
@@ -971,7 +971,7 @@ GUI / backend details
   This is unused and only relevant to the now removed wx "idling" code (note that
   as it is a module-level global, no deprecation warning is emitted when
   accessing it).
-- `.mlab.demean`
+- ``mlab.demean``
 - ``backend_gtk3cairo.FigureCanvasGTK3Cairo``,
 - ``backend_wx.debug_on_error``, ``backend_wx.fake_stderr``,
   ``backend_wx.raise_msg_to_str``, ``backend_wx.MenuButtonWx``,
@@ -1015,7 +1015,7 @@ formatter classes.
 Path tools
 ~~~~~~~~~~
 
-- `.path.get_paths_extents`
+- ``path.get_paths_extents``
 
 Use `~.path.get_path_collection_extents` instead.
 
@@ -1031,9 +1031,9 @@ Text
 ~~~~
 
 - ``text.TextWithDash``
-- `.Text.is_math_text`
-- `.TextPath.is_math_text`
-- `.TextPath.text_get_vertices_codes` (As an alternative, construct a new ``TextPath`` object.)
+- ``Text.is_math_text``
+- ``TextPath.is_math_text``
+- ``TextPath.text_get_vertices_codes`` (As an alternative, construct a new ``TextPath`` object.)
 
 Unused attributes
 ~~~~~~~~~~~~~~~~~

--- a/doc/api/toolkits/mplot3d.rst
+++ b/doc/api/toolkits/mplot3d.rst
@@ -79,25 +79,16 @@ Art3D Utility Functions
    :toctree: ../_as_gen
    :template: autosummary.rst
 
-   art3d.get_colors
    art3d.get_dir_vector
-   art3d.get_patch_verts
    art3d.juggle_axes
    art3d.line_2d_to_3d
    art3d.line_collection_2d_to_3d
-   art3d.norm_angle
-   art3d.norm_text_angle
    art3d.patch_2d_to_3d
    art3d.patch_collection_2d_to_3d
-   art3d.path_to_3d_segment
-   art3d.path_to_3d_segment_with_codes
    art3d.pathpatch_2d_to_3d
-   art3d.paths_to_3d_segments
-   art3d.paths_to_3d_segments_with_codes
    art3d.poly_collection_2d_to_3d
    art3d.rotate_axes
    art3d.text_2d_to_3d
-   art3d.zalpha
 
 .. _toolkit_mplot3d-projapi:
 
@@ -109,20 +100,12 @@ Art3D Utility Functions
    :template: autosummary.rst
 
    proj3d.inv_transform
-   proj3d.line2d
-   proj3d.line2d_dist
-   proj3d.line2d_seg_dist
-   proj3d.mod
    proj3d.persp_transformation
    proj3d.proj_points
-   proj3d.proj_trans_clip_points
    proj3d.proj_trans_points
    proj3d.proj_transform
    proj3d.proj_transform_clip
-   proj3d.proj_transform_vec
-   proj3d.proj_transform_vec_clip
    proj3d.rot_x
    proj3d.transform
-   proj3d.vec_pad_ones
    proj3d.view_transformation
    proj3d.world_transformation

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -157,11 +157,6 @@ class BezierPath(Line2D):
         renderer.close_group('line2d')
 
 
-@cbook.deprecated("3.1")
-class UnimplementedException(Exception):
-    pass
-
-
 class AttributeCopier:
     @cbook.deprecated("3.2")
     def __init__(self, ref_artist, klass=Artist):

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -452,42 +452,10 @@ class GridHelperRectlinear(GridHelperBase):
         return gridlines
 
 
-@cbook.deprecated("3.1")
-class SimpleChainedObjects:
-    def __init__(self, objects):
-        self._objects = objects
-
-    def __getattr__(self, k):
-        _a = SimpleChainedObjects([getattr(a, k) for a in self._objects])
-        return _a
-
-    def __call__(self, *args, **kwargs):
-        for m in self._objects:
-            m(*args, **kwargs)
-
-
 class Axes(maxes.Axes):
 
-    @cbook.deprecated("3.1")
-    class AxisDict(dict):
-        def __init__(self, axes):
-            self.axes = axes
-            super().__init__()
-
-        def __getitem__(self, k):
-            if isinstance(k, tuple):
-                return SimpleChainedObjects(
-                    [dict.__getitem__(self, k1) for k1 in k])
-            elif isinstance(k, slice):
-                if k == slice(None):
-                    return SimpleChainedObjects(list(self.values()))
-                else:
-                    raise ValueError("Unsupported slice")
-            else:
-                return dict.__getitem__(self, k)
-
-        def __call__(self, *args, **kwargs):
-            return maxes.Axes.axis(self.axes, *args, **kwargs)
+    def __call__(self, *args, **kwargs):
+        return maxes.Axes.axis(self.axes, *args, **kwargs)
 
     def __init__(self, *args, grid_helper=None, **kwargs):
         self._axisline_on = True

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -28,24 +28,12 @@ def _norm_angle(a):
     return a
 
 
-@cbook.deprecated("3.1")
-def norm_angle(a):
-    """Return the given angle normalized to -180 < *a* <= 180 degrees."""
-    return _norm_angle(a)
-
-
 def _norm_text_angle(a):
     """Return the given angle normalized to -90 < *a* <= 90 degrees."""
     a = (a + 180) % 180
     if a > 90:
         a = a - 180
     return a
-
-
-@cbook.deprecated("3.1")
-def norm_text_angle(a):
-    """Return the given angle normalized to -90 < *a* <= 90 degrees."""
-    return _norm_text_angle(a)
 
 
 def get_dir_vector(zdir):
@@ -222,12 +210,6 @@ def _path_to_3d_segment(path, zs=0, zdir='z'):
     return seg3d
 
 
-@cbook.deprecated("3.1")
-def path_to_3d_segment(path, zs=0, zdir='z'):
-    """Convert a path to a 3D segment."""
-    return _path_to_3d_segment(path, zs=zs, zdir=zdir)
-
-
 def _paths_to_3d_segments(paths, zs=0, zdir='z'):
     """Convert paths from a collection object to 3D segments."""
 
@@ -235,12 +217,6 @@ def _paths_to_3d_segments(paths, zs=0, zdir='z'):
     segs = [_path_to_3d_segment(path, pathz, zdir)
             for path, pathz in zip(paths, zs)]
     return segs
-
-
-@cbook.deprecated("3.1")
-def paths_to_3d_segments(paths, zs=0, zdir='z'):
-    """Convert paths from a collection object to 3D segments."""
-    return _paths_to_3d_segments(paths, zs=zs, zdir=zdir)
 
 
 def _path_to_3d_segment_with_codes(path, zs=0, zdir='z'):
@@ -258,12 +234,6 @@ def _path_to_3d_segment_with_codes(path, zs=0, zdir='z'):
     return seg3d, list(codes)
 
 
-@cbook.deprecated("3.1")
-def path_to_3d_segment_with_codes(path, zs=0, zdir='z'):
-    """Convert a path to a 3D segment with path codes."""
-    return _path_to_3d_segment_with_codes(path, zs=zs, zdir=zdir)
-
-
 def _paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
     """
     Convert paths from a collection object to 3D segments with path codes.
@@ -277,14 +247,6 @@ def _paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
     else:
         segments, codes = [], []
     return list(segments), list(codes)
-
-
-@cbook.deprecated("3.1")
-def paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
-    """
-    Convert paths from a collection object to 3D segments with path codes.
-    """
-    return _paths_to_3d_segments_with_codes(paths, zs=zs, zdir=zdir)
 
 
 class Line3DCollection(LineCollection):
@@ -397,12 +359,6 @@ def _get_patch_verts(patch):
         return polygons[0]
     else:
         return []
-
-
-@cbook.deprecated("3.1")
-def get_patch_verts(patch):
-    """Return a list of vertices for the path of a patch."""
-    return _get_patch_verts(patch)
 
 
 def patch_2d_to_3d(patch, z=0, zdir='z'):
@@ -806,12 +762,6 @@ def _get_colors(c, num):
         (num, 4))
 
 
-@cbook.deprecated("3.1")
-def get_colors(c, num):
-    """Stretch the color argument to provide the required number *num*."""
-    return _get_colors(c, num)
-
-
 def _zalpha(colors, zs):
     """Modify the alphas of the color list according to depth."""
     # FIXME: This only works well if the points for *zs* are well-spaced
@@ -824,9 +774,3 @@ def _zalpha(colors, zs):
     sats = 1 - norm(zs) * 0.7
     rgba = np.broadcast_to(mcolors.to_rgba_array(colors), (len(zs), 4))
     return np.column_stack([rgba[:, :3], rgba[:, 3] * sats])
-
-
-@cbook.deprecated("3.1")
-def zalpha(colors, zs):
-    """Modify the alphas of the color list according to depth."""
-    return _zalpha(colors, zs)

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -5,17 +5,8 @@
 import numpy as np
 
 from matplotlib import (
-    artist, cbook, lines as mlines, axis as maxis, patches as mpatches,
-    rcParams)
+    artist, lines as mlines, axis as maxis, patches as mpatches, rcParams)
 from . import art3d, proj3d
-
-
-@cbook.deprecated("3.1")
-def get_flip_min_max(coord, index, mins, maxs):
-    if coord[index] == mins[index]:
-        return maxs[index]
-    else:
-        return mins[index]
 
 
 def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
@@ -125,12 +116,6 @@ class Axis(maxis.XAxis):
         # Need to be able to place the label at the correct location
         self.label._transform = self.axes.transData
         self.offsetText._transform = self.axes.transData
-
-    @cbook.deprecated("3.1")
-    def get_tick_positions(self):
-        majorLocs = self.major.locator()
-        majorLabels = self.major.formatter.format_ticks(majorLocs)
-        return majorLabels, majorLocs
 
     def get_major_ticks(self, numticks=None):
         ticks = maxis.XAxis.get_major_ticks(self, numticks)

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -5,43 +5,6 @@ Various transforms used for by the 3D code
 import numpy as np
 import numpy.linalg as linalg
 
-from matplotlib import cbook
-
-
-@cbook.deprecated("3.1")
-def line2d(p0, p1):
-    """
-    Return 2D equation of line in the form ax+by+c = 0
-    """
-    # x + x1  = 0
-    x0, y0 = p0[:2]
-    x1, y1 = p1[:2]
-    #
-    if x0 == x1:
-        a = -1
-        b = 0
-        c = x1
-    elif y0 == y1:
-        a = 0
-        b = 1
-        c = -y1
-    else:
-        a = y0 - y1
-        b = x0 - x1
-        c = x0*y1 - x1*y0
-    return a, b, c
-
-
-@cbook.deprecated("3.1")
-def line2d_dist(l, p):
-    """
-    Distance from line to point
-    line is a tuple of coefficients a, b, c
-    """
-    a, b, c = l
-    x0, y0 = p
-    return abs((a*x0 + b*y0 + c) / np.hypot(a, b))
-
 
 def _line2d_seg_dist(p1, p2, p0):
     """distance(s) from line defined by p1 - p2 to point(s) p0
@@ -63,25 +26,6 @@ def _line2d_seg_dist(p1, p2, p0):
     d = np.hypot(x01 - u*x21, y01 - u*y21)
 
     return d
-
-
-@cbook.deprecated("3.1")
-def line2d_seg_dist(p1, p2, p0):
-    """distance(s) from line defined by p1 - p2 to point(s) p0
-
-    p0[0] = x(s)
-    p0[1] = y(s)
-
-    intersection point p = p1 + u*(p2-p1)
-    and intersection point lies within segment if u is between 0 and 1
-    """
-    return _line2d_seg_dist(p1, p2, p0)
-
-
-@cbook.deprecated("3.1", alternative="np.linalg.norm")
-def mod(v):
-    """3d vector length"""
-    return np.sqrt(v[0]**2+v[1]**2+v[2]**2)
 
 
 def world_transformation(xmin, xmax,
@@ -153,11 +97,6 @@ def _proj_transform_vec(vec, M):
     return txs, tys, tzs
 
 
-@cbook.deprecated("3.1")
-def proj_transform_vec(vec, M):
-    return _proj_transform_vec(vec, M)
-
-
 def _proj_transform_vec_clip(vec, M):
     vecw = np.dot(M, vec)
     w = vecw[3]
@@ -167,11 +106,6 @@ def _proj_transform_vec_clip(vec, M):
     if np.any(tis):
         tis = vecw[1] < 1
     return txs, tys, tzs, tis
-
-
-@cbook.deprecated("3.1")
-def proj_transform_vec_clip(vec, M):
-    return _proj_transform_vec_clip(vec, M)
 
 
 def inv_transform(xs, ys, zs, M):
@@ -187,11 +121,6 @@ def inv_transform(xs, ys, zs, M):
 
 def _vec_pad_ones(xs, ys, zs):
     return np.array([xs, ys, zs, np.ones_like(xs)])
-
-
-@cbook.deprecated("3.1")
-def vec_pad_ones(xs, ys, zs):
-    return _vec_pad_ones(xs, ys, zs)
 
 
 def proj_transform(xs, ys, zs, M):
@@ -222,12 +151,6 @@ def proj_points(points, M):
 def proj_trans_points(points, M):
     xs, ys, zs = zip(*points)
     return proj_transform(xs, ys, zs, M)
-
-
-@cbook.deprecated("3.1")
-def proj_trans_clip_points(points, M):
-    xs, ys, zs = zip(*points)
-    return proj_transform_clip(xs, ys, zs, M)
 
 
 def rot_x(V, alpha):

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -3,10 +3,8 @@ import pytest
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 import matplotlib as mpl
 from matplotlib import cm
-from matplotlib import path as mpath
 from matplotlib import colors as mcolors
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
-from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
 from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Circle
 import matplotlib.pyplot as plt
@@ -866,61 +864,6 @@ def test_inverted_cla():
     assert not ax.xaxis_inverted()
     assert not ax.yaxis_inverted()
     assert not ax.zaxis_inverted()
-
-
-def test_art3d_deprecated():
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.norm_angle(0.0)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.norm_text_angle(0.0)
-
-    path = mpath.Path(np.empty((0, 2)))
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.path_to_3d_segment(path)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.paths_to_3d_segments([path])
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.path_to_3d_segment_with_codes(path)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.paths_to_3d_segments_with_codes([path])
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.get_colors([], 1)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        art3d.zalpha([], [])
-
-
-def test_proj3d_deprecated():
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.line2d([0, 1], [0, 1])
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.line2d_dist([0, 1, 3], [0, 1])
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.mod([1, 1, 1])
-
-    vec = np.arange(4)
-    M = np.ones((4, 4))
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.proj_transform_vec(vec, M)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.proj_transform_vec_clip(vec, M)
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.vec_pad_ones(np.ones(3), np.ones(3), np.ones(3))
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        proj3d.proj_trans_clip_points(np.ones((4, 3)), M)
 
 
 def test_ax3d_tickcolour():


### PR DESCRIPTION
## PR Summary

This pulls out parts of #15890 to make that PR more managable and easier to debug the test failures.

