### PR TITLE
De-deprecate *min/*max parameters to set_x/y/zlim()

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -67,3 +67,9 @@ This attribute is unused and deprecated.
 ``widgets.TextBox.params_to_disable``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This attribute is deprecated.
+
+Revert deprecation \*min, \*max keyword arguments to ``set_x/y/zlim_3d()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These keyword arguments  were deprecated in 3.0, alongside with the respective
+parameters in ``set_xlim()`` / ``set_ylim()``. The deprecations of the 2D
+versions were already reverted in in 3.1.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -578,14 +578,10 @@ class Axes3D(Axes):
         if right is None and np.iterable(left):
             left, right = left
         if xmin is not None:
-            cbook.warn_deprecated('3.0', name='`xmin`',
-                                  alternative='`left`', obj_type='argument')
             if left is not None:
                 raise TypeError('Cannot pass both `xmin` and `left`')
             left = xmin
         if xmax is not None:
-            cbook.warn_deprecated('3.0', name='`xmax`',
-                                  alternative='`right`', obj_type='argument')
             if right is not None:
                 raise TypeError('Cannot pass both `xmax` and `right`')
             right = xmax
@@ -636,14 +632,10 @@ class Axes3D(Axes):
         if top is None and np.iterable(bottom):
             bottom, top = bottom
         if ymin is not None:
-            cbook.warn_deprecated('3.0', name='`ymin`',
-                                  alternative='`bottom`', obj_type='argument')
             if bottom is not None:
                 raise TypeError('Cannot pass both `ymin` and `bottom`')
             bottom = ymin
         if ymax is not None:
-            cbook.warn_deprecated('3.0', name='`ymax`',
-                                  alternative='`top`', obj_type='argument')
             if top is not None:
                 raise TypeError('Cannot pass both `ymax` and `top`')
             top = ymax
@@ -695,14 +687,10 @@ class Axes3D(Axes):
         if top is None and np.iterable(bottom):
             bottom, top = bottom
         if zmin is not None:
-            cbook.warn_deprecated('3.0', name='`zmin`',
-                                  alternative='`bottom`', obj_type='argument')
             if bottom is not None:
                 raise TypeError('Cannot pass both `zmin` and `bottom`')
             bottom = zmin
         if zmax is not None:
-            cbook.warn_deprecated('3.0', name='`zmax`',
-                                  alternative='`top`', obj_type='argument')
             if top is not None:
                 raise TypeError('Cannot pass both `zmax` and `top`')
             top = zmax


### PR DESCRIPTION
## PR Summary

The 2D versions were de-deprecated in #13425. This de-deprecates the 3D versions.
