### PR TITLE
Remove parameters deprecated in 3.1

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -75,3 +75,15 @@ Arguments
 ~~~~~~~~~
 - ``Axes.text()`` / ``pyplot.text()`` do not support the parameter ``withdash``
   anymore. Use ``Axes.annotate()`` and ``pyplot.annotate()`` instead.
+- The first parameter of `matplotlib.use` has been renamed from ``arg`` to
+  ``backend`` (only relevant if you pass by keyword).
+- The parameter ``warn`` of `matplotlib.use` has been removed. A failure to
+  switch the backend will now always raise an ``ImportError`` if ``force`` is
+  set; catch that error if necessary.
+- All parameters of `matplotlib.use` except the first one are now keyword-only.
+- The unused parameters ``shape`` and ``imlim`` of `~.axes.Axes.imshow()` are
+  now removed. All parameters beyond ``extent`` are now keyword-only.
+- The unused parameter ``interp_at_native`` of `.BboxImage` has been removed.
+- The parameter ``usetex`` of `.TextToPath.get_text_path` has been removed.
+  Use ``ismath='TeX'`` instead.
+- The parameter ``block`` of ``show()`` is now keyword-only.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1098,9 +1098,7 @@ class rc_context:
         self.__fallback()
 
 
-@cbook._rename_parameter("3.1", "arg", "backend")
-@cbook._delete_parameter("3.1", "warn")
-def use(backend, warn=False, force=True):
+def use(backend, *, force=True):
     """
     Select the backend used for rendering and GUI integration.
 
@@ -1119,10 +1117,6 @@ def use(backend, warn=False, force=True):
           agg, cairo, pdf, pgf, ps, svg, template
 
         or a string of the form: ``module://my.module.name``.
-
-    warn : bool, default: False
-        If True and not *force*, emit a warning if a failure-to-switch
-        `ImportError` has been suppressed.  This parameter is deprecated.
 
     force : bool, default: True
         If True (the default), raise an `ImportError` if the backend cannot be
@@ -1148,12 +1142,9 @@ def use(backend, warn=False, force=True):
         try:
             from matplotlib import pyplot as plt
             plt.switch_backend(name)
-        except ImportError as exc:
+        except ImportError:
             if force:
                 raise
-            if warn:
-                cbook._warn_external(
-                    f"Failed to switch backend to {backend}: {exc}")
 
 
 if os.environ.get('MPLBACKEND'):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5392,12 +5392,10 @@ default: :rc:`scatter.edgecolors`
 
     #### plotting z(x, y): imshow, pcolor and relatives, contour
     @_preprocess_data()
-    @cbook._delete_parameter("3.1", "shape")
-    @cbook._delete_parameter("3.1", "imlim")
     def imshow(self, X, cmap=None, norm=None, aspect=None,
                interpolation=None, alpha=None, vmin=None, vmax=None,
-               origin=None, extent=None, shape=None, filternorm=True,
-               filterrad=4.0, imlim=None, resample=None, url=None, **kwargs):
+               origin=None, extent=None, *, filternorm=True, filterrad=4.0,
+               resample=None, url=None, **kwargs):
         """
         Display data as an image; i.e. on a 2D regular raster.
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3338,8 +3338,7 @@ class _Backend:
                 cls.trigger_manager_draw(manager)
 
     @classmethod
-    @cbook._make_keyword_only("3.1", "block")
-    def show(cls, block=None):
+    def show(cls, *, block=None):
         """
         Show all figures.
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1323,7 +1323,6 @@ class FigureImage(_ImageBase):
 class BboxImage(_ImageBase):
     """The Image class whose size is determined by the given bbox."""
 
-    @cbook._delete_parameter("3.1", "interp_at_native")
     def __init__(self, bbox,
                  cmap=None,
                  norm=None,
@@ -1332,7 +1331,6 @@ class BboxImage(_ImageBase):
                  filternorm=True,
                  filterrad=4.0,
                  resample=False,
-                 interp_at_native=True,
                  **kwargs
                  ):
         """
@@ -1354,7 +1352,6 @@ class BboxImage(_ImageBase):
         )
 
         self.bbox = bbox
-        self._interp_at_native = interp_at_native
         self._transform = IdentityTransform()
 
     def get_transform(self):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2447,18 +2447,16 @@ def hlines(
 @docstring.copy(Axes.imshow)
 def imshow(
         X, cmap=None, norm=None, aspect=None, interpolation=None,
-        alpha=None, vmin=None, vmax=None, origin=None, extent=None,
-        shape=cbook.deprecation._deprecated_parameter,
-        filternorm=True, filterrad=4.0,
-        imlim=cbook.deprecation._deprecated_parameter, resample=None,
-        url=None, *, data=None, **kwargs):
+        alpha=None, vmin=None, vmax=None, origin=None, extent=None, *,
+        filternorm=True, filterrad=4.0, resample=None, url=None,
+        data=None, **kwargs):
     __ret = gca().imshow(
         X, cmap=cmap, norm=norm, aspect=aspect,
         interpolation=interpolation, alpha=alpha, vmin=vmin,
-        vmax=vmax, origin=origin, extent=extent, shape=shape,
-        filternorm=filternorm, filterrad=filterrad, imlim=imlim,
-        resample=resample, url=url, **({"data": data} if data is not
-        None else {}), **kwargs)
+        vmax=vmax, origin=origin, extent=extent,
+        filternorm=filternorm, filterrad=filterrad, resample=resample,
+        url=url, **({"data": data} if data is not None else {}),
+        **kwargs)
     sci(__ret)
     return __ret
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -15,7 +15,6 @@ from PIL import Image
 
 from matplotlib import (
     colors, image as mimage, patches, pyplot as plt, style, rcParams)
-from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
@@ -1103,20 +1102,6 @@ def test_relim():
     ax.relim()
     ax.autoscale()
     assert ax.get_xlim() == ax.get_ylim() == (0, 1)
-
-
-def test_deprecation():
-    data = [[1, 2], [3, 4]]
-    ax = plt.figure().subplots()
-    for obj in [ax, plt]:
-        with pytest.warns(None) as record:
-            obj.imshow(data)
-            assert len(record) == 0
-        with pytest.warns(MatplotlibDeprecationWarning):
-            obj.imshow(data, shape=None)
-        with pytest.warns(MatplotlibDeprecationWarning):
-            # Enough arguments to pass "shape" positionally.
-            obj.imshow(data, *[None] * 10)
 
 
 def test_respects_bbox():

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -89,8 +89,7 @@ class TextToPath:
         d /= 64.0
         return w * scale, h * scale, d * scale
 
-    @cbook._delete_parameter("3.1", "usetex")
-    def get_text_path(self, prop, s, ismath=False, usetex=False):
+    def get_text_path(self, prop, s, ismath=False):
         """
         Convert text *s* to path (a tuple of vertices and codes for
         matplotlib.path.Path).
@@ -105,9 +104,6 @@ class TextToPath:
 
         ismath : {False, True, "TeX"}
             If True, use mathtext parser.  If "TeX", use tex for renderering.
-
-        usetex : bool, optional
-            If set, forces *ismath* to True.  This parameter is deprecated.
 
         Returns
         -------
@@ -130,8 +126,6 @@ class TextToPath:
 
         Also see `TextPath` for a more direct way to create a path from a text.
         """
-        if usetex:
-            ismath = "TeX"
         if ismath == "TeX":
             glyph_info, glyph_map, rects = self.get_glyphs_tex(prop, s)
         elif not ismath:


### PR DESCRIPTION
## PR Summary

I've additionally made all parameters after a deleted parameter keyword only. Since the position of these parameters changes, there's user action required anyway should the following parameters be passed positionally. It's even a safety check because `use('pyqt5', True)` would otherwise be valid before and after the change but `True` would change from referfing to `warn` to referring to `force`.