### PR TITLE
relax two test tolerances on x86_64

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -168,7 +168,7 @@ def test_pathclip():
 @needs_xelatex
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_mixedmode.pdf'], style='default',
-                  tol={'aarch64': 1.086}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 1.086, 'x86_64': 1.086}.get(platform.machine(), 0.0))
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -168,7 +168,9 @@ def test_pathclip():
 @needs_xelatex
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_mixedmode.pdf'], style='default',
-                  tol={'aarch64': 1.086, 'x86_64': 1.086}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 1.086, 'x86_64': 1.086}.get(
+                      platform.machine(), 0.0
+                      ))
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -12,7 +12,9 @@ if not mpl.checkdep_usetex(True):
 
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
-                  tol={'aarch64': 2.868, 'x86_64': 2.868}.get(platform.machine(), 0.3))
+                  tol={'aarch64': 2.868, 'x86_64': 2.868}.get(
+                      platform.machine(), 0.3
+                      ))
 def test_usetex():
     mpl.rcParams['text.usetex'] = True
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -12,7 +12,7 @@ if not mpl.checkdep_usetex(True):
 
 @image_comparison(baseline_images=['test_usetex'],
                   extensions=['pdf', 'png'],
-                  tol={'aarch64': 2.868}.get(platform.machine(), 0.3))
+                  tol={'aarch64': 2.868, 'x86_64': 2.868}.get(platform.machine(), 0.3))
 def test_usetex():
     mpl.rcParams['text.usetex'] = True
     fig = plt.figure()


### PR DESCRIPTION
When running the tests locally on `x86_64`, I had to relax two tolerances to the same value as `aarch64`.

This is on Ubuntu 20.04, so perhaps the reason why no one else has run into this before is an upgraded version in the dependency stack.