### PR TITLE
prevent needless float() conversion

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -152,20 +152,7 @@ class Line3D(lines.Line2D):
     def set_3d_properties(self, zs=0, zdir='z'):
         xs = self.get_xdata()
         ys = self.get_ydata()
-
-        try:
-            len_zs = len(zs)
-        except TypeError:  # object of type 'int' has no len()
-            zs = np.full(xs.shape, fill_value=zs)
-        else:
-            len_xs = len(xs)
-            if len_zs != len_xs:
-                raise ValueError(
-                    "zs has wrong length (len(zs) = {} != {} = len(xs)).".format(
-                        len_zs, len_xs
-                    )
-                )
-
+        zs = np.broadcast_to(zs, xs.shape)
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -154,11 +154,18 @@ class Line3D(lines.Line2D):
         ys = self.get_ydata()
 
         try:
-            # If *zs* is a list or array, then this will fail and
-            # just proceed to juggle_axes().
-            zs = np.full_like(xs, fill_value=float(zs))
-        except TypeError:
-            pass
+            len_zs = len(zs)
+        except TypeError:  # object of type 'int' has no len()
+            zs = np.full_like(xs, fill_value=zs)
+        else:
+            len_xs = len(xs)
+            if len_zs != len_xs:
+                raise ValueError(
+                    "zs has wrong length (len(zs) = {} != {} = len(xs)).".format(
+                        len_zs, len_xs
+                    )
+                )
+
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -156,7 +156,7 @@ class Line3D(lines.Line2D):
         try:
             len_zs = len(zs)
         except TypeError:  # object of type 'int' has no len()
-            zs = np.full_like(xs, fill_value=zs)
+            zs = np.full(xs.shape, fill_value=zs)
         else:
             len_xs = len(xs)
             if len_zs != len_xs:


### PR DESCRIPTION
In numpy, we're preparing the deprecation of `float(array)` conversions where `array` was allowed to be an array of size 1 (e.g., `numpy.array([[[[[[1]]]]])`), https://github.com/numpy/numpy/pull/10615. matplotlib only needs one change to test without warning. The change also prevents the needless conversion to a float array where int is possible and catches other illegal uses (e.g., passing an array of wrong length for `zs`).