### PR TITLE
Ignore pos in StrCategoryFormatter.__call__ to display correct label in the preview window 

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -138,7 +138,12 @@ class StrCategoryFormatter(ticker.Formatter):
         self._units = units_mapping
 
     def __call__(self, x, pos=None):
-        return '' if pos is None else self.format_ticks([x])[0]
+        """
+        Return the category label string for tick val *x*.
+
+        The position *pos* is ignored.
+        """
+        return self.format_ticks([x])[0]
 
     def format_ticks(self, values):
         r_mapping = {v: self._text(k) for k, v in self._units.items()}

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -154,6 +154,7 @@ class TestStrCategoryFormatter:
         labels = cat.StrCategoryFormatter(unit._mapping)
         for i, d in enumerate(ydata):
             assert labels(i, i) == d
+            assert labels(i, None) == d
 
     @pytest.mark.parametrize("ydata", cases, ids=ids)
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -160,9 +160,8 @@ class TestStrCategoryFormatter:
     def test_StrCategoryFormatterPlot(self, ax, ydata, plotter):
         plotter(ax, range(len(ydata)), ydata)
         for i, d in enumerate(ydata):
-            assert ax.yaxis.major.formatter(i, i) == d
-        assert ax.yaxis.major.formatter(i+1, i+1) == ""
-        assert ax.yaxis.major.formatter(0, None) == ""
+            assert ax.yaxis.major.formatter(i) == d
+        assert ax.yaxis.major.formatter(i+1) == ""
 
 
 def axis_test(axis, labels):


### PR DESCRIPTION
Fixes #14881 

The position *pos* in `__call__` can be ignored as the tick label is independent of position. So, `__call__(value, None)` would return a category label even if *pos* is `None`, which is the expected behavior.

The test case has been modified to pass only a single argument (so *pos* defaults to `None`).