### PR TITLE
Fix search on nested pages

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -51,7 +51,7 @@
             <li><a href="{{ pathto('tutorials/index') }}">Tutorials</a></li>
             <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
             <li class="nav-right">
-                <form class="search" action="search.html" method="get">
+                <form class="search" action="{{ pathto('search') }}" method="get">
                 <input type="text" name="q" aria-labelledby="searchlabel" placeholder="Search"/>
                 </form>
             </li>


### PR DESCRIPTION
## PR Summary

Fixes a regression from #15859. Search got a 404 error on pages that were not on the same directory level as `search.html` (e.g. https://matplotlib.org/devdocs/api/_as_gen/matplotlib.gridspec.GridSpec.html).

Hard-coding `search.html` was a copy-paste error. This fix uses the same solution as the original sphinx search box (https://github.com/sphinx-doc/sphinx/blob/d82e7c12a177a6a547ba1e72540f079f64590f8a/sphinx/themes/basic/searchbox.html#L14).
