### PR TITLE
Replace axes_size.Fraction by multiplication.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -497,12 +497,12 @@ class ImageGrid(Grid):
         if (self._colorbar_mode == "single" and
              self._colorbar_location in ('left', 'bottom')):
             if self._colorbar_location == "left":
-                sz = Size.Fraction(self._nrows, Size.AxesX(self.axes_llc))
+                sz = self._nrows * Size.AxesX(self.axes_llc)
                 h.append(Size.from_any(self._colorbar_size, sz))
                 h.append(Size.from_any(self._colorbar_pad, sz))
                 locator = self._divider.new_locator(nx=0, ny=0, ny1=-1)
             elif self._colorbar_location == "bottom":
-                sz = Size.Fraction(self._ncols, Size.AxesY(self.axes_llc))
+                sz = self._ncols * Size.AxesY(self.axes_llc)
                 v.append(Size.from_any(self._colorbar_size, sz))
                 v.append(Size.from_any(self._colorbar_pad, sz))
                 locator = self._divider.new_locator(nx=0, nx1=-1, ny=0)
@@ -602,12 +602,12 @@ class ImageGrid(Grid):
 
         if self._colorbar_mode == "single":
             if self._colorbar_location == "right":
-                sz = Size.Fraction(self._nrows, Size.AxesX(self.axes_llc))
+                sz = self._nrows * Size.AxesX(self.axes_llc)
                 h.append(Size.from_any(self._colorbar_pad, sz))
                 h.append(Size.from_any(self._colorbar_size, sz))
                 locator = self._divider.new_locator(nx=-2, ny=0, ny1=-1)
             elif self._colorbar_location == "top":
-                sz = Size.Fraction(self._ncols, Size.AxesY(self.axes_llc))
+                sz = self._ncols * Size.AxesY(self.axes_llc)
                 v.append(Size.from_any(self._colorbar_pad, sz))
                 v.append(Size.from_any(self._colorbar_size, sz))
                 locator = self._divider.new_locator(nx=0, nx1=-1, ny=-2)

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -14,10 +14,10 @@ def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True):
 
     divider = make_axes_locatable(ax)
 
-    pad_size = Size.Fraction(pad, Size.AxesY(ax))
+    pad_size = pad * Size.AxesY(ax)
 
-    xsize = Size.Fraction((1.-2.*pad)/3., Size.AxesX(ax))
-    ysize = Size.Fraction((1.-2.*pad)/3., Size.AxesY(ax))
+    xsize = ((1-2*pad)/3) * Size.AxesX(ax)
+    ysize = ((1-2*pad)/3) * Size.AxesY(ax)
 
     divider.set_horizontal([Size.AxesX(ax), pad_size, xsize])
     divider.set_vertical([ysize, pad_size, ysize, pad_size, ysize])
@@ -125,10 +125,10 @@ class RGBAxesBase:
 
         divider = make_axes_locatable(ax)
 
-        pad_size = Size.Fraction(pad, Size.AxesY(ax))
+        pad_size = pad * Size.AxesY(ax)
 
-        xsize = Size.Fraction((1.-2.*pad)/3., Size.AxesX(ax))
-        ysize = Size.Fraction((1.-2.*pad)/3., Size.AxesY(ax))
+        xsize = ((1-2*pad)/3) * Size.AxesX(ax)
+        ysize = ((1-2*pad)/3) * Size.AxesY(ax)
 
         divider.set_horizontal([Size.AxesX(ax), pad_size, xsize])
         divider.set_vertical([ysize, pad_size, ysize, pad_size, ysize])


### PR DESCRIPTION
axes_size defines `__rmul__` exactly for this purpose, and `*` seems
clearer to read.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
