### PR TITLE
Normalize aspect="equal" to aspect=1 in the setter.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1216,18 +1216,17 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        aspect : {'auto', 'equal'} or num
+        aspect : {'auto'} or num
             Possible values:
 
-            ========   ================================================
+            ========   =================================================
             value      description
-            ========   ================================================
-            'auto'     automatic; fill the position rectangle with data
-            'equal'    same scaling from data to plot units for x and y
-             num       a circle will be stretched such that the height
-                       is num times the width. aspect=1 is the same as
-                       aspect='equal'.
-            ========   ================================================
+            ========   =================================================
+            'auto'     automatic; fill the position rectangle with data.
+            num        a circle will be stretched such that the height
+                       is *num* times the width.  'equal' is a synonym
+                       for ``aspect=1``, i.e. same scaling for x and y.
+            ========   =================================================
 
         adjustable : None or {'box', 'datalim'}, optional
             If not ``None``, this defines which parameter will be adjusted to
@@ -1262,14 +1261,14 @@ class _AxesBase(martist.Artist):
         matplotlib.axes.Axes.set_anchor
             defining the position in case of extra space.
         """
-        if not (cbook._str_equal(aspect, 'equal')
-                or cbook._str_equal(aspect, 'auto')):
+        if cbook._str_equal(aspect, 'equal'):
+            aspect = 1
+        if not cbook._str_equal(aspect, 'auto'):
+            if self.name == '3d':
+                raise NotImplementedError(
+                    'It is not currently possible to manually set the aspect '
+                    'on 3D axes')
             aspect = float(aspect)  # raise ValueError if necessary
-
-        if (not cbook._str_equal(aspect, 'auto')) and self.name == '3d':
-            raise NotImplementedError(
-                'It is not currently possible to manually set the aspect '
-                'on 3D axes')
 
         if share:
             axes = {*self._shared_x_axes.get_siblings(self),
@@ -1531,9 +1530,6 @@ class _AxesBase(martist.Artist):
         if aspect == 'auto' and self._box_aspect is None:
             self._set_position(position, which='active')
             return
-
-        if aspect == 'equal':
-            aspect = 1
 
         fig_width, fig_height = self.get_figure().get_size_inches()
         fig_aspect = fig_height / fig_width

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5435,13 +5435,11 @@ def test_square_plot():
     ax.axis('square')
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
     assert np.diff(xlim) == np.diff(ylim)
-    assert ax.get_aspect() == 'equal'
+    assert ax.get_aspect() == 1
     assert_array_almost_equal(
-            ax.get_position(original=True).extents,
-            np.array((0.125, 0.1, 0.9, 0.9)))
+        ax.get_position(original=True).extents, (0.125, 0.1, 0.9, 0.9))
     assert_array_almost_equal(
-        ax.get_position(original=False).extents,
-        np.array((0.2125, 0.1, 0.8125, 0.9)))
+        ax.get_position(original=False).extents, (0.2125, 0.1, 0.8125, 0.9))
 
 
 def test_no_None():

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -84,14 +84,8 @@ Scalable = Scaled
 
 def _get_axes_aspect(ax):
     aspect = ax.get_aspect()
-    # when aspec is "auto", consider it as 1.
-    if aspect in ('normal', 'auto'):
+    if aspect == "auto":
         aspect = 1.
-    elif aspect == "equal":
-        aspect = 1
-    else:
-        aspect = float(aspect)
-
     return aspect
 
 


### PR DESCRIPTION
This avoids having to redo the normalization later.

`aspect="equal"` is probably too widely used to be worth deprecating,
but we can also deemphasize it in the docs.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
