### PR TITLE
Prevent FigureCanvasQT_draw_idle recursively calling itself.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -481,17 +481,16 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             QtCore.QTimer.singleShot(0, self._draw_idle)
 
     def _draw_idle(self):
-        if self.height() < 0 or self.width() < 0:
-            self._draw_pending = False
         if not self._draw_pending:
+            return
+        self._draw_pending = False
+        if self.height() < 0 or self.width() < 0:
             return
         try:
             self.draw()
         except Exception:
             # Uncaught exceptions are fatal for PyQt5, so catch them instead.
             traceback.print_exc()
-        finally:
-            self._draw_pending = False
 
     def drawRectangle(self, rect):
         # Draw the zoom rectangle to the QPainter.  _draw_rect_callback needs


### PR DESCRIPTION
Avoids an infinite loop in examples/event_handling/path_editor.py.

The logic is now similar to the one before 984fba1 (see https://github.com/matplotlib/matplotlib/commit/984fba18bcce543f3dd65c5fe5cadfc40e80e690#diff-24fdb85343951b7d9bd270c47d6abe8fL154, not sure why I had changed that; mplcairo also works fine with the patch).

Closes #15481, AFAICT.  attn @timhoffm, @QuLogic.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
