### PR TITLE
Rely on pytest to record warnings, rather than doing it manually.

### DIFF
--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -1,6 +1,5 @@
 import io
 from itertools import chain
-import warnings
 
 import numpy as np
 
@@ -220,13 +219,10 @@ def test_default_edges():
     ax4.add_patch(pp1)
 
 
-def test_properties():
+def test_properties(recwarn):
     ln = mlines.Line2D([], [])
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-        ln.properties()
-        assert len(w) == 0
+    ln.properties()
+    assert len(recwarn) == 0
 
 
 def test_setp():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5283,17 +5283,13 @@ def test_length_one_hist():
     ax.hist([1])
 
 
-def test_pathological_hexbin():
+def test_pathological_hexbin(recwarn):
     # issue #2863
-    out = io.BytesIO()
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        mylist = [10] * 100
-        fig, ax = plt.subplots(1, 1)
-        ax.hexbin(mylist, mylist)
-        fig.savefig(out)
-        assert len(w) == 0
+    mylist = [10] * 100
+    fig, ax = plt.subplots(1, 1)
+    ax.hexbin(mylist, mylist)
+    fig.savefig(io.BytesIO())
+    assert len(recwarn) == 0
 
 
 def test_color_None():

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import platform
 import sys
 import urllib.request
-import warnings
 
 import numpy as np
 from numpy import ma
@@ -981,11 +980,9 @@ def test_imshow_masked_interpolation():
         ax.axis('off')
 
 
-def test_imshow_no_warn_invalid():
-    with warnings.catch_warnings(record=True) as warns:
-        warnings.simplefilter("always")
-        plt.imshow([[1, 2], [3, np.nan]])
-    assert len(warns) == 0
+def test_imshow_no_warn_invalid(recwarn):
+    plt.imshow([[1, 2], [3, np.nan]])
+    assert len(recwarn) == 0
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -1,4 +1,3 @@
-import warnings
 import numpy as np
 import pytest
 import sys
@@ -72,29 +71,25 @@ def test_quiver_arg_sizes():
         plt.quiver(X2, X2, X2, X2, X3)
 
 
-def test_no_warnings():
+def test_no_warnings(recwarn):
     fig, ax = plt.subplots()
-
     X, Y = np.meshgrid(np.arange(15), np.arange(10))
     U = V = np.ones_like(X)
-
     phi = (np.random.rand(15, 10) - .5) * 150
-    with warnings.catch_warnings(record=True) as w:
-        ax.quiver(X, Y, U, V, angles=phi)
-        fig.canvas.draw()
-    assert len(w) == 0
+    ax.quiver(X, Y, U, V, angles=phi)
+    fig.canvas.draw()
+    assert len(recwarn) == 0
 
 
-def test_zero_headlength():
+def test_zero_headlength(recwarn):
     # Based on report by Doug McNeil:
     # http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html
     fig, ax = plt.subplots()
     X, Y = np.meshgrid(np.arange(10), np.arange(10))
     U, V = np.cos(X), np.sin(Y)
-    with warnings.catch_warnings(record=True) as w:
-        ax.quiver(U, V, headlength=0, headaxislength=0)
-        fig.canvas.draw()
-    assert len(w) == 0
+    ax.quiver(U, V, headlength=0, headaxislength=0)
+    fig.canvas.draw()
+    assert len(recwarn) == 0
 
 
 @image_comparison(['quiver_animated_test_image.png'])


### PR DESCRIPTION
Technically we could even get rid of the `assert len(recwarn) == 0`
lines because we fail the tests on any warning, but I left them there
for explicitness.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
