### PR TITLE
Doc: use empty ScalarMappable for colorbars with no associated image.

### DIFF
--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -147,29 +147,18 @@ axl3 = fig.add_axes([0.69, 0.15, 0.2, 0.05])
 # the colorbar will be used.
 cmap = mpl.cm.viridis
 norm = mpl.colors.Normalize(vmin=1, vmax=17)
-
-# ColorbarBase derives from ScalarMappable and puts a colorbar
-# in a specified axes, so it has everything needed for a
-# standalone colorbar.  There are many more kwargs, but the
-# following gives a basic continuous colorbar with ticks
-# and labels.
-cb1 = mpl.colorbar.ColorbarBase(axl, cmap=cmap, norm=norm,
-                                orientation='horizontal')
+# Create an empty ScalarMappable to set the colorbar's colormap and norm.
+# The following gives a basic continuous colorbar with ticks and labels.
+cb1 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+                   cax=axl, orientation='horizontal')
 cb1.set_label('Some Units')
 
 
-# Set the colormap and norm to correspond to the data for which
-# the colorbar will be used.
+# And again for the second colorbar.
 cmap2 = mpl.cm.cool
 norm2 = mpl.colors.Normalize(vmin=1, vmax=17)
-
-# ColorbarBase derives from ScalarMappable and puts a colorbar
-# in a specified axes, so it has everything needed for a
-# standalone colorbar.  There are many more kwargs, but the
-# following gives a basic continuous colorbar with ticks
-# and labels.
-cb2 = mpl.colorbar.ColorbarBase(axl2, cmap=cmap2, norm=norm2,
-                                orientation='horizontal')
+cb2 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap2, norm=norm2),
+                   cax=axl2, orientation='horizontal')
 cb2.set_label('Some other units')
 
 
@@ -179,20 +168,19 @@ cb2.set_label('Some other units')
 cmap3 = mpl.colors.ListedColormap(['r', 'g', 'b', 'c'])
 cmap3.set_over('0.35')
 cmap3.set_under('0.75')
-
 # If a ListedColormap is used, the length of the bounds array must be
 # one greater than the length of the color list.  The bounds must be
 # monotonically increasing.
 bounds = [2, 3, 7, 9, 15]
 norm3 = mpl.colors.BoundaryNorm(bounds, cmap3.N)
-cb3 = mpl.colorbar.ColorbarBase(axl3, cmap=cmap3, norm=norm3,
-                                # to use 'extend', you must
-                                # specify two extra boundaries:
-                                boundaries=[0] + bounds + [18],
-                                extend='both',
-                                ticks=bounds,  # optional
-                                spacing='proportional',
-                                orientation='horizontal')
+cb3 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap3, norm=norm3),
+                   cax=axl3,
+                   # to use 'extend', you must specify two extra boundaries:
+                   boundaries=[0] + bounds + [18],
+                   extend='both',
+                   ticks=bounds,  # optional
+                   spacing='proportional',
+                   orientation='horizontal')
 cb3.set_label('Discrete intervals, some other units')
 
 

--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -149,17 +149,15 @@ cmap = mpl.cm.viridis
 norm = mpl.colors.Normalize(vmin=1, vmax=17)
 # Create an empty ScalarMappable to set the colorbar's colormap and norm.
 # The following gives a basic continuous colorbar with ticks and labels.
-cb1 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
-                   cax=axl, orientation='horizontal')
-cb1.set_label('Some Units')
+fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+             cax=axl, orientation='horizontal', label='Some Units')
 
 
 # And again for the second colorbar.
 cmap2 = mpl.cm.cool
 norm2 = mpl.colors.Normalize(vmin=1, vmax=17)
-cb2 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap2, norm=norm2),
-                   cax=axl2, orientation='horizontal')
-cb2.set_label('Some other units')
+fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap2, norm=norm2),
+             cax=axl2, orientation='horizontal', label='Some other units')
 
 
 # The second example illustrates the use of a ListedColormap, a
@@ -173,15 +171,15 @@ cmap3.set_under('0.75')
 # monotonically increasing.
 bounds = [2, 3, 7, 9, 15]
 norm3 = mpl.colors.BoundaryNorm(bounds, cmap3.N)
-cb3 = fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap3, norm=norm3),
-                   cax=axl3,
-                   # to use 'extend', you must specify two extra boundaries:
-                   boundaries=[0] + bounds + [18],
-                   extend='both',
-                   ticks=bounds,  # optional
-                   spacing='proportional',
-                   orientation='horizontal')
-cb3.set_label('Discrete intervals, some other units')
+fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap3, norm=norm3),
+             cax=axl3,
+             # to use 'extend', you must specify two extra boundaries:
+             boundaries=[0] + bounds + [18],
+             extend='both',
+             ticks=bounds,  # optional
+             spacing='proportional',
+             orientation='horizontal',
+             label='Discrete intervals, some other units')
 
 
 # Create the 17 segment model

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -35,9 +35,8 @@ fig.subplots_adjust(bottom=0.5)
 cmap = mpl.cm.cool
 norm = mpl.colors.Normalize(vmin=5, vmax=10)
 
-cb1 = fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
-                   cax=ax, orientation='horizontal')
-cb1.set_label('Some Units')
+fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+             cax=ax, orientation='horizontal', label='Some Units')
 
 ###############################################################################
 # Discrete intervals colorbar
@@ -70,15 +69,16 @@ cmap.set_under('0.75')
 
 bounds = [1, 2, 4, 7, 8]
 norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
-cb2 = fig.colorbar(
+fig.colorbar(
     mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
     cax=ax,
     boundaries=[0] + bounds + [13],
     extend='both',
     ticks=bounds,
     spacing='proportional',
-    orientation='horizontal')
-cb2.set_label('Discrete intervals, some other units')
+    orientation='horizontal',
+    label='Discrete intervals, some other units',
+)
 
 ###############################################################################
 # Colorbar with custom extension lengths
@@ -98,7 +98,7 @@ cmap.set_under('blue')
 
 bounds = [-1.0, -0.5, 0.0, 0.5, 1.0]
 norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
-cb3 = fig.colorbar(
+fig.colorbar(
     mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
     cax=ax,
     boundaries=[-10] + bounds + [10],
@@ -106,7 +106,8 @@ cb3 = fig.colorbar(
     extendfrac='auto',
     ticks=bounds,
     spacing='uniform',
-    orientation='horizontal')
-cb3.set_label('Custom extension lengths, some other units')
+    orientation='horizontal',
+    label='Custom extension lengths, some other units',
+)
 
 plt.show()

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -3,25 +3,27 @@
 Customized Colorbars Tutorial
 =============================
 
-This tutorial shows how to build colorbars without an attached plot.
+This tutorial shows how to build and customize standalone colorbars, i.e.
+without an attached plot.
 
 Customized Colorbars
 ====================
 
-`~matplotlib.colorbar.ColorbarBase` puts a colorbar in a specified axes,
-and can make a colorbar for a given colormap; it does not need a mappable
-object like an image. In this tutorial we will explore what can be done with
-standalone colorbar.
+A `~.Figure.colorbar` needs a "mappable" (`matplotlib.cm.ScalarMappable`)
+object (typically, an image) which indicates the colormap and the norm to be
+used.  In order to create a colorbar without an attached image, one can instead
+use a `.ScalarMappable` with no associated data.
 
 Basic continuous colorbar
 -------------------------
 
-Set the colormap and norm to correspond to the data for which the colorbar
-will be used. Then create the colorbar by calling
-:class:`~matplotlib.colorbar.ColorbarBase` and specify axis, colormap, norm
-and orientation as parameters. Here we create a basic continuous colorbar
-with ticks and labels. For more information see the
-:mod:`~matplotlib.colorbar` API.
+Here we create a basic continuous colorbar with ticks and labels.
+
+The arguments to the `~.Figure.colorbar` call are the `.ScalarMappable`
+(constructed using the *norm* and *cmap* arguments), the axes where the
+colorbar should be drawn, and the colorbar's orientation.
+
+For more information see the :mod:`~matplotlib.colorbar` API.
 """
 
 import matplotlib.pyplot as plt
@@ -33,11 +35,9 @@ fig.subplots_adjust(bottom=0.5)
 cmap = mpl.cm.cool
 norm = mpl.colors.Normalize(vmin=5, vmax=10)
 
-cb1 = mpl.colorbar.ColorbarBase(ax, cmap=cmap,
-                                norm=norm,
-                                orientation='horizontal')
+cb1 = fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+                   cax=ax, orientation='horizontal')
 cb1.set_label('Some Units')
-fig.show()
 
 ###############################################################################
 # Discrete intervals colorbar
@@ -56,7 +56,7 @@ fig.show()
 # bounds must be monotonically increasing.
 #
 # This time we pass some more arguments in addition to previous arguments to
-# :class:`~matplotlib.colorbar.ColorbarBase`. For the out-of-range values to
+# `~.Figure.colorbar`. For the out-of-range values to
 # display on the colorbar, we have to use the *extend* keyword argument. To use
 # *extend*, you must specify two extra boundaries. Finally spacing argument
 # ensures that intervals are shown on colorbar proportionally.
@@ -70,15 +70,15 @@ cmap.set_under('0.75')
 
 bounds = [1, 2, 4, 7, 8]
 norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
-cb2 = mpl.colorbar.ColorbarBase(ax, cmap=cmap,
-                                norm=norm,
-                                boundaries=[0] + bounds + [13],
-                                extend='both',
-                                ticks=bounds,
-                                spacing='proportional',
-                                orientation='horizontal')
+cb2 = fig.colorbar(
+    mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+    cax=ax,
+    boundaries=[0] + bounds + [13],
+    extend='both',
+    ticks=bounds,
+    spacing='proportional',
+    orientation='horizontal')
 cb2.set_label('Discrete intervals, some other units')
-fig.show()
 
 ###############################################################################
 # Colorbar with custom extension lengths
@@ -98,13 +98,15 @@ cmap.set_under('blue')
 
 bounds = [-1.0, -0.5, 0.0, 0.5, 1.0]
 norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
-cb3 = mpl.colorbar.ColorbarBase(ax, cmap=cmap,
-                                norm=norm,
-                                boundaries=[-10] + bounds + [10],
-                                extend='both',
-                                extendfrac='auto',
-                                ticks=bounds,
-                                spacing='uniform',
-                                orientation='horizontal')
+cb3 = fig.colorbar(
+    mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
+    cax=ax,
+    boundaries=[-10] + bounds + [10],
+    extend='both',
+    extendfrac='auto',
+    ticks=bounds,
+    spacing='uniform',
+    orientation='horizontal')
 cb3.set_label('Custom extension lengths, some other units')
-fig.show()
+
+plt.show()


### PR DESCRIPTION
This is consistent with the docstring of colorbar(), which explicitly
suggests this approach; this would also later allow deprecating
ColorbarBase, merging it into Colorbar.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
