### PR TITLE
Deprecate unused features of normalize_kwargs.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -159,3 +159,7 @@ e.g. `.FuncFormatter`.
 ``OldAutoLocator``
 ~~~~~~~~~~~~~~~~~~
 This ticker is deprecated.
+
+*required*, *forbidden* and *allowed* parameters of `.cbook.normalize_kwargs`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These parameters are deprecated.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3881,8 +3881,7 @@ class Axes(_AxesBase):
             if not use_marker:
                 d['marker'] = ''
             if explicit is not None:
-                d.update(
-                    cbook.normalize_kwargs(explicit, mlines.Line2D._alias_map))
+                d.update(cbook.normalize_kwargs(explicit, mlines.Line2D))
             return d
 
         # box properties
@@ -3897,8 +3896,7 @@ class Axes(_AxesBase):
             )
             if boxprops is not None:
                 final_boxprops.update(
-                    cbook.normalize_kwargs(
-                        boxprops, mpatches.PathPatch._alias_map))
+                    cbook.normalize_kwargs(boxprops, mpatches.PathPatch))
         else:
             final_boxprops = line_props_with_rcdefaults('boxprops', boxprops,
                                                         use_marker=False)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1682,6 +1682,9 @@ def sanitize_sequence(data):
             else data)
 
 
+@_delete_parameter("3.3", "required")
+@_delete_parameter("3.3", "forbidden")
+@_delete_parameter("3.3", "allowed")
 def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
                      allowed=None):
     """
@@ -1713,16 +1716,16 @@ def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
         mapping.
 
     required : list of str, optional
-        A list of keys that must be in *kws*.
+        A list of keys that must be in *kws*.  This parameter is deprecated.
 
     forbidden : list of str, optional
-        A list of keys which may not be in *kw*.
+        A list of keys which may not be in *kw*.  This parameter is deprecated.
 
     allowed : list of str, optional
         A list of allowed fields.  If this not None, then raise if
         *kw* contains any keys not in the union of *required*
         and *allowed*.  To allow only the required fields pass in
-        an empty tuple ``allowed=()``.
+        an empty tuple ``allowed=()``.  This parameter is deprecated.
 
     Raises
     ------

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -1,7 +1,6 @@
 import itertools
 import pickle
 from weakref import ref
-import warnings
 from unittest.mock import patch, Mock
 
 from datetime import datetime
@@ -329,17 +328,17 @@ pass_mapping = (
 
 @pytest.mark.parametrize('inp, kwargs_to_norm', fail_mapping)
 def test_normalize_kwargs_fail(inp, kwargs_to_norm):
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError), \
+         cbook._suppress_matplotlib_deprecation_warning():
         cbook.normalize_kwargs(inp, **kwargs_to_norm)
 
 
 @pytest.mark.parametrize('inp, expected, kwargs_to_norm',
                          pass_mapping)
-def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm):
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
+def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm, recwarn):
+    with cbook._suppress_matplotlib_deprecation_warning():
         assert expected == cbook.normalize_kwargs(inp, **kwargs_to_norm)
-        assert len(w) == 0
+    assert len(recwarn) == 0
 
 
 def test_warn_external_frame_embedded_python():


### PR DESCRIPTION
The required, forbidden and allowed kwargs of normalize_kwargs have
never been used and add a significant amount of complexity to the
implementation of normalize kwargs, so get rid of them.

Looks like @tacaswell originally introduced *forbidden* for https://github.com/matplotlib/matplotlib/pull/5056 but I think this can be better implemented as a separate "merge-disjoint-dicts" helper.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
