### PR TITLE
Add __repr__ to SubplotSpec.

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -522,6 +522,11 @@ class SubplotSpec:
         else:
             self._layoutbox = None
 
+    def __repr__(self):
+        return (f"{self.get_gridspec()}["
+                f"{self.rowspan.start}:{self.rowspan.stop}, "
+                f"{self.colspan.start}:{self.colspan.stop}]")
+
     @staticmethod
     def _from_subplot_args(figure, args):
         """

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -24,3 +24,8 @@ def test_height_ratios():
     """
     with pytest.raises(ValueError):
         gridspec.GridSpec(1, 1, height_ratios=[2, 1, 3])
+
+
+def test_repr():
+    ss = gridspec.GridSpec(3, 3)[2, 1:3]
+    assert repr(ss) == "GridSpec(3, 3)[2:3, 1:3]"


### PR DESCRIPTION
This allows printing subplotspecs as e.g. `GridSpec(3, 3)[1:3, 2:3]`
which can help with debugging.  (Note that `GridSpec.__repr__` was
already implemented previously.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
