### PR TITLE
Deprecate parameters to colorbar which have no effect.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -96,3 +96,13 @@ colormapping such as ``scatter()`` and ``imshow()`` is deprecated.
 Inestead of ``norm=LogNorm(), vmin=min_val, vmax=max_val`` pass
 ``norm=LogNorm(min_val, max_val)``. *vmin* and *vmax* should only be used
 without setting *norm*.
+
+Effectless parameters of `.Figure.colorbar` and `matplotlib.colorbar.Colorbar`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *cmap* and *norm* parameters of `.Figure.colorbar` and
+`matplotlib.colorbar.Colorbar` have no effect because they are always
+overridden by the mappable's colormap and norm; they are thus deprecated.
+Likewise, passing the *alpha*, *boundaries*, *values*, *extend*, or *filled*
+parameters with a `.ContourSet` mappable, or the *alpha* parameter with an
+`.Artist` mappable, is deprecated, as the mappable would likewise override
+them.

--- a/examples/images_contours_and_fields/contour_demo.py
+++ b/examples/images_contours_and_fields/contour_demo.py
@@ -82,7 +82,7 @@ fig, ax = plt.subplots()
 im = ax.imshow(Z, interpolation='bilinear', origin='lower',
                cmap=cm.gray, extent=(-3, 3, -2, 2))
 levels = np.arange(-1.2, 1.6, 0.2)
-CS = ax.contour(Z, levels, origin='lower', cmap='flag',
+CS = ax.contour(Z, levels, origin='lower', cmap='flag', extend='both',
                 linewidths=2, extent=(-3, 3, -2, 2))
 
 # Thicken the zero contour.
@@ -93,7 +93,7 @@ ax.clabel(CS, levels[1::2],  # label every second level
           inline=1, fmt='%1.1f', fontsize=14)
 
 # make a colorbar for the contour lines
-CB = fig.colorbar(CS, shrink=0.8, extend='both')
+CB = fig.colorbar(CS, shrink=0.8)
 
 ax.set_title('Lines with colorbar')
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -243,8 +243,7 @@ def test_colorbar_closed_patch():
     # because it is matched to the data range in the image and to
     # the number of colors in the LUT.
     values = np.linspace(0, 10, 5)
-    cbar_kw = dict(cmap=cmap, orientation='horizontal', values=values,
-                   ticks=[])
+    cbar_kw = dict(orientation='horizontal', values=values, ticks=[])
 
     # The wide line is to show that the closed path is being handled
     # correctly.  See PR #4186.
@@ -264,9 +263,8 @@ def test_colorbar_ticks():
     Z = X * Y
     clevs = np.array([-12, -5, 0, 5, 12], dtype=float)
     colors = ['r', 'g', 'b', 'c']
-    cs = ax.contourf(X, Y, Z, clevs, colors=colors)
-    cbar = fig.colorbar(cs, ax=ax, extend='neither',
-                        orientation='horizontal', ticks=clevs)
+    cs = ax.contourf(X, Y, Z, clevs, colors=colors, extend='neither')
+    cbar = fig.colorbar(cs, ax=ax, orientation='horizontal', ticks=clevs)
     assert len(cbar.ax.xaxis.get_ticklocs()) == len(clevs)
 
 


### PR DESCRIPTION
Per changelog entry.

I went for a custom helper in colorbar.py rather than a more general one
in cbook as this allowed for a nicer message, and making the general
helper handle the deprecation would be a bit unwieldy.

Supersedes #5056.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
