### PR TITLE
Fix v_interval setter

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -395,7 +395,7 @@ class Axis(maxis.XAxis):
     def v_interval(self):
         return self.get_view_interval()
 
-    @d_interval.setter
+    @v_interval.setter
     def v_interval(self, minmax):
         return self.set_view_interval(*minmax)
 


### PR DESCRIPTION
## PR Summary

Regression from #14579. As a result setting properties `Axis.v_interval` and `Axis.d_interval` did not work.

Comments suggest [testing](https://github.com/matplotlib/matplotlib/pull/16044#discussion_r362162388) or [deprecating](https://github.com/matplotlib/matplotlib/pull/16044#discussion_r362165788). But I don't want to spend more time on this:

- Re testing: More tests are always nice, but here it's obvious that the fix just fixes a copy-paste bug.
- Re deprecating: Might make sense. However, additional properties are not that much of an API problem. They just came in via #14579 when these attibutes were turned into properties.

Therefore I'd like to push this PR as minimal as it is. If anybody want to take further action, feel free.
