### PR TITLE
Simplify colorbar test.

### DIFF
--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -538,17 +538,9 @@ def test_colorbar_inverted_ticks():
 def test_extend_colorbar_customnorm():
     # This was a funny error with TwoSlopeNorm, maybe with other norms,
     # when extend='both'
-    N = 100
-    X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
-    Z1 = np.exp(-X**2 - Y**2)
-    Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
-    Z = (Z1 - Z2) * 2
-
-    fig, ax = plt.subplots(2, 1)
-    pcm = ax[0].pcolormesh(X, Y, Z,
-                           norm=TwoSlopeNorm(vcenter=0., vmin=-2, vmax=1),
-                           cmap='RdBu_r')
-    cb = fig.colorbar(pcm, ax=ax[0], extend='both')
+    fig, (ax0, ax1) = plt.subplots(2, 1)
+    pcm = ax0.pcolormesh([[0]], norm=TwoSlopeNorm(vcenter=0., vmin=-2, vmax=1))
+    cb = fig.colorbar(pcm, ax=ax0, extend='both')
     np.testing.assert_allclose(cb.ax.get_position().extents,
                                [0.78375, 0.536364, 0.796147, 0.9], rtol=1e-3)
 


### PR DESCRIPTION
The test doesn't need to use a complex image, as the norm is all that
matters.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
