### PR TITLE
Cleanup pcolor_demo.

### DIFF
--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -36,18 +36,19 @@ plt.show()
 # Demonstrates similarities between `~.axes.Axes.pcolor`,
 # `~.axes.Axes.pcolormesh`, `~.axes.Axes.imshow` and
 # `~.axes.Axes.pcolorfast` for drawing quadrilateral grids.
+# Note that we call ``imshow`` with ``aspect="auto"`` so that it doesn't force
+# the data pixels to be square (the default is ``aspect="equal"``).
 
 # make these smaller to increase the resolution
 dx, dy = 0.15, 0.05
 
 # generate 2 2d grids for the x & y bounds
-y, x = np.mgrid[slice(-3, 3 + dy, dy),
-                slice(-3, 3 + dx, dx)]
-z = (1 - x / 2. + x ** 5 + y ** 3) * np.exp(-x ** 2 - y ** 2)
+y, x = np.mgrid[-3:3+dy:dy, -3:3+dx:dx]
+z = (1 - x/2 + x**5 + y**3) * np.exp(-x**2 - y**2)
 # x and y are bounds, so z should be the value *inside* those bounds.
 # Therefore, remove the last value from the z array.
 z = z[:-1, :-1]
-z_min, z_max = -np.abs(z).max(), np.abs(z).max()
+z_min, z_max = -abs(z).max(), abs(z).max()
 
 fig, axs = plt.subplots(2, 2)
 
@@ -64,8 +65,8 @@ fig.colorbar(c, ax=ax)
 ax = axs[1, 0]
 c = ax.imshow(z, cmap='RdBu', vmin=z_min, vmax=z_max,
               extent=[x.min(), x.max(), y.min(), y.max()],
-              interpolation='nearest', origin='lower')
-ax.set_title('image (nearest)')
+              interpolation='nearest', origin='lower', aspect='auto')
+ax.set_title('image (nearest, aspect="auto")')
 fig.colorbar(c, ax=ax)
 
 ax = axs[1, 1]
@@ -84,7 +85,7 @@ plt.show()
 # The following shows pcolor plots with a log scale.
 
 N = 100
-X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
+X, Y = np.meshgrid(np.linspace(-3, 3, N), np.linspace(-2, 2, N))
 
 # A low hump with a spike coming out.
 # Needs to have z/colour axis on a log scale so we see both hump and spike.


### PR DESCRIPTION
- Set up the x, y arrays in simpler (IMO) ways.
- Make imshow() use aspect="auto" rather than the default aspect=1,
  to make it more comparable with the pcolor plots.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
