### PR TITLE
Lazier ticks for large speedup when creating large arrays of axes.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -621,11 +621,21 @@ class _LazyTickList:
             if self._major:
                 instance.majorTicks = []
                 tick = instance._get_tick(major=True)
+                try:
+                    tick.set_clip_path(instance.axes.patch)
+                except AttributeError:
+                    pass
+                tick._apply_params(**instance._major_tick_kw)
                 instance.majorTicks.append(tick)
                 return instance.majorTicks
             else:
                 instance.minorTicks = []
                 tick = instance._get_tick(major=False)
+                try:
+                    tick.set_clip_path(instance.axes.patch)
+                except AttributeError:
+                    pass
+                tick._apply_params(**instance._minor_tick_kw)
                 instance.minorTicks.append(tick)
                 return instance.minorTicks
 
@@ -718,6 +728,12 @@ class Axis(martist.Artist):
     # descriptor to make the tick lists lazy and instantiate them as needed.
     majorTicks = _LazyTickList(major=True)
     minorTicks = _LazyTickList(major=False)
+
+    def _lazy_get_ticks_or_empty(self, *, major=True):
+        # Return ticks without triggering auto-instantiation.  This is
+        # important for performance!
+        name = "majorTicks" if major else "minorTicks"
+        return vars(self).get(name, [])
 
     def get_remove_overlapping_locs(self):
         return self._remove_overlapping_locs
@@ -838,11 +854,11 @@ class Axis(martist.Artist):
         else:
             if which in ['major', 'both']:
                 self._major_tick_kw.update(kwtrans)
-                for tick in self.majorTicks:
+                for tick in self._lazy_get_ticks_or_empty(major=True):
                     tick._apply_params(**kwtrans)
             if which in ['minor', 'both']:
                 self._minor_tick_kw.update(kwtrans)
-                for tick in self.minorTicks:
+                for tick in self._lazy_get_ticks_or_empty(major=False):
                     tick._apply_params(**kwtrans)
             # special-case label color to also apply to the offset text
             if 'labelcolor' in kwtrans:
@@ -897,7 +913,8 @@ class Axis(martist.Artist):
 
     def set_clip_path(self, clippath, transform=None):
         martist.Artist.set_clip_path(self, clippath, transform)
-        for child in self.majorTicks + self.minorTicks:
+        for child in (self._lazy_get_ticks_or_empty(major=True)
+                      + self._lazy_get_ticks_or_empty(major=False)):
             child.set_clip_path(clippath, transform)
         self.stale = True
 

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -373,6 +373,16 @@ class Spine(mpatches.Patch):
 
     @allow_rasterization
     def draw(self, renderer):
+        # The calls to get_x/yaxis_transform are necessary to set up the spine
+        # transforms properly in the case of rectilinear axes.  (This was
+        # previously done implicitly on tick init, but now ticks are init'ed
+        # lazily at draw time.)  Really, one just needs to call
+        # _ensure_position_is_set(), except that this breaks polar axes which
+        # are brittle.
+        self.axes.get_xaxis_transform('tick1')
+        self.axes.get_xaxis_transform('tick2')
+        self.axes.get_yaxis_transform('tick1')
+        self.axes.get_yaxis_transform('tick2')
         self._adjust_location()
         ret = super().draw(renderer)
         self.stale = False


### PR DESCRIPTION
Be more careful to not create ticks earlier than needed, as that's quite
costly.

On the following benchmark
```
from matplotlib import pyplot as plt
from time import perf_counter
fig = plt.figure()
for i in range(3):
    print(i)
    start = perf_counter()
    fig.subplots(10, 10)
    print(perf_counter() - start)  # creation time
    start = perf_counter()
    fig.clf()
    print(perf_counter() - start)  # clearance time
```
this speeds up axes creation from ~1.4s to ~0.5s and figure clearance(!)
from ~2.6s to ~0.3s.

Note that a similar idea was already implemented in c935965, which sped
up creation from ~2.6s to 0.8s and clearance from ~2.2s to ~1.8s, but
obviously the whole thing is brittle and got mostly lost at some
point...

Would be nice to track performance regressions (semi)automatically.

attn @timhoffm as you initially had this idea in #9727

(#16066 made this a bit more of a pain than expected)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
