### PR TITLE
Refactor a bit animation start/save interaction.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -237,13 +237,8 @@ def test_failing_ffmpeg(tmpdir, monkeypatch):
             make_animation().save("test.mpeg")
 
 
-@pytest.mark.parametrize("cache_frame_data, weakref_assertion_fn", [
-    pytest.param(
-        False, lambda ref: ref is None, id='cache_frame_data_is_disabled'),
-    pytest.param(
-        True, lambda ref: ref is not None, id='cache_frame_data_is_enabled'),
-])
-def test_funcanimation_holding_frames(cache_frame_data, weakref_assertion_fn):
+@pytest.mark.parametrize("cache_frame_data", [False, True])
+def test_funcanimation_cache_frame_data(cache_frame_data):
     fig, ax = plt.subplots()
     line, = ax.plot([], [])
 
@@ -282,4 +277,6 @@ def test_funcanimation_holding_frames(cache_frame_data, weakref_assertion_fn):
     anim.save('unused.null', writer=writer)
     assert len(frames_generated) == 5
     for f in frames_generated:
-        assert weakref_assertion_fn(f())
+        # If cache_frame_data is True, then the weakref should be alive;
+        # if cache_frame_data is False, then the weakref should be dead (None).
+        assert (f() is None) != cache_frame_data


### PR DESCRIPTION
## PR Summary

1st commit:

This avoids an obscure pytest assertion failure
```
>           assert weakref_assertion_fn(f())
E           assert False
E            +  where False = <function <lambda> at 0x7f49d8bfdb80>(None)
E            +    where None = <weakref at 0x7f49d76c3360; dead>()
```
if refactoring animation and causing the test to fail.  One now gets
```
            # If cache_frame_data is True, then the weakref should be alive;
            # if cache_frame_data is False, then the weakref should be dead (None).
>           assert (f() is None) != cache_frame_data
E           assert (None is None) != True
E            +  where None = <weakref at 0x7f4a3416c7c0; dead>()
```

2nd commit:

Animation connects to draw_event to figure out whether to start the
animation, but needs to temporarily disconnect the draw_event handler to
avoid triggering the animation start when saving the animation.

Instead one can just reuse the canvas._is_saving flag in the draw_event
handler to do that.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
