### PR TITLE
Fix restuctured text formatting

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.1.0.rst
@@ -96,7 +96,7 @@ show in the legend manually.  Now,
 handles and labels for a scatter plot in an automated way. This makes
 creating a legend for a scatter plot as easy as
 
-.. plot ::
+.. plot::
 
     scatter = plt.scatter([1,2,3], [4,5,6], c=[7,2,3])
     plt.legend(*scatter.legend_elements())

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1345,11 +1345,12 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
     """
     A decorator to add a 'data' kwarg to a function.
 
-    ::
+    When applied::
+
         @_preprocess_data()
         def func(ax, *args, **kwargs): ...
 
-    is a function with signature ``decorated(ax, *args, data=None, **kwargs)``
+    the signature is modified to ``decorated(ax, *args, data=None, **kwargs)``
     with the following behavior:
 
     - if called with ``data=None``, forward the other arguments to ``func``;

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1211,7 +1211,7 @@ class DrawEvent(Event):
     updated.  Any extra artists drawn to the canvas's renderer will
     be reflected without an explicit call to ``blit``.
 
-    .. warning ::
+    .. warning::
 
        Calling ``canvas.draw`` and ``canvas.blit`` in these callbacks may
        not be safe with all backends and may cause infinite recursion.
@@ -1386,6 +1386,7 @@ class MouseEvent(LocationEvent):
     Examples
     --------
     ::
+
         def on_press(event):
             print('you pressed', event.button, event.xdata, event.ydata)
 
@@ -1482,6 +1483,7 @@ class KeyEvent(LocationEvent):
     Examples
     --------
     ::
+
         def on_key(event):
             print('you pressed', event.key, event.xdata, event.ydata)
 
@@ -2194,6 +2196,7 @@ class FigureCanvasBase:
         Examples
         --------
         ::
+
             def on_press(event):
                 print('you pressed', event.button, event.xdata, event.ydata)
 
@@ -2209,6 +2212,7 @@ class FigureCanvasBase:
         Examples
         --------
         ::
+
             cid = canvas.mpl_connect('button_press_event', on_press)
             # ... later
             canvas.mpl_disconnect(cid)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2193,6 +2193,7 @@ class _classproperty:
     Examples
     --------
     ::
+
         class C:
             @classproperty
             def foo(cls):

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -268,6 +268,7 @@ def _rename_parameter(since, old, new, func=None):
     Examples
     --------
     ::
+
         @_rename_parameter("3.1", "bad_name", "good_name")
         def func(good_name): ...
     """
@@ -325,6 +326,7 @@ def _delete_parameter(since, name, func=None):
     Examples
     --------
     ::
+
         @_delete_parameter("3.1", "unused")
         def func(used_arg, other_arg, unused, more_args): ...
     """

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -851,11 +851,11 @@ class ListedColormap(Colormap):
     N : int, optional
         Number of entries in the map. The default is *None*, in which case
         there is one colormap entry for each element in the list of colors.
-        If::
+        If ::
 
             N < len(colors)
 
-        the list will be truncated at *N*. If::
+        the list will be truncated at *N*. If ::
 
             N > len(colors)
 
@@ -933,7 +933,7 @@ class Normalize:
         processed.  That is, *__call__(A)* calls *autoscale_None(A)*.
         If *clip* is *True* and the given value falls outside the range,
         the returned value will be 0 or 1, whichever is closer.
-        Returns 0 if::
+        Returns 0 if ::
 
             vmin==vmax
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -688,7 +688,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         List of all the polygon segments for all the *levels*.
         For contour lines ``len(allsegs) == len(levels)``, and for
         filled contour regions ``len(allsegs) = len(levels)-1``. The lists
-        should look like::
+        should look like ::
 
             level0segs = [polygon0, polygon1, ...]
             polygon0 = [[x0, y0], [x1, y1], ...]
@@ -698,7 +698,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         described and used in Path. This is used to allow multiply-
         connected paths such as holes within filled polygons.
         If not ``None``, ``len(allkinds) == len(allsegs)``. The lists
-        should look like::
+        should look like ::
 
             level0kinds = [polygon0kinds, ...]
             polygon0kinds = [vertexcode0, vertexcode1, ...]
@@ -754,7 +754,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             List of all the polygon segments for all the *levels*.
             For contour lines ``len(allsegs) == len(levels)``, and for
             filled contour regions ``len(allsegs) = len(levels)-1``. The lists
-            should look like::
+            should look like ::
 
                 level0segs = [polygon0, polygon1, ...]
                 polygon0 = [[x0, y0], [x1, y1], ...]
@@ -764,7 +764,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             described and used in Path. This is used to allow multiply-
             connected paths such as holes within filled polygons.
             If not ``None``, ``len(allkinds) == len(allsegs)``. The lists
-            should look like::
+            should look like ::
 
                 level0kinds = [polygon0kinds, ...]
                 polygon0kinds = [vertexcode0, vertexcode1, ...]

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -587,6 +587,7 @@ class Vf(Dvi):
     Examples
     --------
     ::
+
         vf = Vf(filename)
         glyph = vf[code]
         glyph.text, glyph.boxes, glyph.width

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -160,7 +160,7 @@ def list_fonts(directory, extensions):
 def win32FontDirectory():
     r"""
     Return the user-specified font directory for Win32.  This is
-    looked up from the registry key::
+    looked up from the registry key ::
 
       \\HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\Fonts
 
@@ -594,7 +594,7 @@ class FontProperties:
         absolute font size, e.g., 12
 
     The default font property for TrueType fonts (as specified in the
-    default rcParams) is::
+    default rcParams) is ::
 
       sans-serif, normal, normal, normal, normal, scalable.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -414,7 +414,7 @@ class Patch(artist.Artist):
 
         Alternatively a dash tuple of the following form can be provided::
 
-            (offset, onoffseq),
+            (offset, onoffseq)
 
         where ``onoffseq`` is an even length tuple of on and off ink in points.
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -134,12 +134,12 @@ def uninstall_repl_displayhook():
     """
     Uninstall the matplotlib display hook.
 
-    .. warning
+    .. warning::
 
        Need IPython >= 2 for this to work.  For IPython < 2 will raise a
        ``NotImplementedError``
 
-    .. warning
+    .. warning::
 
        If you are using vanilla python and have installed another
        display hook this will reset ``sys.displayhook`` to what ever

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -218,9 +218,8 @@ class MaxHeight(_Base):
 class Fraction(_Base):
     """
     An instance whose size is a *fraction* of the *ref_size*.
-    ::
 
-      >>> s = Fraction(0.3, AxesX(ax))
+    >>> s = Fraction(0.3, AxesX(ax))
 
     """
     def __init__(self, fraction, ref_size):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -143,7 +143,7 @@ class Axes3D(Axes):
         For artists in an axes, if the zaxis has units support,
         convert *z* using zaxis unit type
 
-        .. versionadded :: 1.2.1
+        .. versionadded:: 1.2.1
 
         """
         return self.zaxis.convert_units(z)
@@ -330,7 +330,7 @@ class Axes3D(Axes):
         """
         Get whether autoscaling is applied for all axes on plot commands
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         return super().get_autoscale_on() and self.get_autoscalez_on()
@@ -339,7 +339,7 @@ class Axes3D(Axes):
         """
         Get whether autoscaling for the z-axis is applied on plot commands
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         return self._autoscaleZon
@@ -348,7 +348,7 @@ class Axes3D(Axes):
         """
         Set whether autoscaling is applied on plot commands
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
 
         Parameters
@@ -390,7 +390,8 @@ class Axes3D(Axes):
         """
         Convenience method to set or retrieve autoscaling margins.
 
-        signatures::
+        Call signatures::
+
             margins()
 
         returns xmargin, ymargin, zmargin
@@ -505,11 +506,11 @@ class Axes3D(Axes):
         Note that this function applies to the 3D axes, and as such
         adds the *scalez* to the function arguments.
 
-        .. versionchanged :: 1.1.0
+        .. versionchanged:: 1.1.0
             Function signature was changed to better match the 2D version.
             *tight* is now explicitly a kwarg and placed first.
 
-        .. versionchanged :: 1.2.1
+        .. versionchanged:: 1.2.1
             This is now fully functional.
         """
         # This method looks at the rectangular volume (see above)
@@ -737,7 +738,7 @@ class Axes3D(Axes):
     get_xlim3d.__doc__ = maxes.Axes.get_xlim.__doc__
     if get_xlim3d.__doc__ is not None:
         get_xlim3d.__doc__ += """
-        .. versionchanged :: 1.1.0
+        .. versionchanged:: 1.1.0
             This function now correctly refers to the 3D x-limits
         """
 
@@ -746,7 +747,7 @@ class Axes3D(Axes):
     get_ylim3d.__doc__ = maxes.Axes.get_ylim.__doc__
     if get_ylim3d.__doc__ is not None:
         get_ylim3d.__doc__ += """
-        .. versionchanged :: 1.1.0
+        .. versionchanged:: 1.1.0
             This function now correctly refers to the 3D y-limits.
         """
 
@@ -827,7 +828,7 @@ class Axes3D(Axes):
         """
         Get the ztick labels as a list of Text instances
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         return self.zaxis.get_majorticklabels()
 
@@ -839,7 +840,7 @@ class Axes3D(Axes):
             Minor ticks are not supported. This function was added
             only for completeness.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         return self.zaxis.get_minorticklabels()
 
@@ -879,7 +880,7 @@ class Axes3D(Axes):
             Axes3D objects do not officially support dates for ticks,
             and so this may or may not work as expected.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         self.zaxis.axis_date(tz)
@@ -1200,7 +1201,7 @@ class Axes3D(Axes):
         """
         Get the z-label text string.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         label = self.zaxis.get_label()
@@ -1233,7 +1234,7 @@ class Axes3D(Axes):
             :meth:`matplotlib.axes.Axes.grid`, but it is intended to
             eventually support that behavior.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         # TODO: Operate on each axes separately
         if len(kwargs):
@@ -1252,7 +1253,7 @@ class Axes3D(Axes):
         can also take a value of 'z' to apply parameters to the
         z axis.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         _x = axis in ['x', 'both']
@@ -1287,7 +1288,7 @@ class Axes3D(Axes):
         .. note::
            Axes3D currently ignores some of these settings.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         cbook._check_in_list(['x', 'y', 'z', 'both'], axis=axis)
         if axis in ['x', 'y', 'both']:
@@ -1306,7 +1307,7 @@ class Axes3D(Axes):
         """
         Invert the z-axis.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
             This function was added, but not tested. Please report any bugs.
         """
         bottom, top = self.get_zlim()
@@ -1316,7 +1317,7 @@ class Axes3D(Axes):
         """
         Returns True if the z-axis is inverted.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         bottom, top = self.get_zlim()
         return top < bottom
@@ -1325,7 +1326,7 @@ class Axes3D(Axes):
         """
         Return the lower and upper z-axis bounds, in increasing order.
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         bottom, top = self.get_zlim()
         if bottom < top:
@@ -1340,7 +1341,7 @@ class Axes3D(Axes):
         This method will honor axes inversion regardless of parameter order.
         It will not change the autoscaling setting (`.get_autoscalez_on()`).
 
-        .. versionadded :: 1.1.0
+        .. versionadded:: 1.1.0
         """
         if upper is None and np.iterable(lower):
             lower, upper = lower


### PR DESCRIPTION
## PR Summary

- Directives should not have a space before the double colon according to the specs (though is seems to work).
- Literal blocks need an empty line between `::` and the content.
- Code blocks using `>>>` do neither need a leading `::` nor indentation.

