### PR TITLE
Defaut to writing animation frames to a temporary directory.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -56,3 +56,9 @@ Setting the same property under multiple aliases now raises a TypeError
 Previously, calling e.g. ``plot(..., color=somecolor, c=othercolor)`` would
 emit a warning because ``color`` and ``c`` actually map to the same Artist
 property.  This now raises a TypeError.
+
+`.FileMovieWriter` temporary frames directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.FileMovieWriter` now defaults to writing temporary frames in a temporary
+directory, which is always cleared at exit.  In order to keep the individual
+frames saved on the filesystem, pass an explicit *frame_prefix*.


### PR DESCRIPTION
(We could later deprecate clean_temp, as the user can simply pass a
non-None frame_prefix to write temporary frames whereever they want and
keep them there.)

Redo of https://github.com/matplotlib/matplotlib/pull/3536 (see motivation there) and some of https://github.com/matplotlib/matplotlib/pull/11860, also solves https://github.com/matplotlib/matplotlib/pull/11863#issuecomment-570281157.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
