### PR TITLE
FIX: use supported attribute to check pillow version

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -54,7 +54,7 @@ from matplotlib.transforms import Affine2D
 from matplotlib.path import Path
 
 try:
-    from PIL import PILLOW_VERSION
+    from PIL import __version__ as PILLOW_VERSION
     from distutils.version import LooseVersion
     if LooseVersion(PILLOW_VERSION) >= "3.4":
         _has_pil = True


### PR DESCRIPTION
the PILLOW_VERSION attribute was deprecated in pillow 5.2 and removed
in pillow 7.0.  The __version__ attribute is present in the minimum
version we check (3.4).

closes #16083
