### PR TITLE
Change pcolormesh snapping (fixes alpha colorbar/grid issues) [AGG]

### DIFF
--- a/doc/users/next_whats_new/pcolormesh_alpha_improvement.rst
+++ b/doc/users/next_whats_new/pcolormesh_alpha_improvement.rst
@@ -1,0 +1,40 @@
+pcolormesh has improved transparency handling by enabling snapping
+------------------------------------------------------------------
+
+Due to how the snapping keyword argument was getting passed to the AGG backend,
+previous versions of Matplotlib would appear to show lines between the grid
+edges of a mesh with transparency. This version now applies snapping
+by default. To restore the old behavior (e.g., for test images), you may set
+:rc:`pcolormesh.snap` to `False`.
+
+.. plot::
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   # Use old pcolormesh snapping values
+   plt.rcParams['pcolormesh.snap'] = False
+   fig, ax = plt.subplots()
+   xx, yy = np.meshgrid(np.arange(10), np.arange(10))
+   z = (xx + 1) * (yy + 1)
+   mesh = ax.pcolormesh(xx, yy, z, shading='auto', alpha=0.5)
+   fig.colorbar(mesh, orientation='vertical')
+   ax.set_title('Before (pcolormesh.snap = False)')
+
+Note that there are lines between the grid boundaries of the main plot which
+are not the same transparency. The colorbar also shows these lines when a
+transparency is added to the colormap because internally it uses pcolormesh
+to draw the colorbar. With snapping on by default (below), the lines
+at the grid boundaries disappear.
+
+.. plot::
+
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   fig, ax = plt.subplots()
+   xx, yy = np.meshgrid(np.arange(10), np.arange(10))
+   z = (xx + 1) * (yy + 1)
+   mesh = ax.pcolormesh(xx, yy, z, shading='auto', alpha=0.5)
+   fig.colorbar(mesh, orientation='vertical')
+   ax.set_title('After (default: pcolormesh.snap = True)')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6089,6 +6089,8 @@ default: :rc:`scatter.edgecolors`
         collection = mcoll.QuadMesh(Nx - 1, Ny - 1, coords,
                                     antialiased=antialiased, shading=shading,
                                     **kwargs)
+        snap = kwargs.get('snap', rcParams['pcolormesh.snap'])
+        collection.set_snap(snap)
         collection.set_alpha(alpha)
         collection.set_array(C)
         collection.set_cmap(cmap)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2036,6 +2036,7 @@ class QuadMesh(Collection):
             transOffset = transOffset.get_affine()
 
         gc = renderer.new_gc()
+        gc.set_snap(self.get_snap())
         self._set_gc_clip(gc)
         gc.set_linewidth(self.get_linewidth()[0])
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1090,6 +1090,7 @@ _validators = {
 
     ## pcolor(mesh) props:
     "pcolor.shading": ["auto", "flat", "nearest", "gouraud"],
+    "pcolormesh.snap": validate_bool,
 
     ## patch props
     "patch.linewidth":       validate_float,  # line width in points

--- a/lib/matplotlib/tests/test_agg_filter.py
+++ b/lib/matplotlib/tests/test_agg_filter.py
@@ -7,6 +7,9 @@ from matplotlib.testing.decorators import image_comparison
 @image_comparison(baseline_images=['agg_filter_alpha'],
                   extensions=['png', 'pdf'])
 def test_agg_filter_alpha():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     ax = plt.axes()
     x, y = np.mgrid[0:7, 0:8]
     data = x**2 - y**2

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -731,6 +731,10 @@ def test_hexbin_pickable():
 @image_comparison(['hexbin_log.png'], style='mpl20')
 def test_hexbin_log():
     # Issue #1636 (and also test log scaled colorbar)
+
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     np.random.seed(19680801)
     n = 100000
     x = np.random.standard_normal(n)
@@ -992,6 +996,9 @@ def test_pcolorargs_5205():
 
 @image_comparison(['pcolormesh'], remove_text=True)
 def test_pcolormesh():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     n = 12
     x = np.linspace(-1.5, 1.5, n)
     y = np.linspace(-1.5, 1.5, n*2)
@@ -1014,6 +1021,9 @@ def test_pcolormesh():
 @image_comparison(['pcolormesh_alpha'], extensions=["png", "pdf"],
                   remove_text=True)
 def test_pcolormesh_alpha():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     n = 12
     X, Y = np.meshgrid(
         np.linspace(-1.5, 1.5, n),
@@ -1046,6 +1056,9 @@ def test_pcolormesh_alpha():
 @image_comparison(['pcolormesh_datetime_axis.png'],
                   remove_text=False, style='mpl20')
 def test_pcolormesh_datetime_axis():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
     base = datetime.datetime(2013, 1, 1)
@@ -1745,6 +1758,9 @@ def test_contour_hatching():
 
 @image_comparison(['contour_colorbar'], style='mpl20')
 def test_contour_colorbar():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     x, y, z = contour_dat()
 
     fig = plt.figure()
@@ -1768,6 +1784,9 @@ def test_contour_colorbar():
 
 @image_comparison(['hist2d', 'hist2d'], remove_text=True, style='mpl20')
 def test_hist2d():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     np.random.seed(0)
     # make it not symmetric in case we switch x and y axis
     x = np.random.randn(100)*2+5
@@ -1785,6 +1804,9 @@ def test_hist2d():
 
 @image_comparison(['hist2d_transpose'], remove_text=True, style='mpl20')
 def test_hist2d_transpose():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     np.random.seed(0)
     # make sure the output from np.histogram is transposed before
     # passing to pcolorfast

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -101,6 +101,9 @@ def _colorbar_extension_length(spacing):
                    'colorbar_extensions_shape_proportional.png'])
 def test_colorbar_extension_shape():
     """Test rectangular colorbar extensions."""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     # Create figures for uniform and proportionally spaced colorbars.
     _colorbar_extension_shape('uniform')
     _colorbar_extension_shape('proportional')
@@ -110,6 +113,9 @@ def test_colorbar_extension_shape():
                    'colorbar_extensions_proportional.png'])
 def test_colorbar_extension_length():
     """Test variable length colorbar extensions."""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     # Create figures for uniform and proportionally spaced colorbars.
     _colorbar_extension_length('uniform')
     _colorbar_extension_length('proportional')
@@ -124,6 +130,9 @@ def test_colorbar_extension_length():
                   extensions=['png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_colorbar_positioning(use_gridspec):
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     data = np.arange(1200).reshape(30, 40)
     levels = [0, 200, 400, 600, 800, 1000, 1200]
 
@@ -232,6 +241,9 @@ def test_colorbarbase():
 
 @image_comparison(['colorbar_closed_patch'], remove_text=True)
 def test_colorbar_closed_patch():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure(figsize=(8, 6))
     ax1 = fig.add_axes([0.05, 0.85, 0.9, 0.1])
     ax2 = fig.add_axes([0.1, 0.65, 0.75, 0.1])

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -601,6 +601,9 @@ def _mask_tester(norm_instance, vals):
 
 @image_comparison(['levels_and_colors.png'])
 def test_cmap_and_norm_from_levels_and_colors():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     data = np.linspace(-2, 4, 49).reshape(7, 7)
     levels = [-1, 2, 2.5, 3]
     colors = ['red', 'green', 'blue', 'yellow', 'black']
@@ -618,6 +621,8 @@ def test_cmap_and_norm_from_levels_and_colors():
 @image_comparison(baseline_images=['boundarynorm_and_colorbar'],
                   extensions=['png'])
 def test_boundarynorm_and_colorbarbase():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
 
     # Make a figure and axes with dimensions as desired.
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -51,6 +51,9 @@ def test_constrained_layout2():
 @image_comparison(['constrained_layout3.png'])
 def test_constrained_layout3():
     """Test constrained_layout for colorbars with subplots"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     for nn, ax in enumerate(axs.flat):
         pcm = example_pcolor(ax, fontsize=24)
@@ -64,6 +67,9 @@ def test_constrained_layout3():
 @image_comparison(['constrained_layout4'])
 def test_constrained_layout4():
     """Test constrained_layout for a single colorbar with subplots"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     for ax in axs.flat:
         pcm = example_pcolor(ax, fontsize=24)
@@ -76,6 +82,9 @@ def test_constrained_layout5():
     Test constrained_layout for a single colorbar with subplots,
     colorbar bottom
     """
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     for ax in axs.flat:
         pcm = example_pcolor(ax, fontsize=24)
@@ -87,6 +96,9 @@ def test_constrained_layout5():
 @image_comparison(['constrained_layout6.png'])
 def test_constrained_layout6():
     """Test constrained_layout for nested gridspecs"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure(constrained_layout=True)
     gs = fig.add_gridspec(1, 2, figure=fig)
     gsl = gs[0].subgridspec(2, 2)
@@ -126,6 +138,9 @@ def test_constrained_layout7():
 @image_comparison(['constrained_layout8.png'])
 def test_constrained_layout8():
     """Test for gridspecs that are not completely full"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure(figsize=(10, 5), constrained_layout=True)
     gs = gridspec.GridSpec(3, 5, figure=fig)
     axs = []
@@ -153,6 +168,9 @@ def test_constrained_layout8():
 @image_comparison(['constrained_layout9.png'])
 def test_constrained_layout9():
     """Test for handling suptitle and for sharex and sharey"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True,
                             sharex=False, sharey=False)
     for ax in axs.flat:
@@ -176,6 +194,9 @@ def test_constrained_layout10():
 @image_comparison(['constrained_layout11.png'])
 def test_constrained_layout11():
     """Test for multiple nested gridspecs"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure(constrained_layout=True, figsize=(13, 3))
     gs0 = gridspec.GridSpec(1, 2, figure=fig)
     gsl = gridspec.GridSpecFromSubplotSpec(1, 2, gs0[0])
@@ -195,6 +216,9 @@ def test_constrained_layout11():
 @image_comparison(['constrained_layout11rat.png'])
 def test_constrained_layout11rat():
     """Test for multiple nested gridspecs with width_ratios"""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure(constrained_layout=True, figsize=(10, 3))
     gs0 = gridspec.GridSpec(1, 2, figure=fig, width_ratios=[6, 1])
     gsl = gridspec.GridSpecFromSubplotSpec(1, 2, gs0[0])
@@ -236,6 +260,9 @@ def test_constrained_layout12():
 @image_comparison(['constrained_layout13.png'], tol=2.e-2)
 def test_constrained_layout13():
     """Test that padding works."""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     for ax in axs.flat:
         pcm = example_pcolor(ax, fontsize=12)
@@ -246,6 +273,9 @@ def test_constrained_layout13():
 @image_comparison(['constrained_layout14.png'])
 def test_constrained_layout14():
     """Test that padding works."""
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     for ax in axs.flat:
         pcm = example_pcolor(ax, fontsize=12)
@@ -374,6 +404,8 @@ def test_colorbar_location():
     Test that colorbar handling is as expected for various complicated
     cases...
     """
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
 
     fig, axs = plt.subplots(4, 5, constrained_layout=True)
     for ax in axs.flat:

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -136,6 +136,9 @@ def test_contour_labels_size_color():
 
 @image_comparison(['contour_manual_colors_and_levels.png'], remove_text=True)
 def test_given_colors_levels_and_extends():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     _, axs = plt.subplots(2, 4)
 
     data = np.arange(12).reshape(3, 4)
@@ -316,6 +319,9 @@ def test_clabel_zorder(use_clabeltext, contour_zorder, clabel_zorder):
 @image_comparison(['contour_log_extension.png'],
                   remove_text=True, style='mpl20')
 def test_contourf_log_extension():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     # Test that contourf with lognorm is extended correctly
     fig = plt.figure(figsize=(10, 5))
     fig.subplots_adjust(left=0.05, right=0.95)
@@ -355,6 +361,9 @@ def test_contourf_log_extension():
 # tolerance is because image changed minutely when tick finding on
 # colorbars was cleaned up...
 def test_contour_addlines():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig, ax = plt.subplots()
     np.random.seed(19680812)
     X = np.random.rand(10, 10)*10000
@@ -369,6 +378,9 @@ def test_contour_addlines():
 @image_comparison(baseline_images=['contour_uneven'],
                   extensions=['png'], remove_text=True, style='mpl20')
 def test_contour_uneven():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     z = np.arange(24).reshape(4, 6)
     fig, axs = plt.subplots(1, 2)
     ax = axs[0]

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -796,6 +796,9 @@ def test_image_preserve_size2():
 
 @image_comparison(['mask_image_over_under.png'], remove_text=True)
 def test_mask_image_over_under():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     delta = 0.025
     x = y = np.arange(-3.0, 3.0, delta)
     X, Y = np.meshgrid(x, y)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -43,6 +43,9 @@ def test_simple():
 @image_comparison(['multi_pickle.png'], remove_text=True, style='mpl20',
                   tol={'aarch64': 0.082}.get(platform.machine(), 0.0))
 def test_complete():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure('Figure with a label?', figsize=(10, 6))
 
     plt.suptitle('Can you fit any more in a figure?')

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -42,6 +42,9 @@ def test_startpoints():
 @image_comparison(['streamplot_colormap'],
                   tol=.04, remove_text=True, style='mpl20')
 def test_colormap():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     X, Y, U, V = velocity_field()
     plt.streamplot(X, Y, U, V, color=U, density=0.6, linewidth=2,
                    cmap=plt.cm.autumn)

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -73,6 +73,10 @@ def test_pre_transform_plotting():
     # a catch-all for as many as possible plot layouts which handle
     # pre-transforming the data NOTE: The axis range is important in this
     # plot. It should be x10 what the data suggests it should be
+
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     ax = plt.axes()
     times10 = mtransforms.Affine2D().scale(10)
 

--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -16,6 +16,9 @@ from mpl_toolkits.axes_grid1 import ImageGrid
 @image_comparison(['imagegrid_cbar_mode.png'],
                   remove_text=True, style='mpl20', tol=0.3)
 def test_imagegrid_cbar_mode_edge(legacy_colorbar):
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     mpl.rcParams["mpl_toolkits.legacy_colorbar"] = legacy_colorbar
 
     X, Y = np.meshgrid(np.linspace(0, 6, 30), np.linspace(0, 6, 30))

--- a/lib/mpl_toolkits/tests/test_axisartist_axislines.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axislines.py
@@ -62,6 +62,8 @@ def test_Axes():
 @image_comparison(['ParasiteAxesAuxTrans_meshplot.png'],
                   remove_text=True, style='default', tol=0.075)
 def test_ParasiteAxesAuxTrans():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
 
     data = np.ones((6, 6))
     data[2, 2] = 2

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -299,6 +299,9 @@ def test_plot_3d_from_2d():
 
 @mpl3d_image_comparison(['surface3d.png'])
 def test_surface3d():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
     fig = plt.figure()
     ax = fig.gca(projection='3d')
     X = np.arange(-5, 5, 0.25)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -131,6 +131,9 @@
 #markers.fillstyle: full  # {full, left, right, bottom, top, none}
 
 #pcolor.shading : flat
+#pcolormesh.snap : True  # Whether to snap the mesh to pixel boundaries. This
+                         # is provided solely to allow old test images to remain
+                         # unchanged. Set to False to obtain the previous behavior.
 
 ## ***************************************************************************
 ## * PATCHES                                                                 *

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -1160,13 +1160,6 @@ inline void RendererAgg::draw_quad_mesh(GCAgg &gc,
     array::scalar<double, 1> linewidths(gc.linewidth);
     array::scalar<uint8_t, 1> antialiaseds(antialiased);
     DashesVector linestyles;
-    ColorArray *edgecolors_ptr = &edgecolors;
-
-    if (edgecolors.size() == 0) {
-        if (antialiased) {
-            edgecolors_ptr = &facecolors;
-        }
-    }
 
     _draw_path_collection_generic(gc,
                                   master_transform,
@@ -1178,12 +1171,12 @@ inline void RendererAgg::draw_quad_mesh(GCAgg &gc,
                                   offsets,
                                   offset_trans,
                                   facecolors,
-                                  *edgecolors_ptr,
+                                  edgecolors,
                                   linewidths,
                                   linestyles,
                                   antialiaseds,
                                   OFFSET_POSITION_FIGURE,
-                                  false,
+                                  true, // check_snap
                                   false);
 }
 


### PR DESCRIPTION
## PR Summary

This fixes longstanding issues with dark or white lines showing up in colorbars and grids when alpha is present.
(#1188 and many other references to similar issues, it is all over stackoverflow as well)

It also appears to fix some grid positioning issues as well: #7341

## Consequences
There are more than 40 failing images due to this change (I think all due to pixel offsets in colorbar/pcolormesh image comparisons from what I can tell). These images would all have to be updated. I also suspect that lots of downstream libraries depending on matplotlib would be impacted by this in their image comparisons as well.

I am not an expert on the Agg/rendering machinery, so I welcome feedback/discussion on this.

Timing appears inconsequential (actually faster) during my basic tests of increasing the mesh size, but I haven't done anything rigorous.

## Proposed Changes

There are two issues here.
1) Push the edgecolor logic up into the Python callers (for some reason if antialiasing was set and edgecolors was empty the C++ would override edgecolors. That magic validations should happen upstream if this is desired.

2) Call the mesh generation code with check_snap set to true.

## Comparison results

### Before:
![pcolormesh_snap_false](https://user-images.githubusercontent.com/12417828/71766903-86e66280-2ec2-11ea-9b14-c7f98f856034.png)

### After:
![pcolormesh_snap_true](https://user-images.githubusercontent.com/12417828/71766910-8d74da00-2ec2-11ea-9338-55f063debd08.png)

### Demo code:
```
import numpy as np
import matplotlib
import matplotlib.pyplot as plt
print(matplotlib.__version__, matplotlib.get_backend())

import time

N = 10

x = np.arange(N)
y = np.arange(N)
X, Y = np.meshgrid(x, y)
z = (X[:-1, :-1] + 1)*(Y[:-1, :-1] + 1)

# Set up the colormaps
cmap = plt.get_cmap('viridis')
cmap_data = cmap(np.arange(cmap.N))
# Set a linear ramp in alpha
cmap_data[:, -1] = np.linspace(0.2, 1, cmap.N)
# Create new colormap
cmap_alpha = matplotlib.colors.ListedColormap(cmap_data)
norm = matplotlib.colors.Normalize(vmin=np.min(z), vmax=np.max(z))

ec = 'none'
cmap1 = cmap

# Row 1: alpha_cmap: aa False
# Row 2: normal_cmap: aa False
# Row 3: alpha_cmap: aa True
# Row 4: normal_cmap: aa True
# col 1: rectangle ec: none
# col 2: rectangle ec: 'face'
# col 3: diagonal ec: none
# col 4: diagonal ec: 'face'

t0 = time.time()
fig, axs = plt.subplots(4, 4, figsize=(8, 8), sharex=True, sharey=True, constrained_layout=True)


def plot_func(axs, i, j):
    if i in (0, 2):
        cm = cmap_alpha
    else:
        cm = cmap
    if i in (0, 1):
        aa = False
    else:
        aa = True

    if j in (0, 2):
        ec = 'none'
    else:
        ec = 'face'

    if j in (0, 1):
        mesh = axs[i, j].pcolormesh(X, Y, z, norm=norm, cmap=cm,
                             antialiased=aa, edgecolors=ec)
    else:
        mesh = axs[i, j].pcolormesh(X+0.2*Y, Y+0.2*X, z, norm=norm, cmap=cm,
                             antialiased=aa, edgecolors=ec)
    if i == 0 and j == 0:
        fig.colorbar(mesh, ax=axs[0:2, :], orientation='vertical')
    if i == 1 and j == 0:
        fig.colorbar(mesh, ax=axs[2:4, :], orientation='vertical')
    axs[i, j].set_xticks([])
    axs[i, j].set_yticks([])

# Bottom row labels
axs[3, 0].set_xlabel('ec: none')
axs[3, 1].set_xlabel('ec: face')
axs[3, 2].set_xlabel('ec: none')
axs[3, 3].set_xlabel('ec: face')

# Left column labels
axs[0, 0].set_ylabel('aa: False')
axs[1, 0].set_ylabel('aa: False')
axs[2, 0].set_ylabel('aa: True')
axs[3, 0].set_ylabel('aa: True')

for i in range(4):
    for j in range(4):
        plot_func(axs, i, j)

# plt.show()

fig.savefig('pcolormesh_snap.png')

t1 = time.time()
print("Total execution time (s): ", t1-t0)
```