### PR TITLE
Deprecate clear_temp param/attr of FileMovieWriter.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -204,3 +204,10 @@ use e.g. ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This method is deprecated.  If you previously reimplemented it in a subclass,
 set the artist's picker instead with `.Artist.set_picker`.
+
+*clear_temp* parameter and attribute of `.FileMovieWriter`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *clear_temp* parameter and attribute of `.FileMovieWriter` is
+deprecated.  In the future, files placed in a temporary directory (using
+``frame_prefix=None``, the default) will be cleared; files placed elsewhere
+will not.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -497,10 +497,10 @@
       "doc/users/prev_whats_new/whats_new_2.1.0.rst:409"
     ],
     "matplotlib.test": [
-      "doc/devel/testing.rst:84"
+      "doc/devel/testing.rst:79"
     ],
     "matplotlib.testing.conftest.mpl_test_settings": [
-      "doc/devel/testing.rst:111"
+      "doc/devel/testing.rst:106"
     ]
   },
   "py:meth": {
@@ -624,7 +624,7 @@
       "doc/api/prev_api_changes/api_changes_0.91.0.rst:34"
     ],
     "matplotlib.tests.test_basic": [
-      "doc/devel/testing.rst:98"
+      "doc/devel/testing.rst:93"
     ]
   },
   "py:obj": {
@@ -816,8 +816,7 @@
     ],
     "Timer": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.FigureCanvasBase.new_timer:2",
-      "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.TimerBase:14",
-      "lib/matplotlib/backends/backend_nbagg.py:docstring of matplotlib.backends.backend_nbagg.FigureCanvasNbAgg.new_timer:2"
+      "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.TimerBase:14"
     ],
     "Tool": [
       "doc/devel/MEP/MEP22.rst:60",
@@ -1137,7 +1136,7 @@
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.AVConvBase.isAvailable:1:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.args_key": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.bin_path": [
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
@@ -1145,17 +1144,20 @@
     "matplotlib.animation.AVConvFileWriter.cleanup": [
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
     ],
+    "matplotlib.animation.AVConvFileWriter.clear_temp": [
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
+    ],
     "matplotlib.animation.AVConvFileWriter.exec_key": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.finish": [
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.frame_format": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.frame_size": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.grab_frame": [
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
@@ -1164,7 +1166,7 @@
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.output_args": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.saving": [
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
@@ -1173,7 +1175,7 @@
       "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvFileWriter.supported_formats": [
-      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:38:<autosummary>:1"
+      "doc/api/_as_gen/matplotlib.animation.AVConvFileWriter.rst:39:<autosummary>:1"
     ],
     "matplotlib.animation.AVConvWriter.args_key": [
       "doc/api/_as_gen/matplotlib.animation.AVConvWriter.rst:36:<autosummary>:1"
@@ -1231,6 +1233,9 @@
     ],
     "matplotlib.animation.FFMpegFileWriter.cleanup": [
       "doc/api/_as_gen/matplotlib.animation.FFMpegFileWriter.rst:28:<autosummary>:1"
+    ],
+    "matplotlib.animation.FFMpegFileWriter.clear_temp": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FFMpegFileWriter.supported_formats:1:<autosummary>:1"
     ],
     "matplotlib.animation.FFMpegFileWriter.exec_key": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.FFMpegFileWriter.supported_formats:1:<autosummary>:1"
@@ -1328,6 +1333,9 @@
     "matplotlib.animation.HTMLWriter.cleanup": [
       "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
     ],
+    "matplotlib.animation.HTMLWriter.clear_temp": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+    ],
     "matplotlib.animation.HTMLWriter.exec_key": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
     ],
@@ -1348,6 +1356,9 @@
     ],
     "matplotlib.animation.ImageMagickFileWriter.cleanup": [
       "doc/api/_as_gen/matplotlib.animation.ImageMagickFileWriter.rst:28:<autosummary>:1"
+    ],
+    "matplotlib.animation.ImageMagickFileWriter.clear_temp": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.ImageMagickFileWriter.supported_formats:1:<autosummary>:1"
     ],
     "matplotlib.animation.ImageMagickFileWriter.delay": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.ImageMagickFileWriter.supported_formats:1:<autosummary>:1"

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -427,6 +427,7 @@ class FileMovieWriter(MovieWriter):
         MovieWriter.__init__(self, *args, **kwargs)
         self.frame_format = mpl.rcParams['animation.frame_format']
 
+    @cbook._delete_parameter("3.3", "clear_temp")
     def setup(self, fig, outfile, dpi=None, frame_prefix=None,
               clear_temp=True):
         """
@@ -464,10 +465,19 @@ class FileMovieWriter(MovieWriter):
         else:
             self._tmpdir = None
             self.temp_prefix = frame_prefix
-        self.clear_temp = clear_temp
+        self._clear_temp = clear_temp
         self._frame_counter = 0  # used for generating sequential file names
         self._temp_paths = list()
         self.fname_format_str = '%s%%07d.%s'
+
+    @cbook.deprecated("3.3")
+    @property
+    def clear_temp(self):
+        return self._clear_temp
+
+    @clear_temp.setter
+    def clear_temp(self, value):
+        self._clear_temp = value
 
     @property
     def frame_format(self):
@@ -526,7 +536,7 @@ class FileMovieWriter(MovieWriter):
             _log.debug('MovieWriter: clearing temporary path=%s', self._tmpdir)
             self._tmpdir.cleanup()
         else:
-            if self.clear_temp:
+            if self._clear_temp:
                 _log.debug('MovieWriter: clearing temporary paths=%s',
                            self._temp_paths)
                 for path in self._temp_paths:
@@ -824,7 +834,8 @@ class HTMLWriter(FileMovieWriter):
         else:
             frame_prefix = None
 
-        super().setup(fig, outfile, dpi, frame_prefix, clear_temp=False)
+        super().setup(fig, outfile, dpi, frame_prefix)
+        self._clear_temp = False
 
     def grab_frame(self, **savefig_kwargs):
         if self.embed_frames:


### PR DESCRIPTION
It overlaps in awkward ways with frame_prefix, which effectively
provides the same functionality.

followup to https://github.com/matplotlib/matplotlib/pull/16082.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
