### PR TITLE
Consistently name callback arguments event instead of evt

### DIFF
--- a/examples/event_handling/close_event.py
+++ b/examples/event_handling/close_event.py
@@ -8,11 +8,11 @@ Example to show connecting events that occur when the figure closes.
 import matplotlib.pyplot as plt
 
 
-def handle_close(evt):
+def on_close(event):
     print('Closed Figure!')
 
 fig = plt.figure()
-fig.canvas.mpl_connect('close_event', handle_close)
+fig.canvas.mpl_connect('close_event', on_close)
 
 plt.text(0.35, 0.5, 'Close Me!', dict(size=30))
 plt.show()

--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -181,7 +181,7 @@ class Game:
                                   animated=False)
         self.canvas.mpl_connect('key_press_event', self.key_press)
 
-    def draw(self, evt):
+    def draw(self, event):
         draw_artist = self.ax.draw_artist
         if self.background is None:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)

--- a/examples/event_handling/timers.py
+++ b/examples/event_handling/timers.py
@@ -27,7 +27,7 @@ timer.add_callback(update_title, ax)
 timer.start()
 
 # Or could start the timer on first figure draw
-#def start_timer(evt):
+#def start_timer(event):
 #    timer.start()
 #    fig.canvas.mpl_disconnect(drawid)
 #drawid = fig.canvas.mpl_connect('draw_event', start_timer)

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -78,7 +78,7 @@ class PlotPanel(wx.Panel):
         # unmanaged toolbar in your frame
         return self.toolbar
 
-    def OnWhiz(self, evt):
+    def OnWhiz(self, event):
         self.x += np.pi / 15
         self.y += np.pi / 20
         z = np.sin(self.x) + np.cos(self.y)

--- a/examples/user_interfaces/embedding_in_wx4_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx4_sgskip.py
@@ -28,7 +28,7 @@ class MyNavigationToolbar(NavigationToolbar):
                             'Activate custom control')
         self.Bind(wx.EVT_TOOL, self._on_custom, id=tool.GetId())
 
-    def _on_custom(self, evt):
+    def _on_custom(self, event):
         # add some text to the axes in a random location in axes coords with a
         # random color
         ax = self.canvas.figure.axes[0]
@@ -36,7 +36,7 @@ class MyNavigationToolbar(NavigationToolbar):
         rgb = np.random.rand(3)  # generate a random color
         ax.text(x, y, 'You clicked me', transform=ax.transAxes, color=rgb)
         self.canvas.draw()
-        evt.Skip()
+        event.Skip()
 
 
 class CanvasFrame(wx.Frame):

--- a/examples/user_interfaces/fourier_demo_wx_sgskip.py
+++ b/examples/user_interfaces/fourier_demo_wx_sgskip.py
@@ -89,11 +89,11 @@ class SliderGroup(Knob):
         self.param = param
         self.param.attach(self)
 
-    def sliderHandler(self, evt):
-        value = evt.GetInt() / 1000.
+    def sliderHandler(self, event):
+        value = event.GetInt() / 1000.
         self.param.set(value)
 
-    def sliderTextHandler(self, evt):
+    def sliderTextHandler(self, event):
         value = float(self.sliderText.GetValue())
         self.param.set(value)
 
@@ -148,21 +148,21 @@ class FourierDemoFrame(wx.Frame):
         self.amplitudeSliderGroup = SliderGroup(panel, label=' Amplitude a:',
                                                 param=self.A)
 
-    def mouseDown(self, evt):
-        if self.lines[0].contains(evt)[0]:
+    def mouseDown(self, event):
+        if self.lines[0].contains(event)[0]:
             self.state = 'frequency'
-        elif self.lines[1].contains(evt)[0]:
+        elif self.lines[1].contains(event)[0]:
             self.state = 'time'
         else:
             self.state = ''
-        self.mouseInfo = (evt.xdata, evt.ydata,
+        self.mouseInfo = (event.xdata, event.ydata,
                           max(self.f0.value, .1),
                           self.A.value)
 
-    def mouseMotion(self, evt):
+    def mouseMotion(self, event):
         if self.state == '':
             return
-        x, y = evt.xdata, evt.ydata
+        x, y = event.xdata, event.ydata
         if x is None:  # outside the axes
             return
         x0, y0, f0Init, AInit = self.mouseInfo
@@ -173,7 +173,7 @@ class FourierDemoFrame(wx.Frame):
             if (x - x0) / x0 != -1.:
                 self.f0.set(1. / (1. / f0Init + (1. / f0Init * (x - x0) / x0)))
 
-    def mouseUp(self, evt):
+    def mouseUp(self, event):
         self.state = ''
 
     def createPlots(self):

--- a/examples/user_interfaces/svg_tooltip_sgskip.py
+++ b/examples/user_interfaces/svg_tooltip_sgskip.py
@@ -63,7 +63,7 @@ plt.savefig(f, format="svg")
 
 # Create XML tree from the SVG file.
 tree, xmlid = ET.XMLID(f.getvalue())
-tree.set('onload', 'init(evt)')
+tree.set('onload', 'init(event)')
 
 for i in shapes:
     # Get the index of the shape
@@ -81,9 +81,9 @@ script = """
     <script type="text/ecmascript">
     <![CDATA[
 
-    function init(evt) {
+    function init(event) {
         if ( window.svgDocument == null ) {
-            svgDocument = evt.target.ownerDocument;
+            svgDocument = event.target.ownerDocument;
             }
         }
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1266,7 +1266,7 @@ class Animation:
         self._resize_id = self._fig.canvas.mpl_connect('draw_event',
                                                        self._end_redraw)
 
-    def _end_redraw(self, evt):
+    def _end_redraw(self, event):
         # Now that the redraw has happened, do the post draw flushing and
         # blit handling. Then re-enable all of the original events.
         self._post_draw(None, False)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -230,8 +230,8 @@ class FigureCanvasTk(FigureCanvasBase):
 
         # Can't get destroy events by binding to _tkcanvas. Therefore, bind
         # to the window and filter.
-        def filter_destroy(evt):
-            if evt.widget is self._tkcanvas:
+        def filter_destroy(event):
+            if event.widget is self._tkcanvas:
                 self._master.update_idletasks()
                 self.close_event()
         root.bind("<Destroy>", filter_destroy, "+")

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -688,7 +688,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         if self._isDrawn:
             self.draw()
 
-    def _onPaint(self, evt):
+    def _onPaint(self, event):
         """Called when wxPaintEvt is generated."""
         _log.debug("%s - _onPaint()", type(self))
         drawDC = wx.PaintDC(self)
@@ -698,7 +698,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             self.gui_repaint(drawDC=drawDC)
         drawDC.Destroy()
 
-    def _onSize(self, evt):
+    def _onSize(self, event):
         """
         Called when wxEventSize is generated.
 
@@ -742,41 +742,41 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         self.Refresh(eraseBackground=False)
         FigureCanvasBase.resize_event(self)
 
-    def _get_key(self, evt):
+    def _get_key(self, event):
 
-        keyval = evt.KeyCode
+        keyval = event.KeyCode
         if keyval in self.keyvald:
             key = self.keyvald[keyval]
         elif keyval < 256:
             key = chr(keyval)
             # wx always returns an uppercase, so make it lowercase if the shift
             # key is not depressed (NOTE: this will not handle Caps Lock)
-            if not evt.ShiftDown():
+            if not event.ShiftDown():
                 key = key.lower()
         else:
             key = None
 
         for meth, prefix in (
-                [evt.AltDown, 'alt'],
-                [evt.ControlDown, 'ctrl'], ):
+                [event.AltDown, 'alt'],
+                [event.ControlDown, 'ctrl'], ):
             if meth():
                 key = '{0}+{1}'.format(prefix, key)
 
         return key
 
-    def _onKeyDown(self, evt):
+    def _onKeyDown(self, event):
         """Capture key press."""
-        key = self._get_key(evt)
-        FigureCanvasBase.key_press_event(self, key, guiEvent=evt)
+        key = self._get_key(event)
+        FigureCanvasBase.key_press_event(self, key, guiEvent=event)
         if self:
-            evt.Skip()
+            event.Skip()
 
-    def _onKeyUp(self, evt):
+    def _onKeyUp(self, event):
         """Release key."""
-        key = self._get_key(evt)
-        FigureCanvasBase.key_release_event(self, key, guiEvent=evt)
+        key = self._get_key(event)
+        FigureCanvasBase.key_release_event(self, key, guiEvent=event)
         if self:
-            evt.Skip()
+            event.Skip()
 
     def _set_capture(self, capture=True):
         """Control wx mouse capture."""
@@ -785,39 +785,40 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         if capture:
             self.CaptureMouse()
 
-    def _onCaptureLost(self, evt):
+    def _onCaptureLost(self, event):
         """Capture changed or lost"""
         self._set_capture(False)
 
-    def _onMouseButton(self, evt):
+    def _onMouseButton(self, event):
         """Start measuring on an axis."""
-        evt.Skip()
-        self._set_capture(evt.ButtonDown() or evt.ButtonDClick())
-        x = evt.X
-        y = self.figure.bbox.height - evt.Y
+        event.Skip()
+        self._set_capture(event.ButtonDown() or event.ButtonDClick())
+        x = event.X
+        y = self.figure.bbox.height - event.Y
         button_map = {
             wx.MOUSE_BTN_LEFT: MouseButton.LEFT,
             wx.MOUSE_BTN_MIDDLE: MouseButton.MIDDLE,
             wx.MOUSE_BTN_RIGHT: MouseButton.RIGHT,
         }
-        button = evt.GetButton()
+        button = event.GetButton()
         button = button_map.get(button, button)
-        if evt.ButtonDown():
-            self.button_press_event(x, y, button, guiEvent=evt)
-        elif evt.ButtonDClick():
-            self.button_press_event(x, y, button, dblclick=True, guiEvent=evt)
-        elif evt.ButtonUp():
-            self.button_release_event(x, y, button, guiEvent=evt)
+        if event.ButtonDown():
+            self.button_press_event(x, y, button, guiEvent=event)
+        elif event.ButtonDClick():
+            self.button_press_event(x, y, button, dblclick=True,
+                                    guiEvent=event)
+        elif event.ButtonUp():
+            self.button_release_event(x, y, button, guiEvent=event)
 
-    def _onMouseWheel(self, evt):
+    def _onMouseWheel(self, event):
         """Translate mouse wheel events into matplotlib events"""
         # Determine mouse location
-        x = evt.GetX()
-        y = self.figure.bbox.height - evt.GetY()
+        x = event.GetX()
+        y = self.figure.bbox.height - event.GetY()
         # Convert delta/rotation/rate into a floating point step size
-        step = evt.LinesPerAction * evt.WheelRotation / evt.WheelDelta
+        step = event.LinesPerAction * event.WheelRotation / event.WheelDelta
         # Done handling event
-        evt.Skip()
+        event.Skip()
         # Mac gives two events for every wheel event; skip every second one.
         if wx.Platform == '__WXMAC__':
             if not hasattr(self, '_skipwheelevent'):
@@ -827,26 +828,26 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
                 return  # Return without processing event
             else:
                 self._skipwheelevent = True
-        FigureCanvasBase.scroll_event(self, x, y, step, guiEvent=evt)
+        FigureCanvasBase.scroll_event(self, x, y, step, guiEvent=event)
 
-    def _onMotion(self, evt):
+    def _onMotion(self, event):
         """Start measuring on an axis."""
-        x = evt.GetX()
-        y = self.figure.bbox.height - evt.GetY()
-        evt.Skip()
-        FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=evt)
+        x = event.GetX()
+        y = self.figure.bbox.height - event.GetY()
+        event.Skip()
+        FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
 
-    def _onLeave(self, evt):
+    def _onLeave(self, event):
         """Mouse has left the window."""
-        evt.Skip()
-        FigureCanvasBase.leave_notify_event(self, guiEvent=evt)
+        event.Skip()
+        FigureCanvasBase.leave_notify_event(self, guiEvent=event)
 
-    def _onEnter(self, evt):
+    def _onEnter(self, event):
         """Mouse has entered the window."""
-        x = evt.GetX()
-        y = self.figure.bbox.height - evt.GetY()
-        evt.Skip()
-        FigureCanvasBase.enter_notify_event(self, guiEvent=evt, xy=(x, y))
+        x = event.GetX()
+        y = self.figure.bbox.height - event.GetY()
+        event.Skip()
+        FigureCanvasBase.enter_notify_event(self, guiEvent=event, xy=(x, y))
 
 
 class FigureCanvasWx(_FigureCanvasWxBase):
@@ -1024,7 +1025,7 @@ class FigureFrameWx(wx.Frame):
         _log.debug("%s - get_figure_manager()", type(self))
         return self.figmgr
 
-    def _onClose(self, evt):
+    def _onClose(self, event):
         _log.debug("%s - onClose()", type(self))
         self.canvas.close_event()
         self.canvas.stop_event_loop()
@@ -1593,10 +1594,10 @@ class _HelpDialog(wx.Dialog):
         self.Bind(wx.EVT_CLOSE, self.OnClose)
         OK.Bind(wx.EVT_BUTTON, self.OnClose)
 
-    def OnClose(self, evt):
+    def OnClose(self, event):
         _HelpDialog._instance = None  # remove global reference
         self.DestroyLater()
-        evt.Skip()
+        event.Skip()
 
     @classmethod
     def show(cls, parent, help_entries):

--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -72,7 +72,7 @@ class Thumbnail(QtWidgets.QFrame):
         layout.addWidget(self.image)
         self.setLayout(layout)
 
-    def mousePressEvent(self, ev):
+    def mousePressEvent(self, event):
         self.parent.set_large_image(self.index)
 
 


### PR DESCRIPTION
## PR Summary

Changes are only made to examples and internal methods, so no deprecation necessary.

This addresses:
- Matplotlib callbacks
- Wx callbacks, which also use `event` as variable name (c.f. second code example at https://wxpython.org/Phoenix/docs/html/events_overview.html)