### PR TITLE
Consistently name event callbacks on_[event]

### DIFF
--- a/examples/event_handling/data_browser.py
+++ b/examples/event_handling/data_browser.py
@@ -27,7 +27,7 @@ class PointBrowser:
         self.selected, = ax.plot([xs[0]], [ys[0]], 'o', ms=12, alpha=0.4,
                                  color='yellow', visible=False)
 
-    def onpress(self, event):
+    def on_press(self, event):
         if self.lastind is None:
             return
         if event.key not in ('n', 'p'):
@@ -41,7 +41,7 @@ class PointBrowser:
         self.lastind = np.clip(self.lastind, 0, len(xs) - 1)
         self.update()
 
-    def onpick(self, event):
+    def on_pick(self, event):
 
         if event.artist != line:
             return True
@@ -95,7 +95,7 @@ if __name__ == '__main__':
 
     browser = PointBrowser()
 
-    fig.canvas.mpl_connect('pick_event', browser.onpick)
-    fig.canvas.mpl_connect('key_press_event', browser.onpress)
+    fig.canvas.mpl_connect('pick_event', browser.on_pick)
+    fig.canvas.mpl_connect('key_press_event', browser.on_press)
 
     plt.show()

--- a/examples/event_handling/figure_axes_enter_leave.py
+++ b/examples/event_handling/figure_axes_enter_leave.py
@@ -9,25 +9,25 @@ frame colors on enter and leave
 import matplotlib.pyplot as plt
 
 
-def enter_axes(event):
+def on_enter_axes(event):
     print('enter_axes', event.inaxes)
     event.inaxes.patch.set_facecolor('yellow')
     event.canvas.draw()
 
 
-def leave_axes(event):
+def on_leave_axes(event):
     print('leave_axes', event.inaxes)
     event.inaxes.patch.set_facecolor('white')
     event.canvas.draw()
 
 
-def enter_figure(event):
+def on_enter_figure(event):
     print('enter_figure', event.canvas.figure)
     event.canvas.figure.patch.set_facecolor('red')
     event.canvas.draw()
 
 
-def leave_figure(event):
+def on_leave_figure(event):
     print('leave_figure', event.canvas.figure)
     event.canvas.figure.patch.set_facecolor('grey')
     event.canvas.draw()
@@ -37,19 +37,19 @@ def leave_figure(event):
 fig1, (ax, ax2) = plt.subplots(2, 1)
 fig1.suptitle('mouse hover over figure or axes to trigger events')
 
-fig1.canvas.mpl_connect('figure_enter_event', enter_figure)
-fig1.canvas.mpl_connect('figure_leave_event', leave_figure)
-fig1.canvas.mpl_connect('axes_enter_event', enter_axes)
-fig1.canvas.mpl_connect('axes_leave_event', leave_axes)
+fig1.canvas.mpl_connect('figure_enter_event', on_enter_figure)
+fig1.canvas.mpl_connect('figure_leave_event', on_leave_figure)
+fig1.canvas.mpl_connect('axes_enter_event', on_enter_axes)
+fig1.canvas.mpl_connect('axes_leave_event', on_leave_axes)
 
 ###############################################################################
 
 fig2, (ax, ax2) = plt.subplots(2, 1)
 fig2.suptitle('mouse hover over figure or axes to trigger events')
 
-fig2.canvas.mpl_connect('figure_enter_event', enter_figure)
-fig2.canvas.mpl_connect('figure_leave_event', leave_figure)
-fig2.canvas.mpl_connect('axes_enter_event', enter_axes)
-fig2.canvas.mpl_connect('axes_leave_event', leave_axes)
+fig2.canvas.mpl_connect('figure_enter_event', on_enter_figure)
+fig2.canvas.mpl_connect('figure_leave_event', on_leave_figure)
+fig2.canvas.mpl_connect('axes_enter_event', on_enter_axes)
+fig2.canvas.mpl_connect('axes_leave_event', on_leave_axes)
 
 plt.show()

--- a/examples/event_handling/image_slices_viewer.py
+++ b/examples/event_handling/image_slices_viewer.py
@@ -22,7 +22,7 @@ class IndexTracker:
         self.im = ax.imshow(self.X[:, :, self.ind])
         self.update()
 
-    def onscroll(self, event):
+    def on_scroll(self, event):
         print("%s %s" % (event.button, event.step))
         if event.button == 'up':
             self.ind = (self.ind + 1) % self.slices
@@ -43,5 +43,5 @@ X = np.random.rand(20, 20, 40)
 tracker = IndexTracker(ax, X)
 
 
-fig.canvas.mpl_connect('scroll_event', tracker.onscroll)
+fig.canvas.mpl_connect('scroll_event', tracker.on_scroll)
 plt.show()

--- a/examples/event_handling/keypress_demo.py
+++ b/examples/event_handling/keypress_demo.py
@@ -10,7 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def press(event):
+def on_press(event):
     print('press', event.key)
     sys.stdout.flush()
     if event.key == 'x':
@@ -24,7 +24,7 @@ np.random.seed(19680801)
 
 fig, ax = plt.subplots()
 
-fig.canvas.mpl_connect('key_press_event', press)
+fig.canvas.mpl_connect('key_press_event', on_press)
 
 ax.plot(np.random.rand(12), np.random.rand(12), 'go')
 xl = ax.set_xlabel('easy come, easy go')

--- a/examples/event_handling/lasso_demo.py
+++ b/examples/event_handling/lasso_demo.py
@@ -49,7 +49,7 @@ class LassoManager:
 
         ax.add_collection(self.collection)
 
-        self.cid = self.canvas.mpl_connect('button_press_event', self.onpress)
+        self.cid = self.canvas.mpl_connect('button_press_event', self.on_press)
 
     def callback(self, verts):
         facecolors = self.collection.get_facecolors()
@@ -65,7 +65,7 @@ class LassoManager:
         self.canvas.widgetlock.release(self.lasso)
         del self.lasso
 
-    def onpress(self, event):
+    def on_press(self, event):
         if self.canvas.widgetlock.locked():
             return
         if event.inaxes is None:

--- a/examples/event_handling/legend_picking.py
+++ b/examples/event_handling/legend_picking.py
@@ -29,7 +29,7 @@ for legline, origline in zip(leg.get_lines(), lines):
     lined[legline] = origline
 
 
-def onpick(event):
+def on_pick(event):
     # on the pick event, find the orig line corresponding to the
     # legend proxy line, and toggle the visibility
     legline = event.artist
@@ -44,6 +44,6 @@ def onpick(event):
         legline.set_alpha(0.2)
     fig.canvas.draw()
 
-fig.canvas.mpl_connect('pick_event', onpick)
+fig.canvas.mpl_connect('pick_event', on_pick)
 
 plt.show()

--- a/examples/event_handling/looking_glass.py
+++ b/examples/event_handling/looking_glass.py
@@ -26,13 +26,13 @@ ax.set_title("Left click and drag to move looking glass")
 
 class EventHandler:
     def __init__(self):
-        fig.canvas.mpl_connect('button_press_event', self.onpress)
-        fig.canvas.mpl_connect('button_release_event', self.onrelease)
-        fig.canvas.mpl_connect('motion_notify_event', self.onmove)
+        fig.canvas.mpl_connect('button_press_event', self.on_press)
+        fig.canvas.mpl_connect('button_release_event', self.on_release)
+        fig.canvas.mpl_connect('motion_notify_event', self.on_move)
         self.x0, self.y0 = circ.center
         self.pressevent = None
 
-    def onpress(self, event):
+    def on_press(self, event):
         if event.inaxes != ax:
             return
 
@@ -41,11 +41,11 @@ class EventHandler:
 
         self.pressevent = event
 
-    def onrelease(self, event):
+    def on_release(self, event):
         self.pressevent = None
         self.x0, self.y0 = circ.center
 
-    def onmove(self, event):
+    def on_move(self, event):
         if self.pressevent is None or event.inaxes != self.pressevent.inaxes:
             return
 

--- a/examples/event_handling/path_editor.py
+++ b/examples/event_handling/path_editor.py
@@ -66,7 +66,7 @@ class PathInteractor:
         canvas.mpl_connect('button_press_event', self.on_button_press)
         canvas.mpl_connect('key_press_event', self.on_key_press)
         canvas.mpl_connect('button_release_event', self.on_button_release)
-        canvas.mpl_connect('motion_notify_event', self.on_motion_notify)
+        canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
         self.canvas = canvas
 
     def get_ind_under_point(self, event):
@@ -119,7 +119,7 @@ class PathInteractor:
                 self._ind = None
         self.canvas.draw()
 
-    def on_motion_notify(self, event):
+    def on_mouse_move(self, event):
         """Callback for mouse movements."""
         if (self._ind is None
                 or event.inaxes is None

--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -179,7 +179,7 @@ class Game:
                                   multialignment='left',
                                   textcoords='axes fraction',
                                   animated=False)
-        self.canvas.mpl_connect('key_press_event', self.key_press)
+        self.canvas.mpl_connect('key_press_event', self.on_key_press)
 
     def draw(self, evt):
         draw_artist = self.ax.draw_artist
@@ -237,7 +237,7 @@ class Game:
         self.cnt += 1
         return True
 
-    def key_press(self, event):
+    def on_key_press(self, event):
         if event.key == '3':
             self.res *= 5.0
         if event.key == '4':

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -75,14 +75,14 @@ class PolygonInteractor:
         self.cid = self.poly.add_callback(self.poly_changed)
         self._ind = None  # the active vert
 
-        canvas.mpl_connect('draw_event', self.draw_callback)
-        canvas.mpl_connect('button_press_event', self.button_press_callback)
-        canvas.mpl_connect('key_press_event', self.key_press_callback)
-        canvas.mpl_connect('button_release_event', self.button_release_callback)
-        canvas.mpl_connect('motion_notify_event', self.motion_notify_callback)
+        canvas.mpl_connect('draw_event', self.on_draw)
+        canvas.mpl_connect('button_press_event', self.on_button_press)
+        canvas.mpl_connect('key_press_event', self.on_key_press)
+        canvas.mpl_connect('button_release_event', self.on_button_release)
+        canvas.mpl_connect('motion_notify_event', self.on_mouse_move)
         self.canvas = canvas
 
-    def draw_callback(self, event):
+    def on_draw(self, event):
         self.background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self.poly)
         self.ax.draw_artist(self.line)
@@ -114,7 +114,7 @@ class PolygonInteractor:
 
         return ind
 
-    def button_press_callback(self, event):
+    def on_button_press(self, event):
         """Callback for mouse button presses."""
         if not self.showverts:
             return
@@ -124,7 +124,7 @@ class PolygonInteractor:
             return
         self._ind = self.get_ind_under_point(event)
 
-    def button_release_callback(self, event):
+    def on_button_release(self, event):
         """Callback for mouse button releases."""
         if not self.showverts:
             return
@@ -132,7 +132,7 @@ class PolygonInteractor:
             return
         self._ind = None
 
-    def key_press_callback(self, event):
+    def on_key_press(self, event):
         """Callback for key presses."""
         if not event.inaxes:
             return
@@ -164,7 +164,7 @@ class PolygonInteractor:
         if self.line.stale:
             self.canvas.draw_idle()
 
-    def motion_notify_callback(self, event):
+    def on_mouse_move(self, event):
         """Callback for mouse movements."""
         if not self.showverts:
             return

--- a/examples/event_handling/pong_sgskip.py
+++ b/examples/event_handling/pong_sgskip.py
@@ -27,7 +27,7 @@ if fig.canvas.manager.key_press_handler_id is not None:
 
 
 # reset the blitting background on redraw
-def handle_redraw(event):
+def on_redraw(event):
     animation.background = None
 
 
@@ -40,7 +40,7 @@ def start_anim(event):
             animation.draw(None)
     start_anim.timer.add_callback(local_draw)
     start_anim.timer.start()
-    canvas.mpl_connect('draw_event', handle_redraw)
+    canvas.mpl_connect('draw_event', on_redraw)
 
 
 start_anim.cid = canvas.mpl_connect('draw_event', start_anim)

--- a/examples/event_handling/trifinder_event_demo.py
+++ b/examples/event_handling/trifinder_event_demo.py
@@ -23,7 +23,7 @@ def update_polygon(tri):
     polygon.set_xy(np.column_stack([xs, ys]))
 
 
-def motion_notify(event):
+def on_mouse_move(event):
     if event.inaxes is None:
         tri = -1
     else:
@@ -57,5 +57,5 @@ plt.triplot(triang, 'bo-')
 polygon = Polygon([[0, 0], [0, 0]], facecolor='y')  # dummy data for (xs, ys)
 update_polygon(-1)
 plt.gca().add_patch(polygon)
-plt.gcf().canvas.mpl_connect('motion_notify_event', motion_notify)
+plt.gcf().canvas.mpl_connect('motion_notify_event', on_mouse_move)
 plt.show()

--- a/examples/event_handling/zoom_window.py
+++ b/examples/event_handling/zoom_window.py
@@ -31,7 +31,7 @@ axsrc.scatter(x, y, s, c)
 axzoom.scatter(x, y, s, c)
 
 
-def onpress(event):
+def on_press(event):
     if event.button != 1:
         return
     x, y = event.xdata, event.ydata
@@ -39,5 +39,5 @@ def onpress(event):
     axzoom.set_ylim(y - 0.1, y + 0.1)
     figzoom.canvas.draw()
 
-figsrc.canvas.mpl_connect('button_press_event', onpress)
+figsrc.canvas.mpl_connect('button_press_event', on_press)
 plt.show()

--- a/examples/misc/cursor_demo_sgskip.py
+++ b/examples/misc/cursor_demo_sgskip.py
@@ -30,7 +30,7 @@ class Cursor:
         # text location in axes coords
         self.txt = ax.text(0.7, 0.9, '', transform=ax.transAxes)
 
-    def mouse_move(self, event):
+    def on_mouse_move(self, event):
         if not event.inaxes:
             return
 
@@ -58,7 +58,7 @@ class SnaptoCursor:
         # text location in axes coords
         self.txt = ax.text(0.7, 0.9, '', transform=ax.transAxes)
 
-    def mouse_move(self, event):
+    def on_mouse_move(self, event):
         if not event.inaxes:
             return
 
@@ -81,11 +81,11 @@ s = np.sin(2 * 2 * np.pi * t)
 fig, ax = plt.subplots()
 ax.plot(t, s, 'o')
 cursor = Cursor(ax)
-fig.canvas.mpl_connect('motion_notify_event', cursor.mouse_move)
+fig.canvas.mpl_connect('motion_notify_event', cursor.on_mouse_move)
 
 fig, ax = plt.subplots()
 ax.plot(t, s, 'o')
 snap_cursor = SnaptoCursor(ax, t, s)
-fig.canvas.mpl_connect('motion_notify_event', snap_cursor.mouse_move)
+fig.canvas.mpl_connect('motion_notify_event', snap_cursor.on_mouse_move)
 
 plt.show()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1251,10 +1251,10 @@ class Animation:
         self._blit_cache = dict()
         self._drawn_artists = []
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
-                                                       self._handle_resize)
+                                                       self._on_resize)
         self._post_draw(None, self._blit)
 
-    def _handle_resize(self, *args):
+    def _on_resize(self, event):
         # On resize, we need to disable the resize event handling so we don't
         # get too many events. Also stop the animation events, so that
         # we're paused. Reset the cache and re-init. Set up an event handler
@@ -1273,7 +1273,7 @@ class Animation:
         self.event_source.start()
         self._fig.canvas.mpl_disconnect(self._resize_id)
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
-                                                       self._handle_resize)
+                                                       self._on_resize)
 
     def to_html5_video(self, embed_limit=None):
         """

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -183,11 +183,11 @@ def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
         def key(self): return getattr(qt_core.Qt, qt_key)
         def modifiers(self): return qt_mod
 
-    def receive(event):
+    def on_key_press(event):
         assert event.key == answer
 
     qt_canvas = plt.figure().canvas
-    qt_canvas.mpl_connect('key_press_event', receive)
+    qt_canvas.mpl_connect('key_press_event', on_key_press)
     qt_canvas.keyPressEvent(_Event())
 
 


### PR DESCRIPTION
## PR Summary

Changes are only made to examples and internal methods, so no deprecation necessary.
