### PR TITLE
Fix incorrect doc regarding projections.

### DIFF
--- a/doc/devel/add_new_projection.rst
+++ b/doc/devel/add_new_projection.rst
@@ -16,13 +16,11 @@ that handle data in two or more dimensions at a time, are called
 "projections".
 
 From the user's perspective, the scale of a plot can be set with
-:meth:`~matplotlib.axes.Axes.set_xscale` and
-:meth:`~matplotlib.axes.Axes.set_yscale`.  Projections can be chosen
-using the ``projection`` keyword argument to the
-:func:`~matplotlib.pylab.plot` or :func:`~matplotlib.pylab.subplot`
-functions, e.g.::
+`.Axes.set_xscale` and `.Axes.set_yscale`.  Projections can be chosen using the
+*projection* keyword argument of functions that create Axes, such as
+`.pyplot.subplot` or `.pyplot.axes`, e.g. ::
 
-    plot(x, y, projection="custom")
+    plt.subplot(projection="custom")
 
 This document is intended for developers and advanced users who need
 to create new scales and projections for Matplotlib.  The necessary


### PR DESCRIPTION
`plot(x, y, projection="custom")` (e.g. `projection="polar"`) doesn't
actually work (and would go against the mpl model of separating axes and
artists that are axes children, anyways).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
