### PR TITLE
Fix legend dragging.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -74,10 +74,10 @@ class DraggableLegend(DraggableOffsetBox):
         return self.legend.contains(evt)
 
     def finalize_offset(self):
-        update_method = cbook._check_getitem(
-            {"loc": self._update_loc, "bbox": self._bbox_to_anchor},
-            update=self._update)
-        update_method(self.get_loc_in_canvas())
+        if self._update == "loc":
+            self._update_loc(self.get_loc_in_canvas())
+        elif self._update == "bbox":
+            self._bbox_to_anchor(self.get_loc_in_canvas())
 
     def _update_loc(self, loc_in_canvas):
         bbox = self.legend.get_bbox_to_anchor()


### PR DESCRIPTION
Without this PR, after
```
plot([1, 2], label="foo"); legend().set_draggable(True)
```
when dragging the legend, releasing the mouse button results in
```
Traceback (most recent call last):
  File ".../matplotlib/cbook/__init__.py", line 236, in process
    func(*args, **kwargs)
  File ".../matplotlib/offsetbox.py", line 1716, in on_release
    self.finalize_offset()
  File ".../matplotlib/legend.py", line 78, in finalize_offset
    {"loc": self._update_loc, "bbox": self._bbox_to_anchor},
AttributeError: 'DraggableLegend' object has no attribute '_bbox_to_anchor'
```
See comment in code for more explanations.

A test may be nice but tricky to write...

Came in in #15086, so RC for 3.2.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
