### PR TITLE
Name Axes variables ax instead of a

### DIFF
--- a/examples/misc/hyperlinks_sgskip.py
+++ b/examples/misc/hyperlinks_sgskip.py
@@ -16,14 +16,14 @@ import matplotlib.pyplot as plt
 
 ###############################################################################
 
-f = plt.figure()
+fig = plt.figure()
 s = plt.scatter([1, 2, 3], [4, 5, 6])
 s.set_urls(['http://www.bbc.co.uk/news', 'http://www.google.com', None])
-f.savefig('scatter.svg')
+fig.savefig('scatter.svg')
 
 ###############################################################################
 
-f = plt.figure()
+fig = plt.figure()
 delta = 0.025
 x = y = np.arange(-3.0, 3.0, delta)
 X, Y = np.meshgrid(x, y)
@@ -35,4 +35,4 @@ im = plt.imshow(Z, interpolation='bilinear', cmap=cm.gray,
                 origin='lower', extent=[-3, 3, -3, 3])
 
 im.set_url('http://www.google.com')
-f.savefig('image.svg')
+fig.savefig('image.svg')

--- a/examples/shapes_and_collections/ellipse_demo.py
+++ b/examples/shapes_and_collections/ellipse_demo.py
@@ -42,20 +42,17 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Ellipse
 
-delta = 45.0  # degrees
+angle_step = 45  # degrees
+angles = np.arange(0, 360, angle_step)
 
-angles = np.arange(0, 360 + delta, delta)
-ells = [Ellipse((1, 1), 4, 2, a) for a in angles]
+ax = plt.subplot(aspect='equal')
 
-a = plt.subplot(111, aspect='equal')
+for angle in angles:
+    ellipse = Ellipse((0, 0), 4, 2, angle=angle, alpha=0.1)
+    ax.add_artist(ellipse)
 
-for e in ells:
-    e.set_clip_box(a.bbox)
-    e.set_alpha(0.1)
-    a.add_artist(e)
-
-plt.xlim(-2, 4)
-plt.ylim(-1, 3)
+plt.xlim(-2.2, 2.2)
+plt.ylim(-2.2, 2.2)
 
 plt.show()
 

--- a/examples/subplots_axes_and_figures/gridspec_nested.py
+++ b/examples/subplots_axes_and_figures/gridspec_nested.py
@@ -18,24 +18,24 @@ def format_axes(fig):
 
 
 # gridspec inside gridspec
-f = plt.figure()
+fig = plt.figure()
 
-gs0 = gridspec.GridSpec(1, 2, figure=f)
+gs0 = gridspec.GridSpec(1, 2, figure=fig)
 
 gs00 = gridspec.GridSpecFromSubplotSpec(3, 3, subplot_spec=gs0[0])
 
-ax1 = f.add_subplot(gs00[:-1, :])
-ax2 = f.add_subplot(gs00[-1, :-1])
-ax3 = f.add_subplot(gs00[-1, -1])
+ax1 = fig.add_subplot(gs00[:-1, :])
+ax2 = fig.add_subplot(gs00[-1, :-1])
+ax3 = fig.add_subplot(gs00[-1, -1])
 
 # the following syntax does the same as the GridSpecFromSubplotSpec call above:
 gs01 = gs0[1].subgridspec(3, 3)
 
-ax4 = f.add_subplot(gs01[:, :-1])
-ax5 = f.add_subplot(gs01[:-1, -1])
-ax6 = f.add_subplot(gs01[-1, -1])
+ax4 = fig.add_subplot(gs01[:, :-1])
+ax5 = fig.add_subplot(gs01[:-1, -1])
+ax6 = fig.add_subplot(gs01[-1, -1])
 
 plt.suptitle("GridSpec Inside GridSpec")
-format_axes(f)
+format_axes(fig)
 
 plt.show()

--- a/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
@@ -22,17 +22,17 @@ win.connect("delete-event", Gtk.main_quit)
 win.set_default_size(400, 300)
 win.set_title("Embedding in GTK")
 
-f = Figure(figsize=(5, 4), dpi=100)
-a = f.add_subplot(1, 1, 1)
+fig = Figure(figsize=(5, 4), dpi=100)
+ax = fig.add_subplot(1, 1, 1)
 t = np.arange(0.0, 3.0, 0.01)
 s = np.sin(2*np.pi*t)
-a.plot(t, s)
+ax.plot(t, s)
 
 vbox = Gtk.VBox()
 win.add(vbox)
 
 # Add canvas to vbox
-canvas = FigureCanvas(f)  # a Gtk.DrawingArea
+canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
 vbox.pack_start(canvas, True, True, 0)
 
 # Create toolbar

--- a/examples/user_interfaces/embedding_in_gtk3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_sgskip.py
@@ -21,18 +21,18 @@ win.connect("delete-event", Gtk.main_quit)
 win.set_default_size(400, 300)
 win.set_title("Embedding in GTK")
 
-f = Figure(figsize=(5, 4), dpi=100)
-a = f.add_subplot(111)
+fig = Figure(figsize=(5, 4), dpi=100)
+ax = fig.add_subplot(111)
 t = np.arange(0.0, 3.0, 0.01)
 s = np.sin(2*np.pi*t)
-a.plot(t, s)
+ax.plot(t, s)
 
 sw = Gtk.ScrolledWindow()
 win.add(sw)
 # A scrolled window border goes outside the scrollbars and viewport
 sw.set_border_width(10)
 
-canvas = FigureCanvas(f)  # a Gtk.DrawingArea
+canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
 canvas.set_size_request(800, 600)
 sw.add_with_viewport(canvas)
 

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -57,19 +57,19 @@ class PlotPanel(wx.Panel):
         self.Fit()
 
     def init_plot_data(self):
-        a = self.fig.add_subplot(111)
+        ax = self.fig.add_subplot(111)
 
         x = np.arange(120.0) * 2 * np.pi / 60.0
         y = np.arange(100.0) * 2 * np.pi / 50.0
         self.x, self.y = np.meshgrid(x, y)
         z = np.sin(self.x) + np.cos(self.y)
-        self.im = a.imshow(z, cmap=cm.RdBu)
+        self.im = ax.imshow(z, cmap=cm.RdBu)
 
         zmax = np.max(z) - ERR_TOL
         ymax_i, xmax_i = np.nonzero(z >= zmax)
         if self.im.origin == 'upper':
             ymax_i = z.shape[0] - ymax_i
-        self.lines = a.plot(xmax_i, ymax_i, 'ko')
+        self.lines = ax.plot(xmax_i, ymax_i, 'ko')
 
         self.toolbar.update()  # Not sure why this is needed - ADS
 

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -38,10 +38,10 @@ def create_figure():
     Creates a simple example figure.
     """
     fig = Figure()
-    a = fig.add_subplot(111)
+    ax = fig.add_subplot(111)
     t = np.arange(0.0, 3.0, 0.01)
     s = np.sin(2 * np.pi * t)
-    a.plot(t, s)
+    ax.plot(t, s)
     return fig
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1358,8 +1358,8 @@ default: 'top'
 
         if isinstance(args[0], SubplotBase):
 
-            a = args[0]
-            if a.get_figure() is not self:
+            ax = args[0]
+            if ax.get_figure() is not self:
                 raise ValueError(
                     "The Subplot must have been created in the present figure")
             # make a key for the subplot (which includes the axes object id
@@ -1385,9 +1385,9 @@ default: 'top'
                     # more similar to add_axes.
                     self._axstack.remove(ax)
 
-            a = subplot_class_factory(projection_class)(self, *args, **kwargs)
+            ax = subplot_class_factory(projection_class)(self, *args, **kwargs)
 
-        return self._add_axes_internal(key, a)
+        return self._add_axes_internal(key, ax)
 
     def _add_axes_internal(self, key, ax):
         """Private helper for `add_axes` and `add_subplot`."""

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -961,18 +961,18 @@ def subplot(*args, **kwargs):
                          "and/or 'nrows'.  Did you intend to call subplots()?")
 
     fig = gcf()
-    a = fig.add_subplot(*args, **kwargs)
-    bbox = a.bbox
-    byebye = []
-    for other in fig.axes:
-        if other == a:
+    ax = fig.add_subplot(*args, **kwargs)
+    bbox = ax.bbox
+    axes_to_delete = []
+    for other_ax in fig.axes:
+        if other_ax == ax:
             continue
-        if bbox.fully_overlaps(other.bbox):
-            byebye.append(other)
-    for ax in byebye:
-        delaxes(ax)
+        if bbox.fully_overlaps(other_ax.bbox):
+            axes_to_delete.append(other_ax)
+    for ax_to_del in axes_to_delete:
+        delaxes(ax_to_del)
 
-    return a
+    return ax
 
 
 def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
@@ -1151,18 +1151,18 @@ def subplot2grid(shape, loc, rowspan=1, colspan=1, fig=None, **kwargs):
     subplotspec = GridSpec(s1, s2).new_subplotspec(loc,
                                                    rowspan=rowspan,
                                                    colspan=colspan)
-    a = fig.add_subplot(subplotspec, **kwargs)
-    bbox = a.bbox
-    byebye = []
-    for other in fig.axes:
-        if other == a:
+    ax = fig.add_subplot(subplotspec, **kwargs)
+    bbox = ax.bbox
+    axes_to_delete = []
+    for other_ax in fig.axes:
+        if other_ax == ax:
             continue
-        if bbox.fully_overlaps(other.bbox):
-            byebye.append(other)
-    for ax in byebye:
-        delaxes(ax)
+        if bbox.fully_overlaps(other_ax.bbox):
+            axes_to_delete.append(other_ax)
+    for ax_to_del in axes_to_delete:
+        delaxes(ax_to_del)
 
-    return a
+    return ax
 
 
 def twinx(ax=None):

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -38,9 +38,9 @@ def generate_EventCollection_plot():
                            )
 
     fig = plt.figure()
-    splt = fig.add_subplot(1, 1, 1)
-    splt.add_collection(coll)
-    splt.set_title('EventCollection: default')
+    ax = fig.add_subplot(1, 1, 1)
+    ax.add_collection(coll)
+    ax.set_title('EventCollection: default')
     props = {'positions': positions,
              'extra_positions': extra_positions,
              'orientation': orientation,
@@ -51,9 +51,9 @@ def generate_EventCollection_plot():
              'linestyle': linestyle,
              'antialiased': antialiased
              }
-    splt.set_xlim(-1, 22)
-    splt.set_ylim(0, 2)
-    return splt, coll, props
+    ax.set_xlim(-1, 22)
+    ax.set_ylim(0, 2)
+    return ax, coll, props
 
 
 @image_comparison(['EventCollection_plot__default'])

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -518,8 +518,8 @@ def test_image_shift():
 
 
 def test_image_edges():
-    f = plt.figure(figsize=[1, 1])
-    ax = f.add_axes([0, 0, 1, 1], frameon=False)
+    fig = plt.figure(figsize=[1, 1])
+    ax = fig.add_axes([0, 0, 1, 1], frameon=False)
 
     data = np.tile(np.arange(12), 15).reshape(20, 9)
 
@@ -534,7 +534,7 @@ def test_image_edges():
     ax.set_yticks([])
 
     buf = io.BytesIO()
-    f.savefig(buf, facecolor=(0, 1, 0))
+    fig.savefig(buf, facecolor=(0, 1, 0))
 
     buf.seek(0)
 

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -214,14 +214,14 @@ imgplot = plt.imshow(lum_img, clim=(0.0, 0.7))
 ###############################################################################
 # You can also specify the clim using the returned object
 fig = plt.figure()
-a = fig.add_subplot(1, 2, 1)
+ax = fig.add_subplot(1, 2, 1)
 imgplot = plt.imshow(lum_img)
-a.set_title('Before')
+ax.set_title('Before')
 plt.colorbar(ticks=[0.1, 0.3, 0.5, 0.7], orientation='horizontal')
-a = fig.add_subplot(1, 2, 2)
+ax = fig.add_subplot(1, 2, 2)
 imgplot = plt.imshow(lum_img)
 imgplot.set_clim(0.0, 0.7)
-a.set_title('After')
+ax.set_title('After')
 plt.colorbar(ticks=[0.1, 0.3, 0.5, 0.7], orientation='horizontal')
 
 ###############################################################################


### PR DESCRIPTION
## PR Summary

For consistency.

- Axes are typically named `ax` not `a`.
- Figures are typically named `fig` not `f`.
- Shortend the Ellipse Demo.