### PR TITLE
Move locking of fontlist.json *into* json_dump.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -147,3 +147,6 @@ The parameter ``s`` to `.Axes.annotate` and  `.pyplot.annotate` is renamed to
 The old parameter name remains supported, but
 support for it will be dropped in a future Matplotlib release.
 
+`.font_manager.json_dump` now locks the font manager dump file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... to prevent multiple processes from writing to it at the same time.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -912,8 +912,11 @@ def json_dump(data, filename):
     File paths that are children of the Matplotlib data path (typically, fonts
     shipped with Matplotlib) are stored relative to that data path (to remain
     valid across virtualenvs).
+
+    This function temporarily locks the output file to prevent multiple
+    processes from overwriting one another's output.
     """
-    with open(filename, 'w') as fh:
+    with cbook._lock_path(filename), open(filename, 'w') as fh:
         try:
             json.dump(data, fh, cls=_JSONEncoder, indent=2)
         except OSError as e:
@@ -1333,8 +1336,7 @@ def _rebuild():
     global fontManager
     _log.info("Generating new fontManager, this may take some time...")
     fontManager = FontManager()
-    with cbook._lock_path(_fmcache):
-        json_dump(fontManager, _fmcache)
+    json_dump(fontManager, _fmcache)
 
 
 try:


### PR DESCRIPTION
This makes it easier for end users to call json_dump (which is public
API) safely, given that _lock_path is not public API.

Side point of the discussion at #15943.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
