### PR TITLE
CI: Fail when failed to install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,13 +104,16 @@ before_install: |
     export PATH=/usr/lib/ccache:$PATH
     ;;
   osx)
+    set -e
     ci/silence brew update
     brew uninstall numpy gdal postgis
+    brew unlink python@2
     brew upgrade python
-    brew install ffmpeg imagemagick mplayer ccache font-wenquanyi-zen-hei
+    brew install ffmpeg imagemagick mplayer ccache
     hash -r
     which python
     python --version
+    set +e
     # We could install ghostscript and inkscape here to test svg and pdf
     # but this makes the test time really long.
     # brew install ghostscript inkscape
@@ -128,6 +131,8 @@ install:
   - |
     # Install dependencies from PyPI.
     python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
+  - |
+    # Install optional dependencies from PyPI.
     # GUI toolkits are pip-installable only for some versions of Python so
     # don't fail if we can't install them.  Make it easier to check whether the
     # install was successful by trying to import the toolkit (sometimes, the


### PR DESCRIPTION
`font-wenquanyi-zen-hei` was removed from Homebrew https://github.com/Homebrew/homebrew-cask-fonts/pull/1924

I will try to change the font for `Noto Sans CJK` in subsequent PR.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
