### PR TITLE
Merge pull request #16117 from Kojoley/ci-appveyor-unify-reqs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,7 @@ environment:
     - PYTHON_VERSION: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
+      EXTRAREQS: "-r requirements/testing/travis36.txt"
     - PYTHON_VERSION: "3.7"
       CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
       TEST_ALL: "no"
@@ -49,22 +50,18 @@ install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
   - set PYTHONUNBUFFERED=1
   - conda config --set always_yes true
-  - conda update --all
   - conda config --set show_channel_urls yes
   - conda config --prepend channels conda-forge
-  # this is now the downloaded conda...
-  - activate
-  - conda info -a
 
-  # For building, use a new environment which only includes the requirements for mpl
-  # if conda-forge gets a new pyqt, it might be nice to install it as well to have more backends
-  # https://github.com/conda-forge/conda-forge.github.io/issues/157#issuecomment-223536381
-  - conda create -q -n test-environment python=%PYTHON_VERSION%
-    freetype=2.6 tk=8.5
-    pip setuptools numpy sphinx tornado
+  # For building, use a new environment
+  - conda create -q -n test-environment python=%PYTHON_VERSION% tk
   - activate test-environment
   - echo %PYTHON_VERSION% %TARGET_ARCH%
-  - pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis36.txt
+  # Install dependencies from PyPI.
+  - python -mpip install --upgrade -r requirements/testing/travis_all.txt %EXTRAREQS% %PINNEDVERS%
+  # Install optional dependencies from PyPI.
+  # Sphinx is needed to run sphinxext tests
+  - python -mpip install --upgrade sphinx
 
   # Apply patch to `subprocess` on Python versions > 2 and < 3.6.3
   # https://github.com/matplotlib/matplotlib/issues/9176
@@ -84,7 +81,7 @@ test_script:
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'
 
   # this are optional dependencies so that we don't skip so many tests...
-  - if x%TEST_ALL% == xyes conda install -q ffmpeg inkscape miktex pillow
+  - if x%TEST_ALL% == xyes conda install -q ffmpeg inkscape miktex
   # missing packages on conda-forge for avconv imagemagick
   # This install sometimes failed randomly :-(
   #- choco install imagemagick

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,6 +133,8 @@ install:
     python -mpip install --upgrade $PRE -r requirements/testing/travis_all.txt $EXTRAREQS $PINNEDVERS
   - |
     # Install optional dependencies from PyPI.
+    # Sphinx is needed to run sphinxext tests
+    python -mpip install --upgrade sphinx
     # GUI toolkits are pip-installable only for some versions of Python so
     # don't fail if we can't install them.  Make it easier to check whether the
     # install was successful by trying to import the toolkit (sometimes, the


### PR DESCRIPTION
- Do not update default Conda packages (saves 5 minutes on 3.6 job)
- Do not install Freetype2 from Conda (we do not use it anyway)
- Install dependencies via pip, the same way as it's done on Travis.
  However, `travis36minver.txt` cannot be used, because of some bugs
  in the pinned versions (something with pandas/pytz/dateutils)
- Test sphinext on Travis too

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
