### PR TITLE
Deprecate some Transform aliases in scale.py.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -124,3 +124,10 @@ The following parameters do not have any effect and are deprecated:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This method is deprecated.  Use
 ``ax.dataLim.set(Bbox.union([ax.dataLim, bounds]))`` instead.
+
+``{,Symmetrical}LogScale.{,Inverted}LogTransform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``LogScale.LogTransform``, ``LogScale.InvertedLogTransform``,
+``SymmetricalScale.SymmetricalTransform`` and
+``SymmetricalScale.InvertedSymmetricalTransform`` are deprecated.  Directly
+access the transform classes from the :mod:`.scale` module.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -344,8 +344,16 @@ class LogScale(ScaleBase):
     InvertedLog2Transform = InvertedLog2Transform
     NaturalLogTransform = NaturalLogTransform
     InvertedNaturalLogTransform = InvertedNaturalLogTransform
-    LogTransform = LogTransform
-    InvertedLogTransform = InvertedLogTransform
+
+    @cbook.deprecated("3.3", alternative="scale.LogTransform")
+    @property
+    def LogTransform(self):
+        return LogTransform
+
+    @cbook.deprecated("3.3", alternative="scale.InvertedLogTransform")
+    @property
+    def InvertedLogTransform(self):
+        return InvertedLogTransform
 
     def __init__(self, axis, **kwargs):
         """
@@ -535,9 +543,17 @@ class SymmetricalLogScale(ScaleBase):
         the logarithmic range.
     """
     name = 'symlog'
-    # compatibility shim
-    SymmetricalLogTransform = SymmetricalLogTransform
-    InvertedSymmetricalLogTransform = InvertedSymmetricalLogTransform
+
+    @cbook.deprecated("3.3", alternative="scale.SymmetricalLogTransform")
+    @property
+    def SymmetricalLogTransform(self):
+        return SymmetricalLogTransform
+
+    @cbook.deprecated(
+        "3.3", alternative="scale.InvertedSymmetricalLogTransform")
+    @property
+    def InvertedSymmetricalLogTransform(self):
+        return InvertedSymmetricalLogTransform
 
     def __init__(self, axis, **kwargs):
         if axis.axis_name == 'x':

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -3,11 +3,11 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_equal, assert_array_almost_equal)
 import pytest
 
+from matplotlib import scale
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.transforms as mtransforms
 from matplotlib.path import Path
-from matplotlib.scale import LogScale
 from matplotlib.testing.decorators import image_comparison
 
 
@@ -196,7 +196,7 @@ def test_clipping_of_log():
 
     # something like this happens in plotting logarithmic histograms
     trans = mtransforms.BlendedGenericTransform(
-        mtransforms.Affine2D(), LogScale.LogTransform(10, 'clip'))
+        mtransforms.Affine2D(), scale.LogTransform(10, 'clip'))
     tpath = trans.transform_path_non_affine(path)
     result = tpath.iter_segments(trans.get_affine(),
                                  clip=(0, 0, 100, 100),


### PR DESCRIPTION
They are available as globals in the module.  More annoyingly, having
them duplicated prevents one from writing
```
`.LogTransform`
```
in the docs because sphinx doesn't know whether to resolve this to
`mpl.scale.LogTransform` or `mpl.scale.LogScale.LogTransform` (it
doesn't realize these are the same).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
