### PR TITLE
Avoid using np.r_, np.c_.

### DIFF
--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -64,8 +64,8 @@ def filled_hist(ax, edges, values, bottoms=None, orientation='v',
         bottoms = 0
     bottoms = np.broadcast_to(bottoms, values.shape)
 
-    values = np.r_[values, values[-1]]
-    bottoms = np.r_[bottoms, bottoms[-1]]
+    values = np.append(values, values[-1])
+    bottoms = np.append(bottoms, bottoms[-1])
     if orientation == 'h':
         return ax.fill_betweenx(edges, values, bottoms,
                                 **kwargs)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -331,11 +331,9 @@ class ContourLabeler:
         # Check if closed and, if so, rotate contour so label is at edge
         closed = _is_closed_polygon(slc)
         if closed:
-            slc = np.r_[slc[ind:-1], slc[:ind + 1]]
-
+            slc = np.concatenate([slc[ind:-1], slc[:ind + 1]])
             if len(lc):  # Rotate lc also if not empty
-                lc = np.r_[lc[ind:-1], lc[:ind + 1]]
-
+                lc = np.concatenate([lc[ind:-1], lc[:ind + 1]])
             ind = 0
 
         # Calculate path lengths
@@ -494,7 +492,7 @@ class ContourLabeler:
         # if there isn't a vertex close enough
         if not np.allclose(xcmin, lc[imin]):
             # insert new data into the vertex list
-            lc = np.r_[lc[:imin], np.array(xcmin)[None, :], lc[imin:]]
+            lc = np.row_stack([lc[:imin], xcmin, lc[imin:]])
             # replace the path with the new one
             paths[segmin] = mpath.Path(lc)
 
@@ -568,7 +566,7 @@ class ContourLabeler:
                 # functions, this is not necessary and should probably be
                 # eventually removed.
                 if _is_closed_polygon(lc):
-                    slc = np.r_[slc0, slc0[1:2, :]]
+                    slc = np.row_stack([slc0, slc0[1:2]])
                 else:
                     slc = slc0
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1681,7 +1681,7 @@ def test_bar_pandas_indexed(pd):
 @image_comparison(['hist_log'], remove_text=True)
 def test_hist_log():
     data0 = np.linspace(0, 1, 200)**3
-    data = np.r_[1-data0, 1+data0]
+    data = np.concatenate([1 - data0, 1 + data0])
     fig = plt.figure()
     ax = fig.add_subplot(111)
     ax.hist(data, fill=False, log=True)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1576,7 +1576,8 @@ class Transform(TransformNode):
         if not radians:
             angles = np.deg2rad(angles)
         # Move a short distance away
-        pts2 = pts + pushoff * np.c_[np.cos(angles), np.sin(angles)]
+        pts2 = pts + pushoff * np.column_stack([np.cos(angles),
+                                                np.sin(angles)])
         # Transform both sets of points
         tpts = self.transform(pts)
         tpts2 = self.transform(pts2)


### PR DESCRIPTION
They are *really* slow
```
In [3]: %timeit np.c_[np.arange(10), np.arange(10)]
11.7 µs ± 60.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: %timeit np.column_stack([np.arange(10), np.arange(10)])
3.91 µs ± 154 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```
and the alternative are (slightly) more readable (IMO).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
