### PR TITLE
Simplify transforms addition.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -820,9 +820,7 @@ class PolarAxes(Axes):
             .scale(self._default_theta_direction, 1.0)
         self._theta_offset = mtransforms.Affine2D() \
             .translate(self._default_theta_offset, 0.0)
-        self.transShift = mtransforms.composite_transform_factory(
-            self._direction,
-            self._theta_offset)
+        self.transShift = self._direction + self._theta_offset
         # A view limit shifted to the correct location after accounting for
         # orientation and offset.
         self._realViewLim = mtransforms.TransformedBbox(self.viewLim,

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1243,23 +1243,11 @@ class Transform(TransformNode):
 
     def __add__(self, other):
         """
-        Composes two transforms together such that *self* is followed
-        by *other*.
+        Compose two transforms together so that *self* is followed by *other*.
         """
-        if isinstance(other, Transform):
-            return composite_transform_factory(self, other)
-        raise TypeError(
-            "Can not add Transform to object of type '%s'" % type(other))
-
-    def __radd__(self, other):
-        """
-        Composes two transforms together such that *self* is followed
-        by *other*.
-        """
-        if isinstance(other, Transform):
-            return composite_transform_factory(other, self)
-        raise TypeError(
-            "Can not add Transform to object of type '%s'" % type(other))
+        return (composite_transform_factory(self, other)
+                if isinstance(other, Transform) else
+                NotImplemented)
 
     # Equality is based on object identity for `Transform`s (so we don't
     # override `__eq__`), but some subclasses, such as TransformWrapper &
@@ -2289,9 +2277,9 @@ class CompositeGenericTransform(Transform):
         Create a new composite transform that is the result of
         applying transform *a* then transform *b*.
 
-        You will generally not call this constructor directly but use the
-        `composite_transform_factory` function instead, which can automatically
-        choose the best kind of composite transform instance to create.
+        You will generally not call this constructor directly but write ``a +
+        b`` instead, which will automatically choose the best kind of composite
+        transform instance to create.
         """
         if a.output_dims != b.input_dims:
             raise ValueError("The output dimension of 'a' must be equal to "
@@ -2405,13 +2393,11 @@ class CompositeAffine2D(Affine2DBase):
     def __init__(self, a, b, **kwargs):
         """
         Create a new composite transform that is the result of
-        applying transform *a* then transform *b*.
+        applying `Affine2DBase` *a* then `Affine2DBase` *b*.
 
-        Both *a* and *b* must be instances of :class:`Affine2DBase`.
-
-        You will generally not call this constructor directly but use the
-        `composite_transform_factory` function instead, which can automatically
-        choose the best kind of composite transform instance to create.
+        You will generally not call this constructor directly but write ``a +
+        b`` instead, which will automatically choose the best kind of composite
+        transform instance to create.
         """
         if not a.is_affine or not b.is_affine:
             raise ValueError("'a' and 'b' must be affine transforms")


### PR DESCRIPTION
- Suggest `tr1 + tr2` instead of `composite_transform_factory(tr1, tr2)`.
- No need to implement `Transform.__radd__` -- we can only add
  transforms so `__add__` is enough.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
