### PR TITLE
Inline _init_axes_pad into Grid.__init__.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -149,7 +149,8 @@ class Grid:
 
         self.ngrids = ngrids
 
-        self._init_axes_pad(axes_pad)
+        self._horiz_pad_size, self._vert_pad_size = map(
+            Size.Fixed, np.broadcast_to(axes_pad, 2))
 
         cbook._check_in_list(["column", "row"], direction=direction)
         self._direction = direction
@@ -191,11 +192,6 @@ class Grid:
                 fig.add_axes(ax)
 
         self.set_label_mode(label_mode)
-
-    def _init_axes_pad(self, axes_pad):
-        axes_pad = np.broadcast_to(axes_pad, 2)
-        self._horiz_pad_size = Size.Fixed(axes_pad[0])
-        self._vert_pad_size = Size.Fixed(axes_pad[1])
 
     def _init_locators(self):
 
@@ -256,8 +252,6 @@ class Grid:
         axes_pad : (float, float)
             The padding (horizontal pad, vertical pad) in inches.
         """
-        # Differs from _init_axes_pad by 1) not broacasting, 2) modifying the
-        # Size.Fixed objects in-place.
         self._horiz_pad_size.fixed_size = axes_pad[0]
         self._vert_pad_size.fixed_size = axes_pad[1]
 


### PR DESCRIPTION
It's only called from `__init__`, so inlining it defines more attributes
directly in `__init__`.  Also avoids having to wonder about the
difference between _init_axes_pad and set_axes_pad.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
