### PR TITLE
Initialize members of PathClipper

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -295,7 +295,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(-1.0, -1.0, width + 1.0, height + 1.0),
+          m_lastX(0.0),
+          m_lastY(0.0),
           m_moveto(true),
+          m_initX(0.0),
+          m_initY(0.0),
           m_has_init(false)
     {
         // empty
@@ -305,7 +309,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(rect),
+          m_lastX(0.0),
+          m_lastY(0.0),
           m_moveto(true),
+          m_initX(0.0),
+          m_initY(0.0),
           m_has_init(false)
     {
         m_cliprect.x1 -= 1.0;


### PR DESCRIPTION
MemorySanitizer complains about use-of-uninitialized-value in one of my tests.

WARNING: MemorySanitizer: use-of-uninitialized-value [....]src/path_converters.h:425:42 in PathClipper<PathNanRemover<agg::conv_transform<py::PathIterator, agg::trans_affine> > >::vertex(double*, double*)

## PR Summary

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
