### PR TITLE
Deprecate old and little used formatters.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -150,3 +150,12 @@ and containment checks) via `.Line2D.set_picker` is deprecated.  Use
 The ``on_mappable_changed`` and ``update_bruteforce`` methods of
 `~matplotlib.colorbar.Colorbar` are deprecated; both can be replaced by calls
 to `~matplotlib.colorbar.Colorbar.update_normal`.
+
+``OldScalarFormatter``, ``IndexFormatter`` and ``DateIndexFormatter``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These formatters are deprecated.  Their functionality can be implemented using
+e.g. `.FuncFormatter`.
+
+``OldAutoLocator``
+~~~~~~~~~~~~~~~~~~
+This ticker is deprecated.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -604,6 +604,7 @@ class DateFormatter(ticker.Formatter):
         self.tz = tz
 
 
+@cbook.deprecated("3.3")
 class IndexDateFormatter(ticker.Formatter):
     """Use with `.IndexLocator` to cycle format strings by index."""
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib
+from matplotlib import cbook
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
@@ -457,7 +458,8 @@ class TestIndexFormatter:
                                           (2, 'label2'),
                                           (2.5, '')])
     def test_formatting(self, x, label):
-        formatter = mticker.IndexFormatter(['label0', 'label1', 'label2'])
+        with cbook._suppress_matplotlib_deprecation_warning():
+            formatter = mticker.IndexFormatter(['label0', 'label1', 'label2'])
         assert formatter(x) == label
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -293,6 +293,7 @@ class Formatter(TickHelper):
         pass
 
 
+@cbook.deprecated("3.3")
 class IndexFormatter(Formatter):
     """
     Format the position x to the nearest i-th label where ``i = int(x + 0.5)``.
@@ -322,13 +323,10 @@ class IndexFormatter(Formatter):
 
 
 class NullFormatter(Formatter):
-    """
-    Always return the empty string.
-    """
+    """Always return the empty string."""
+
     def __call__(self, x, pos=None):
-        """
-        Returns an empty string for all inputs.
-        """
+        # docstring inherited
         return ''
 
 
@@ -428,6 +426,7 @@ class StrMethodFormatter(Formatter):
         return self.fmt.format(x=x, pos=pos)
 
 
+@cbook.deprecated("3.3")
 class OldScalarFormatter(Formatter):
     """
     Tick location is a plain old number.
@@ -2867,6 +2866,7 @@ class AutoMinorLocator(Locator):
                                   '%s type.' % type(self))
 
 
+@cbook.deprecated("3.3")
 class OldAutoLocator(Locator):
     """
     On autoscale this class picks the best MultipleLocator to set the


### PR DESCRIPTION
- The new ScalarFormatter replaced OldScalarFormatter in 3910bb9 (2005).
- IndexFormatter appeared in e66091d (2009) but was never used in the
  examples; IndexDateFormatter is unused in the docs since 4ea4b96
  (2009); both can be fairly easily implemented in terms of
  FuncFormatter.

I'm willing to back off the deprecations if there's demand to keep them,
though.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
