### PR TITLE
FIX: ignore axes that aren't visible

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -254,10 +254,7 @@ def _make_ghost_gridspec_slots(fig, gs):
             # this gridspec slot doesn't have an axis so we
             # make a "ghost".
             ax = fig.add_subplot(gs[nn])
-            ax.set_frame_on(False)
-            ax.set_xticks([])
-            ax.set_yticks([])
-            ax.set_facecolor((1, 0, 0, 0))
+            ax.set_visible(False)
 
 
 def _make_layout_margins(ax, renderer, h_pad, w_pad):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1832,7 +1832,7 @@ class FigureCanvasBase:
 
     def inaxes(self, xy):
         """
-        Return the topmost `~.axes.Axes` containing the point *xy*.
+        Return the topmost visible `~.axes.Axes` containing the point *xy*.
 
         Parameters
         ----------
@@ -1842,11 +1842,10 @@ class FigureCanvasBase:
         Returns
         -------
         axes : `~matplotlib.axes.Axes` or None
-            The topmost axes containing the point, or None if no axes.
+            The topmost visible axes containing the point, or None if no axes.
         """
         axes_list = [a for a in self.figure.get_axes()
-                     if a.patch.contains_point(xy)]
-
+                     if a.patch.contains_point(xy) and a.get_visible()]
         if axes_list:
             axes = cbook._topmost_artist(axes_list)
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6898,3 +6898,11 @@ def test_pi_get_negative_values():
     fig, ax = plt.subplots()
     with pytest.raises(ValueError):
         ax.pie([5, 5, -3], explode=[0, .1, .2])
+
+
+def test_invisible_axes():
+    # invisible axes should not respond to events...
+    fig, ax = plt.subplots()
+    assert fig.canvas.inaxes((200, 200)) is not None
+    ax.set_visible(False)
+    assert fig.canvas.inaxes((200, 200)) is None


### PR DESCRIPTION
## PR Summary

Closes #16173

Layering subplots causes the topmost subplot to capture mouse events, which seems fine.  However, if the topmost subplot is made invisible (which is a trick we use in `cosntrained_layout`) then it would *still* capture the mouse event.  Given that an axes with `ax.get_visble() is False` is never drawn, not are any of its children, it seem unlikely that anyone would want to pick on a placeholder like that so the son here is to ignore invisible axes.

Note that I also changed how `constrained_layout` makes the axes invisible.  It passes all the tests, so this is preferable to the way I was doing it before.

### Test

```python
import matplotlib.pyplot as plt
import matplotlib.gridspec as gridspec
from matplotlib.widgets import Button

def on_click(event):
    print("hey")

fig = plt.figure(constrained_layout=True)

gs = gridspec.GridSpec(2, 1, figure=fig)

ax1 = fig.add_subplot(gs[0, 0])
ax1.text(0.5, 0.5, "ax1", va="center", ha="center")

gs2 = gs[1, 0].subgridspec(1, 2)
ax2 = fig.add_subplot(gs2[0, 1])

b = Button(ax2, 'hey')
b.on_clicked(on_click)

plt.show()

```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
