### PR TITLE
Initialize members of PathClipper and check for m_has_init

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -295,11 +295,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(-1.0, -1.0, width + 1.0, height + 1.0),
-          m_lastX(0.0),
-          m_lastY(0.0),
+          m_lastX(nan),
+          m_lastY(nan),
           m_moveto(true),
-          m_initX(0.0),
-          m_initY(0.0),
+          m_initX(nan),
+          m_initY(nan),
           m_has_init(false)
     {
         // empty
@@ -309,11 +309,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(rect),
-          m_lastX(0.0),
-          m_lastY(0.0),
+          m_lastX(nan),
+          m_lastY(nan),
           m_moveto(true),
-          m_initX(0.0),
-          m_initY(0.0),
+          m_initX(nan),
+          m_initY(nan),
           m_has_init(false)
     {
         m_cliprect.x1 -= 1.0;

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -295,7 +295,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(-1.0, -1.0, width + 1.0, height + 1.0),
+          m_lastX(0.0),
+          m_lastY(0.0),
           m_moveto(true),
+          m_initX(0.0),
+          m_initY(0.0),
           m_has_init(false)
     {
         // empty
@@ -305,7 +309,11 @@ class PathClipper : public EmbeddedQueue<3>
         : m_source(&source),
           m_do_clipping(do_clipping),
           m_cliprect(rect),
+          m_lastX(0.0),
+          m_lastY(0.0),
           m_moveto(true),
+          m_initX(0.0),
+          m_initY(0.0),
           m_has_init(false)
     {
         m_cliprect.x1 -= 1.0;
@@ -421,7 +429,7 @@ class PathClipper : public EmbeddedQueue<3>
                 return code;
             }
 
-            if (m_moveto &&
+            if (m_moveto && m_has_init &&
                 m_lastX >= m_cliprect.x1 &&
                 m_lastX <= m_cliprect.x2 &&
                 m_lastY >= m_cliprect.y1 &&


### PR DESCRIPTION
MemorySanitizer complains about use-of-uninitialized-value in one of my tests.

WARNING: MemorySanitizer: use-of-uninitialized-value [....]src/path_converters.h:425:42 in PathClipper<PathNanRemover<agg::conv_transform<py::PathIterator, agg::trans_affine> > >::vertex(double*, double*)