### PR TITLE
Further simplify setupext.

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -18,18 +18,11 @@
 
 [gui_support]
 # Matplotlib supports multiple GUI toolkits, known as backends.
-# The Mac OSX backend requires the Cocoa headers included with XCode.
+# The MacOSX backend requires the Cocoa headers included with XCode.
 # You can select whether to build it by uncommenting the following line.
-# Acceptable values are:
+# It is never built on Linux or Windows, regardless of the config value.
 #
-#     True: build the extension. Exits with a warning if the
-#           required dependencies are not available
-#     False: do not build the extension
-#     auto: build if the required dependencies are available,
-#           otherwise skip silently. This is the default
-#           behavior
-#
-#macosx = auto
+#macosx = True
 
 [rc_options]
 # User-configurable options

--- a/setup.py
+++ b/setup.py
@@ -187,15 +187,13 @@ if __name__ == '__main__':
         good_packages = []
         for package in mpl_packages:
             try:
-                result = package.check()
-                if result is not None:
-                    print_status(package.name, 'yes [%s]' % result)
-            except setupext.CheckFailed as e:
-                print_status(package.name, 'no  [%s]' % str(e))
-                if not package.optional:
-                    sys.exit("Failed to build %s" % package.name)
-            else:
-                good_packages.append(package)
+                message = package.check()
+            except setupext.Skipped as e:
+                print_status(package.name, f"no  [{e}]")
+                continue
+            if message is not None:
+                print_status(package.name, f"yes [{message}]")
+            good_packages.append(package)
 
         print_raw()
 

--- a/setupext.py
+++ b/setupext.py
@@ -256,30 +256,30 @@ def pkg_config_setup_extension(
     ext.libraries.extend(default_libraries)
 
 
-class CheckFailed(Exception):
+class Skipped(Exception):
     """
-    Exception thrown when a `SetupPackage.check` method fails.
+    Exception thrown by `SetupPackage.check` to indicate that a package should
+    be skipped.
     """
-    pass
 
 
 class SetupPackage:
-    optional = False
 
     def check(self):
         """
-        Checks whether the build dependencies are met.  Should raise a
-        `CheckFailed` exception if the dependency could not be met, otherwise
-        return a string indicating a version number or some other message
-        indicating what was found.
+        If the package should be installed, return an informative string, or
+        None if no information should be displayed at all.
+
+        If the package should be skipped, raise a `Skipped` exception.
+
+        If a missing build dependency is fatal, call `sys.exit`.
         """
-        pass
 
     def get_package_data(self):
         """
         Get a package data dictionary to add to the configuration.
-        These are merged into to the `package_data` list passed to
-        `distutils.setup`.
+        These are merged into to the *package_data* list passed to
+        `setuptools.setup`.
         """
         return {}
 
@@ -287,7 +287,7 @@ class SetupPackage:
         """
         Get a list of C extensions (`distutils.core.Extension`
         objects) to add to the configuration.  These are added to the
-        `extensions` list passed to `distutils.setup`.
+        *extensions* list passed to `setuptools.setup`.
         """
         return None
 
@@ -297,29 +297,11 @@ class SetupPackage:
         third-party library, before building an extension, it should
         override this method.
         """
-        pass
 
 
 class OptionalPackage(SetupPackage):
-    optional = True
     config_category = "packages"
-    default_config = "auto"
-
-    @classmethod
-    def get_config(cls):
-        """
-        Look at `setup.cfg` and return one of ["auto", True, False] indicating
-        if the package is at default state ("auto"), forced by the user (case
-        insensitively defined as 1, true, yes, on for True) or opted-out (case
-        insensitively defined as 0, false, no, off for False).
-        """
-        conf = cls.default_config
-        if config.has_option(cls.config_category, cls.name):
-            try:
-                conf = config.getboolean(cls.config_category, cls.name)
-            except ValueError:
-                conf = config.get(cls.config_category, cls.name)
-        return conf
+    default_config = True
 
     def check(self):
         """
@@ -327,13 +309,11 @@ class OptionalPackage(SetupPackage):
 
         May be overridden by subclasses for additional checks.
         """
-        conf = self.get_config()  # Check configuration file
-        if conf in [True, 'auto']:  # Default "auto", or install forced by user
-            if conf is True:  # Set non-optional if user sets `True` in config
-                self.optional = False
+        if config.getboolean(self.config_category, self.name,
+                             fallback=self.default_config):
             return "installing"
         else:  # Configuration opt-out by user
-            raise CheckFailed("skipping due to configuration")
+            raise Skipped("skipping due to configuration")
 
 
 class Platform(SetupPackage):
@@ -745,7 +725,7 @@ class BackendMacOSX(OptionalPackage):
 
     def check(self):
         if sys.platform != 'darwin':
-            raise CheckFailed("Mac OS-X only")
+            raise Skipped("Mac OS-X only")
         return super().check()
 
     def get_extension(self):


### PR DESCRIPTION
Remove `config = "auto"` and `SetupPackage.optional`, which were
effectively unused.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
