### PR TITLE
Add multiple label support for Axes.plot()

### DIFF
--- a/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
+++ b/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
@@ -1,7 +1,9 @@
 An iterable object with labels can be passed to `.Axes.plot`
--------------------------------------------------------------
+------------------------------------------------------------
 
-When plotting multiple datasets by passing 2D data as *y* value to `~.Axes.plot`, labels for the datasets can be passed as a list, the length matching the number of columns in *y*.
+When plotting multiple datasets by passing 2D data as *y* value to 
+`~.Axes.plot`, labels for the datasets can be passed as a list, the 
+length matching the number of columns in *y*.
 
 .. plot::
 

--- a/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
+++ b/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
@@ -1,20 +1,17 @@
 An iterable object with labels can be passed to `.Axes.plot`
 -------------------------------------------------------------
 
-If multidimensional data is used for plotting, labels can be specified in
-a vectorized way with an iterable object of size corresponding to the
-data array shape (exactly 5 labels are expected when plotting 5 lines).
-It works with `.Axes.plot` as well as with it's wrapper `.pyplot.plot`.
+When plotting multiple datasets by passing 2D data as *y* value to `~.Axes.plot`, labels for the datasets can be passed as a list, the length matching the number of columns in *y*.
 
 .. plot::
 
-    from matplotlib import pyplot as plt
+    import matplotlib.pyplot as plt
+    
+    x = [1, 2, 3]
 
-    x = [1, 2, 5]
+    y = [[1, 9],
+         [2, 8],
+         [4, 6]]
 
-    y = [[2, 4, 3],
-        [4, 7, 1],
-        [3, 9, 2]]
-
-    plt.plot(x, y, label=['one', 'two', 'three'])
+    plt.plot(x, y, label=['low', 'high'])
     plt.legend()

--- a/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
+++ b/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
@@ -1,0 +1,20 @@
+An iterable object with labels can be passed to `Axes.plot()`
+-------------------------------------------------------------
+
+If multidimensional data is used for plotting, labels can be specified in
+a vectorized way with an iterable object of size corresponding to the
+data array shape (exactly 5 labels are expected when plotting 5 lines).
+It works with `Axes.plot()` as well as with it's wrapper `plt.plot()`.
+
+.. plot::
+
+    from matplotlib import pyplot as plt
+
+    x = [1, 2, 5]
+
+    y = [[2, 4, 3],
+        [4, 7, 1],
+        [3, 9, 2]]
+
+    plt.plot(x, y, label=['one', 'two', 'three'])
+    plt.legend()

--- a/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
+++ b/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
@@ -1,10 +1,10 @@
-An iterable object with labels can be passed to `Axes.plot()`
+An iterable object with labels can be passed to `.Axes.plot`
 -------------------------------------------------------------
 
 If multidimensional data is used for plotting, labels can be specified in
 a vectorized way with an iterable object of size corresponding to the
 data array shape (exactly 5 labels are expected when plotting 5 lines).
-It works with `Axes.plot()` as well as with it's wrapper `plt.plot()`.
+It works with `.Axes.plot` as well as with it's wrapper `.pyplot.plot`.
 
 .. plot::
 

--- a/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
+++ b/doc/users/next_whats_new/multiple_labels_for_Axes_plot.rst
@@ -9,9 +9,9 @@ When plotting multiple datasets by passing 2D data as *y* value to `~.Axes.plot`
     
     x = [1, 2, 3]
 
-    y = [[1, 9],
-         [2, 8],
-         [4, 6]]
+    y = [[1, 2],
+         [2, 5],
+         [4, 9]]
 
     plt.plot(x, y, label=['low', 'high'])
     plt.legend()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1499,6 +1499,8 @@ class Axes(_AxesBase):
 
             If you make multiple lines with one plot call, the kwargs
             apply to all those lines.
+            In case if label object is iterable, each its element is
+            used as label for a separate line.
 
             Here is a list of available `.Line2D` properties:
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -293,7 +293,8 @@ class _process_plot_var_args:
                     replaced[label_namer_idx], args[label_namer_idx])
             args = replaced
 
-        if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs.get("label")):
+        if len(args) >= 4 and not cbook.is_scalar_or_string(
+                kwargs.get("label")):
             raise ValueError("plot() with multiple groups of data (i.e., "
                              "pairs of x and y) does not support multiple "
                              "labels")

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -294,8 +294,9 @@ class _process_plot_var_args:
             args = replaced
 
         if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs["label"]):
-            raise ValueError("plot() with multiple groups of data (i.e., pairs"
-                             " of x and y) does not support multiple labels")
+            raise ValueError("plot() with multiple groups of data (i.e., "
+                             "pairs of x and y) does not support multiple "
+                             "labels")
 
         # Repeatedly grab (x, y) or (x, y, format) from the front of args and
         # massage them into arguments to plot() or fill().

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -293,7 +293,7 @@ class _process_plot_var_args:
                     replaced[label_namer_idx], args[label_namer_idx])
             args = replaced
 
-        if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs["label"]):
+        if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs.get("label")):
             raise ValueError("plot() with multiple groups of data (i.e., "
                              "pairs of x and y) does not support multiple "
                              "labels")

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -449,8 +449,8 @@ class _process_plot_var_args:
             raise ValueError(f"x has {ncx} columns but y has {ncy} columns")
 
         if ('label' in kwargs and max(ncx, ncy) > 1
-                    and isinstance(kwargs['label'], Iterable)
-                    and not isinstance(kwargs['label'], str)):
+                and isinstance(kwargs['label'], Iterable)
+                and not isinstance(kwargs['label'], str)):
             if len(kwargs['label']) != max(ncx, ncy):
                 raise ValueError(f"if label is iterable label and input data"
                                  f" must have same length, but have lengths "

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -459,8 +459,8 @@ class _process_plot_var_args:
             labels = [label] * n_datasets
 
         result = (func(x[:, j % ncx], y[:, j % ncy], kw,
-                     {**kwargs, 'label': label})
-                for j, label in enumerate(labels))
+                       {**kwargs, 'label': label})
+                  for j, label in enumerate(labels))
 
         if return_kwargs:
             return list(result)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -448,22 +448,20 @@ class _process_plot_var_args:
         if ncx > 1 and ncy > 1 and ncx != ncy:
             raise ValueError(f"x has {ncx} columns but y has {ncy} columns")
 
-        if ('label' in kwargs and max(ncx, ncy) > 1
-                and isinstance(kwargs['label'], Iterable)
-                and not isinstance(kwargs['label'], str)):
-            if len(kwargs['label']) != max(ncx, ncy):
-                raise ValueError(f"if label is iterable label and input data"
-                                 f" must have same length, but have lengths "
-                                 f"{len(kwargs['label'])} and "
-                                 f"{max(ncx, ncy)}")
-        elif 'label' in kwargs:
-            kwargs['label'] = [kwargs['label']] * max(ncx, ncy)
+        label = kwargs.get('label')
+        n_datasets = max(ncx, ncy)
+        if n_datasets > 1 and not cbook.is_scalar_or_string(label):
+            if len(label) != n_datasets:
+                raise ValueError(f"label must be scalar or have the same "
+                                 f"length as the input data, but found "
+                                 f"{len(label)} for {n_datasets} datasets.")
+            labels = label
         else:
-            kwargs['label'] = [None] * max(ncx, ncy)
+            labels = [label] * n_datasets
 
         result = (func(x[:, j % ncx], y[:, j % ncy], kw,
-                     {**kwargs, 'label': kwargs['label'][j]})
-                for j in range(max(ncx, ncy)))
+                     {**kwargs, 'label': label})
+                for j, label in enumerate(labels))
 
         if return_kwargs:
             return list(result)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -294,8 +294,8 @@ class _process_plot_var_args:
             args = replaced
 
         if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs["label"]):
-            raise ValueError("plot() with multiple groups of data (i.e., pairs "
-                             "of x and y) does not support multiple labels")
+            raise ValueError("plot() with multiple groups of data (i.e., pairs"
+                             " of x and y) does not support multiple labels")
 
         # Repeatedly grab (x, y) or (x, y, format) from the front of args and
         # massage them into arguments to plot() or fill().

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from collections.abc import Iterable
 from contextlib import ExitStack
 import functools
 import inspect

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -448,8 +448,9 @@ class _process_plot_var_args:
         if ncx > 1 and ncy > 1 and ncx != ncy:
             raise ValueError(f"x has {ncx} columns but y has {ncy} columns")
 
-        if ('label' in kwargs and isinstance(kwargs['label'], Iterable)
-                        and not isinstance(kwargs['label'], str)):
+        if ('label' in kwargs and max(ncx, ncy) > 1
+                    and isinstance(kwargs['label'], Iterable)
+                    and not isinstance(kwargs['label'], str)):
             if len(kwargs['label']) != max(ncx, ncy):
                 raise ValueError(f"if label is iterable label and input data"
                                  f" must have same length, but have lengths "

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -293,6 +293,10 @@ class _process_plot_var_args:
                     replaced[label_namer_idx], args[label_namer_idx])
             args = replaced
 
+        if len(args) >= 4 and not cbook.is_scalar_or_string(kwargs["label"]):
+            raise ValueError("plot() with multiple groups of data (i.e., pairs "
+                             "of x and y) does not support multiple labels")
+
         # Repeatedly grab (x, y) or (x, y, format) from the front of args and
         # massage them into arguments to plot() or fill().
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -456,12 +456,13 @@ class _process_plot_var_args:
                                  f" must have same length, but have lengths "
                                  f"{len(kwargs['label'])} and "
                                  f"{max(ncx, ncy)}")
+        elif 'label' in kwargs:
+            kwargs['label'] = [kwargs['label']] * max(ncx, ncy)
+        else:
+            kwargs['label'] = [None] * max(ncx, ncy)
 
-            result = (func(x[:, j % ncx], y[:, j % ncy], kw,
-                {**kwargs, 'label':kwargs['label'][j]})
-                     for j in range(max(ncx, ncy)))
-
-        result = (func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
+        result = (func(x[:, j % ncx], y[:, j % ncy], kw,
+                     {**kwargs, 'label': kwargs['label'][j]})
                 for j in range(max(ncx, ncy)))
 
         if return_kwargs:

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -688,10 +688,8 @@ def test_plot_multiple_input_multiple_label():
         ax.plot(x, y, label=label)
         leg = ax.legend()
 
-        assert len(leg.get_texts()) == 3
-        assert leg.get_texts()[0].get_text() == 'one'
-        assert leg.get_texts()[1].get_text() == 'two'
-        assert leg.get_texts()[2].get_text() == 'three'
+        legend_texts = [entry.get_text() for entry in leg.get_texts()]
+        assert legend_texts == ['one', 'two', 'three']
 
 
 def test_plot_multiple_input_single_label():
@@ -706,10 +704,8 @@ def test_plot_multiple_input_single_label():
         ax.plot(x, y, label=label)
         leg = ax.legend()
 
-        assert len(leg.get_texts()) == 3
-        assert leg.get_texts()[0].get_text() == str(label)
-        assert leg.get_texts()[1].get_text() == str(label)
-        assert leg.get_texts()[2].get_text() == str(label)
+        legend_texts = [entry.get_text() for entry in leg.get_texts()]
+        assert legend_texts == [str(label)] * 3
 
 
 def test_plot_single_input_multiple_label():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -680,8 +680,8 @@ def test_plot_multiple_input_multiple_label():
     y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
 
     label_arrays = [['one', 'two', 'three'],
-                   ('one', 'two', 'three'),
-                   np.array(['one', 'two', 'three'])]
+                    ('one', 'two', 'three'),
+                    np.array(['one', 'two', 'three'])]
 
     for label in label_arrays:
         fig, ax = plt.subplots()
@@ -719,8 +719,8 @@ def test_plot_single_input_multiple_label():
     y = [2, 4, 3]
 
     label_arrays = [['one', 'two', 'three'],
-                   ('one', 'two', 'three'),
-                   np.array(['one', 'two', 'three'])]
+                    ('one', 'two', 'three'),
+                    np.array(['one', 'two', 'three'])]
 
     for label in label_arrays:
         fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -673,7 +673,9 @@ def test_no_warn_big_data_when_loc_specified():
     fig.draw_artist(legend)  # Check that no warning is emitted.
 
 
-@pytest.mark.parametrize('label_array', [['low', 'high'], ('low', 'high'), np.array(['low', 'high'])])
+@pytest.mark.parametrize('label_array', [['low', 'high'],
+                                         ('low', 'high'),
+                                         np.array(['low', 'high'])])
 def test_plot_multiple_input_multiple_label(label_array):
     # test ax.plot() with multidimensional input
     # and multiple labels
@@ -705,7 +707,9 @@ def test_plot_multiple_input_single_label(label):
     assert legend_texts == [str(label)] * 2
 
 
-@pytest.mark.parametrize('label_array', [['low', 'high'], ('low', 'high'), np.array(['low', 'high'])])
+@pytest.mark.parametrize('label_array', [['low', 'high'],
+                                         ('low', 'high'),
+                                         np.array(['low', 'high'])])
 def test_plot_single_input_multiple_label(label_array):
     # test ax.plot() with 1D array like input
     # and iterable label

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -732,9 +732,9 @@ def test_plot_single_input_multiple_label():
 
 
 def test_plot_multiple_label_incorrect_length_exception():
-    # check that exception is raised for
-    # iterable label with incorrect length
-    with pytest.raises(Exception):
+    # check that excepton is raised if multiple labels
+    # are given, but number of on labels != number of lines
+    with pytest.raises(ValueError):
         x = [1, 2, 5]
         y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
         label = ['one', 'two']

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -676,53 +676,49 @@ def test_no_warn_big_data_when_loc_specified():
 def test_plot_multiple_input_multiple_label():
     # test ax.plot() with multidimensional input
     # and multiple labels
-    x = [1, 2, 5]
-    y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
-
-    label_arrays = [['one', 'two', 'three'],
-                    ('one', 'two', 'three'),
-                    np.array(['one', 'two', 'three'])]
-
+    x = [1, 2, 3]
+    y = [[1, 2],
+         [2, 5],
+         [4, 9]]
+    label_arrays = [['low', 'high'],
+                    ('low', 'high'),
+                    np.array(['low', 'high'])]
     for label in label_arrays:
         fig, ax = plt.subplots()
         ax.plot(x, y, label=label)
         leg = ax.legend()
-
         legend_texts = [entry.get_text() for entry in leg.get_texts()]
-        assert legend_texts == ['one', 'two', 'three']
+        assert legend_texts == ['low', 'high']
 
 
 def test_plot_multiple_input_single_label():
     # test ax.plot() with multidimensional input
     # and single label
-    x = [1, 2, 5]
-    y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
+    x = [1, 2, 3]
+    y = [[1, 2],
+         [2, 5],
+         [4, 9]]
     labels = ['one', 1, int]
-
     for label in labels:
         fig, ax = plt.subplots()
         ax.plot(x, y, label=label)
         leg = ax.legend()
-
         legend_texts = [entry.get_text() for entry in leg.get_texts()]
-        assert legend_texts == [str(label)] * 3
+        assert legend_texts == [str(label)] * 2
 
 
 def test_plot_single_input_multiple_label():
     # test ax.plot() with 1D array like input
     # and iterable label
-    x = [1, 2, 5]
-    y = [2, 4, 3]
-
-    label_arrays = [['one', 'two', 'three'],
-                    ('one', 'two', 'three'),
-                    np.array(['one', 'two', 'three'])]
-
+    x = [1, 2, 3]
+    y = [2, 5, 6]
+    label_arrays = [['low', 'high'],
+                    ('low', 'high'),
+                    np.array(['low', 'high'])]
     for label in label_arrays:
         fig, ax = plt.subplots()
         ax.plot(x, y, label=label)
         leg = ax.legend()
-
         assert len(leg.get_texts()) == 1
         assert leg.get_texts()[0].get_text() == str(label)
 
@@ -731,8 +727,10 @@ def test_plot_multiple_label_incorrect_length_exception():
     # check that excepton is raised if multiple labels
     # are given, but number of on labels != number of lines
     with pytest.raises(ValueError):
-        x = [1, 2, 5]
-        y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
-        label = ['one', 'two']
+        x = [1, 2, 3]
+        y = [[1, 2],
+             [2, 5],
+             [4, 9]]
+        label = ['high', 'low', 'medium']
         fig, ax = plt.subplots()
         ax.plot(x, y, label=label)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -671,3 +671,72 @@ def test_no_warn_big_data_when_loc_specified():
         ax.plot(np.arange(5000), label=idx)
     legend = ax.legend('best')
     fig.draw_artist(legend)  # Check that no warning is emitted.
+
+
+def test_plot_multiple_input_multiple_label():
+    # test ax.plot() with multidimensional input
+    # and multiple labels
+    x = [1, 2, 5]
+    y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
+
+    label_arrays = [['one', 'two', 'three'],
+                   ('one', 'two', 'three'),
+                   np.array(['one', 'two', 'three'])]
+
+    for label in label_arrays:
+        fig, ax = plt.subplots()
+        ax.plot(x, y, label=label)
+        leg = ax.legend()
+
+        assert len(leg.get_texts()) == 3
+        assert leg.get_texts()[0].get_text() == 'one'
+        assert leg.get_texts()[1].get_text() == 'two'
+        assert leg.get_texts()[2].get_text() == 'three'
+
+
+def test_plot_multiple_input_single_label():
+    # test ax.plot() with multidimensional input
+    # and single label
+    x = [1, 2, 5]
+    y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
+    labels = ['one', 1, int]
+
+    for label in labels:
+        fig, ax = plt.subplots()
+        ax.plot(x, y, label=label)
+        leg = ax.legend()
+
+        assert len(leg.get_texts()) == 3
+        assert leg.get_texts()[0].get_text() == str(label)
+        assert leg.get_texts()[1].get_text() == str(label)
+        assert leg.get_texts()[2].get_text() == str(label)
+
+
+def test_plot_single_input_multiple_label():
+    # test ax.plot() with 1D array like input
+    # and iterable label
+    x = [1, 2, 5]
+    y = [2, 4, 3]
+
+    label_arrays = [['one', 'two', 'three'],
+                   ('one', 'two', 'three'),
+                   np.array(['one', 'two', 'three'])]
+
+    for label in label_arrays:
+        fig, ax = plt.subplots()
+        ax.plot(x, y, label=label)
+        leg = ax.legend()
+
+        assert len(leg.get_texts()) == 1
+        assert leg.get_texts()[0].get_text() == str(label)
+
+
+def test_plot_multiple_label_incorrect_length_exception():
+    # check that exception is raised for
+    # iterable label with incorrect length
+    with pytest.raises(Exception):
+        x = [1, 2, 5]
+        y = [[2, 4, 3], [4, 7, 1], [3, 9, 2]]
+        label = ['one', 'two']
+        fig, ax = plt.subplots()
+        ax.plot(x, y, label=label)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -673,54 +673,49 @@ def test_no_warn_big_data_when_loc_specified():
     fig.draw_artist(legend)  # Check that no warning is emitted.
 
 
-def test_plot_multiple_input_multiple_label():
+@pytest.mark.parametrize('label_array', [['low', 'high'], ('low', 'high'), np.array(['low', 'high'])])
+def test_plot_multiple_input_multiple_label(label_array):
     # test ax.plot() with multidimensional input
     # and multiple labels
     x = [1, 2, 3]
     y = [[1, 2],
          [2, 5],
          [4, 9]]
-    label_arrays = [['low', 'high'],
-                    ('low', 'high'),
-                    np.array(['low', 'high'])]
-    for label in label_arrays:
-        fig, ax = plt.subplots()
-        ax.plot(x, y, label=label)
-        leg = ax.legend()
-        legend_texts = [entry.get_text() for entry in leg.get_texts()]
-        assert legend_texts == ['low', 'high']
+
+    fig, ax = plt.subplots()
+    ax.plot(x, y, label=label_array)
+    leg = ax.legend()
+    legend_texts = [entry.get_text() for entry in leg.get_texts()]
+    assert legend_texts == ['low', 'high']
 
 
-def test_plot_multiple_input_single_label():
+@pytest.mark.parametrize('label', ['one', 1, int])
+def test_plot_multiple_input_single_label(label):
     # test ax.plot() with multidimensional input
     # and single label
     x = [1, 2, 3]
     y = [[1, 2],
          [2, 5],
          [4, 9]]
-    labels = ['one', 1, int]
-    for label in labels:
-        fig, ax = plt.subplots()
-        ax.plot(x, y, label=label)
-        leg = ax.legend()
-        legend_texts = [entry.get_text() for entry in leg.get_texts()]
-        assert legend_texts == [str(label)] * 2
+
+    fig, ax = plt.subplots()
+    ax.plot(x, y, label=label)
+    leg = ax.legend()
+    legend_texts = [entry.get_text() for entry in leg.get_texts()]
+    assert legend_texts == [str(label)] * 2
 
 
-def test_plot_single_input_multiple_label():
+@pytest.mark.parametrize('label_array', [['low', 'high'], ('low', 'high'), np.array(['low', 'high'])])
+def test_plot_single_input_multiple_label(label_array):
     # test ax.plot() with 1D array like input
     # and iterable label
     x = [1, 2, 3]
     y = [2, 5, 6]
-    label_arrays = [['low', 'high'],
-                    ('low', 'high'),
-                    np.array(['low', 'high'])]
-    for label in label_arrays:
-        fig, ax = plt.subplots()
-        ax.plot(x, y, label=label)
-        leg = ax.legend()
-        assert len(leg.get_texts()) == 1
-        assert leg.get_texts()[0].get_text() == str(label)
+    fig, ax = plt.subplots()
+    ax.plot(x, y, label=label_array)
+    leg = ax.legend()
+    assert len(leg.get_texts()) == 1
+    assert leg.get_texts()[0].get_text() == str(label_array)
 
 
 def test_plot_multiple_label_incorrect_length_exception():


### PR DESCRIPTION
## PR Summary

Since plt.plot() supports multidimensional input it would be reasonable to support multiple labels. 
It was mentioned on SO [here](https://stackoverflow.com/questions/11481644/how-do-i-assign-multiple-labels-at-once-in-matplotlib).

```python
from matplotlib import pyplot as plt

x = [1, 2, 5]

y = [[2, 4, 3],
    [4, 7, 1],
    [3, 9, 2]]

plt.plot(x, y, label=['one', 'two', 'three'])
plt.legend()
```
<img width="363" alt="example" src="https://user-images.githubusercontent.com/35387375/72165590-d227d600-33d8-11ea-9c4a-6c3b170903d0.png">

It works with all iterable types, with string instances and non-iterables the behavior is just the same as before.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
