### PR TITLE
Expire a mpl2.2-deprecated API

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -62,3 +62,11 @@ property.  This now raises a TypeError.
 `.FileMovieWriter` now defaults to writing temporary frames in a temporary
 directory, which is always cleared at exit.  In order to keep the individual
 frames saved on the filesystem, pass an explicit *frame_prefix*.
+
+`.Axes.plot` no longer accepts *x* and *y* being both 2D and with different numbers of columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, calling `.Axes.plot` e.g. with *x* of shape ``(n, 3)`` and *y* of
+shape ``(n, 2)`` would plot the first column of *x* against the first column
+of *y*, the second column of *x* against the second column of *y*, **and** the
+first column of *x* against the third column of *y*.  This now raises an error
+instead.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -356,9 +356,7 @@ class _process_plot_var_args:
 
         ncx, ncy = x.shape[1], y.shape[1]
         if ncx > 1 and ncy > 1 and ncx != ncy:
-            cbook.warn_deprecated(
-                "2.2", message="cycling among columns of inputs with "
-                "non-matching shapes is deprecated.")
+            raise ValueError(f"x has {ncx} columns but y has {ncy} columns")
         return [func(x[:, j % ncx], y[:, j % ncy], kw, kwargs)
                 for j in range(max(ncx, ncy))]
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5479,12 +5479,13 @@ def test_square_plot():
         ax.get_position(original=False).extents, (0.2125, 0.1, 0.8125, 0.9))
 
 
-def test_no_None():
-    fig, ax = plt.subplots()
+def test_bad_plot_args():
     with pytest.raises(ValueError):
         plt.plot(None)
     with pytest.raises(ValueError):
         plt.plot(None, None)
+    with pytest.raises(ValueError):
+        plt.plot(np.zeros((2, 2)), np.zeros((2, 3)))
 
 
 @pytest.mark.parametrize(
@@ -6225,11 +6226,6 @@ def test_empty_errorbar_legend():
     ax.errorbar([], [], xerr=[], label='empty y')
     ax.errorbar([], [], yerr=[], label='empty x')
     ax.legend()
-
-
-def test_plot_columns_cycle_deprecation():
-    with pytest.warns(MatplotlibDeprecationWarning):
-        plt.plot(np.zeros((2, 2)), np.zeros((2, 3)))
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR Summary

Edit: looks like there's some issues with animation (save_count=100/=None) that needs to be fixed.  I reverted it for now...  I think I may have messed up that deprecation and it may need to go for another two minor releases :(.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
