### PR TITLE
Remove ref. to non-existent method in animation tests.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -132,13 +132,6 @@ WRITER_OUTPUT += [
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, output', WRITER_OUTPUT)
 def test_save_animation_smoketest(tmpdir, writer, output):
-    try:
-        # for ImageMagick the rcparams must be patched to account for
-        # 'convert' being a built in MS tool, not the imagemagick
-        # tool.
-        writer._init_from_registry()
-    except AttributeError:
-        pass
     if not animation.writers.is_available(writer):
         pytest.skip("writer '%s' not available on this system" % writer)
     fig, ax = plt.subplots()
@@ -182,8 +175,7 @@ def test_movie_writer_registry():
     assert len(animation.writers._registered) > 0
     mpl.rcParams['animation.ffmpeg_path'] = "not_available_ever_xxxx"
     assert not animation.writers.is_available("ffmpeg")
-    # something which is guaranteed to be available in path
-    # and exits immediately
+    # something guaranteed to be available in path and exits immediately
     bin = "true" if sys.platform != 'win32' else "where"
     mpl.rcParams['animation.ffmpeg_path'] = bin
     assert animation.writers.is_available("ffmpeg")


### PR DESCRIPTION
_init_from_registry was removed in 39c23a8.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
