### PR TITLE
MNT: set default canvas when un-pickling

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1999,7 +1999,7 @@ default: 'top'
 
         # re-initialise some of the unstored state information
         self._axobservers = []
-        self.canvas = None
+        FigureCanvasBase(self)  # Set self.canvas.
         self._layoutbox = None
 
         if restore_to_pylab:

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -10,6 +10,7 @@ from matplotlib.testing.decorators import image_comparison
 from matplotlib.dates import rrulewrapper
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
+import matplotlib.figure as mfigure
 
 
 def test_simple():
@@ -194,3 +195,13 @@ def test_shared():
 @pytest.mark.parametrize("cmap", cm.cmap_d.values())
 def test_cmap(cmap):
     pickle.dumps(cmap)
+
+
+def test_unpickle_canvas():
+    fig = mfigure.Figure()
+    assert fig.canvas is not None
+    out = BytesIO()
+    pickle.dump(fig, out)
+    out.seek(0)
+    fig2 = pickle.load(out)
+    assert fig2.canvas is not None


### PR DESCRIPTION
In 380c531d58dd0dacbd303f06f2c2d3711eee1ff4 / #12450 we set the
default canvas on Figure `__init__` to FigureCanvasBase but were still
setting it to `None` in `__setstate__`.


Found this while investigating https://github.com/matplotlib/matplotlib/issues/8291. After inline displays itself it removes itself from the list of active figures according to pyplot so on un-pickling we don't set the canvas.  This causes the figure to fail to display (due to `fig.canvas` being `None`).