### PR TITLE
Catch shadowed imports in style checks.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ ignore =
     E265, E266,
     E305, E306,
     E722, E741,
-    F811, F841,
+    F841,
     # Some new flake8 ignores:
     N801, N802, N803, N806, N812,
     # pydocstyle
@@ -50,7 +50,7 @@ per-file-ignores =
     lib/matplotlib/lines.py: F401
     lib/matplotlib/mathtext.py: E221, E251
     lib/matplotlib/pylab.py: F401, F403
-    lib/matplotlib/pyplot.py: F401
+    lib/matplotlib/pyplot.py: F401, F811
     lib/matplotlib/rcsetup.py: E501
     lib/matplotlib/style/__init__.py: F401
     lib/matplotlib/testing/conftest.py: F401

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7,12 +7,12 @@ from numbers import Number
 import numpy as np
 from numpy import ma
 
-import matplotlib.category as _  # <-registers a category unit converter
+import matplotlib.category  # Register category unit converter as side-effect.
 import matplotlib.cbook as cbook
 import matplotlib.collections as mcoll
 import matplotlib.colors as mcolors
 import matplotlib.contour as mcontour
-import matplotlib.dates as _  # <-registers a date unit converter
+import matplotlib.dates  # Register date unit converter as side-effect.
 import matplotlib.docstring as docstring
 import matplotlib.image as mimage
 import matplotlib.legend as mlegend

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -40,7 +40,6 @@ from matplotlib.backend_bases import FigureCanvasBase, MouseButton
 from matplotlib.figure import Figure, figaspect
 from matplotlib.gridspec import GridSpec
 from matplotlib import rcParams, rcParamsDefault, get_backend, rcParamsOrig
-from matplotlib import rc_context
 from matplotlib.rcsetup import interactive_bk as _interactive_bk
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes, Subplot

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -3,7 +3,6 @@ import numpy as np
 import matplotlib
 from matplotlib import cbook, docstring, rcParams
 from matplotlib.artist import allow_rasterization
-import matplotlib.cbook as cbook
 import matplotlib.transforms as mtransforms
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath


### PR DESCRIPTION
`matplotlib.rc_context` is redefined in pyplot with a wrapper function
so that it shows up in the docs (like setp, getp and a few others).

spines imports cbook twice.

The imports of category and dates in `_axes.py` don't need to be assigned
to "_" (they're not assigned to a global name to start with anyways).

Would have caught https://github.com/matplotlib/matplotlib/pull/16189#discussion_r365578035.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
