### PR TITLE
Remove em dash

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1502,9 +1502,9 @@ class Arc(Ellipse):
 
     - The arc cannot be filled.
 
-    - The arc must be used in an `~.axes.Axes` instance---it can not be
-      added directly to a `.Figure`---because it is optimized to only render
-      the segments that are inside the axes bounding box with high resolution.
+    - The arc must be used in an `~.axes.Axes` instance. It can not be added
+      directly to a `.Figure` because it is optimized to only render the
+      segments that are inside the axes bounding box with high resolution.
     """
     def __str__(self):
         pars = (self.center[0], self.center[1], self.width,

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -578,8 +578,8 @@ class BboxBase(TransformNode):
         """
         Return a copy of the :class:`Bbox`, shrunk so that it is as
         large as it can be while having the desired aspect ratio,
-        *box_aspect*.  If the box coordinates are relative---that
-        is, fractions of a larger box such as a figure---then the
+        *box_aspect*.  If the box coordinates are relative (i.e.
+        fractions of a larger box such as a figure) then the
         physical aspect ratio of that figure is specified with
         *fig_aspect*, so that *box_aspect* can also be given as a
         ratio of the absolute dimensions, not the relative dimensions.

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -26,8 +26,8 @@ on many things including:
 
 - If there is a standard in the field the audience may be expecting
 
-For many applications, a perceptually uniform colormap is the best
-choice --- one in which equal steps in data are perceived as equal
+For many applications, a perceptually uniform colormap is the best choice;
+i.e. a colormap in which equal steps in data are perceived as equal
 steps in the color space. Researchers have found that the human brain
 perceives changes in the lightness parameter as changes in the data
 much better than, for example, changes in hue. Therefore, colormaps


### PR DESCRIPTION
## PR Summary

Triple dashes in doc sources are note converted anymore to em dashes. This is due to #11562, in which we deactivated smart quoting for good reason.

This PR removes the few remaining triple dashes and replaces them by other wording.