### PR TITLE
Deprecate Artist.{set,get}_contains.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -142,8 +142,13 @@ Setting a `.Line2D`\'s pickradius (i.e. the tolerance for pick events
 and containment checks) via `.Line2D.set_picker` is deprecated.  Use
 `.Line2D.set_pickradius` instead.
 
-`.Line2D.set_picker` no longer sets the artist's custom-contain() check.  Use
-``Line2D.set_contains`` instead.
+`.Line2D.set_picker` no longer sets the artist's custom-contain() check.
+
+``Artist.set_contains``, ``Artist.get_contains``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting a custom method overridding `.Artist.contains` is deprecated.
+There is no replacement, but you may still customize pick events using
+`.Artist.set_picker`.
 
 `~matplotlib.colorbar.Colorbar` methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -383,7 +383,7 @@ class Artist:
         """
         Base impl. for checking whether a mouseevent happened in an artist.
 
-        1. If the artist defines a custom checker, use it.
+        1. If the artist defines a custom checker, use it (deprecated).
         2. If the artist figure is known and the event did not occur in that
            figure (by checking its ``canvas`` attribute), reject it.
         3. Otherwise, return `None, {}`, indicating that the subclass'
@@ -396,7 +396,7 @@ class Artist:
                 return inside, info
             # subclass-specific implementation follows
 
-        The `canvas` kwarg is provided for the implementation of
+        The *figure* kwarg is provided for the implementation of
         `Figure.contains`.
         """
         if callable(self._contains):
@@ -406,7 +406,8 @@ class Artist:
         return None, {}
 
     def contains(self, mouseevent):
-        """Test whether the artist contains the mouse event.
+        """
+        Test whether the artist contains the mouse event.
 
         Parameters
         ----------
@@ -420,10 +421,6 @@ class Artist:
             An artist-specific dictionary of details of the event context,
             such as which points are contained in the pick radius. See the
             individual Artist subclasses for details.
-
-        See Also
-        --------
-        set_contains, get_contains
         """
         inside, info = self._default_contains(mouseevent)
         if inside is not None:
@@ -431,6 +428,7 @@ class Artist:
         _log.warning("%r needs 'contains' method", self.__class__.__name__)
         return False, {}
 
+    @cbook.deprecated("3.3", alternative="set_picker")
     def set_contains(self, picker):
         """
         Define a custom contains test for the artist.
@@ -458,6 +456,7 @@ class Artist:
             raise TypeError("picker is not a callable")
         self._contains = picker
 
+    @cbook.deprecated("3.3", alternative="get_picker")
     def get_contains(self):
         """
         Return the custom contains function of the artist if set, or *None*.


### PR DESCRIPTION
I don't think it makes sense to allow overriding contains() checks
per instance -- and if someone really need that, they can use a custom
artist subclass or even just monkeypatch the contains method; if they
need it for pick events there's still Artist.set_picker which is not
going away.

This came in in 8111a3a (2007) and was apparently never used or tested.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
