### PR TITLE
Remove outdated statement in tight_layout guide.

### DIFF
--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -336,15 +336,15 @@ plt.tight_layout()
 # ========
 #
 # If you create a colorbar with `.Figure.colorbar`, the created colorbar is
-# an instance of Axes, *not* Subplot, so tight_layout does not work. With
-# Matplotlib v1.1, you may create a colorbar as a subplot using the gridspec.
+# drawn in a Subplot as long as the parent axes is also a Subplot, so
+# `.Figure.tight_layout` will work.
 
 plt.close('all')
 arr = np.arange(100).reshape((10, 10))
 fig = plt.figure(figsize=(4, 4))
 im = plt.imshow(arr, interpolation="none")
 
-plt.colorbar(im, use_gridspec=True)
+plt.colorbar(im)
 
 plt.tight_layout()
 


### PR DESCRIPTION
use_gridspec has been the default since c3ce78d (2012).  Admittedly
explaining the difference between Subplot and Axes (the former can be
tightlayouted, not the latter) would be nice, but that's another
project.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
