### PR TITLE
Port fontconfig's font weight detection to font_manager.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1018,7 +1018,7 @@ class FontManager:
     # Increment this version number whenever the font cache data
     # format or behavior has changed and requires a existing font
     # cache files to be rebuilt.
-    __version__ = 310
+    __version__ = 330
 
     def __init__(self, size=None, weight='normal'):
         self._version = self.__version__

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -105,7 +105,7 @@ def test_utf16m_sfnt():
     else:
         # Check that we successfully read "semibold" from the font's sfnt table
         # and set its weight accordingly.
-        assert entry.weight == "semibold"
+        assert entry.weight == 600
 
 
 def test_find_ttc():


### PR DESCRIPTION
## PR Summary

This (should) fix the various font weight detection problems (#4822 #8551 #8607 #8788 #8800) by reusing fontconfig's font weight detection algorithm (specifically https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/452be81/src/fcfreetype.c#L1859 https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/452be81/src/fcfreetype.c#L1928 https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/452be81/src/fcfreetype.c#L2006 https://gitlab.freedesktop.org/fontconfig/fontconfig/blob/452be81/src/fcfreetype.c#L2044).

The first commit is a straight port of fontconfig's algorithm, and outputs *fontconfig weights*; the second commit reverts to using CSS/OpenType weights, which is what we were using so far (see discussion in https://github.com/matplotlib/matplotlib/issues/10249).

To test this, delete your last fontlist-v310.json and regen one by importing matplotlib.font_manager with or without this PR *and* setting the PYTHONHASHSEED envvar to a fixed value -- this ensures that the json dumps stay in the same order, as we use sets, whose order depend on the hash seed.

(If we agree on the PR I'll need to bump the fontlist version number as well.)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
