### PR TITLE
Deprecate the empty matplotlib.compat.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -169,3 +169,7 @@ The ``TTFPATH`` and ``AFMPATH`` environment variables
 Support for the (undocumented) ``TTFPATH`` and ``AFMPATH`` environment
 variables is deprecated.  Additional fonts may be registered using
 ``matplotlib.font_manager.fontManager.addfont()``.
+
+``matplotlib.compat``
+~~~~~~~~~~~~~~~~~~~~~
+This module is deprecated.

--- a/lib/matplotlib/compat/__init__.py
+++ b/lib/matplotlib/compat/__init__.py
@@ -1,0 +1,4 @@
+from matplotlib import cbook
+
+
+cbook.warn_deprecated("3.3", name=__name__, obj_type="module")


### PR DESCRIPTION
If we ever need something like it again we'll likely make the compat
shims private anyways...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
