### PR TITLE
DOC: ValidateInterval was deprecated in 3.2, not 3.1

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -662,7 +662,7 @@ def validate_sketch(s):
     return result
 
 
-@cbook.deprecated("3.1")
+@cbook.deprecated("3.2")
 class ValidateInterval:
     """
     Value must be in interval


### PR DESCRIPTION
The PR missed the cut off for 3.1, actually landed for 3.2

This class has already been removed on master, we probably should put it back.