### PR TITLE
Simplify CallbackRegistry pickling.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -151,9 +151,8 @@ class CallbackRegistry:
     """
 
     # We maintain two mappings:
-    #   callbacks: signal -> {cid -> callback}
-    #   _func_cid_map: signal -> {callback -> cid}
-    # (actually, callbacks are weakrefs to the actual callbacks).
+    #   callbacks: signal -> {cid -> weakref-to-callback}
+    #   _func_cid_map: signal -> {weakref-to-callback -> cid}
 
     def __init__(self, exception_handler=_exception_printer):
         self.exception_handler = exception_handler
@@ -161,19 +160,9 @@ class CallbackRegistry:
         self._cid_gen = itertools.count()
         self._func_cid_map = {}
 
-    # In general, callbacks may not be pickled; thus, we simply recreate an
-    # empty dictionary at unpickling.  In order to ensure that `__setstate__`
-    # (which just defers to `__init__`) is called, `__getstate__` must
-    # return a truthy value (for pickle protocol>=3, i.e. Py3, the
-    # *actual* behavior is that `__setstate__` will be called as long as
-    # `__getstate__` does not return `None`, but this is undocumented -- see
-    # http://bugs.python.org/issue12290).
-
     def __getstate__(self):
-        return {'exception_handler': self.exception_handler}
-
-    def __setstate__(self, state):
-        self.__init__(**state)
+        # In general, callbacks may not be pickled, so we just drop them.
+        return {**vars(self), "callbacks": {}, "_func_cid_map": {}}
 
     def connect(self, s, func):
         """Register *func* to be called when signal *s* is generated.


### PR DESCRIPTION
The deleted comment was really only relevant to Py2.
Preserving _cid_gen (which is picklable) is necessary to later enable
careful pickling of select callbacks, such as 3d mouse handlers (https://github.com/matplotlib/matplotlib/issues/10843)
(otherwise, the same cid may be assigned twice, one before pickling and
once after unpickling).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
