### PR TITLE
Fix interaction with unpickled 3d plots.

### DIFF
--- a/doc/api/next_api_changes/behavior/16220-AL.rst
+++ b/doc/api/next_api_changes/behavior/16220-AL.rst
@@ -1,0 +1,8 @@
+Canvas's callback registry now stored on Figure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The canonical location of the `~.cbook.CallbackRegistry` used to
+handle Figure/Canvas events has been moved from the Canvas to the
+Figure.  This change should be transparent to almost all users,
+however if you are swapping switching the Figure out from on top of a
+Canvas or visa versa you may see a change in behavior.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1718,8 +1718,6 @@ class FigureCanvasBase:
         figure.set_canvas(self)
         self.figure = figure
         self.manager = None
-        # a dictionary from event name to a dictionary that maps cid->func
-        self.callbacks = cbook.CallbackRegistry()
         self.widgetlock = widgets.LockDraw()
         self._button = None  # the button pressed
         self._key = None  # the key pressed
@@ -1729,6 +1727,10 @@ class FigureCanvasBase:
         self.mouse_grabber = None  # the axes currently grabbing mouse
         self.toolbar = None  # NavigationToolbar2 will set me
         self._is_idle_drawing = False
+
+    @property
+    def callbacks(self):
+        return self.figure._canvas_callbacks
 
     @classmethod
     @functools.lru_cache()

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -104,6 +104,16 @@ class _StrongRef:
         return hash(self._obj)
 
 
+def _weak_or_strong_ref(func, callback):
+    """
+    Return a `WeakMethod` wrapping *func* if possible, else a `_StrongRef`.
+    """
+    try:
+        return weakref.WeakMethod(func, callback)
+    except TypeError:
+        return _StrongRef(func)
+
+
 class CallbackRegistry:
     """
     Handle registering and disconnecting for a set of signals and callbacks:
@@ -163,21 +173,37 @@ class CallbackRegistry:
         self.callbacks = {}
         self._cid_gen = itertools.count()
         self._func_cid_map = {}
+        # A hidden variable that marks cids that need to be pickled.
+        self._pickled_cids = set()
 
     def __getstate__(self):
-        # In general, callbacks may not be pickled, so we just drop them.
-        return {**vars(self), "callbacks": {}, "_func_cid_map": {}}
+        return {
+            **vars(self),
+            # In general, callbacks may not be pickled, so we just drop them,
+            # unless directed otherwise by self._pickled_cids.
+            "callbacks": {s: {cid: proxy() for cid, proxy in d.items()
+                              if cid in self._pickled_cids}
+                          for s, d in self.callbacks.items()},
+            # It is simpler to reconstruct this from callbacks in __setstate__.
+            "_func_cid_map": None,
+        }
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+        self.callbacks = {
+            s: {cid: _weak_or_strong_ref(func, self._remove_proxy)
+                for cid, func in d.items()}
+            for s, d in self.callbacks.items()}
+        self._func_cid_map = {
+            s: {proxy: cid for cid, proxy in d.items()}
+            for s, d in self.callbacks.items()}
 
     def connect(self, s, func):
         """Register *func* to be called when signal *s* is generated."""
         self._func_cid_map.setdefault(s, {})
-        try:
-            proxy = weakref.WeakMethod(func, self._remove_proxy)
-        except TypeError:
-            proxy = _StrongRef(func)
+        proxy = _weak_or_strong_ref(func, self._remove_proxy)
         if proxy in self._func_cid_map[s]:
             return self._func_cid_map[s][proxy]
-
         cid = next(self._cid_gen)
         self._func_cid_map[s][proxy] = cid
         self.callbacks.setdefault(s, {})

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2280,6 +2280,10 @@ class Figure(FigureBase):
         super().__init__()
 
         self.callbacks = cbook.CallbackRegistry()
+        # Callbacks traditionally associated with the canvas (and exposed with
+        # a proxy property), but that actually need to be on the figure for
+        # pickling.
+        self._canvas_callbacks = cbook.CallbackRegistry()
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -118,12 +118,14 @@ class Axes3D(Axes):
             self._zcid = None
 
         self.mouse_init()
-        self.figure.canvas.mpl_connect(
-            'motion_notify_event', self._on_move),
-        self.figure.canvas.mpl_connect(
-            'button_press_event', self._button_press),
-        self.figure.canvas.mpl_connect(
-            'button_release_event', self._button_release),
+        self.figure.canvas.callbacks._pickled_cids.update({
+            self.figure.canvas.mpl_connect(
+                'motion_notify_event', self._on_move),
+            self.figure.canvas.mpl_connect(
+                'button_press_event', self._button_press),
+            self.figure.canvas.mpl_connect(
+                'button_release_event', self._button_release),
+        })
         self.set_top_view()
 
         self.patch.set_linewidth(0)


### PR DESCRIPTION
## PR Summary

In order to reset the mouse interaction callbacks on unpickled 3d plots,
the callback registry really needs to be on the Figure object rather
than the Canvas, because the canvas doesn't exist yet when the 3d axes
is being unpickled (it is only set on the figure at the very end of
unpickling).

So move the callback registry to the figure (with a proxy property on
the canvas).

Then, add a private mechanism to pickle select callbacks, and combine
everything together.  (Bound methods of picklable objects are picklable.)

Test with e.g.
```
import matplotlib.pyplot as plt
import pickle

fig = plt.figure()
fig.add_subplot(111, projection='3d')

p = pickle.dumps(fig)
plt.close("all")

pickle.loads(p)

plt.show()
```

Closes #10843.

Goes on top of #15855.  Would also be nice to get #16219 in first and rebase on top of it, but not compulsory.

The same mechanism would likely be usable e.g. for the "units finalize" callbacks (grep for this in axes/_base.py) which are likewise dropped on pickling/unpickling, but probably no one ever tried doing funky things with unit changes and pickling so no one noticed...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
