### PR TITLE
Make Animation.repeat_delay an int, not an int-or-None.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1391,19 +1391,17 @@ class TimedAnimation(Animation):
         Whether blitting is used to optimize drawing.
     """
 
-    def __init__(self, fig, interval=200, repeat_delay=None, repeat=True,
+    def __init__(self, fig, interval=200, repeat_delay=0, repeat=True,
                  event_source=None, *args, **kwargs):
-        # Store the timing information
         self._interval = interval
-        self._repeat_delay = repeat_delay
+        # Undocumented support for repeat_delay = None as backcompat.
+        self._repeat_delay = repeat_delay if repeat_delay is not None else 0
         self.repeat = repeat
-
         # If we're not given an event source, create a new timer. This permits
         # sharing timers between animation objects for syncing animations.
         if event_source is None:
             event_source = fig.canvas.new_timer()
             event_source.interval = self._interval
-
         Animation.__init__(self, fig, event_source=event_source,
                            *args, **kwargs)
 
@@ -1419,13 +1417,10 @@ class TimedAnimation(Animation):
         if not still_going and self.repeat:
             self._init_draw()
             self.frame_seq = self.new_frame_seq()
-            if self._repeat_delay:
-                self.event_source.remove_callback(self._step)
-                self.event_source.add_callback(self._loop_delay)
-                self.event_source.interval = self._repeat_delay
-                return True
-            else:
-                return Animation._step(self, *args)
+            self.event_source.remove_callback(self._step)
+            self.event_source.add_callback(self._loop_delay)
+            self.event_source.interval = self._repeat_delay
+            return True
         else:
             return still_going
 


### PR DESCRIPTION
## PR Summary

I didn't bother going through a deprecation in case someone was really
explicitly passing None...  (i.e. I left the backcompat)

Suggested in https://github.com/matplotlib/matplotlib/pull/16218#discussion_r366547968; goes on top of #16218 (edit: which has now been merged).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
