### PR TITLE
Allow directly passing explicit font paths.

### DIFF
--- a/doc/users/next_whats_new/2020-02-03-fontpath.rst
+++ b/doc/users/next_whats_new/2020-02-03-fontpath.rst
@@ -1,0 +1,5 @@
+Simple syntax to select fonts by absolute path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fonts can now be selected by passing an absolute `pathlib.Path` to the *font*
+kwarg of `.Text`.

--- a/examples/text_labels_and_annotations/font_file.py
+++ b/examples/text_labels_and_annotations/font_file.py
@@ -1,11 +1,12 @@
-"""
+r"""
 ===================================
 Using a ttf font file in Matplotlib
 ===================================
 
 Although it is usually not a good idea to explicitly point to a single ttf file
-for a font instance, you can do so using the `.font_manager.FontProperties`
-*fname* argument.
+for a font instance, you can do so by passing a `pathlib.Path` instance as the
+*font* parameter.  Note that passing paths as `str`\s is intentionally not
+supported, but you can simply wrap `str`\s in `pathlib.Path`\s as needed.
 
 Here, we use the Computer Modern roman font (``cmr10``) shipped with
 Matplotlib.
@@ -18,14 +19,12 @@ For a more flexible solution, see
 from pathlib import Path
 
 import matplotlib as mpl
-from matplotlib import font_manager as fm
 import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots()
 
 fpath = Path(mpl.get_data_path(), "fonts/ttf/cmr10.ttf")
-prop = fm.FontProperties(fname=fpath)
-ax.set_title(f'This is a special font: {fpath.name}', fontproperties=prop)
+ax.set_title(f'This is a special font: {fpath.name}', font=fpath)
 ax.set_xlabel('This is the default font')
 
 plt.show()
@@ -42,5 +41,4 @@ plt.show()
 # in this example:
 
 import matplotlib
-matplotlib.font_manager.FontProperties
 matplotlib.axes.Axes.set_title

--- a/examples/text_labels_and_annotations/font_table.py
+++ b/examples/text_labels_and_annotations/font_table.py
@@ -15,6 +15,7 @@ investigate a font by running ::
 """
 
 import os
+from pathlib import Path
 import unicodedata
 
 import matplotlib.font_manager as fm
@@ -101,7 +102,7 @@ def draw_font_table(path):
     for key, cell in table.get_celld().items():
         row, col = key
         if row > 0 and col > -1:  # Beware of table's idiosyncratic indexing...
-            cell.set_text_props(fontproperties=fm.FontProperties(fname=path))
+            cell.set_text_props(font=Path(path))
 
     fig.tight_layout()
     plt.show()

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -598,8 +598,10 @@ class FontProperties:
 
       sans-serif, normal, normal, normal, normal, scalable.
 
-    Alternatively, a font may be specified using an absolute path to a
-    .ttf file, by using the *fname* kwarg.
+    Alternatively, a font may be specified using the absolute path to a font
+    file, by using the *fname* kwarg.  However, in this case, it is typically
+    simpler to just pass the path (as a `pathlib.Path`, not a `str`) to the
+    *font* kwarg of the `.Text` object.
 
     The preferred usage of font sizes is to use the relative values,
     e.g.,  'large', instead of absolute font sizes, e.g., 12.  This
@@ -656,6 +658,17 @@ class FontProperties:
         self.set_stretch(stretch)
         self.set_file(fname)
         self.set_size(size)
+
+    @classmethod
+    def _from_any(cls, arg):
+        if isinstance(arg, cls):
+            return arg
+        elif isinstance(arg, os.PathLike):
+            return cls(fname=arg)
+        elif isinstance(arg, str):
+            return cls(arg)
+        else:
+            return cls(**arg)
 
     def __hash__(self):
         l = (tuple(self.get_family()),
@@ -1230,8 +1243,7 @@ class FontManager:
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
                          rebuild_if_missing, rc_params):
 
-        if not isinstance(prop, FontProperties):
-            prop = FontProperties(prop)
+        prop = FontProperties._from_any(prop)
 
         fname = prop.get_file()
         if fname is not None:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -364,12 +364,10 @@ class Legend(Artist):
                 self.prop = FontProperties(size=fontsize)
             else:
                 self.prop = FontProperties(size=rcParams["legend.fontsize"])
-        elif isinstance(prop, dict):
-            self.prop = FontProperties(**prop)
-            if "size" not in prop:
-                self.prop.set_size(rcParams["legend.fontsize"])
         else:
-            self.prop = prop
+            self.prop = FontProperties._from_any(prop)
+            if isinstance(prop, dict) and "size" not in prop:
+                self.prop.set_size(rcParams["legend.fontsize"])
 
         self._fontsize = self.prop.get_size_in_points()
 
@@ -876,8 +874,6 @@ class Legend(Artist):
             self._legend_title_box.set_visible(False)
 
         if prop is not None:
-            if isinstance(prop, dict):
-                prop = FontProperties(**prop)
             self._legend_title_box._text.set_fontproperties(prop)
 
         self.stale = True

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1101,12 +1101,10 @@ class AnchoredOffsetbox(OffsetBox):
 
         if prop is None:
             self.prop = FontProperties(size=rcParams["legend.fontsize"])
-        elif isinstance(prop, dict):
-            self.prop = FontProperties(**prop)
-            if "size" not in prop:
-                self.prop.set_size(rcParams["legend.fontsize"])
         else:
-            self.prop = prop
+            self.prop = FontProperties._from_any(prop)
+            if isinstance(prop, dict) and "size" not in prop:
+                self.prop.set_size(rcParams["legend.fontsize"])
 
         self.patch = FancyBboxPatch(
             xy=(0.0, 0.0), width=1., height=1.,

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -282,10 +282,10 @@ class QuiverKey(martist.Artist):
         _fp = self.fontproperties
         # boxprops = dict(facecolor='red')
         self.text = mtext.Text(
-                        text=label,  # bbox=boxprops,
-                        horizontalalignment=self.halign[self.labelpos],
-                        verticalalignment=self.valign[self.labelpos],
-                        fontproperties=font_manager.FontProperties(**_fp))
+            text=label,  # bbox=boxprops,
+            horizontalalignment=self.halign[self.labelpos],
+            verticalalignment=self.valign[self.labelpos],
+            fontproperties=font_manager.FontProperties._from_any(_fp))
 
         if self.labelcolor is not None:
             self.text.set_color(self.labelcolor)

--- a/lib/matplotlib/tests/test_ttconv.py
+++ b/lib/matplotlib/tests/test_ttconv.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import matplotlib
-from matplotlib.font_manager import FontProperties
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 
@@ -10,10 +9,9 @@ import matplotlib.pyplot as plt
 # mpltest.ttf does not have "l"/"p" glyphs so we get a warning when trying to
 # get the font extents.
 def test_truetype_conversion(recwarn):
-    fontprop = FontProperties(
-        fname=str(Path(__file__).with_name('mpltest.ttf').resolve()), size=80)
     matplotlib.rcParams['pdf.fonttype'] = 3
     fig, ax = plt.subplots()
-    ax.text(0, 0, "ABCDE", fontproperties=fontprop)
+    ax.text(0, 0, "ABCDE",
+            font=Path(__file__).with_name("mpltest.ttf"), fontsize=80)
     ax.set_xticks([])
     ax.set_yticks([])

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -105,7 +105,7 @@ def _get_textbox(text, renderer):
 @cbook._define_aliases({
     "color": ["c"],
     "fontfamily": ["family"],
-    "fontproperties": ["font_properties"],
+    "fontproperties": ["font", "font_properties"],
     "horizontalalignment": ["ha"],
     "multialignment": ["ma"],
     "fontname": ["name"],
@@ -1221,11 +1221,12 @@ class Text(Artist):
 
         Parameters
         ----------
-        fp : `.font_manager.FontProperties`
+        fp : `.font_manager.FontProperties` or `str` or `pathlib.Path`
+            If a `str`, it is interpreted as a fontconfig pattern parsed by
+            `.FontProperties`.  If a `pathlib.Path`, it is interpreted as the
+            absolute path to a font file.
         """
-        if isinstance(fp, str):
-            fp = FontProperties(fp)
-        self._fontproperties = fp.copy()
+        self._fontproperties = FontProperties._from_any(fp).copy()
         self.stale = True
 
     def set_usetex(self, usetex):

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -400,6 +400,8 @@ class TextPath(Path):
 
         if prop is None:
             prop = FontProperties()
+        else:
+            prop = FontProperties._from_any(prop)
         if size is None:
             size = prop.get_size_in_points()
 

--- a/tools/make_icons.py
+++ b/tools/make_icons.py
@@ -15,7 +15,6 @@ import urllib.request
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from matplotlib.font_manager import FontProperties
 import numpy as np
 
 
@@ -45,13 +44,10 @@ def save_icon(fig, dest_dir, name):
 
 
 def make_icon(font_path, ccode):
-    prop = FontProperties(fname=font_path, size=68)
-
     fig = plt.figure(figsize=(1, 1))
     fig.patch.set_alpha(0.0)
     text = fig.text(0.5, 0.48, chr(ccode), ha='center', va='center',
-                    fontproperties=prop)
-
+                    font=font_path, fontsize=68)
     return fig
 
 


### PR DESCRIPTION
This allows one to use `text(..., font=Path("/path/to/font.ttf"))`
rather than the more cumbersome
`fontproperties=FontProperties(fname="/path/to/font.ttf")`.

Note that we do not allow `font="/path/to/font.ttf"` and instead only
support Path objects because we also already support `font="DejaVu Sans"`
and I would rather not guess whether we have been passed a path or a
family (if there is really demand for that we can always add it later
anyways).

See https://github.com/matplotlib/matplotlib/issues/10249.

Needs whatsnew, but just posting this here for discussion.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
