### PR TITLE
Deprecate JPEG-specific kwargs and rcParams to savefig.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -225,7 +225,6 @@ The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_movie_frame_fmt``, ``validate_axis_locator``,
 ``validate_movie_html_fmt``, ``validate_grid_axis``,
 ``validate_axes_titlelocation``, ``validate_toolbar``,
-<<<<<<< HEAD
 ``validate_ps_papersize``, ``validate_legend_loc``,
 ``validate_bool_maybe_none``, ``validate_hinting``,
 ``validate_movie_writers``.
@@ -299,3 +298,12 @@ is deprecated, set the offset to 0 instead.
 ``autofmt_xdate(which=None)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This is deprecated, use its more explicit synonym, ``which="major"``, instead.
+
+JPEG options
+~~~~~~~~~~~~
+The *quality*, *optimize*, and *progressive* keyword arguments to
+`~.Figure.savefig`, which were only used when saving to JPEG, are deprecated.
+:rc:`savefig.jpeg_quality` is likewise deprecated.
+
+Such options should now be directly passed to Pillow using
+``savefig(..., pil_kwargs={"quality": ..., "optimize": ..., "progressive": ...})``.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -604,6 +604,7 @@ _deprecated_remain_as_none = {
     'animation.avconv_args': ('3.3',),
     'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
+    'savefig.jpeg_quality': ('3.3',),
 }
 
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -885,8 +885,9 @@ class FigureCanvasWx(_FigureCanvasWxBase):
         # are saving a JPEG, convert the wx.Bitmap to a wx.Image,
         # and set the quality.
         if filetype == wx.BITMAP_TYPE_JPEG:
-            jpeg_quality = kwargs.get('quality',
-                                      mpl.rcParams['savefig.jpeg_quality'])
+            jpeg_quality = kwargs.get(
+                'quality',
+                dict.__getitem__(mpl.rcParams, 'savefig.jpeg_quality'))
             image = self.bitmap.ConvertToImage()
             image.SetOption(wx.IMAGE_OPTION_QUALITY, str(jpeg_quality))
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2065,16 +2065,22 @@ default: 'top'
             the JPEG compression algorithm, and results in large files
             with hardly any gain in image quality.
 
+            This parameter is deprecated.
+
         optimize : bool, default: False
             Applicable only if *format* is 'jpg' or 'jpeg', ignored otherwise.
 
             Whether the encoder should make an extra pass over the image
             in order to select optimal encoder settings.
 
+            This parameter is deprecated.
+
         progressive : bool, default: False
             Applicable only if *format* is 'jpg' or 'jpeg', ignored otherwise.
 
             Whether the image should be stored as a progressive JPEG file.
+
+            This parameter is deprecated.
 
         facecolor : color, default: :rc:`savefig.facecolor`
             The facecolor of the figure.

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -420,7 +420,6 @@ savefig.bbox        : standard # 'tight' or 'standard'.
                                # e.g. setting animation.writer to ffmpeg will not work,
                                # use ffmpeg_file instead
 savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'
-savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
 savefig.transparent : False    # setting that controls whether figures are saved with a
                                # transparent background by default
 savefig.orientation : portrait

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -574,6 +574,28 @@ def test_safe_first_element_pandas_series(pd):
     assert actual == 0
 
 
+def test_delete_parameter():
+    @cbook._delete_parameter("3.0", "foo")
+    def func1(foo=None):
+        pass
+
+    @cbook._delete_parameter("3.0", "foo")
+    def func2(**kwargs):
+        pass
+
+    for func in [func1, func2]:
+        func()  # No warning.
+        with pytest.warns(MatplotlibDeprecationWarning):
+            func(foo="bar")
+
+    def pyplot_wrapper(foo=cbook.deprecation._deprecated_parameter):
+        func1(foo)
+
+    pyplot_wrapper()  # No warning.
+    with pytest.warns(MatplotlibDeprecationWarning):
+        func(foo="bar")
+
+
 def test_make_keyword_only():
     @cbook._make_keyword_only("3.0", "arg")
     def func(pre, arg, post=None):

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -651,7 +651,6 @@
                                 # e.g. setting animation.writer to ffmpeg will not work,
                                 # use ffmpeg_file instead
 #savefig.pad_inches:   0.1      # Padding to be used when bbox is set to 'tight'
-#savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
 #savefig.directory:    ~        # default directory in savefig dialog box,
                                 # leave empty to always use current working directory
 #savefig.transparent: False     # setting that controls whether figures are saved with a


### PR DESCRIPTION
Saving Matplotlib figures to jpeg is generally not a great idea to start
with (even at the default quality of 95 there are visible (faint)
artefacts around sharp lines, and at quality=95 the files produced are
bigger than the corresponding pngs anyways).

We don't need to completely get rid of jpeg support, but we can at least
simplify the code path (which otherwise also needs to be duplicated in
mplcairo) and not have to document these jpeg-specific kwargs (in two
places!).  Note that users can still set them via `pil_kwargs`.

The changes to _delete_parameter are so that we can write
```
@_delete_parameter(..., "foo")
def f(**kwargs): ...
```
where `foo` actually only shows up in `kwargs`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
