### PR TITLE
Reword ScalarFormatter docstrings.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -274,6 +274,12 @@ class Formatter(TickHelper):
         return ''
 
     def set_locs(self, locs):
+        """
+        Set the locations of the ticks.
+
+        This method is called before computing the tick labels because some
+        formatters need to know all tick locations to do so.
+        """
         self.locs = locs
 
     @staticmethod
@@ -496,14 +502,13 @@ class ScalarFormatter(Formatter):
     """
     Format tick values as a number.
 
-    Tick value is interpreted as a plain old number. If
-    ``useOffset==True`` and the data range is much smaller than the data
+    If ``useOffset == True`` and the data range is much smaller than the data
     average, then an offset will be determined such that the tick labels
-    are meaningful. Scientific notation is used for ``data < 10^-n`` or
-    ``data >= 10^m``, where ``n`` and ``m`` are the power limits set
-    using ``set_powerlimits((n, m))``. The defaults for these are
-    controlled by the ``axes.formatter.limits`` rc parameter.
+    are meaningful.  Scientific notation is used for ``data < 10^-n`` or
+    ``data >= 10^m``, where ``n`` and ``m`` are the power limits set using
+    ``set_powerlimits((n, m))``, defaulting to :rc:`axes.formatter.limits`.
     """
+
     def __init__(self, useOffset=None, useMathText=None, useLocale=None):
         # useOffset allows plotting small data ranges with large offsets: for
         # example: [1+1e-9, 1+2e-9, 1+3e-9] useMathText will render the offset
@@ -618,9 +623,7 @@ class ScalarFormatter(Formatter):
                 "%-12g" % value))
 
     def format_data(self, value):
-        """
-        Return a formatted string representation of a number.
-        """
+        # docstring inherited
         if self._useLocale:
             s = locale.format_string('%1.10e', (value,))
         else:
@@ -657,9 +660,7 @@ class ScalarFormatter(Formatter):
         return self.fix_minus(s)
 
     def set_locs(self, locs):
-        """
-        Set the locations of the ticks.
-        """
+        # docstring inherited
         self.locs = locs
         if len(self.locs) > 0:
             if self._useOffset:


### PR DESCRIPTION
I don't think "tick value is interpreted as a plain old number" adds
much...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
