### PR TITLE
FIX: AttributeError in TimerBase.start

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1086,7 +1086,7 @@ class TimerBase:
             if provided.
         """
         if interval is not None:
-            self._set_interval(interval)
+            self.interval = interval
         self._timer_start()
 
     def stop(self):


### PR DESCRIPTION
## PR Summary
When calling `TimerBase.start` with a new interval, an AttributeError is raised because `TimerBase` has no method `_set_interval`.

Don't call `TimerBase._set_interval` (does not exist) but set the property `TimerBase .interval` instead.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
