### PR TITLE
CI: Remove PYTHONUNBUFFERED=1 on Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,7 +47,6 @@ init:
 
 install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
-  - set PYTHONUNBUFFERED=1
   - conda config --set always_yes true
   - conda update --all
   - conda config --set show_channel_urls yes


### PR DESCRIPTION
It is there for unknown reason, since Appveyor setup. I do not expect something
to break, probably it was somehow related to multiprocess bug in Python 3 prior
to 3.6.3, and we have a fix for it already.

I expect to see some insignificant speed-up (should be much more on pdf tests).