### PR TITLE
Fix Boxplot Outlier and Whisker Calculation

### DIFF
--- a/MPL_Whisker_adjustment_test.ipynb
+++ b/MPL_Whisker_adjustment_test.ipynb
@@ -1,0 +1,83 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "MPL Whisker adjustment test",
+      "provenance": [],
+      "authorship_tag": "ABX9TyNLLO/riwcOr+RpCq5Xl6YL"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "DDIdCaMmUBzp",
+        "colab_type": "code",
+        "outputId": "452e100f-9819-4565-8354-1641852c8421",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "source": [
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "import matplotlib.cbook as cbook\n",
+        "\n",
+        "new_list = [0.0471054, 0.0262474, 0.12289739999999999, 0.1379574, 0.1473904, \n",
+        "            0.24473540000000002, 0.2560634, 0.0769904, 0.1388934, 0.0989914, \n",
+        "            0.10793639999999999]\n",
+        "x = np.asarray(df['col2'])\n",
+        "original = cbook.boxplot_stats(x)\n",
+        "\n",
+        "whis=1.5\n",
+        "stats = {}\n",
+        "stats['mean'] = np.mean(x)\n",
+        "q1, med, q3 = np.percentile(x, [25, 50, 75])\n",
+        "stats['iqr'] = q3 - q1\n",
+        "\n",
+        "\n",
+        "loval = q1 - whis * stats['iqr']\n",
+        "hival = q3 + whis * stats['iqr']\n",
+        "\n",
+        "\n",
+        "\n",
+        "if hival >= np.max(x):\n",
+        "  stats['whishi'] = np.max(x)\n",
+        "else:\n",
+        "  stats['whishi'] = hival\n",
+        "\n",
+        "if loval <= np.min(x):\n",
+        "  stats['whislo'] = np.min(x)\n",
+        "else:\n",
+        "  stats['whislo'] = loval\n",
+        "\n",
+        "stats['fliers'] = np.hstack([\n",
+        "                             x[x < stats['whislo']],\n",
+        "                             x[x > stats['whishi']],\n",
+        "                             ])\n",
+        "\n",
+        "stats['q1'], stats['med'], stats['q3'] = q1, med, q3\n",
+        "print(\"High Whisker as outputted by cookbook: {}\".format(original[0]['whishi']))\n",
+        "print(\"High Whisker adjusted: {}\".format(stats['whishi']))\n",
+        "\n"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "High Whisker as outputted by cookbook: 0.1473904\n",
+            "High Whisker calculated: 0.22586839999999997\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    }
+  ]
+}

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1283,7 +1283,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
             stats['whishi'] = hival
 
         # get low extreme
-        if loval <= np.min(x)::
+        if loval <= np.min(x):
             stats['whislo'] = np.min(x)
         else:
             stats['whislo'] = loval

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1276,19 +1276,17 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
         else:
             loval, hival = np.percentile(x, whis)
 
-        # get high extreme
-        wiskhi = x[x <= hival]
-        if len(wiskhi) == 0 or np.max(wiskhi) < q3:
-            stats['whishi'] = q3
+         # get high extreme
+        if hival >= np.max(x):
+            stats['whishi'] = np.max(x)
         else:
-            stats['whishi'] = np.max(wiskhi)
+            stats['whishi'] = hival
 
         # get low extreme
-        wisklo = x[x >= loval]
-        if len(wisklo) == 0 or np.min(wisklo) > q1:
-            stats['whislo'] = q1
+        if loval <= np.min(x)::
+            stats['whislo'] = np.min(x)
         else:
-            stats['whislo'] = np.min(wisklo)
+            stats['whislo'] = loval
 
         # compute a single array of outliers
         stats['fliers'] = np.hstack([


### PR DESCRIPTION
I noticed that the boxplot's generated by seaborn were quite different than the ones generated by pandas. I traced the error back to this document in "boxplot_stats". Made corrections to make it calculate the actual whisker ranges and outliers.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
