### PR TITLE
TST: something changed in pytest 5.3.3 that breaks our qt fixtures

### DIFF
--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -5,7 +5,7 @@ cycler
 numpy
 pillow
 pyparsing
-pytest!=4.6.0
+pytest!=4.6.0,!=5.3.3
 pytest-cov
 pytest-rerunfailures
 pytest-timeout


### PR DESCRIPTION
It looks like something (have not tracked down what yet) changed in pytest 5.3.3.  I'm working on tracking it down and will either make a bug report upstream or will put in a fix on our side, but in the mean time if this makes CI green again I intend to self-merge.