### PR TITLE
TST: move the Qt-specific handling to conftest

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -46,7 +46,7 @@ def mpl_test_settings(request):
             prev_backend = matplotlib.get_backend()
 
             # special case Qt backend importing to avoid conflicts
-            if backend == 'Qt4Agg':
+            if backend.lower().startswith('qt4'):
                 if any(k in sys.modules for k in ('PyQt5', 'PySide2')):
                     pytest.skip('Qt5 binding already imported')
                 try:
@@ -57,7 +57,7 @@ def mpl_test_settings(request):
                         import PySide
                     except ImportError:
                         pytest.skip("Failed to import a Qt4 binding.")
-            elif backend == 'Qt5Agg':
+            elif backend.lower().startswith('qt5'):
                 if any(k in sys.modules for k in ('PyQt4', 'PySide')):
                     pytest.skip('Qt4 binding already imported')
                 try:

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-
+import sys
 import matplotlib
 from matplotlib import cbook
 
@@ -44,6 +44,30 @@ def mpl_test_settings(request):
             skip_on_importerror = backend_marker.kwargs.get(
                 'skip_on_importerror', False)
             prev_backend = matplotlib.get_backend()
+
+            # special case Qt backend importing to avoid conflicts
+            if backend == 'Qt4Agg':
+                if any(k in sys.modules for k in ('PyQt5', 'PySide2')):
+                    pytest.skip('Qt5 binding already imported')
+                try:
+                    import PyQt4
+                # RuntimeError if PyQt5 already imported.
+                except (ImportError, RuntimeError):
+                    try:
+                        import PySide
+                    except ImportError:
+                        pytest.skip("Failed to import a Qt4 binding.")
+            elif backend == 'Qt5Agg':
+                if any(k in sys.modules for k in ('PyQt4', 'PySide')):
+                    pytest.skip('Qt4 binding already imported')
+                try:
+                    import PyQt5
+                # RuntimeError if PyQt4 already imported.
+                except (ImportError, RuntimeError):
+                    try:
+                        import PySide2
+                    except ImportError:
+                        pytest.skip("Failed to import a Qt5 binding.")
 
         # Default of cleanup and image_comparison too.
         style = ["classic", "_classic_test_patch"]

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -10,47 +10,9 @@ from matplotlib._pylab_helpers import Gcf
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def mpl_test_settings(qt_core, mpl_test_settings):
-    """
-    Ensure qt_core fixture is *first* fixture.
-
-    We override the `mpl_test_settings` fixture and depend on the `qt_core`
-    fixture first. It is very important that it is first, because it skips
-    tests when Qt is not available, and if not, then the main
-    `mpl_test_settings` fixture will try to switch backends before the skip can
-    be triggered.
-    """
-
-
 @pytest.fixture
 def qt_core(request):
     backend, = request.node.get_closest_marker('backend').args
-    if backend == 'Qt4Agg':
-        if any(k in sys.modules for k in ('PyQt5', 'PySide2')):
-            pytest.skip('Qt5 binding already imported')
-        try:
-            import PyQt4
-        # RuntimeError if PyQt5 already imported.
-        except (ImportError, RuntimeError):
-            try:
-                import PySide
-            except ImportError:
-                pytest.skip("Failed to import a Qt4 binding.")
-    elif backend == 'Qt5Agg':
-        if any(k in sys.modules for k in ('PyQt4', 'PySide')):
-            pytest.skip('Qt4 binding already imported')
-        try:
-            import PyQt5
-        # RuntimeError if PyQt4 already imported.
-        except (ImportError, RuntimeError):
-            try:
-                import PySide2
-            except ImportError:
-                pytest.skip("Failed to import a Qt5 binding.")
-    else:
-        raise ValueError('Backend marker has unknown value: ' + backend)
-
     qt_compat = pytest.importorskip('matplotlib.backends.qt_compat')
     QtCore = qt_compat.QtCore
 

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -5,7 +5,7 @@ cycler
 numpy
 pillow
 pyparsing
-pytest!=4.6.0,!=5.3.3
+pytest!=4.6.0
 pytest-cov
 pytest-rerunfailures
 pytest-timeout


### PR DESCRIPTION
The order fixtures are applied appears to have changed / become
indeterminate in pytest 5.3.3 which breaks the over-riding of
mpl_test_settings that we were doing in test_backend_qt5.

This moves the skipping logic to mpl_test_settings, but leaves the
importing of QtCore in the qt_core fixture.

This is a follow on to #16259 that should work for all versions of pytest.