### PR TITLE
Move mplot3d autoregistration api changes to 3.2.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -17,14 +17,6 @@ regardless of whether `matplotlib.pyplot` has been imported. If the user
 tries to switch from an already-started interactive backend to a different
 interactive backend, an `ImportError` will be raised.
 
-mplot3d auto-registration
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-`mpl_toolkits.mplot3d` is always registered by default now. It is no
-longer necessary to import mplot3d to create 3d axes with ::
-
-  ax = fig.add_subplot(111, projection="3d")
-
 Invalid points in PathCollections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PathCollections created with `~.Axes.scatter` now keep track of invalid points.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -299,3 +299,11 @@ package, and Axes methods that take a ``norm`` parameter.
 
 If extra kwargs are passed to `.LogScale`, `TypeError` will now be
 raised instead of `ValueError`.
+
+mplot3d auto-registration
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`mpl_toolkits.mplot3d` is always registered by default now. It is no
+longer necessary to import mplot3d to create 3d axes with ::
+
+  ax = fig.add_subplot(111, projection="3d")


### PR DESCRIPTION
This was wrongly put into the 3.1 notes.

Closes #16192.

Should perhaps also be backported to 3.1.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
