### PR TITLE
Tiny cleanups to set_xlabel(..., loc=...).

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -217,22 +217,20 @@ class Axes(_AxesBase):
         """
         if labelpad is not None:
             self.xaxis.labelpad = labelpad
-        _protected_kw = ['x', 'horizontalalignment', 'ha']
-        if any([k in kwargs for k in _protected_kw]):
+        protected_kw = ['x', 'horizontalalignment', 'ha']
+        if {*kwargs} & {*protected_kw}:
             if loc is not None:
-                raise TypeError('Specifying *loc* is disallowed when any of '
-                                'its corresponding low level kwargs {} '
-                                'are supplied as well.'.format(_protected_kw))
+                raise TypeError(f"Specifying 'loc' is disallowed when any of "
+                                f"its corresponding low level kwargs "
+                                f"({protected_kw}) are supplied as well")
             loc = 'center'
         else:
             loc = loc if loc is not None else rcParams['xaxis.labellocation']
         cbook._check_in_list(('left', 'center', 'right'), loc=loc)
-        if loc == 'right':
-            kwargs['x'] = 1.
-            kwargs['horizontalalignment'] = 'right'
-        elif loc == 'left':
-            kwargs['x'] = 0.
-            kwargs['horizontalalignment'] = 'left'
+        if loc == 'left':
+            kwargs.update(x=0, horizontalalignment='left')
+        elif loc == 'right':
+            kwargs.update(x=1, horizontalalignment='right')
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
     def get_ylabel(self):
@@ -272,22 +270,20 @@ class Axes(_AxesBase):
         """
         if labelpad is not None:
             self.yaxis.labelpad = labelpad
-        _protected_kw = ['y', 'horizontalalignment', 'ha']
-        if any([k in kwargs for k in _protected_kw]):
+        protected_kw = ['y', 'horizontalalignment', 'ha']
+        if {*kwargs} & {*protected_kw}:
             if loc is not None:
-                raise TypeError('Specifying *loc* is disallowed when any of '
-                                'its corresponding low level kwargs {} '
-                                'are supplied as well.'.format(_protected_kw))
+                raise TypeError(f"Specifying 'loc' is disallowed when any of "
+                                f"its corresponding low level kwargs "
+                                f"({protected_kw}) are supplied as well")
             loc = 'center'
         else:
             loc = loc if loc is not None else rcParams['yaxis.labellocation']
         cbook._check_in_list(('bottom', 'center', 'top'), loc=loc)
-        if loc == 'top':
-            kwargs['y'] = 1.
-            kwargs['horizontalalignment'] = 'right'
-        elif loc == 'bottom':
-            kwargs['y'] = 0.
-            kwargs['horizontalalignment'] = 'left'
+        if loc == 'bottom':
+            kwargs.update(y=0, horizontalalignment='left')
+        elif loc == 'top':
+            kwargs.update(y=1, horizontalalignment='right')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def get_legend_handles_labels(self, legend_handler_map=None):


### PR DESCRIPTION
## PR Summary

Followup to https://github.com/matplotlib/matplotlib/pull/15974 that did not warrant holding up the PR.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
