### PR TITLE
Cleanup docstring of print_figure, savefig.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1974,11 +1974,8 @@ class FigureCanvasBase:
 
         Parameters
         ----------
-        filename
-            can also be a file object on image backends
-
-        orientation : {'landscape', 'portrait'}, default: 'portrait'
-            only currently applies to PostScript printing.
+        filename : str or path-like or file-like
+            The file where the figure is saved.
 
         dpi : float, default: :rc:`savefig.dpi`
             The dots per inch to save the figure in.
@@ -1989,16 +1986,17 @@ class FigureCanvasBase:
         edgecolor : color, default: :rc:`savefig.edgecolor`
             The edgecolor of the figure.
 
+        orientation : {'landscape', 'portrait'}, default: 'portrait'
+            Only currently applies to PostScript printing.
+
         format : str, optional
             Force a specific file format. If not given, the format is inferred
             from the *filename* extension, and if that fails from
             :rc:`savefig.format`.
 
-        bbox_inches : 'tight' or `~matplotlib.transforms.Bbox`, \
-default: :rc:`savefig.bbox`
-            Bbox in inches. Only the given portion of the figure is
-            saved. If 'tight', try to figure out the tight bbox of
-            the figure.
+        bbox_inches : 'tight' or `.Bbox`, default: :rc:`savefig.bbox`
+            Bounding box in inches: only the given portion of the figure is
+            saved.  If 'tight', try to figure out the tight bbox of the figure.
 
         pad_inches : float, default: :rc:`savefig.pad_inches`
             Amount of padding around the figure when *bbox_inches* is 'tight'.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2112,10 +2112,9 @@ default: 'top'
             transparency of these patches will be restored to their
             original values upon exit of this function.
 
-        bbox_inches : str or `~matplotlib.transforms.Bbox`, optional
-            Bbox in inches. Only the given portion of the figure is
-            saved. If 'tight', try to figure out the tight bbox of
-            the figure. If None, use savefig.bbox
+        bbox_inches : str or `.Bbox`, default: :rc:`savefig.bbox`
+            Bounding box in inches: only the given portion of the figure is
+            saved.  If 'tight', try to figure out the tight bbox of the figure.
 
         pad_inches : scalar, optional
             Amount of padding around the figure when bbox_inches is


### PR DESCRIPTION
Correct doc for filename.  Move doc for orientation down to its position
in the signature.  Make typespec for bbox_inches fit in one line (I
think the line continuation is ugly enough to prefer not using a fully
qualified name for .Bbox).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
