### PR TITLE
Deprecate RendererCairo.font{weights,angles}

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -278,3 +278,7 @@ property of `.Line2D` and `.LineCollection`.  Previously, certain APIs would
 accept ``offset = None`` as a synonym for ``offset = 0``, but this was never
 universally implemented, e.g. for vector output.  Support for ``offset = None``
 is deprecated, set the offset to 0 instead.
+
+``RendererCairo.fontweights``, ``RendererCairo.fontangles``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.


### PR DESCRIPTION
They don't really need to be public to start with, and are rendered quite uglyly in the html docs (https://matplotlib.org/devdocs/api/backend_cairo_api.html#matplotlib.backends.backend_cairo.RendererCairo.fontangles) given that we shim cairo using mock (when building the docs).

See https://github.com/Kozea/CairoSVG/pull/259 for the choice of cutoff between NORMAL and BOLD.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
