### PR TITLE
Split Norm and LinearNorm up

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4326,10 +4326,10 @@ class Axes(_AxesBase):
             A `.Colormap` instance or registered colormap name. *cmap* is only
             used if *c* is an array of floats.
 
-        norm : `~matplotlib.colors.Normalize`, default: None
-            A `.Normalize` instance is used to scale luminance data to 0, 1.
+        norm : `~matplotlib.colors.Norm`, default: None
+            A `.Norm` instance is used to scale luminance data to 0, 1.
             *norm* is only used if *c* is an array of floats. If *None*, use
-            the default `.colors.Normalize`.
+            the default `.colors.Norm`.
 
         vmin, vmax : scalar, default: None
             *vmin* and *vmax* are used in conjunction with *norm* to normalize
@@ -4553,14 +4553,14 @@ default: :rc:`scatter.edgecolors`
             The Colormap instance or registered colormap name used to map
             the bin values to colors.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            The Normalize instance scales the bin values to the canonical
+        norm : `~matplotlib.colors.Norm`, optional
+            The Norm instance scales the bin values to the canonical
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
         vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `~.Norm` instance (defaults to
             the respective min/max values of the bins in case of the default
             linear scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -5459,8 +5459,8 @@ default: :rc:`scatter.edgecolors`
             The Colormap instance or registered colormap name used to map
             scalar data to colors. This parameter is ignored for RGB(A) data.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            The `.Normalize` instance used to scale scalar data to the [0, 1]
+        norm : `~matplotlib.colors.Norm`, optional
+            The `.Norm` instance used to scale scalar data to the [0, 1]
             range before mapping to colors using *cmap*. By default, a linear
             scaling mapping the lowest value to 0 and the highest to 1 is used.
             This parameter is ignored for RGB(A) data.
@@ -5746,14 +5746,14 @@ default: :rc:`scatter.edgecolors`
             A Colormap instance or registered colormap name. The colormap
             maps the *C* values to colors.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            The Normalize instance scales the data values to the canonical
+        norm : `~matplotlib.colors.Norm`, optional
+            The Norm instance scales the data values to the canonical
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
         vmin, vmax : scalar, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `~.Norm` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -5977,14 +5977,14 @@ default: :rc:`scatter.edgecolors`
             A Colormap instance or registered colormap name. The colormap
             maps the *C* values to colors.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            The Normalize instance scales the data values to the canonical
+        norm : `~matplotlib.colors.Norm`, optional
+            The Norm instance scales the data values to the canonical
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
         vmin, vmax : scalar, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `~.Norm` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -6211,14 +6211,14 @@ default: :rc:`scatter.edgecolors`
             A Colormap instance or registered colormap name. The colormap
             maps the *C* values to colors.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            The Normalize instance scales the data values to the canonical
+        norm : `~matplotlib.colors.Norm`, optional
+            The Norm instance scales the data values to the canonical
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
         vmin, vmax : scalar, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `~.Norm` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -6871,13 +6871,13 @@ default: :rc:`scatter.edgecolors`
         cmap : Colormap or str, optional
             A `.colors.Colormap` instance.  If not set, use rc settings.
 
-        norm : Normalize, optional
-            A `.colors.Normalize` instance is used to
+        norm : Norm, optional
+            A `.colors.Norm` instance is used to
             scale luminance data to ``[0, 1]``. If not set, defaults to
-            `.colors.Normalize()`.
+            `.colors.Norm()`.
 
         vmin/vmax : None or scalar, optional
-            Arguments passed to the `~.colors.Normalize` instance.
+            Arguments passed to the `~.colors.Norm` instance.
 
         alpha : ``0 <= scalar <= 1`` or ``None``, optional
             The alpha blending value.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -159,10 +159,10 @@ class ScalarMappable:
 
         Parameters
         ----------
-        norm : `matplotlib.colors.Normalize` (or subclass thereof)
+        norm : `matplotlib.colors.Norm` (or subclass thereof)
             The normalizing object which scales data, typically into the
             interval ``[0, 1]``.
-            If *None*, *norm* defaults to a *colors.Normalize* object which
+            If *None*, *norm* defaults to a *colors.LinearNorm* object which
             initializes its scaling based on the first data processed.
         cmap : str or `~matplotlib.colors.Colormap`
             The colormap used to map normalized data values to RGBA colors.
@@ -173,7 +173,7 @@ class ScalarMappable:
         if cmap is None:
             cmap = get_cmap()
         if norm is None:
-            norm = colors.Normalize()
+            norm = colors.LinearNorm()
 
         self._A = None
         #: The Normalization instance of this ScalarMappable.
@@ -351,7 +351,7 @@ class ScalarMappable:
 
         Parameters
         ----------
-        norm : `.Normalize`
+        norm : `.Norm`
 
         Notes
         -----
@@ -360,9 +360,9 @@ class ScalarMappable:
         on the colorbar to default.
 
         """
-        cbook._check_isinstance((colors.Normalize, None), norm=norm)
+        cbook._check_isinstance((colors.Norm, None), norm=norm)
         if norm is None:
-            norm = colors.Normalize()
+            norm = colors.LinearNorm()
         self.norm = norm
         self.changed()
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1306,8 +1306,8 @@ class LineCollection(Collection):
             where ``onoffseq`` is an even length tuple of on and off ink
             in points.
 
-        norm : Normalize, optional
-            `~.colors.Normalize` instance.
+        norm : Norm, optional
+            `~.colors.Norm` instance.
 
         cmap : str or Colormap, optional
             Colormap name or `~.colors.Colormap` instance.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -337,7 +337,7 @@ class ColorbarBase:
     None, then the colormap will be displayed on a 0-1 scale. To show the
     under- and over-value colors, specify the *norm* as::
 
-        norm=colors.Normalize(clip=False)
+        norm=colors.LinearNorm(clip=False)
 
     To show the colors versus index instead of on the 0-1 scale,
     use::
@@ -362,7 +362,7 @@ class ColorbarBase:
         The `~.axes.Axes` instance in which the colorbar is drawn.
     cmap : `~matplotlib.colors.Colormap`, default: :rc:`image.cmap`
         The colormap to use.
-    norm : `~matplotlib.colors.Normalize`
+    norm : `~matplotlib.colors.Norm`
 
     alpha : float
         The colorbar transparency between 0 (transparent) and 1 (opaque).
@@ -427,7 +427,7 @@ class ColorbarBase:
         if cmap is None:
             cmap = cm.get_cmap()
         if norm is None:
-            norm = colors.Normalize()
+            norm = colors.LinearNorm()
         self.alpha = alpha
         self.cmap = cmap
         self.norm = norm
@@ -585,7 +585,7 @@ class ColorbarBase:
         one.  (check is used twice so factored out here...)
         """
         contouring = self.boundaries is not None and self.spacing == 'uniform'
-        return (type(self.norm) in [colors.Normalize, colors.LogNorm]
+        return (type(self.norm) in [colors.LinearNorm, colors.LogNorm]
                 and not contouring)
 
     def _reset_locator_formatter_scale(self):
@@ -1094,7 +1094,7 @@ class ColorbarBase:
         if self.extend in ('both', 'max'):
             y[-1] = 1. + extendlength[1]
         yi = y[self._inside]
-        norm = colors.Normalize(yi[0], yi[-1])
+        norm = colors.LinearNorm(yi[0], yi[-1])
         y[self._inside] = np.ma.filled(norm(yi), np.nan)
         return y
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1645,14 +1645,14 @@ class QuadContourSet(ContourSet):
 
             If both *colors* and *cmap* are given, an error is raised.
 
-        norm : `~matplotlib.colors.Normalize`, optional
-            If a colormap is used, the `.Normalize` instance scales the level
+        norm : `~matplotlib.colors.Norm`, optional
+            If a colormap is used, the `.Norm` instance scales the level
             values to the canonical colormap range [0, 1] for mapping to
             colors. If not given, the default linear scaling is used.
 
         vmin, vmax : float, optional
             If not *None*, either or both of these values will be supplied to
-            the `.Normalize` instance, overriding the default color scaling
+            the `.Norm` instance, overriding the default color scaling
             based on *levels*.
 
         origin : {*None*, 'upper', 'lower', 'image'}, optional

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -780,8 +780,8 @@ default: 'top'
         alpha : None or float
             The alpha blending value.
 
-        norm : `matplotlib.colors.Normalize`
-            A :class:`.Normalize` instance to map the luminance to the
+        norm : `matplotlib.colors.Norm`
+            A :class:`.Norm` instance to map the luminance to the
             interval [0, 1].
 
         cmap : str or `matplotlib.colors.Colormap`, default: :rc:`image.cmap`

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -221,7 +221,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
     interpolation and cmap default to their rc settings
 
     cmap is a colors.Colormap instance
-    norm is a colors.Normalize instance to map luminance to 0-1
+    norm is a colors.Norm instance to map luminance to 0-1
 
     extent is data axes (left, right, bottom, top) for making image plots
     registered with data plots.  Default is to label the pixel
@@ -827,7 +827,7 @@ class AxesImage(_ImageBase):
     cmap : str or `~matplotlib.colors.Colormap`, default: :rc:`image.cmap`
         The Colormap instance or registered colormap name used to map scalar
         data to colors.
-    norm : `~matplotlib.colors.Normalize`
+    norm : `~matplotlib.colors.Norm`
         Maps luminance to 0-1.
     interpolation : str, default: :rc:`image.interpolation`
         Supported values are 'none', 'antialiased', 'nearest', 'bilinear',
@@ -1148,7 +1148,7 @@ class PcolorImage(AxesImage):
         cmap : str or `~matplotlib.colors.Colormap`, default: :rc:`image.cmap`
             The Colormap instance or registered colormap name used to map
             scalar data to colors.
-        norm : `~matplotlib.colors.Normalize`
+        norm : `~matplotlib.colors.Norm`
             Maps luminance to 0-1.
         **kwargs : `.Artist` properties
         """
@@ -1285,7 +1285,7 @@ class FigureImage(_ImageBase):
                  ):
         """
         cmap is a colors.Colormap instance
-        norm is a colors.Normalize instance to map luminance to 0-1
+        norm is a colors.Norm instance to map luminance to 0-1
 
         kwargs are an optional list of Artist keyword args
         """
@@ -1346,7 +1346,7 @@ class BboxImage(_ImageBase):
                  ):
         """
         cmap is a colors.Colormap instance
-        norm is a colors.Normalize instance to map luminance to 0-1
+        norm is a colors.Norm instance to map luminance to 0-1
 
         kwargs are an optional list of Artist keyword args
         """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -54,7 +54,7 @@ from matplotlib.cm import get_cmap, register_cmap
 import numpy as np
 
 # We may not need the following imports here:
-from matplotlib.colors import Normalize
+from matplotlib.colors import Normalize, LinearNorm
 from matplotlib.lines import Line2D
 from matplotlib.text import Text, Annotation
 from matplotlib.patches import Polygon, Rectangle, Circle, Arrow

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -48,8 +48,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     cmap : `~matplotlib.colors.Colormap`
         Colormap used to plot streamlines and arrows. This is only used if
         *color* is an array.
-    norm : `~matplotlib.colors.Normalize`
-        Normalize object used to scale luminance data to 0, 1. If ``None``,
+    norm : `~matplotlib.colors.Norm`
+        Norm object used to scale luminance data to 0, 1. If ``None``,
         stretch (min, max) to (0, 1). This is only used if *color* is an array.
     arrowsize : float
         Scaling factor for the arrow size.
@@ -174,7 +174,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     if use_multicolor_lines:
         if norm is None:
-            norm = mcolors.Normalize(color.min(), color.max())
+            norm = mcolors.LinearNorm(color.min(), color.max())
         if cmap is None:
             cmap = cm.get_cmap(matplotlib.rcParams['image.cmap'])
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1018,7 +1018,7 @@ def test_imshow_norm_vminvmax(fig_test, fig_ref):
     with pytest.warns(MatplotlibDeprecationWarning,
                       match="Passing parameters norm and vmin/vmax "
                             "simultaneously is deprecated."):
-        ax.imshow(a, norm=mcolors.Normalize(-10, 10), vmin=0, vmax=5)
+        ax.imshow(a, norm=mcolors.LinearNorm(-10, 10), vmin=0, vmax=5)
 
 
 @image_comparison(['polycollection_joinstyle'], remove_text=True)
@@ -2000,7 +2000,7 @@ class TestScatter:
         with pytest.warns(MatplotlibDeprecationWarning,
                           match="Passing parameters norm and vmin/vmax "
                                 "simultaneously is deprecated."):
-            ax.scatter(x, x, c=x, norm=mcolors.Normalize(-10, 10),
+            ax.scatter(x, x, c=x, norm=mcolors.LinearNorm(-10, 10),
                        vmin=0, vmax=5)
 
     @check_figures_equal(extensions=["png"])

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -7,7 +7,7 @@ import matplotlib.colors as mcolors
 from matplotlib import rc_context
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
-from matplotlib.colors import (BoundaryNorm, LogNorm, PowerNorm, Normalize,
+from matplotlib.colors import (BoundaryNorm, LogNorm, PowerNorm, LinearNorm,
                                TwoSlopeNorm)
 from matplotlib.colorbar import ColorbarBase, _ColorbarLogLocator
 from matplotlib.ticker import FixedLocator
@@ -499,7 +499,7 @@ def test_colorbar_scale_reset():
 
     pcm.set_norm(LogNorm(vmin=1, vmax=100))
     assert cbar.ax.yaxis.get_scale() == 'log'
-    pcm.set_norm(Normalize(vmin=-20, vmax=20))
+    pcm.set_norm(LinearNorm(vmin=-20, vmax=20))
     assert cbar.ax.yaxis.get_scale() == 'linear'
 
 
@@ -545,7 +545,7 @@ def test_extend_colorbar_customnorm():
 
 def test_mappable_no_alpha():
     fig, ax = plt.subplots()
-    sm = cm.ScalarMappable(norm=mcolors.Normalize(), cmap='viridis')
+    sm = cm.ScalarMappable(norm=mcolors.LinearNorm(), cmap='viridis')
     fig.colorbar(sm)
     sm.set_cmap('plasma')
     plt.draw()

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -232,7 +232,7 @@ def test_lognorm_invalid(vmin, vmax):
 def test_LogNorm():
     """
     LogNorm ignored clip, now it has the same
-    behavior as Normalize, e.g., values > vmax are bigger than 1
+    behavior as LinearNorm, e.g., values > vmax are bigger than 1
     without clip, with clip they are 1.
     """
     ln = mcolors.LogNorm(clip=True, vmax=5)
@@ -242,7 +242,7 @@ def test_LogNorm():
 def test_PowerNorm():
     a = np.array([0, 0.5, 1, 1.5], dtype=float)
     pnorm = mcolors.PowerNorm(1)
-    norm = mcolors.Normalize()
+    norm = mcolors.LinearNorm()
     assert_array_almost_equal(norm(a), pnorm(a))
 
     a = np.array([-0.5, 0, 2, 4, 8], dtype=float)
@@ -279,8 +279,8 @@ def test_PowerNorm_translation_invariance():
     assert_array_almost_equal(pnorm(a - 2), expected)
 
 
-def test_Normalize():
-    norm = mcolors.Normalize()
+def test_LinearNorm():
+    norm = mcolors.LinearNorm()
     vals = np.arange(-10, 10, 1, dtype=float)
     _inverse_tester(norm, vals)
     _scalar_tester(norm, vals)
@@ -289,17 +289,17 @@ def test_Normalize():
     # Handle integer input correctly (don't overflow when computing max-min,
     # i.e. 127-(-128) here).
     vals = np.array([-128, 127], dtype=np.int8)
-    norm = mcolors.Normalize(vals.min(), vals.max())
+    norm = mcolors.LinearNorm(vals.min(), vals.max())
     assert_array_equal(np.asarray(norm(vals)), [0, 1])
 
     # Don't lose precision on longdoubles (float128 on Linux):
     # for array inputs...
     vals = np.array([1.2345678901, 9.8765432109], dtype=np.longdouble)
-    norm = mcolors.Normalize(vals.min(), vals.max())
+    norm = mcolors.LinearNorm(vals.min(), vals.max())
     assert_array_equal(np.asarray(norm(vals)), [0, 1])
     # and for scalar ones.
     eps = np.finfo(np.longdouble).resolution
-    norm = plt.Normalize(1, 1 + 100 * eps)
+    norm = plt.LinearNorm(1, 1 + 100 * eps)
     # This returns exactly 0.5 when longdouble is extended precision (80-bit),
     # but only a value close to it when it is quadruple precision (128-bit).
     assert 0 < norm(1 + 50 * eps) < 1
@@ -904,9 +904,9 @@ def test_ndarray_subclass_norm(recwarn):
     data = np.arange(-10, 10, 1, dtype=float).reshape((10, 2))
     mydata = data.view(MyArray)
 
-    for norm in [mcolors.Normalize(), mcolors.LogNorm(),
+    for norm in [mcolors.LinearNorm(), mcolors.LogNorm(),
                  mcolors.SymLogNorm(3, vmax=5, linscale=1),
-                 mcolors.Normalize(vmin=mydata.min(), vmax=mydata.max()),
+                 mcolors.LinearNorm(vmin=mydata.min(), vmax=mydata.max()),
                  mcolors.SymLogNorm(3, vmin=mydata.min(), vmax=mydata.max()),
                  mcolors.PowerNorm(1)]:
         assert_array_equal(norm(mydata), norm(data))

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -681,7 +681,7 @@ def test_nonuniformimage_setcmap():
 def test_nonuniformimage_setnorm():
     ax = plt.gca()
     im = NonUniformImage(ax)
-    im.set_norm(plt.Normalize())
+    im.set_norm(plt.LinearNorm())
 
 
 def test_jpeg_2d():
@@ -892,7 +892,7 @@ def test_mask_image_over_under():
     fig, (ax1, ax2) = plt.subplots(1, 2)
     im = ax1.imshow(Zm, interpolation='bilinear',
                     cmap=palette,
-                    norm=colors.Normalize(vmin=-1.0, vmax=1.0, clip=False),
+                    norm=colors.LinearNorm(vmin=-1.0, vmax=1.0, clip=False),
                     origin='lower', extent=[-3, 3, -3, 3])
     ax1.set_title('Green=low, Red=high, Blue=bad')
     fig.colorbar(im, extend='both', orientation='horizontal',
@@ -951,7 +951,7 @@ def test_imshow_masked_interpolation():
     cm.set_bad('k')
 
     N = 20
-    n = colors.Normalize(vmin=0, vmax=N*N-1)
+    n = colors.LinearNorm(vmin=0, vmax=N*N-1)
 
     data = np.arange(N*N, dtype=float).reshape(N, N)
 
@@ -1037,7 +1037,7 @@ def test_imshow_bignumbers_real():
 
 @pytest.mark.parametrize(
     "make_norm",
-    [colors.Normalize,
+    [colors.LinearNorm,
      colors.LogNorm,
      lambda: colors.SymLogNorm(1),
      lambda: colors.PowerNorm(1)])
@@ -1148,6 +1148,6 @@ def test_image_array_alpha(fig_test, fig_ref):
     ax.imshow(zz, alpha=alpha, cmap=cmap, interpolation='nearest')
 
     ax = fig_ref.add_subplot(111)
-    rgba = cmap(colors.Normalize()(zz))
+    rgba = cmap(colors.LinearNorm()(zz))
     rgba[..., -1] = alpha
     ax.imshow(rgba, interpolation='nearest')

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -181,8 +181,8 @@ def tricontour(ax, *args, **kwargs):
         *None*. If *cmap* is *None* and *colors* is *None*, a
         default Colormap is used.
 
-        *norm*: [ *None* | Normalize ]
-        A :class:`matplotlib.colors.Normalize` instance for
+        *norm*: [ *None* | Norm ]
+        A :class:`matplotlib.colors.Norm` instance for
         scaling data values to colors. If *norm* is *None* and
         *colors* is *None*, the default linear scaling is used.
 

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from matplotlib import cbook
 from matplotlib.collections import PolyCollection, TriMesh
-from matplotlib.colors import Normalize
+from matplotlib.colors import Norm
 from matplotlib.tri.triangulation import Triangulation
 
 
@@ -117,7 +117,7 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
 
     collection.set_alpha(alpha)
     collection.set_array(C)
-    cbook._check_isinstance((Normalize, None), norm=norm)
+    cbook._check_isinstance((Norm, None), norm=norm)
     collection.set_cmap(cmap)
     collection.set_norm(norm)
     collection._scale_norm(norm, vmin, vmax)


### PR DESCRIPTION
A draft of creating a base class for Norms. I've called it simply `Norm`, on the basis that the base for colorbars is simply `Colorbar`.

With these changes:
- There is an abstract base class called `Norm`, which all norms should inherit from
- The linear normaliser (previously `Normalize`) is now called `LinearNorm`
- `Normalize` still works as before, with a deprecation warning

Reasons this is useful
- Currently all norms inherit from `Normalize`, so if they don't define `__call__` or `inverse` they silently inherit linear verisons, which could be confusing
- `LinearNorm` is a much clearer name than `Normalize` for a linear normalisation.
- Adding `Norm` as an abstract base class with non-specific implementations allows for generic documentation on how to construct norm classes, and making it an abstract class forces `__call__` and `inverse` to be defined for all norms.

n.b. this will break `isinstance(norm, Normalize)` - instead users will need to do `isinstance(norm, Norm)`. Are we happy making this breaking change? I couldn't think of a way to deprecate that kind of thing.

This needs a comprehensive changelog.