### PR TITLE
More edits to Normalize docstrings.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -914,29 +914,28 @@ class Normalize:
     A class which, when called, linearly normalizes data into the
     ``[0.0, 1.0]`` interval.
     """
+
     def __init__(self, vmin=None, vmax=None, clip=False):
         """
         Parameters
         ----------
-        vmin : float
-        vmax : float
-        clip : bool
+        vmin, vmax : float or None
+            If *vmin* and/or *vmax* is not given, they are initialized from the
+            minimum and maximum value, respectively, of the first input
+            processed; i.e., ``__call__(A)`` calls ``autoscale_None(A)``.
+
+        clip : bool, default: False
             If ``True`` values falling outside the range ``[vmin, vmax]``,
             are mapped to 0 or 1, whichever is closer, and masked values are
-            set to 1. If ``False`` masked values remain masked.
+            set to 1.  If ``False`` masked values remain masked.
+
+            Clipping silently defeats the purpose of setting the over, under,
+            and masked colors in a colormap, so it is likely to lead to
+            surprises; therefore the default is ``clip=False``.
 
         Notes
         -----
-        If neither *vmin* or *vmax* are given, they are initialized from the
-        minimum and maximum value respectively of the first input
-        processed.  That is, ``__call__(A)`` calls ``autoscale_None(A)``.
-        Returns 0 if::
-
-            vmin==vmax
-
-        Clipping silently defeats the purpose of setting the over, under, and
-        masked colors in a colormap, so it is likely to lead to surprises;
-        therefore the default is ``clip=False``.
+        Returns 0 if ``vmin == vmax``.
         """
         self.vmin = _sanitize_extrema(vmin)
         self.vmax = _sanitize_extrema(vmax)
@@ -954,7 +953,7 @@ class Normalize:
         result : masked array
             Masked array with the same shape as *value*.
         is_scalar : bool
-            ``True`` if *value* is a scalar.
+            Whether *value* is a scalar.
 
         Notes
         -----


### PR DESCRIPTION
## PR Summary

followup to #16271.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
