### PR TITLE
Don't default to negative radii in polar plot.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -385,6 +385,7 @@ class RadialLocator(mticker.Locator):
     :class:`~matplotlib.ticker.Locator` (which may be different
     depending on the scale of the *r*-axis.
     """
+
     def __init__(self, base, axes=None):
         self.base = base
         self._axes = axes
@@ -415,6 +416,11 @@ class RadialLocator(mticker.Locator):
     def refresh(self):
         # docstring inherited
         return self.base.refresh()
+
+    def nonsingular(self, vmin, vmax):
+        # docstring inherited
+        return ((0, 1) if (vmin, vmax) == (-np.inf, np.inf)  # Init. limits.
+                else self.base.nonsingular(vmin, vmax))
 
     def view_limits(self, vmin, vmax):
         vmin, vmax = self.base.view_limits(vmin, vmax)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2240,6 +2240,17 @@ def test_log_scales_invalid():
         ax.set_ylim(-1, 10)
 
 
+def test_polar_no_data():
+    plt.subplot(projection="polar")
+    ax = plt.gca()
+    assert ax.get_rmin() == 0 and ax.get_rmax() == 1
+    plt.close("all")
+    # Used to behave differently (by triggering an autoscale with no data).
+    plt.polar()
+    ax = plt.gca()
+    assert ax.get_rmin() == 0 and ax.get_rmax() == 1
+
+
 @image_comparison(['stackplot_test_image', 'stackplot_test_image'])
 def test_stackplot():
     fig = plt.figure()


### PR DESCRIPTION
Previously a call to `polar()` (with no args) would default the rlims to
-0.05, +0.05 (unlike `subplot(projection="polar")` which would default
the rlims to a more sane (0, 1)).  Fix that.

I guess this would be nice for 3.2, but won't insist on it, feel free to milestone as preferred.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
