### PR TITLE
Dedupe Legend.draw_frame which is the same as set_frame_on.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -874,16 +874,6 @@ class Legend(Artist):
 
         return [vertices, bboxes, lines, offsets]
 
-    def draw_frame(self, b):
-        """
-        Set whether to draw a frame around the legend box.
-
-        Parameters
-        ----------
-        b : bool
-        """
-        self.set_frame_on(b)
-
     def get_children(self):
         """Return the list of child artists."""
         children = []
@@ -971,6 +961,8 @@ class Legend(Artist):
         """
         self._drawFrame = b
         self.stale = True
+
+    draw_frame = set_frame_on  # Backcompat alias.
 
     def get_bbox_to_anchor(self):
         """Return the bbox that the legend will be anchored to."""


### PR DESCRIPTION
I don't care enough to bother deprecating it, but maintaining a separate
(in fact, slightly different) docstring and having it count against
coverage seems a bit silly.

I left set_frame_on be the "canonical" version as there's also
get_frame_on.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
