### PR TITLE
CI: Use Ubuntu Bionic compatible package names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ addons:
       - libgeos-dev
       - libgirepository1.0-dev
       - lmodern
-      - otf-freefont
-      - pgf
+      - fonts-freefont-otf
+      - texlive-pictures
       - pkg-config
       - qtbase5-dev
       - texlive-fonts-recommended

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,8 @@ steps:
         libgeos-dev \
         libgirepository-1.0.1 \
         lmodern \
-        otf-freefont \
-        pgf \
+        fonts-freefont-otf \
+        texlive-pictures \
         texlive-fonts-recommended \
         texlive-latex-base \
         texlive-latex-extra \


### PR DESCRIPTION
otf-freefont was renamed to fonts-freefont-otf
pgf is now provided with texlive-pictures
