### PR TITLE
don't override non-Python signal handlers

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1034,9 +1034,9 @@ class _BackendQT5(_Backend):
     def mainloop():
         old_signal = signal.getsignal(signal.SIGINT)
         # allow SIGINT exceptions to close the plot window.
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        if old_signal: signal.signal(signal.SIGINT, signal.SIG_DFL)
         try:
             qApp.exec_()
         finally:
             # reset the SIGINT exception handler
-            signal.signal(signal.SIGINT, old_signal)
+            if old_signal: signal.signal(signal.SIGINT, old_signal)

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1034,9 +1034,11 @@ class _BackendQT5(_Backend):
     def mainloop():
         old_signal = signal.getsignal(signal.SIGINT)
         # allow SIGINT exceptions to close the plot window.
-        if old_signal: signal.signal(signal.SIGINT, signal.SIG_DFL)
+        if old_signal:
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
         try:
             qApp.exec_()
         finally:
             # reset the SIGINT exception handler
-            if old_signal: signal.signal(signal.SIGINT, old_signal)
+            if old_signal:
+                signal.signal(signal.SIGINT, old_signal)


### PR DESCRIPTION
The qt5 backend's `mainloop()` function (used by the non-interactive `show()`) calls `signal(SIGINT, SIG_DFL)` to temporarily override the `SIGINT` handler while the plot window is open.     Unfortunately, this fails when Python has been embedded in another program and a non-Python signal handler is installed, as we encountered in Julia at JuliaPy/PyPlot.jl#459.

In particular, when `signal.getsignal(SIGINT)` returns `None`, this is [documented to mean that](https://docs.python.org/3/library/signal.html#signal.getsignal) "the previous signal handler was not installed from Python."    In this case, you should not override the signal handler because there is no way to restore it — the `signal(SIGINT, old_signal)` function throws a `TypeError` if `old_signal` is `None`.

The fix is simple: don't try to override the `SIGINT` handler if `old_signal` is `None`.