### PR TITLE
Remove unnecessary Legend._approx_text_height.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -610,16 +610,6 @@ class Legend(Artist):
         renderer.close_group('legend')
         self.stale = False
 
-    def _approx_text_height(self, renderer=None):
-        """
-        Return the approximate height of the text. This is used to place
-        the legend handle.
-        """
-        if renderer is None:
-            return self._fontsize
-        else:
-            return renderer.points_to_pixels(self._fontsize)
-
     # _default_handler_map defines the default mapping between plot
     # elements and the legend handlers.
 
@@ -731,9 +721,9 @@ class Legend(Artist):
 
         # The approximate height and descent of text. These values are
         # only used for plotting the legend handle.
-        descent = 0.35 * self._approx_text_height() * (self.handleheight - 0.7)
+        descent = 0.35 * fontsize * (self.handleheight - 0.7)
         # 0.35 and 0.7 are just heuristic numbers and may need to be improved.
-        height = self._approx_text_height() * self.handleheight - descent
+        height = fontsize * self.handleheight - descent
         # each handle needs to be drawn inside a box of (x, y, w, h) =
         # (0, -descent, width, height).  And their coordinates should
         # be given in the display coordinates.


### PR DESCRIPTION
It is only ever called with renderer=None, returning the fontsize
directly.  In fact the rest of the code assumes that the font size is
in points (inch/72), not in pixels.  This can be checked by setting the
dpi to a large value (e.g. 500), forcing the renderer to be not None by
adding `renderer = self.figure.canvas._cachedRenderer` and making sure
that a cached renderer exists (via `fig.canvas.draw()`) before creating
the legend -- such a patch results in a highly distorted legend layout,
whereas just using fontsize is fine even at high dpi.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
