### PR TITLE
Cleanup constrainedlayout_guide.

### DIFF
--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -44,7 +44,6 @@ In Matplotlib, the location of axes (including subplots) are specified in
 normalized figure coordinates. It can happen that your axis labels or
 titles (or sometimes even ticklabels) go outside the figure area, and are thus
 clipped.
-
 """
 
 # sphinx_gallery_thumbnail_number = 18
@@ -58,19 +57,20 @@ import numpy as np
 
 plt.rcParams['savefig.facecolor'] = "0.8"
 plt.rcParams['figure.figsize'] = 4.5, 4.
+plt.rcParams['figure.max_open_warning'] = 50
 
 
-def example_plot(ax, fontsize=12, nodec=False):
+def example_plot(ax, fontsize=12, hide_labels=False):
     ax.plot([1, 2])
 
     ax.locator_params(nbins=3)
-    if not nodec:
+    if hide_labels:
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
+    else:
         ax.set_xlabel('x-label', fontsize=fontsize)
         ax.set_ylabel('y-label', fontsize=fontsize)
         ax.set_title('Title', fontsize=fontsize)
-    else:
-        ax.set_xticklabels('')
-        ax.set_yticklabels('')
 
 
 fig, ax = plt.subplots(constrained_layout=False)
@@ -266,17 +266,13 @@ fig.savefig('CL02.png', bbox_inches='tight', dpi=100)
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flat:
-    example_plot(ax, nodec=True)
-    ax.set_xticklabels('')
-    ax.set_yticklabels('')
+    example_plot(ax, hide_labels=True)
 fig.set_constrained_layout_pads(w_pad=4./72., h_pad=4./72.,
         hspace=0., wspace=0.)
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flat:
-    example_plot(ax, nodec=True)
-    ax.set_xticklabels('')
-    ax.set_yticklabels('')
+    example_plot(ax, hide_labels=True)
 fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
         hspace=0., wspace=0.)
 
@@ -289,9 +285,7 @@ fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)
 for ax in axs.flat:
-    example_plot(ax, nodec=True)
-    ax.set_xticklabels('')
-    ax.set_yticklabels('')
+    example_plot(ax, hide_labels=True)
 fig.set_constrained_layout_pads(w_pad=2./72., h_pad=2./72.,
         hspace=0.2, wspace=0.2)
 


### PR DESCRIPTION
- Avoid repeated "More than X figures opened, too much memory" warning
  by setting :rc:figure.max_open_warning.

- Rename nodec to something slightly more explanatory, and invert the
  logic (`not nodec` is too twisted for me :)).  Avoid unnecessary
  duplication of `set_x/yticklabels("")` both inside and outside the
  function.  Also the arg to set_x/yticklabels is a list, not a string
  (even though an empty string "just happens to work"...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
