### PR TITLE
Put doc for XAxis befor YAxis and likewise for XTick, YTick.

### DIFF
--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -176,6 +176,19 @@ Incremental navigation
    Axis.pan
    Axis.zoom
 
+XAxis Specific
+--------------
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   XAxis.axis_name
+   XAxis.get_text_heights
+   XAxis.get_ticks_position
+   XAxis.set_ticks_position
+   XAxis.tick_bottom
+   XAxis.tick_top
 
 YAxis Specific
 --------------
@@ -192,22 +205,6 @@ YAxis Specific
    YAxis.set_ticks_position
    YAxis.tick_left
    YAxis.tick_right
-
-
-XAxis Specific
---------------
-.. autosummary::
-   :toctree: _as_gen
-   :template: autosummary.rst
-   :nosignatures:
-
-   XAxis.axis_name
-   XAxis.get_text_heights
-   XAxis.get_ticks_position
-   XAxis.set_ticks_position
-   XAxis.tick_bottom
-   XAxis.tick_top
-
 
 Other
 -----
@@ -279,8 +276,8 @@ not used together may de-couple your tick labels from your data.
 Common and inherited methods
 ============================
 
-``XTick``
----------
+XTick
+-----
 
 .. autosummary::
    :toctree: _as_gen
@@ -322,81 +319,13 @@ YTick
    YTick.set_pad
    YTick.update_position
 
-YAxis
+XAxis
 -----
 
 .. autosummary::
    :toctree: _as_gen
    :template: autosummary.rst
    :nosignatures:
-
-
-
-   YAxis.OFFSETTEXTPAD
-   YAxis.axis_date
-   YAxis.cla
-   YAxis.convert_units
-   YAxis.get_data_interval
-   YAxis.get_gridlines
-   YAxis.get_label_position
-   YAxis.get_label_text
-   YAxis.get_major_formatter
-   YAxis.get_major_locator
-   YAxis.get_major_ticks
-   YAxis.get_majorticklabels
-   YAxis.get_majorticklines
-   YAxis.get_majorticklocs
-   YAxis.get_minor_formatter
-   YAxis.get_minor_locator
-   YAxis.get_minor_ticks
-   YAxis.get_minorticklabels
-   YAxis.get_minorticklines
-   YAxis.get_minorticklocs
-   YAxis.get_minpos
-   YAxis.get_offset_text
-   YAxis.get_pickradius
-   YAxis.get_scale
-   YAxis.get_smart_bounds
-   YAxis.get_tick_padding
-   YAxis.get_tick_space
-   YAxis.get_ticklabel_extents
-   YAxis.get_ticklabels
-   YAxis.get_ticklines
-   YAxis.get_ticklocs
-   YAxis.get_tightbbox
-   YAxis.get_units
-   YAxis.get_view_interval
-   YAxis.grid
-   YAxis.limit_range_for_scale
-   YAxis.pan
-   YAxis.reset_ticks
-   YAxis.set_data_interval
-   YAxis.set_default_intervals
-   YAxis.set_label_coords
-   YAxis.set_label_position
-   YAxis.set_label_text
-   YAxis.set_major_formatter
-   YAxis.set_major_locator
-   YAxis.set_minor_formatter
-   YAxis.set_minor_locator
-   YAxis.set_pickradius
-   YAxis.set_smart_bounds
-   YAxis.set_tick_params
-   YAxis.set_ticklabels
-   YAxis.set_ticks
-   YAxis.set_units
-   YAxis.set_view_interval
-   YAxis.update_units
-   YAxis.zoom
-
-XAxis
----------
-
-.. autosummary::
-   :toctree: _as_gen
-   :template: autosummary.rst
-   :nosignatures:
-
 
    XAxis.OFFSETTEXTPAD
    XAxis.axis_date
@@ -455,7 +384,70 @@ XAxis
    XAxis.update_units
    XAxis.zoom
 
+YAxis
+-----
 
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   YAxis.OFFSETTEXTPAD
+   YAxis.axis_date
+   YAxis.cla
+   YAxis.convert_units
+   YAxis.get_data_interval
+   YAxis.get_gridlines
+   YAxis.get_label_position
+   YAxis.get_label_text
+   YAxis.get_major_formatter
+   YAxis.get_major_locator
+   YAxis.get_major_ticks
+   YAxis.get_majorticklabels
+   YAxis.get_majorticklines
+   YAxis.get_majorticklocs
+   YAxis.get_minor_formatter
+   YAxis.get_minor_locator
+   YAxis.get_minor_ticks
+   YAxis.get_minorticklabels
+   YAxis.get_minorticklines
+   YAxis.get_minorticklocs
+   YAxis.get_minpos
+   YAxis.get_offset_text
+   YAxis.get_pickradius
+   YAxis.get_scale
+   YAxis.get_smart_bounds
+   YAxis.get_tick_padding
+   YAxis.get_tick_space
+   YAxis.get_ticklabel_extents
+   YAxis.get_ticklabels
+   YAxis.get_ticklines
+   YAxis.get_ticklocs
+   YAxis.get_tightbbox
+   YAxis.get_units
+   YAxis.get_view_interval
+   YAxis.grid
+   YAxis.limit_range_for_scale
+   YAxis.pan
+   YAxis.reset_ticks
+   YAxis.set_data_interval
+   YAxis.set_default_intervals
+   YAxis.set_label_coords
+   YAxis.set_label_position
+   YAxis.set_label_text
+   YAxis.set_major_formatter
+   YAxis.set_major_locator
+   YAxis.set_minor_formatter
+   YAxis.set_minor_locator
+   YAxis.set_pickradius
+   YAxis.set_smart_bounds
+   YAxis.set_tick_params
+   YAxis.set_ticklabels
+   YAxis.set_ticks
+   YAxis.set_units
+   YAxis.set_view_interval
+   YAxis.update_units
+   YAxis.zoom
 
 Inherited from artist
 ---------------------


### PR DESCRIPTION
The ordering was just strange.

Also unmarkuped XTick, which was the only heading with markup among its
siblings.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
