### PR TITLE
Cleanup list copying

### DIFF
--- a/doc/sphinxext/missing_references.py
+++ b/doc/sphinxext/missing_references.py
@@ -254,7 +254,7 @@ def prepare_missing_references_handler(app):
 
     sphinx_logger = logging.getLogger('sphinx')
     missing_reference_filter = MissingReferenceFilter(app)
-    for handler in sphinx_logger.handlers[:]:
+    for handler in sphinx_logger.handlers:
         if (isinstance(handler, sphinx_logging.WarningStreamHandler)
                 and missing_reference_filter not in handler.filters):
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1065,8 +1065,8 @@ class Artist:
         self._label = other._label
         self._sketch = other._sketch
         self._path_effects = other._path_effects
-        self.sticky_edges.x[:] = other.sticky_edges.x[:]
-        self.sticky_edges.y[:] = other.sticky_edges.y[:]
+        self.sticky_edges.x[:] = other.sticky_edges.x.copy()
+        self.sticky_edges.y[:] = other.sticky_edges.y.copy()
         self.pchanged()
         self.stale = True
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -258,6 +258,9 @@ class RendererBase:
 
         Parameters
         ----------
+        gc : `.GraphicsContextBase`
+            The graphics context.
+
         points : array-like, shape=(3, 2)
             Array of (x, y) points for the triangle.
 
@@ -1059,7 +1062,7 @@ class TimerBase:
         if callbacks is None:
             self.callbacks = []
         else:
-            self.callbacks = callbacks[:]  # Create a copy
+            self.callbacks = callbacks.copy()
 
         if interval is None:
             self._interval = 1000

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -650,6 +650,8 @@ class RendererSVG(RendererBase):
         self._path_collection_id += 1
 
     def draw_gouraud_triangle(self, gc, points, colors, trans):
+        # docstring inherited
+
         # This uses a method described here:
         #
         #   http://www.svgopen.org/2005/papers/Converting3DFaceToSVG/index.html
@@ -685,9 +687,9 @@ class RendererSVG(RendererBase):
                        ' \n1 1 1 1 0 \n0 0 0 0 1 ')
             writer.end('filter')
 
-        avg_color = np.sum(colors[:, :], axis=0) / 3.0
-        # Just skip fully-transparent triangles
-        if avg_color[-1] == 0.0:
+        avg_color = np.average(colors, axis=0)
+        if avg_color[-1] == 0:
+            # Skip fully-transparent triangles
             return
 
         trans_and_flip = self._make_flip_transform(trans)
@@ -698,7 +700,7 @@ class RendererSVG(RendererBase):
             x1, y1 = tpoints[i]
             x2, y2 = tpoints[(i + 1) % 3]
             x3, y3 = tpoints[(i + 2) % 3]
-            c = colors[i][:]
+            rgba_color = colors[i]
 
             if x2 == x3:
                 xb = x2
@@ -723,12 +725,13 @@ class RendererSVG(RendererBase):
             writer.element(
                 'stop',
                 offset='1',
-                style=generate_css({'stop-color': rgb2hex(avg_color),
-                                    'stop-opacity': short_float_fmt(c[-1])}))
+                style=generate_css({
+                    'stop-color': rgb2hex(avg_color),
+                    'stop-opacity': short_float_fmt(rgba_color[-1])}))
             writer.element(
                 'stop',
                 offset='0',
-                style=generate_css({'stop-color': rgb2hex(c),
+                style=generate_css({'stop-color': rgb2hex(rgba_color),
                                     'stop-opacity': "0"}))
 
             writer.end('linearGradient')

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3159,11 +3159,8 @@ class ArrowStyle(_Style):
 
             if aspect_ratio is not None:
                 # Squeeze the given height by the aspect_ratio
-
-                vertices, codes = path.vertices[:], path.codes[:]
-                # Squeeze the height
-                vertices[:, 1] = vertices[:, 1] / aspect_ratio
-                path_shrunk = Path(vertices, codes)
+                vertices = path.vertices / [1, aspect_ratio]
+                path_shrunk = Path(vertices, path.codes)
                 # call transmute method with squeezed height.
                 path_mutated, fillable = self.transmute(path_shrunk,
                                                         linewidth,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2578,7 +2578,7 @@ class PolygonSelector(_SelectorWidget):
                 self._active_handle_idx = h_idx
         # Save the vertex positions at the time of the press event (needed to
         # support the 'move_all' state modifier).
-        self._xs_at_press, self._ys_at_press = self._xs[:], self._ys[:]
+        self._xs_at_press, self._ys_at_press = self._xs.copy(), self._ys.copy()
 
     def _release(self, event):
         """Button release event handler"""


### PR DESCRIPTION
## PR Summary

- use `list.copy()` instead of `list[:]`. This is supported since Python 3.3 (and also works for numpy arrays).
- Two places actually did not need a copy because the resulting list is not modified.
- some further cleanup in `draw_gouraud_triangle`
