### PR TITLE
Make Artist.set() apply properties in the order in which they are given.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -545,3 +545,12 @@ The ``cbid`` and ``locator`` attribute are deprecated.  Use
 ~~~~~~~~~~~~~~~~~~~~~~
 This function is deprecated in prevision of the future release of PyQt6.  The
 Qt version can be checked using ``QtCore.QT_VERSION_STR``.
+
+Reordering of parameters by `.Artist.set`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In a future version, ``Artist.set`` will apply artist properties in the order
+in which they are given.  This only affects the interaction between the
+*color*, *edgecolor*, *facecolor*, and, for `.Collection`\s, *alpha*
+properties: the *color* property now needs to be passed first in order not to
+override the other properties.  This is consistent with e.g. `.Artist.update`,
+which did not reorder the properties passed to it.


### PR DESCRIPTION
... with a deprecation period (see changelog).

- This is consistent with Artist.update, and we don't reorder separate
  calls to set_color and set_edgecolor either (we can't really to that,
  indeed).
- The _prop_order mechanism was a slightly complex machinery for a
  single use case (applying "color" first).
- Writing `p.set(edgecolor="r", color="g")` seems a bit twisted anyways.

Also rewrote (and simplified) normalize kwargs to make it *also*
maintain kwarg order, as that's necessary to make the warning emitted in
the correct cases.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
