### PR TITLE
ENH: add zorder kwarg to contour clabel (and a better default value for zorder)

### DIFF
--- a/doc/users/next_whats_new/2020-01-25-clabel_zorder.rst
+++ b/doc/users/next_whats_new/2020-01-25-clabel_zorder.rst
@@ -1,0 +1,4 @@
+Set zorder of contour labels
+----------------------------
+`~.axes.Axes.clabel` now accepts a ``zorder`` kwarg
+making it easier to set the ``zorder`` of contour labels.

--- a/doc/users/next_whats_new/2020-01-25-clabel_zorder.rst
+++ b/doc/users/next_whats_new/2020-01-25-clabel_zorder.rst
@@ -2,3 +2,8 @@ Set zorder of contour labels
 ----------------------------
 `~.axes.Axes.clabel` now accepts a ``zorder`` kwarg
 making it easier to set the ``zorder`` of contour labels.
+If not specified, the default ``zorder`` of clabels used to always be 3
+(i.e. the default ``zorder`` of `~.text.Text`) irrespective of the ``zorder``
+passed to `~.axes.Axes.contour`/`~.axes.Axes.contourf`.
+The new default ``zorder`` for clabels has been changed to (2 + ``zorder``
+passed to `~.axes.Axes.contour`/`~.axes.Axes.contourf`).

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -159,7 +159,6 @@ class ContourLabeler:
         else:
             self._clabel_zorder = zorder
 
-
         if levels is None:
             levels = self.levels
             indices = list(range(len(self.cvalues)))

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -51,7 +51,7 @@ class ContourLabeler:
     def clabel(self, levels=None, *,
                fontsize=None, inline=True, inline_spacing=5, fmt='%1.3f',
                colors=None, use_clabeltext=False, manual=False,
-               rightside_up=True):
+               rightside_up=True, zorder=None):
         """
         Label a contour plot.
 
@@ -124,6 +124,11 @@ class ContourLabeler:
             of texts during the drawing time, therefore this can be used if
             aspect of the axes changes.
 
+        zorder : float or None, optional
+            zorder of the contour labels.
+
+            If not specified, the default zorder of `.Text` class is used.
+
         Returns
         -------
         labels
@@ -144,6 +149,7 @@ class ContourLabeler:
         # Detect if manual selection is desired and remove from argument list.
         self.labelManual = manual
         self.rightside_up = rightside_up
+        self._zorder = zorder
 
         if levels is None:
             levels = self.levels
@@ -397,7 +403,7 @@ class ContourLabeler:
         dx, dy = self.ax.transData.inverted().transform((x, y))
         t = text.Text(dx, dy, rotation=rotation,
                       horizontalalignment='center',
-                      verticalalignment='center')
+                      verticalalignment='center', zorder=self._zorder)
         return t
 
     def _get_label_clabeltext(self, x, y, rotation):
@@ -411,7 +417,7 @@ class ContourLabeler:
                                                   np.array([[x, y]]))
         t = ClabelText(dx, dy, rotation=drotation[0],
                        horizontalalignment='center',
-                       verticalalignment='center')
+                       verticalalignment='center', zorder=self._zorder)
 
         return t
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -127,7 +127,9 @@ class ContourLabeler:
         zorder : float or None, optional
             zorder of the contour labels.
 
-            If not specified, the default zorder of `.Text` class is used.
+            If not specified, the zorder of contour labels is set to either
+            (2 + zorder of contours) or (1 + zorder of contours) depending on
+            whether the contours are filled or not filled.
 
         Returns
         -------
@@ -149,7 +151,14 @@ class ContourLabeler:
         # Detect if manual selection is desired and remove from argument list.
         self.labelManual = manual
         self.rightside_up = rightside_up
-        self._zorder = zorder
+        if zorder is None:
+            if self.filled:
+                self._clabel_zorder = 2+self._contour_zorder
+            else:
+                self._clabel_zorder = 1+self._contour_zorder
+        else:
+            self._clabel_zorder = zorder
+
 
         if levels is None:
             levels = self.levels
@@ -403,7 +412,7 @@ class ContourLabeler:
         dx, dy = self.ax.transData.inverted().transform((x, y))
         t = text.Text(dx, dy, rotation=rotation,
                       horizontalalignment='center',
-                      verticalalignment='center', zorder=self._zorder)
+                      verticalalignment='center', zorder=self._clabel_zorder)
         return t
 
     def _get_label_clabeltext(self, x, y, rotation):
@@ -417,7 +426,7 @@ class ContourLabeler:
                                                   np.array([[x, y]]))
         t = ClabelText(dx, dy, rotation=drotation[0],
                        horizontalalignment='center',
-                       verticalalignment='center', zorder=self._zorder)
+                       verticalalignment='center', zorder=self._clabel_zorder)
 
         return t
 
@@ -875,7 +884,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                 self.allkinds = [None] * len(self.allsegs)
 
             # Default zorder taken from Collection
-            zorder = kwargs.pop('zorder', 1)
+            self._contour_zorder = kwargs.pop('zorder', 1)
             for level, level_upper, segs, kinds in \
                     zip(lowers, uppers, self.allsegs, self.allkinds):
                 paths = self._make_paths(segs, kinds)
@@ -886,7 +895,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     edgecolors='none',
                     alpha=self.alpha,
                     transform=self.get_transform(),
-                    zorder=zorder)
+                    zorder=self._contour_zorder)
                 self.ax.add_collection(col, autolim=False)
                 self.collections.append(col)
         else:
@@ -897,7 +906,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             if aa is not None:
                 aa = (self.antialiased,)
             # Default zorder taken from LineCollection
-            zorder = kwargs.pop('zorder', 2)
+            self._contour_zorder = kwargs.pop('zorder', 2)
             for level, width, lstyle, segs in \
                     zip(self.levels, tlinewidths, tlinestyles, self.allsegs):
                 col = mcoll.LineCollection(
@@ -907,7 +916,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     linestyles=[lstyle],
                     alpha=self.alpha,
                     transform=self.get_transform(),
-                    zorder=zorder)
+                    zorder=self._contour_zorder)
                 col.set_label('_nolegend_')
                 self.ax.add_collection(col, autolim=False)
                 self.collections.append(col)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -127,9 +127,8 @@ class ContourLabeler:
         zorder : float or None, optional
             zorder of the contour labels.
 
-            If not specified, the zorder of contour labels is set to either
-            (2 + zorder of contours) or (1 + zorder of contours) depending on
-            whether the contours are filled or not filled.
+            If not specified, the zorder of contour labels is set to
+            (2 + zorder of contours).
 
         Returns
         -------
@@ -152,10 +151,7 @@ class ContourLabeler:
         self.labelManual = manual
         self.rightside_up = rightside_up
         if zorder is None:
-            if self.filled:
-                self._clabel_zorder = 2+self._contour_zorder
-            else:
-                self._clabel_zorder = 1+self._contour_zorder
+            self._clabel_zorder = 2+self._contour_zorder
         else:
             self._clabel_zorder = zorder
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -290,6 +290,22 @@ def test_circular_contour_warning():
     assert len(record) == 0
 
 
+@pytest.mark.parametrize("use_clabeltext", [True, False])
+def test_clabel_zorder(use_clabeltext):
+    x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
+    z = np.max(np.dstack([abs(x), abs(y)]), 2)
+
+    fig, (ax1, ax2) = plt.subplots(ncols=2)
+    cs1 = ax1.contour(x, y, z)
+    cs2 = ax2.contourf(x, y, z)
+    clabels1 = cs1.clabel(zorder=1234, use_clabeltext=use_clabeltext)
+    clabels2 = cs2.clabel(zorder=12345, use_clabeltext=use_clabeltext)
+    for clabel in clabels1:
+        assert clabel.get_zorder() == 1234
+    for clabel in clabels2:
+        assert clabel.get_zorder() == 12345
+
+
 @image_comparison(['contour_log_extension.png'],
                   remove_text=True, style='mpl20')
 def test_contourf_log_extension():

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -290,20 +290,31 @@ def test_circular_contour_warning():
     assert len(record) == 0
 
 
-@pytest.mark.parametrize("use_clabeltext", [True, False])
-def test_clabel_zorder(use_clabeltext):
+@pytest.mark.parametrize("use_clabeltext, contour_zorder, clabel_zorder",
+                         [(True, 123, 1234), (False, 123, 1234),
+                          (True, 123, None), (False, 123, None)])
+def test_clabel_zorder(use_clabeltext, contour_zorder, clabel_zorder):
     x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
     z = np.max(np.dstack([abs(x), abs(y)]), 2)
 
     fig, (ax1, ax2) = plt.subplots(ncols=2)
-    cs1 = ax1.contour(x, y, z)
-    cs2 = ax2.contourf(x, y, z)
-    clabels1 = cs1.clabel(zorder=1234, use_clabeltext=use_clabeltext)
-    clabels2 = cs2.clabel(zorder=12345, use_clabeltext=use_clabeltext)
+    cs = ax1.contour(x, y, z, zorder=contour_zorder)
+    cs_filled = ax2.contourf(x, y, z, zorder=contour_zorder)
+    clabels1 = cs.clabel(zorder=clabel_zorder, use_clabeltext=use_clabeltext)
+    clabels2 = cs_filled.clabel(zorder=clabel_zorder,
+                                use_clabeltext=use_clabeltext)
+
+    if clabel_zorder is None:
+        expected_clabel_zorder = 1+contour_zorder
+        expected_filled_clabel_zorder = 2+contour_zorder
+    else:
+        expected_clabel_zorder = clabel_zorder
+        expected_filled_clabel_zorder = clabel_zorder
+
     for clabel in clabels1:
-        assert clabel.get_zorder() == 1234
+        assert clabel.get_zorder() == expected_clabel_zorder
     for clabel in clabels2:
-        assert clabel.get_zorder() == 12345
+        assert clabel.get_zorder() == expected_filled_clabel_zorder
 
 
 @image_comparison(['contour_log_extension.png'],

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -305,16 +305,14 @@ def test_clabel_zorder(use_clabeltext, contour_zorder, clabel_zorder):
                                 use_clabeltext=use_clabeltext)
 
     if clabel_zorder is None:
-        expected_clabel_zorder = 1+contour_zorder
-        expected_filled_clabel_zorder = 2+contour_zorder
+        expected_clabel_zorder = 2+contour_zorder
     else:
         expected_clabel_zorder = clabel_zorder
-        expected_filled_clabel_zorder = clabel_zorder
 
     for clabel in clabels1:
         assert clabel.get_zorder() == expected_clabel_zorder
     for clabel in clabels2:
-        assert clabel.get_zorder() == expected_filled_clabel_zorder
+        assert clabel.get_zorder() == expected_clabel_zorder
 
 
 @image_comparison(['contour_log_extension.png'],


### PR DESCRIPTION
## PR Summary
Fixes #7957
```python
import matplotlib.pyplot as plt
import numpy as np

x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
z = np.max(np.dstack([abs(x), abs(y)]), 2)

fig, ax = plt.subplots(figsize=(3.5, 3), constrained_layout=True)
ax.contour(x, y, z, colors='0.50', linewidths=8.0, zorder=10) 
cs = ax.contour(x, y, z, zorder=11)
clabels = cs.clabel(colors='k', zorder=12)
# currently the zorder kwarg is not supported
# hence the following lines are required to set the zorder 
# for the contour labels' text manually.
# for clabel in clabels: 
#    clabel.set_zorder(12)
fig.savefig('clabel_zorder.png')
```
![clabel_zorder_after](https://user-images.githubusercontent.com/15175620/73129883-a2252900-3fbb-11ea-8058-4cf09101f5ed.png)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [NA] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [NA] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
