### PR TITLE
Document animation HTML writer.

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -168,6 +168,14 @@ all data in memory.
 
    PillowWriter
 
+The HTML writer generates JavaScript-based animations.
+
+.. autosummary::
+   :toctree: _as_gen
+   :nosignatures:
+
+   HTMLWriter
+
 The pipe-based writers stream the captured frames over a pipe to an external
 process.  The pipe-based variants tend to be more performant, but may not work
 on all systems.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -752,7 +752,7 @@
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:119"
     ],
     "MovieWriter.saving": [
-      "doc/api/animation_api.rst:213"
+      "doc/api/animation_api.rst:221"
     ],
     "MovieWriterBase": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.AVConvBase:4",
@@ -971,6 +971,9 @@
     ],
     "cbook.warn_deprecated()": [
       "doc/devel/contributing.rst:309"
+    ],
+    "cleanup": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.setup:19"
     ],
     "collections.LineCollection.get_segements()": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:280"
@@ -1316,9 +1319,26 @@
     "matplotlib.animation.FuncAnimation.to_jshtml": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.FuncAnimation.new_frame_seq:1:<autosummary>:1"
     ],
-    "matplotlib.animation.HTMLWriter": [
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:40",
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:51"
+    "matplotlib.animation.HTMLWriter.args_key": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.bin_path": [
+      "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.cleanup": [
+      "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.exec_key": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.frame_format": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.frame_size": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+    ],
+    "matplotlib.animation.HTMLWriter.saving": [
+      "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.ImageMagickFileWriter.args_key": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.ImageMagickFileWriter.supported_formats:1:<autosummary>:1"

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -777,6 +777,8 @@ def _embedded_frames(frame_list, frame_format):
 
 @writers.register('html')
 class HTMLWriter(FileMovieWriter):
+    """Writer for JavaScript-based HTML movies."""
+
     supported_formats = ['png', 'jpeg', 'tiff', 'svg']
     _args_key = 'animation.html_args'
 


### PR DESCRIPTION
Just like all animation writers, it needs to be whitelisted in
missing-references.json due to the way animation_api.rst uses
autosummary.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
