### PR TITLE
Document SymmetricalLogLocator parameters.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2499,11 +2499,28 @@ class LogLocator(Locator):
 
 class SymmetricalLogLocator(Locator):
     """
-    Determine the tick locations for symmetric log axes
+    Determine the tick locations for symmetric log axes.
     """
 
     def __init__(self, transform=None, subs=None, linthresh=None, base=None):
-        """Place ticks on the locations ``base**i*subs[j]``."""
+        """
+        Parameters
+        ----------
+        transform : `~.scale.SymmetricalLogTransform`, optional
+            If set, defines the *base* and *linthresh* of the symlog transform.
+        base, linthresh : float, optional
+            The *base* and *linthresh* of the symlog transform, as documented
+            for `.SymmetricalLogScale`.  These parameters are only used if
+            *transform* is not set.
+        subs : sequence of float, default: [1]
+            The multiples of integer powers of the base where ticks are placed,
+            i.e., ticks are placed at
+            ``[sub * base**i for i in ... for sub in subs]``.
+
+        Notes
+        -----
+        Either *transform*, or both *base* and *linthresh*, must be given.
+        """
         if transform is not None:
             self._base = transform.base
             self._linthresh = transform.linthresh


### PR DESCRIPTION
I didn't want to duplicate all the math explained in
SymmetricalLogScale, just to point out the (awkward) interaction between
*transform* and *base*/*linthresh*.  (Probably one should deprecate
*transform* and make the Locator behave more like LogLocator...)

see https://discourse.matplotlib.org/t/the-transform-argument-of-symmetricalloglocator/20847/1 / https://gitter.im/matplotlib/matplotlib?at=5e2d39f71a1c2739e3002586

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
