### PR TITLE
SymmetricalLogLocator docstring

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2500,6 +2500,27 @@ class LogLocator(Locator):
 class SymmetricalLogLocator(Locator):
     """
     Determine the tick locations for symmetric log axes
+    
+    Parameters
+    ----------
+    transform : None or SymmetricalLogTransform object, default = None
+        Initialised with a `base`, `linthresh` and `linscale`
+        If `transform` is None,  then both `base` and `linthresh`
+        must be specified (`linscale` is ignored here).
+    
+    base : None or float, default = None
+        The base of the log scaling
+        Places a major tick every base**i, where i is an integer
+    
+    linthresh : None or float, default = None
+        linear range threshold
+        Defines the range (-x, x), within which the plot is linear.
+        This avoids having the plot go to infinity around zero.
+    
+    subs : None or str or sequence of float, default = None
+        Gives the multiples of integer powers of the base at which to
+        place ticks. (see LogLocator for more details)
+    
     """
 
     def __init__(self, transform=None, subs=None, linthresh=None, base=None):
@@ -2518,7 +2539,7 @@ class SymmetricalLogLocator(Locator):
         else:
             self._subs = subs
         self.numticks = 15
-
+        
     def set_params(self, subs=None, numticks=None):
         """Set parameters within this locator."""
         if numticks is not None:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2500,27 +2500,27 @@ class LogLocator(Locator):
 class SymmetricalLogLocator(Locator):
     """
     Determine the tick locations for symmetric log axes
-    
+
     Parameters
     ----------
     transform : None or SymmetricalLogTransform object, default = None
         Initialised with a `base`, `linthresh` and `linscale`
         If `transform` is None,  then both `base` and `linthresh`
         must be specified (`linscale` is ignored here).
-    
+
     base : None or float, default = None
         The base of the log scaling
         Places a major tick every base**i, where i is an integer
-    
+
     linthresh : None or float, default = None
         linear range threshold
         Defines the range (-x, x), within which the plot is linear.
         This avoids having the plot go to infinity around zero.
-    
+
     subs : None or str or sequence of float, default = None
         Gives the multiples of integer powers of the base at which to
         place ticks. (see LogLocator for more details)
-    
+
     """
 
     def __init__(self, transform=None, subs=None, linthresh=None, base=None):
@@ -2539,7 +2539,7 @@ class SymmetricalLogLocator(Locator):
         else:
             self._subs = subs
         self.numticks = 15
-        
+
     def set_params(self, subs=None, numticks=None):
         """Set parameters within this locator."""
         if numticks is not None:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2500,31 +2500,38 @@ class LogLocator(Locator):
 class SymmetricalLogLocator(Locator):
     """
     Determine the tick locations for symmetric log axes
-
-    Parameters
-    ----------
-    transform : None or SymmetricalLogTransform object, default = None
-        Initialised with a `base`, `linthresh` and `linscale`
-        If `transform` is None,  then both `base` and `linthresh`
-        must be specified (`linscale` is ignored here).
-
-    base : None or float, default = None
-        The base of the log scaling
-        Places a major tick every base**i, where i is an integer
-
-    linthresh : None or float, default = None
-        linear range threshold
-        Defines the range (-x, x), within which the plot is linear.
-        This avoids having the plot go to infinity around zero.
-
-    subs : None or str or sequence of float, default = None
-        Gives the multiples of integer powers of the base at which to
-        place ticks. (see LogLocator for more details)
-
     """
 
     def __init__(self, transform=None, subs=None, linthresh=None, base=None):
-        """Place ticks on the locations ``base**i*subs[j]``."""
+        """
+        Places a major tick every base**i, where i is an integer.
+
+        Parameters
+        ----------
+        transform : None or `~SymmetricalLogTransform` object, default: None
+            The `.SymmetricalLogTransform` instance provides this object with
+            values for *base* and *linthresh*. If *transform* is None, then
+            both *base* and *linthresh* must be specified separately.
+
+        base : None or float, default: None
+            The base of the log scaling
+
+        linthresh : None or float, default: None
+            linear range threshold
+            Defines the range (-x, x), within which the plot is linear.
+            This avoids having the plot go to infinity around zero.
+
+        subs : None or str or sequence of float, default: None
+            Gives the multiples of integer powers of the base at which
+            to place ticks.
+
+        See also
+        --------
+        transform : `~matplotlib.scale.SymmetricalLogTransform`
+        linthresh : `~matplotlib.colors.SymLogNorm`
+        subs : `~matplotlib.ticker.LogLocator`
+
+        """
         if transform is not None:
             self._base = transform.base
             self._linthresh = transform.linthresh


### PR DESCRIPTION
Improved documentation in response to forum question: https://discourse.matplotlib.org/t/20847/2

## PR Summary

## PR Checklist

- [N/A (tested as not broken)] Has Pytest style unit tests
- [Y ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A (documentation only)] New features are documented, with examples if plot related
- [Y] Documentation is sphinx and numpydoc compliant
- [N/A (documentation only)] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A (documentation only)] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
