### PR TITLE
Cast vmin/vmax to floats before nonsingular-expanding them.

### DIFF
--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -570,3 +570,14 @@ def test_colorbar_label():
 
     cbar3 = fig.colorbar(im, orientation='horizontal', label='horizontal cbar')
     assert cbar3.ax.get_xlabel() == 'horizontal cbar'
+
+
+@pytest.mark.parametrize("clim", [(-20000, 20000), (-32768, 0)])
+def test_colorbar_int(clim):
+    # Check that we cast to float early enough to not
+    # overflow ``int16(20000) - int16(-20000)`` or
+    # run into ``abs(int16(-32768)) == -32768``.
+    fig, ax = plt.subplots()
+    im = ax.imshow([[*map(np.int16, clim)]])
+    fig.colorbar(im)
+    assert (im.norm.vmin, im.norm.vmax) == clim

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2791,6 +2791,10 @@ def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):
         vmin, vmax = vmax, vmin
         swapped = True
 
+    # Expand vmin, vmax to float: if they were integer types, they can wrap
+    # around in abs (abs(np.int8(-128)) == -128) and vmax - vmin can overflow.
+    vmin, vmax = map(float, [vmin, vmax])
+
     maxabsvalue = max(abs(vmin), abs(vmax))
     if maxabsvalue < (1e6 / tiny) * np.finfo(float).tiny:
         vmin = -expander


### PR DESCRIPTION
Nonsingular-expansion is fundamentally about adding small floats to
separate vmin/vmax so casting to float is normal; this avoids running
into plain wrong autoscales with
```
im = imshow([[np.int16(-20000), np.int16(20000)]])
colorbar()
print(im.norm.vmin, im.norm.vmax)
```
![20000](https://user-images.githubusercontent.com/1322974/73187200-59878000-4121-11ea-8efb-34bcea896ae8.png)
(note the extra expansion above 20000 and below -20000, which is not normally not present)
or
```
im = imshow([[np.int16(-32768), np.int16(0)]])
colorbar()
print(im.norm.vmin, im.norm.vmax)
```
![32768](https://user-images.githubusercontent.com/1322974/73187197-57252600-4121-11ea-9fde-b0dfca301769.png)
(note the completely wrong colormapping)

(The bug is present as far back as 2.2.0.  This would be somewhat nice to have in 3.2, but I'm not insisting on it either.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
