### PR TITLE
Pin docutils

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -7,6 +7,7 @@
 #     pip install -r doc-requirements.txt
 #
 sphinx>=1.3,!=1.5.0,!=1.6.4,!=1.7.3,<2
+docutils<0.16
 colorspacious
 ipython
 ipywidgets


### PR DESCRIPTION
## PR Summary

We have pinned sphinx<2 on the 2.2.x branch. As a follow-up we also have to pin docutils<0.16.

Docutils 0.16 introduced FutureWarnings on node list access:
~~~
/home/circleci/.local/lib/python3.5/site-packages/sphinx/util/nodes.py:94: FutureWarning: 
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
~~~
https://sourceforge.net/p/docutils/mailman/message/36765733/

Code that circumvents these warnings was only introduced in sphinx 2.3 (https://github.com/sphinx-doc/sphinx/issues/6887).

We have two options:

- either limit docutils to <0.16
- or pull sphinx for this branch up (which probably needs additional backports, because we had a reason to pin sphinx.

The former seems far easier and is thus what this PR does.

This is required to get 2.2.x docs build and in particular the prerequisite for #16352.