### PR TITLE
Make Text.update_from copy usetex state.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -70,3 +70,6 @@ shape ``(n, 2)`` would plot the first column of *x* against the first column
 of *y*, the second column of *x* against the second column of *y*, **and** the
 first column of *x* against the third column of *y*.  This now raises an error
 instead.
+
+`.Text.update_from` now copies usetex state from the source Text 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -533,6 +533,21 @@ def test_hinting_factor_backends():
 
 
 @needs_usetex
+def test_usetex_is_copied():
+    # Indirectly tests that update_from (which is used to copy tick label
+    # properties) copies usetex state.
+    fig = plt.figure()
+    plt.rcParams["text.usetex"] = False
+    ax1 = fig.add_subplot(121)
+    plt.rcParams["text.usetex"] = True
+    ax2 = fig.add_subplot(122)
+    fig.canvas.draw()
+    for ax, usetex in [(ax1, False), (ax2, True)]:
+        for t in ax.xaxis.majorTicks:
+            assert t.label1.get_usetex() == usetex
+
+
+@needs_usetex
 def test_single_artist_usetex():
     # Check that a single artist marked with usetex does not get passed through
     # the mathtext parser at all (for the Agg backend) (the mathtext parser

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -262,6 +262,7 @@ class Text(Artist):
         self._verticalalignment = other._verticalalignment
         self._horizontalalignment = other._horizontalalignment
         self._fontproperties = other._fontproperties.copy()
+        self._usetex = other._usetex
         self._rotation = other._rotation
         self._picker = other._picker
         self._linespacing = other._linespacing


### PR DESCRIPTION
This is used in particular by tick handling code to propagate text
properties across ticks, so this change avoids having some ticks using
usetex and others not using usetex if the rcParam value changes after
axes creation.

As an example, see the "-1" tick on the left of https://github.com/matplotlib/matplotlib/issues/6323#issuecomment-270385277 which is the only one not using usetex, even though the entire left axes should not be using usetex.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
