### PR TITLE
Backport PR #16347: FIX: catch warnings from pandas in cbook._check_1d

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2066,11 +2066,33 @@ def _check_1d(x):
         return np.atleast_1d(x)
     else:
         try:
-            ndim = x[:, None].ndim
-            # work around https://github.com/pandas-dev/pandas/issues/27775
-            # which mean the shape is not as expected. That this ever worked
-            # was an unintentional quirk of pandas the above line will raise
-            # an exception in the future.
+            # work around
+            # https://github.com/pandas-dev/pandas/issues/27775 which
+            # means the shape of multi-dimensional slicing is not as
+            # expected.  That this ever worked was an unintentional
+            # quirk of pandas and will raise an exception in the
+            # future.  This slicing warns in pandas >= 1.0rc0 via
+            # https://github.com/pandas-dev/pandas/pull/30588
+            #
+            # < 1.0rc0 : x[:, None].ndim == 1, no warning, custom type
+            # >= 1.0rc1 : x[:, None].ndim == 2, warns, numpy array
+            # future : x[:, None] -> raises
+            #
+            # This code should correctly identify and coerce to a
+            # numpy array all pandas versions.
+            with warnings.catch_warnings(record=True) as w:
+                warnings.filterwarnings("always",
+                                        category=DeprecationWarning,
+                                        module='pandas[.*]')
+
+                ndim = x[:, None].ndim
+                # we have definitely hit a pandas index or series object
+                # cast to a numpy array.
+                if len(w) > 0:
+                    return np.asanyarray(x)
+            # We have likely hit a pandas object, or at least
+            # something where 2D slicing does not result in a 2D
+            # object.
             if ndim < 2:
                 return np.atleast_1d(x)
             return x

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1472,6 +1472,15 @@ def test_hist_log():
     ax.hist(data, fill=False, log=True)
 
 
+def test_pandas_minimal_plot(pd):
+    # smoke test that series and index objcets do not warn
+    x = pd.Series([1, 2], dtype="float64")
+    plt.plot(x, x)
+    plt.plot(x.index, x)
+    plt.plot(x)
+    plt.plot(x.index)
+
+
 @image_comparison(baseline_images=['hist_bar_empty'], remove_text=True,
                   extensions=['png'])
 def test_hist_bar_empty():


### PR DESCRIPTION
Merge pull request #16347 from tacaswell/fix_pandas_index_deprecation

FIX: catch warnings from pandas in cbook._check_1d
 Conflicts:
	lib/matplotlib/tests/test_axes.py
         - new test in middle of section of tests not on v2.2.x yet, only kept
           new test

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
