### PR TITLE
Special-case usetex minus to zero depth.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -566,6 +566,12 @@ class DviFont:
                 result.append(0)
             else:
                 result.append(_mul2012(value, self._scale))
+        # cmsy10 glyph 0 ("minus") has a nonzero descent so that TeX aligns
+        # equations properly (https://tex.stackexchange.com/questions/526103/),
+        # but we actually care about the rasterization depth to align the
+        # dvipng-generated images.
+        if self.texname == b"cmsy10" and char == 0:
+            result[-1] = 0
         return result
 
 


### PR DESCRIPTION
This avoids vertical misalignment between e.g. "$1$" and "$-1$":
```
for x in [-1, 1]: figtext(.5, .5, f"${x}$", usetex=True, ha="right")
```
old (note the misalignment of baselines of "1"):
![old](https://user-images.githubusercontent.com/1322974/73351912-48a94c80-4290-11ea-9062-e5ed026385aa.png)
new:
![new](https://user-images.githubusercontent.com/1322974/73351922-4ba43d00-4290-11ea-8be6-5995e25d02d4.png)

Closes #6323, although more robust (and more complex...) solutions are discussed in https://github.com/matplotlib/matplotlib/issues/6323#issuecomment-579691674.

Mostly the same as #6333 which this supersedes, but here I explicitly only override the metrics for computer modern symbols (I have no idea whether other fonts have this problem), and added a test.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
