### PR TITLE
Improve warning for unsupported scripts.

### DIFF
--- a/lib/matplotlib/_text_helpers.py
+++ b/lib/matplotlib/_text_helpers.py
@@ -4,11 +4,35 @@ Low-level text helper utilities.
 
 import dataclasses
 
+from . import _api
 from .ft2font import KERNING_DEFAULT, LOAD_NO_HINTING
 
 
 LayoutItem = dataclasses.make_dataclass(
     "LayoutItem", ["char", "glyph_idx", "x", "prev_kern"])
+
+
+def warn_on_missing_glyph(codepoint):
+    _api.warn_external(
+        "Glyph {} ({}) missing from current font.".format(
+            codepoint,
+            chr(codepoint).encode("ascii", "namereplace").decode("ascii")))
+    block = ("Hebrew" if 0x0590 <= codepoint <= 0x05ff else
+             "Arabic" if 0x0600 <= codepoint <= 0x06ff else
+             "Devanagari" if 0x0900 <= codepoint <= 0x097f else
+             "Bengali" if 0x0980 <= codepoint <= 0x09ff else
+             "Gurmukhi" if 0x0a00 <= codepoint <= 0x0a7f else
+             "Gujarati" if 0x0a80 <= codepoint <= 0x0aff else
+             "Oriya" if 0x0b00 <= codepoint <= 0x0b7f else
+             "Tamil" if 0x0b80 <= codepoint <= 0x0bff else
+             "Telugu" if 0x0c00 <= codepoint <= 0x0c7f else
+             "Kannada" if 0x0c80 <= codepoint <= 0x0cff else
+             "Malayalam" if 0x0d00 <= codepoint <= 0x0d7f else
+             "Sinhala" if 0x0d80 <= codepoint <= 0x0dff else
+             None)
+    if block:
+        _api.warn_external(
+            f"Matplotlib currently does not support {block} natively.")
 
 
 def layout(string, font, *, kern_mode=KERNING_DEFAULT):

--- a/lib/matplotlib/_text_helpers.py
+++ b/lib/matplotlib/_text_helpers.py
@@ -1,5 +1,5 @@
 """
-Text layouting utilities.
+Low-level text helper utilities.
 """
 
 import dataclasses

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -24,7 +24,7 @@ import numpy as np
 from PIL import Image
 
 import matplotlib as mpl
-from matplotlib import _api, _text_layout, cbook
+from matplotlib import _api, _text_helpers, cbook
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
@@ -2296,7 +2296,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             # List of (start_x, glyph_index).
             multibyte_glyphs = []
             prev_was_multibyte = True
-            for item in _text_layout.layout(
+            for item in _text_helpers.layout(
                     s, font, kern_mode=KERNING_UNFITTED):
                 if ord(item.char) <= 255:
                     if prev_was_multibyte:

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -18,8 +18,7 @@ import time
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _api, cbook, _path
-from matplotlib import _text_layout
+from matplotlib import _api, cbook, _path, _text_helpers
 from matplotlib.afm import AFM
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
@@ -613,7 +612,7 @@ grestore
             font.set_text(s, 0, flags=LOAD_NO_HINTING)
             self._character_tracker.track(font, s)
             xs_names = [(item.x, font.get_glyph_name(item.glyph_idx))
-                        for item in _text_layout.layout(s, font)]
+                        for item in _text_helpers.layout(s, font)]
 
         self.set_color(*gc.get_rgb())
         ps_name = (font.postscript_name

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -720,3 +720,14 @@ def test_invalid_color():
 def test_pdf_kerning():
     plt.figure()
     plt.figtext(0.1, 0.5, "ATATATATATATATATATA", size=30)
+
+
+def test_unsupported_script(recwarn):
+    fig = plt.figure()
+    fig.text(.5, .5, "\N{BENGALI DIGIT ZERO}")
+    fig.canvas.draw()
+    assert all(isinstance(warn.message, UserWarning) for warn in recwarn)
+    assert (
+        [warn.message.args for warn in recwarn] ==
+        [(r"Glyph 2534 (\N{BENGALI DIGIT ZERO}) missing from current font.",),
+         (r"Matplotlib currently does not support Bengali natively.",)])

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import numpy as np
 
-from matplotlib import _text_layout, dviread, font_manager, rcParams
+from matplotlib import _text_helpers, dviread, font_manager, rcParams
 from matplotlib.font_manager import FontProperties, get_font
 from matplotlib.ft2font import LOAD_NO_HINTING, LOAD_TARGET_LIGHT
 from matplotlib.mathtext import MathTextParser
@@ -149,7 +149,7 @@ class TextToPath:
 
         xpositions = []
         glyph_ids = []
-        for item in _text_layout.layout(s, font):
+        for item in _text_helpers.layout(s, font):
             char_id = self._get_char_id(font, ord(item.char))
             glyph_ids.append(char_id)
             xpositions.append(item.x)


### PR DESCRIPTION
## PR Summary

Improves the warning for cases like https://github.com/matplotlib/matplotlib/issues/16367.

Trying e.g. to use an Indic script now gives
```
<string>:5: UserWarning: Glyph 3520 (\N{SINHALA LETTER VAYANNA}) missing from current font.
<string>:5: UserWarning: Matplotlib currently does not support Sinhala natively.
```
We could even make the warning point to mplcairo... not that I particularly relish getting tons of bug reports about how to install it on obscure (i.e. nonlinux :-)) platforms.

The list of unicode blocks is at https://en.wikipedia.org/wiki/Unicode_block (I don't think it's available in the stdlib); I just hardcoded a few (Hebrew, Arabic, various Indic scripts) that I know are (almost) certainly not working due to shaping needs.

I moved the warning generation to Python because I don't particularly want to figure out how to call `encode("ascii", "namereplace")` from C (well, it's just a big bunch of Py_CallFoo and Py_XDECREFs...), and anyways we're in a non-working case so the performance loss should be a big deal.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
