### PR TITLE
Fix usetex_baseline_test.

### DIFF
--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -8,39 +8,31 @@ Usetex Baseline Test
 import matplotlib.pyplot as plt
 import matplotlib.axes as maxes
 
-from matplotlib import rcParams
-rcParams['text.usetex'] = True
+
+plt.rcParams.update({"mathtext.fontset": "cm", "mathtext.rm": "serif"})
 
 
-class Axes(maxes.Axes):
+@maxes.subplot_class_factory
+class LatexPreviewSubplot(maxes.Axes):
     """
-    A hackish way to simultaneously draw texts w/ usetex=True and
-    usetex=False in the same figure. It does not work in the ps backend.
+    A hackish way to simultaneously draw texts with text.latex.preview=True and
+    text.latex.preview=False in the same figure.  It does not work with the ps
+    backend.
     """
 
-    def __init__(self, *args, usetex=False, preview=False, **kwargs):
-        self.usetex = usetex
+    def __init__(self, *args, preview=False, **kwargs):
         self.preview = preview
         super().__init__(*args, **kwargs)
 
     def draw(self, renderer):
-        with plt.rc_context({"text.usetex": self.usetex,
-                             "text.latex.preview": self.preview}):
+        with plt.rc_context({"text.latex.preview": self.preview}):
             super().draw(renderer)
-
-
-subplot = maxes.subplot_class_factory(Axes)
 
 
 def test_window_extent(ax, usetex, preview):
 
-    va = "baseline"
     ax.xaxis.set_visible(False)
     ax.yaxis.set_visible(False)
-
-    text_kw = dict(va=va,
-                   size=50,
-                   bbox=dict(pad=0., ec="k", fc="none"))
 
     test_strings = ["lg", r"$\frac{1}{2}\pi$",
                     r"$p^{3^A}$", r"$p_{3_2}$"]
@@ -48,14 +40,20 @@ def test_window_extent(ax, usetex, preview):
     ax.axvline(0, color="r")
 
     for i, s in enumerate(test_strings):
-
         ax.axhline(i, color="r")
-        ax.text(0., 3 - i, s, **text_kw)
+        ax.text(0., 3 - i, s,
+                usetex=usetex,
+                verticalalignment="baseline",
+                size=50,
+                bbox=dict(pad=0, ec="k", fc="none"))
 
     ax.set_xlim(-0.1, 1.1)
     ax.set_ylim(-.8, 3.9)
 
-    ax.set_title("usetex=%s\npreview=%s" % (str(usetex), str(preview)))
+    title = f"usetex={usetex}\n"
+    if usetex:
+        title += f"preview={preview}"
+    ax.set_title(title)
 
 
 fig = plt.figure(figsize=(2 * 3, 6.5))
@@ -63,7 +61,7 @@ fig = plt.figure(figsize=(2 * 3, 6.5))
 for i, usetex, preview in [[0, False, False],
                            [1, True, False],
                            [2, True, True]]:
-    ax = subplot(fig, 1, 3, i + 1, usetex=usetex, preview=preview)
+    ax = LatexPreviewSubplot(fig, 1, 3, i + 1, preview=preview)
     fig.add_subplot(ax)
     fig.subplots_adjust(top=0.85)
 


### PR DESCRIPTION
The previous version didn't actually compare usetex=False and
usetex=True because usetex state is stored in the text instance, so fix
that.  (The custom axes subclass remains necessary to compare
text.latex.preview=False and =True.)

Also misc. cleanups.

old:
![old](https://user-images.githubusercontent.com/1322974/73443783-9dfc6100-4357-11ea-8d46-c98dc1b849a5.png)
new:
![new](https://user-images.githubusercontent.com/1322974/73443798-a18fe800-4357-11ea-83f4-b45cbcd29c45.png)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
