### PR TITLE
Log about font manager generation beforehand.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1334,10 +1334,10 @@ def get_font(filename, hinting_factor=None):
 
 def _rebuild():
     global fontManager
+    _log.info("Generating new fontManager, this may take some time...")
     fontManager = FontManager()
     with cbook._lock_path(_fmcache):
         json_dump(fontManager, _fmcache)
-    _log.info("generated new fontManager")
 
 
 try:


### PR DESCRIPTION
## PR Summary

Changes an info level log message to debug. This reduces noise on the root logger, e.g.
```
2020-01-30 13:45:33,150 INFO matplotlib.font_manager generated new fontManager
2020-01-30 13:45:33,150 INFO matplotlib.font_manager generated new fontManager
```
It's not very descriptive or helpful in general.

## PR Checklist

- [ ] ~~Has Pytest style unit tests~~
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] ~~New features are documented, with examples if plot related~~
- [ ] ~~Documentation is sphinx and numpydoc compliant~~
- [ ] ~~Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
- [ ] ~~Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
