### PR TITLE
Add set/get for ellipse width/height

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1465,8 +1465,8 @@ class Ellipse(Patch):
         Return the width of the ellipse
         '''
         return self._width
-	
-	width = property(get_width, set_width)
+    
+    width = property(get_width, set_width)
     
     def set_height(self, height):
         '''
@@ -1484,8 +1484,8 @@ class Ellipse(Patch):
         Return the height of the ellipse
         '''
         return self._height
-		
-	height = property(get_height, set_height)
+        
+    height = property(get_height, set_height)
 
 class Circle(Ellipse):
     """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1397,7 +1397,7 @@ class Ellipse(Patch):
 
         self._center = xy
         self._width, self._height = width, height
-        self.angle = angle
+        self._angle = angle
         self._path = Path.unit_circle()
         # Note: This cannot be calculated until this is added to an Axes
         self._patch_transform = transforms.IdentityTransform()
@@ -1486,6 +1486,25 @@ class Ellipse(Patch):
         return self._height
 
     height = property(get_height, set_height)
+
+    def set_angle(self, angle):
+        """
+        Set the angle of the ellipse.
+
+        Parameters
+        ----------
+        angle : float
+        """
+        self._angle = angle
+        self.stale = True
+
+    def get_angle(self):
+        """
+        Return the angle of the ellipse.
+        """
+        return self._angle
+
+    angle = property(get_angle, set_angle)
 
 
 class Circle(Ellipse):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1443,49 +1443,50 @@ class Ellipse(Patch):
 
     def get_center(self):
         """
-        Return the center of the ellipse
+        Return the center of the ellipse.
         """
         return self._center
 
     center = property(get_center, set_center)
 
     def set_width(self, width):
-        '''
-        Set the width of the ellipse
-        
+        """
+        Set the width of the ellipse.
+
         Parameters
         ----------
         width : float
-        '''
+        """
         self._width = width
         self.stale = True
-        
+
     def get_width(self):
-        '''
-        Return the width of the ellipse
-        '''
+        """
+        Return the width of the ellipse.
+        """
         return self._width
-    
+
     width = property(get_width, set_width)
-    
+
     def set_height(self, height):
-        '''
-        Set the height of the ellipse
-        
+        """
+        Set the height of the ellipse.
+
         Parameters
         ----------
         height : float
-        '''
+        """
         self._height = height
         self.stale = True
-    
+
     def get_height(self):
-        '''
-        Return the height of the ellipse
-        '''
+        """
+        Return the height of the ellipse.
+        """
         return self._height
-        
+
     height = property(get_height, set_height)
+
 
 class Circle(Ellipse):
     """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1396,7 +1396,7 @@ class Ellipse(Patch):
         Patch.__init__(self, **kwargs)
 
         self._center = xy
-        self.width, self.height = width, height
+        self._width, self._height = width, height
         self.angle = angle
         self._path = Path.unit_circle()
         # Note: This cannot be calculated until this is added to an Axes
@@ -1413,8 +1413,8 @@ class Ellipse(Patch):
         """
         center = (self.convert_xunits(self._center[0]),
                   self.convert_yunits(self._center[1]))
-        width = self.convert_xunits(self.width)
-        height = self.convert_yunits(self.height)
+        width = self.convert_xunits(self._width)
+        height = self.convert_yunits(self._height)
         self._patch_transform = transforms.Affine2D() \
             .scale(width * 0.5, height * 0.5) \
             .rotate_deg(self.angle) \
@@ -1457,14 +1457,16 @@ class Ellipse(Patch):
         ----------
         width : float
         '''
-        self.width = width
+        self._width = width
         self.stale = True
         
     def get_width(self):
         '''
         Return the width of the ellipse
         '''
-        return self.width
+        return self._width
+	
+	width = property(get_width, set_width)
     
     def set_height(self, height):
         '''
@@ -1474,14 +1476,16 @@ class Ellipse(Patch):
         ----------
         height : float
         '''
-        self.height = height
+        self._height = height
         self.stale = True
     
     def get_height(self):
         '''
         Return the height of the ellipse
         '''
-        return self.height
+        return self._height
+		
+	height = property(get_height, set_height)
 
 class Circle(Ellipse):
     """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1449,6 +1449,39 @@ class Ellipse(Patch):
 
     center = property(get_center, set_center)
 
+    def set_width(self, width):
+        '''
+        Set the width of the ellipse
+        
+        Parameters
+        ----------
+        width : float
+        '''
+        self.width = width
+        self.stale = True
+        
+    def get_width(self):
+        '''
+        Return the width of the ellipse
+        '''
+        return self.width
+    
+    def set_height(self, height):
+        '''
+        Set the height of the ellipse
+        
+        Parameters
+        ----------
+        height : float
+        '''
+        self.height = height
+        self.stale = True
+    
+    def get_height(self):
+        '''
+        Return the height of the ellipse
+        '''
+        return self.height
 
 class Circle(Ellipse):
     """


### PR DESCRIPTION
## PR Summary
Add methods to set/get the width/height for Ellipse Patches.
Mostly the setter methods are interesting, as they set `self.stale=True` to force redrawing the patch at the next plot call.
I used those methods for interactive plotting, they have similar use than the existing `set_center`. 
The `stale=True` was not be obvious to update the shape size interactively so I think the method could benefit others. 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
