### PR TITLE
Deprecate avconv animation writers.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -173,3 +173,14 @@ variables is deprecated.  Additional fonts may be registered using
 ``matplotlib.compat``
 ~~~~~~~~~~~~~~~~~~~~~
 This module is deprecated.
+
+AVConv animation writer deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``AVConvBase``, ``AVConvWriter`` and ``AVConvFileWriter`` classes, and the
+associated ``animation.avconv_path`` and ``animation.avconv_args`` rcParams are
+deprecated.
+
+Debian 8 (2015, EOL 06/2020) and Ubuntu 14.04 (EOL 04/2019) were the
+last versions of Debian and Ubuntu to ship avconv.  It remains possible
+to force the use of avconv by using the ffmpeg-based writers with
+:rc:`animation.ffmpeg_path` set to "avconv".

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -609,6 +609,8 @@ _deprecated_ignore_map = {
 # listed in the rcParams (not included in _all_deprecated).
 # Values are tuples of (version,)
 _deprecated_remain_as_none = {
+    'animation.avconv_path': ('3.3',),
+    'animation.avconv_args': ('3.3',),
 }
 
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -644,6 +644,7 @@ class FFMpegFileWriter(FFMpegBase, FileMovieWriter):
 
 
 # Base class of avconv information.  AVConv has identical arguments to FFMpeg.
+@cbook.deprecated('3.3')
 class AVConvBase(FFMpegBase):
     """
     Mixin class for avconv output.

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -478,9 +478,6 @@ animation.frame_format: png       # Controls frame format used by temp files
 animation.ffmpeg_path: ffmpeg     # Path to ffmpeg binary. Without full path
                                   # $PATH is searched
 animation.ffmpeg_args:            # Additional arguments to pass to ffmpeg
-animation.avconv_path: avconv     # Path to avconv binary. Without full path
-                                  # $PATH is searched
-animation.avconv_args:            # Additional arguments to pass to avconv
 animation.convert_path: convert   # Path to ImageMagick's convert binary.
                                   # On Windows use the full path since convert
                                   # is also the name of a system tool.

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -744,9 +744,6 @@
 #animation.ffmpeg_path  : ffmpeg   ## Path to ffmpeg binary. Without full path
                                    ## $PATH is searched
 #animation.ffmpeg_args  :          ## Additional arguments to pass to ffmpeg
-#animation.avconv_path  : avconv   ## Path to avconv binary. Without full path
-                                   ## $PATH is searched
-#animation.avconv_args  :          ## Additional arguments to pass to avconv
 #animation.convert_path : convert  ## Path to ImageMagick's convert binary.
                                    ## On Windows use the full path since convert
                                    ## is also the name of a system tool.


### PR DESCRIPTION
See changelog.  (avconv was a fork of ffmpeg which has kept the same
CLI, so the ffmpeg writers are good enough anyways.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
