### PR TITLE
Fix support for empty usetex strings.

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -31,6 +31,12 @@ def test_usetex():
 
 
 @check_figures_equal()
+def test_empty(fig_test, fig_ref):
+    mpl.rcParams['text.usetex'] = True
+    fig_test.text(.5, .5, "% a comment")
+
+
+@check_figures_equal()
 def test_unicode_minus(fig_test, fig_ref):
     mpl.rcParams['text.usetex'] = True
     fig_test.text(.5, .5, "$-$")

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -214,7 +214,8 @@ class TexManager:
 \usepackage[papersize={72in,72in},body={70in,70in},margin={1in,1in}]{geometry}
 \pagestyle{empty}
 \begin{document}
-\fontsize{%f}{%f}%s
+%% The empty hbox ensures that a page is printed even for empty inputs.
+\fontsize{%f}{%f}\hbox{}%s
 \end{document}
 """ % (self._get_preamble(), fontsize, fontsize * 1.25, fontcmd % tex),
             encoding='utf-8')


### PR DESCRIPTION
Currently, `figtext(.5, .5, "%foo", usetex=True)` results in an obscure
exception (`FileNotFoundError: No such file or directory: blah.dvi`).
    
Fix that by forcing tex to always generate a page, by inserting at least
an empty \hbox{}.

Closes https://github.com/matplotlib/matplotlib/issues/16409.

Edit: looks like this shifts some tex strings a tiny bit, but I already have another patch which shifts them more -- specifically, a followup to https://github.com/matplotlib/matplotlib/pull/16373 which actually gives correct baselines even without using tex.latex.preview.  So I'll just wait for that.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
