### PR TITLE
Replace some usages of OrderedDict by a regular dict.

### DIFF
--- a/lib/matplotlib/_color_data.py
+++ b/lib/matplotlib/_color_data.py
@@ -1,6 +1,3 @@
-from collections import OrderedDict
-
-
 BASE_COLORS = {
     'b': (0, 0, 1),        # blue
     'g': (0, 0.5, 0),      # green
@@ -13,23 +10,20 @@ BASE_COLORS = {
 }
 
 
-# These colors are from Tableau
-TABLEAU_COLORS = (
-    ('blue', '#1f77b4'),
-    ('orange', '#ff7f0e'),
-    ('green', '#2ca02c'),
-    ('red', '#d62728'),
-    ('purple', '#9467bd'),
-    ('brown', '#8c564b'),
-    ('pink', '#e377c2'),
-    ('gray', '#7f7f7f'),
-    ('olive', '#bcbd22'),
-    ('cyan', '#17becf'),
-)
+# These colors are from Tableau, prefixed by 'tab:' to prevent name collisions.
+TABLEAU_COLORS = {
+    'tab:blue': '#1f77b4',
+    'tab:orange': '#ff7f0e',
+    'tab:green': '#2ca02c',
+    'tab:red': '#d62728',
+    'tab:purple': '#9467bd',
+    'tab:brown': '#8c564b',
+    'tab:pink': '#e377c2',
+    'tab:gray': '#7f7f7f',
+    'tab:olive': '#bcbd22',
+    'tab:cyan': '#17becf',
+}
 
-# Normalize name to "tab:<name>" to avoid name collisions.
-TABLEAU_COLORS = OrderedDict(
-    ('tab:' + name, value) for name, value in TABLEAU_COLORS)
 
 # This mapping of color names -> hex values is taken from
 # a survey run by Randall Munroe see:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from functools import wraps
 import inspect
 import logging
@@ -1578,8 +1578,7 @@ def setp(obj, *args, **kwargs):
     if len(args) % 2:
         raise ValueError('The set args must be string, value pairs')
 
-    # put args into ordereddict to maintain order
-    funcvals = OrderedDict((k, v) for k, v in zip(args[::2], args[1::2]))
+    funcvals = {k: v for k, v in zip(args[::2], args[1::2])}
     ret = [o.update(funcvals) for o in objs] + [o.set(**kwargs) for o in objs]
     return list(cbook.flatten(ret))
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -521,11 +521,11 @@ class PdfFile:
         self._soft_mask_seq = (Name(f'SM{i}') for i in itertools.count(1))
         self._soft_mask_groups = []
         # reproducible writeHatches needs an ordered dict:
-        self.hatchPatterns = collections.OrderedDict()
+        self.hatchPatterns = {}
         self._hatch_pattern_seq = (Name(f'H{i}') for i in itertools.count(1))
         self.gouraudTriangles = []
 
-        self._images = collections.OrderedDict()   # reproducible writeImages
+        self._images = {}   # reproducible writeImages
         self._image_seq = (Name(f'I{i}') for i in itertools.count(1))
 
         self.markers = collections.OrderedDict()   # reproducible writeMarkers

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import base64
 import gzip
 import hashlib
@@ -281,13 +280,13 @@ class RendererSVG(RendererBase):
         self._groupd = {}
         self.basename = basename
         self._image_counter = itertools.count()
-        self._clipd = OrderedDict()
+        self._clipd = {}
         self._markers = {}
         self._path_collection_id = 0
-        self._hatchd = OrderedDict()
+        self._hatchd = {}
         self._has_gouraud = False
         self._n_gradients = 0
-        self._fonts = OrderedDict()
+        self._fonts = {}
         self.mathtext_parser = MathTextParser('SVG')
 
         RendererBase.__init__(self)
@@ -1092,7 +1091,7 @@ class RendererSVG(RendererBase):
             writer.start('text')
 
             # Sort the characters by font, and output one tspan for each.
-            spans = OrderedDict()
+            spans = {}
             for font, fontsize, thetext, new_x, new_y, metrics in svg_glyphs:
                 style = generate_css({
                     'font-size': short_float_fmt(fontsize) + 'px',

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -10,7 +10,6 @@ strings to integers and provides a tick locator, a tick formatter, and the
 `.UnitData` class that creates and stores the string-to-integer mapping.
 """
 
-from collections import OrderedDict
 import dateutil.parser
 import itertools
 import logging
@@ -170,7 +169,7 @@ class UnitData:
         data : iterable
             sequence of string values
         """
-        self._mapping = OrderedDict()
+        self._mapping = {}
         self._counter = itertools.count()
         if data is not None:
             self.update(data)
@@ -206,8 +205,7 @@ class UnitData:
         data = np.atleast_1d(np.array(data, dtype=object))
         # check if convertible to number:
         convertible = True
-        for val in OrderedDict.fromkeys(data):
-            # OrderedDict just iterates over unique values in data.
+        for val in dict.fromkeys(data):  # iterate over unique values in data.
             cbook._check_isinstance((str, bytes), value=val)
             if convertible:
                 # this will only be called so long as convertible is True.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import copy
 import os
 from pathlib import Path
@@ -456,8 +455,7 @@ def test_rcparams_reset_after_fail():
         assert mpl.rcParams['text.usetex'] is False
 
         with pytest.raises(KeyError):
-            with mpl.rc_context(rc=OrderedDict([('text.usetex', True),
-                                                ('test.blah', True)])):
+            with mpl.rc_context(rc={'text.usetex': True, 'test.blah': True}):
                 pass
 
         assert mpl.rcParams['text.usetex'] is False

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from contextlib import contextmanager
 import gc
 from pathlib import Path
@@ -137,7 +136,7 @@ def test_context_with_union_of_dict_and_namedstyle():
 def test_context_with_badparam():
     original_value = 'gray'
     other_value = 'blue'
-    d = OrderedDict([(PARAM, original_value), ('badparam', None)])
+    d = {PARAM: original_value, 'badparam': None}
     with style.context({PARAM: other_value}):
         assert mpl.rcParams[PARAM] == other_value
         x = style.context([d])


### PR DESCRIPTION
## PR Summary

Since Python 3.6 the order is guaranteed also for regular dicts. OrderedDicts do only have benefits in some rare cases (popping from the ends).

If we just need regular operations, like construction, iteration etc. regular dicts are slightly faster and more memory-efficient.
