### PR TITLE
Expire some APIs deprecated in mpl3.1.

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -2,6 +2,11 @@ Removals
 --------
 The following deprecated APIs have been removed:
 
+Modules
+~~~~~~~
+- ``backends.qt_editor.formlayout`` (use the formlayout module available on
+  PyPI instead).
+
 Classes and methods
 ~~~~~~~~~~~~~~~~~~~
 - ``backend_bases.RendererBase.strip_math()``
@@ -126,3 +131,7 @@ rcParams
   :rc:`savefig.facecolor` to "none" to get a transparent background.
 - The ``pgf.debug``, ``verbose.fileo`` and ``verbose.verbose.level`` rcParams,
   which had no effect, have been removed.
+
+Environment variables
+~~~~~~~~~~~~~~~~~~~~~
+- ``MATPLOTLIBDATA`` (no replacement).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -510,15 +510,6 @@ def get_cachedir():
 def _get_data_path():
     """Return the path to matplotlib data."""
 
-    if 'MATPLOTLIBDATA' in os.environ:
-        path = os.environ['MATPLOTLIBDATA']
-        if not os.path.isdir(path):
-            raise RuntimeError('Path in environment MATPLOTLIBDATA not a '
-                               'directory')
-        cbook.warn_deprecated(
-            "3.1", name="MATPLOTLIBDATA", obj_type="environment variable")
-        return path
-
     path = Path(__file__).with_name("mpl-data")
     if path.is_dir():
         return str(path)

--- a/lib/matplotlib/backends/qt_editor/formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/formlayout.py
@@ -1,7 +1,0 @@
-from .. import cbook
-from ._formlayout import *
-
-
-cbook.warn_deprecated(
-    "3.1", name=__name__, obj_type="module",
-    alternative="the formlayout module available on PyPI")


### PR DESCRIPTION
## PR Summary

(which do not overlap with #15890 or #16047)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
