### PR TITLE
Deprecate rcParams["datapath"] in favor of mpl.get_data_path().

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -179,6 +179,7 @@ rcParams
 - The ``pgf.debug``, ``verbose.fileo`` and ``verbose.verbose.level`` rcParams,
   which had no effect, have been removed.
 - Support for setting :rc:`mathtext.default` to "circled" has been removed.
+- The ``datapath`` rcParam has been removed.  Use `.get_data_path` instead.
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -509,29 +509,8 @@ def get_cachedir():
 
 
 @_logged_cached('matplotlib data path: %s')
-def get_data_path(*, _from_rc=None):
+def get_data_path():
     """Return the path to Matplotlib data."""
-    if _from_rc is not None:
-        cbook.warn_deprecated(
-            "3.2",
-            message=("Setting the datapath via matplotlibrc is deprecated "
-                     "%(since)s and will be removed in %(removal)s."),
-            removal='3.3')
-        path = Path(_from_rc)
-        if path.is_dir():
-            defaultParams['datapath'][0] = str(path)
-            return str(path)
-        else:
-            warnings.warn(f"You passed datapath: {_from_rc!r} in your "
-                          f"matplotribrc file ({matplotlib_fname()}). "
-                          "However this path does not exist, falling back "
-                          "to standard paths.")
-
-    return _get_data_path()
-
-
-@_logged_cached('(private) matplotlib data path: %s')
-def _get_data_path():
     path = Path(__file__).with_name("mpl-data")
     if path.is_dir():
         defaultParams['datapath'][0] = str(path)
@@ -594,7 +573,7 @@ def matplotlib_fname():
             yield matplotlibrc
             yield os.path.join(matplotlibrc, 'matplotlibrc')
         yield os.path.join(get_configdir(), 'matplotlibrc')
-        yield os.path.join(_get_data_path(), 'matplotlibrc')
+        yield os.path.join(get_data_path(), 'matplotlibrc')
 
     for fname in gen_candidates():
         if os.path.exists(fname) and not os.path.isdir(fname):
@@ -861,10 +840,7 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
     config.update(config_from_file)
 
     with cbook._suppress_matplotlib_deprecation_warning():
-        if config['datapath'] is None:
-            config['datapath'] = _get_data_path()
-        else:
-            config['datapath'] = get_data_path(_from_rc=config['datapath'])
+        config['datapath'] = get_data_path()
 
     if "".join(config['text.latex.preamble']):
         _log.info("""


### PR DESCRIPTION
The rcParam cannot be meaningfully set by the end user from their
matplotlibrc or Python code.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
