### PR TITLE
Backend timer simplifications.

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -117,6 +117,9 @@ Arguments
 - The parameter ``block`` of ``show()`` is now keyword-only.
 - The parameter ``frameon`` of `.Figure.savefig` has been removed.  Use
   ``facecolor="none"`` to get a transparent background.
+- Passing a ``wx.EvtHandler`` as the first argument to ``backend_wx.TimerWx``
+  is not supported anymore; the signature of ``TimerWx`` is now consistent with
+  `.TimerBase`.
 
 rcParams
 ~~~~~~~~

--- a/examples/event_handling/pong_sgskip.py
+++ b/examples/event_handling/pong_sgskip.py
@@ -44,8 +44,7 @@ def start_anim(event):
 
 
 start_anim.cid = canvas.mpl_connect('draw_event', start_anim)
-start_anim.timer = animation.canvas.new_timer()
-start_anim.timer.interval = 1
+start_anim.timer = animation.canvas.new_timer(interval=1)
 
 tstart = time.time()
 

--- a/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -45,8 +45,8 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self._static_ax.plot(t, np.tan(t), ".")
 
         self._dynamic_ax = dynamic_canvas.figure.subplots()
-        self._timer = dynamic_canvas.new_timer(
-            50, [(self._update_canvas, (), {})])
+        self._timer = dynamic_canvas.new_timer(50)
+        self._timer.add_callback(self._update_canvas)
         self._timer.start()
 
     def _update_canvas(self):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1401,8 +1401,7 @@ class TimedAnimation(Animation):
         # If we're not given an event source, create a new timer. This permits
         # sharing timers between animation objects for syncing animations.
         if event_source is None:
-            event_source = fig.canvas.new_timer()
-            event_source.interval = self._interval
+            event_source = fig.canvas.new_timer(interval=self._interval)
         Animation.__init__(self, fig, event_source=event_source,
                            *args, **kwargs)
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1057,6 +1057,7 @@ class TimerBase:
         timer events. This list can be manipulated directly, or the
         functions `add_callback` and `remove_callback` can be used.
     """
+
     def __init__(self, interval=None, callbacks=None):
         #Initialize empty callbacks list and setup default settings if necssary
         if callbacks is None:
@@ -2222,15 +2223,19 @@ class FigureCanvasBase:
         """
         return self.callbacks.disconnect(cid)
 
-    def new_timer(self, *args, **kwargs):
+    # Internal subclasses can override _timer_cls instead of new_timer, though
+    # this is not a public API for third-party subclasses.
+    _timer_cls = TimerBase
+
+    def new_timer(self, interval=None, callbacks=None):
         """
         Create a new backend-specific subclass of `.Timer`.
 
         This is useful for getting periodic events through the backend's native
         event loop.  Implemented only for backends with GUIs.
 
-        Other Parameters
-        ----------------
+        Parameters
+        ----------
         interval : int
             Timer interval in milliseconds.
 
@@ -2243,9 +2248,9 @@ class FigureCanvasBase:
 
         Examples
         --------
-        >>> timer = fig.canvas.new_timer(callbacks=[(f1, (1, ), {'a': 3}),])
+        >>> timer = fig.canvas.new_timer(callbacks=[(f1, (1,), {'a': 3})])
         """
-        return TimerBase(*args, **kwargs)
+        return self._timer_cls(interval=interval, callbacks=callbacks)
 
     def flush_events(self):
         """

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -98,6 +98,7 @@ class TimerGTK3(TimerBase):
 
 class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
     required_interactive_framework = "gtk3"
+    _timer_cls = TimerGTK3
 
     keyvald = {65507: 'control',
                65505: 'shift',
@@ -304,10 +305,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
                 self._idle_draw_id = 0
             return False
         self._idle_draw_id = GLib.idle_add(idle_draw)
-
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerGTK3(*args, **kwargs)
 
     def flush_events(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -55,6 +55,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
     """
 
     required_interactive_framework = "macosx"
+    _timer_cls = TimerMac
 
     def __init__(self, figure):
         FigureCanvasBase.__init__(self, figure)
@@ -98,10 +99,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
                                     forward=False)
         FigureCanvasBase.resize_event(self)
         self.draw_idle()
-
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerMac(*args, **kwargs)
 
 
 class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -142,9 +142,7 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
 
 
 class FigureCanvasNbAgg(FigureCanvasWebAggCore):
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerTornado(*args, **kwargs)
+    _timer_cls = TimerTornado
 
 
 class CommSocket:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -215,6 +215,7 @@ class TimerQT(TimerBase):
 
 class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     required_interactive_framework = "qt5"
+    _timer_cls = TimerQT
 
     # map Qt button codes to MouseEvent's ones:
     buttond = {QtCore.Qt.LeftButton: MouseButton.LEFT,
@@ -433,10 +434,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
         mods.reverse()
         return '+'.join(mods + [key])
-
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerQT(*args, **kwargs)
 
     def flush_events(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -48,14 +48,12 @@ webagg_server_thread = ServerThread()
 
 
 class FigureCanvasWebAgg(core.FigureCanvasWebAggCore):
+    _timer_cls = TimerTornado
+
     def show(self):
         # show the figure window
         global show  # placates pyflakes: created by @_Backend.export below
         show()
-
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerTornado(*args, **kwargs)
 
 
 class WebAggApplication(tornado.web.Application):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -86,11 +86,6 @@ class TimerWx(TimerBase):
     """
 
     def __init__(self, *args, **kwargs):
-        if args and isinstance(args[0], wx.EvtHandler):
-            cbook.warn_deprecated(
-                "3.0", message="Passing a wx.EvtHandler as first argument to "
-                "the TimerWx constructor is deprecated since %(since)s.")
-            args = args[1:]
         TimerBase.__init__(self, *args, **kwargs)
         self._timer = wx.Timer()
         self._timer.Notify = self._on_timer
@@ -468,6 +463,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
     """
 
     required_interactive_framework = "wx"
+    _timer_cls = TimerWx
 
     keyvald = {
         wx.WXK_CONTROL: 'control',
@@ -597,10 +593,6 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # until later. The platform will send the event when it thinks it is
         # a good time (usually as soon as there are no other events pending).
         self.Refresh(eraseBackground=False)
-
-    def new_timer(self, *args, **kwargs):
-        # docstring inherited
-        return TimerWx(*args, **kwargs)
 
     def flush_events(self):
         # docstring inherited


### PR DESCRIPTION
Instead of overriding new_timer, let subclasses set the _timer_cls
attribute.  This makes new_timer have a consistent and useful signature
(`interval=None, callbacks=None`) rather than `*args, **kwargs` without
having to repeat it across subclasses.  Don't do it with backend_tk,
whose timer has a different signature (similar to the "old" wx timer
signature, now removed).

Also some timer-related cleanups in examples.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
