### PR TITLE
MNT: rename internal variable

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -2354,7 +2354,7 @@ class Parser:
         p.simple           = Forward()
         p.simple_group     = Forward()
         p.single_symbol    = Forward()
-        p.snowflake        = Forward()
+        p.accentprefixed   = Forward()
         p.space            = Forward()
         p.sqrt             = Forward()
         p.stackrel         = Forward()
@@ -2391,7 +2391,7 @@ class Parser:
         p.single_symbol <<= Regex(
             r"([a-zA-Z0-9 +\-*/<>=:,.;!\?&'@()\[\]|%s])|(\\[%%${}\[\]_|])" %
             unicode_range)
-        p.snowflake     <<= Suppress(p.bslash) + oneOf(self._snowflake)
+        p.accentprefixed <<= Suppress(p.bslash) + oneOf(self._accentprefixed)
         p.symbol_name   <<= (
             Combine(p.bslash + oneOf(list(tex2uni)))
             + FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd())
@@ -2494,8 +2494,8 @@ class Parser:
         )
 
         p.placeable     <<= (
-            p.snowflake  # Must be before accent so named symbols that are
-                         # prefixed with an accent name work
+            p.accentprefixed  # Must be before accent so named symbols that are
+                              # prefixed with an accent name work
             | p.accent   # Must be before symbol as all accents are symbols
             | p.symbol   # Must be third to catch all named symbols and single
                          # chars not in a group
@@ -2742,7 +2742,7 @@ class Parser:
                                do_kern = True)]
         return [char]
 
-    snowflake = symbol
+    accentprefixed = symbol
 
     def unknown_symbol(self, s, loc, toks):
         c = toks[0]
@@ -2816,9 +2816,10 @@ class Parser:
     _wide_accents = set(r"widehat widetilde widebar".split())
 
     # make a lambda and call it to get the namespace right
-    _snowflake = (lambda am: [p for p in tex2uni if
-                              any(p.startswith(a) and a != p for a in am)])(
-                                  set(_accent_map))
+    _accentprefixed = (lambda am: [
+        p for p in tex2uni
+        if any(p.startswith(a) and a != p for a in am)
+    ])(set(_accent_map))
 
     def accent(self, s, loc, toks):
         assert len(toks) == 1

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -101,7 +101,7 @@ math_tests = [
     r'${xyz}^k{x}_{k}{x}^{p}{y}^{p-2} {d}_{i}^{j}{b}_{j}{c}_{k}{d} {x}^{j}_{i}{E}^{0}{E}^0_u$',
     r'${\int}_x^x x\oint_x^x x\int_{X}^{X}x\int_x x \int^x x \int_{x} x\int^{x}{\int}_{x} x{\int}^{x}_{x}x$',
     r'testing$^{123}$',
-    ' '.join('$\\' + p + '$' for p in sorted(mathtext.Parser._snowflake)),
+    ' '.join('$\\' + p + '$' for p in sorted(mathtext.Parser._accentprefixed)),
     r'$6-2$; $-2$; $ -2$; ${-2}$; ${  -2}$; $20^{+3}_{-2}$',
     r'$\overline{\omega}^x \frac{1}{2}_0^x$',  # github issue #5444
     r'$,$ $.$ $1{,}234{, }567{ , }890$ and $1,234,567,890$',  # github issue 5799


### PR DESCRIPTION

## PR Summary

When I wrote this code ~4.5 years ago I was a bit cranky and used a
very sarcastic variable name (snowflake) to handle a class of special
cases when parsing math text.  It has recently come to light that this
name can make it into user visible error messages.  This renames the
variable to a less sarcastic and more descriptive variable name (it
handles the case of symbols who's names start with a valid accent; we
should parse it as the symbol, not an accent on the rest of the symbol
name).


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

