### PR TITLE
Prefer geomspace() to logspace().

### DIFF
--- a/examples/text_labels_and_annotations/custom_legends.py
+++ b/examples/text_labels_and_annotations/custom_legends.py
@@ -27,8 +27,7 @@ import numpy as np
 np.random.seed(19680801)
 
 N = 10
-data = np.transpose([np.logspace(0, 1, 100) + np.random.randn(100) + ii
-                     for ii in range(N)])
+data = (np.geomspace(1, 10, 100) + np.random.randn(N, 100)).T
 cmap = plt.cm.coolwarm
 rcParams['axes.prop_cycle'] = cycler(color=cmap(np.linspace(0, 1, N)))
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -968,7 +968,7 @@ class LogFormatter(Formatter):
             # Add labels between bases at log-spaced coefficients;
             # include base powers in case the locations include
             # "major" and "minor" points, as in colorbar.
-            c = np.logspace(0, 1, int(b)//2 + 1, base=b)
+            c = np.geomspace(1, b, int(b)//2 + 1)
             self._sublabels = set(np.round(c))
             # For base 10, this yields (1, 2, 3, 4, 6, 10).
         else:

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -634,7 +634,7 @@ class ColorbarBase(cm.ScalarMappable):
         """
         vmin, vmax = self._get_colorbar_limits()
         if isinstance(self.norm, colors.LogNorm):
-            y = np.logspace(np.log10(vmin), np.log10(vmax), N)
+            y = np.geomspace(vmin, vmax, N)
         else:
             y = np.linspace(vmin, vmax, N)
         return y

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -670,7 +670,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #   # Setup, and create the data to plot
 #   y = np.random.rand(100000)
 #   y[50000:] *= 2
-#   y[np.logspace(1, np.log10(50000), 400).astype(int)] = -1
+#   y[np.geomspace(10, 50000, 400).astype(int)] = -1
 #   mpl.rcParams['path.simplify'] = True
 #
 #   mpl.rcParams['path.simplify_threshold'] = 0.0
@@ -749,7 +749,7 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 #   # Setup, and create the data to plot
 #   y = np.random.rand(100000)
 #   y[50000:] *= 2
-#   y[np.logspace(1, np.log10(50000), 400).astype(int)] = -1
+#   y[np.geomspace(10, 50000, 400).astype(int)] = -1
 #   mpl.rcParams['path.simplify'] = True
 #
 #   mpl.rcParams['agg.path.chunksize'] = 0


### PR DESCRIPTION
geomspace() ("geometric progression from `a` to `b`") is, I think,
easier to read than logspace ("geometric progression from `10**a` to
`10**b`") -- see eg changes in ticker.py, colorbar.py.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
