### PR TITLE
Remove np.random.seed from tests that don't need it.

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -71,13 +71,9 @@ def test_marker_with_nan():
 
 
 def test_long_path():
-    buff = io.BytesIO()
-
     fig, ax = plt.subplots()
-    np.random.seed(0)
-    points = np.random.rand(70000)
-    ax.plot(points)
-    fig.savefig(buff, format='png')
+    ax.plot(np.random.rand(70000))
+    fig.savefig(io.BytesIO(), format='png')
 
 
 @image_comparison(['agg_filter.png'], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -121,7 +121,6 @@ def test_acorr(fig_test, fig_ref):
 
 @check_figures_equal(extensions=["png"])
 def test_spy(fig_test, fig_ref):
-    np.random.seed(19680801)
     a = np.ones(32 * 32)
     a[:16 * 32] = 0
     np.random.shuffle(a)
@@ -2872,7 +2871,6 @@ def test_manage_xticks():
     _, ax = plt.subplots()
     ax.set_xlim(0, 4)
     old_xlim = ax.get_xlim()
-    np.random.seed(0)
     y1 = np.random.normal(10, 3, 20)
     y2 = np.random.normal(3, 1, 20)
     ax.boxplot([y1, y2], positions=[1, 2], manage_ticks=False)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -273,7 +273,6 @@ def test_colorbar_ticks():
 
 def test_colorbar_minorticks_on_off():
     # test for github issue #11510 and PR #11584
-    np.random.seed(seed=12345)
     data = np.random.randn(20, 20)
     with rc_context({'_internal.classic_mode': False}):
         fig, ax = plt.subplots()
@@ -534,13 +533,11 @@ def test_colorbar_scale_reset():
 
 
 def test_colorbar_get_ticks_2():
-    with rc_context({'_internal.classic_mode': False}):
-
-        fig, ax = plt.subplots()
-        np.random.seed(19680801)
-        pc = ax.pcolormesh(np.random.rand(30, 30))
-        cb = fig.colorbar(pc)
-        np.testing.assert_allclose(cb.get_ticks(), [0.2, 0.4, 0.6, 0.8])
+    plt.rcParams["_internal.classic_mode"] = False
+    fig, ax = plt.subplots()
+    pc = ax.pcolormesh([[.05, .95]])
+    cb = fig.colorbar(pc)
+    np.testing.assert_allclose(cb.get_ticks(), [0.2, 0.4, 0.6, 0.8])
 
 
 def test_colorbar_inverted_ticks():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -599,7 +599,6 @@ def test_cmap_and_norm_from_levels_and_colors2():
 
 def test_rgb_hsv_round_trip():
     for a_shape in [(500, 500, 3), (500, 3), (1, 3), (3,)]:
-        np.random.seed(0)
         tt = np.random.random(a_shape)
         assert_array_almost_equal(
             tt, mcolors.hsv_to_rgb(mcolors.rgb_to_hsv(tt)))

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -125,7 +125,6 @@ def test_image_python_io():
 @check_figures_equal(extensions=['png'])
 def test_imshow_antialiased(fig_test, fig_ref,
                             img_size, fig_size, interpolation):
-    np.random.seed(19680801)
     dpi = plt.rcParams["savefig.dpi"]
     A = np.random.rand(int(dpi * img_size), int(dpi * img_size))
     for fig in [fig_test, fig_ref]:
@@ -141,7 +140,6 @@ def test_imshow_antialiased(fig_test, fig_ref,
 @check_figures_equal(extensions=['png'])
 def test_imshow_zoom(fig_test, fig_ref):
     # should be less than 3 upsample, so should be nearest...
-    np.random.seed(19680801)
     dpi = plt.rcParams["savefig.dpi"]
     A = np.random.rand(int(dpi * 3), int(dpi * 3))
     for fig in [fig_test, fig_ref]:
@@ -194,7 +192,7 @@ def test_imsave(fmt):
     # So we do the traditional case (dpi == 1), and the new case (dpi
     # == 100) and read the resulting PNG files back in and make sure
     # the data is 100% identical.
-    np.random.seed(1)
+
     # The height of 1856 pixels was selected because going through creating an
     # actual dpi=100 figure to save the image to a Pillow-provided format would
     # cause a rounding error resulting in a final image of shape 1855.
@@ -227,7 +225,6 @@ def test_imsave_color_alpha():
     # Test that imsave accept arrays with ndim=3 where the third dimension is
     # color and alpha without raising any exceptions, and that the data is
     # acceptably preserved through a save/read roundtrip.
-    np.random.seed(1)
 
     for origin in ['lower', 'upper']:
         data = np.random.rand(16, 16, 4)
@@ -699,7 +696,6 @@ def test_minimized_rasterized():
     # are the same size.
     from xml.etree import ElementTree
 
-    np.random.seed(0)
     data = np.random.rand(10, 10)
 
     fig, ax = plt.subplots(1, 2)

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -67,9 +67,7 @@ def test_invisible_Line_rendering():
 def test_set_line_coll_dash():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
-    np.random.seed(0)
-    # Testing setting linestyles for line collections.
-    # This should not produce an error.
+    # Setting linestyles for line collections should not error.
     ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -144,9 +144,7 @@ def _apply_window(*args, **kwargs):
 
 class TestWindow:
     def setup(self):
-        np.random.seed(0)
         n = 1000
-
         self.sig_rand = np.random.standard_normal(n) + 100.
         self.sig_ones = np.ones(n)
 
@@ -396,7 +394,6 @@ class TestWindow:
 
 class TestDetrend:
     def setup(self):
-        np.random.seed(0)
         n = 1000
         x = np.linspace(0., 100, n)
 
@@ -1529,17 +1526,12 @@ class TestGaussianKDE:
         np.testing.assert_array_almost_equal(y_expected, y2, decimal=7)
 
     def test_kde_bandwidth_method(self):
-
-        np.random.seed(8765678)
         n_basesample = 50
         xn = np.random.randn(n_basesample)
 
-        # Default
-        gkde = mlab.GaussianKDE(xn)
-        # Supply a callable
-        gkde2 = mlab.GaussianKDE(xn, 'scott')
-        # Supply a scalar
-        gkde3 = mlab.GaussianKDE(xn, bw_method=gkde.factor)
+        gkde = mlab.GaussianKDE(xn)  # Default
+        gkde2 = mlab.GaussianKDE(xn, 'scott')  # Supply a callable
+        gkde3 = mlab.GaussianKDE(xn, bw_method=gkde.factor)  # Supply a scalar
 
         xs = np.linspace(-7, 7, 51)
         kdepdf = gkde.evaluate(xs)
@@ -1592,8 +1584,7 @@ class TestGaussianKDECustom:
             mlab.GaussianKDE([], bw_method=5)
 
     def test_scalar_covariance_dataset(self):
-        """Test a scalar's cov factor."""
-        np.random.seed(8765678)
+        """Use a dataset and test a scalar's cov factor."""
         n_basesample = 50
         multidim_data = [np.random.randn(n_basesample) for i in range(5)]
 
@@ -1601,8 +1592,7 @@ class TestGaussianKDECustom:
         assert kde.covariance_factor() == 0.5
 
     def test_callable_covariance_dataset(self):
-        """Test the callable's cov factor for a multi-dimensional array."""
-        np.random.seed(8765678)
+        """Use a nD array as dataset and test the callable's cov factor."""
         n_basesample = 50
         multidim_data = [np.random.randn(n_basesample) for i in range(5)]
 
@@ -1613,7 +1603,6 @@ class TestGaussianKDECustom:
 
     def test_callable_singledim_dataset(self):
         """Test the callable's cov factor for a single-dimensional array."""
-        np.random.seed(8765678)
         n_basesample = 50
         multidim_data = np.random.randn(n_basesample)
 
@@ -1623,7 +1612,6 @@ class TestGaussianKDECustom:
 
     def test_wrong_bw_method(self):
         """Test the error message that should be called when bw is invalid."""
-        np.random.seed(8765678)
         n_basesample = 50
         data = np.random.randn(n_basesample)
         with pytest.raises(ValueError):
@@ -1651,7 +1639,6 @@ class TestGaussianKDEEvaluate:
         Invert the dimensions; i.e., for a dataset of dimension 1 [3, 2, 4],
         the points should have a dimension of 3 [[3], [2], [4]].
         """
-        np.random.seed(8765678)
         n_basesample = 50
         multidim_data = np.random.randn(n_basesample)
         kde = mlab.GaussianKDE(multidim_data)

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -147,7 +147,6 @@ def test_antiparallel_simplification():
 @pytest.mark.parametrize('offset', [0, .5])
 def test_angled_antiparallel(angle, offset):
     scale = 5
-    np.random.seed(19680801)
     # get 15 random offsets
     # TODO: guarantee offset > 0 results in some offsets < 0
     vert_offsets = (np.random.rand(15) - offset) * scale
@@ -184,8 +183,7 @@ def test_angled_antiparallel(angle, offset):
     p = Path(np.vstack([x, y]).T)
     p2 = p.cleaned(simplify=True)
 
-    assert_array_almost_equal(p_expected.vertices,
-                              p2.vertices)
+    assert_array_almost_equal(p_expected.vertices, p2.vertices)
     assert_array_equal(p_expected.codes, p2.codes)
 
 

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -60,13 +60,11 @@ def test_delaunay_duplicate_points():
     duplicate_of = 3
 
     np.random.seed(23)
-    x = np.random.random(npoints)
-    y = np.random.random(npoints)
-    x[duplicate] = x[duplicate_of]
-    y[duplicate] = y[duplicate_of]
+    xy = np.random.random((npoints, 2))
+    xy[duplicate] = xy[duplicate_of]
 
     # Create delaunay triangulation.
-    triang = mtri.Triangulation(x, y)
+    triang = mtri.Triangulation(*xy.T)
 
     # Duplicate points should be ignored, so the index of the duplicate points
     # should not appear in any triangle.


### PR DESCRIPTION
e.g. check_figures_equal tests should typically work regardless of
the random dataset used.  If anything this may slightly help catching
brittle tests that only work for certain seed values.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
