### PR TITLE
Use pytest.raises(match=...)

### DIFF
--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -44,9 +44,8 @@ def test_PsfontsMap(monkeypatch):
     entry = fontmap[b'TeXfont9']
     assert entry.filename == b'/absolute/font9.pfb'
     # Missing font
-    with pytest.raises(KeyError) as exc:
+    with pytest.raises(KeyError, match='no-such-font'):
         fontmap[b'no-such-font']
-    assert 'no-such-font' in str(exc.value)
 
 
 @pytest.mark.skipif(shutil.which("kpsewhich") is None,

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -254,9 +254,8 @@ def test_fontinfo():
 def test_mathtext_exceptions(math, msg):
     parser = mathtext.MathTextParser('agg')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=re.escape(msg)):
         parser.parse(math)
-    excinfo.match(re.escape(msg))
 
 
 def test_single_minus_sign():

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1033,74 +1033,82 @@ def test_internal_cpp_api():
     # Following github issue 8197.
 
     # C++ Triangulation.
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(
+            TypeError,
+            match=r'function takes exactly 7 arguments \(0 given\)'):
         mpl._tri.Triangulation()
-    excinfo.match(r'function takes exactly 7 arguments \(0 given\)')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError, match=r'x and y must be 1D arrays of the same length'):
         mpl._tri.Triangulation([], [1], [[]], None, None, None, False)
-    excinfo.match(r'x and y must be 1D arrays of the same length')
 
     x = [0, 1, 1]
     y = [0, 0, 1]
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError,
+            match=r'triangles must be a 2D array of shape \(\?,3\)'):
         mpl._tri.Triangulation(x, y, [[0, 1]], None, None, None, False)
-    excinfo.match(r'triangles must be a 2D array of shape \(\?,3\)')
 
     tris = [[0, 1, 2]]
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError,
+            match=r'mask must be a 1D array with the same length as the '
+                  r'triangles array'):
         mpl._tri.Triangulation(x, y, tris, [0, 1], None, None, False)
-    excinfo.match(r'mask must be a 1D array with the same length as the ' +
-                  r'triangles array')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError, match=r'edges must be a 2D array with shape \(\?,2\)'):
         mpl._tri.Triangulation(x, y, tris, None, [[1]], None, False)
-    excinfo.match(r'edges must be a 2D array with shape \(\?,2\)')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError,
+            match=r'neighbors must be a 2D array with the same shape as the '
+                  r'triangles array'):
         mpl._tri.Triangulation(x, y, tris, None, None, [[-1]], False)
-    excinfo.match(r'neighbors must be a 2D array with the same shape as the ' +
-                  r'triangles array')
 
     triang = mpl._tri.Triangulation(x, y, tris, None, None, None, False)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError,
+            match=r'z array must have same length as triangulation x and y '
+                  r'array'):
         triang.calculate_plane_coefficients([])
-    excinfo.match(r'z array must have same length as triangulation x and y ' +
-                  r'arrays')
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError,
+            match=r'mask must be a 1D array with the same length as the '
+                  r'triangles array'):
         triang.set_mask([0, 1])
-    excinfo.match(r'mask must be a 1D array with the same length as the ' +
-                  r'triangles array')
 
     # C++ TriContourGenerator.
-    with pytest.raises(TypeError) as excinfo:
-        tcg = mpl._tri.TriContourGenerator()
-    excinfo.match(r'function takes exactly 2 arguments \(0 given\)')
+    with pytest.raises(
+            TypeError,
+            match=r'function takes exactly 2 arguments \(0 given\)'):
+        mpl._tri.TriContourGenerator()
 
-    with pytest.raises(ValueError) as excinfo:
-        tcg = mpl._tri.TriContourGenerator(triang, [1])
-    excinfo.match(r'z must be a 1D array with the same length as the x and ' +
-                  r'y arrays')
+    with pytest.raises(
+            ValueError,
+            match=r'z must be a 1D array with the same length as the x and y '
+                  r'arrays'):
+        mpl._tri.TriContourGenerator(triang, [1])
 
     z = [0, 1, 2]
     tcg = mpl._tri.TriContourGenerator(triang, z)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError, match=r'filled contour levels must be increasing'):
         tcg.create_filled_contour(1, 0)
-    excinfo.match(r'filled contour levels must be increasing')
 
     # C++ TrapezoidMapTriFinder.
-    with pytest.raises(TypeError) as excinfo:
-        trifinder = mpl._tri.TrapezoidMapTriFinder()
-    excinfo.match(r'function takes exactly 1 argument \(0 given\)')
+    with pytest.raises(
+            TypeError, match=r'function takes exactly 1 argument \(0 given\)'):
+        mpl._tri.TrapezoidMapTriFinder()
 
     trifinder = mpl._tri.TrapezoidMapTriFinder(triang)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(
+            ValueError, match=r'x and y must be array-like with same shape'):
         trifinder.find_many([0], [0, 1])
-    excinfo.match(r'x and y must be array-like with same shape')
 
 
 def test_qhull_large_offset():

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -809,13 +809,11 @@ class TestVoxels:
             ax.voxels(x, y, z, filled=filled, **kw)
 
         # duplicate argument
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(TypeError, match='voxels'):
             ax.voxels(x, y, z, filled, filled=filled)
-        exc.match(".*voxels.*")
         # missing arguments
-        with pytest.raises(TypeError) as exc:
+        with pytest.raises(TypeError, match='voxels'):
             ax.voxels(x, y)
-        exc.match(".*voxels.*")
         # x, y, z are positional only - this passes them on as attributes of
         # Poly3DCollection
         with pytest.raises(AttributeError):


### PR DESCRIPTION
## PR Summary

`Use pytest.raises(match=...)` instead of catching the `excinfo` and matching on that.

I've checked that is is available in the minimal pytest version we require (3.6).

