### PR TITLE
Enable more font_manager tests to be run locally.

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -95,28 +95,24 @@ def test_hinting_factor(factor):
                                rtol=0.1)
 
 
-@pytest.mark.skipif(sys.platform != "win32",
-                    reason="Need Windows font to test against")
 def test_utf16m_sfnt():
-    segoe_ui_semibold = None
-    for f in fontManager.ttflist:
+    try:
         # seguisbi = Microsoft Segoe UI Semibold
-        if f.fname[-12:] == "seguisbi.ttf":
-            segoe_ui_semibold = f
-            break
+        entry = next(entry for entry in fontManager.ttflist
+                     if Path(entry.fname).name == "seguisbi.ttf")
+    except StopIteration:
+        pytest.skip("Couldn't find font to test against.")
     else:
-        pytest.xfail(reason="Couldn't find font to test against.")
-
-    # Check that we successfully read the "semibold" from the font's
-    # sfnt table and set its weight accordingly
-    assert segoe_ui_semibold.weight == "semibold"
+        # Check that we successfully read "semibold" from the font's sfnt table
+        # and set its weight accordingly.
+        assert entry.weight == "semibold"
 
 
-@pytest.mark.xfail(not (os.environ.get("TRAVIS") and sys.platform == "linux"),
-                   reason="Font may be missing.")
 def test_find_ttc():
     fp = FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(findfont(fp)).name != "wqy-zenhei.ttc":
+        if not os.environ.get("TRAVIS") or sys.platform != "linux":
+            pytest.skip("Font may be missing")
         # Travis appears to fail to pick up the ttc file sometimes.  Try to
         # rebuild the cache and try again.
         fm._rebuild()


### PR DESCRIPTION
- test_utf16m_sfnt can also be run on non-Windows, which may *still*
  have seguisbi.ttf installed.  In any case the test is skipped cleanly
  if the font is not present (I replaced the xfail by a skip for
  consistency with test_find_ttc, and in any case it's clearly a case of
  "the setup doesn't allow the test to be run", not "the test ran and
  failed").
- test_find_ttc can be run on non-Travis as long as the qwy-zenhei.ttc
  is present -- again, we just need to quit cleanly if it is not.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
