### PR TITLE
FIX: colorbar minorticks when rcParams['x/ytick.minor.visible'] = True

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -517,8 +517,12 @@ class ColorbarBase:
 
         if self.orientation == 'vertical':
             long_axis, short_axis = ax.yaxis, ax.xaxis
+            if mpl.rcParams['ytick.minor.visible']:
+                self.minorticks_on()
         else:
             long_axis, short_axis = ax.xaxis, ax.yaxis
+            if mpl.rcParams['xtick.minor.visible']:
+                self.minorticks_on()
 
         long_axis.set_label_position(self.ticklocation)
         long_axis.set_ticks_position(self.ticklocation)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -327,6 +327,34 @@ def test_colorbar_minorticks_on_off():
     np.testing.assert_equal(cbar.ax.yaxis.get_minorticklocs(), [])
 
 
+def test_cbar_minorticks_for_rc_xyminortickvisible():
+    """
+    issue gh-16468.
+
+    Making sure that minor ticks on the colorbar are turned on
+    (internally) using the cbar.minorticks_on() method when
+    rcParams['xtick.minor.visible'] = True (for horizontal cbar)
+    rcParams['ytick.minor.visible'] = True (for vertical cbar).
+    Using cbar.minorticks_on() ensures that the minor ticks
+    don't overflow into the extend regions of the colorbar.
+    """
+
+    plt.rcParams['ytick.minor.visible'] = True
+    plt.rcParams['xtick.minor.visible'] = True
+
+    vmin, vmax = 0.4, 2.6
+    fig, ax = plt.subplots()
+    im = ax.pcolormesh([[1, 2]], vmin=vmin, vmax=vmax)
+
+    cbar = fig.colorbar(im, extend='both', orientation='vertical')
+    assert cbar.ax.yaxis.get_minorticklocs()[0] >= vmin
+    assert cbar.ax.yaxis.get_minorticklocs()[-1] <= vmax
+
+    cbar = fig.colorbar(im, extend='both', orientation='horizontal')
+    assert cbar.ax.xaxis.get_minorticklocs()[0] >= vmin
+    assert cbar.ax.xaxis.get_minorticklocs()[-1] <= vmax
+
+
 def test_colorbar_autoticks():
     # Test new autotick modes. Needs to be classic because
     # non-classic doesn't go this route.


### PR DESCRIPTION
## PR Summary
closes #16468
## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
