### PR TITLE
Use vlines() and plot(), not stem(), in timeline example.

### DIFF
--- a/examples/lines_bars_and_markers/timeline.py
+++ b/examples/lines_bars_and_markers/timeline.py
@@ -53,10 +53,10 @@ except Exception:
     dates = [datetime.strptime(d, "%Y-%m-%d") for d in dates]
 
 ##############################################################################
-# Next, we'll create a `~.Axes.stem` plot with some variation in levels as to
-# distinguish even close-by events. In contrast to a usual stem plot, we will
-# shift the markers to the baseline for visual emphasis on the one-dimensional
-# nature of the time line.
+# Next, we'll create a stem plot with some variation in levels as to
+# distinguish even close-by events. We add markers on the baseline for visual
+# emphasis on the one-dimensional nature of the time line.
+#
 # For each event, we add a text label via `~.Axes.annotate`, which is offset
 # in units of points from the tip of the event line.
 #
@@ -71,13 +71,9 @@ levels = np.tile([-5, 5, -3, 3, -1, 1],
 fig, ax = plt.subplots(figsize=(8.8, 4), constrained_layout=True)
 ax.set(title="Matplotlib release dates")
 
-markerline, stemline, baseline = ax.stem(dates, levels,
-                                         linefmt="C3-", basefmt="k-")
-
-plt.setp(markerline, mec="k", mfc="w", zorder=3)
-
-# Shift the markers to the baseline by replacing the y-data by zeros.
-markerline.set_ydata(np.zeros(len(dates)))
+ax.vlines(dates, 0, levels, color="tab:red")  # The vertical stems.
+ax.plot(dates, np.zeros_like(dates), "-o",
+        color="k", markerfacecolor="w")  # Baseline and markers on it.
 
 # annotate lines
 for d, l, r in zip(dates, levels, names):
@@ -111,8 +107,8 @@ plt.show()
 # in this example:
 
 import matplotlib
-matplotlib.axes.Axes.stem
 matplotlib.axes.Axes.annotate
+matplotlib.axes.Axes.vlines
 matplotlib.axis.Axis.set_major_locator
 matplotlib.axis.Axis.set_major_formatter
 matplotlib.dates.MonthLocator


### PR DESCRIPTION
It's actually easier (IMO...) to achieve the desired result by
combining vlines() and plot() is actually much easier rather than by
using stem() and then fiddling with the artists.

(The visual result is unchanged.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
