### PR TITLE
Remove some APIs deprecated in mpl3.1.

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -80,6 +80,8 @@ Classes and methods
 - ``dates.minutes()`` (no replacement)
 - ``dates.hours()`` (no replacement)
 - ``dates.weeks()`` (no replacement)
+- ``dates.strpdate2num`` and ``dates.bytespdate2num`` (use `time.strptime` or
+  `dateutil.parser.parse` or `.dates.datestr2num` instead)
 
 - ``font_manager.OSXInstalledFonts()`` (no replacement)
 
@@ -150,6 +152,7 @@ rcParams
   :rc:`savefig.facecolor` to "none" to get a transparent background.
 - The ``pgf.debug``, ``verbose.fileo`` and ``verbose.verbose.level`` rcParams,
   which had no effect, have been removed.
+- Support for setting :rc:`mathtext.default` to "circled" has been removed.
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -915,8 +915,8 @@ Date related functions
 - ``dates.minutes()``
 - ``dates.hours()``
 - ``dates.weeks()``
-- `.dates.strpdate2num`
-- `.dates.bytespdate2num`
+- ``dates.strpdate2num``
+- ``dates.bytespdate2num``
 
 These are brittle in the presence of locale changes.  Use standard datetime
 parsers such as `time.strptime` or `dateutil.parser.parse`, and additionally

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -137,7 +137,6 @@ import functools
 import logging
 import math
 import re
-import time
 
 from dateutil.rrule import (rrule, MO, TU, WE, TH, FR, SA, SU, YEARLY,
                             MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY,
@@ -306,67 +305,6 @@ def _from_ordinalf(x, tz=None):
 
 # a version of _from_ordinalf that can operate on numpy arrays
 _from_ordinalf_np_vectorized = np.vectorize(_from_ordinalf, otypes="O")
-
-
-@cbook.deprecated(
-    "3.1", alternative="time.strptime or dateutil.parser.parse or datestr2num")
-class strpdate2num:
-    """
-    Use this class to parse date strings to matplotlib datenums when
-    you know the date format string of the date you are parsing.
-    """
-    def __init__(self, fmt):
-        """
-        Parameters
-        ----------
-        fmt : any valid strptime format
-        """
-        self.fmt = fmt
-
-    def __call__(self, s):
-        """
-        Parameters
-        ----------
-        s : str
-
-        Returns
-        -------
-        date2num float
-        """
-        return date2num(datetime.datetime(*time.strptime(s, self.fmt)[:6]))
-
-
-@cbook.deprecated(
-    "3.1", alternative="time.strptime or dateutil.parser.parse or datestr2num")
-class bytespdate2num(strpdate2num):
-    """
-    Use this class to parse date strings to matplotlib datenums when
-    you know the date format string of the date you are parsing.  See
-    :doc:`/gallery/misc/load_converter.py`.
-    """
-    def __init__(self, fmt, encoding='utf-8'):
-        """
-        Parameters
-        ----------
-        fmt : any valid strptime format
-        encoding : str
-            Encoding to use on byte input.
-        """
-        super().__init__(fmt)
-        self.encoding = encoding
-
-    def __call__(self, b):
-        """
-        Parameters
-        ----------
-        b : bytes
-
-        Returns
-        -------
-        date2num float
-        """
-        s = b.decode(self.encoding)
-        return super().__call__(s)
 
 
 # a version of dateutil.parser.parse that can operate on numpy arrays

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -16,7 +16,7 @@ from matplotlib.cbook import flatten, silent_list, iterable, dedent
 import matplotlib as mpl
 
 from matplotlib.dates import (
-    date2num, num2date, datestr2num, strpdate2num, drange, epoch2num,
+    date2num, num2date, datestr2num, drange, epoch2num,
     num2epoch, mx2num, DateFormatter, IndexDateFormatter, DateLocator,
     RRuleLocator, YearLocator, MonthLocator, WeekdayLocator, DayLocator,
     HourLocator, MinuteLocator, SecondLocator, rrule, MO, TU, WE, TH, FR,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -422,17 +422,8 @@ def validate_font_properties(s):
 validate_fontset = ValidateInStrings(
     'fontset',
     ['dejavusans', 'dejavuserif', 'cm', 'stix', 'stixsans', 'custom'])
-
-
-def validate_mathtext_default(s):
-    if s == "circled":
-        cbook.warn_deprecated(
-            "3.1", message="Support for setting the mathtext.default rcParam "
-            "to 'circled' is deprecated since %(since)s and will be removed "
-            "%(removal)s.")
-    return ValidateInStrings(
-        'default',
-        "rm cal it tt sf bf default bb frak circled scr regular".split())(s)
+validate_mathtext_default = ValidateInStrings(
+    'default', "rm cal it tt sf bf default bb frak scr regular".split())
 
 
 _validate_alignment = ValidateInStrings(


### PR DESCRIPTION
## PR Summary

A few things that were missed in https://github.com/matplotlib/matplotlib/pull/16204 & https://github.com/matplotlib/matplotlib/pull/16047 (given that @timhoffm already went through dates.py).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
