### PR TITLE
Don't forget to set stretch when exporting font as svg reference.

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1027,11 +1027,12 @@ class RendererSVG(RendererBase):
             font.set_text(s, 0.0, flags=LOAD_NO_HINTING)
 
             attrib = {}
+            style['font-family'] = str(font.family_name)
+            style['font-weight'] = str(prop.get_weight()).lower()
+            style['font-stretch'] = str(prop.get_stretch()).lower()
+            style['font-style'] = prop.get_style().lower()
             # Must add "px" to workaround a Firefox bug
             style['font-size'] = short_float_fmt(prop.get_size()) + 'px'
-            style['font-family'] = str(font.family_name)
-            style['font-style'] = prop.get_style().lower()
-            style['font-weight'] = str(prop.get_weight()).lower()
             attrib['style'] = generate_css(style)
 
             if mtext and (angle == 0 or mtext.get_rotation_mode() == "anchor"):

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -141,6 +141,8 @@ def test_svgnone_with_data_coordinates():
         buf = fd.read().decode()
 
     assert expected in buf
+    for prop in ["family", "weight", "stretch", "style", "size"]:
+        assert f"font-{prop}:" in buf
 
 
 def test_gid():


### PR DESCRIPTION
Also reordered properties to match the css standard
https://drafts.csswg.org/css-fonts-3/#basic-font-props

Closes #16479.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
