### PR TITLE
Simplify validate_color_for_prop_cycle.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -101,3 +101,8 @@ deprecation warning.
 Previously setting the *ecolor* would turn off automatic color cycling for the plot, leading to the 
 the lines and markers defaulting to whatever the first color in the color cycle was in the case of 
 multiple plot calls. 
+
+`.rcsetup.validate_color_for_prop_cycle` now always raises TypeError for bytes input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It previously raised `TypeError`, **except** when the input was of the form
+``b"C[number]"`` in which case it raised a ValueError.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -322,18 +322,9 @@ def validate_color_or_auto(s):
 
 
 def validate_color_for_prop_cycle(s):
-    # Special-case the N-th color cycle syntax, this obviously can not
-    # go in the color cycle.
-    if isinstance(s, bytes):
-        match = re.match(b'^C[0-9]$', s)
-        if match is not None:
-            raise ValueError('Can not put cycle reference ({cn!r}) in '
-                             'prop_cycler'.format(cn=s))
-    elif isinstance(s, str):
-        match = re.match('^C[0-9]$', s)
-        if match is not None:
-            raise ValueError('Can not put cycle reference ({cn!r}) in '
-                             'prop_cycler'.format(cn=s))
+    # N-th color cycle syntax can't go into the color cycle.
+    if isinstance(s, str) and re.match("^C[0-9]$", s):
+        raise ValueError(f"Cannot put cycle reference ({s!r}) in prop_cycler")
     return validate_color(s)
 
 


### PR DESCRIPTION
No need to special case bytes -- validate_colors is going to raise a
TypeError on bytes input anyways (_is_nth_color checks that the input is
str as well).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
