### PR TITLE
Simplify validate_color, and make it slightly stricter.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -78,3 +78,10 @@ instead.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This creates the stem plot as a `.LineCollection` rather than individual
 `.Line2D` objects, greatly improving performance.
+
+rcParams color validator is now stricter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, rcParams entries whose values were color-like accepted "spurious"
+extra letters or characters in the "middle" of the string, e.g. ``"(0, 1a, '0.5')"``
+would be interpreted as ``(0, 1, 0.5)``.  These extra characters (including the
+internal quotes) now cause a ValueError to be raised.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -326,13 +326,9 @@ def validate_color_for_prop_cycle(s):
 
 def validate_color(s):
     """Return a valid color arg."""
-    try:
+    if isinstance(s, str):
         if s.lower() == 'none':
             return 'none'
-    except AttributeError:
-        pass
-
-    if isinstance(s, str):
         if len(s) == 6 or len(s) == 8:
             stmp = '#' + s
             if is_color_like(stmp):
@@ -341,25 +337,16 @@ def validate_color(s):
     if is_color_like(s):
         return s
 
-    # If it is still valid, it must be a tuple.
-    colorarg = s
-    msg = ''
-    if s.find(',') >= 0:
-        # get rid of grouping symbols
-        stmp = ''.join([c for c in s if c.isdigit() or c == '.' or c == ','])
-        vals = stmp.split(',')
-        if len(vals) not in [3, 4]:
-            msg = '\nColor tuples must be of length 3 or 4'
-        else:
-            try:
-                colorarg = [float(val) for val in vals]
-            except ValueError:
-                msg = '\nCould not convert all entries to floats'
+    # If it is still valid, it must be a tuple (as a string from matplotlibrc).
+    try:
+        color = ast.literal_eval(s)
+    except (SyntaxError, ValueError):
+        pass
+    else:
+        if is_color_like(color):
+            return color
 
-    if not msg and is_color_like(colorarg):
-        return colorarg
-
-    raise ValueError('%s does not look like a color arg%s' % (s, msg))
+    raise ValueError(f'{s!r} does not look like a color arg')
 
 
 validate_colorlist = _listify_validator(

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -310,16 +310,16 @@ def generate_validator_testcases(valid):
                      ('AABBCC00', '#AABBCC00'),  # RGBA hex code
                      ('tab:blue', 'tab:blue'),  # named color
                      ('C12', 'C12'),  # color from cycle
-                     ('(0, 1, 0)', [0.0, 1.0, 0.0]),  # RGB tuple
+                     ('(0, 1, 0)', (0.0, 1.0, 0.0)),  # RGB tuple
                      ((0, 1, 0), (0, 1, 0)),  # non-string version
-                     ('(0, 1, 0, 1)', [0.0, 1.0, 0.0, 1.0]),  # RGBA tuple
+                     ('(0, 1, 0, 1)', (0.0, 1.0, 0.0, 1.0)),  # RGBA tuple
                      ((0, 1, 0, 1), (0, 1, 0, 1)),  # non-string version
-                     ('(0, 1, "0.5")', [0.0, 1.0, 0.5]),  # unusual but valid
                      ),
          'fail': (('tab:veryblue', ValueError),  # invalid name
                   ('(0, 1)', ValueError),  # tuple with length < 3
                   ('(0, 1, 0, 1, 0)', ValueError),  # tuple with length > 4
                   ('(0, 1, none)', ValueError),  # cannot cast none to float
+                  ('(0, 1, "0.5")', ValueError),  # last one not a float
                   ),
          },
         {'validator': validate_hist_bins,


### PR DESCRIPTION
Previously, validate_color would accept nonsensical strings such as
`".a2,.2f4,.6"` by dropping the letters and just reading the rest (i.e.
`(0.2, 0.24, 0.6)`.  Reject such inputs now, and make the parsing much
simpler (it's just ast.literal_eval).

The only vaguely reasonable string that was accepted and that is not
accepted anymore is (e.g.) `'(0, 1, "0.5")'` (the quotes would be
dropped), i.e. one could write `rcParams["lines.color"] = '(0, 1, "0.5")'`.
I think this can also be dropped given that the corresponding
`rcParams["lines.color"] = (0, 1, "0.5")` (passing in the tuple
directly) didn't work...

I added a changelog entry just to be safe, but it's the kind of entry
that's probably just going to confuse everyone with no real benefit...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
