### PR TITLE
DOC: suppress warning on pcolor demo

### DIFF
--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -96,11 +96,11 @@ Z = Z1 + 50 * Z2
 
 fig, (ax0, ax1) = plt.subplots(2, 1)
 
-c = ax0.pcolor(X, Y, Z,
+c = ax0.pcolor(X, Y, Z, shading='auto',
                norm=LogNorm(vmin=Z.min(), vmax=Z.max()), cmap='PuBu_r')
 fig.colorbar(c, ax=ax0)
 
-c = ax1.pcolor(X, Y, Z, cmap='PuBu_r')
+c = ax1.pcolor(X, Y, Z, cmap='PuBu_r', shading='auto')
 fig.colorbar(c, ax=ax1)
 
 plt.show()


### PR DESCRIPTION
## PR Summary

Closes #16493

With the new pcolor change we get warning is if pcolor  x, y, Z are all the same size.  This is one instance where that is the case, so suppress..



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
