### PR TITLE
Add custom math fallback [WIP]

### DIFF
--- a/doc/users/next_whats_new/2020-02-24-mathtext-fallback.rst
+++ b/doc/users/next_whats_new/2020-02-24-mathtext-fallback.rst
@@ -1,0 +1,5 @@
+Add generalized "mathtext.fallback" rcParam
+------------------------------------------------------------------------
+New  "mathtext.fallback" rcParam. Takes "cm", "stix", "stixsans"
+or "none" to turn fallback off. "mathtext.fallback_to_cm" is
+deprecated, but if used, will override new fallback.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -602,6 +602,7 @@ _deprecated_ignore_map = {
 _deprecated_remain_as_none = {
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
+    'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
 }
 

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -154,9 +154,10 @@ mathtext.bf  : serif:bold
 mathtext.sf  : sans\-serif
 mathtext.fontset : cm # Should be 'cm' (Computer Modern), 'stix',
                       # 'stixsans' or 'custom'
-mathtext.fallback_to_cm : True  # When True, use symbols from the Computer Modern
-                                # fonts when a symbol can not be found in one of
-                                # the custom math fonts.
+mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
+                       # 'stixsans'] when a symbol can not be found in one of the 
+                       # custom math fonts. Select 'None' to not perform fallback
+                       # and replace the missing character by a dummy.
 
 mathtext.default : it # The default font to use for math.
                       # Can be any of the LaTeX font names, including

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -413,6 +413,37 @@ def validate_font_properties(s):
     return s
 
 
+def _validate_mathtext_fallback_to_cm(b):
+    """
+    Temporary validate for fallback_to_cm, while deprecated
+
+    """
+    if isinstance(b, str):
+        b = b.lower()
+    if b is None or b == 'none':
+        return None
+    else:
+        cbook.warn_deprecated(
+            "3.3", message="Support for setting the 'mathtext.fallback_to_cm' rcParam "
+            "is deprecated since %(since)s and will be removed "
+            "%(removal)s; use 'mathtext.fallback : 'cm' instead.")
+        return validate_bool_maybe_none(b)
+
+
+def _validate_mathtext_fallback(s):
+    _fallback_fonts = ['cm', 'stix', 'stixsans']
+    if isinstance(s, str):
+        s = s.lower()
+    if s is None or s == 'none':
+        return None
+    elif s.lower() in _fallback_fonts:
+        return s
+    else:
+        raise ValueError(f"{s} is not a valid fallback font name. Valid fallback "
+                         f"font names are {','.join(_fallback_fonts)}. Passing "
+                         f"'None' will turn fallback off.")
+
+
 validate_fontset = ValidateInStrings(
     'fontset',
     ['dejavusans', 'dejavuserif', 'cm', 'stix', 'stixsans', 'custom'],
@@ -1150,7 +1181,8 @@ defaultParams = {
     'mathtext.default':        [
         'it',
         ['rm', 'cal', 'it', 'tt', 'sf', 'bf', 'default', 'bb', 'frak', 'scr', 'regular']],
-    'mathtext.fallback_to_cm': [True, validate_bool],
+    'mathtext.fallback_to_cm': [None, _validate_mathtext_fallback_to_cm],
+    'mathtext.fallback':       ['cm', _validate_mathtext_fallback],
 
     'image.aspect':        ['equal', validate_aspect],  # equal, auto, a number
     'image.interpolation': ['antialiased', validate_string],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -329,9 +329,10 @@
 #mathtext.rm:  sans
 #mathtext.sf:  sans
 #mathtext.tt:  monospace
-#mathtext.fallback_to_cm: True  # When True, use symbols from the Computer Modern
-                                # fonts when a symbol can not be found in one of
-                                # the custom math fonts.
+#mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
+                        # 'stixsans'] when a symbol can not be found in one of the 
+                        # custom math fonts. Select 'None' to not perform fallback
+                        # and replace the missing character by a dummy symbol.
 #mathtext.default: it  # The default font to use for math.
                        # Can be any of the LaTeX font names, including
                        # the special name "regular" for the same font

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -296,8 +296,9 @@ yet-to-be-written font chapter).
 The fonts used should have a Unicode mapping in order to find any
 non-Latin characters, such as Greek.  If you want to use a math symbol
 that is not contained in your custom fonts, you can set
-:rc:`mathtext.fallback_to_cm` to ``True`` which will cause the mathtext system
-to use characters from the default Computer Modern fonts whenever a particular
+:rc:`mathtext.fallback` to either ``'cm'``, ``'stix'`` or ``'stixsans'``
+which will cause the mathtext system to use
+characters from an alternative font whenever a particular
 character can not be found in the custom font.
 
 Note that the math glyphs specified in Unicode have evolved over time, and many


### PR DESCRIPTION
## PR Summary

Follow-up on #11644

I've switched the logic so it's more transparent when `mathtext.fallback` is by default 'cm' . The original `mathtext.fallback_to_cm` defaults to `None`, but either `True` or` False` will raise a warning  and override the `mathtext.fallback`  setting.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

