### PR TITLE
Fix a bunch of random typos.

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -163,4 +163,4 @@ mathtext
 - The ``\stackrel`` command (which behaved differently from its LaTeX version)
   has been removed.  Use ``\genfrac`` instead.
 - The ``\mathcircled`` command has been removed.  Directly use Unicode
-  characters, such as ``'\N{CIRCLED LATIN CAPITAL LETTER A}``, instead.
+  characters, such as ``'\N{CIRCLED LATIN CAPITAL LETTER A}'``, instead.

--- a/doc/users/next_whats_new/2019-12-20-set_xy_position
+++ b/doc/users/next_whats_new/2019-12-20-set_xy_position
@@ -2,6 +2,6 @@ Align labels to axes edges
 --------------------------
 `~.axes.Axes.set_xlabel`, `~.axes.Axes.set_ylabel` and `ColorbarBase.set_label`
 support a parameter ``loc`` for simplified positioning. Supported values are
-'left', 'center', 'right' The default is controlled via :rc:`xaxis.labelposition`
-and :rc:`yaxis.labelposition`; the Colorbar label takes the rcParam based on its
-orientation.
+'left', 'center', or 'right'. The default is controlled via
+:rc:`xaxis.labelposition` and :rc:`yaxis.labelposition`; the Colorbar label
+takes the rcParam based on its orientation.

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -24,8 +24,8 @@ import numpy as np
 # ------------
 #
 # The grid specification with the least assumptions is ``shading='flat'``
-# and if the grid is one larger than the data in each dimesion, i.e. has shape
-# *(M+1, N+1)*.  In that case *X* and *Y* sepcify the corners of quadrilaterals
+# and if the grid is one larger than the data in each dimension, i.e. has shape
+# *(M+1, N+1)*.  In that case *X* and *Y* specify the corners of quadrilaterals
 # that are colored with the values in *Z*. Here we specify the edges of the
 # *(3, 5)* quadrilaterals with *X* and *Y* that  are *(4, 6)*.
 
@@ -71,8 +71,8 @@ _annotate(ax, x, y, "shading='flat': X, Y, C same shape")
 # --------------------------------
 #
 # Usually, dropping a row and column of data is not what the user means when
-# the make *X*, *Y* and *Z* all the same shape.  For this case, Matplotlib
-# allows ``shading='nearest'`` and centers the colored qudrilaterals on the
+# they make *X*, *Y* and *Z* all the same shape.  For this case, Matplotlib
+# allows ``shading='nearest'`` and centers the colored quadrilaterals on the
 # grid points.
 #
 # If a grid that is not the correct shape is passed with ``shading='nearest'``
@@ -86,9 +86,9 @@ _annotate(ax, x, y, "shading='nearest'")
 # Auto Shading
 # ------------
 #
-# Its possible that the user would like the code to automatically choose
-# which to use, in which case ``shading='auto'`` will decide whether to
-# use 'flat' or 'nearest' shading based on the shapes of *X*, *Y* and *Z*.
+# It's possible that the user would like the code to automatically choose which
+# to use, in this case ``shading='auto'`` will decide whether to use 'flat' or
+# 'nearest' shading based on the shapes of *X*, *Y* and *Z*.
 
 fig, axs = plt.subplots(2, 1, constrained_layout=True)
 ax = axs[0]
@@ -108,9 +108,8 @@ _annotate(ax, x, y, "shading='auto'; X, Y one larger than Z (flat)")
 # ---------------
 #
 # `Gouraud shading <https://en.wikipedia.org/wiki/Gouraud_shading>`_ can also
-# be specified, where the colour in the quadrilaterals is linearly
-# interpolated between the grid points.  The shapes of *X*, *Y*, *Z* must
-# be the same.
+# be specified, where the color in the quadrilaterals is linearly interpolated
+# between the grid points.  The shapes of *X*, *Y*, *Z* must be the same.
 
 fig, ax = plt.subplots(constrained_layout=True)
 x = np.arange(ncols)

--- a/examples/misc/cursor_demo.py
+++ b/examples/misc/cursor_demo.py
@@ -168,7 +168,7 @@ class SnappingCursor:
     A cross hair cursor that snaps to the data point of a line, which is
     closest to the *x* position of the cursor.
 
-    For simplicity, this assumes that *x* values of the data is sorted.
+    For simplicity, this assumes that *x* values of the data are sorted.
     """
     def __init__(self, ax, line):
         self.ax = ax

--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -25,7 +25,7 @@ def line_select_callback(eclick, erelease):
     x1, y1 = eclick.xdata, eclick.ydata
     x2, y2 = erelease.xdata, erelease.ydata
     print(f"({x1:3.2f}, {y1:3.2f}) --> ({x2:3.2f}, {y2:3.2f})")
-    print(" The button you used were: {eclick.button} {erelease.button}")
+    print(f" The buttons you used were: {eclick.button} {erelease.button}")
 
 
 def toggle_selector(event):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -204,7 +204,7 @@ class Axes(_AxesBase):
 
         loc : {'left', 'center', 'right'}, default: :rc:`xaxis.labellocation`
             The label position. This is a high-level alternative for passing
-            parameters *x* and *horizonatalalignment*.
+            parameters *x* and *horizontalalignment*.
 
         Other Parameters
         ----------------
@@ -213,7 +213,7 @@ class Axes(_AxesBase):
 
         See also
         --------
-        text : for information on how override and the optional args work
+        text : for information on how override and the optional arguments work
         """
         if labelpad is not None:
             self.xaxis.labelpad = labelpad
@@ -221,8 +221,9 @@ class Axes(_AxesBase):
         if {*kwargs} & {*protected_kw}:
             if loc is not None:
                 raise TypeError(f"Specifying 'loc' is disallowed when any of "
-                                f"its corresponding low level kwargs "
-                                f"({protected_kw}) are supplied as well")
+                                f"its corresponding low level keyword "
+                                f"arguments ({protected_kw}) are also "
+                                f"supplied")
             loc = 'center'
         else:
             loc = loc if loc is not None else rcParams['xaxis.labellocation']
@@ -256,7 +257,7 @@ class Axes(_AxesBase):
 
         loc : {'bottom', 'center', 'top'}, default: :rc:`yaxis.labellocation`
             The label position. This is a high-level alternative for passing
-            parameters *y* and *horizonatalalignment*.
+            parameters *y* and *horizontalalignment*.
 
         Other Parameters
         ----------------
@@ -265,8 +266,7 @@ class Axes(_AxesBase):
 
         See also
         --------
-        text : for information on how override and the optional args work
-
+        text : for information on how override and the optional arguments work
         """
         if labelpad is not None:
             self.yaxis.labelpad = labelpad
@@ -274,8 +274,9 @@ class Axes(_AxesBase):
         if {*kwargs} & {*protected_kw}:
             if loc is not None:
                 raise TypeError(f"Specifying 'loc' is disallowed when any of "
-                                f"its corresponding low level kwargs "
-                                f"({protected_kw}) are supplied as well")
+                                f"its corresponding low level keyword "
+                                f"arguments ({protected_kw}) are also "
+                                f"supplied")
             loc = 'center'
         else:
             loc = loc if loc is not None else rcParams['yaxis.labellocation']
@@ -5780,7 +5781,7 @@ default: :rc:`scatter.edgecolors`
 
         shading : {'flat', 'nearest', 'auto'}, optional
             The fill style for the quadrilateral; defaults to 'flat' or
-            ':rc:`pcolor.shading`. Possible values:
+            :rc:`pcolor.shading`. Possible values:
 
             - 'flat': A solid color is used for each quad. The color of the
               quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
@@ -6060,7 +6061,7 @@ default: :rc:`scatter.edgecolors`
 
         shading : {'flat', 'nearest', 'gouraud', 'auto'}, optional
             The fill style for the quadrilateral; defaults to
-            'flat' or ':rc:`pcolor.shading`. Possible values:
+            'flat' or :rc:`pcolor.shading`. Possible values:
 
             - 'flat': A solid color is used for each quad. The color of the
               quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
@@ -6076,7 +6077,7 @@ default: :rc:`scatter.edgecolors`
               the area in between is interpolated from the corner values.
               The dimensions of *X* and *Y* must be the same as *C*. When
               Gouraud shading is used, *edgecolors* is ignored.
-            - 'auto': Choose 'flat' if diemnsions of *X* and *Y* are one
+            - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
               larger than *C*.  Choose 'nearest' if dimensions are the same.
 
             See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -754,9 +754,9 @@ class ColorbarBase:
         _protected_kw = [_pos_xy, 'horizontalalignment', 'ha']
         if any([k in kwargs for k in _protected_kw]):
             if loc is not None:
-                raise TypeError('Specifying *loc* is disallowed when any of '
-                               'its corresponding low level kwargs {} '
-                               'are supplied as well.'.format(_protected_kw))
+                raise TypeError(f'Specifying *loc* is disallowed when any of '
+                                f'its corresponding low level keyword '
+                                f'arguments {_protected_kw} are also supplied')
             loc = 'center'
         else:
             if loc is None:

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -121,8 +121,8 @@ lowergreek = ("\\alpha \\beta \\gamma \\delta \\epsilon \\zeta \\eta \\theta \\i
 all = [digits, uppercase, lowercase, uppergreek, lowergreek]
 
 # Use stubs to reserve space if tests are removed
-# stub should be of the form (None, N) where is the number of
-# strings that used to be tested
+# stub should be of the form (None, N) where N is the number of strings that
+# used to be tested
 # Add new tests at the end.
 font_test_specs = [
     ([], all),

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -408,10 +408,10 @@
 #axes3d.grid    : True  # display grid on 3d axes
 
 ## ***************************************************************************
-## * AXIS                                                      *
+## * AXIS                                                                    *
 ## ***************************************************************************
-#xaxis.labellocation : center  ## alignment of the xaxis label: {left, right, center}
-#yaxis.labellocation : center  ## alignment of the yaxis label: {bottom, top, center}
+#xaxis.labellocation : center  # alignment of the xaxis label: {left, right, center}
+#yaxis.labellocation : center  # alignment of the yaxis label: {bottom, top, center}
 
 
 ## ***************************************************************************

--- a/tutorials/advanced/patheffects_guide.py
+++ b/tutorials/advanced/patheffects_guide.py
@@ -12,11 +12,11 @@ multiple draw stage to any Artist which can be rendered via a `.path.Path`.
 
 Artists which can have a path effect applied to them include `.patches.Patch`,
 `.lines.Line2D`, `.collections.Collection` and even `.text.Text`. Each artist's
-path effects can be controlled via the `.Artist.set_path_effects` method ,
+path effects can be controlled via the `.Artist.set_path_effects` method,
 which takes an iterable of `AbstractPathEffect` instances.
 
-The simplest path effect is the `Normal` effect, which simply
-draws the artist without any effect:
+The simplest path effect is the `Normal` effect, which simply draws the artist
+without any effect:
 """
 
 import matplotlib.pyplot as plt
@@ -31,7 +31,7 @@ plt.show()
 
 ###############################################################################
 # Whilst the plot doesn't look any different to what you would expect without
-# any path effects, the drawing of the text now been changed to use the
+# any path effects, the drawing of the text has now been changed to use the
 # path effects framework, opening up the possibilities for more interesting
 # examples.
 #

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -339,7 +339,7 @@ plt.show()
 # ================ ============================================================
 # axes             A list of Axes instances (includes Subplot)
 # patch            The Rectangle background
-# images           A list of FigureImages patches -
+# images           A list of FigureImage patches -
 #                  useful for raw pixel display
 # legends          A list of Figure Legend instances
 #                  (different from Axes.legends)

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -64,9 +64,9 @@ f2_ax4 = fig2.add_subplot(spec2[1, 1])
 
 #############################################################################
 # The power of gridspec comes in being able to create subplots that span
-# rows and columns.  Note the `Numpy slice
+# rows and columns.  Note the `NumPy slice syntax
 # <https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html>`_
-# syntax for selecting the part of the gridspec each subplot will occupy.
+# for selecting the part of the gridspec each subplot will occupy.
 #
 # Note that we have also used the convenience method `.Figure.add_gridspec`
 # instead of `.gridspec.GridSpec`, potentially saving the user an import,


### PR DESCRIPTION
## PR Summary

I'm going through old PR notifications, and just fixing some typos I noticed.

It should be all documentation (no behaviour changes), except the one example, which adds a missing f-string.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way