### PR TITLE
Avoid single_path_optimization if offsets are non-zero

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -350,7 +350,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         # (https://github.com/matplotlib/matplotlib/issues/16496)
         # This should be fixed eventually, but for now don't use the optimized
         # code path if some of the offsets are non-zero
-        if not np.all(offsets == 0) and self._offset_position == 'data':
+        if np.any(offsets != 0) and self._offset_position == 'data':
             do_single_path_optimization = False
 
         if self._joinstyle:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -345,6 +345,14 @@ class Collection(artist.Artist, cm.ScalarMappable):
                     and extents.height < self.figure.bbox.height):
                 do_single_path_optimization = True
 
+        # The single path optimization code path is currently broken when
+        # offsets are specified
+        # (https://github.com/matplotlib/matplotlib/issues/16496)
+        # This should be fixed eventually, but for now don't use the optimized
+        # code path if some of the offsets are non-zero
+        if not np.all(offsets == 0) and self._offset_position == 'data':
+            do_single_path_optimization = False
+
         if self._joinstyle:
             gc.set_joinstyle(self._joinstyle)
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
 import matplotlib.transforms as mtransforms
 from matplotlib.collections import Collection, LineCollection, EventCollection
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
 def generate_EventCollection_plot():
@@ -612,3 +612,25 @@ def test_EventCollection_nosort():
     arr = np.array([3, 2, 1, 10])
     coll = EventCollection(arr)
     np.testing.assert_array_equal(arr, np.array([3, 2, 1, 10]))
+
+
+@check_figures_equal()
+def test_collection_offset(fig_test, fig_ref):
+    polygon = np.array([[-1, -1], [-1, 1], [1, 1], [1, -1]]) * 0.1
+    offsets = np.array([2, 2])
+
+    # Add the collection off the edge of the axes, so if offsets is applied
+    # correctly it is not within the axes bounds
+    ax = fig_test.subplots()
+    # edgecolors and linewidths must be set to trigger the right code path
+    collection = mcollections.PolyCollection(
+        [polygon],
+        edgecolors='face',
+        linewidths=[1],
+        offsets=offsets,
+        transOffset=mtransforms.IdentityTransform(),
+        offset_position="data")
+    ax.add_collection(collection)
+
+    # Create an empty figure
+    ax = fig_ref.subplots()


### PR DESCRIPTION
This is a stopgap to fix #16461 - I am guessing this is made redundant by https://github.com/matplotlib/matplotlib/pull/13696, but is a simpler fix and probably easier to get into 3.2.0.