### PR TITLE
Cleanup docstrings

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -38,44 +38,44 @@ _views_positions = 'viewpos'
 
 class ToolBase:
     """
-    Base tool class
+    Base tool class.
 
     A base tool, only implements `trigger` method or not method at all.
-    The tool is instantiated by `matplotlib.backend_managers.ToolManager`
+    The tool is instantiated by `matplotlib.backend_managers.ToolManager`.
 
     Attributes
     ----------
     toolmanager : `matplotlib.backend_managers.ToolManager`
-        ToolManager that controls this Tool
+        ToolManager that controls this Tool.
     figure : `FigureCanvas`
-        Figure instance that is affected by this Tool
+        Figure instance that is affected by this Tool.
     name : str
         Used as **Id** of the tool, has to be unique among tools of the same
-        ToolManager
+        ToolManager.
     """
 
     default_keymap = None
     """
-    Keymap to associate with this tool
+    Keymap to associate with this tool.
 
     **String**: List of comma separated keys that will be used to call this
-    tool when the keypress event of ``self.figure.canvas`` is emitted
+    tool when the keypress event of ``self.figure.canvas`` is emitted.
     """
 
     description = None
     """
-    Description of the Tool
+    Description of the Tool.
 
     **String**: If the Tool is included in the Toolbar this text is used
-    as a Tooltip
+    as a Tooltip.
     """
 
     image = None
     """
-    Filename of the image
+    Filename of the image.
 
     **String**: Filename of the image to use in the toolbar. If None, the
-    *name* is used as a label in the toolbar button
+    *name* is used as a label in the toolbar button.
     """
 
     def __init__(self, toolmanager, name):
@@ -115,7 +115,7 @@ class ToolBase:
 
     def set_figure(self, figure):
         """
-        Assign a figure to the tool
+        Assign a figure to the tool.
 
         Parameters
         ----------
@@ -125,71 +125,71 @@ class ToolBase:
 
     def trigger(self, sender, event, data=None):
         """
-        Called when this tool gets used
+        Called when this tool gets used.
 
         This method is called by
-        `matplotlib.backend_managers.ToolManager.trigger_tool`
+        `matplotlib.backend_managers.ToolManager.trigger_tool`.
 
         Parameters
         ----------
         event : `.Event`
-            The Canvas event that caused this tool to be called
+            The canvas event that caused this tool to be called.
         sender : object
-            Object that requested the tool to be triggered
+            Object that requested the tool to be triggered.
         data : object
-            Extra data
+            Extra data.
         """
         pass
 
     @property
     def name(self):
-        """Tool Id"""
+        """Tool Id."""
         return self._name
 
     def destroy(self):
         """
-        Destroy the tool
+        Destroy the tool.
 
         This method is called when the tool is removed by
-        `matplotlib.backend_managers.ToolManager.remove_tool`
+        `matplotlib.backend_managers.ToolManager.remove_tool`.
         """
         pass
 
 
 class ToolToggleBase(ToolBase):
     """
-    Toggleable tool
+    Toggleable tool.
 
-    Every time it is triggered, it switches between enable and disable
+    Every time it is triggered, it switches between enable and disable.
 
     Parameters
     ----------
     ``*args``
-        Variable length argument to be used by the Tool
+        Variable length argument to be used by the Tool.
     ``**kwargs``
         `toggled` if present and True, sets the initial state of the Tool
         Arbitrary keyword arguments to be consumed by the Tool
     """
 
     radio_group = None
-    """Attribute to group 'radio' like tools (mutually exclusive)
+    """Attribute to group 'radio' like tools (mutually exclusive).
 
     **String** that identifies the group or **None** if not belonging to a
-    group
+    group.
     """
 
     cursor = None
-    """Cursor to use when the tool is active"""
+    """Cursor to use when the tool is active."""
 
     default_toggled = False
-    """Default of toggled state"""
+    """Default of toggled state."""
 
     def __init__(self, *args, **kwargs):
         self._toggled = kwargs.pop('toggled', self.default_toggled)
         ToolBase.__init__(self, *args, **kwargs)
 
     def trigger(self, sender, event, data=None):
-        """Calls `enable` or `disable` based on `toggled` value"""
+        """Calls `enable` or `disable` based on `toggled` value."""
         if self._toggled:
             self.disable(event)
         else:
@@ -198,30 +198,30 @@ class ToolToggleBase(ToolBase):
 
     def enable(self, event=None):
         """
-        Enable the toggle tool
+        Enable the toggle tool.
 
-        `trigger` calls this method when `toggled` is False
+        `trigger` calls this method when `toggled` is False.
         """
         pass
 
     def disable(self, event=None):
         """
-        Disable the toggle tool
+        Disable the toggle tool.
 
         `trigger` call this method when `toggled` is True.
 
-        This can happen in different circumstances
+        This can happen in different circumstances.
 
-        * Click on the toolbar tool button
-        * Call to `matplotlib.backend_managers.ToolManager.trigger_tool`
+        * Click on the toolbar tool button.
+        * Call to `matplotlib.backend_managers.ToolManager.trigger_tool`.
         * Another `ToolToggleBase` derived tool is triggered
-          (from the same `.ToolManager`)
+          (from the same `.ToolManager`).
         """
         pass
 
     @property
     def toggled(self):
-        """State of the toggled tool"""
+        """State of the toggled tool."""
 
         return self._toggled
 
@@ -246,10 +246,10 @@ class ToolToggleBase(ToolBase):
 
 class SetCursorBase(ToolBase):
     """
-    Change to the current cursor while inaxes
+    Change to the current cursor while inaxes.
 
     This tool, keeps track of all `ToolToggleBase` derived tools, and calls
-    set_cursor when a tool gets triggered
+    `set_cursor` when a tool gets triggered.
     """
     def __init__(self, *args, **kwargs):
         ToolBase.__init__(self, *args, **kwargs)
@@ -308,18 +308,18 @@ class SetCursorBase(ToolBase):
 
     def set_cursor(self, cursor):
         """
-        Set the cursor
+        Set the cursor.
 
-        This method has to be implemented per backend
+        This method has to be implemented per backend.
         """
         raise NotImplementedError
 
 
 class ToolCursorPosition(ToolBase):
     """
-    Send message with the current pointer position
+    Send message with the current pointer position.
 
-    This tool runs in the background reporting the position of the cursor
+    This tool runs in the background reporting the position of the cursor.
     """
     def __init__(self, *args, **kwargs):
         self._idDrag = None
@@ -334,7 +334,7 @@ class ToolCursorPosition(ToolBase):
                 'motion_notify_event', self.send_message)
 
     def send_message(self, event):
-        """Call `matplotlib.backend_managers.ToolManager.message_event`"""
+        """Call `matplotlib.backend_managers.ToolManager.message_event`."""
         if self.toolmanager.messagelock.locked():
             return
 
@@ -363,9 +363,9 @@ class ToolCursorPosition(ToolBase):
 
 
 class RubberbandBase(ToolBase):
-    """Draw and remove rubberband"""
+    """Draw and remove a rubberband."""
     def trigger(self, sender, event, data):
-        """Call `draw_rubberband` or `remove_rubberband` based on data"""
+        """Call `draw_rubberband` or `remove_rubberband` based on data."""
         if not self.figure.canvas.widgetlock.available(sender):
             return
         if data is not None:
@@ -375,23 +375,23 @@ class RubberbandBase(ToolBase):
 
     def draw_rubberband(self, *data):
         """
-        Draw rubberband
+        Draw rubberband.
 
-        This method must get implemented per backend
+        This method must get implemented per backend.
         """
         raise NotImplementedError
 
     def remove_rubberband(self):
         """
-        Remove rubberband
+        Remove rubberband.
 
-        This method should get implemented per backend
+        This method should get implemented per backend.
         """
         pass
 
 
 class ToolQuit(ToolBase):
-    """Tool to call the figure manager destroy method"""
+    """Tool to call the figure manager destroy method."""
 
     description = 'Quit the figure'
     default_keymap = rcParams['keymap.quit']
@@ -401,7 +401,7 @@ class ToolQuit(ToolBase):
 
 
 class ToolQuitAll(ToolBase):
-    """Tool to call the figure manager destroy method"""
+    """Tool to call the figure manager destroy method."""
 
     description = 'Quit all figures'
     default_keymap = rcParams['keymap.quit_all']
@@ -411,7 +411,7 @@ class ToolQuitAll(ToolBase):
 
 
 class ToolEnableAllNavigation(ToolBase):
-    """Tool to enable all axes for toolmanager interaction"""
+    """Tool to enable all axes for toolmanager interaction."""
 
     description = 'Enable all axes toolmanager'
     default_keymap = rcParams['keymap.all_axes']
@@ -427,7 +427,7 @@ class ToolEnableAllNavigation(ToolBase):
 
 
 class ToolEnableNavigation(ToolBase):
-    """Tool to enable a specific axes for toolmanager interaction"""
+    """Tool to enable a specific axes for toolmanager interaction."""
 
     description = 'Enable one axes toolmanager'
     default_keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
@@ -479,7 +479,7 @@ class _ToolGridBase(ToolBase):
 
 
 class ToolGrid(_ToolGridBase):
-    """Tool to toggle the major grids of the figure"""
+    """Tool to toggle the major grids of the figure."""
 
     description = 'Toggle major grids'
     default_keymap = rcParams['keymap.grid']
@@ -500,7 +500,7 @@ class ToolGrid(_ToolGridBase):
 
 
 class ToolMinorGrid(_ToolGridBase):
-    """Tool to toggle the major and minor grids of the figure"""
+    """Tool to toggle the major and minor grids of the figure."""
 
     description = 'Toggle major and minor grids'
     default_keymap = rcParams['keymap.grid_minor']
@@ -520,7 +520,7 @@ class ToolMinorGrid(_ToolGridBase):
 
 
 class ToolFullScreen(ToolToggleBase):
-    """Tool to toggle full screen"""
+    """Tool to toggle full screen."""
 
     description = 'Toggle fullscreen mode'
     default_keymap = rcParams['keymap.fullscreen']
@@ -533,7 +533,7 @@ class ToolFullScreen(ToolToggleBase):
 
 
 class AxisScaleBase(ToolToggleBase):
-    """Base Tool to toggle between linear and logarithmic"""
+    """Base Tool to toggle between linear and logarithmic."""
 
     def trigger(self, sender, event, data=None):
         if event.inaxes is None:
@@ -550,7 +550,7 @@ class AxisScaleBase(ToolToggleBase):
 
 
 class ToolYScale(AxisScaleBase):
-    """Tool to toggle between linear and logarithmic scales on the Y axis"""
+    """Tool to toggle between linear and logarithmic scales on the Y axis."""
 
     description = 'Toggle scale Y axis'
     default_keymap = rcParams['keymap.yscale']
@@ -560,7 +560,7 @@ class ToolYScale(AxisScaleBase):
 
 
 class ToolXScale(AxisScaleBase):
-    """Tool to toggle between linear and logarithmic scales on the X axis"""
+    """Tool to toggle between linear and logarithmic scales on the X axis."""
 
     description = 'Toggle scale X axis'
     default_keymap = rcParams['keymap.xscale']
@@ -571,7 +571,7 @@ class ToolXScale(AxisScaleBase):
 
 class ToolViewsPositions(ToolBase):
     """
-    Auxiliary Tool to handle changes in views and positions
+    Auxiliary Tool to handle changes in views and positions.
 
     Runs in the background and should get used by all the tools that
     need to access the figure's history of views and positions, e.g.
@@ -590,7 +590,7 @@ class ToolViewsPositions(ToolBase):
         ToolBase.__init__(self, *args, **kwargs)
 
     def add_figure(self, figure):
-        """Add the current figure to the stack of views and positions"""
+        """Add the current figure to the stack of views and positions."""
 
         if figure not in self.views:
             self.views[figure] = cbook.Stack()
@@ -602,7 +602,7 @@ class ToolViewsPositions(ToolBase):
             figure.add_axobserver(lambda fig: self.update_home_views(fig))
 
     def clear(self, figure):
-        """Reset the axes stack"""
+        """Reset the axes stack."""
         if figure in self.views:
             self.views[figure].clear()
             self.positions[figure].clear()
@@ -642,7 +642,7 @@ class ToolViewsPositions(ToolBase):
 
     def push_current(self, figure=None):
         """
-        Push the current view limits and position onto their respective stacks
+        Push the current view limits and position onto their respective stacks.
         """
         if not figure:
             figure = self.figure
@@ -656,17 +656,17 @@ class ToolViewsPositions(ToolBase):
 
     def _axes_pos(self, ax):
         """
-        Return the original and modified positions for the specified axes
+        Return the original and modified positions for the specified axes.
 
         Parameters
         ----------
-        ax : (matplotlib.axes.AxesSubplot)
-        The axes to get the positions for
+        ax : matplotlib.axes.Axes
+            The `.Axes` to get the positions for.
 
         Returns
         -------
-        limits : (tuple)
-        A tuple of the original and modified positions
+        original_position, modified_position
+            A tuple of the original and modified positions.
         """
 
         return (ax.get_position(True).frozen(),
@@ -685,7 +685,7 @@ class ToolViewsPositions(ToolBase):
                 self.home_views[figure][a] = a._get_view()
 
     def refresh_locators(self):
-        """Redraw the canvases, update the locators"""
+        """Redraw the canvases, update the locators."""
         for a in self.figure.get_axes():
             xaxis = getattr(a, 'xaxis', None)
             yaxis = getattr(a, 'yaxis', None)
@@ -706,23 +706,23 @@ class ToolViewsPositions(ToolBase):
         self.figure.canvas.draw_idle()
 
     def home(self):
-        """Recall the first view and position from the stack"""
+        """Recall the first view and position from the stack."""
         self.views[self.figure].home()
         self.positions[self.figure].home()
 
     def back(self):
-        """Back one step in the stack of views and positions"""
+        """Back one step in the stack of views and positions."""
         self.views[self.figure].back()
         self.positions[self.figure].back()
 
     def forward(self):
-        """Forward one step in the stack of views and positions"""
+        """Forward one step in the stack of views and positions."""
         self.views[self.figure].forward()
         self.positions[self.figure].forward()
 
 
 class ViewsPositionsBase(ToolBase):
-    """Base class for `ToolHome`, `ToolBack` and `ToolForward`"""
+    """Base class for `ToolHome`, `ToolBack` and `ToolForward`."""
 
     _on_trigger = None
 
@@ -734,7 +734,7 @@ class ViewsPositionsBase(ToolBase):
 
 
 class ToolHome(ViewsPositionsBase):
-    """Restore the original view lim"""
+    """Restore the original view limits."""
 
     description = 'Reset original view'
     image = 'home'
@@ -743,7 +743,7 @@ class ToolHome(ViewsPositionsBase):
 
 
 class ToolBack(ViewsPositionsBase):
-    """Move back up the view lim stack"""
+    """Move back up the view limits stack."""
 
     description = 'Back to previous view'
     image = 'back'
@@ -752,7 +752,7 @@ class ToolBack(ViewsPositionsBase):
 
 
 class ToolForward(ViewsPositionsBase):
-    """Move forward in the view lim stack"""
+    """Move forward in the view lim stack."""
 
     description = 'Forward to next view'
     image = 'forward'
@@ -761,14 +761,14 @@ class ToolForward(ViewsPositionsBase):
 
 
 class ConfigureSubplotsBase(ToolBase):
-    """Base tool for the configuration of subplots"""
+    """Base tool for the configuration of subplots."""
 
     description = 'Configure subplots'
     image = 'subplots'
 
 
 class SaveFigureBase(ToolBase):
-    """Base tool for figure saving"""
+    """Base tool for figure saving."""
 
     description = 'Save the figure'
     image = 'filesave'
@@ -776,7 +776,7 @@ class SaveFigureBase(ToolBase):
 
 
 class ZoomPanBase(ToolToggleBase):
-    """Base class for `ToolZoom` and `ToolPan`"""
+    """Base class for `ToolZoom` and `ToolPan`."""
     def __init__(self, *args):
         ToolToggleBase.__init__(self, *args)
         self._button_pressed = None
@@ -789,7 +789,7 @@ class ZoomPanBase(ToolToggleBase):
         self.lastscroll = time.time()-self.scrollthresh
 
     def enable(self, event):
-        """Connect press/release events and lock the canvas"""
+        """Connect press/release events and lock the canvas."""
         self.figure.canvas.widgetlock(self)
         self._idPress = self.figure.canvas.mpl_connect(
             'button_press_event', self._press)
@@ -799,7 +799,7 @@ class ZoomPanBase(ToolToggleBase):
             'scroll_event', self.scroll_zoom)
 
     def disable(self, event):
-        """Release the canvas and disconnect press/release events"""
+        """Release the canvas and disconnect press/release events."""
         self._cancel_action()
         self.figure.canvas.widgetlock.release(self)
         self.figure.canvas.mpl_disconnect(self._idPress)
@@ -840,7 +840,7 @@ class ZoomPanBase(ToolToggleBase):
 
 
 class ToolZoom(ZoomPanBase):
-    """Zoom to rectangle"""
+    """A Tool for zooming using a rectangle selector."""
 
     description = 'Zoom to rectangle'
     image = 'zoom_to_rect'
@@ -966,7 +966,7 @@ class ToolZoom(ZoomPanBase):
 
 
 class ToolPan(ZoomPanBase):
-    """Pan axes with left mouse, zoom with right"""
+    """Pan axes with left mouse, zoom with right."""
 
     default_keymap = rcParams['keymap.pan']
     description = 'Pan axes with left mouse, zoom with right'
@@ -1070,7 +1070,7 @@ class ToolHelpBase(ToolBase):
 
 
 class ToolCopyToClipboardBase(ToolBase):
-    """Tool to copy the figure to the clipboard"""
+    """Tool to copy the figure to the clipboard."""
 
     description = 'Copy the canvas figure to clipboard'
     default_keymap = rcParams['keymap.copy']
@@ -1132,11 +1132,10 @@ def add_tools_to_container(container, tools=default_toolbar_tools):
     Parameters
     ----------
     container : Container
-        `backend_bases.ToolContainerBase` object that will get the tools added
+        `backend_bases.ToolContainerBase` object that will get the tools added.
     tools : list, optional
-        List in the form
-        [[group1, [tool1, tool2 ...]], [group2, [...]]]
-        Where the tools given by tool1, and tool2 will display in group1.
+        List in the form ``[[group1, [tool1, tool2 ...]], [group2, [...]]]``
+        where the tools ``[tool1, tool2, ...]`` will display in group1.
         See `add_tool` for details.
     """
 

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -211,9 +211,7 @@ class Dvi:
         return None
 
     def __enter__(self):
-        """
-        Context manager enter method, does nothing.
-        """
+        """Context manager enter method, does nothing."""
         return self
 
     def __exit__(self, etype, evalue, etrace):
@@ -242,9 +240,7 @@ class Dvi:
             yield self._output()
 
     def close(self):
-        """
-        Close the underlying file if it is open.
-        """
+        """Close the underlying file if it is open."""
         if not self.file.closed:
             self.file.close()
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -1,15 +1,11 @@
-"""
-Contains a classes for generating hatch patterns.
-"""
+"""Contains classes for generating hatch patterns."""
 
 import numpy as np
 from matplotlib.path import Path
 
 
 class HatchPatternBase:
-    """
-    The base class for a hatch pattern.
-    """
+    """The base class for a hatch pattern."""
     pass
 
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -864,9 +864,8 @@ class Rectangle(Patch):
 
 
 class RegularPolygon(Patch):
-    """
-    A regular polygon patch.
-    """
+    """A regular polygon patch."""
+
     def __str__(self):
         s = "RegularPolygon((%g, %g), %d, radius=%g, orientation=%g)"
         return s % (self._xy[0], self._xy[1], self._numVertices, self._radius,
@@ -955,9 +954,8 @@ class RegularPolygon(Patch):
 
 
 class PathPatch(Patch):
-    """
-    A general polycurve path patch.
-    """
+    """A general polycurve path patch."""
+
     _edge_default = True
 
     def __str__(self):
@@ -984,9 +982,8 @@ class PathPatch(Patch):
 
 
 class Polygon(Patch):
-    """
-    A general polygon patch.
-    """
+    """A general polygon patch."""
+
     def __str__(self):
         s = "Polygon%d((%g, %g) ...)"
         return s % (len(self._path.vertices), *tuple(self._path.vertices[0]))
@@ -1081,9 +1078,8 @@ class Polygon(Patch):
 
 
 class Wedge(Patch):
-    """
-    Wedge shaped patch.
-    """
+    """Wedge shaped patch."""
+
     def __str__(self):
         pars = (self.center[0], self.center[1], self.r,
                 self.theta1, self.theta2, self.width)
@@ -1172,9 +1168,8 @@ class Wedge(Patch):
 
 # COVERAGE NOTE: Not used internally or from examples
 class Arrow(Patch):
-    """
-    An arrow patch.
-    """
+    """An arrow patch."""
+
     def __str__(self):
         return "Arrow()"
 
@@ -1335,9 +1330,8 @@ docstring.interpd.update(
 
 
 class CirclePolygon(RegularPolygon):
-    """
-    A polygon-approximation of a circle patch.
-    """
+    """A polygon-approximation of a circle patch."""
+
     def __str__(self):
         s = "CirclePolygon((%g, %g), radius=%g, resolution=%d)"
         return s % (self._xy[0], self._xy[1], self._radius, self._numVertices)
@@ -1364,9 +1358,8 @@ class CirclePolygon(RegularPolygon):
 
 
 class Ellipse(Patch):
-    """
-    A scale-free ellipse.
-    """
+    """A scale-free ellipse."""
+
     def __str__(self):
         pars = (self._center[0], self._center[1],
                 self.width, self.height, self.angle)
@@ -1421,9 +1414,7 @@ class Ellipse(Patch):
             .translate(*center)
 
     def get_path(self):
-        """
-        Return the path of the ellipse
-        """
+        """Return the path of the ellipse."""
         return self._path
 
     def get_patch_transform(self):
@@ -1442,9 +1433,7 @@ class Ellipse(Patch):
         self.stale = True
 
     def get_center(self):
-        """
-        Return the center of the ellipse.
-        """
+        """Return the center of the ellipse."""
         return self._center
 
     center = property(get_center, set_center)
@@ -1480,9 +1469,7 @@ class Ellipse(Patch):
         self.stale = True
 
     def get_height(self):
-        """
-        Return the height of the ellipse.
-        """
+        """Return the height of the ellipse."""
         return self._height
 
     height = property(get_height, set_height)
@@ -1499,18 +1486,15 @@ class Ellipse(Patch):
         self.stale = True
 
     def get_angle(self):
-        """
-        Return the angle of the ellipse.
-        """
+        """Return the angle of the ellipse."""
         return self._angle
 
     angle = property(get_angle, set_angle)
 
 
 class Circle(Ellipse):
-    """
-    A circle patch.
-    """
+    """A circle patch."""
+
     def __str__(self):
         pars = self.center[0], self.center[1], self.radius
         fmt = "Circle(xy=(%g, %g), radius=%g)"
@@ -1533,7 +1517,7 @@ class Circle(Ellipse):
 
     def set_radius(self, radius):
         """
-        Set the radius of the circle
+        Set the radius of the circle.
 
         Parameters
         ----------
@@ -1543,9 +1527,7 @@ class Circle(Ellipse):
         self.stale = True
 
     def get_radius(self):
-        """
-        Return the radius of the circle
-        """
+        """Return the radius of the circle."""
         return self.width / 2.
 
     radius = property(get_radius, set_radius)
@@ -1876,24 +1858,17 @@ class _Style:
 
     @classmethod
     def get_styles(cls):
-        """
-        A class method which returns a dictionary of available styles.
-        """
+        """Return a dictionary of available styles."""
         return cls._style_list
 
     @classmethod
     def pprint_styles(cls):
-        """
-        A class method which returns a string of the available styles.
-        """
+        """Return the available styles as pretty-printed string."""
         return _pprint_styles(cls._style_list)
 
     @classmethod
     def register(cls, name, style):
-        """
-        Register a new style.
-        """
-
+        """Register a new style."""
         if not issubclass(style, cls._Base):
             raise ValueError("%s must be a subclass of %s" % (style,
                                                               cls._Base))
@@ -3367,18 +3342,14 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="-")
     class Curve(_Curve):
-        """
-        A simple curve without any arrow head.
-        """
+        """A simple curve without any arrow head."""
 
         def __init__(self):
             super().__init__(beginarrow=False, endarrow=False)
 
     @_register_style(_style_list, name="<-")
     class CurveA(_Curve):
-        """
-        An arrow with a head at its begin point.
-        """
+        """An arrow with a head at its begin point."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3395,9 +3366,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="->")
     class CurveB(_Curve):
-        """
-        An arrow with a head at its end point.
-        """
+        """An arrow with a head at its end point."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3414,9 +3383,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="<->")
     class CurveAB(_Curve):
-        """
-        An arrow with heads both at the begin and the end point.
-        """
+        """An arrow with heads both at the begin and the end point."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3433,9 +3400,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="<|-")
     class CurveFilledA(_Curve):
-        """
-        An arrow with filled triangle head at the begin.
-        """
+        """An arrow with filled triangle head at the begin."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3453,9 +3418,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="-|>")
     class CurveFilledB(_Curve):
-        """
-        An arrow with filled triangle head at the end.
-        """
+        """An arrow with filled triangle head at the end."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3473,9 +3436,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="<|-|>")
     class CurveFilledAB(_Curve):
-        """
-        An arrow with filled triangle heads at both ends.
-        """
+        """An arrow with filled triangle heads at both ends."""
 
         def __init__(self, head_length=.4, head_width=.2):
             """
@@ -3570,9 +3531,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="]-[")
     class BracketAB(_Bracket):
-        """
-        An arrow with a bracket(]) at both ends.
-        """
+        """An arrow with outward square brackets at both ends."""
 
         def __init__(self,
                      widthA=1., lengthA=0.2, angleA=None,
@@ -3604,9 +3563,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="]-")
     class BracketA(_Bracket):
-        """
-        An arrow with a bracket(])  at its end.
-        """
+        """An arrow with an outward square bracket at its start."""
 
         def __init__(self, widthA=1., lengthA=0.2, angleA=None):
             """
@@ -3626,9 +3583,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="-[")
     class BracketB(_Bracket):
-        """
-        An arrow with a bracket([)  at its end.
-        """
+        """An arrow with an outward square bracket at its end."""
 
         def __init__(self, widthB=1., lengthB=0.2, angleB=None):
             """
@@ -3648,9 +3603,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list, name="|-|")
     class BarAB(_Bracket):
-        """
-        An arrow with a bar(|) at both ends.
-        """
+        """An arrow with vertical bars ``|`` at both ends."""
 
         def __init__(self,
                      widthA=1., angleA=None,
@@ -3676,9 +3629,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list)
     class Simple(_Base):
-        """
-        A simple arrow. Only works with a quadratic Bezier curve.
-        """
+        """A simple arrow. Only works with a quadratic Bezier curve."""
 
         def __init__(self, head_length=.5, head_width=.5, tail_width=.2):
             """
@@ -3758,9 +3709,7 @@ class ArrowStyle(_Style):
 
     @_register_style(_style_list)
     class Fancy(_Base):
-        """
-        A fancy arrow. Only works with a quadratic Bezier curve.
-        """
+        """A fancy arrow. Only works with a quadratic Bezier curve."""
 
         def __init__(self, head_length=.4, head_width=.4, tail_width=.4):
             """
@@ -4178,9 +4127,7 @@ default: 'arc3'
         self.stale = True
 
     def get_arrowstyle(self):
-        """
-        Return the arrowstyle object.
-        """
+        """Return the arrowstyle object."""
         return self._arrow_transmuter
 
     def set_mutation_scale(self, scale):
@@ -4216,9 +4163,7 @@ default: 'arc3'
         self.stale = True
 
     def get_mutation_aspect(self):
-        """
-        Return the aspect ratio of the bbox mutation.
-        """
+        """Return the aspect ratio of the bbox mutation."""
         return self._mutation_aspect
 
     def get_path(self):
@@ -4233,10 +4178,7 @@ default: 'arc3'
         return self.get_transform().inverted().transform_path(_path)
 
     def get_path_in_displaycoord(self):
-        """
-        Return the mutated path of the arrow in display coordinates.
-        """
-
+        """Return the mutated path of the arrow in display coordinates."""
         dpi_cor = self.get_dpi_cor()
 
         if self._posA_posB is not None:

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -16,8 +16,8 @@ class AbstractPathEffect:
 
     Subclasses should override the ``draw_path`` method to add effect
     functionality.
-
     """
+
     def __init__(self, offset=(0., 0.)):
         """
         Parameters
@@ -76,8 +76,8 @@ class PathEffectRenderer(RendererBase):
         Not all methods have been overridden on this RendererBase subclass.
         It may be necessary to add further methods to extend the PathEffects
         capabilities further.
-
     """
+
     def __init__(self, path_effects, renderer):
         """
         Parameters
@@ -164,6 +164,7 @@ class Normal(AbstractPathEffect):
 
 class Stroke(AbstractPathEffect):
     """A line based PathEffect which re-draws a stroke."""
+
     def __init__(self, offset=(0, 0), **kwargs):
         """
         The path will be stroked with its gc updated with the given
@@ -174,9 +175,7 @@ class Stroke(AbstractPathEffect):
         self._gc = kwargs
 
     def draw_path(self, renderer, gc, tpath, affine, rgbFace):
-        """
-        Draw the path with updated gc.
-        """
+        """Draw the path with updated gc."""
         gc0 = renderer.new_gc()  # Don't modify gc, but a copy!
         gc0.copy_properties(gc)
         gc0 = self._update_gc(gc0, self._gc)
@@ -189,8 +188,8 @@ class withStroke(Stroke):
     """
     Adds a simple :class:`Stroke` and then draws the
     original Artist to avoid needing to call :class:`Normal`.
-
     """
+
     def draw_path(self, renderer, gc, tpath, affine, rgbFace):
         Stroke.draw_path(self, renderer, gc, tpath, affine, rgbFace)
         renderer.draw_path(gc, tpath, affine, rgbFace)
@@ -198,6 +197,7 @@ class withStroke(Stroke):
 
 class SimplePatchShadow(AbstractPathEffect):
     """A simple shadow via a filled patch."""
+
     def __init__(self, offset=(2, -2),
                  shadow_rgbFace=None, alpha=None,
                  rho=0.3, **kwargs):
@@ -265,8 +265,8 @@ class withSimplePatchShadow(SimplePatchShadow):
     """
     Adds a simple :class:`SimplePatchShadow` and then draws the
     original Artist to avoid needing to call :class:`Normal`.
-
     """
+
     def draw_path(self, renderer, gc, tpath, affine, rgbFace):
         SimplePatchShadow.draw_path(self, renderer, gc, tpath, affine, rgbFace)
         renderer.draw_path(gc, tpath, affine, rgbFace)
@@ -274,6 +274,7 @@ class withSimplePatchShadow(SimplePatchShadow):
 
 class SimpleLineShadow(AbstractPathEffect):
     """A simple shadow via a line."""
+
     def __init__(self, offset=(2, -2),
                  shadow_color='k', alpha=0.3, rho=0.3, **kwargs):
         """
@@ -330,10 +331,10 @@ class SimpleLineShadow(AbstractPathEffect):
 
 class PathPatchEffect(AbstractPathEffect):
     """
-    Draws a :class:`~matplotlib.patches.PathPatch` instance whose Path
-    comes from the original PathEffect artist.
-
+    Draws a `.PathPatch` instance whose Path comes from the original
+    PathEffect artist.
     """
+
     def __init__(self, offset=(0, 0), **kwargs):
         """
         Parameters


### PR DESCRIPTION
## PR Summary

Docstring cleanups:

- (Half)-sentences should always end with a period (PEP-257: The docstring is a phrase ending in a period; and numpydoc style)
- pydocstyle D200: One-line docstring should fit on one line with quotes.
- No trailing blank lines in docstrings.
- Blank line after class docstring. (PEP-257: Insert a blank line after all docstrings (one-line or multi-line) that document a class -- generally speaking, the class's methods are separated from each other by a single blank line, and the docstring needs to be offset from the first method by a blank line.)
- Some other misc cleanups.
