### PR TITLE
Backport PR #16480 on v.3.2.x: Re-phrase doc for bottom kwarg to hist

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6446,15 +6446,12 @@ optional.
             ``True``, then the histogram is normalized such that the first bin
             equals 1.
 
-            Default is ``False``
-
-        bottom : array-like, scalar, or None
-            Location of the bottom baseline of each bin.  If a scalar,
-            the base line for each bin is shifted by the same amount.
-            If an array, each bin is shifted independently and the length
-            of bottom must match the number of bins.  If None, defaults to 0.
-
-            Default is ``None``
+        bottom : array-like, scalar, or None, default: None
+            Location of the bottom of each bin, ie. bins are drawn from
+            ``bottom`` to ``bottom + hist(x, bins)`` If a scalar, the bottom
+            of each bin is shifted by the same amount. If an array, each bin
+            is shifted independently and the length of bottom must match the
+            number of bins. If None, defaults to 0.
 
         histtype : {'bar', 'barstacked', 'step',  'stepfilled'}, optional
             The type of histogram to draw.


### PR DESCRIPTION
## PR Summary

Backport PR #16480 on v.3.2.x: Re-phrase doc for bottom kwarg to hist.

