### PR TITLE
Improve test failure messages on warnings.

### DIFF
--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -219,10 +219,9 @@ def test_default_edges():
     ax4.add_patch(pp1)
 
 
-def test_properties(recwarn):
+def test_properties():
     ln = mlines.Line2D([], [])
-    ln.properties()
-    assert len(recwarn) == 0
+    ln.properties()  # Check that no warning is emitted.
 
 
 def test_setp():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4723,13 +4723,12 @@ def test_length_one_hist():
     ax.hist([1])
 
 
-def test_pathological_hexbin(recwarn):
+def test_pathological_hexbin():
     # issue #2863
     mylist = [10] * 100
     fig, ax = plt.subplots(1, 1)
     ax.hexbin(mylist, mylist)
-    fig.savefig(io.BytesIO())
-    assert len(recwarn) == 0
+    fig.savefig(io.BytesIO())  # Check that no warning is emitted.
 
 
 def test_color_None():

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -335,10 +335,10 @@ def test_normalize_kwargs_fail(inp, kwargs_to_norm):
 
 @pytest.mark.parametrize('inp, expected, kwargs_to_norm',
                          pass_mapping)
-def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm, recwarn):
+def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm):
     with cbook._suppress_matplotlib_deprecation_warning():
+        # No other warning should be emitted.
         assert expected == cbook.normalize_kwargs(inp, **kwargs_to_norm)
-    assert len(recwarn) == 0
 
 
 def test_warn_external_frame_embedded_python():
@@ -574,13 +574,12 @@ def test_safe_first_element_pandas_series(pd):
     assert actual == 0
 
 
-def test_make_keyword_only(recwarn):
+def test_make_keyword_only():
     @cbook._make_keyword_only("3.0", "arg")
     def func(pre, arg, post=None):
         pass
 
-    func(1, arg=2)
-    assert len(recwarn) == 0
+    func(1, arg=2)  # Check that no warning is emitted.
 
     with pytest.warns(MatplotlibDeprecationWarning):
         func(1, 2)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -890,7 +890,7 @@ def test_tableau_order():
     assert list(mcolors.TABLEAU_COLORS.values()) == dflt_cycle
 
 
-def test_ndarray_subclass_norm(recwarn):
+def test_ndarray_subclass_norm():
     # Emulate an ndarray subclass that handles units
     # which objects when adding or subtracting with other
     # arrays. See #6622 and #8696
@@ -912,9 +912,7 @@ def test_ndarray_subclass_norm(recwarn):
         assert_array_equal(norm(mydata), norm(data))
         fig, ax = plt.subplots()
         ax.imshow(mydata, norm=norm)
-        fig.canvas.draw()
-        assert len(recwarn) == 0
-        recwarn.clear()
+        fig.canvas.draw()  # Check that no warning is emitted.
 
 
 def test_same_color():

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -279,14 +279,11 @@ def test_internal_cpp_api_2():
 
 def test_circular_contour_warning():
     # Check that almost circular contours don't throw a warning
-    with pytest.warns(None) as record:
-        x, y = np.meshgrid(np.linspace(-2, 2, 4), np.linspace(-2, 2, 4))
-        r = np.hypot(x, y)
-
-        plt.figure()
-        cs = plt.contour(x, y, r)
-        plt.clabel(cs)
-    assert len(record) == 0
+    x, y = np.meshgrid(np.linspace(-2, 2, 4), np.linspace(-2, 2, 4))
+    r = np.hypot(x, y)
+    plt.figure()
+    cs = plt.contour(x, y, r)
+    plt.clabel(cs)
 
 
 @pytest.mark.parametrize("use_clabeltext, contour_zorder, clabel_zorder",

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -975,9 +975,8 @@ def test_imshow_masked_interpolation():
         ax.axis('off')
 
 
-def test_imshow_no_warn_invalid(recwarn):
-    plt.imshow([[1, 2], [3, np.nan]])
-    assert len(recwarn) == 0
+def test_imshow_no_warn_invalid():
+    plt.imshow([[1, 2], [3, np.nan]])  # Check that no warning is emitted.
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -570,6 +570,4 @@ def test_no_warn_big_data_when_loc_specified():
     for idx in range(1000):
         ax.plot(np.arange(5000), label=idx)
     legend = ax.legend('best')
-    with pytest.warns(None) as records:
-        fig.draw_artist(legend)
-    assert len(records) == 0
+    fig.draw_artist(legend)  # Check that no warning is emitted.

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -71,25 +71,23 @@ def test_quiver_arg_sizes():
         plt.quiver(X2, X2, X2, X2, X3)
 
 
-def test_no_warnings(recwarn):
+def test_no_warnings():
     fig, ax = plt.subplots()
     X, Y = np.meshgrid(np.arange(15), np.arange(10))
     U = V = np.ones_like(X)
     phi = (np.random.rand(15, 10) - .5) * 150
     ax.quiver(X, Y, U, V, angles=phi)
-    fig.canvas.draw()
-    assert len(recwarn) == 0
+    fig.canvas.draw()  # Check that no warning is emitted.
 
 
-def test_zero_headlength(recwarn):
+def test_zero_headlength():
     # Based on report by Doug McNeil:
     # http://matplotlib.1069221.n5.nabble.com/quiver-warnings-td28107.html
     fig, ax = plt.subplots()
     X, Y = np.meshgrid(np.arange(10), np.arange(10))
     U, V = np.cos(X), np.sin(Y)
     ax.quiver(U, V, headlength=0, headaxislength=0)
-    fig.canvas.draw()
-    assert len(recwarn) == 0
+    fig.canvas.draw()  # Check that no warning is emitted.
 
 
 @image_comparison(['quiver_animated_test_image.png'])

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -506,11 +506,9 @@ def test_if_rctemplate_would_be_valid(tmpdir):
     fname = str(d.join('testrcvalid.temp'))
     with open(fname, "w") as f:
         f.writelines(newlines)
-    with pytest.warns(None) as record:
-        mpl.rc_params_from_file(fname,
-                                fail_on_error=True,
-                                use_default_template=False)
-        assert len(record) == 0
+    mpl.rc_params_from_file(fname,
+                            fail_on_error=True,  # Test also fails on warning.
+                            use_default_template=False)
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")


### PR DESCRIPTION
When a test fails due to a warning, this improves the failure message
from `assert 1 == 0 where 1 = len(WarningsChecker(record=True))` to the
actual warning message.

See e.g. https://github.com/matplotlib/matplotlib/pull/16509#discussion_r379896825.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
