### PR TITLE
Deprecate toggling axes navigatability using the keyboard.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -223,3 +223,12 @@ The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_ps_papersize``, ``validate_legend_log``.  To test whether an rcParam
 value would be acceptable, one can test e.g. ``rc = RcParams(); rc[k] = v``
 raises an exception.
+
+Toggling axes navigation from the keyboard using "a" and digit keys
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Axes navigation can still be toggled programmatically using
+`.Axes.set_navigate`.
+
+The following related APIs are also deprecated:
+``backend_tools.ToolEnableAllNavigation``,
+``backend_tools.ToolEnableNavigation``, and ``rcParams["keymap.all_axes"]``.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -145,45 +145,6 @@
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_non_affine:20"
     ],
-    "transforms.Bbox.bounds": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:91"
-    ],
-    "transforms.Bbox.intervalx": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:99"
-    ],
-    "transforms.Bbox.intervaly": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:102"
-    ],
-    "transforms.Bbox.x0": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:105"
-    ],
-    "transforms.Bbox.x1": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:113"
-    ],
-    "transforms.Bbox.y0": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
-    ],
-    "transforms.Bbox.y1": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
-    ],
-    "transforms.BboxBase.height": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:96"
-    ],
-    "transforms.BboxBase.width": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:93"
-    ],
-    "transforms.BboxBase.xmax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:113"
-    ],
-    "transforms.BboxBase.xmin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:105"
-    ],
-    "transforms.BboxBase.ymax": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:117"
-    ],
-    "transforms.BboxBase.ymin": [
-      "doc/api/prev_api_changes/api_changes_0.98.0.rst:109"
-    ],
     "triangulation": [
       "lib/matplotlib/tri/trirefine.py:docstring of matplotlib.tri.UniformTriRefiner.refine_triangulation:2"
     ],
@@ -269,6 +230,12 @@
     "matplotlib.backend_bases._Backend": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ShowBase:1"
     ],
+    "matplotlib.backend_tools._ToolEnableAllNavigation": [
+      "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolEnableAllNavigation:1"
+    ],
+    "matplotlib.backend_tools._ToolEnableNavigation": [
+      "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolEnableNavigation:1"
+    ],
     "matplotlib.backend_tools._ToolGridBase": [
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolGrid:1",
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolMinorGrid:1"
@@ -303,13 +270,7 @@
     "matplotlib.contours.ContourSet": [
       "lib/mpl_toolkits/axes_grid1/colorbar.py:docstring of mpl_toolkits.axes_grid1.colorbar.colorbar:92"
     ],
-    "matplotlib.dates.bytespdate2num": [
-      "doc/api/dates_api.rst:11"
-    ],
     "matplotlib.dates.rrulewrapper": [
-      "doc/api/dates_api.rst:11"
-    ],
-    "matplotlib.dates.strpdate2num": [
       "doc/api/dates_api.rst:11"
     ],
     "matplotlib.figure._AxesStack": [
@@ -891,13 +852,13 @@
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:933"
     ],
     "axes_grid1": [
-      "doc/index.rst:154"
+      "doc/index.rst:157"
     ],
     "axis.Axis.get_ticks_position": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:821"
     ],
     "axisartist": [
-      "doc/index.rst:154"
+      "doc/index.rst:157"
     ],
     "backend_bases.RendererBase": [
       "lib/matplotlib/backends/backend_template.py:docstring of matplotlib.backends.backend_template.RendererTemplate:4"
@@ -982,12 +943,6 @@
     ],
     "converter": [
       "lib/matplotlib/testing/compare.py:docstring of matplotlib.testing.compare.compare_images:4"
-    ],
-    "dates.bytespdate2num": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:919"
-    ],
-    "dates.strpdate2num": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:918"
     ],
     "fc-list": [
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager.get_fontconfig_fonts:2"
@@ -1514,7 +1469,7 @@
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist:26"
     ],
     "mplot3d": [
-      "doc/index.rst:154"
+      "doc/index.rst:157"
     ],
     "new_figure_manager": [
       "doc/devel/MEP/MEP23.rst:75"

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -602,6 +602,7 @@ _deprecated_ignore_map = {
 _deprecated_remain_as_none = {
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
+    'keymap.all_axes': ('3.3',),
 }
 
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2321,7 +2321,7 @@ def key_press_handler(event, canvas, toolbar=None):
     grid_minor_keys = rcParams['keymap.grid_minor']
     toggle_yscale_keys = rcParams['keymap.yscale']
     toggle_xscale_keys = rcParams['keymap.xscale']
-    all_keys = rcParams['keymap.all_axes']
+    all_keys = dict.__getitem__(rcParams, 'keymap.all_axes')
 
     # toggle fullscreen mode ('f', 'ctrl + f')
     if event.key in fullscreen_keys:
@@ -2443,6 +2443,10 @@ def key_press_handler(event, canvas, toolbar=None):
         for a in canvas.figure.get_axes():
             if (event.x is not None and event.y is not None
                     and a.in_axes(event)):  # FIXME: Why only these?
+                cbook.warn_deprecated(
+                    "3.3", message="Toggling axes navigation from the "
+                    "keyboard is deprecated since %(since)s and will be "
+                    "removed %(removal)s.")
                 a.set_navigate(True)
     # enable navigation only for axes with this index (if such an axes exist,
     # otherwise do nothing)
@@ -2452,6 +2456,10 @@ def key_press_handler(event, canvas, toolbar=None):
             for i, a in enumerate(canvas.figure.get_axes()):
                 if (event.x is not None and event.y is not None
                         and a.in_axes(event)):  # FIXME: Why only these?
+                    cbook.warn_deprecated(
+                        "3.3", message="Toggling axes navigation from the "
+                        "keyboard is deprecated since %(since)s and will be "
+                        "removed %(removal)s.")
                     a.set_navigate(i == n)
 
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -410,38 +410,34 @@ class ToolQuitAll(ToolBase):
         Gcf.destroy_all()
 
 
-class ToolEnableAllNavigation(ToolBase):
+class _ToolEnableAllNavigation(ToolBase):
     """Tool to enable all axes for toolmanager interaction."""
 
     description = 'Enable all axes toolmanager'
     default_keymap = mpl.rcParams['keymap.all_axes']
 
     def trigger(self, sender, event, data=None):
-        if event.inaxes is None:
-            return
-
-        for a in self.figure.get_axes():
-            if (event.x is not None and event.y is not None
-                    and a.in_axes(event)):
-                a.set_navigate(True)
+        mpl.backend_bases.key_press_handler(event, self.figure.canvas, None)
 
 
-class ToolEnableNavigation(ToolBase):
+@cbook.deprecated("3.3")
+class ToolEnableAllNavigation(_ToolEnableAllNavigation):
+    pass
+
+
+class _ToolEnableNavigation(ToolBase):
     """Tool to enable a specific axes for toolmanager interaction."""
 
     description = 'Enable one axes toolmanager'
     default_keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
 
     def trigger(self, sender, event, data=None):
-        if event.inaxes is None:
-            return
+        mpl.backend_bases.key_press_handler(event, self.figure.canvas, None)
 
-        n = int(event.key) - 1
-        if n < len(self.figure.get_axes()):
-            for i, a in enumerate(self.figure.get_axes()):
-                if (event.x is not None and event.y is not None
-                        and a.in_axes(event)):
-                    a.set_navigate(i == n)
+
+@cbook.deprecated("3.3")
+class ToolEnableNavigation(_ToolEnableNavigation):
+    pass
 
 
 class _ToolGridBase(ToolBase):
@@ -1089,8 +1085,8 @@ default_tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
                  'fullscreen': ToolFullScreen,
                  'quit': ToolQuit,
                  'quit_all': ToolQuitAll,
-                 'allnav': ToolEnableAllNavigation,
-                 'nav': ToolEnableNavigation,
+                 'allnav': _ToolEnableAllNavigation,
+                 'nav': _ToolEnableNavigation,
                  'xscale': ToolXScale,
                  'yscale': ToolYScale,
                  'position': ToolCursorPosition,

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -467,7 +467,6 @@ keymap.quit : ctrl+w, cmd+w         # close the current figure
 keymap.grid : g                     # switching on/off a grid in current axes
 keymap.yscale : l                   # toggle scaling of y-axes ('log'/'linear')
 keymap.xscale : k, L                # toggle scaling of x-axes ('log'/'linear')
-keymap.all_axes : a                 # enable all axes
 
 ###ANIMATION settings
 animation.writer : ffmpeg         # MovieWriter 'backend' to use

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -717,7 +717,6 @@
 #keymap.grid_minor: G           # switching on/off minor grids in current axes
 #keymap.yscale: l               # toggle scaling of y-axes ('log'/'linear')
 #keymap.xscale: k, L            # toggle scaling of x-axes ('log'/'linear')
-#keymap.all_axes: a             # enable all axes
 #keymap.copy: ctrl+c, cmd+c     # Copy figure to clipboard
 
 


### PR DESCRIPTION
I made the backend_tools version just point to backend_bases to avoid
repeating the deprecation.

See discussion at https://github.com/matplotlib/matplotlib/issues/11432 (TL;DR: this feature is both confusing and buggy).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
