### PR TITLE
Document default value of save_count parameter in FuncAnimation

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1577,8 +1577,10 @@ class FuncAnimation(TimedAnimation):
     fargs : tuple or None, optional
         Additional arguments to pass to each call to *func*.
 
-    save_count : int, optional
-        The number of values from *frames* to cache.
+    save_count : int, default: 100
+        Fallback for the number of values from *frames* to cache. This is
+        only used if the number of frames cannot be inferred from *frames*,
+        i.e. when it's an iterator without length or a generator.
 
     interval : int, default: 200
         Delay between frames in milliseconds.


### PR DESCRIPTION
## PR Summary

Reduces the confusion of #8278 (in particular https://github.com/matplotlib/matplotlib/issues/8278#issuecomment-568750251 and https://github.com/matplotlib/matplotlib/issues/8278#issuecomment-583733083) by documenting the current behavior.
