### PR TITLE
DOC: MaxNLocator and contour/contourf doc update (replaces #16428)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1612,8 +1612,10 @@ class QuadContourSet(ContourSet):
         levels : int or array-like, optional
             Determines the number and positions of the contour lines / regions.
 
-            If an int *n*, use *n* data intervals; i.e. draw *n+1* contour
-            lines. The level heights are automatically chosen.
+            If an int *n*, use an algorithm
+            (see `~matplotlib.ticker.MaxNLocator`) that tries to provide
+            no more than *n+1* "nice" contour levels between vmin and vmax.
+            The level heights are automatically chosen.
 
             If array-like, draw contour lines at the specified levels.
             The values must be in increasing order.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1991,7 +1991,8 @@ class _Edge_integer:
 
 class MaxNLocator(Locator):
     """
-    Select no more than N intervals at nice locations.
+    Find nice tick locations with no more than N being within the view limits.
+    Locations beyond the limits are added to support autoscaling.
     """
     default_params = dict(nbins=10,
                           steps=None,


### PR DESCRIPTION
## PR Summary
closes  #12729 

I messed my github matplotlib repo settings (and not github doesn't recognize my old branch... it says `pharshalp wants to merge 1 commit into matplotlib:master from **unknown repository**`) so closed the older PR and recreated it here.
Sorry for the noise!
**Please see #16428 the reviewers' comments, suggestions and discussion.**

---------------------------
`MaxNLocator`'s docs were incorrect (please see the details described in #12729).

Here is a numerical experiment that I ran to determine the difference between the number of tick locations returned by `MaxNLocator` and the argument `nbins`.

```python
import matplotlib.ticker as mticker
import numpy as np

steps = np.linspace(1, 10, 37)   # Overkill -- 1.  ,  1.25,  1.5 ,  1.75,  2.... , 10
vmax_arr = np.linspace(0, 1, 1001)[1:]  # Overkill

# number of ticks - number of bins
nticks_minus_nbins = np.zeros((1001, 40, 3), dtype=np.int64)
for vmax_ind, vmax in enumerate(vmax_arr):
    for nbins in range(1, 40+1):
        locator = mticker.MaxNLocator(nbins, steps=steps, min_n_ticks=1)
        nticks_minus_nbins[vmax_ind, nbins-1, 0] = len(locator.tick_values(0, vmax))-nbins
        nticks_minus_nbins[vmax_ind, nbins-1, 1] = len(locator.tick_values(-vmax, 0))-nbins
        nticks_minus_nbins[vmax_ind, nbins-1, 2] = len(locator.tick_values(-vmax, vmax))-nbins
print(np.max(nticks_minus_nbins))  # returns 2
```

It turns out (as was shown in the original issue) that `MaxNLocator` returns at most `nbins+2` tick locations (`nbins+1` intervals).

Since contour/contourf uses MaxNLocator (as pointed out in the original issue) updated their docs as well.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
