### PR TITLE
API/TST: minimum versions

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ environment:
     - PYTHON_VERSION: "3.6"
       CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
       TEST_ALL: "no"
-      EXTRAREQS: "-r requirements/testing/travis36.txt"
+      EXTRAREQS: "-r requirements/testing/travis_extra.txt"
     - PYTHON_VERSION: "3.7"
       CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
       TEST_ALL: "no"

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,10 @@ matrix:
         - PINNEDVERS='-c requirements/testing/travis36minver.txt'
         - DELETE_FONT_CACHE=1
     - python: 3.7
+      env:
         - EXTRAREQS='-r requirements/testing/travis_extra.txt'
     - python: 3.8
+      env:
         - EXTRAREQS='-r requirements/testing/travis_extra.txt'
     - python: "nightly"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,10 @@ matrix:
       env:
         - PINNEDVERS='-c requirements/testing/travis36minver.txt'
         - DELETE_FONT_CACHE=1
-        - EXTRAREQS='-r requirements/testing/travis36.txt'
     - python: 3.7
+        - EXTRAREQS='-r requirements/testing/travis_extra.txt'
     - python: 3.8
+        - EXTRAREQS='-r requirements/testing/travis_extra.txt'
     - python: "nightly"
       env:
         - PRE=--pre

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -114,7 +114,7 @@ Matplotlib requires the following dependencies:
 * `dateutil <https://pypi.org/project/python-dateutil>`_ (>= 2.1)
 * `kiwisolver <https://github.com/nucleic/kiwi>`_ (>= 1.0.0)
 * `Pillow <https://pillow.readthedocs.io/en/latest/>`_ (>= 6.2)
-* `pyparsing <https://pyparsing.wikispaces.com/>`_
+* `pyparsing <https://pyparsing.wikispaces.com/>`_ (>=2.0.3)
 
 Optionally, you can also install a number of packages to enable better user
 interface toolkits. See :ref:`what-is-a-backend` for more details on the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,7 +93,7 @@ steps:
 
 - bash: |
     python -m pip install --upgrade pip
-    python -m pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis36.txt ||
+    python -m pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis_extra.txt ||
       [[ "$PYTHON_VERSION" = 'Pre' ]]
   displayName: 'Install dependencies with pip'
 

--- a/requirements/testing/travis36minver.txt
+++ b/requirements/testing/travis36minver.txt
@@ -3,4 +3,4 @@
 cycler==0.10
 python-dateutil==2.1
 numpy==1.15.0
-pyparsing==2.0.1
+pyparsing==2.0.3

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -1,10 +1,6 @@
 # pip requirements for all the travis builds
 
 coverage
-cycler
-numpy
-pillow
-pyparsing
 pytest!=4.6.0
 pytest-cov
 pytest-rerunfailures

--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -12,4 +12,3 @@ pytest-timeout
 pytest-xdist
 python-dateutil
 tornado
-tox

--- a/requirements/testing/travis_extra.txt
+++ b/requirements/testing/travis_extra.txt
@@ -1,4 +1,4 @@
-# Extra pip requirements for the travis python 3.6 build
+# Extra pip requirements for the travis python 3.7+ builds
 
 ipykernel
 nbconvert[execute]

--- a/setup.py
+++ b/setup.py
@@ -262,7 +262,7 @@ if __name__ == '__main__':
             "kiwisolver>=1.0.1",
             "numpy>=1.15",
             "pillow>=6.2.0",
-            "pyparsing>=2.0.1,!=2.0.4,!=2.1.2,!=2.1.6",
+            "pyparsing>=2.0.3,!=2.0.4,!=2.1.2,!=2.1.6",
             "python-dateutil>=2.1",
         ],
 


### PR DESCRIPTION
Closes #16116


This:
 - bumps the minimum version of pyparsing from 2.0.1 -> 2.0.2
 - cleans up the requirement files used with on CI
 - move testing with pandas to py37/py38