### PR TITLE
Delay checking for existence of postscript distillers.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -24,7 +24,6 @@ import re
 
 import numpy as np
 
-import matplotlib as mpl
 from matplotlib import animation, cbook
 from matplotlib.cbook import ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
@@ -486,24 +485,8 @@ def validate_ps_distiller(s):
         s = s.lower()
     if s in ('none', None, 'false', False):
         return None
-    elif s in ('ghostscript', 'xpdf'):
-        try:
-            mpl._get_executable_info("gs")
-        except mpl.ExecutableNotFoundError:
-            _log.warning("Setting rcParams['ps.usedistiller'] requires "
-                         "ghostscript.")
-            return None
-        if s == "xpdf":
-            try:
-                mpl._get_executable_info("pdftops")
-            except mpl.ExecutableNotFoundError:
-                _log.warning("Setting rcParams['ps.usedistiller'] to 'xpdf' "
-                             "requires xpdf.")
-                return None
-        return s
     else:
-        raise ValueError('matplotlibrc ps.usedistiller must either be none, '
-                         'ghostscript or xpdf')
+        return ValidateInStrings('ps.usedistiller', ['ghostscript', 'xpdf'])(s)
 
 
 # A validator dedicated to the named line styles, based on the items in


### PR DESCRIPTION
Currently, if one has `ps.usedistiller` set in their matplotlibrc,
matplotlib will immediately check for the presence of ghostscript (and
possibly pstopdf) at import time and run them in subprocesses to check
their version, even though they may not be needed at all (if the user is
not going to save a postscript image); this can quite slow down import
time.  Compare e.g. with `text.usetex` which requires the presence of
a `tex` install, but doesn't check for its presence until it is actually
needed.

Delay the checking for the presence of the distillers until we actually
need them.  For consistency with the old behavior, don't error out if
they are missing, but just emit a warning.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
