### PR TITLE
Cleanup imports

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -24,7 +24,6 @@ import traceback
 import types
 import warnings
 import weakref
-from weakref import WeakMethod
 
 import numpy as np
 
@@ -180,7 +179,7 @@ class CallbackRegistry:
         """
         self._func_cid_map.setdefault(s, {})
         try:
-            proxy = WeakMethod(func, self._remove_proxy)
+            proxy = weakref.WeakMethod(func, self._remove_proxy)
         except TypeError:
             proxy = _StrongRef(func)
         if proxy in self._func_cid_map[s]:

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -33,7 +33,6 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.image import BboxImage
 from matplotlib.patches import (
     FancyBboxPatch, FancyArrowPatch, bbox_artist as mbbox_artist)
-from matplotlib.text import _AnnotationBase
 from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
 
 
@@ -1410,7 +1409,7 @@ class OffsetImage(OffsetBox):
         self.stale = False
 
 
-class AnnotationBbox(martist.Artist, _AnnotationBase):
+class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
     """
     Container for an `OffsetBox` referring to a specific position *xy*.
 
@@ -1475,10 +1474,10 @@ class AnnotationBbox(martist.Artist, _AnnotationBase):
         """
 
         martist.Artist.__init__(self, **kwargs)
-        _AnnotationBase.__init__(self,
-                                 xy,
-                                 xycoords=xycoords,
-                                 annotation_clip=annotation_clip)
+        mtext._AnnotationBase.__init__(self,
+                                       xy,
+                                       xycoords=xycoords,
+                                       annotation_clip=annotation_clip)
 
         self.offsetbox = offsetbox
 

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -94,7 +94,6 @@ from matplotlib import cbook, rcParams
 import matplotlib.artist as martist
 import matplotlib.text as mtext
 
-from matplotlib.artist import Artist
 from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from matplotlib.patches import PathPatch
@@ -158,7 +157,7 @@ class BezierPath(Line2D):
 
 class AttributeCopier:
     @cbook.deprecated("3.2")
-    def __init__(self, ref_artist, klass=Artist):
+    def __init__(self, ref_artist, klass=martist.Artist):
         self._klass = klass
         self._ref_artist = ref_artist
         super().__init__()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -24,7 +24,6 @@ import matplotlib.colors as mcolors
 import matplotlib.docstring as docstring
 import matplotlib.scale as mscale
 from matplotlib.axes import Axes, rcParams
-from matplotlib.colors import Normalize, LightSource
 from matplotlib.transforms import Bbox
 from matplotlib.tri.triangulation import Triangulation
 
@@ -1650,7 +1649,7 @@ class Axes3D(Axes):
         """
         if lightsource is None:
             # chosen for backwards-compatibility
-            lightsource = LightSource(azdeg=225, altdeg=19.4712)
+            lightsource = mcolors.LightSource(azdeg=225, altdeg=19.4712)
 
         with np.errstate(invalid="ignore"):
             shade = ((normals / np.linalg.norm(normals, axis=1, keepdims=True))
@@ -1659,8 +1658,8 @@ class Axes3D(Axes):
 
         if mask.any():
             # convert dot product to allowed shading fractions
-            in_norm = Normalize(-1, 1)
-            out_norm = Normalize(0.3, 1).inverse
+            in_norm = mcolors.Normalize(-1, 1)
+            out_norm = mcolors.Normalize(0.3, 1).inverse
 
             def norm(x):
                 return out_norm(in_norm(x))

--- a/setupext.py
+++ b/setupext.py
@@ -16,7 +16,6 @@ import sys
 import tarfile
 import textwrap
 import urllib.request
-from urllib.request import Request
 import versioneer
 
 _log = logging.getLogger(__name__)
@@ -99,7 +98,7 @@ def download_or_cache(url, sha):
     # default User-Agent, but not (for example) wget; so I don't feel too
     # bad passing in an empty User-Agent.
     with urllib.request.urlopen(
-            Request(url, headers={"User-Agent": ""})) as req:
+            urllib.request.Request(url, headers={"User-Agent": ""})) as req:
         file_contents = BytesIO(req.read())
         file_contents.seek(0)
 


### PR DESCRIPTION
## PR Summary

Do not explicitly import single classes that are rarely used if the respective module is imported anyway. Use `module.Class` instead.
