### PR TITLE
Merge pull request #16404 from jklymak/fix-add-base-symlognorm

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -311,7 +311,7 @@ longer necessary to import mplot3d to create 3d axes with ::
 `.SymLogNorm` now has a *base* parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, `.SymLogNorm` had no *base* kwarg and the base was
+Previously, `.SymLogNorm` had no *base* keyword argument and the base was
 hard-coded to ``base=np.e``. This was inconsistent with the default
 behavior of `.SymLogScale` (which defaults to ``base=10``) and the use
 of the word "decade" in the documentation.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -307,3 +307,15 @@ mplot3d auto-registration
 longer necessary to import mplot3d to create 3d axes with ::
 
   ax = fig.add_subplot(111, projection="3d")
+
+`.SymLogNorm` now has a *base* parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, `.SymLogNorm` had no *base* kwarg and the base was
+hard-coded to ``base=np.e``. This was inconsistent with the default
+behavior of `.SymLogScale` (which defaults to ``base=10``) and the use
+of the word "decade" in the documentation.
+
+In preparation for changing the default base to 10, calling
+`.SymLogNorm` without the new *base* kwarg emits a deprecation
+warning.

--- a/examples/userdemo/colormap_normalizations.py
+++ b/examples/userdemo/colormap_normalizations.py
@@ -69,7 +69,7 @@ fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolormesh(X, Y, Z1,
                        norm=colors.SymLogNorm(linthresh=0.03, linscale=0.03,
-                                              vmin=-1.0, vmax=1.0),
+                                              vmin=-1.0, vmax=1.0, base=10),
                        cmap='RdBu_r')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 

--- a/examples/userdemo/colormap_normalizations_symlognorm.py
+++ b/examples/userdemo/colormap_normalizations_symlognorm.py
@@ -29,7 +29,7 @@ fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolormesh(X, Y, Z,
                        norm=colors.SymLogNorm(linthresh=0.03, linscale=0.03,
-                                              vmin=-1.0, vmax=1.0),
+                                              vmin=-1.0, vmax=1.0, base=10),
                        cmap='RdBu_r')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1218,16 +1218,19 @@ class SymLogNorm(Normalize):
             The range within which the plot is linear (to avoid having the plot
             go to infinity around zero).
         linscale : float, default: 1
-            This allows the linear range (-*linthresh* to *linthresh*) to be
-            stretched relative to the logarithmic range. Its value is the
-            number of powers of *base* (decades for base 10) to use for each
-            half of the linear range. For example, when *linscale* == 1.0
-            (the default), the space used for the positive and negative halves
-            of the linear range will be equal to a decade in the logarithmic
-            range if ``base=10``.
+            This allows the linear range (-*linthresh* to *linthresh*)
+            to be stretched relative to the logarithmic range. Its
+            value is the number of powers of *base* to use for each
+            half of the linear range.
+
+            For example, when *linscale* == 1.0 (the default) and
+            ``base=10``, then space used for the positive and negative
+            halves of the linear range will be equal to a decade in
+            the logarithmic.
+
         base : float, default: None
-            If not given, defaults to ``np.e``, consistent with prior
-            behavior and warns.
+            If not given, defaults to ``np.e`` (consistent with prior
+            behavior) and warns.
 
             In v3.3 the default value will change to 10 to be consistent with
             `.SymLogNorm`.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1232,7 +1232,7 @@ class SymLogNorm(Normalize):
             In v3.3 the default value will change to 10 to be consistent with
             `.SymLogNorm`.
 
-            To suppress the warning pass base as a kwarg.
+            To suppress the warning pass *base* as a keyword argument.
 
         """
         Normalize.__init__(self, vmin, vmax, clip)
@@ -1240,7 +1240,7 @@ class SymLogNorm(Normalize):
             self._base = np.e
             cbook.warn_deprecated("3.3", message="default base may change "
                 "from np.e to 10.  To suppress this warning specify the base "
-                "kwarg.")
+                "keyword argument.")
         else:
             self._base = base
         self._log_base = np.log(self._base)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -388,7 +388,7 @@ def test_SymLogNorm():
     """
     Test SymLogNorm behavior
     """
-    norm = mcolors.SymLogNorm(3, vmax=5, linscale=1.2)
+    norm = mcolors.SymLogNorm(3, vmax=5, linscale=1.2, base=np.e)
     vals = np.array([-30, -1, 2, 6], dtype=float)
     normed_vals = norm(vals)
     expected = [0., 0.53980074, 0.826991, 1.02758204]
@@ -398,16 +398,30 @@ def test_SymLogNorm():
     _mask_tester(norm, vals)
 
     # Ensure that specifying vmin returns the same result as above
-    norm = mcolors.SymLogNorm(3, vmin=-30, vmax=5, linscale=1.2)
+    norm = mcolors.SymLogNorm(3, vmin=-30, vmax=5, linscale=1.2, base=np.e)
     normed_vals = norm(vals)
     assert_array_almost_equal(normed_vals, expected)
+
+    # test something more easily checked.
+    norm = mcolors.SymLogNorm(1, vmin=-np.e**3, vmax=np.e**3, base=np.e)
+    nn = norm([-np.e**3, -np.e**2, -np.e**1, -1,
+              0, 1, np.e**1, np.e**2, np.e**3])
+    xx = np.array([0., 0.109123, 0.218246, 0.32737, 0.5, 0.67263,
+                   0.781754, 0.890877, 1.])
+    assert_array_almost_equal(nn, xx)
+    norm = mcolors.SymLogNorm(1, vmin=-10**3, vmax=10**3, base=10)
+    nn = norm([-10**3, -10**2, -10**1, -1,
+              0, 1, 10**1, 10**2, 10**3])
+    xx = np.array([0., 0.121622, 0.243243, 0.364865, 0.5, 0.635135,
+                   0.756757, 0.878378, 1.])
+    assert_array_almost_equal(nn, xx)
 
 
 def test_SymLogNorm_colorbar():
     """
     Test un-called SymLogNorm in a colorbar.
     """
-    norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1)
+    norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1, base=np.e)
     fig = plt.figure()
     mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
     plt.close(fig)
@@ -418,7 +432,7 @@ def test_SymLogNorm_single_zero():
     Test SymLogNorm to ensure it is not adding sub-ticks to zero label
     """
     fig = plt.figure()
-    norm = mcolors.SymLogNorm(1e-5, vmin=-1, vmax=1)
+    norm = mcolors.SymLogNorm(1e-5, vmin=-1, vmax=1, base=np.e)
     cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
     ticks = cbar.get_ticks()
     assert sum(ticks == 0) == 1
@@ -895,9 +909,10 @@ def test_ndarray_subclass_norm(recwarn):
     mydata = data.view(MyArray)
 
     for norm in [mcolors.Normalize(), mcolors.LogNorm(),
-                 mcolors.SymLogNorm(3, vmax=5, linscale=1),
+                 mcolors.SymLogNorm(3, vmax=5, linscale=1, base=np.e),
                  mcolors.Normalize(vmin=mydata.min(), vmax=mydata.max()),
-                 mcolors.SymLogNorm(3, vmin=mydata.min(), vmax=mydata.max()),
+                 mcolors.SymLogNorm(3, vmin=mydata.min(), vmax=mydata.max(),
+                                    base=np.e),
                  mcolors.PowerNorm(1)]:
         assert_array_equal(norm(mydata), norm(data))
         fig, ax = plt.subplots()

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -98,7 +98,7 @@ fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolormesh(X, Y, Z,
                        norm=colors.SymLogNorm(linthresh=0.03, linscale=0.03,
-                                              vmin=-1.0, vmax=1.0),
+                                              vmin=-1.0, vmax=1.0, base=10),
                        cmap='RdBu_r')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 


### PR DESCRIPTION
FIX: add base kwarg to symlognor

Conflicts:
	doc/api/next_api_changes/behaviour.rst
          - moved to
            doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst and re-worded.
	lib/matplotlib/colors.py
          - implicitly backported converting the docstring to numpy
            doc style.  Re-worded new docstring

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
