### PR TITLE
Backport PR #16006: Ignore pos in StrCategoryFormatter.__call__ to di…

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -138,7 +138,12 @@ class StrCategoryFormatter(ticker.Formatter):
         self._units = units_mapping
 
     def __call__(self, x, pos=None):
-        return '' if pos is None else self.format_ticks([x])[0]
+        """
+        Return the category label string for tick val *x*.
+
+        The position *pos* is ignored.
+        """
+        return self.format_ticks([x])[0]
 
     def format_ticks(self, values):
         r_mapping = {v: self._text(k) for k, v in self._units.items()}

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -156,16 +156,16 @@ class TestStrCategoryFormatter:
         unit = cat.UnitData(ydata)
         labels = cat.StrCategoryFormatter(unit._mapping)
         for i, d in enumerate(ydata):
-            assert labels(i, i) == _to_str(d)
+            assert labels(i, i) == d
+            assert labels(i, None) == d
 
     @pytest.mark.parametrize("ydata", cases, ids=ids)
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)
     def test_StrCategoryFormatterPlot(self, ax, ydata, plotter):
         plotter(ax, range(len(ydata)), ydata)
         for i, d in enumerate(ydata):
-            assert ax.yaxis.major.formatter(i, i) == _to_str(d)
-        assert ax.yaxis.major.formatter(i+1, i+1) == ""
-        assert ax.yaxis.major.formatter(0, None) == ""
+            assert ax.yaxis.major.formatter(i) == d
+        assert ax.yaxis.major.formatter(i+1) == ""
 
 
 def axis_test(axis, labels):


### PR DESCRIPTION
…splay correct label in the preview window

Ignore pos in StrCategoryFormatter.__call__ to display correct… (#16006)

Ignore pos in StrCategoryFormatter.__call__ to display correct label in the preview window
Conflicts:
	lib/matplotlib/tests/test_category.py
         - collision with py2 removal work (_to_str)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
