### PR TITLE
Improve documentation for examples/widgets/textbox.py

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -262,3 +262,4 @@ per-file-ignores =
     examples/userdemo/connectionstyle_demo.py: E402
     examples/userdemo/custom_boxstyle01.py: E402
     examples/userdemo/pgf_preamble_sgskip.py: E402
+    examples/widgets/textbox.py: E402

--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -5,11 +5,11 @@ Textbox
 
 The Textbox widget lets users interactively provide text input, including
 formulas. In this example, the plot is updated using the `.on_submit` method.
-This method triggers the execution of the `submit` function when the user
-presses enter in the textbox or leaves the textbox. 
+This method triggers the execution of the *submit* function when the
+user presses enter in the textbox or leaves the textbox.
 
-Note:  The `Textbox` widget is different from the following static elements:
-:doc:`/tutorials/text/annotations` and
+Note:  The `matplotlib.widgets.TextBox` widget is different from the following
+static elements: :doc:`/tutorials/text/annotations` and
 :doc:`/gallery/recipes/placing_text_boxes`.
 """
 

--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -5,9 +5,13 @@ Textbox
 
 Allowing text input with the Textbox widget.
 
-You can use the Textbox widget to let users provide any text that needs to be
-displayed, including formulas. You can use a submit button to create plots
-with the given input.
+You can use the Textbox widget to let users interactively provide any text 
+that needs to be displayed, including formulas. You can use a submit button to 
+create plots with the given input.
+
+Note to not get confused with 
+:doc:`/tutorials/text/annotations` and 
+:doc:`/gallery/recipes/placing_text_boxes`, both of which are static elements.
 """
 
 import numpy as np
@@ -22,7 +26,9 @@ l, = plt.plot(t, s, lw=2)
 
 
 def submit(text):
-    ydata = eval(text)
+    # user can enter a new math expression that uses "t" as its independent 
+    # variable. The plot refreshes on entering. Example: try "t ** 3"
+    ydata = eval(text)  
     l.set_ydata(ydata)
     ax.set_ylim(np.min(ydata), np.max(ydata))
     plt.draw()
@@ -32,3 +38,15 @@ text_box = TextBox(axbox, 'Evaluate', initial=initial_text)
 text_box.on_submit(submit)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+from matplotlib.widgets import TextBox

--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -3,15 +3,14 @@
 Textbox
 =======
 
-Allowing text input with the Textbox widget.
+The Textbox widget lets users interactively provide text input, including
+formulas. In this example, the plot is updated using the `.on_submit` method.
+This method triggers the execution of the `submit` function when the user
+presses enter in the textbox or leaves the textbox. 
 
-You can use the Textbox widget to let users interactively provide any text 
-that needs to be displayed, including formulas. You can use a submit button to 
-create plots with the given input.
-
-Note to not get confused with 
-:doc:`/tutorials/text/annotations` and 
-:doc:`/gallery/recipes/placing_text_boxes`, both of which are static elements.
+Note:  The `Textbox` widget is different from the following static elements:
+:doc:`/tutorials/text/annotations` and
+:doc:`/gallery/recipes/placing_text_boxes`.
 """
 
 import numpy as np
@@ -22,13 +21,17 @@ plt.subplots_adjust(bottom=0.2)
 t = np.arange(-2.0, 2.0, 0.001)
 s = t ** 2
 initial_text = "t ** 2"
-l, = plt.plot(t, s, lw=2)
+l, = plt.plot(t, s, lw=2)  # make a plot for the math expression "t ** 2"
 
 
-def submit(text):
-    # user can enter a new math expression that uses "t" as its independent 
-    # variable. The plot refreshes on entering. Example: try "t ** 3"
-    ydata = eval(text)  
+def submit(expression):
+    """
+    Update the plotted function to the new math *expression*.
+
+    *expession* is a string using "t" as its independent variable, e.g.
+    "t ** 3".
+    """
+    ydata = eval(expression)
     l.set_ydata(ydata)
     ax.set_ylim(np.min(ydata), np.max(ydata))
     plt.draw()


### PR DESCRIPTION
## PR Summary

The current documentation in textbox.py doesn't explicitly explain that this is an interactive GUI. Its name *textbox* may be easily confused with normal text with box, which is probably used more often. And it's hard to tell otherwise from the embedded screenshot. It fooled me for a good minute at least. I added a few notes in docstring and comment to stress the fact that this is different than just inserting a static text box. Also to bring more clarity to the purpose of the "submit" function.
 
This PR is also related to https://github.com/matplotlib/matplotlib/issues/11654

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
