### PR TITLE
Make backend_ps test robust against timestamp changes in ghostscript.

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -1,5 +1,6 @@
 import io
 from pathlib import Path
+import re
 import tempfile
 
 import pytest
@@ -68,6 +69,13 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation,
 
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()
+
+        if rcParams.get("ps.usedistiller") or rcParams.get("text.usetex"):
+            # Strip out CreationDate betcase ghostscript doesn't obey
+            # SOURCE_DATE_EPOCH.  Note that in usetex mode, we *always* call
+            # gs_distill, even if ps.usedistiller is unset.
+            s_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", s_val)
+            b_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", b_val)
 
         assert s_val == b_val.replace(b'\r\n', b'\n')
 


### PR DESCRIPTION
Ghostscript doesn't obey SOURCE_DATE_EPOCH
(https://bugs.ghostscript.com/show_bug.cgi?id=696765) so locally
test_savefig_to_stringio is a bit flaky -- sometimes the string
comparisons fail due to differences in timestamps between two
ghostscript invocations (I'm actually a bit curious why this never fails
on CI).
Fix that by stripping out the timestamp.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
