### PR TITLE
3D example avoid using statefull .gca()

### DIFF
--- a/examples/mplot3d/surface3d.py
+++ b/examples/mplot3d/surface3d.py
@@ -15,9 +15,7 @@ from matplotlib import cm
 from matplotlib.ticker import LinearLocator, FormatStrFormatter
 import numpy as np
 
-
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
 # Make data.
 X = np.arange(-5, 5, 0.25)


### PR DESCRIPTION
explicit is better than implicit, gca is not explicit
