### PR TITLE
Parametrize imshow antialiased tests.

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -115,102 +115,44 @@ def test_image_python_io():
     plt.imread(buffer)
 
 
+@pytest.mark.parametrize(
+    "img_size, fig_size, interpolation",
+    [(5, 2, "hanning"),  # data larger than figure.
+     (5, 5, "nearest"),  # exact resample.
+     (5, 10, "nearest"),  # double sample.
+     (3, 2.9, "hanning"),  # <3 upsample.
+     (3, 9.1, "nearest"),  # >3 upsample.
+     ])
 @check_figures_equal(extensions=['png'])
-def test_imshow_subsample(fig_test, fig_ref):
-    # data is bigger than figure, so subsampling with hanning
+def test_imshow_antialiased(fig_test, fig_ref,
+                            img_size, fig_size, interpolation):
     np.random.seed(19680801)
-    dpi = 100
-    A = np.random.rand(int(dpi * 5), int(dpi * 5))
+    dpi = plt.rcParams["savefig.dpi"]
+    A = np.random.rand(int(dpi * img_size), int(dpi * img_size))
     for fig in [fig_test, fig_ref]:
-        fig.set_size_inches(2, 2)
-
+        fig.set_size_inches(fig_size, fig_size)
     axs = fig_test.subplots()
     axs.set_position([0, 0, 1, 1])
     axs.imshow(A, interpolation='antialiased')
     axs = fig_ref.subplots()
     axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='hanning')
-
-
-@check_figures_equal(extensions=['png'])
-def test_imshow_samesample(fig_test, fig_ref):
-    # exact resample, so should be same as nearest....
-    np.random.seed(19680801)
-    dpi = 100
-    A = np.random.rand(int(dpi * 5), int(dpi * 5))
-    for fig in [fig_test, fig_ref]:
-        fig.set_size_inches(5, 5)
-    axs = fig_test.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='antialiased')
-    axs = fig_ref.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='nearest')
-
-
-@check_figures_equal(extensions=['png'])
-def test_imshow_doublesample(fig_test, fig_ref):
-    # should be exactly a double sample, so should use nearest neighbour
-    # which is the same as "none"
-    np.random.seed(19680801)
-    dpi = 100
-    A = np.random.rand(int(dpi * 5), int(dpi * 5))
-    for fig in [fig_test, fig_ref]:
-        fig.set_size_inches(10, 10)
-    axs = fig_test.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='antialiased')
-    axs = fig_ref.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='nearest')
-
-
-@check_figures_equal(extensions=['png'])
-def test_imshow_upsample(fig_test, fig_ref):
-    # should be less than 3 upsample, so should be nearest...
-    np.random.seed(19680801)
-    dpi = 100
-    A = np.random.rand(int(dpi * 3), int(dpi * 3))
-    for fig in [fig_test, fig_ref]:
-        fig.set_size_inches(2.9, 2.9)
-    axs = fig_test.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='antialiased')
-    axs = fig_ref.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='hanning')
-
-
-@check_figures_equal(extensions=['png'])
-def test_imshow_upsample3(fig_test, fig_ref):
-    # should be greater than 3 upsample, so should be nearest...
-    np.random.seed(19680801)
-    dpi = 100
-    A = np.random.rand(int(dpi * 3), int(dpi * 3))
-    for fig in [fig_test, fig_ref]:
-        fig.set_size_inches(9.1, 9.1)
-    axs = fig_test.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='antialiased')
-    axs = fig_ref.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='nearest')
+    axs.imshow(A, interpolation=interpolation)
 
 
 @check_figures_equal(extensions=['png'])
 def test_imshow_zoom(fig_test, fig_ref):
     # should be less than 3 upsample, so should be nearest...
     np.random.seed(19680801)
-    dpi = 100
+    dpi = plt.rcParams["savefig.dpi"]
     A = np.random.rand(int(dpi * 3), int(dpi * 3))
     for fig in [fig_test, fig_ref]:
         fig.set_size_inches(2.9, 2.9)
     axs = fig_test.subplots()
-    axs.imshow(A, interpolation='nearest')
+    axs.imshow(A, interpolation='antialiased')
     axs.set_xlim([10, 20])
     axs.set_ylim([10, 20])
     axs = fig_ref.subplots()
-    axs.imshow(A, interpolation='antialiased')
+    axs.imshow(A, interpolation='nearest')
     axs.set_xlim([10, 20])
     axs.set_ylim([10, 20])
 


### PR DESCRIPTION
Note that one of the old comments "should use nearest" should
actually have been "should use hanning"...

Also not hardcoding rcParams["savefig.dpi"] should be slightly more
robust.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
