### PR TITLE
Fix documentation to change cycler instead of lines.color.

### DIFF
--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -107,15 +107,24 @@ plt.show()
 # the matplotlib package. rcParams can be modified directly, for example:
 
 mpl.rcParams['lines.linewidth'] = 2
-mpl.rcParams['lines.color'] = 'r'
+mpl.rcParams['lines.linestyle'] = '--'
 plt.plot(data)
+
+###############################################################################
+# Note, that in order to change the usual `plot` color you have to change the 
+# `prop_cycle` property of `axes`:
+
+from cycler import cycler
+
+mpl.rcParams['axes.prop_cycle'] = cycler(color=['r', 'g', 'b', 'y'])
+plt.plot(data) # first color is red
 
 ###############################################################################
 # Matplotlib also provides a couple of convenience functions for modifying rc
 # settings. `matplotlib.rc` can be used to modify multiple
 # settings in a single group at once, using keyword arguments:
 
-mpl.rc('lines', linewidth=4, color='g')
+mpl.rc('lines', linewidth=4, linestyle='-.')
 plt.plot(data)
 
 ###############################################################################

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -112,7 +112,7 @@ plt.plot(data)
 
 ###############################################################################
 # Note, that in order to change the usual `plot` color you have to change the 
-# `prop_cycle` property of `axes`:
+# *prop_cycle* property of *axes*:
 
 from cycler import cycler
 

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -21,6 +21,7 @@ just add:
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+from cycler import cycler
 plt.style.use('ggplot')
 data = np.random.randn(50)
 
@@ -111,13 +112,11 @@ mpl.rcParams['lines.linestyle'] = '--'
 plt.plot(data)
 
 ###############################################################################
-# Note, that in order to change the usual `plot` color you have to change the 
+# Note, that in order to change the usual `plot` color you have to change the
 # *prop_cycle* property of *axes*:
 
-from cycler import cycler
-
 mpl.rcParams['axes.prop_cycle'] = cycler(color=['r', 'g', 'b', 'y'])
-plt.plot(data) # first color is red
+plt.plot(data)  # first color is red
 
 ###############################################################################
 # Matplotlib also provides a couple of convenience functions for modifying rc


### PR DESCRIPTION
## PR Summary

Changes according to https://github.com/matplotlib/matplotlib/issues/16434#issuecomment-583834800

Refers to #16434

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
