### PR TITLE
MNT: improve the error message in Path init

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2182,14 +2182,14 @@ def _check_shape(_shape, **kwargs):
     For each *key, value* pair in *kwargs*, check that *value* has the shape
     *_shape*, if not, raise an appropriate ValueError.
 
-    None in the shape is treated as a "free" sizes that can have any length.
+    *None* in the shape is treated as a "free" size that can have any length.
     e.g. (None, 2) -> (N, 2)
 
     The values checked must be numpy arrays.
 
     Examples
     --------
-    To check from (N, 2) shaped arrays
+    To check for (N, 2) shaped arrays
 
     >>> cbook._check_in_list((None, 2), arg=arg, other_arg=other_arg)
     """
@@ -2204,8 +2204,9 @@ def _check_shape(_shape, **kwargs):
             dim_labels = iter(itertools.chain(
                 'MNLIJKLH',
                 (f"D{i}" for i in itertools.count())))
-            text_shape = ", ".join(str(_) for _ in
-                                   (n if n is not None else next(dim_labels)
+            text_shape = ", ".join((str(n)
+                                    if n is not None
+                                    else next(dim_labels)
                                     for n in target_shape))
 
             raise ValueError(

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2197,24 +2197,20 @@ def _check_shape(_shape, **kwargs):
     for k, v in kwargs.items():
         data_shape = v.shape
 
-        if not (
-            len(data_shape) == len(target_shape)
-            and all(
-                (t == s if t is not None else True)
+        if len(target_shape) != len(data_shape) or any(
+                t not in [s, None]
                 for t, s in zip(target_shape, data_shape)
-            )
         ):
-            def format_dims(target_shape):
-                dim_labels = iter(itertools.chain(
-                    'MNLIJKLH',
-                    (f"D{i}" for i in itertools.count())))
-                text_shape = tuple(n if n is not None else next(dim_labels)
-                                   for n in target_shape)
-                return '(' + ", ".join(str(_) for _ in text_shape) + ')'
+            dim_labels = iter(itertools.chain(
+                'MNLIJKLH',
+                (f"D{i}" for i in itertools.count())))
+            text_shape = ", ".join(str(_) for _ in
+                                   (n if n is not None else next(dim_labels)
+                                    for n in target_shape))
 
             raise ValueError(
                 f"{k!r} must be {len(target_shape)}D "
-                f"with shape {format_dims(target_shape)}. "
+                f"with shape ({text_shape}). "
                 f"Your input has shape {v.shape}."
             )
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -141,7 +141,7 @@ class Path:
             if len(codes) and codes[0] != self.MOVETO:
                 raise ValueError("The first element of 'code' must be equal "
                                  f"to 'MOVETO' ({self.MOVETO}).  "
-                                 f"Your first code if {codes[0]}")
+                                 f"Your first code is {codes[0]}")
         elif closed and len(vertices):
             codes = np.empty(len(vertices), dtype=self.code_type)
             codes[0] = self.MOVETO

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -129,10 +129,7 @@ class Path:
             and codes as read-only arrays.
         """
         vertices = _to_unmasked_float_array(vertices)
-        if vertices.ndim != 2 or vertices.shape[1] != 2:
-            raise ValueError(
-                "'vertices' must be a 2D list or array with shape (N, 2). "
-                f"Your input has shape {vertices.shape}.")
+        cbook._check_shape((None, 2), vertices=vertices)
 
         if codes is not None:
             codes = np.asarray(codes, self.code_type)

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -131,16 +131,20 @@ class Path:
         vertices = _to_unmasked_float_array(vertices)
         if vertices.ndim != 2 or vertices.shape[1] != 2:
             raise ValueError(
-                "'vertices' must be a 2D list or array with shape Nx2")
+                "'vertices' must be a 2D list or array with shape (N, 2). "
+                f"Your input has shape {vertices.shape}.")
 
         if codes is not None:
             codes = np.asarray(codes, self.code_type)
             if codes.ndim != 1 or len(codes) != len(vertices):
                 raise ValueError("'codes' must be a 1D list or array with the "
-                                 "same length of 'vertices'")
+                                 "same length of 'vertices'. "
+                                 f"Your vertices have shape {vertices.shape} "
+                                 f"but your codes have shape {codes.shape}")
             if len(codes) and codes[0] != self.MOVETO:
                 raise ValueError("The first element of 'code' must be equal "
-                                 "to 'MOVETO' ({})".format(self.MOVETO))
+                                 f"to 'MOVETO' ({self.MOVETO}).  "
+                                 f"Your first code if {codes[0]}")
         elif closed and len(vertices):
             codes = np.empty(len(vertices), dtype=self.code_type)
             codes[0] = self.MOVETO

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -1,5 +1,7 @@
 import itertools
 import pickle
+import re
+
 from weakref import ref
 from unittest.mock import patch, Mock
 
@@ -633,3 +635,19 @@ def test_array_patch_perimeters():
         for rstride, cstride in itertools.product(divisors(rows - 1),
                                                   divisors(cols - 1)):
             check(x, rstride=rstride, cstride=cstride)
+
+
+@pytest.mark.parametrize('target,test_shape',
+                         [((None, ), (1, 3)),
+                          ((None, 3), (1,)),
+                          ((None, 3), (1, 2)),
+                          ((1, 5), (1, 9)),
+                          ((None, 2, None), (1, 3, 1))
+                          ])
+def test_check_shape(target, test_shape):
+    error_pattern = (f"^'aardvark' must be {len(target)}D.*" +
+                     re.escape(f'has shape {test_shape}'))
+    data = np.zeros(test_shape)
+    with pytest.raises(ValueError,
+                       match=error_pattern):
+        cbook._check_shape(target, aardvark=data)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -1,5 +1,5 @@
 import copy
-
+import re
 import numpy as np
 
 from numpy.testing import assert_array_equal
@@ -28,6 +28,25 @@ def test_readonly_path():
 
     with pytest.raises(AttributeError):
         modify_vertices()
+
+
+def test_path_exceptions():
+    bad_verts1 = np.arange(12).reshape(4, 3)
+    with pytest.raises(ValueError,
+                       match=re.escape(f'has shape {bad_verts1.shape}')):
+        Path(bad_verts1)
+
+    bad_verts2 = np.arange(12).reshape(2, 3, 2)
+    with pytest.raises(ValueError,
+                       match=re.escape(f'has shape {bad_verts2.shape}')):
+        Path(bad_verts2)
+
+    good_verts = np.arange(12).reshape(6, 2)
+    bad_codes = np.arange(2)
+    msg = re.escape(f"Your vertices have shape {good_verts.shape} "
+                    f"but your codes have shape {bad_codes.shape}")
+    with pytest.raises(ValueError, match=msg):
+        Path(good_verts, bad_codes)
 
 
 def test_point_in_path():

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -1,5 +1,6 @@
 import copy
 import re
+
 import numpy as np
 
 from numpy.testing import assert_array_equal


### PR DESCRIPTION
Improve the error messages when invalidly shaped data is passed to
`matplotlib.path.Path.__init__`.


- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->