### PR TITLE
Remove some remnants of hist{,2d}(normed=...).

### DIFF
--- a/examples/statistics/histogram_features.py
+++ b/examples/statistics/histogram_features.py
@@ -1,12 +1,12 @@
 """
-=========================================================
-Demo of the histogram (hist) function with a few features
-=========================================================
+==============================================
+Some features of the histogram (hist) function
+==============================================
 
 In addition to the basic histogram, this demo shows a few optional features:
 
 * Setting the number of data bins.
-* The ``normed`` flag, which normalizes bin heights so that the integral of
+* The *density* parameter, which normalizes bin heights so that the integral of
   the histogram is 1. The resulting histogram is an approximation of the
   probability density function.
 * Setting the face color of the bars.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6476,22 +6476,22 @@ default: :rc:`scatter.edgecolors`
             range of x.
 
         density : bool, default: False
-            If ``True``, the first element of the return tuple will
-            be the raw counts per bin normalized to form a probability density
-            so that the area under the histogram will integrate to 1, i.e.
-            ``np.sum(n * np.diff(bins)) == 1``.  (Computed by dividing the
-            raw counts ``n0`` by the total number of data points and
-            multiplying by the bin width: ``n = n0 / sum(n0) * np.diff(bins)``)
+            If ``True``, draw and return a probability density: each bin
+            will display the bin's raw count divided by the total number of
+            counts *and the bin width*
+            (``density = counts / (sum(counts) * np.diff(bins))``),
+            so that the area under the histogram integrates to 1
+            (``np.sum(density * np.diff(bins)) == 1``).
 
             If *stacked* is also ``True``, the sum of the histograms is
             normalized to 1.
 
         weights : (n,) array-like or None, default: None
-            An array of weights, of the same shape as *x*.  Each value in *x*
-            only contributes its associated weight towards the bin count
-            (instead of 1).  If *normed* or *density* is ``True``,
-            the weights are normalized, so that the integral of the density
-            over the range remains 1.
+            An array of weights, of the same shape as *x*.  Each value in
+            *x* only contributes its associated weight towards the bin count
+            (instead of 1).  If *density* is ``True``, the weights are
+            normalized, so that the integral of the density over the range
+            remains 1.
 
             This parameter can be used to draw a histogram of data that has
             already been binned, e.g. using `numpy.histogram` (by treating each
@@ -6916,8 +6916,8 @@ default: :rc:`scatter.edgecolors`
             considered outliers and not tallied in the histogram.
 
         density : bool, default: False
-            Normalize histogram.  *normed* is a deprecated synonym for this
-            parameter.
+            Normalize histogram.  See the documentation for the *density*
+            parameter of `~.Axes.hist` for more details.
 
         weights : array-like, shape (n, ), optional
             An array of values w_i weighing each sample (x_i, y_i).
@@ -6976,7 +6976,7 @@ default: :rc:`scatter.edgecolors`
         """
 
         h, xedges, yedges = np.histogram2d(x, y, bins=bins, range=range,
-                                           normed=density, weights=weights)
+                                           density=density, weights=weights)
 
         if cmin is not None:
             h[h < cmin] = None


### PR DESCRIPTION
- Remove mentions of it from docstrings, example.
- np.histogram2d also supports density since np1.15
  https://github.com/eric-wieser/numpy/commit/081050ae2811a0f962805cb616554913a225a4db
- Reword docs for `density` in a hopefully(?) clearer manner?  In
  particular, few users will care about the "first element of the return
  tuple"; what mostly matters is what gets drawn.
- Refer to hist's `density` in hist2d.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
