### PR TITLE
WIP: for non-interactive backends make fig.canvas.draw() force the render

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,8 @@
 # Create and test a Python package on multiple Python versions.
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
+pr: none
+trigger: none
 
 strategy:
   matrix:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -870,6 +870,12 @@ class FigureCanvasPgf(FigureCanvasBase):
         writeln(fh, r"\makeatother")
         writeln(fh, r"\endgroup")
 
+
+    def draw(self):
+        # docstring inherited
+        self.figure.draw(self.get_renderer())
+
+
     def print_pgf(self, fname_or_fh, *args, **kwargs):
         """
         Output pgf macros for drawing the figure so it can be included and

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -324,3 +324,16 @@ def test_bbox_inches_tight(tmpdir):
     ax.imshow([[0, 1], [2, 3]])
     fig.savefig(os.path.join(tmpdir, "test.pdf"), backend="pgf",
                 bbox_inches="tight")
+
+
+@needs_pdflatex
+@pytest.mark.style('default')
+@pytest.mark.backend('pgf')
+def test_draw():
+    mpl.rcParams['pgf.texsystem'] =  'pdflatex'
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    old_Nticks = len(ax.yaxis.majorTicks)
+    fig.canvas.draw()
+    new_Nticks = len(ax.yaxis.majorTicks)
+    assert old_Nticks != new_Nticks


### PR DESCRIPTION
## PR Summary
[ci skip]
[azurepipelines skip]

make fig.canvas.draw() behave similar to fig.draw(fig.canvas.get_renderer()) for non-interactive backends.
attempts to address #16558

I will be making incremental changes (still haven't completely understood the machinery for all the non-interactive backends).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
