### PR TITLE
Style fix for dynamic axes subclass generation in mpl_toolkits.

### DIFF
--- a/lib/mpl_toolkits/axes_grid/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid/parasite_axes.py
@@ -5,10 +5,6 @@ from mpl_toolkits.axisartist.axislines import Axes
 
 
 ParasiteAxes = parasite_axes_class_factory(Axes)
-
-ParasiteAxesAuxTrans = \
-    parasite_axes_auxtrans_class_factory(axes_class=ParasiteAxes)
-
-HostAxes = host_axes_class_factory(axes_class=Axes)
-
+ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
+HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)

--- a/lib/mpl_toolkits/axisartist/__init__.py
+++ b/lib/mpl_toolkits/axisartist/__init__.py
@@ -2,20 +2,14 @@ from .axislines import (
     Axes, AxesZero, AxisArtistHelper, AxisArtistHelperRectlinear,
     GridHelperBase, GridHelperRectlinear, Subplot, SubplotZero)
 from .axis_artist import AxisArtist, GridlinesCollection
-
 from .grid_helper_curvelinear import GridHelperCurveLinear
-
 from .floating_axes import FloatingAxes, FloatingSubplot
-
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
     parasite_axes_auxtrans_class_factory, subplot_class_factory)
 
+
 ParasiteAxes = parasite_axes_class_factory(Axes)
-
-ParasiteAxesAuxTrans = \
-    parasite_axes_auxtrans_class_factory(axes_class=ParasiteAxes)
-
-HostAxes = host_axes_class_factory(axes_class=Axes)
-
+ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
+HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)

--- a/lib/mpl_toolkits/axisartist/parasite_axes.py
+++ b/lib/mpl_toolkits/axisartist/parasite_axes.py
@@ -1,15 +1,10 @@
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
     parasite_axes_auxtrans_class_factory, subplot_class_factory)
-
 from .axislines import Axes
 
 
 ParasiteAxes = parasite_axes_class_factory(Axes)
-
-ParasiteAxesAuxTrans = \
-    parasite_axes_auxtrans_class_factory(axes_class=ParasiteAxes)
-
-HostAxes = host_axes_class_factory(axes_class=Axes)
-
+ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
+HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)


### PR DESCRIPTION
The various factories take a single argument, which we can just pass
positionally.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
