### PR TITLE
Deprecate arg-less calls to subplot_class_factory (and similar factories)

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -317,3 +317,12 @@ Axis and Locator ``pan`` and ``zoom``
 The unused ``pan`` and ``zoom`` methods of `~.axis.Axis` and `~.ticker.Locator`
 are deprecated.  Panning and zooming are now implemented using the
 ``start_pan``, ``drag_pan``, and ``end_pan`` methods of `~.axes.Axes`.
+
+Passing None to various Axes subclass factories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for passing ``None`` as base class to `.axes.subplot_class_factory`,
+``axes_grid1.parasite_axes.host_axes_class_factory``,
+``axes_grid1.parasite_axes.host_subplot_class_factory``,
+``axes_grid1.parasite_axes.parasite_axes_class_factory``, and
+``axes_grid1.parasite_axes.parasite_axes_auxtrans_class_factory`` is deprecated.
+Explicitly pass the correct base ``Axes`` class instead.

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -186,6 +186,9 @@ def subplot_class_factory(axes_class=None):
     not have to be created for every type of Axes.
     """
     if axes_class is None:
+        cbook.warn_deprecated(
+            "3.3", message="Support for passing None to subplot_class_factory "
+            "is deprecated; explicitly pass the default Axes class instead.")
         axes_class = Axes
     try:
         # Avoid creating two different instances of GeoAxesSubplot...
@@ -199,8 +202,7 @@ def subplot_class_factory(axes_class=None):
                     {'_axes_class': axes_class})
 
 
-# This is provided for backward compatibility
-Subplot = subplot_class_factory()
+Subplot = subplot_class_factory(Axes)  # Provided for backward compatibility.
 
 
 def _picklable_subplot_class_constructor(axes_class):

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -52,13 +52,17 @@ class ParasiteAxesBase:
 @functools.lru_cache(None)
 def parasite_axes_class_factory(axes_class=None):
     if axes_class is None:
+        cbook.warn_deprecated(
+            "3.3", message="Support for passing None to "
+            "parasite_axes_class_factory is deprecated; explicitly pass the "
+            "default Axes class instead.")
         axes_class = Axes
 
     return type("%sParasite" % axes_class.__name__,
                 (ParasiteAxesBase, axes_class), {})
 
 
-ParasiteAxes = parasite_axes_class_factory()
+ParasiteAxes = parasite_axes_class_factory(Axes)
 
 
 class ParasiteAxesAuxTransBase:
@@ -175,6 +179,10 @@ class ParasiteAxesAuxTransBase:
 @functools.lru_cache(None)
 def parasite_axes_auxtrans_class_factory(axes_class=None):
     if axes_class is None:
+        cbook.warn_deprecated(
+            "3.3", message="Support for passing None to "
+            "parasite_axes_auxtrans_class_factory is deprecated; explicitly "
+            "pass the default ParasiteAxes class instead.")
         parasite_axes_class = ParasiteAxes
     elif not issubclass(axes_class, ParasiteAxesBase):
         parasite_axes_class = parasite_axes_class_factory(axes_class)
@@ -185,8 +193,7 @@ def parasite_axes_auxtrans_class_factory(axes_class=None):
                 {'name': 'parasite_axes'})
 
 
-ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(
-    axes_class=ParasiteAxes)
+ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
 
 
 class HostAxesBase:
@@ -194,7 +201,7 @@ class HostAxesBase:
         self.parasites = []
         super().__init__(*args, **kwargs)
 
-    def get_aux_axes(self, tr, viewlim_mode="equal", axes_class=None):
+    def get_aux_axes(self, tr, viewlim_mode="equal", axes_class=ParasiteAxes):
         parasite_axes_class = parasite_axes_auxtrans_class_factory(axes_class)
         ax2 = parasite_axes_class(self, tr, viewlim_mode)
         # note that ax2.transData == tr + ax1.transData
@@ -354,6 +361,9 @@ class HostAxesBase:
 @functools.lru_cache(None)
 def host_axes_class_factory(axes_class=None):
     if axes_class is None:
+        cbook.warn_deprecated(
+            "3.3", message="Support for passing None to host_axes_class is "
+            "deprecated; explicitly pass the default Axes class instead.")
         axes_class = Axes
 
     def _get_base_axes(self):
@@ -365,16 +375,16 @@ def host_axes_class_factory(axes_class=None):
 
 
 def host_subplot_class_factory(axes_class):
-    host_axes_class = host_axes_class_factory(axes_class=axes_class)
+    host_axes_class = host_axes_class_factory(axes_class)
     subplot_host_class = subplot_class_factory(host_axes_class)
     return subplot_host_class
 
 
-HostAxes = host_axes_class_factory(axes_class=Axes)
+HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
 
 
-def host_axes(*args, axes_class=None, figure=None, **kwargs):
+def host_axes(*args, axes_class=Axes, figure=None, **kwargs):
     """
     Create axes that can act as a hosts to parasitic axes.
 
@@ -397,7 +407,7 @@ def host_axes(*args, axes_class=None, figure=None, **kwargs):
     return ax
 
 
-def host_subplot(*args, axes_class=None, figure=None, **kwargs):
+def host_subplot(*args, axes_class=Axes, figure=None, **kwargs):
     """
     Create a subplot that can act as a host to parasitic axes.
 


### PR DESCRIPTION
Explicitly passing the base class is not too onerous; end users should
typically not have to handle the arg-less case because we provide these
classes at the toplevel anyways (`Subplot`, `ParasiteAxes`, etc.), and
this refactor should ultimately help with factoring all these factories
together, in particular to make mpl_toolkits Axes picklable (right now
they aren't) without duplicating the somewhat heavy machinery that makes
Subplots picklable (_picklable_subplot_class_constructor, etc.).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
