### PR TITLE
Use rc() less often in examples/tutorials.

### DIFF
--- a/examples/misc/multipage_pdf.py
+++ b/examples/misc/multipage_pdf.py
@@ -26,8 +26,8 @@ with PdfPages('multipage_pdf.pdf') as pdf:
     pdf.savefig()  # saves the current figure into a pdf page
     plt.close()
 
-    # if LaTeX is not installed or error caught, change to `usetex=False`
-    plt.rc('text', usetex=True)
+    # if LaTeX is not installed or error caught, change to `False`
+    plt.rcParams['text.usetex'] = True
     plt.figure(figsize=(8, 6))
     x = np.arange(0, 5, 0.1)
     plt.plot(x, np.sin(x), 'b-')
@@ -36,7 +36,7 @@ with PdfPages('multipage_pdf.pdf') as pdf:
     pdf.savefig()
     plt.close()
 
-    plt.rc('text', usetex=False)
+    plt.rcParams['text.usetex'] = False
     fig = plt.figure(figsize=(4, 5))
     plt.plot(x, x ** 2, 'ko')
     plt.title('Page Three')

--- a/examples/text_labels_and_annotations/mathtext_asarray.py
+++ b/examples/text_labels_and_annotations/mathtext_asarray.py
@@ -8,8 +8,6 @@ Make images from LaTeX strings.
 
 import matplotlib.mathtext as mathtext
 import matplotlib.pyplot as plt
-import matplotlib
-matplotlib.rc('image', origin='upper')
 
 parser = mathtext.MathTextParser("Bitmap")
 parser.to_png('test2.png',

--- a/examples/text_labels_and_annotations/usetex_fonteffects.py
+++ b/examples/text_labels_and_annotations/usetex_fonteffects.py
@@ -7,9 +7,7 @@ This script demonstrates that font effects specified in your pdftex.map
 are now supported in pdf usetex.
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
-matplotlib.rc('text', usetex=True)
 
 
 def setfont(font):
@@ -22,7 +20,7 @@ for y, font, text in zip(range(5),
                          ['Nimbus Roman No9 L ' + x for x in
                           ['', 'Italics (real italics for comparison)',
                            '(slanted)', '(condensed)', '(extended)']]):
-    plt.text(0, y, setfont(font) + text)
+    plt.text(0, y, setfont(font) + text, usetex=True)
 
 plt.ylim(-1, 5)
 plt.xlim(-0.2, 0.6)

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -21,7 +21,6 @@ This was derived from embedding_in_wx and dynamic_image_wxagg.
 Thanks to matplotlib and wx teams for creating such great software!
 """
 
-import matplotlib
 import matplotlib.cm as cm
 import matplotlib.cbook as cbook
 from matplotlib.backends.backend_wxagg import (
@@ -34,9 +33,6 @@ import wx
 import wx.xrc as xrc
 
 ERR_TOL = 1e-5  # floating point slop for peak-detection
-
-
-matplotlib.rc('image', origin='lower')
 
 
 class PlotPanel(wx.Panel):
@@ -64,7 +60,7 @@ class PlotPanel(wx.Panel):
         y = np.arange(100.0) * 2 * np.pi / 50.0
         self.x, self.y = np.meshgrid(x, y)
         z = np.sin(self.x) + np.cos(self.y)
-        self.im = ax.imshow(z, cmap=cm.RdBu)
+        self.im = ax.imshow(z, cmap=cm.RdBu, origin='lower')
 
         zmax = np.max(z) - ERR_TOL
         ymax_i, xmax_i = np.nonzero(z >= zmax)

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -45,11 +45,17 @@ Computer Modern math fonts. See the PSNFSS_ documentation for more details.
 To use LaTeX and select Helvetica as the default font, without editing
 matplotlibrc use::
 
-  from matplotlib import rc
-  rc('font', **{'family': 'sans-serif', 'sans-serif': ['Helvetica']})
+  import matplotlib as mpl
+  plt.rcParams.update({
+      "text.usetex": True,
+      "font.family": "sans-serif",
+      "font.sans-serif": ["Helvetica"]})
   ## for Palatino and other serif fonts use:
-  # rc('font', **{'family': 'serif', 'serif': ['Palatino']})
-  rc('text', usetex=True)
+  plt.rcParams.update({
+      "text.usetex": True,
+      "font.family": "serif",
+      "font.serif": ["Palatino"],
+  })
 
 Here is the standard example,
 :file:`/gallery/text_labels_and_annotations/tex_demo`:


### PR DESCRIPTION
If a user learns rcParams.update / dict.update, they'll know how to
merge any dicts, whereas rc() is a matplotlib-specific API which is
hardly shorter (and needing star-unpacking in the case of
tutorials/text/usetex.py, which makes things worse overall).

Also it's often better to just pass the argument to the single
function call (`text(..., usetex=True)`, `imshow(..., origin="lower")`)
which avoids unnecessarily touching global state.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
