### PR TITLE
Update usetex_fonteffects example.

### DIFF
--- a/examples/text_labels_and_annotations/usetex_fonteffects.py
+++ b/examples/text_labels_and_annotations/usetex_fonteffects.py
@@ -4,26 +4,25 @@ Usetex Fonteffects
 ==================
 
 This script demonstrates that font effects specified in your pdftex.map
-are now supported in pdf usetex.
+are now supported in usetex mode.
 """
 
 import matplotlib.pyplot as plt
 
 
 def setfont(font):
-    return r'\font\a %s at 14pt\a ' % font
+    return rf'\font\a {font} at 14pt\a '
 
 
+fig = plt.figure()
 for y, font, text in zip(range(5),
                          ['ptmr8r', 'ptmri8r', 'ptmro8r',
                           'ptmr8rn', 'ptmrr8re'],
                          ['Nimbus Roman No9 L ' + x for x in
                           ['', 'Italics (real italics for comparison)',
                            '(slanted)', '(condensed)', '(extended)']]):
-    plt.text(0, y, setfont(font) + text, usetex=True)
+    fig.text(.1, 1 - (y + 1) / 6, setfont(font) + text, usetex=True)
 
-plt.ylim(-1, 5)
-plt.xlim(-0.2, 0.6)
-plt.setp(plt.gca(), frame_on=False, xticks=(), yticks=())
-plt.title('Usetex font effects')
-plt.savefig('usetex_fonteffects.pdf')
+fig.suptitle('Usetex font effects')
+# Would also work if saving to pdf.
+plt.show()


### PR DESCRIPTION
- Use Figure.text() / Figure.suptitle() instead of adding text to an
  Axes and then going through the bother of setting the axes limits and
  then hiding the axes.
- Explicitly pass usetex=True to the sole text() call instead of using
  rc().
- Show the figure, demonstrating that things work in agg as well,
  instead of creating a pdf file that then needs to be cleaned out of
  the source tree (but mention that saving to pdf works too).
- fstringify.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
