### PR TITLE
Rename font_bunch to psfont in textpath.

### DIFF
--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -296,15 +296,15 @@ class TextToPath:
     @functools.lru_cache(50)
     def _get_ps_font_and_encoding(texname):
         tex_font_map = dviread.PsfontsMap(dviread.find_tex_file('pdftex.map'))
-        font_bunch = tex_font_map[texname]
-        if font_bunch.filename is None:
+        psfont = tex_font_map[texname]
+        if psfont.filename is None:
             raise ValueError(
-                f"No usable font file found for {font_bunch.psname} "
-                f"({texname}). The font may lack a Type-1 version.")
+                f"No usable font file found for {psfont.psname} ({texname}). "
+                f"The font may lack a Type-1 version.")
 
-        font = get_font(font_bunch.filename)
+        font = get_font(psfont.filename)
 
-        if font_bunch.encoding:
+        if psfont.encoding:
             # If psfonts.map specifies an encoding, use it: it gives us a
             # mapping of glyph indices to Adobe glyph names; use it to convert
             # dvi indices to glyph names and use the FreeType-synthesized
@@ -312,7 +312,7 @@ class TextToPath:
             # FT_Get_Name_Index/get_name_index), and load the glyph using
             # FT_Load_Glyph/load_glyph.  (That charmap has a coverage at least
             # as good as, and possibly better than, the native charmaps.)
-            enc = dviread._parse_enc(font_bunch.encoding)
+            enc = dviread._parse_enc(psfont.encoding)
         else:
             # If psfonts.map specifies no encoding, the indices directly
             # map to the font's "native" charmap; so don't use the
@@ -331,7 +331,7 @@ class TextToPath:
                     break
             else:
                 _log.warning("No supported encoding in font (%s).",
-                             font_bunch.filename)
+                             psfont.filename)
             enc = None
 
         return font, enc


### PR DESCRIPTION
It's a PsFont instance.  Given than there's quite a few different font
classes involved here (DviFont, PsFont, FT2Font, ...), let's use a less
ambiguous name.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
