### PR TITLE
Deprecate recursionlimit kwarg to matplotlib.test().

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -232,3 +232,7 @@ Axes navigation can still be toggled programmatically using
 The following related APIs are also deprecated:
 ``backend_tools.ToolEnableAllNavigation``,
 ``backend_tools.ToolEnableNavigation``, and ``rcParams["keymap.all_axes"]``.
+
+``matplotlib.test(recursionlimit=...)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *recursionlimit* parameter of ``matplotlib.test`` is deprecated.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1177,6 +1177,7 @@ def _init_tests():
 
 
 @cbook._delete_parameter("3.2", "switch_backend_warn")
+@cbook._delete_parameter("3.3", "recursionlimit")
 def test(verbosity=None, coverage=False, switch_backend_warn=True,
          recursionlimit=0, **kwargs):
     """Run the matplotlib test suite."""

--- a/tests.py
+++ b/tests.py
@@ -39,11 +39,14 @@ if __name__ == '__main__':
     from matplotlib import test
 
     parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument('--recursionlimit', type=int, default=0,
+    parser.add_argument('--recursionlimit', type=int, default=None,
                         help='Specify recursionlimit for test run')
     args, extra_args = parser.parse_known_args()
 
     print('Python byte-compilation optimization level:', sys.flags.optimize)
 
-    retcode = test(argv=extra_args, recursionlimit=args.recursionlimit)
+    if args.recursionlimit is not None:  # Will trigger deprecation.
+        retcode = test(argv=extra_args, recursionlimit=args.recursionlimit)
+    else:
+        retcode = test(argv=extra_args)
     sys.exit(retcode)


### PR DESCRIPTION
It was added in c013ed7 to apparently fix a failure on OSX/Py36, but in
fact it's been unused ever since https://github.com/MacPython/matplotlib-wheels/commit/90a94c0b30114e58af736927da6394cbfa21f5bd
(merely a month later), and tests apparently still pass fine.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
