### PR TITLE
Remove warnings control from tests.py.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -13,29 +13,6 @@ import argparse
 
 
 if __name__ == '__main__':
-
-    import dateutil.parser
-    try:
-        import setuptools
-    except ImportError:
-        pass
-
-    # The warnings need to be before any of matplotlib imports, but after
-    # dateutil.parser and setuptools (if present) which has syntax error with
-    # the warnings enabled.  Filtering by module does not work as this will be
-    # raised by Python itself so `module=matplotlib.*` is out of question.
-
-    import warnings
-
-    # Python 3.6 deprecate invalid character-pairs \A, \* ... in non
-    # raw-strings and other things. Let's not re-introduce them
-    warnings.filterwarnings('error', '.*invalid escape sequence.*',
-                            category=DeprecationWarning)
-    warnings.filterwarnings(
-        'default',
-        r'.*inspect.getargspec\(\) is deprecated.*',
-        category=DeprecationWarning)
-
     from matplotlib import test
 
     parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
We already perform such warnings handling in conftest.py, which will be
executed by matplotlib.test, so no need to dupe it here.

(Together with https://github.com/matplotlib/matplotlib/pull/16586 this will ultimately enable `tests.py` to be reduced to basically just `import sys, matplotlib; if __name__ == "__main__": sys.exit(matplotlib.test(sys.argv))`.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
