### PR TITLE
Deprecate dviread.Encoding.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -307,3 +307,7 @@ The *quality*, *optimize*, and *progressive* keyword arguments to
 
 Such options should now be directly passed to Pillow using
 ``savefig(..., pil_kwargs={"quality": ..., "optimize": ..., "progressive": ...})``.
+
+``dviread.Encoding``
+~~~~~~~~~~~~~~~~~~~~
+This class was (mostly) broken and is deprecated.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -763,12 +763,11 @@ class PdfFile:
 
         # Encoding (if needed)
         if fontinfo.encodingfile is not None:
-            enc = dviread._parse_enc(fontinfo.encodingfile)
-            differencesArray = [Name(ch) for ch in enc]
-            differencesArray = [0] + differencesArray
-            fontdict['Encoding'] = \
-                {'Type': Name('Encoding'),
-                 'Differences': differencesArray}
+            fontdict['Encoding'] = {
+                'Type': Name('Encoding'),
+                'Differences': [
+                    0, *map(Name, dviread._parse_enc(fontinfo.encodingfile))],
+            }
 
         # If no file is specified, stop short
         if fontinfo.fontfile is None:

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -763,7 +763,7 @@ class PdfFile:
 
         # Encoding (if needed)
         if fontinfo.encodingfile is not None:
-            enc = dviread.Encoding(fontinfo.encodingfile)
+            enc = dviread._parse_enc(fontinfo.encodingfile)
             differencesArray = [Name(ch) for ch in enc]
             differencesArray = [0] + differencesArray
             fontdict['Encoding'] = \

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -919,6 +919,7 @@ class PsfontsMap:
                 encoding=encoding, filename=filename)
 
 
+@cbook.deprecated("3.3")
 class Encoding:
     r"""
     Parses a \*.enc file referenced from a psfonts.map style file.

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -989,8 +989,7 @@ def _parse_enc(path):
         The nth entry of the list is the PostScript glyph name of the nth
         glyph.
     """
-    with open(path, encoding="ascii") as file:
-        no_comments = "\n".join(line.split("%")[0].rstrip() for line in file)
+    no_comments = re.sub("%.*", "", Path(path).read_text(encoding="ascii"))
     array = re.search(r"(?s)\[(.*)\]", no_comments).group(1)
     lines = [line for line in array.split() if line]
     if all(line.startswith("/") for line in lines):


### PR DESCRIPTION
## PR Summary

In 2c0f5ec I found that dviread.Encoding was mostly broken (it didn't
correctly split entries in the encoding file and instead returned
everything concatenated as a single string) and introduced _parse_enc to
make usetex loading work in SVG.  I didn't deprecate Encoding yet
because it appeared to work for the pdf backend.

As it turns out it "works" because the format needed by the pdf backend
is exactly the same as the one in enc files, so it doesn't mind the
failure to split the string.  Still, using a proper parser (_parse_enc)
seems better...  So deprecate the broken Encoding.

---

second commit is a minor style fix at the same place, and a small microoptimization of _parse_enc which is both slightly faster and shorter.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
