### PR TITLE
close #16593: setting ecolor turns off color cycling

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -95,7 +95,7 @@ the default 10, calling `.SymLogNorm` without the new *base* kwarg emits a
 deprecation warning.
 
 
-`~Axes.errorbar` now color cycles when only errorbar color is set
+`~.Axes.errorbar` now color cycles when only errorbar color is set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously setting the *ecolor* would turn off automatic color cycling for the plot, leading to the 

--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -93,3 +93,11 @@ Previously, `.SymLogNorm` had no *base* kwarg, and defaulted to ``base=np.e``
 whereas the documentation said it was ``base=10``.  In preparation to make
 the default 10, calling `.SymLogNorm` without the new *base* kwarg emits a
 deprecation warning.
+
+
+`~Axes.errorbar` now color cycles when only errorbar color is set
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously setting the *ecolor* would turn off automatic color cycling for the plot, leading to the 
+the lines and markers defaulting to whatever the first color in the color cycle was in the case of 
+multiple plot calls. 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3226,7 +3226,6 @@ class Axes(_AxesBase):
         base_style.update(fmt_style_kwargs)
         if 'color' not in base_style:
             base_style['color'] = 'C0'
-            color = 'C0'
         if ecolor is None:
             ecolor = base_style['color']
         # make sure all the args are iterable; use lists not arrays to

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3215,8 +3215,7 @@ class Axes(_AxesBase):
             # Remove alpha=0 color that _process_plot_format returns
             fmt_style_kwargs.pop('color')
 
-        if ('color' in kwargs or 'color' in fmt_style_kwargs or
-                ecolor is not None):
+        if ('color' in kwargs or 'color' in fmt_style_kwargs):
             base_style = {}
             if 'color' in kwargs:
                 base_style['color'] = kwargs.pop('color')
@@ -3227,6 +3226,7 @@ class Axes(_AxesBase):
         base_style.update(fmt_style_kwargs)
         if 'color' not in base_style:
             base_style['color'] = 'C0'
+            color = 'C0'
         if ecolor is None:
             ecolor = base_style['color']
         # make sure all the args are iterable; use lists not arrays to

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3157,6 +3157,21 @@ def test_errorbar_colorcycle():
     assert mcolors.to_rgba(ln1.get_color()) == mcolors.to_rgba('C2')
 
 
+@check_figures_equal()
+def test_errorbar_cycle_ecolor(fig_test, fig_ref):
+    x = np.arange(0.1, 4, 0.5)
+    y = [np.exp(-x+n) for n in range(4)]
+
+    axt = fig_test.subplots()
+    axr = fig_ref.subplots()
+
+    for yi, color in zip(y, ['C0', 'C1', 'C2', 'C3']):
+        axt.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
+                     marker='o', ecolor='black')
+        axr.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
+                     marker='o', color=color, ecolor='black')
+
+
 def test_errorbar_shape():
     fig = plt.figure()
     ax = fig.gca()


### PR DESCRIPTION
Co-authored-by: @tacaswell 

## PR Summary
Removed ecolor is not none from the codepath choosing between cycler and no cyclers; ecolor is none still defaults to cycler. This is arguably the preferred behavior as the user specifying the color of the errorbars does not tell us anything about what colors they'd like the actual plots to be (which is what cycler prefers). 
A longer discussion should probably be had about cycler semantics - in which cases should the code default to the color the user passed in - I'm team basically any artist color not explicitly set should be controlled by the cycler. 

## PR Checklist
- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant