### PR TITLE
Cleanup dolphin example.

### DIFF
--- a/examples/shapes_and_collections/dolphin.py
+++ b/examples/shapes_and_collections/dolphin.py
@@ -75,18 +75,19 @@ codes = []
 parts = dolphin.split()
 i = 0
 code_map = {
-    'M': (Path.MOVETO, 1),
-    'C': (Path.CURVE4, 3),
-    'L': (Path.LINETO, 1)}
+    'M': Path.MOVETO,
+    'C': Path.CURVE4,
+    'L': Path.LINETO,
+}
 
 while i < len(parts):
-    code = parts[i]
-    path_code, npoints = code_map[code]
+    path_code = code_map[parts[i]]
+    npoints = Path.NUM_VERTICES_FOR_CODE[path_code]
     codes.extend([path_code] * npoints)
-    vertices.extend([[float(x) for x in y.split(',')] for y in
-                     parts[i + 1:i + npoints + 1]])
+    vertices.extend([[*map(float, y.split(','))]
+                     for y in parts[i + 1:][:npoints]])
     i += npoints + 1
-vertices = np.array(vertices, float)
+vertices = np.array(vertices)
 vertices[:, 1] -= 160
 
 dolphin_path = Path(vertices, codes)


### PR DESCRIPTION
- Use NUM_VERTICES_PER_CODE table already present in lib.
- I think the new version of `vertices.extend` is easier to read
  ("start at index i+1 and take npoints").
- vertices is already a float array.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
