### PR TITLE
Deprecate more rc validators.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -220,9 +220,11 @@ The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_movie_frame_fmt``, ``validate_axis_locator``,
 ``validate_movie_html_fmt``, ``validate_grid_axis``,
 ``validate_axes_titlelocation``, ``validate_toolbar``,
-``validate_ps_papersize``, ``validate_legend_log``.  To test whether an rcParam
-value would be acceptable, one can test e.g. ``rc = RcParams(); rc[k] = v``
-raises an exception.
+``validate_ps_papersize``, ``validate_legend_loc``,
+``validate_bool_maybe_none``, ``validate_hinting``,
+``validate_movie_writers``.
+To test whether an rcParam value would be acceptable, one can test e.g. ``rc =
+RcParams(); rc[k] = v`` raises an exception.
 
 Toggling axes navigation from the keyboard using "a" and digit keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -140,6 +140,7 @@ def validate_bool(b):
         raise ValueError('Could not convert "%s" to bool' % b)
 
 
+@cbook.deprecated("3.3")
 def validate_bool_maybe_none(b):
     """Convert b to ``bool`` or raise, passing through *None*."""
     if isinstance(b, str):
@@ -646,7 +647,13 @@ validate_svg_fonttype = ValidateInStrings(
     'svg.fonttype', ['none', 'path'], _deprecated_since="3.3")
 
 
+@cbook.deprecated("3.3")
 def validate_hinting(s):
+    return _validate_hinting(s)
+
+
+# Replace by plain list in _prop_validators after deprecation period.
+def _validate_hinting(s):
     if s in (True, False):
         cbook.warn_deprecated(
             "3.2", message="Support for setting the text.hinting rcParam to "
@@ -663,6 +670,7 @@ validate_pgf_texsystem = ValidateInStrings(
     _deprecated_since="3.3")
 
 
+@cbook.deprecated("3.3")
 def validate_movie_writer(s):
     # writers.list() would only list actually available writers, but
     # FFMpeg.isAvailable is slow and not worth paying for at every import.
@@ -1133,7 +1141,7 @@ defaultParams = {
     'text.usetex':         [False, validate_bool],
     'text.latex.preamble': ['', _validate_tex_preamble],
     'text.latex.preview':  [False, validate_bool],
-    'text.hinting':        ['auto', validate_hinting],
+    'text.hinting':        ['auto', _validate_hinting],
     'text.hinting_factor': [8, validate_int],
     'text.kerning_factor': [0, validate_int],
     'text.antialiased':    [True, validate_bool],
@@ -1452,7 +1460,7 @@ defaultParams = {
     # Limit, in MB, of size of base64 encoded animation in HTML
     # (i.e. IPython notebook)
     'animation.embed_limit':  [20, validate_float],
-    'animation.writer':       ['ffmpeg', validate_movie_writer],
+    'animation.writer':       ['ffmpeg', validate_string],
     'animation.codec':        ['h264', validate_string],
     'animation.bitrate':      [-1, validate_int],
     # Controls image format when frames are written to disk

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -125,9 +125,8 @@ def test_Bug_2543():
         # real test is that this does not raise
         assert validate_bool_maybe_none(None) is None
         assert validate_bool_maybe_none("none") is None
-
-    with pytest.raises(ValueError):
-        validate_bool_maybe_none("blah")
+        with pytest.raises(ValueError):
+            validate_bool_maybe_none("blah")
     with pytest.raises(ValueError):
         validate_bool(None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
- validate_bool_maybe_none is now unused; if we really need it back
  we'd make it private and I'd anyways rather add machinery so that
  one can just specify it as `[bool, None]` (or `Optional[bool]`) in
  _prop_validators.
- validate_hinting will become a plain list after the deprecation
  period.
- validate_movie_writer makes it impossible to set movie.writer to
  a third-party animation writer, because that third-party module
  will necessarily first import matplotlib before being able to
  register its writer, and thus the matplotlibrc file will be parsed
  before the writer is registered.  In any case,
  `MovieWriterRegistry.__getitem__` also raises an informative error
  on unknown writer names, which should be enough, so let's just
  accept any string.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
