### PR TITLE
CI: tweak the vm images we use on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ strategy:
       vmImage: 'ubuntu-16.04'
       python.version: '3.7'
     Linux_py38:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-16.04'
       python.version: '3.8'
     macOS_py36:
       vmImage: 'macOS-10.14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,16 +12,16 @@ strategy:
       vmImage: 'ubuntu-16.04'
       python.version: '3.7'
     Linux_py38:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
       python.version: '3.8'
     macOS_py36:
-      vmImage: 'xcode9-macOS10.13'
+      vmImage: 'macOS-10.14'
       python.version: '3.6'
     macOS_py37:
-      vmImage: 'xcode9-macOS10.13'
+      vmImage: 'macOS-10.15'
       python.version: '3.7'
     macOS_py38:
-      vmImage: 'xcode9-macOS10.13'
+      vmImage: 'macOS-latest'
       python.version: '3.8'
     Windows_py36:
       vmImage: 'vs2017-win2016'
@@ -30,7 +30,7 @@ strategy:
       vmImage: 'vs2017-win2016'
       python.version: '3.7'
     Windows_py38:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
       python.version: '3.8'
     Windows_pyPre:
       vmImage: 'vs2017-win2016'


### PR DESCRIPTION
This is prompted by the osx image we were using being deprecated [1].
Looking at [2] to update the osx images, found we are now a version
behind on both win and linux as well.  Change so that the newer python
versions run on newer images.

[1] https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/
[2] https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops

Need to backport this or CI will start failing on 3.2.x