### PR TITLE
Stricter validation of rcParams["axes.axisbelow"].

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -224,6 +224,12 @@ The following validators, defined in `.rcsetup`, are deprecated:
 value would be acceptable, one can test e.g. ``rc = RcParams(); rc[k] = v``
 raises an exception.
 
+Stricter rcParam validation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:rc:`axes.axisbelow` currently normalizes all strings starting with "line"
+(case-insensitive) to the option "line".  This is deprecated; in a future
+version only the exact string "line" (case-sensitive) will be supported.
+
 Toggling axes navigation from the keyboard using "a" and digit keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Axes navigation can still be toggled programmatically using

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -180,8 +180,14 @@ def validate_axisbelow(s):
         return validate_bool(s)
     except ValueError:
         if isinstance(s, str):
-            s = s.lower()
-            if s.startswith('line'):
+            if s == 'line':
+                return 'line'
+            if s.lower().startswith('line'):
+                cbook.warn_deprecated(
+                    "3.3", message=f"Support for setting axes.axisbelow to "
+                    f"{s!r} to mean 'line' is deprecated since %(since)s and "
+                    f"will be removed in %(removal)s; set it to 'line' "
+                    "instead.")
                 return 'line'
     raise ValueError('%s cannot be interpreted as'
                      ' True, False, or "line"' % s)


### PR DESCRIPTION
I don't see a good reason to support "LiNefoobar" to mean "line", tbh...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
