### PR TITLE
Added graphviz_docs to conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -369,6 +369,7 @@ html4_writer = True
 
 inheritance_node_attrs = dict(fontsize=16)
 
+graphviz_dot = shutil.which('dot')
 graphviz_output_format = 'svg'
 
 


### PR DESCRIPTION
## PR Summary
Was having trouble getting my docs to build, build kept reporting it couldn't find `graphviz_dot` environment variable and only thing that seemed to fix it was setting the `graphviz_dot` variable in conf.py. (longer description on [discourse](https://discourse.matplotlib.org/t/graphviz-dot-binarys-conf-py/20917/2))
Used `shutil.where('dot')` since that's used earlier in the file to check if graphviz is installed so it should be portable/universal. Can do something like this instead though if folks think it's a better idea:
```python
graphviz_dot =  sys.env['GRAPHVIZ_DOT'] if sys.env['GRAPHVIZ_DOT'] else shutils.which('dot')
```
 
