### PR TITLE
Backport PR #16605: CI: tweak the vm images we use on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,17 +12,23 @@ strategy:
       vmImage: 'ubuntu-16.04'
       python.version: '3.7'
     macOS_py36:
-      vmImage: 'xcode9-macOS10.13'
+      vmImage: 'macOS-10.14'
       python.version: '3.6'
     macOS_py37:
-      vmImage: 'xcode9-macOS10.13'
+      vmImage: 'macOS-10.15'
       python.version: '3.7'
+    macOS_py38:
+      vmImage: 'macOS-latest'
+      python.version: '3.8'
     Windows_py36:
       vmImage: 'vs2017-win2016'
       python.version: '3.6'
     Windows_py37:
       vmImage: 'vs2017-win2016'
       python.version: '3.7'
+    Windows_py38:
+      vmImage: 'windows-latest'
+      python.version: '3.8'
     Windows_pyPre:
       vmImage: 'vs2017-win2016'
       python.version: 'Pre'


### PR DESCRIPTION
The conflicts were that we weren't testing Python 3.8 on this branch, but we probably should, so I've added that into the matrix.