### PR TITLE
Fix edge-case in preprocess_data, if label_namer is optional and unset.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1382,9 +1382,6 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
             return func(ax, *map(sanitize_sequence, args), **kwargs)
 
         bound = new_sig.bind(ax, *args, **kwargs)
-        needs_label = (label_namer
-                       and "label" not in bound.arguments
-                       and "label" not in bound.kwargs)
         auto_label = (bound.arguments.get(label_namer)
                       or bound.kwargs.get(label_namer))
 
@@ -1403,10 +1400,10 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
         new_args = bound.args
         new_kwargs = bound.kwargs
 
-        if needs_label:
-            all_kwargs = {**bound.arguments, **bound.kwargs}
+        args_and_kwargs = {**bound.arguments, **bound.kwargs}
+        if label_namer and "label" not in args_and_kwargs:
             new_kwargs["label"] = _label_from_arg(
-                all_kwargs.get(label_namer), auto_label)
+                args_and_kwargs.get(label_namer), auto_label)
 
         return func(*new_args, **new_kwargs)
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1405,10 +1405,8 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
 
         if needs_label:
             all_kwargs = {**bound.arguments, **bound.kwargs}
-            # label_namer will be in all_kwargs as we asserted above that
-            # `label_namer is None or label_namer in arg_names`.
             new_kwargs["label"] = _label_from_arg(
-                all_kwargs[label_namer], auto_label)
+                all_kwargs.get(label_namer), auto_label)
 
         return func(*new_args, **new_kwargs)
 


### PR DESCRIPTION
## PR Summary

First commit (the important one):

9728144 removed a call to `BoundArguments.apply_defaults` to guard
against an API change in Py3.9.  As it turns out this means that
`all_kwargs[label_namer]` can now fail, in theory, if _preprocess_data
is used on a function for which label_namer is an *optional* parameter
(because the default won't be set in all_kwargs).  Fortunately, 1) there
is no such case (it would be semantically questionable to derive the
label from a non-required argument...) and 2) the fix is simple (use
`all_kwargs.get` instead -- _label_namer properly handles None).

(TL;DR: 9728144 broke _preprocess_data in an edge case that isn't
exercised anywhere in mpl; it's private API so in theory no one else
should be exercising that edge case but let's still fix it.)

Second commit (just a simplification):

We don't need to evaluate needs_label at the top, we can just do it when
needed.  Also rename all_kwargs to args_and_kwargs, as it's really a
mapping of all arg names to their values, whether they have been passed
positionally or by keyword.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
