### PR TITLE
v3.2.x: Make Azure use local FreeType.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ steps:
   displayName: 'Install dependencies with pip'
 
 - bash: |
-    python -m pip install -ve . ||
+    MPLLOCALFREETYPE=1 python -m pip install -ve . ||
       [[ "$PYTHON_VERSION" = 'Pre' ]]
   displayName: "Install self"
 


### PR DESCRIPTION
Unfortunately, Azure doesn't build on non-`master` PRs, so we will not know whether this works right away.

Fixes #16624.

