### PR TITLE
ci: Restore nuget install step on Azure for v3.2.x.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,6 +81,12 @@ steps:
       brew install pkg-config ffmpeg imagemagick mplayer ccache
       ;;
     win32)
+      nuget install libpng-msvc14-x64 -ExcludeVersion -OutputDirectory "$(build.BinariesDirectory)"
+      nuget install zlib-msvc14-x64 -ExcludeVersion -OutputDirectory "$(build.BinariesDirectory)"
+      echo ##vso[task.prependpath]$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\bin_release
+      echo ##vso[task.prependpath]$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\bin_release
+      echo ##vso[task.setvariable variable=CL]/I$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\include /I$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\include
+      echo ##vso[task.setvariable variable=LINK]/LIBPATH:$(build.BinariesDirectory)\libpng-msvc14-x64\build\native\lib_release /LIBPATH:$(build.BinariesDirectory)\zlib-msvc14-x64\build\native\lib_release
       ;;
     *)
       exit 1


### PR DESCRIPTION
This was removed in a cleanup on `master`, and backported to `v3.2.x`. While the cleanup was good, the `v3.2.x` branch still requires the use of libpng, so that step must be restored.

I _think_ this fully fixes #16624.