### PR TITLE
Deprecate autofmt_xdate(which=None) to mean which="major".

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -284,3 +284,7 @@ is deprecated, set the offset to 0 instead.
 ``RendererCairo.fontweights``, ``RendererCairo.fontangles``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ... are deprecated.
+
+``autofmt_xdate(which=None)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is deprecated, use its more explicit synonym, ``which="major"``, instead.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -574,7 +574,8 @@ class Figure(Artist):
 
         return w_pad, h_pad, wspace, hspace
 
-    def autofmt_xdate(self, bottom=0.2, rotation=30, ha='right', which=None):
+    def autofmt_xdate(
+            self, bottom=0.2, rotation=30, ha='right', which='major'):
         """
         Date ticklabels often overlap, so it is useful to rotate them
         and right align them.  Also, a common use case is a number of
@@ -586,18 +587,19 @@ class Figure(Artist):
         Parameters
         ----------
         bottom : scalar
-            The bottom of the subplots for :meth:`subplots_adjust`.
-
+            The bottom of the subplots for `subplots_adjust`.
         rotation : angle in degrees
             The rotation of the xtick labels.
-
         ha : str
             The horizontal alignment of the xticklabels.
-
-        which : {None, 'major', 'minor', 'both'}
-            Selects which ticklabels to rotate. Default is None which works
-            the same as major.
+        which : {'major', 'minor', 'both'}, default: 'major'
+            Selects which ticklabels to rotate.
         """
+        if which is None:
+            cbook.warn_deprecated(
+                "3.3", message="Support for passing which=None to mean "
+                "which='major' is deprecated since %(since)s and will be "
+                "removed %(removal)s.")
         allsubplots = all(hasattr(ax, 'is_last_row') for ax in self.axes)
         if len(self.axes) == 1:
             for label in self.axes[0].get_xticklabels(which=which):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -2,6 +2,10 @@ from datetime import datetime
 from pathlib import Path
 import platform
 import warnings
+try:
+    from contextlib import nullcontext
+except ImportError:
+    from contextlib import ExitStack as nullcontext  # Py3.6
 
 import matplotlib as mpl
 from matplotlib import rcParams
@@ -318,7 +322,9 @@ def test_autofmt_xdate(which):
             'FixedFormatter should only be used together with FixedLocator')
         ax.xaxis.set_minor_formatter(FixedFormatter(minors))
 
-    fig.autofmt_xdate(0.2, angle, 'right', which)
+    with (pytest.warns(mpl.MatplotlibDeprecationWarning) if which is None else
+          nullcontext()):
+        fig.autofmt_xdate(0.2, angle, 'right', which)
 
     if which in ('both', 'major', None):
         for label in fig.axes[0].get_xticklabels(False, 'major'):


### PR DESCRIPTION
This makes the docstring and signature simpler, and explicitly passing
which=None to mean which="major" just seems wicked...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
