### PR TITLE
Remove unused, outdated division operators on jpl_units.

### DIFF
--- a/lib/matplotlib/testing/jpl_units/Duration.py
+++ b/lib/matplotlib/testing/jpl_units/Duration.py
@@ -132,28 +132,6 @@ class Duration:
         """
         return Duration(self._frame, self._seconds * float(lhs))
 
-    def __div__(self, rhs):
-        """Divide a Duration by a value.
-
-        = INPUT VARIABLES
-        - rhs     The scalar to divide by.
-
-        = RETURN VALUE
-        - Returns the scaled Duration.
-        """
-        return Duration(self._frame, self._seconds / rhs)
-
-    def __rdiv__(self, rhs):
-        """Divide a Duration by a value.
-
-        = INPUT VARIABLES
-        - rhs     The scalar to divide by.
-
-        = RETURN VALUE
-        - Returns the scaled Duration.
-        """
-        return Duration(self._frame, rhs / self._seconds)
-
     def __str__(self):
         """Print the Duration."""
         return "%g %s" % (self._seconds, self._frame)

--- a/lib/matplotlib/testing/jpl_units/UnitDbl.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDbl.py
@@ -175,17 +175,6 @@ class UnitDbl:
         """
         return UnitDbl(self._value * lhs, self._units)
 
-    def __div__(self, rhs):
-        """Divide a UnitDbl by a value.
-
-        = INPUT VARIABLES
-        - rhs     The scalar to divide by.
-
-        = RETURN VALUE
-        - Returns the scaled UnitDbl.
-        """
-        return UnitDbl(self._value / rhs, self._units)
-
     def __str__(self):
         """Print the UnitDbl."""
         return "%g *%s" % (self._value, self._units)


### PR DESCRIPTION
Py3 doesn't have `__div__`, it has `__truediv__` and `__floordiv__`.

Given that no one has ever complained about this, I am going to boldly
claim that no one is using division of jpl_units on Py3, and just delete
them without providing replacements.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
