### PR TITLE
 Changing the symlog function to use arcsinh(x/2).

### DIFF
--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -27,7 +27,7 @@ def test_log_scales(fig_test, fig_ref):
 def test_symlog_mask_nan():
     # Use a transform round-trip to verify that the forward and inverse
     # transforms work, and that they respect nans and/or masking.
-    slt = SymmetricalLogTransform(10, 2, 1)
+    slt = SymmetricalLogTransform(10, 2)
     slti = slt.inverted()
 
     x = np.arange(-1.5, 5, 0.5)


### PR DESCRIPTION
## PR Summary

Changing the SymLogTransform math function to be
`f(x) = arcsinh(x/2) = ln(x/2 + sqrt(x/2 + 1))`

Reasoning: This has a well-defined mathematical function over the entire real number line and a simple inverse. It was mentioned elsewhere that most people using SymLog are using it in a qualitative sense (myself included), and this allows for a nice qualitative plot, along with a reproducible mathematical function underlying it if you want to reproduce the data.

This is a follow-on to a lot of the recent discussion about SymLog changes. See: #16280, #16376, #16391, #16392

I have only updated the SymLogTransform here because of #16457 which I think is the right way to build Norm's, which will inherently change SymLogNorm if it gets put in. This will then allow one place for all of the SymLog math to be consistent.

Before going too far down the path of updating everything, I wanted to push this up and get feedback on whether people think this is a good idea to change the underlying function or not. Pinging @dstansby, @jklymak since you two have been doing most of the recent updates with the SymLog work.

## Implications

* It removes the `linscale` argument that allows stretching/shrinking the linear region.
* There is a smooth transition region where the function is neither linear nor logarithmic.
* Deprecations may get a little messy due to the other SymLog changes taking place in the various versions.

## TODOs

- [ ] Update deprecation and warnings
- [ ] Update documentation and API changes
- [ ] Update test_scales SymLog figures

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
