### PR TITLE
Deprecate validate_webagg_address.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -225,11 +225,22 @@ The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_movie_frame_fmt``, ``validate_axis_locator``,
 ``validate_movie_html_fmt``, ``validate_grid_axis``,
 ``validate_axes_titlelocation``, ``validate_toolbar``,
+<<<<<<< HEAD
 ``validate_ps_papersize``, ``validate_legend_loc``,
 ``validate_bool_maybe_none``, ``validate_hinting``,
 ``validate_movie_writers``.
 To test whether an rcParam value would be acceptable, one can test e.g. ``rc =
 RcParams(); rc[k] = v`` raises an exception.
+||||||| constructed merge base
+``validate_ps_papersize``, ``validate_legend_log``.  To test whether an rcParam
+value would be acceptable, one can test e.g. ``rc = RcParams(); rc[k] = v``
+raises an exception.
+=======
+``validate_ps_papersize``, ``validate_legend_loc``,
+``validate_webagg_address``.
+To test whether an rcParam value would be acceptable, one can test e.g. ``rc =
+RcParams(); rc[k] = v`` raises an exception.
+>>>>>>> Deprecate validate_webagg_address.
 
 Stricter rcParam validation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -992,6 +992,7 @@ def validate_animation_writer_path(p):
     return p
 
 
+@cbook.deprecated("3.3")
 def validate_webagg_address(s):
     if s is not None:
         import socket
@@ -1026,7 +1027,7 @@ defaultParams = {
     'backend':           [_auto_backend_sentinel, validate_backend],
     'backend_fallback':  [True, validate_bool],
     'webagg.port':       [8988, validate_int],
-    'webagg.address':    ['127.0.0.1', validate_webagg_address],
+    'webagg.address':    ['127.0.0.1', validate_string],
     'webagg.open_in_browser': [True, validate_bool],
     'webagg.port_retries': [50, validate_int],
     'toolbar':           ['toolbar2', _ignorecase(['none', 'toolbar2', 'toolmanager'])],


### PR DESCRIPTION
It is overly strict: it only accepts IPv4 addresses, even though e.g.
"localhost" works just fine, as can be checked with e.g.
```
$ MPLBACKEND=webagg python -c 'from pylab import *; dict.__setitem__(rcParams, "webagg.address", "localhost"); plot(); show()'
```
(really, just an excuse to further trim down rcsetup...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
