### PR TITLE
Docs: Change Python 2 note to past tense

### DIFF
--- a/doc/_templates/sidebar_announcement.html
+++ b/doc/_templates/sidebar_announcement.html
@@ -1,5 +1,5 @@
 <div class="sidebar-announcement">
   <p>Matplotlib 3.0 is Python 3 only.</p>
-  <p>For Python 2 support, Matplotlib 2.2.x will be continued as a LTS release
-      and updated with bugfixes until January 1, 2020.</p>
+  <p>Python 2 support has been dropped on January 1, 2020.</p>
+  <p>The last Python 2 compatible release is 2.2.5.</p>
 </div>


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [n/a] Has Pytest style unit tests
- [n/a] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

I noticed the announcement on https://matplotlib.org/ is written for when 2020-01-01 is in the future:

![image](https://user-images.githubusercontent.com/1324225/75814239-16f93900-5d9a-11ea-81b8-b749c72beb31.png)

The announcement for the LTS releases on https://matplotlib.org/2.2.5/index.html is:

![image](https://user-images.githubusercontent.com/1324225/75814281-29737280-5d9a-11ea-8eb1-ae9aff3e8bc2.png)

This PR combines the texts, in the past tense.
