### PR TITLE
Deprecate {Locator,Axis}.{pan,zoom}.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -311,3 +311,9 @@ Such options should now be directly passed to Pillow using
 ``dviread.Encoding``
 ~~~~~~~~~~~~~~~~~~~~
 This class was (mostly) broken and is deprecated.
+
+Axis and Locator ``pan`` and ``zoom``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The unused ``pan`` and ``zoom`` methods of `~.axis.Axis` and `~.ticker.Locator`
+are deprecated.  Panning and zooming are now implemented using the
+``start_pan``, ``drag_pan``, and ``end_pan`` methods of `~.axes.Axes`.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1708,10 +1708,12 @@ class Axis(martist.Artist):
         """
         raise NotImplementedError('Derived must override')
 
+    @cbook.deprecated("3.3")
     def pan(self, numsteps):
         """Pan by *numsteps* (can be positive or negative)."""
         self.major.locator.pan(numsteps)
 
+    @cbook.deprecated("3.3")
     def zoom(self, direction):
         """Zoom in/out on axis; if *direction* is >0 zoom in, else zoom out."""
         self.major.locator.zoom(direction)

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -203,6 +203,7 @@ class ThetaLocator(mticker.Locator):
     def autoscale(self):
         return self.base.autoscale()
 
+    @cbook.deprecated("3.3")
     def pan(self, numsteps):
         return self.base.pan(numsteps)
 
@@ -214,6 +215,7 @@ class ThetaLocator(mticker.Locator):
         vmin, vmax = np.rad2deg((vmin, vmax))
         return np.deg2rad(self.base.view_limits(vmin, vmax))
 
+    @cbook.deprecated("3.3")
     def zoom(self, direction):
         return self.base.zoom(direction)
 
@@ -387,9 +389,11 @@ class RadialLocator(mticker.Locator):
     def autoscale(self):
         return self.base.autoscale()
 
+    @cbook.deprecated("3.3")
     def pan(self, numsteps):
         return self.base.pan(numsteps)
 
+    @cbook.deprecated("3.3")
     def zoom(self, direction):
         return self.base.zoom(direction)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1644,6 +1644,7 @@ class Locator(TickHelper):
         """Autoscale the view limits."""
         return self.view_limits(*self.axis.get_view_interval())
 
+    @cbook.deprecated("3.3")
     def pan(self, numsteps):
         """Pan numticks (can be positive or negative)"""
         ticks = self()
@@ -1661,6 +1662,7 @@ class Locator(TickHelper):
         vmax += step
         self.axis.set_view_interval(vmin, vmax, ignore=True)
 
+    @cbook.deprecated("3.3")
     def zoom(self, direction):
         """Zoom in/out on axis; if direction is >0 zoom in, else zoom out."""
 


### PR DESCRIPTION
They are unused since the old NavigationToolbar(1) has been removed (in
2013, #2251); panning and zooming are now implemented at the Axes level.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
