### PR TITLE
Tutorials: make path/URL option clearer in matplotlibrc tutorial

### DIFF
--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -53,13 +53,14 @@ print(plt.style.available)
 #    >>> import matplotlib.pyplot as plt
 #    >>> plt.style.use('./images/presentation.mplstyle')
 #
-# Alternatively, you can load your custom style sheet with a call to
-# ``style.use(<style-name>)`` by placing your ``<style-name>.mplstyle`` file
-# into ``mpl_configdir/stylelib``.  By default ``mpl_configdir`` should be
+# Alternatively, you can make your style known to Matplotlib by placing
+# your ``<style-name>.mplstyle`` file into ``mpl_configdir/stylelib``.  You
+# can then load your custom style sheet with a call to
+# ``style.use(<style-name>)``.  By default ``mpl_configdir`` should be
 # ``~/.config/matplotlib``, but you can check where yours is with
-# `matplotlib.get_configdir()`; you may need to create this directory. You also
-#  can change the directory where Matplotlib looks for the stylelib/ folder by
-# setting the :envvar:`MPLCONFIGDIR` environment variable, see
+# `matplotlib.get_configdir()`; you may need to create this directory. You
+# also can change the directory where Matplotlib looks for the stylelib/
+# folder by setting the :envvar:`MPLCONFIGDIR` environment variable, see
 # :ref:`locating-matplotlib-config-dir`.
 #
 # Note that a custom style sheet in ``mpl_configdir/stylelib`` will override a
@@ -69,7 +70,7 @@ print(plt.style.available)
 # ``mpl_configdir`` you can specify your style with::
 #
 #    >>> import matplotlib.pyplot as plt
-#    >>> plt.style.use('<style-name>')
+#    >>> plt.style.use(<style-name>)
 #
 #
 # Composing styles

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -38,7 +38,7 @@ print(plt.style.available)
 # the path or URL to the style sheet.
 #
 # For example, you might want to create
-# ``../images/presentation.mplstyle`` with the following::
+# ``./images/presentation.mplstyle`` with the following::
 #
 #    axes.titlesize : 24
 #    axes.labelsize : 20

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -51,7 +51,7 @@ print(plt.style.available)
 # good in a presentation, you can just add::
 #
 #    >>> import matplotlib.pyplot as plt
-#    >>> plt.style.use('../images/presentation.mplstyle')
+#    >>> plt.style.use('./images/presentation.mplstyle')
 #
 # Alternatively, you can load your custom style sheet with a call to
 # ``style.use(<style-name>)`` by placing your ``<style-name>.mplstyle`` file

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -35,20 +35,10 @@ print(plt.style.available)
 # -----------------------
 #
 # You can create custom styles and use them by calling `.style.use` with
-# the path or URL to the style sheet. Additionally, if you add your
-# ``<style-name>.mplstyle`` file to ``mpl_configdir/stylelib``, you can reuse
-# your custom style sheet with a call to ``style.use(<style-name>)``. By
-# default ``mpl_configdir`` should be ``~/.config/matplotlib``, but you can
-# check where yours is with `matplotlib.get_configdir()`; you may need to
-# create this directory. You also can change the directory where Matplotlib
-# looks for the stylelib/ folder by setting the :envvar:`MPLCONFIGDIR`
-# environment variable, see :ref:`locating-matplotlib-config-dir`.
-#
-# Note that a custom style sheet in ``mpl_configdir/stylelib`` will override a
-# style sheet defined by Matplotlib if the styles have the same name.
+# the path or URL to the style sheet. 
 #
 # For example, you might want to create
-# ``mpl_configdir/stylelib/presentation.mplstyle`` with the following::
+# ``../images/presentation.mplstyle`` with the following::
 #
 #    axes.titlesize : 24
 #    axes.labelsize : 20
@@ -61,7 +51,25 @@ print(plt.style.available)
 # good in a presentation, you can just add::
 #
 #    >>> import matplotlib.pyplot as plt
-#    >>> plt.style.use('presentation')
+#    >>> plt.style.use('../images/presentation.mplstyle')
+#
+# Alternatively, you can load your custom style sheet with a call to 
+# ``style.use(<style-name>)`` by placing your ``<style-name>.mplstyle`` file 
+# into ``mpl_configdir/stylelib``.  By default ``mpl_configdir`` should be 
+# ``~/.config/matplotlib``, but you can check where yours is with 
+# `matplotlib.get_configdir()`; you may need to create this directory. You also
+#  can change the directory where Matplotlib looks for the stylelib/ folder by 
+# setting the :envvar:`MPLCONFIGDIR` environment variable, see 
+# :ref:`locating-matplotlib-config-dir`.
+#
+# Note that a custom style sheet in ``mpl_configdir/stylelib`` will override a
+# style sheet defined by Matplotlib if the styles have the same name.
+#
+# Once your ``<style-name>.mplstyle`` file is in the appropriate 
+# ``mpl_configdir`` you can specify your style with::
+#
+#    >>> import matplotlib.pyplot as plt
+#    >>> plt.style.use('<style-name>')
 #
 #
 # Composing styles
@@ -142,8 +150,9 @@ plt.plot(data)
 # kinds of properties, which we call 'rc settings' or 'rc parameters'. You can
 # control the defaults of almost every property in Matplotlib: figure size and
 # DPI, line width, color and style, axes, axis and grid properties, text and
-# font properties and so on. Matplotlib looks for :file:`matplotlibrc` in four
-# locations, in the following order:
+# font properties and so on. When a URL or path is not specified with a call to
+# `style.use('<path>/<style-name>.mplstyle')`, Matplotlib looks for 
+# :file:`matplotlibrc` in four locations, in the following order:
 #
 # 1. :file:`matplotlibrc` in the current working directory, usually used for
 #    specific customizations that you do not want to apply elsewhere.

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -35,7 +35,7 @@ print(plt.style.available)
 # -----------------------
 #
 # You can create custom styles and use them by calling `.style.use` with
-# the path or URL to the style sheet. 
+# the path or URL to the style sheet.
 #
 # For example, you might want to create
 # ``../images/presentation.mplstyle`` with the following::
@@ -53,19 +53,19 @@ print(plt.style.available)
 #    >>> import matplotlib.pyplot as plt
 #    >>> plt.style.use('../images/presentation.mplstyle')
 #
-# Alternatively, you can load your custom style sheet with a call to 
-# ``style.use(<style-name>)`` by placing your ``<style-name>.mplstyle`` file 
-# into ``mpl_configdir/stylelib``.  By default ``mpl_configdir`` should be 
-# ``~/.config/matplotlib``, but you can check where yours is with 
+# Alternatively, you can load your custom style sheet with a call to
+# ``style.use(<style-name>)`` by placing your ``<style-name>.mplstyle`` file
+# into ``mpl_configdir/stylelib``.  By default ``mpl_configdir`` should be
+# ``~/.config/matplotlib``, but you can check where yours is with
 # `matplotlib.get_configdir()`; you may need to create this directory. You also
-#  can change the directory where Matplotlib looks for the stylelib/ folder by 
-# setting the :envvar:`MPLCONFIGDIR` environment variable, see 
+#  can change the directory where Matplotlib looks for the stylelib/ folder by
+# setting the :envvar:`MPLCONFIGDIR` environment variable, see
 # :ref:`locating-matplotlib-config-dir`.
 #
 # Note that a custom style sheet in ``mpl_configdir/stylelib`` will override a
 # style sheet defined by Matplotlib if the styles have the same name.
 #
-# Once your ``<style-name>.mplstyle`` file is in the appropriate 
+# Once your ``<style-name>.mplstyle`` file is in the appropriate
 # ``mpl_configdir`` you can specify your style with::
 #
 #    >>> import matplotlib.pyplot as plt
@@ -151,7 +151,7 @@ plt.plot(data)
 # control the defaults of almost every property in Matplotlib: figure size and
 # DPI, line width, color and style, axes, axis and grid properties, text and
 # font properties and so on. When a URL or path is not specified with a call to
-# `style.use('<path>/<style-name>.mplstyle')`, Matplotlib looks for 
+# ``style.use('<path>/<style-name>.mplstyle')``, Matplotlib looks for
 # :file:`matplotlibrc` in four locations, in the following order:
 #
 # 1. :file:`matplotlibrc` in the current working directory, usually used for


### PR DESCRIPTION
## PR Summary

I recently noticed that the tutorial explaining how to create custom matplotlib styles mentions that the `style.use()` function can take a path or URL as an argument.  This is a very useful feature; I've suggested changes to try to make this more apparent.

This PR is to request review of the proposed changes.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way