### PR TITLE
Make test_imagegrid_cbar_mode_edge less flaky.

### DIFF
--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -12,10 +12,16 @@ from mpl_toolkits.axes_grid1 import ImageGrid
 # The original version of this test relied on mpl_toolkits's slightly different
 # colorbar implementation; moving to matplotlib's own colorbar implementation
 # caused the small image comparison error.
-@pytest.mark.parametrize("legacy_colorbar", [False, True])
-@image_comparison(['imagegrid_cbar_mode.png'],
+@image_comparison(['imagegrid_cbar_mode.png', 'imagegrid_cbar_mode.png'],
                   remove_text=True, style='mpl20', tol=0.3)
-def test_imagegrid_cbar_mode_edge(legacy_colorbar):
+def test_imagegrid_cbar_mode_edge():
+    # Note, we don't use @pytest.mark.parametrize, because in parallel this
+    # might cause one process result to overwrite another's.
+    for legacy_colorbar in [False, True]:
+        _test_imagegrid_cbar_mode_edge(legacy_colorbar)
+
+
+def _test_imagegrid_cbar_mode_edge(legacy_colorbar):
     mpl.rcParams["mpl_toolkits.legacy_colorbar"] = legacy_colorbar
 
     X, Y = np.meshgrid(np.linspace(0, 6, 30), np.linspace(0, 6, 30))


### PR DESCRIPTION
## PR Summary

Since parametrizing the test allows it to run in parallel, this makes it flaky, as one process can overwrite the test result image of another.

Our standard way for dealing with tests that use the same baseline image is to pass duplicate filenames to `image_comparison`, because that is serialized.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way