### PR TITLE
In docs, add multi-axes connectionpatches to Figure, not Axes.

### DIFF
--- a/examples/userdemo/connect_simple01.py
+++ b/examples/userdemo/connect_simple01.py
@@ -31,7 +31,7 @@ con = ConnectionPatch(
     xyA=xy, coordsA=ax2.transData,
     xyB=xy, coordsB=ax1.transData,
     arrowstyle="->", shrinkB=5)
-ax2.add_artist(con)
+fig.add_artist(con)
 
 # Draw a line between the different points, defined in different coordinate
 # systems.

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -499,15 +499,15 @@ more control, it supports a few other options.
 Using ConnectionPatch
 ~~~~~~~~~~~~~~~~~~~~~
 
-The ConnectionPatch is like an annotation without text. While the annotate
-function is recommended in most situations, the ConnectionPatch is useful when
-you want to connect points in different axes. ::
+ConnectionPatch is like an annotation without text. While `~.Axes.annotate`
+is sufficient in most situations, ConnectionPatch is useful when you want to
+connect points in different axes. ::
 
   from matplotlib.patches import ConnectionPatch
   xy = (0.2, 0.2)
   con = ConnectionPatch(xyA=xy, coordsA=ax1.transData,
                         xyB=xy, coordsB=ax2.transData)
-  ax2.add_artist(con)
+  fig.add_artist(con)
 
 The above code connects point *xy* in the data coordinates of ``ax1`` to
 point *xy* in the data coordinates of ``ax2``. Here is a simple example.
@@ -519,9 +519,10 @@ point *xy* in the data coordinates of ``ax2``. Here is a simple example.
 
    Connect Simple01
 
-While the ConnectionPatch instance can be added to any axes, you may want to
-add it to the axes that is drawn last, to prevent it from being covered by
-other axes.
+Here, we added the ConnectionPatch to the *figure* (with `~.Figure.add_artist`)
+rather than to either axes: this ensures that it is drawn on top of both axes,
+and is also necessary if using :doc:`constrained_layout
+</tutorials/intermediate/constrainedlayout_guide>` for positioning the axes.
 
 Advanced Topics
 ---------------


### PR DESCRIPTION
Per the new tutorial text: "this ensures that it is drawn on top of both
axes, and is also necessary if using constrained_layout for positioning
the axes" (#14957).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
