### PR TITLE
Update CircleCI and add direct artifact link 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Circle CI configuration file
 # https://circleci.com/docs/
 
-version: 2
+version: 2.1
 
 
 ###########################################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,6 @@ jobs:
       - store_artifacts:
           path: doc/build/html
 
-      - run:
-          name: "Built documentation is available at:"
-          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/doc/build/html/index.html"
-
   docs-python37:
     docker:
       - image: circleci/python:3.7
@@ -141,10 +137,6 @@ jobs:
       - store_artifacts:
           path: doc/build/html
 
-      - run:
-          name: "Built documentation is available at:"
-          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/doc/build/html/index.html"
-
   docs-python38:
     docker:
       - image: circleci/python:3.8
@@ -166,10 +158,6 @@ jobs:
 
       - store_artifacts:
           path: doc/build/html
-
-      - run:
-          name: "Built documentation is available at:"
-          command: echo "${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/doc/build/html/index.html"
 
       - add_ssh_keys:
           fingerprints:

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,0 +1,12 @@
+on: [status]
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/doc/build/html/index.html
+          circleci-jobs: docs-python36,docs-python37,docs-python38


### PR DESCRIPTION
CircleCI is turning on Pipelines next week. @tacaswell flipped the switch, but they also say to update the version in the config file (to be able use new stuff), which is done here. In Cartopy, I tried to convert to their new reusable config format, but it didn't really have much benefit, so I didn't bother here.

Additionally, I dropped the printing of the link to the documentation in the build, because it stopped working. When you're already on the build page, it's easier to go through the artifacts tab at the top. For a quick link directly from the PR, I've added a GitHub Action that posts a status with the correct link (the Action knows the right way to get the link.) Note, it does note post here yet because the Action is not in this repo, but you can see it if you look at the commit in my repo (Cartopy):

![image](https://user-images.githubusercontent.com/302469/75960541-370a2480-5e8e-11ea-89b0-73107421bff7.png)

The App (an older version of the Action) is used in, e.g., scikit-learn/scikit-learn#14731 and scipy/scipy#10707.