### PR TITLE
Turn mathtext.GlueSpec into a (private) namedtuple.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -242,3 +242,8 @@ The following related APIs are also deprecated:
 ``matplotlib.test(recursionlimit=...)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The *recursionlimit* parameter of ``matplotlib.test`` is deprecated.
+
+mathtext glues
+~~~~~~~~~~~~~~
+The *copy* parameter of ``mathtext.Glue`` is deprecated (the underlying glue
+spec is now immutable).  ``mathtext.GlueSpec`` is deprecated.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1849,41 +1849,57 @@ class Vrule(Rule):
         Rule.__init__(self, thickness, np.inf, np.inf, state)
 
 
+_GlueSpec = namedtuple(
+    "_GlueSpec", "width stretch stretch_order shrink shrink_order")
+_GlueSpec._named = {
+    'fil':         _GlueSpec(0., 1., 1, 0., 0),
+    'fill':        _GlueSpec(0., 1., 2, 0., 0),
+    'filll':       _GlueSpec(0., 1., 3, 0., 0),
+    'neg_fil':     _GlueSpec(0., 0., 0, 1., 1),
+    'neg_fill':    _GlueSpec(0., 0., 0, 1., 2),
+    'neg_filll':   _GlueSpec(0., 0., 0, 1., 3),
+    'empty':       _GlueSpec(0., 0., 0, 0., 0),
+    'ss':          _GlueSpec(0., 1., 1, -1., 1),
+}
+
+
 class Glue(Node):
     """
     Most of the information in this object is stored in the underlying
-    `GlueSpec` class, which is shared between multiple glue objects.
+    ``_GlueSpec`` class, which is shared between multiple glue objects.
     (This is a memory optimization which probably doesn't matter anymore, but
     it's easier to stick to what TeX does.)
     """
 
+    @cbook.deprecated("3.3")
+    @property
+    def glue_subtype(self):
+        return "normal"
+
+    @cbook._delete_parameter("3.3", "copy")
     def __init__(self, glue_type, copy=False):
         Node.__init__(self)
-        self.glue_subtype   = 'normal'
         if isinstance(glue_type, str):
-            glue_spec = GlueSpec.factory(glue_type)
-        elif isinstance(glue_type, GlueSpec):
+            glue_spec = _GlueSpec._named[glue_type]
+        elif isinstance(glue_type, _GlueSpec):
             glue_spec = glue_type
         else:
             raise ValueError("glue_type must be a glue spec name or instance")
-        if copy:
-            glue_spec = glue_spec.copy()
-        self.glue_spec      = glue_spec
+        self.glue_spec = glue_spec
 
     def shrink(self):
         Node.shrink(self)
         if self.size < NUM_SIZE_LEVELS:
-            if self.glue_spec.width != 0.:
-                self.glue_spec = self.glue_spec.copy()
-                self.glue_spec.width *= SHRINK_FACTOR
+            g = self.glue_spec
+            self.glue_spec = g._replace(width=g.width * SHRINK_FACTOR)
 
     def grow(self):
         Node.grow(self)
-        if self.glue_spec.width != 0.:
-            self.glue_spec = self.glue_spec.copy()
-            self.glue_spec.width *= GROW_FACTOR
+        g = self.glue_spec
+        self.glue_spec = g._replace(width=g.width * GROW_FACTOR)
 
 
+@cbook.deprecated("3.3")
 class GlueSpec:
     """See `Glue`."""
 
@@ -1908,16 +1924,9 @@ class GlueSpec:
         return cls._types[glue_type]
 
 
-GlueSpec._types = {
-    'fil':         GlueSpec(0., 1., 1, 0., 0),
-    'fill':        GlueSpec(0., 1., 2, 0., 0),
-    'filll':       GlueSpec(0., 1., 3, 0., 0),
-    'neg_fil':     GlueSpec(0., 0., 0, 1., 1),
-    'neg_fill':    GlueSpec(0., 0., 0, 1., 2),
-    'neg_filll':   GlueSpec(0., 0., 0, 1., 3),
-    'empty':       GlueSpec(0., 0., 0, 0., 0),
-    'ss':          GlueSpec(0., 1., 1, -1., 1)
-}
+with cbook._suppress_matplotlib_deprecation_warning():
+    GlueSpec._types = {k: GlueSpec(**v._asdict())
+                       for k, v in _GlueSpec._named.items()}
 
 
 # Some convenient ways to get common kinds of glue


### PR DESCRIPTION
The old implementation was basically a hand-rolled (mutable) namedtuple.
Because actual namedtuples are immutable, Glue(..., copy=True/False) has
no effect anymore, so deprecate it too.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
