### PR TITLE
Deprecate Substitution.from_params.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -333,3 +333,8 @@ In :mod:`mpl_toolkits.axes_grid1.axes_rgb`, ``imshow_rgb`` is deprecated (use
 ``ax.imshow(np.dstack([r, g, b]))`` instead); ``RGBAxesBase`` is deprecated
 (use ``RGBAxes`` instead); ``RGBAxes.add_RGB_to_figure`` is deprecated (it was
 an internal helper).
+
+``Substitution.from_params``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This method is deprecated.  If needed, directly assign to the ``params``
+attribute of the Substitution object.

--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -1,5 +1,7 @@
 import inspect
 
+from matplotlib import cbook
+
 
 class Substitution:
     """
@@ -45,6 +47,7 @@ class Substitution:
         self.params.update(*args, **kwargs)
 
     @classmethod
+    @cbook.deprecated("3.3", alternative="assign to the params attribute")
     def from_params(cls, params):
         """
         In the case where the params is a mutable sequence (list or


### PR DESCRIPTION
This method has never, ever been used.  It is readily replaced, if truly
needed (I would consider Substitution to be semi-private API
anyways...), by creating an empty Substitution object and assigning to
its params attribute.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
