### PR TITLE
Store vertices as (masked) arrays in Poly3DCollection

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -673,7 +673,10 @@ class Poly3DCollection(PolyCollection):
         needs_masking = self._invalid_vertices is not False
         num_faces = len(self._faces)
 
-        pfaces = proj3d._proj_transform_vectors(self._faces, renderer.M)
+        # Some faces might contain masked vertices, so we want to ignore any
+        # errors that those might cause
+        with np.errstate(invalid='ignore', divide='ignore'):
+            pfaces = proj3d._proj_transform_vectors(self._faces, renderer.M)
         pzs = pfaces[..., 2]
         if needs_masking:
             pzs = np.ma.MaskedArray(pzs, mask=self._invalid_vertices)

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -145,7 +145,7 @@ transform = proj_transform
 
 
 def _proj_transform_vectors(vecs, M):
-    """Vector version of ``project_transform`` able to handle MaskedArrays.
+    """Vectorized version of ``_proj_transform_vec``.
 
     Parameters
     ----------
@@ -158,18 +158,12 @@ def _proj_transform_vectors(vecs, M):
     vecs_shape = vecs.shape
     vecs = vecs.reshape(-1, 3).T
 
-    is_masked = isinstance(vecs, np.ma.MaskedArray)
-    if is_masked:
-        mask = vecs.mask
-
     vecs_pad = np.empty((vecs.shape[0] + 1,) + vecs.shape[1:])
     vecs_pad[:-1] = vecs
     vecs_pad[-1] = 1
     product = np.dot(M, vecs_pad)
     tvecs = product[:3] / product[3]
 
-    if is_masked:
-        tvecs = np.ma.array(tvecs, mask=mask)
     return tvecs.T.reshape(vecs_shape)
 
 

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -149,7 +149,7 @@ def _proj_transform_vectors(vecs, M):
 
     Parameters
     ----------
-    vecs : ... x 3 np.ndarray or np.ma.MaskedArray
+    vecs : ... x 3 np.ndarray
         Input vectors
 
     M : 4 x 4 np.ndarray


### PR DESCRIPTION
## PR Summary

This removes a bunch of very expensive list comprehensions, dropping
rendering times by half for some 3D surface plots.

Runtime of the following code drops from 16s to 10s after #16675, while stacking this PR on top of #16675 lowers the time further to around 5s. Another 3s are now spent in `PolyCollection.set_verts` which I'm hoping to improve later.

```python
import numpy as np
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.gca(projection='3d')

x = y = np.linspace(-1, 1, 400)
x, y = np.meshgrid(x, y)
z = x ** 2 + y ** 2

ax.plot_surface(x, y, z, rstride=1, cstride=1)
fig.savefig('dump.png')
plt.close()
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
