### PR TITLE
Allow MarkerStyle instances as input for lines

### DIFF
--- a/doc/users/next_whats_new/2020-03-05_markerstyle-for-lines.rst
+++ b/doc/users/next_whats_new/2020-03-05_markerstyle-for-lines.rst
@@ -1,0 +1,7 @@
+Lines now accept ``MarkerStyle`` instances as input
+---------------------------------------------------
+Similar to `~.Axes.scatter`, `~.Axes.plot` and `~.lines.Line2D` now accept
+`~.markers.MarkerStyle` instances as input for the *marker* parameter::
+
+    plt.plot(..., marker=matplotlib.markers.MarkerStyle("D"))
+

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1195,7 +1195,7 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        marker : marker style
+        marker : marker style string, `~.path.Path` or `~.markers.MarkerStyle`
             See `~matplotlib.markers` for full description of possible
             arguments.
         """

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -283,16 +283,19 @@ class MarkerStyle:
               marker in self.markers):
             self._marker_function = getattr(
                 self, '_set_' + self.markers[marker])
+        elif isinstance(marker, MarkerStyle):
+            self.__dict__.update(marker.__dict__)
         else:
             try:
                 Path(marker)
                 self._marker_function = self._set_vertices
-            except ValueError:
+            except ValueError as err:
                 raise ValueError('Unrecognized marker style {!r}'
-                                 .format(marker))
+                                 .format(marker)) from err
 
-        self._marker = marker
-        self._recache()
+        if not isinstance(marker, MarkerStyle):
+            self._marker = marker
+            self._recache()
 
     def get_path(self):
         return self._path

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -7,10 +7,13 @@ import timeit
 
 from cycler import cycler
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 import matplotlib
 import matplotlib.lines as mlines
+from matplotlib.markers import MarkerStyle
+from matplotlib.path import Path
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
@@ -194,3 +197,23 @@ def test_nan_is_sorted():
 def test_step_markers(fig_test, fig_ref):
     fig_test.subplots().step([0, 1], "-o")
     fig_ref.subplots().plot([0, 0, 1], [0, 1, 1], "-o", markevery=[0, 2])
+
+
+def test_marker_as_markerstyle():
+    fig, ax = plt.subplots()
+    line, = ax.plot([2, 4, 3], marker=MarkerStyle("D"))
+    fig.canvas.draw()
+    assert line.get_marker() == "D"
+
+    # continue with smoke tests:
+    line.set_marker("s")
+    fig.canvas.draw()
+    line.set_marker(MarkerStyle("o"))
+    fig.canvas.draw()
+    # test Path roundtrip
+    triangle1 = Path([[-1., -1.], [1., -1.], [0., 2.], [0., 0.]], closed=True)
+    line2, = ax.plot([1, 3, 2], marker=MarkerStyle(triangle1), ms=22)
+    line3, = ax.plot([0, 2, 1], marker=triangle1, ms=22)
+
+    assert_array_equal(line2.get_marker().vertices, triangle1.vertices)
+    assert_array_equal(line3.get_marker().vertices, triangle1.vertices)


### PR DESCRIPTION
## PR Summary

`scatter` allows to pass a `MarkerStyle` instances as  `marker`.

     plt.scatter(..., marker=MarkerStyle("D"))

`plot` did not allow for that up to now. 

This PR fixes this, such that 

    plt.plot(..., marker=MarkerStyle("D"))

will work as expected.

This is leveraged by allowing `MarkerStyle` to take an instance of itself as input.



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
