### PR TITLE
TST: use pytest name in naming files for check_figures_equal

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -388,15 +388,14 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
         _, result_dir = _image_directories(func)
 
         @pytest.mark.parametrize("ext", extensions)
-        def wrapper(*args, ext, **kwargs):
+        def wrapper(*args, ext, request, **kwargs):
+            fn = request.node.name
             try:
                 fig_test = plt.figure("test")
                 fig_ref = plt.figure("reference")
                 func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
-                test_image_path = result_dir / (func.__name__ + "." + ext)
-                ref_image_path = result_dir / (
-                    func.__name__ + "-expected." + ext
-                )
+                test_image_path = result_dir / (fn + "." + ext)
+                ref_image_path = result_dir / (fn + "-expected." + ext)
                 fig_test.savefig(test_image_path)
                 fig_ref.savefig(ref_image_path)
                 _raise_on_image_difference(
@@ -411,7 +410,9 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             parameters=([param
                          for param in sig.parameters.values()
                          if param.name not in {"fig_test", "fig_ref"}]
-                        + [inspect.Parameter("ext", POSITIONAL_OR_KEYWORD)])
+                        + [inspect.Parameter("ext", POSITIONAL_OR_KEYWORD),
+                           inspect.Parameter("request", POSITIONAL_OR_KEYWORD),
+                          ])
         )
         wrapper.__signature__ = new_sig
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -381,7 +381,7 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             fig_test.subplots().plot([1, 3, 5])
             fig_ref.subplots().plot([0, 1, 2], [1, 3, 5])
     """
-    POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
+    KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
     def decorator(func):
         import pytest
 
@@ -410,9 +410,10 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             parameters=([param
                          for param in sig.parameters.values()
                          if param.name not in {"fig_test", "fig_ref"}]
-                        + [inspect.Parameter("ext", POSITIONAL_OR_KEYWORD),
-                           inspect.Parameter("request", POSITIONAL_OR_KEYWORD),
-                          ])
+                        + [
+                            inspect.Parameter("ext", KEYWORD_ONLY),
+                            inspect.Parameter("request", KEYWORD_ONLY),
+                        ])
         )
         wrapper.__signature__ = new_sig
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -18,7 +18,7 @@ from matplotlib import cbook
 from matplotlib import ft2font
 from matplotlib import pyplot as plt
 from matplotlib import ticker
-from . import is_called_from_pytest
+
 from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 


### PR DESCRIPTION
## PR Summary

If you stacked `pytest.mark.parametrize` with check_figures_equal
every pass through would write to the same files.  This uses the request fixture to extract the name.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
