### PR TITLE
Lower Text's FontProperties priority when updating

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -653,3 +653,12 @@ def test_buffer_size(fig_test, fig_ref):
     ax = fig_ref.add_subplot()
     ax.set_yticks([0, 1])
     ax.set_yticklabels(["€", ""])
+
+
+def test_fontproperties_kwarg_precedence():
+    """Test that kwargs take precedence over fontproperties defaults."""
+    plt.figure()
+    text1 = plt.xlabel("value", fontproperties='Times New Roman', size=40.0)
+    text2 = plt.ylabel("counts", size=40.0, fontproperties='Times New Roman')
+    assert text1.get_size() == 40.0
+    assert text2.get_size() == 40.0

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -174,8 +174,12 @@ class Text(Artist):
 
     def update(self, kwargs):
         # docstring inherited
-        # Update bbox last, as it depends on font properties.
         sentinel = object()  # bbox can be None, so use another sentinel.
+        # Update fontproperties first, as it has lowest priority.
+        fontproperties = kwargs.pop("fontproperties", sentinel)
+        if fontproperties is not sentinel:
+            self.set_fontproperties(fontproperties)
+        # Update bbox last, as it depends on font properties.
         bbox = kwargs.pop("bbox", sentinel)
         super().update(kwargs)
         if bbox is not sentinel:


### PR DESCRIPTION
Co-authored-by: Robert Augustynowicz <robert.augustynowicz@mail.utoronto.ca>
Closes: #16389

## PR Summary

When `fontproperties` is being used, it's default values are overwriting explicit font attributes such as `size`.

```
plt.xlabel("value", fontproperties='SimHei',size=20) # this will work
plt.ylabel("counts",size=20, fontproperties='SimHei')  # this doesn't
```

### Before
![fontproperties_presedence](https://user-images.githubusercontent.com/12089120/76056141-c9b8cb00-5f43-11ea-8b2e-73acf3fc79d4.png)

### After
![fontproperties_presedence-expected_ svg](https://user-images.githubusercontent.com/12089120/76056147-cd4c5200-5f43-11ea-925b-52ffa9f48101.png)

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [X] New features are documented, with examples if plot related
- [X] Documentation is sphinx and numpydoc compliant
- [X] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [X] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
