### PR TITLE
Restart pgf's latex instance after bad latex inputs.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 import os
 from pathlib import Path
 import shutil
@@ -269,3 +270,15 @@ def test_pdf_pages_lualatex():
         pdf.savefig(fig)
 
         assert pdf.get_pagecount() == 2
+
+
+@needs_xelatex
+def test_tex_restart_after_error():
+    fig = plt.figure()
+    fig.suptitle(r"\oops")
+    with pytest.raises(ValueError):
+        fig.savefig(BytesIO(), format="pgf")
+
+    fig = plt.figure()  # start from scratch
+    fig.suptitle(r"this is ok")
+    fig.savefig(BytesIO(), format="pgf")


### PR DESCRIPTION
... and also move the warning about pgf-to-stream not supporting raster
images to when actually outputting a raster image (otherwise the warning
is spurious, and affects e.g. test_tex_restart_after_error).

backport of #15969.  closes https://discourse.matplotlib.org/t/user-warning-steamed-pgf-code-does-not-support-raster-graphics/20934.

(this was not detected previously because we didn't cover the pgf+savefig("tight") combo)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
