### PR TITLE
Update docstrings for plot_directive.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -16,7 +16,7 @@ The source code for the plot may be included in one of three ways:
 
      .. plot:: path/to/plot.py
 
-        This is the caption for the plot
+        The plot's caption.
 
    Additionally, one may specify the name of a function to call (with
    no arguments) immediately after importing the module::
@@ -36,6 +36,7 @@ The source code for the plot may be included in one of three ways:
 3. Using **doctest** syntax::
 
      .. plot::
+
         A plotting example:
         >>> import matplotlib.pyplot as plt
         >>> plt.plot([1, 2, 3], [4, 5, 6])
@@ -221,10 +222,7 @@ def mark_plot_labels(app, document):
 
 
 class PlotDirective(Directive):
-    """Implementation of the ``.. plot::`` directive.
-
-    See the module docstring for details.
-    """
+    """The ``.. plot::`` directive, as documented in the module's docstring."""
 
     has_content = True
     required_arguments = 0


### PR DESCRIPTION
- Small edit to PlotDirective's docstring.
- In the module's docstring, avoid having tokens ("is", "for") that
  would get misthighlighted as Python keywords.  I did not move the
  entire block into a `.. code-block:: rst` because there are later
  cases where we show a python snippet under `.. plot::`, in which
  case having Python syntax highlighting is actually nicer.

(see https://matplotlib.org/devdocs/api/sphinxext_plot_directive_api.html)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
