### PR TITLE
Use ASCII hyphen in README.rst to prevent setup.py from raising UnicodeDecodeError when reading that file to set long_description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,9 +73,9 @@ Contribute
 ==========
 You've discovered a bug or something else you want to change - excellent!
 
-You've worked out a way to fix it – even better!
+You've worked out a way to fix it - even better!
 
-You want to tell us about it – best of all!
+You want to tell us about it - best of all!
 
 Start at the `contributing guide <http://matplotlib.org/devdocs/devel/contributing.html>`_!
 


### PR DESCRIPTION
When installing matplotlib under pypy (nightly build, downloaded an hour ago):

```sh
$ pypy
Python 3.7.4 (cadeed6ce576, Mar 01 2020, 14:23:41)
[PyPy 7.3.1-alpha0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]
```

I get the following exception:

```
$ pip install matplotlib
Collecting matplotlib
  Using cached matplotlib-3.2.0.tar.gz (40.5 MB)
    ERROR: Command errored out with exit status 1:
     command: /home/terry/.virtualenvs/pypy/bin/pypy3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-q6fmzymu/matplotlib/setup.py'"'"'; __file__='"'"'/tmp/pip-install-q6fmzymu/matplotlib/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-q6fmzymu/matplotlib/pip-egg-info
         cwd: /tmp/pip-install-q6fmzymu/matplotlib/
    Complete output (21 lines):
    
    Edit setup.cfg to change the build options; suppress output with --quiet.
    
    BUILDING MATPLOTLIB
      matplotlib: yes [3.2.0]
          python: yes [3.7.4 (cadeed6ce576, Mar 01 2020, 14:23:41) [PyPy
                      7.3.1-alpha0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]]
        platform: yes [linux]
     sample_data: yes [installing]
           tests: no  [skipping due to configuration]
             agg: yes [installing]
           tkagg: yes [installing; run-time loading from Python Tcl/Tk]
          macosx: no  [Mac OS-X only]
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-q6fmzymu/matplotlib/setup.py", line 229, in <module>
        long_description = fd.read()
      File "/home/terry/.virtualenvs/pypy/lib-python/3/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2619: ordinal not in range(128)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

which you can also see here:

```sh
$ python
Python 3.7.4 (cadeed6ce576, Mar 01 2020, 14:23:41)
[PyPy 7.3.1-alpha0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
And now for something completely different: ``it's nonsense all the way down,
and also all the way up''
>>>> f = open('README.rst')
>>>> d = f.read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/terry/.virtualenvs/pypy/lib-python/3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3082: ordinal not in range(128)
```

Looking in `README.rst` at offset 3082 I found a non-ASCII hyphen (and a second one a couple of lines later). Changing them to regular hyphens (as in this pr) fixes the error.
