### PR TITLE
Fix saving PNGs to file objects in some places

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -666,7 +666,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         from matplotlib import _png
         im = self.to_rgba(self._A[::-1] if self.origin == 'lower' else self._A,
                           bytes=True, norm=True)
-        with open(fname, "wb") as file:
+        with cbook.open_file_cm(fname, "wb") as file:
             _png.write_png(im, file)
 
     def set_data(self, A):

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -3433,7 +3433,7 @@ class MathTextParser:
         from matplotlib import _png
         rgba, depth = self.to_rgba(
             texstr, color=color, dpi=dpi, fontsize=fontsize)
-        with open(filename, "wb") as file:
+        with cbook.open_file_cm(filename, "wb") as file:
             _png.write_png(rgba, file)
         return depth
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -280,3 +280,14 @@ def test_single_minus_sign():
 def test_spaces(fig_test, fig_ref):
     fig_test.subplots().set_title(r"$1\,2\>3\ 4$")
     fig_ref.subplots().set_title(r"$1\/2\:3~4$")
+
+
+def test_math_to_image(tmpdir):
+    mathtext.math_to_image('$x^2$', str(tmpdir.join('example.png')))
+    mathtext.math_to_image('$x^2$', io.BytesIO())
+
+
+def test_mathtext_to_png(tmpdir):
+    mt = mathtext.MathTextParser('bitmap')
+    mt.to_png(str(tmpdir.join('example.png')), '$x^2$')
+    mt.to_png(io.BytesIO(), '$x^2$')


### PR DESCRIPTION
## PR Summary

The [IPython automated rebuild](https://koschei.fedoraproject.org/build/8057914) started failing when Matplotlib 3.2.0 was introduced, with stuff like:
```pytb
  File "/builddir/build/BUILDROOT/ipython-7.13.0-1.fc33.noarch/usr/lib/python3.8/site-packages/IPython/lib/tests/test_latextools.py", line 64, in test_latex_to_html
    img = latextools.latex_to_html("$x^2$")
  File "/builddir/build/BUILDROOT/ipython-7.13.0-1.fc33.noarch/usr/lib/python3.8/site-packages/IPython/lib/latextools.py", line 216, in latex_to_html
    base64_data = latex_to_png(s, encode=True).decode('ascii')
  File "/builddir/build/BUILDROOT/ipython-7.13.0-1.fc33.noarch/usr/lib/python3.8/site-packages/IPython/lib/latextools.py", line 104, in latex_to_png
    bin_data = f(s, wrap, color, scale)
  File "/builddir/build/BUILDROOT/ipython-7.13.0-1.fc33.noarch/usr/lib/python3.8/site-packages/IPython/lib/latextools.py", line 126, in latex_to_png_mpl
    mt.to_png(f, s, fontsize=12, dpi=dpi, color=color)
  File "/usr/lib64/python3.8/site-packages/matplotlib/mathtext.py", line 3436, in to_png
    with open(filename, "wb") as file:
TypeError: expected str, bytes or os.PathLike object, not _io.BytesIO
```
`MathText.to_png` is documented as accepting a file-like object though, and this was dropped accidentally as the `_png` modle was refactored, so this PR fixes that. I also found that `_ImageBase.write_png` was changed in a similar way in the same commit, so I also modified it. But I couldn't find any usage of it and its parameters are undocumented, so I'm not sure whether that was necessary.

This PR targets `v3.2.x` directly, because `master` was subsequently switched to direct Pillow calls that accept file-like objects themselves.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way