### PR TITLE
Make format_coord messagebox resize with the window and the content in osx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1256,6 +1256,8 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     rect.size.height = 0;
     rect.origin.x += height;
     NSTextView* messagebox = [[NSTextView alloc] initWithFrame: rect];
+    messagebox.textContainer.maximumNumberOfLines = 2;
+    messagebox.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
     [messagebox setFont: font];
     [messagebox setDrawsBackground: NO];
     [messagebox setSelectable: NO];
@@ -1305,9 +1307,9 @@ NavigationToolbar2_set_message(NavigationToolbar2 *self, PyObject* args)
         [messagebox setString: text];
         
         // Adjust width with the window size
-        NSRect window_rect = [messagebox.superview frame];
+        NSRect rectWindow = [messagebox.superview frame];
         NSRect rect = [messagebox frame];
-        rect.size.width = window_rect.size.width - rect.origin.x;
+        rect.size.width = rectWindow.size.width - rect.origin.x;
         [messagebox setFrame: rect];
         
         // Adjust height with the content size

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -931,8 +931,9 @@ static PyTypeObject FigureManagerType = {
 typedef struct {
     PyObject_HEAD
     NSPopUpButton* menu;
-    NSText* messagebox;
+    NSTextView* messagebox;
     NavigationToolbar2Handler* handler;
+    int height;
 } NavigationToolbar2;
 
 @implementation NavigationToolbar2Handler
@@ -1139,7 +1140,9 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     const float gap = 2;
     const int height = 36;
     const int imagesize = 24;
-
+    
+    self->height = height;
+    
     const char* basedir;
 
     obj = PyObject_GetAttrString((PyObject*)self, "canvas");
@@ -1252,7 +1255,7 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     rect.size.width = 300;
     rect.size.height = 0;
     rect.origin.x += height;
-    NSText* messagebox = [[NSText alloc] initWithFrame: rect];
+    NSTextView* messagebox = [[NSTextView alloc] initWithFrame: rect];
     [messagebox setFont: font];
     [messagebox setDrawsBackground: NO];
     [messagebox setSelectable: NO];
@@ -1294,12 +1297,26 @@ NavigationToolbar2_set_message(NavigationToolbar2 *self, PyObject* args)
 
     if(!PyArg_ParseTuple(args, "y", &message)) return NULL;
 
-    NSText* messagebox = self->messagebox;
+    NSTextView* messagebox = self->messagebox;
 
     if (messagebox)
     {   NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
         NSString* text = [NSString stringWithUTF8String: message];
         [messagebox setString: text];
+        
+        // Adjust width with the window size
+        NSRect window_rect = [messagebox.superview frame];
+        NSRect rect = [messagebox frame];
+        rect.size.width = window_rect.size.width - rect.origin.x;
+        [messagebox setFrame: rect];
+        
+        // Adjust height with the content size
+        [messagebox.layoutManager ensureLayoutForTextContainer: messagebox.textContainer];
+        NSRect contentSize = [messagebox.layoutManager usedRectForTextContainer: messagebox.textContainer];
+        rect = [messagebox frame];
+        rect.origin.y = 0.5 * (self->height - contentSize.size.height);
+        [messagebox setFrame: rect];
+        
         [pool release];
     }
 


### PR DESCRIPTION
## PR Summary

- adjust the width of messagebox with the window size
- display in two lines properly when its width is not enough for single-line display

closes #16498 

**Example:**
```
from matplotlib import pyplot as plt
import numpy as np

x = np.linspace(-5, 5, 1000)
y = x ** 2

fig = plt.figure()
ax1 = fig.add_subplot(1, 1, 1)

def my_format_coord(x, y):
    return f'the x-coordinate = {x}, the y-coordinate = {y}'

ax1.format_coord = my_format_coord
ax1.plot(x, y)
plt.show()
```

**Before:**
<img width="350" alt="before1" src="https://user-images.githubusercontent.com/18026801/76160153-a324ab00-6162-11ea-860c-d4e66a926fb0.png">
<img width="512" alt="before2" src="https://user-images.githubusercontent.com/18026801/76160156-a61f9b80-6162-11ea-9112-944404ea180d.png">

**After:**
<img width="269" alt="after1" src="https://user-images.githubusercontent.com/18026801/76160162-b3d52100-6162-11ea-867c-cf45acca6dcc.png">
<img width="356" alt="after2" src="https://user-images.githubusercontent.com/18026801/76160163-b6377b00-6162-11ea-9f82-4a94426f7655.png">
<img width="512" alt="after3" src="https://user-images.githubusercontent.com/18026801/76160164-b899d500-6162-11ea-829f-eeaaff6630d2.png">

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->