### PR TITLE
Legend auto positioning takes text objects into account

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -38,6 +38,7 @@ from matplotlib.collections import (LineCollection, RegularPolyCollection,
                                     PolyCollection)
 from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
 from matplotlib.transforms import BboxTransformTo, BboxTransformFrom
+from matplotlib.text import Text
 
 from matplotlib.offsetbox import HPacker, VPacker, TextArea, DrawingArea
 from matplotlib.offsetbox import DraggableOffsetBox
@@ -839,8 +840,9 @@ class Legend(Artist):
             for offset in transOffset.transform(hoffsets):
                 offsets.append(offset)
 
-        texts = [text.get_bbox_patch())
+        texts = [text._get_xy_display()
                 for text in ax.texts]
+
         return bboxes, lines, offsets, texts
 
     def get_children(self):
@@ -1033,7 +1035,7 @@ class Legend(Artist):
                            for line in lines)
                        + legendBox.count_contains(offsets)
                        + legendBox.count_overlaps(bboxes)
-                       + legendBox.count_overlaps(texts)
+                       + legendBox.count_contains(texts)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))
             if badness == 0:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -838,7 +838,10 @@ class Legend(Artist):
             _, transOffset, hoffsets, _ = handle._prepare_points()
             for offset in transOffset.transform(hoffsets):
                 offsets.append(offset)
-        return bboxes, lines, offsets
+
+        texts = [text.get_bbox_patch())
+                for text in ax.texts]
+        return bboxes, lines, offsets, texts
 
     def get_children(self):
         # docstring inherited
@@ -1011,7 +1014,7 @@ class Legend(Artist):
 
         start_time = time.perf_counter()
 
-        bboxes, lines, offsets = self._auto_legend_data()
+        bboxes, lines, offsets, texts = self._auto_legend_data()
 
         bbox = Bbox.from_bounds(0, 0, width, height)
         if consider is None:
@@ -1030,6 +1033,7 @@ class Legend(Artist):
                            for line in lines)
                        + legendBox.count_contains(offsets)
                        + legendBox.count_overlaps(bboxes)
+                       + legendBox.count_overlaps(texts)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))
             if badness == 0:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -840,7 +840,7 @@ class Legend(Artist):
                 offsets.append(offset)
 
         texts = [text.get_window_extent()
-                for text in ax.texts]
+                    for text in ax.texts]
 
         return bboxes, lines, offsets, texts
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -38,7 +38,6 @@ from matplotlib.collections import (LineCollection, RegularPolyCollection,
                                     PolyCollection)
 from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
 from matplotlib.transforms import BboxTransformTo, BboxTransformFrom
-from matplotlib.text import Text
 
 from matplotlib.offsetbox import HPacker, VPacker, TextArea, DrawingArea
 from matplotlib.offsetbox import DraggableOffsetBox

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -840,7 +840,7 @@ class Legend(Artist):
                 offsets.append(offset)
 
         texts = [text.get_window_extent()
-                    for text in ax.texts]
+                 for text in ax.texts]
 
         return bboxes, lines, offsets, texts
 
@@ -1031,12 +1031,12 @@ class Legend(Artist):
             # XXX TODO: If markers are present, it would be good to take them
             # into account when checking vertex overlaps in the next line.
             badness = (sum(legendBox.count_contains(line.vertices)
-                           for line in lines)
-                       + legendBox.count_contains(offsets)
-                       + legendBox.count_overlaps(bboxes)
-                       + legendBox.count_overlaps(texts)
-                       + sum(line.intersects_bbox(legendBox, filled=False)
-                             for line in lines))
+                           for line in lines) +
+                       legendBox.count_contains(offsets) +
+                       legendBox.count_overlaps(bboxes) +
+                       legendBox.count_overlaps(texts) +
+                       sum(line.intersects_bbox(legendBox, filled=False)
+                           for line in lines))
             if badness == 0:
                 return l, b
             # Include the index to favor lower codes in case of a tie.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -840,7 +840,7 @@ class Legend(Artist):
             for offset in transOffset.transform(hoffsets):
                 offsets.append(offset)
 
-        texts = [text._get_xy_display()
+        texts = [text.get_window_extent()
                 for text in ax.texts]
 
         return bboxes, lines, offsets, texts
@@ -1035,7 +1035,7 @@ class Legend(Artist):
                            for line in lines)
                        + legendBox.count_contains(offsets)
                        + legendBox.count_overlaps(bboxes)
-                       + legendBox.count_contains(texts)
+                       + legendBox.count_overlaps(texts)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))
             if badness == 0:

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -570,3 +570,38 @@ def test_no_warn_big_data_when_loc_specified():
         ax.plot(np.arange(5000), label=idx)
     legend = ax.legend('best')
     fig.draw_artist(legend)  # Check that no warning is emitted.
+
+
+def test_overlap_no_texts():
+    # test there is no error without text
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    legend = ax.legend()
+    fig.draw_artist(legend)
+
+
+def test_overlap_one_text():
+    # test legend doesn't overlap with one text
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    ax.text(1, 0, "Text")
+    legend = ax.legend()
+    fig.draw_artist(legend)
+    texts = [text.get_window_extent()
+             for text in ax.texts]
+
+    assert legend.get_window_extent().count_overlaps(texts) == 0
+
+
+def test_overlap_two_texts():
+    # test legend doesn't overlap with two texts
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    ax.text(1, 0, "Text")
+    ax.text(0, 1, "Text")
+    legend = ax.legend()
+    fig.draw_artist(legend)
+    texts = [text.get_window_extent()
+             for text in ax.texts]
+
+    assert legend.get_window_extent().count_overlaps(texts) == 0


### PR DESCRIPTION
## PR Summary
This PR addresses issue #7869 Take text objects into account in legend auto positioning. The legend's auto positioning will now take into account text objects so that they will not overlap.
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
