### PR TITLE
Bugfix for issue 16501 raised ValueError polar subplot with (thetamax - thetamin) > 2pi

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -997,12 +997,12 @@ class PolarAxes(Axes):
         if 'thetamax' in kwargs:
             thetamax = np.deg2rad(kwargs.pop('thetamax'))
             kwargs['xmax'] = thetamax
-        
+
         if args.__len__() == 2:
             if args[0] is not None and args[1] is not None:
                 if(abs(args[1] - args[0]) > 2 * np.pi):
                     raise ValueError('Cannot pass angle range > 2 pi')
-        
+
         if 'xmin' in kwargs and 'xmax' in kwargs:
             if(abs(thetamax - thetamin) > 2 * np.pi):
                 raise ValueError('Cannot pass angle range > 2 pi')

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1001,11 +1001,11 @@ class PolarAxes(Axes):
         if args.__len__() == 2:
             if args[0] is not None and args[1] is not None:
                 if(abs(args[1] - args[0]) > 2 * np.pi):
-                    raise TypeError('Cannot pass angle range > 2 pi')
+                    raise ValueError('Cannot pass angle range > 2 pi')
         
         if 'xmin' in kwargs and 'xmax' in kwargs:
             if(abs(thetamax - thetamin) > 2 * np.pi):
-                raise TypeError('Cannot pass angle range > 2 pi')
+                raise ValueError('Cannot pass angle range > 2 pi')
         return tuple(np.rad2deg(self.set_xlim(*args, **kwargs)))
 
     def set_theta_offset(self, offset):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -987,7 +987,8 @@ class PolarAxes(Axes):
         where minval and maxval are the minimum and maximum limits. Values are
         wrapped in to the range :math:`[0, 2\pi]` (in radians), so for example
         it is possible to do ``set_thetalim(-np.pi / 2, np.pi / 2)`` to have
-        an axes symmetric around 0.
+        an axes symmetric around 0. If not within range :math:`[0, 2\pi]` a
+        ValueError is raised.
         """
         thetamin = 0
         thetamax = 0

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -988,28 +988,27 @@ class PolarAxes(Axes):
         wrapped in to the range :math:`[0, 2\pi]` (in radians), so for example
         it is possible to do ``set_thetalim(-np.pi / 2, np.pi / 2)`` to have
         an axes symmetric around 0. A ValueError is raised if the absolute
-        angle difference is larger than :math:2\pi.
+        angle difference is larger than :math:`2\pi`.
         """
         thetamin = None
         thetamax = None
         left = None
         right = None
 
+        if len(args) == 2:
+            if args[0] is not None and args[1] is not None:
+                left, right = args
+                if abs(right - left) > 2 * np.pi:
+                    raise ValueError('The angle range must be <= 2 pi')
+
         if 'thetamin' in kwargs:
             thetamin = np.deg2rad(kwargs.pop('thetamin'))
         if 'thetamax' in kwargs:
             thetamax = np.deg2rad(kwargs.pop('thetamax'))
 
-        if len(args) == 2:
-            if args[0] is not None and args[1] is not None:
-                left = args[0]
-                right = args[1]
-                if(abs(right - left) > 2 * np.pi):
-                    raise ValueError('Cannot pass angle range > 2 pi')
-
-        if(thetamin is not None and thetamax is not None):
-            if(abs(thetamax - thetamin) > 2 * np.pi):
-                raise ValueError('Cannot pass angle range > 2 pi')
+        if thetamin is not None and thetamax is not None:
+            if abs(thetamax - thetamin) > 2 * np.pi:
+                raise ValueError('The angle range must be<= 360 degrees')
         return tuple(np.rad2deg(self.set_xlim(left=left, right=right,
                                               xmin=thetamin, xmax=thetamax)))
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -987,27 +987,31 @@ class PolarAxes(Axes):
         where minval and maxval are the minimum and maximum limits. Values are
         wrapped in to the range :math:`[0, 2\pi]` (in radians), so for example
         it is possible to do ``set_thetalim(-np.pi / 2, np.pi / 2)`` to have
-        an axes symmetric around 0. If not within range :math:`[0, 2\pi]` a
-        ValueError is raised.
+        an axes symmetric around 0. A ValueError is raised if the absolute
+        angle difference is larger than :math:2\pi.
         """
-        thetamin = 0
-        thetamax = 0
+        thetamin = None
+        thetamax = None
+        left = None
+        right = None
+
         if 'thetamin' in kwargs:
             thetamin = np.deg2rad(kwargs.pop('thetamin'))
-            kwargs['xmin'] = thetamin
         if 'thetamax' in kwargs:
             thetamax = np.deg2rad(kwargs.pop('thetamax'))
-            kwargs['xmax'] = thetamax
 
-        if args.__len__() == 2:
+        if len(args) == 2:
             if args[0] is not None and args[1] is not None:
-                if(abs(args[1] - args[0]) > 2 * np.pi):
+                left = args[0]
+                right = args[1]
+                if(abs(right - left) > 2 * np.pi):
                     raise ValueError('Cannot pass angle range > 2 pi')
 
-        if 'xmin' in kwargs and 'xmax' in kwargs:
+        if(thetamin is not None and thetamax is not None):
             if(abs(thetamax - thetamin) > 2 * np.pi):
                 raise ValueError('Cannot pass angle range > 2 pi')
-        return tuple(np.rad2deg(self.set_xlim(*args, **kwargs)))
+        return tuple(np.rad2deg(self.set_xlim(left=left, right=right,
+                                              xmin=thetamin, xmax=thetamax)))
 
     def set_theta_offset(self, offset):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -989,10 +989,23 @@ class PolarAxes(Axes):
         it is possible to do ``set_thetalim(-np.pi / 2, np.pi / 2)`` to have
         an axes symmetric around 0.
         """
+        thetamin = 0
+        thetamax = 0
         if 'thetamin' in kwargs:
-            kwargs['xmin'] = np.deg2rad(kwargs.pop('thetamin'))
+            thetamin = np.deg2rad(kwargs.pop('thetamin'))
+            kwargs['xmin'] = thetamin
         if 'thetamax' in kwargs:
-            kwargs['xmax'] = np.deg2rad(kwargs.pop('thetamax'))
+            thetamax = np.deg2rad(kwargs.pop('thetamax'))
+            kwargs['xmax'] = thetamax
+        
+        if args.__len__() == 2:
+            if args[0] is not None and args[1] is not None:
+                if(abs(args[1] - args[0]) > 2 * np.pi):
+                    raise TypeError('Cannot pass angle range > 2 pi')
+        
+        if 'xmin' in kwargs and 'xmax' in kwargs:
+            if(abs(thetamax - thetamin) > 2 * np.pi):
+                raise TypeError('Cannot pass angle range > 2 pi')
         return tuple(np.rad2deg(self.set_xlim(*args, **kwargs)))
 
     def set_theta_offset(self, offset):

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -174,10 +174,12 @@ def test_dont_mutate_kwargs():
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
 
+
 def test_subplot_theta_min_max():
     with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
         ax = plt.subplot(111, projection='polar')
-        ax.set_thetalim(thetamin = 800, thetamax=400)
+        ax.set_thetalim(thetamin=800, thetamax=400)
+
 
 def test_subplot_theta_range():
     with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -176,7 +176,7 @@ def test_dont_mutate_kwargs():
 
 
 def test_subplot_theta_min_max_raise():
-    with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
+    with pytest.raises(ValueError, match='The angle range must be<= 360 degrees'):
         ax = plt.subplot(111, projection='polar')
         ax.set_thetalim(thetamin=800, thetamax=400)
 
@@ -187,7 +187,7 @@ def test_subplot_theta_min_max_non_raise():
 
 
 def test_subplot_theta_range_raise():
-    with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
+    with pytest.raises(ValueError, match='The angle range must be <= 2 pi'):
         ax = plt.subplot(111, projection='polar')
         ax.set_thetalim(0, 3 * numpy.pi)
 

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -176,7 +176,8 @@ def test_dont_mutate_kwargs():
 
 
 def test_subplot_theta_min_max_raise():
-    with pytest.raises(ValueError, match='The angle range must be<= 360 degrees'):
+    with pytest.raises(ValueError, match='The angle range ' +
+                                         'must be<= 360 degrees'):
         ax = plt.subplot(111, projection='polar')
         ax.set_thetalim(thetamin=800, thetamax=400)
 

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -175,13 +175,23 @@ def test_dont_mutate_kwargs():
     assert gridspec_kw == {'width_ratios': [1, 2]}
 
 
-def test_subplot_theta_min_max():
+def test_subplot_theta_min_max_raise():
     with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
         ax = plt.subplot(111, projection='polar')
         ax.set_thetalim(thetamin=800, thetamax=400)
 
 
-def test_subplot_theta_range():
+def test_subplot_theta_min_max_non_raise():
+    ax = plt.subplot(111, projection='polar')
+    ax.set_thetalim(thetamin=800, thetamax=440)
+
+
+def test_subplot_theta_range_raise():
     with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
         ax = plt.subplot(111, projection='polar')
         ax.set_thetalim(0, 3 * numpy.pi)
+
+
+def test_subplot_theta_range_normal_non_raise():
+    ax = plt.subplot(111, projection='polar')
+    ax.set_thetalim(0, 2 * numpy.pi)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -173,3 +173,13 @@ def test_dont_mutate_kwargs():
                            gridspec_kw=gridspec_kw)
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
+
+def test_subplot_theta_min_max():
+    with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
+        ax = plt.subplot(111, projection='polar')
+        ax.set_thetalim(thetamin = 800, thetamax=400)
+
+def test_subplot_theta_range():
+    with pytest.raises(ValueError, match="Cannot pass angle range > 2 pi"):
+        ax = plt.subplot(111, projection='polar')
+        ax.set_thetalim(0, 3 * numpy.pi)


### PR DESCRIPTION
## PR Summary
Recopy of old PR: https://github.com/matplotlib/matplotlib/pull/16711. 
This PR addresses issue #16501 set_thetalim takes in parameters as radians or degrees but the problem occurs when the range or difference between the parameters is large than 2pi radians or larger than 360 in terms of degrees. The polar subplot will produce a deformed graph as it is shown in the Github issue 16501.

Fix: The fix was done using a check for ranges larger than 2pi, and if so ValueError is raised

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
