### PR TITLE
Deprecate rcParams["datapath"] in favor of mpl.get_data_path().

### DIFF
--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -43,6 +43,8 @@ Default values and styling
 
 .. autofunction:: matplotlib_fname
 
+.. autofunction:: get_data_path
+
 Logging
 =======
 

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -294,4 +294,6 @@ are deprecated.
 The ``datapath`` rcParam
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Use `.get_data_path` instead.  (The rcParam is deprecated because it cannot be
-meaningfully set by an end user.)  This was deprecated only in 3.2.1.
+meaningfully set by an end user.)  The rcParam had no effect from 3.2.0, but
+was deprecated only in 3.2.1.  In 3.2.1+ if ``'datapath'`` is set in a
+``matplotlibrc`` file it will be respected, but this behavior well be removed in 3.3.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -296,4 +296,4 @@ The ``datapath`` rcParam
 Use `.get_data_path` instead.  (The rcParam is deprecated because it cannot be
 meaningfully set by an end user.)  The rcParam had no effect from 3.2.0, but
 was deprecated only in 3.2.1.  In 3.2.1+ if ``'datapath'`` is set in a
-``matplotlibrc`` file it will be respected, but this behavior well be removed in 3.3.
+``matplotlibrc`` file it will be respected, but this behavior will be removed in 3.3.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -290,3 +290,8 @@ from the public API in future versions.
 
 ``style.core.is_style_file`` and ``style.core.iter_style_files``
 are deprecated.
+
+The ``datapath`` rcParam
+~~~~~~~~~~~~~~~~~~~~~~~~
+Use `.get_data_path` instead.  (The rcParam is deprecated because it cannot be
+meaningfully set by an end user.)  This was deprecated only in 3.2.1.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -439,7 +439,7 @@ def get_sample_data(fname, asfileobj=True):
 
     If the filename ends in .gz, the file is implicitly ungzipped.
     """
-    path = Path(matplotlib._get_data_path(), 'sample_data', fname)
+    path = Path(matplotlib.get_data_path(), 'sample_data', fname)
     if asfileobj:
         suffix = path.suffix.lower()
         if suffix == '.gz':

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -103,10 +103,6 @@
 #toolbar     : toolbar2  ## {None, toolbar2}
 #timezone    : UTC       ## a pytz timezone string, e.g., US/Central or Europe/Paris
 
-## Where your matplotlib data lives if you installed to a non-default
-## location.  This is where the matplotlib fonts, bitmaps, etc reside
-#datapath : /home/jdhunter/mpldata
-
 
 ## ***************************************************************************
 ## * LINES                                                                   *


### PR DESCRIPTION
The rcParam cannot be meaningfully set by the end user from their
matplotlibrc or Python code.

(This is a manual backport to 3.2.x of #16417; see discussion there.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
