### PR TITLE
Fixed incorrect colour in ErrorBar when Nan value is presented

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1129,10 +1129,10 @@ class Axes(_AxesBase):
         xmax = np.ravel(xmax)
 
         masked_verts = np.ma.empty((len(y), 2, 2))
-        masked_verts[:, 0, 1] = y
-        masked_verts[:, 1, 1] = y
         masked_verts[:, 0, 0] = xmin
+        masked_verts[:, 0, 1] = y
         masked_verts[:, 1, 0] = xmax
+        masked_verts[:, 1, 1] = y
 
         lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
@@ -1212,8 +1212,8 @@ class Axes(_AxesBase):
 
         masked_verts = np.ma.empty((len(x), 2, 2))
         masked_verts[:, 0, 0] = x
-        masked_verts[:, 1, 0] = x
         masked_verts[:, 0, 1] = ymin
+        masked_verts[:, 1, 0] = x
         masked_verts[:, 1, 1] = ymax
 
         lines = mcoll.LineCollection(masked_verts, colors=colors,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1125,13 +1125,15 @@ class Axes(_AxesBase):
         # Create and combine masked_arrays from input
         y, xmin, xmax = cbook._combine_masks(y, xmin, xmax)
         y = np.ravel(y)
-        xmin = np.ma.resize(xmin, y.shape)
-        xmax = np.ma.resize(xmax, y.shape)
+        xmin = np.ravel(xmin)
+        xmax = np.ravel(xmax)
 
-        masked_verts = [np.ma.array([y_xmin, y_xmax])
-                        for y_xmin, y_xmax in
-                        zip(np.ma.array([xmin, y]).T,
-                            np.ma.array([xmax, y]).T)]
+        masked_verts = np.ma.empty((len(y), 2, 2))
+        masked_verts[:, 0, 1] = y
+        masked_verts[:, 1, 1] = y
+        masked_verts[:, 0, 0] = xmin
+        masked_verts[:, 1, 0] = xmax
+
         lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)
@@ -1205,13 +1207,15 @@ class Axes(_AxesBase):
         # Create and combine masked_arrays from input
         x, ymin, ymax = cbook._combine_masks(x, ymin, ymax)
         x = np.ravel(x)
-        ymin = np.ma.resize(ymin, x.shape)
-        ymax = np.ma.resize(ymax, x.shape)
+        ymin = np.ravel(ymin)
+        ymax = np.ravel(ymax)
 
-        masked_verts = [np.ma.array([xymin, xymax])
-                        for xymin, xymax in
-                        zip(np.ma.array([x, ymin]).T,
-                            np.ma.array([x, ymax]).T)]
+        masked_verts = np.ma.empty((len(x), 2, 2))
+        masked_verts[:, 0, 0] = x
+        masked_verts[:, 1, 0] = x
+        masked_verts[:, 0, 1] = ymin
+        masked_verts[:, 1, 1] = ymax
+
         lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1122,15 +1122,17 @@ class Axes(_AxesBase):
         if not np.iterable(xmax):
             xmax = [xmax]
 
-        y, xmin, xmax = cbook.delete_masked_points(y, xmin, xmax)
-
+        # Create and combine masked_arrays from input
+        y, xmin, xmax = cbook._combine_masks(y, xmin, xmax)
         y = np.ravel(y)
-        xmin = np.resize(xmin, y.shape)
-        xmax = np.resize(xmax, y.shape)
+        xmin = np.ma.resize(xmin, y.shape)
+        xmax = np.ma.resize(xmax, y.shape)
 
-        verts = [((thisxmin, thisy), (thisxmax, thisy))
-                 for thisxmin, thisxmax, thisy in zip(xmin, xmax, y)]
-        lines = mcoll.LineCollection(verts, colors=colors,
+        masked_verts = [np.ma.array([y_xmin, y_xmax])
+                        for y_xmin, y_xmax in
+                        zip(np.ma.array([xmin, y]).T,
+                            np.ma.array([xmax, y]).T)]
+        lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)
         lines.update(kwargs)
@@ -1200,15 +1202,17 @@ class Axes(_AxesBase):
         if not np.iterable(ymax):
             ymax = [ymax]
 
-        x, ymin, ymax = cbook.delete_masked_points(x, ymin, ymax)
-
+        # Create and combine masked_arrays from input
+        x, ymin, ymax = cbook._combine_masks(x, ymin, ymax)
         x = np.ravel(x)
-        ymin = np.resize(ymin, x.shape)
-        ymax = np.resize(ymax, x.shape)
+        ymin = np.ma.resize(ymin, x.shape)
+        ymax = np.ma.resize(ymax, x.shape)
 
-        verts = [((thisx, thisymin), (thisx, thisymax))
-                 for thisx, thisymin, thisymax in zip(x, ymin, ymax)]
-        lines = mcoll.LineCollection(verts, colors=colors,
+        masked_verts = [np.ma.array([xymin, xymax])
+                        for xymin, xymax in
+                        zip(np.ma.array([x, ymin]).T,
+                            np.ma.array([x, ymax]).T)]
+        lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)
         lines.update(kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3992,6 +3992,74 @@ def test_hlines():
     ax5.set_ylim(0, 15)
 
 
+def generate_hlines_with_colors_inputs():
+    colors = cycler('colors', [['red', 'green', 'blue', 'purple', 'orange']])
+    base_y = cycler(
+        'y', [[1, 2, 3, np.nan, 5], np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
+    base_max = cycler('xmax', [np.ones(5)])
+    base_min = cycler('xmin', [0])
+    base_line_width = cycler('linewidth', [5])
+    original = base_y * base_min * base_max * colors * base_line_width
+
+    expect = {
+        'y': [1, 2, 3, 5],
+        'xmin': 0, 'xmax': [1, 2, 3, 5],
+        'colors': ['red', 'green', 'blue', 'orange']}
+
+    result = []
+
+    for i in original:
+        result.append({'original': i, 'expect': expect})
+
+    return result
+
+
+@pytest.mark.parametrize('kwargs', generate_hlines_with_colors_inputs())
+@check_figures_equal(extensions=["png"])
+def test_hlines_with_colors(fig_test, fig_ref, kwargs):
+    fig_test, ax0 = plt.subplots()
+    test = kwargs.pop('original')
+    ax0.hlines(**test)
+
+    fig_ref, ax1 = plt.subplots()
+    ref = kwargs.pop('expect')
+    ax1.hlines(**ref)
+
+
+def generate_vlines_with_colors_inputs():
+    colors = cycler('colors', [['red', 'green', 'blue', 'purple', 'orange']])
+    base_x = cycler(
+        'x', [[1, 2, 3, np.nan, 5], np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
+    base_max = cycler('ymax', [np.ones(5)])
+    base_min = cycler('ymin', [0])
+    base_line_width = cycler('linewidth', [5])
+    original = base_x * base_min * base_max * colors * base_line_width
+
+    expect = {
+        'x': [1, 2, 3, 5],
+        'ymin': 0,
+        'ymax': [1, 2, 3, 5],
+        'colors': ['red', 'green', 'blue', 'orange']}
+
+    result = []
+    for i in original:
+        result.append({'original': i, 'expect': expect})
+
+    return result
+
+
+@pytest.mark.parametrize('kwargs', generate_vlines_with_colors_inputs())
+@check_figures_equal(extensions=["png"])
+def test_vlines_with_colors(fig_test, fig_ref, kwargs):
+    fig_test, ax0 = plt.subplots()
+    test = kwargs.pop('original')
+    ax0.vlines(**test)
+
+    fig_ref, ax1 = plt.subplots()
+    ref = kwargs.pop('expect')
+    ax1.vlines(**ref)
+
+
 @image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True)
 def test_step_linestyle():
     x = y = np.arange(10)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3992,72 +3992,57 @@ def test_hlines():
     ax5.set_ylim(0, 15)
 
 
-def generate_hlines_with_colors_inputs():
-    colors = cycler('colors', [['red', 'green', 'blue', 'purple', 'orange']])
-    base_y = cycler(
-        'y', [[1, 2, 3, np.nan, 5], np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
-    base_max = cycler('xmax', [np.ones(5)])
-    base_min = cycler('xmin', [0])
-    base_line_width = cycler('linewidth', [5])
-    original = base_y * base_min * base_max * colors * base_line_width
+def generate_lines_with_colors_inputs():
+    colors = ['red', 'green', 'blue', 'purple', 'orange']
+    xy_nan = [1, 2, 3, np.nan, 5]
+    xy_mask = np.ma.masked_equal([1, 2, 3, 4, 5], 4)
+    lines_nan = [{'base_xy': xy_nan,
+                    'base_max': np.ones(5),
+                    'base_min': [0],
+                    'linewidth': 5,
+                    'colors': colors}]
+    lines_mask = [{'base_xy': xy_mask,
+                    'base_max': np.ones(5),
+                    'base_min': [0],
+                    'linewidth': 5,
+                    'colors': colors}]
 
-    expect = {
-        'y': [1, 2, 3, 5],
-        'xmin': 0, 'xmax': [1, 2, 3, 5],
-        'colors': ['red', 'green', 'blue', 'orange']}
-
-    result = []
-
-    for i in original:
-        result.append({'original': i, 'expect': expect})
-
-    return result
+    return [*lines_nan, *lines_mask]
 
 
-@pytest.mark.parametrize('kwargs', generate_hlines_with_colors_inputs())
-@check_figures_equal(extensions=["png"])
-def test_hlines_with_colors(fig_test, fig_ref, kwargs):
-    fig_test, ax0 = plt.subplots()
-    test = kwargs.pop('original')
-    ax0.hlines(**test)
-
-    fig_ref, ax1 = plt.subplots()
-    ref = kwargs.pop('expect')
-    ax1.hlines(**ref)
-
-
-def generate_vlines_with_colors_inputs():
-    colors = cycler('colors', [['red', 'green', 'blue', 'purple', 'orange']])
-    base_x = cycler(
-        'x', [[1, 2, 3, np.nan, 5], np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
-    base_max = cycler('ymax', [np.ones(5)])
-    base_min = cycler('ymin', [0])
-    base_line_width = cycler('linewidth', [5])
-    original = base_x * base_min * base_max * colors * base_line_width
-
-    expect = {
-        'x': [1, 2, 3, 5],
-        'ymin': 0,
-        'ymax': [1, 2, 3, 5],
-        'colors': ['red', 'green', 'blue', 'orange']}
-
-    result = []
-    for i in original:
-        result.append({'original': i, 'expect': expect})
-
-    return result
-
-
-@pytest.mark.parametrize('kwargs', generate_vlines_with_colors_inputs())
+@pytest.mark.parametrize('kwargs', generate_lines_with_colors_inputs())
 @check_figures_equal(extensions=["png"])
 def test_vlines_with_colors(fig_test, fig_ref, kwargs):
-    fig_test, ax0 = plt.subplots()
-    test = kwargs.pop('original')
-    ax0.vlines(**test)
+    kwargs['x'] = kwargs.pop('base_xy')
+    kwargs['ymin'] = kwargs.pop('base_min')
+    kwargs['ymax'] = kwargs.pop('base_max')
+    fig_test.subplots().vlines(**kwargs)
 
-    fig_ref, ax1 = plt.subplots()
-    ref = kwargs.pop('expect')
-    ax1.vlines(**ref)
+    expect = {
+    'x': [1, 2, 3, 5],
+    'ymin': [0],
+    'ymax': np.ones(4),
+    'colors': ['red', 'green', 'blue', 'orange'],
+    'linewidth': 5}
+    fig_ref.subplots().vlines(**expect)
+
+
+@pytest.mark.parametrize('kwargs', generate_lines_with_colors_inputs())
+@check_figures_equal(extensions=["png"])
+def test_hlines_with_colors(fig_test, fig_ref, kwargs):
+    kwargs['y'] = kwargs.pop('base_xy')
+    kwargs['xmin'] = kwargs.pop('base_min')
+    kwargs['xmax'] = kwargs.pop('base_max')
+    fig_test.subplots().hlines(**kwargs)
+
+    expect = {
+    'y': [1, 2, 3, 5],
+    'xmin': [0],
+    'xmax': np.ones(4),
+    'colors': ['red', 'green', 'blue', 'orange'],
+    'linewidth': 5}
+
+    fig_ref.subplots().hlines(**expect)
 
 
 @image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3992,57 +3992,22 @@ def test_hlines():
     ax5.set_ylim(0, 15)
 
 
-def generate_lines_with_colors_inputs():
-    colors = ['red', 'green', 'blue', 'purple', 'orange']
-    xy_nan = [1, 2, 3, np.nan, 5]
-    xy_mask = np.ma.masked_equal([1, 2, 3, 4, 5], 4)
-    lines_nan = [{'base_xy': xy_nan,
-                    'base_max': np.ones(5),
-                    'base_min': [0],
-                    'linewidth': 5,
-                    'colors': colors}]
-    lines_mask = [{'base_xy': xy_mask,
-                    'base_max': np.ones(5),
-                    'base_min': [0],
-                    'linewidth': 5,
-                    'colors': colors}]
-
-    return [*lines_nan, *lines_mask]
-
-
-@pytest.mark.parametrize('kwargs', generate_lines_with_colors_inputs())
+@pytest.mark.parametrize('data', [[1, 2, 3, np.nan, 5],
+                                  np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
 @check_figures_equal(extensions=["png"])
-def test_vlines_with_colors(fig_test, fig_ref, kwargs):
-    kwargs['x'] = kwargs.pop('base_xy')
-    kwargs['ymin'] = kwargs.pop('base_min')
-    kwargs['ymax'] = kwargs.pop('base_max')
-    fig_test.subplots().vlines(**kwargs)
+def test_lines_with_colors(fig_test, fig_ref, data):
+    test_colors = ['red', 'green', 'blue', 'purple', 'orange']
+    fig_test.add_subplot(2, 1, 1).vlines(data, 0, 1,
+                                         colors=test_colors, linewidth=5)
+    fig_test.add_subplot(2, 1, 2).hlines(data, 0, 1,
+                                         colors=test_colors, linewidth=5)
 
-    expect = {
-    'x': [1, 2, 3, 5],
-    'ymin': [0],
-    'ymax': np.ones(4),
-    'colors': ['red', 'green', 'blue', 'orange'],
-    'linewidth': 5}
-    fig_ref.subplots().vlines(**expect)
-
-
-@pytest.mark.parametrize('kwargs', generate_lines_with_colors_inputs())
-@check_figures_equal(extensions=["png"])
-def test_hlines_with_colors(fig_test, fig_ref, kwargs):
-    kwargs['y'] = kwargs.pop('base_xy')
-    kwargs['xmin'] = kwargs.pop('base_min')
-    kwargs['xmax'] = kwargs.pop('base_max')
-    fig_test.subplots().hlines(**kwargs)
-
-    expect = {
-    'y': [1, 2, 3, 5],
-    'xmin': [0],
-    'xmax': np.ones(4),
-    'colors': ['red', 'green', 'blue', 'orange'],
-    'linewidth': 5}
-
-    fig_ref.subplots().hlines(**expect)
+    expect_xy = [1, 2, 3, 5]
+    expect_color = ['red', 'green', 'blue', 'orange']
+    fig_ref.add_subplot(2, 1, 1).vlines(expect_xy, 0, 1,
+                                        colors=expect_color, linewidth=5)
+    fig_ref.add_subplot(2, 1, 2).hlines(expect_xy, 0, 1,
+                                        colors=expect_color, linewidth=5)
 
 
 @image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True)


### PR DESCRIPTION
## PR Summary
Fixed incorrect colour in ErrorBar when Nan value is presented
See #13799
Co-author : Dennis Tismenko <Dennis.Tismenko@mail.utoronto.ca>

After analyzing the codebase, the inconsistency issue was traced to the difference between the handling of NaN values in Axes.scatter versus Axes.hlines/Axes.vlines. In the latter case, NaN values were being deleted from their respective np.array, whereas in the former case, NaN values were handled by using a np.ma.array (masked array), where the NaN values were simply masked.

Removed cbook.delete_masked_points() when passing X and Y to Errorbar.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
