### PR TITLE
TST/CI: also try to run test_user_fonts_win32 on azure

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -156,10 +156,11 @@ def test_user_fonts_linux(tmpdir, monkeypatch):
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='Windows only')
 def test_user_fonts_win32():
-    if not os.environ.get('APPVEYOR', False):
-        pytest.xfail("This test does only work on appveyor since user fonts "
-                     "are Windows specific and the developer's font directory "
-                     "should remain unchanged.")
+    if not (os.environ.get('APPVEYOR', False) or
+            os.environ.get('TF_BUILD', False)):
+        pytest.xfail("This test should only run on CI (appveyor or azure) "
+                     "as the developer's font directory should remain "
+                     "unchanged.")
 
     font_test_file = 'mpltest.ttf'
 


### PR DESCRIPTION
This will hopefully also help make our code coverage results less
flaky.

I think what is happening is:

 - on master branch azure does upload so we see coverage on the
   pytest.xfail line
 - on PRs azure does not upload so we do not see coverage on the
   pytest.xfail and the measured code coverage goes down :facepalm:

Hopefully this will always skip this line on CI (as it will actually
run the tests!) which should make our coverage more stable.  I suspect
it would be better to move this check into a pytest.mark, but....

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)