### PR TITLE
Bug fix for Issue 16580 raises RuntimeError when calling blit function on a closed figure.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -75,6 +75,10 @@ def blit(photoimage, aggimage, offsets, bbox=None):
     else:
         photoimage.blank()
         bboxptr = (0, width, 0, height)
+    try:
+        photoimage.tk.call(photoimage, "get", 0, 0)
+    except tk.TclError:
+        raise RuntimeError(f"{photoimage} has been deleted") from None
     _tkagg.blit(
         photoimage.tk.interpaddr(), str(photoimage), dataptr, offsets, bboxptr)
 

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -31,7 +31,6 @@ def test_blit():
 def test_blit_error_on_closed_figure():
     # render figure with TkAgg backend and then close
     fig, axes = plt.subplots()
-    axes.imshow(np.zeros((1000, 1000, 3), dtype=np.uint8))
     fig.canvas.draw()
     plt.close(fig.number)
     # assert runtime error is thrown from the blit function after figure is closed

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -26,3 +26,15 @@ def test_blit():
                       np.ones((4, 4, 4)),
                       (0, 1, 2, 3),
                       bad_boxes)
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+def test_blit_error_on_closed_figure():
+    # render figure with TkAgg backend and then close
+    fig, axes = plt.subplots()
+    axes.imshow(np.zeros((1000, 1000, 3), dtype=np.uint8))
+    fig.canvas.draw()
+    plt.close(fig.number)
+    # assert runtime error is thrown from the blit function after figure is closed
+    with pytest.raises(RuntimeError) as seg_info:
+        fig.canvas.blit(axes.bbox)
+    assert f"{fig.canvas._tkphoto} has been deleted" in str(seg_info.value)

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -27,13 +27,14 @@ def test_blit():
                       (0, 1, 2, 3),
                       bad_boxes)
 
+
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
 def test_blit_error_on_closed_figure():
     # render figure with TkAgg backend and then close
     fig, axes = plt.subplots()
     fig.canvas.draw()
     plt.close(fig.number)
-    # assert runtime error is thrown from the blit function after figure is closed
+    # assert runtime error is thrown after figure is closed
     with pytest.raises(RuntimeError) as seg_info:
         fig.canvas.blit(axes.bbox)
     assert f"{fig.canvas._tkphoto} has been deleted" in str(seg_info.value)


### PR DESCRIPTION
## PR Summary
Address [issue 16580](https://github.com/matplotlib/matplotlib/issues/16580) where calling the blit() function on fig.canvas after closing the figure would cause a segmentation fault. The fix raises a RuntimeError when the blit function is called on a closed figure to inform the user of what went wrong. 
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
