### PR TITLE
Update xtick.alignment parameter in rcsetup to validate against correct values

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1344,7 +1344,7 @@ defaultParams = {
     'xtick.labelsize':   ['medium', validate_fontsize],
     'xtick.direction':   ['out', validate_string],            # direction of xticks
     'xtick.alignment':   ['center',
-                          ['center', 'top', 'bottom', 'baseline', 'center_baseline']],
+                          ['center', 'right', 'left']],
 
     'ytick.left':        [True, validate_bool],  # draw ticks on the left side
     'ytick.right':       [False, validate_bool],  # draw ticks on the right side


### PR DESCRIPTION
## PR Summary

The issue is related to [16584](https://github.com/matplotlib/matplotlib/issues/16583). Users were not able to set xtick.alignment parameter from rcsetup.py in their matplotlibrc files due to validation values not being set correctly. Validation values are now set to ['center', 'right', 'left'] and no errors are thrown when xtick.alignment is set to any of these valid values. Value erro is thrown when set otherwise as expected.

I had added test cases for this issue but commented them out because it seems the warnings they had generated were causing failures:

`FixedFormatter should only be used together with FixedLocator`

Was not sure if these test cases were necessary for this change so I have them commented out for now but will fix them if required.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
