### PR TITLE
Disable draw_foo methods on renderer used to estimate tight extents.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1489,10 +1489,15 @@ class KeyEvent(LocationEvent):
         self.key = key
 
 
-def _get_renderer(figure, print_method):
+def _get_renderer(figure, print_method, *, draw_disabled=False):
     """
     Get the renderer that would be used to save a `~.Figure`, and cache it on
     the figure.
+
+    If *draw_disabled* is True, additionally replace draw_foo methods on
+    *renderer* by no-ops.  This is used by the tight-bbox-saving renderer,
+    which needs to walk through the artist tree to compute the tight-bbox, but
+    for which the output file may be closed early.
     """
     # This is implemented by triggering a draw, then immediately jumping out of
     # Figure.draw() by raising an exception.
@@ -1506,8 +1511,14 @@ def _get_renderer(figure, print_method):
         try:
             print_method(io.BytesIO())
         except Done as exc:
-            figure._cachedRenderer, = exc.args
-            return figure._cachedRenderer
+            renderer, = figure._cachedRenderer, = exc.args
+
+    if draw_disabled:
+        for meth_name in dir(RendererBase):
+            if meth_name.startswith("draw_"):
+                setattr(renderer, meth_name, lambda *args, **kwargs: None)
+
+    return renderer
 
 
 def _is_non_interactive_terminal_ipython(ip):
@@ -2058,7 +2069,8 @@ class FigureCanvasBase:
                     renderer = _get_renderer(
                         self.figure,
                         functools.partial(
-                            print_method, dpi=dpi, orientation=orientation))
+                            print_method, dpi=dpi, orientation=orientation),
+                        draw_disabled=True)
                     self.figure.draw(renderer)
                     bbox_artists = kwargs.pop("bbox_extra_artists", None)
                     bbox_inches = self.figure.get_tightbbox(

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -291,3 +291,11 @@ def test_tex_restart_after_error():
     fig = plt.figure()  # start from scratch
     fig.suptitle(r"this is ok")
     fig.savefig(BytesIO(), format="pgf")
+
+
+@needs_xelatex
+def test_bbox_inches_tight(tmpdir):
+    fig, ax = plt.subplots()
+    ax.imshow([[0, 1], [2, 3]])
+    fig.savefig(os.path.join(tmpdir, "test.pdf"), backend="pgf",
+                bbox_inches="tight")


### PR DESCRIPTION
For the pgf backend, in particular draw_image() cannot succeed because
that needs actual filesystem access (to set up \includegraphics).

I think this is a better solution than #16732 to close #16731, and should work both on master and backported to 3.2.

Note that this disabling of draw_foo methods was already done previously, in a piecemeal fashion, at https://github.com/matplotlib/matplotlib/blob/v3.2.0/lib/matplotlib/backends/backend_pgf.py#L422 or (in a different fashion) at https://github.com/matplotlib/matplotlib/blob/v3.2.0/lib/matplotlib/backends/backend_ps.py#L924.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
