### PR TITLE
Make test_stem less flaky.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3342,10 +3342,15 @@ def test_hist_stacked_weighted():
     ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
 
 
-@pytest.mark.parametrize("use_line_collection", [True, False],
-                         ids=['w/ line collection', 'w/o line collection'])
-@image_comparison(['stem.png'], style='mpl20', remove_text=True)
-def test_stem(use_line_collection):
+@image_comparison(['stem.png', 'stem.png'], style='mpl20', remove_text=True)
+def test_stem():
+    # Note, we don't use @pytest.mark.parametrize, because in parallel this
+    # might cause one process result to overwrite another's.
+    for use_line_collection in [True, False]:
+        _test_stem(use_line_collection)
+
+
+def _test_stem(use_line_collection):
     x = np.linspace(0.1, 2 * np.pi, 100)
     args = (x, np.cos(x))
     # Label is a single space to force a legend to be drawn, but to avoid any


### PR DESCRIPTION
## PR Summary

Since parametrizing the test allows it to run in parallel, this makes it flaky, as one process can overwrite the test result image of another.

Our standard way for dealing with tests that use the same baseline image is to pass duplicate filenames to `image_comparison`, because that is serialized.

This is basically the same as #16656 for `test_stem`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way