### PR TITLE
xpdf: Set AutoRotatePages to None, not false.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1198,7 +1198,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         ["ps2pdf",
          "-dAutoFilterColorImages#false",
          "-dAutoFilterGrayImages#false",
-         "-dAutoRotatePages#false",
+         "-sAutoRotatePages#None",
          "-sGrayImageFilter#FlateEncode",
          "-sColorImageFilter#FlateEncode",
          "-dEPSCrop" if eps else "-sPAPERSIZE#%s" % ptype,


### PR DESCRIPTION
## PR Summary

Looking at the Ghostscript source code, it should take None/All/PageByPage instead of a boolean.

Fixes #16538, but let's see if it works on CI with older versions.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way