### PR TITLE
pyplot.subplots() accepts subplot arguments through **kwargs

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1032,7 +1032,7 @@ def subplot(*args, **kwargs):
 
 
 def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
-             subplot_kw=None, gridspec_kw=None, **fig_kw):
+             subplot_kw=None, gridspec_kw=None, **kwargs):
     """
     Create a figure and a set of subplots.
 
@@ -1082,9 +1082,11 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         Dict with keywords passed to the `~matplotlib.gridspec.GridSpec`
         constructor used to create the grid the subplots are placed on.
 
-    **fig_kw
-        All additional keyword arguments are passed to the
-        `.pyplot.figure` call.
+    **kwargs
+        Keyword arguements that are "projections", "polar", or "label"
+        are passed to the `~matplotlib.figure.Figure.add_subplot` call used
+        to create each subplot. All additional keyword arguments are
+        passed to the `.pyplot.figure` call.
 
     Returns
     -------
@@ -1132,7 +1134,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         ax2.scatter(x, y)
 
         # Create four polar axes and access them through the returned array
-        fig, axs = plt.subplots(2, 2, subplot_kw=dict(polar=True))
+        fig, axs = plt.subplots(2, 2, polar=True)
         axs[0, 0].plot(x, y)
         axs[1, 1].scatter(x, y)
 
@@ -1161,7 +1163,17 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
     .Figure.add_subplot
 
     """
-    fig = figure(**fig_kw)
+    if subplot_kw is None:
+        subplot_kw = {}
+    for arg in ["projection", "polar", "label"]:
+        if arg in kwargs:
+            if arg in subplot_kw:
+                raise TypeError("subplots() got multiple values for "
+                                 "keyword argument '{}'".format(arg))
+            subplot_kw[arg] = kwargs[arg]
+            kwargs.pop(arg)
+
+    fig = figure(**kwargs)
     axs = fig.subplots(nrows=nrows, ncols=ncols, sharex=sharex, sharey=sharey,
                        squeeze=squeeze, subplot_kw=subplot_kw,
                        gridspec_kw=gridspec_kw)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -173,3 +173,8 @@ def test_dont_mutate_kwargs():
                            gridspec_kw=gridspec_kw)
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
+
+
+def test_combine_subplot_kw_fig_kw():
+    fig1, axs1 = plt.subplots(2, 2, polar=True)
+    assert type(axs1[0][0]).__name__ == "PolarAxesSubplot"


### PR DESCRIPTION
Fixes #1460  

## PR Summary
`pyplot.subplots()` now accepts subplot arguments through **kwargs without the need of using dictionaries. 

```
figure1, axis1 = plt.subplots(figsize=(10,20), polar=True)
figure2, axis2 = plt.subplots(figsize=(10,20), subplot_kw=dict(polar=True)) # this still works
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way