### PR TITLE
Fix type of `dpi` in docstrings.

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -498,9 +498,9 @@ effect.
 .. code-block:: rst
 
    Prefer:
-       dpi : int, default: :rc:`figure.dpi`
+       dpi : float, default: :rc:`figure.dpi`
    over:
-       dpi : int, default: None
+       dpi : float, default: None
 
    Prefer:
        textprops : dict, optional

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -208,7 +208,7 @@ class AbstractMovieWriter(abc.ABC):
             The figure object that contains the information for frames.
         outfile : str
             The filename of the resulting movie file.
-        dpi : int, optional, default: ``fig.dpi``
+        dpi : float, optional, default: ``fig.dpi``
             The DPI (or resolution) for the file.  This controls the size
             in pixels of the resulting movie file.
         """
@@ -434,10 +434,10 @@ class FileMovieWriter(MovieWriter):
             The figure to grab the rendered frames from.
         outfile : str
             The filename of the resulting movie file.
-        dpi : number, optional
+        dpi : float, optional
             The dpi of the output file. This, with the figure size,
             controls the size in pixels of the resulting movie file.
-            Default is fig.dpi.
+            Default is ``fig.dpi``.
         frame_prefix : str, optional
             The filename prefix to use for temporary files.  If None (the
             default), files are written to a temporary directory which is
@@ -981,7 +981,7 @@ class Animation:
             Movie frame rate (per second).  If not set, the frame rate from the
             animation's frame interval.
 
-        dpi : int, default: :rc:`savefig.dpi`
+        dpi : float, default: :rc:`savefig.dpi`
             Controls the dots per inch for the movie frames.  Together with
             the figure's size in inches, this controls the size of the movie.
 

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -27,7 +27,7 @@ class MixedModeRenderer:
         height : scalar
             The height of the canvas in logical units
 
-        dpi : scalar
+        dpi : float
             The dpi of the canvas
 
         vector_renderer : `matplotlib.backend_bases.RendererBase`

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1495,9 +1495,10 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
     origin : {'upper', 'lower'}, default: :rc:`image.origin`
         Indicates whether the ``(0, 0)`` index of the array is in the upper
         left or lower left corner of the axes.
-    dpi : int
+    dpi : float
         The DPI to store in the metadata of the file.  This does not affect the
-        resolution of the output image.
+        resolution of the output image.  Depending on file format, this may be
+        rounded to the nearest integer.
     metadata : dict, optional
         Metadata in the image file.  The supported keys depend on the output
         format, see the documentation of the respective backends for more

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -470,7 +470,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
     figsize : (float, float), default: :rc:`figure.figsize`
         Width, height in inches.
 
-    dpi : int, default: :rc:`figure.dpi`
+    dpi : float, default: :rc:`figure.dpi`
         The resolution of the figure in dots-per-inch.
 
     facecolor : color, default: :rc:`figure.facecolor`


### PR DESCRIPTION
## PR Summary

It should be `float`, except possibly when saving to certain formats via Pillow.

Fixes #16718.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way