### PR TITLE
nbagg: Don't send events if manager is disconnected.

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -341,7 +341,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             self.draw_idle()
 
     def send_event(self, event_type, **kwargs):
-        self.manager._send_event(event_type, **kwargs)
+        if self.manager:
+            self.manager._send_event(event_type, **kwargs)
 
 
 _JQUERY_ICON_CLASSES = {


### PR DESCRIPTION
## PR Summary

This occurs, e.g., when saving figures, as one of the first things `print_figure` does is to remove the figure manager. This does mean that nbagg won't be able to set the wait cursor when saving a file, but before 0944dcbe6dd755fd51a91f9ca2eb57c4ae798624 that was not being done,and after, saving was broken, so there's no net loss.

Fixes #16721.

Not sure if there's a way to write a test for this yet.

## PR Checklist

- [?] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way