### PR TITLE
Allow numbers to set uvc for all arrows in quiver.set_UVC, fixes #16743

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -585,7 +585,7 @@ class Quiver(mcollections.PolyCollection):
         if C is not None:
             C = ma.masked_invalid(C, copy=True).ravel()
         for name, var in zip(('U', 'V', 'C'), (U, V, C)):
-            if var is not None and var.size != self.N and var.size != 1:
+            if not (var is None or var.size == self.N or var.size == 1):
                 raise ValueError(f'Argument {name} has a size {var.size}'
                                  f' which does not match {self.N},'
                                  ' the number of arrow positions')

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -585,7 +585,7 @@ class Quiver(mcollections.PolyCollection):
         if C is not None:
             C = ma.masked_invalid(C, copy=True).ravel()
         for name, var in zip(('U', 'V', 'C'), (U, V, C)):
-            if var is not None and var.size != self.N:
+            if var is not None and var.size != self.N and var.size != 1:
                 raise ValueError(f'Argument {name} has a size {var.size}'
                                  f' which does not match {self.N},'
                                  ' the number of arrow positions')

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -247,3 +247,15 @@ def test_quiverkey_angles():
     # The arrows are only created when the key is drawn
     fig.canvas.draw()
     assert len(qk.verts) == 1
+
+
+def test_quiver_setuvc_numbers():
+    """Check that it is possible to set all arrow UVC to the same numbers"""
+
+    fig, ax = plt.subplots()
+
+    X, Y = np.meshgrid(np.arange(2), np.arange(2))
+    U = V = np.ones_like(X)
+
+    q = ax.quiver(X, Y, U, V)
+    q.set_UVC(0, 1)


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [X] Has Pytest style unit tests
- [X] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


Fix for #16743
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
