### PR TITLE
Document behavior of savefig("extensionless-name").

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2044,12 +2044,16 @@ default: 'top'
             possibly some backend-dependent object such as
             `matplotlib.backends.backend_pdf.PdfPages`.
 
-            If *format* is not set, then the output format is inferred from
-            the extension of *fname*, if any, and from :rc:`savefig.format`
-            otherwise.  If *format* is set, it determines the output format.
+            If *format* is set, it determines the output format, and the file
+            is saved as *fname*.  Note that *fname* is used verbatim, and there
+            is no attempt to make the extension, if any, of *fname* match
+            *format*, and no extension is appended.
 
-            Hence, if *fname* is not a path or has no extension, remember to
-            specify *format* to ensure that the correct backend is used.
+            If *format* is not set, then the format is inferred from the
+            extension of *fname*, if there is one.  If *format* is not
+            set and *fname* has no extension, then the file is saved with
+            :rc:`savefig.format` and the appropriate extension is appended to
+            *fname*.
 
         Other Parameters
         ----------------


### PR DESCRIPTION
When the filename has no extension *and* the `format` kwarg is unset,
the suffix derived from the savefig.format rcparam is appended to the
filename.

(I'm not sure the behavior is really that nice, but that's what it is
right now; this is just documenting it.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
