### PR TITLE
ci: Disallow pytest 5.4.0, which is crashing.

### DIFF
--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -1,7 +1,7 @@
 # pip requirements for all the travis builds
 
 coverage
-pytest!=4.6.0
+pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures
 pytest-timeout


### PR DESCRIPTION
## PR Summary

All CIs (except docs) are failing with an internal pytest error. The exact error is inconsistent, but sometimes it is:
```
============================= test session starts ==============================
platform linux -- Python 3.8.0, pytest-5.4.0, py-1.8.0, pluggy-0.13.0
rootdir: /home/travis/build/matplotlib/matplotlib, inifile: pytest.ini, testpaths: lib
plugins: cov-2.8.1, timeout-1.3.4, forked-1.1.3, rerunfailures-8.0, xdist-1.31.0
timeout: 300.0s
timeout method: signal
timeout func_only: False
gw0 I / gw1 I
gw0 [1135] / gw1 [1135]
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/_pytest/main.py", line 191, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/_pytest/main.py", line 247, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/manager.py", line 92, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/manager.py", line 83, in <lambda>
INTERNALERROR>     self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/xdist/dsession.py", line 112, in pytest_runtestloop
INTERNALERROR>     self.loop_once()
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/xdist/dsession.py", line 135, in loop_once
INTERNALERROR>     call(**kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.8.0/lib/python3.8/site-packages/xdist/dsession.py", line 177, in worker_workerfinished
INTERNALERROR>     assert not crashitem, (crashitem, node)
INTERNALERROR> AssertionError: ('lib/matplotlib/tests/test_afm.py::test_parse_header', <WorkerController gw1>)
INTERNALERROR> assert not 'lib/matplotlib/tests/test_afm.py::test_parse_header'
```
but the exact test case on which it fails changes. Sometimes it is:
```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/_pytest/main.py", line 191, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/_pytest/main.py", line 247, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/hooks.py", line 286, in __call__
INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/callers.py", line 203, in _multicall
INTERNALERROR>     gen.send(outcome)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/dsession.py", line 112, in pytest_runtestloop
INTERNALERROR>     self.loop_once()
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/dsession.py", line 135, in loop_once
INTERNALERROR>     call(**kwargs)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/dsession.py", line 241, in worker_collectionfinish
INTERNALERROR>     self.sched.schedule()
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/scheduler/load.py", line 249, in schedule
INTERNALERROR>     self._send_tests(next(nodes), 1)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/scheduler/load.py", line 261, in _send_tests
INTERNALERROR>     node.send_runtest_some(tests_per_node)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/workermanage.py", line 281, in send_runtest_some
INTERNALERROR>     self.sendcommand("runtests", indices=indices)
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/xdist/workermanage.py", line 297, in sendcommand
INTERNALERROR>     self.channel.send((name, kwargs))
INTERNALERROR>   File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/execnet/gateway_base.py", line 728, in send
INTERNALERROR>     raise IOError("cannot send to {!r}".format(self))
INTERNALERROR> OSError: cannot send to <Channel id=1 closed>
```
