### PR TITLE
ENH: Allow for non-normalized and transformed markers

### DIFF
--- a/doc/users/next_whats_new/2020-03-16_markerstyle_normalization.rst
+++ b/doc/users/next_whats_new/2020-03-16_markerstyle_normalization.rst
@@ -1,0 +1,12 @@
+Allow for custom marker scaling
+-------------------------------
+`~.markers.MarkerStyle` gained a keyword argument *normalization*, which may be
+set to *"none"* to allow for custom paths to not be scaled.::
+
+    MarkerStyle(Path(...), normalization="none")
+
+`~.markers.MarkerStyle` also gained a `~.markers.MarkerStyle.set_transform`
+method to set affine transformations to existing markers.::
+
+    m = MarkerStyle("d")
+    m.set_transform(m.get_transform() + Affine2D().rotate_deg(30))

--- a/examples/lines_bars_and_markers/scatter_piecharts.py
+++ b/examples/lines_bars_and_markers/scatter_piecharts.py
@@ -3,15 +3,19 @@
 Scatter plot with pie chart markers
 ===================================
 
-This example makes custom 'pie charts' as the markers for a scatter plot.
-
-Thanks to Manuel Metz for the example.
+This example shows two methods to make custom 'pie charts' as the markers
+for a scatter plot.
 """
+
+##########################################################################
+# Manually creating marker vertices
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
 
 import numpy as np
 import matplotlib.pyplot as plt
 
-# first define the ratios
+# first define the cumulative ratios
 r1 = 0.2       # 20%
 r2 = r1 + 0.4  # 40%
 
@@ -36,10 +40,55 @@ xy3 = np.row_stack([[0, 0], np.column_stack([x3, y3])])
 s3 = np.abs(xy3).max()
 
 fig, ax = plt.subplots()
-ax.scatter(range(3), range(3), marker=xy1, s=s1**2 * sizes, facecolor='blue')
-ax.scatter(range(3), range(3), marker=xy2, s=s2**2 * sizes, facecolor='green')
-ax.scatter(range(3), range(3), marker=xy3, s=s3**2 * sizes, facecolor='red')
+ax.scatter(range(3), range(3), marker=xy1, s=s1**2 * sizes, facecolor='C0')
+ax.scatter(range(3), range(3), marker=xy2, s=s2**2 * sizes, facecolor='C1')
+ax.scatter(range(3), range(3), marker=xy3, s=s3**2 * sizes, facecolor='C2')
 
+plt.show()
+
+
+##########################################################################
+# Using wedges as markers
+# ~~~~~~~~~~~~~~~~~~~~~~~
+#
+# An alternative is to create custom markers from the `~.path.Path` of a
+# `~.patches.Wedge`, which might be more versatile.
+#
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.patches import Wedge
+from matplotlib.markers import MarkerStyle
+
+# first define the ratios
+r1 = 0.2          # 20%
+r2 = r1 + 0.3     # 50%
+r3 = 1 - r1 - r2  # 30%
+
+
+def markers_from_ratios(ratios, width=1):
+    markers = []
+    angles = 360*np.concatenate(([0], np.cumsum(ratios)))
+    for i in range(len(angles)-1):
+        # create a Wedge within the unit square in between the given angles...
+        w = Wedge((0, 0), 0.5, angles[i], angles[i+1], width=width/2)
+        # ... and create a custom Marker from its path.
+        markers.append(MarkerStyle(w.get_path(), normalization="none"))
+    return markers
+
+# define some sizes of the scatter marker
+sizes = np.array([100, 200, 400, 800])
+# collect the markers and some colors
+markers = markers_from_ratios([r1, r2, r3], width=0.6)
+colors = plt.cm.tab10.colors[:len(markers)]
+
+fig, ax = plt.subplots()
+
+for marker, color in zip(markers, colors):
+    ax.scatter(range(len(sizes)), range(len(sizes)), marker=marker, s=sizes,
+               edgecolor="none", facecolor=color)
+
+ax.margins(0.1)
 plt.show()
 
 #############################################################################
@@ -55,3 +104,5 @@ plt.show()
 import matplotlib
 matplotlib.axes.Axes.scatter
 matplotlib.pyplot.scatter
+matplotlib.patches.Wedge
+matplotlib.markers.MarkerStyle

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -2,8 +2,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import markers
 from matplotlib.path import Path
-from matplotlib.testing.decorators import check_figures_equal
+from matplotlib.transforms import Affine2D
 
+from matplotlib.testing.decorators import check_figures_equal
 import pytest
 
 
@@ -133,3 +134,24 @@ def test_asterisk_marker(fig_test, fig_ref, request):
 
     ax_test.set(xlim=(-0.5, 1.5), ylim=(-0.5, 1.5))
     ax_ref.set(xlim=(-0.5, 1.5), ylim=(-0.5, 1.5))
+
+
+@check_figures_equal(extensions=["png"])
+def test_marker_normalization(fig_test, fig_ref):
+    plt.style.use("mpl20")
+
+    ax = fig_ref.subplots()
+    ax.margins(0.3)
+    ax.scatter([0, 1], [0, 0], s=400, marker="s", c="C2")
+
+    ax = fig_test.subplots()
+    ax.margins(0.3)
+    # test normalize
+    p = Path([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], closed=True)
+    p1 = p.transformed(Affine2D().translate(-.5, -.5).scale(20))
+    m1 = markers.MarkerStyle(p1, normalization="none")
+    ax.scatter([0], [0], s=1, marker=m1, c="C2")
+    # test transform
+    m2 = markers.MarkerStyle("s")
+    m2.set_transform(m2.get_transform() + Affine2D().scale(20))
+    ax.scatter([1], [0], s=1, marker=m2, c="C2")


### PR DESCRIPTION
## PR Summary

This PR allows markers to be non-normalized or transformed:
* `MarkerStyle` now gets a `normalize_path` argument, which defaults to `True`, but can be set `False` to allow for custom paths that are input to not be normalized to the unit square. That is, the following two will result in the same plot
    ```
    p = Path([[-1,-1],[1,-1],[0,1]])
    ax.scatter(...., s=20**2, marker=MarkerStyle(p))
    ax.scatter(...., s=1, marker=MarkerStyle(p.transformed(Affine2D().scale(10)), 
                 normalize_path=False))
    ```
* `MarkerStyle` now gets a `set_transform` method, that allows to externally set a transform to the marker. I.e., the following two result in the same plot
    ```
    ax.scatter(...., s=20**2, marker=MarkerStyle("s"))
    m = MarkerStyle("s")
    m.set_transform(Affine2D().scale(20))
    ax.scatter(...., s=1, marker=m)
    ```

## Why is this useful?

Until now, it is impossible use arbitrary custom markers. Custom markers are always normalized to the unit square. So for a given path, the size and center point of the marker are changed by matplotlib. 

Common problems:
* You want to rotate a given marker without it changing size. See 
    * https://stackoverflow.com/questions/53227057/size-distortion-when-rotating-custom-path-marker-in-matplotlib or
    * https://stackoverflow.com/questions/49660174/rotate-existing-matplotlib-markers
* You want to create a custom marker that is sized relative to another marker, see e.g. https://matplotlib.org/gallery/lines_bars_and_markers/scatter_piecharts.html, without setting its size via the `markersize` property of the artist, or that is off-centered.

* Finally, you may want to create a set of markers that are uniform in area, or perceptually uniform, as desired in https://github.com/matplotlib/matplotlib/issues/15703

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
