### PR TITLE
Avoid vstack() when possible.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -330,13 +330,8 @@ class Path:
         if not args:
             return Path(np.empty([0, 2], dtype=np.float32))
 
-        lengths = [len(x) for x in args]
-        total_length = sum(lengths)
-
-        vertices = np.vstack([x.vertices for x in args])
-        vertices.reshape((total_length, 2))
-
-        codes = np.empty(total_length, dtype=cls.code_type)
+        vertices = np.concatenate([x.vertices for x in args])
+        codes = np.empty(len(vertices), dtype=cls.code_type)
         i = 0
         for path in args:
             if path.codes is None:

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2176,10 +2176,9 @@ class BlendedGenericTransform(_BlendedMixin, Transform):
             else:
                 x_mtx = self._x.get_affine().get_matrix()
                 y_mtx = self._y.get_affine().get_matrix()
-                # This works because we already know the transforms are
-                # separable, though normally one would want to set b and
-                # c to zero.
-                mtx = np.vstack((x_mtx[0], y_mtx[1], [0.0, 0.0, 1.0]))
+                # We already know the transforms are separable, so we can skip
+                # setting b and c to zero.
+                mtx = np.array([x_mtx[0], y_mtx[1], [0.0, 0.0, 1.0]])
                 self._affine = Affine2D(mtx)
             self._invalid = 0
         return self._affine
@@ -2229,10 +2228,9 @@ class BlendedAffine2D(_BlendedMixin, Affine2DBase):
             else:
                 x_mtx = self._x.get_matrix()
                 y_mtx = self._y.get_matrix()
-                # This works because we already know the transforms are
-                # separable, though normally one would want to set b and
-                # c to zero.
-                self._mtx = np.vstack((x_mtx[0], y_mtx[1], [0.0, 0.0, 1.0]))
+                # We already know the transforms are separable, so we can skip
+                # setting b and c to zero.
+                self._mtx = np.array([x_mtx[0], y_mtx[1], [0.0, 0.0, 1.0]])
             self._inverted = None
             self._invalid = 0
         return self._mtx


### PR DESCRIPTION
In transforms.py, array() is faster -- the changes speeds up the
proposed precision-sensitive version of format_data_short (#16776) by ~10%
(essentially because we get to skip the calls to np.atleast_2d in
vstack).

Also replace a vstack() call by a concatenate() in path.py, while we're
at it.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
