### PR TITLE
Adding png image return for inline backend figures with _repr_html_

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1596,71 +1596,43 @@ class FigureCanvasBase:
         self._is_idle_drawing = False
 
     def _repr_html_(self):
-        if not self.figure.axes and not self.figure.lines:
-            return
-
-        dpi = self.figure.dpi
-        is_retina = False
-
-        import IPython
-        ip = IPython.get_ipython()
-        ib_list = [c for c in ip.configurables 
-                    if 'InlineBackend' in type(c).__name__]
-
-        # having an 'inline' backend doesn't mean '%matplotlib inline' has been run
-        # Running %matplotlib inline runs pylabtools.configure_inline_support
-        # which appends the InlineBackend to the list of configurables
-        if get_backend() == 'module://ipykernel.pylab.backend_inline' and ib_list:
-            ib = ib_list[0]
-            bbox_inches = ib.print_figure_kwargs['bbox_inches']
-            fmt = next(iter(ib.figure_formats))
-            if fmt == 'retina':
-                is_retina = True
-                dpi = dpi * 2
-                fmt = self.get_default_filetype()
-        else:
-            bbox_inches = 'tight' # how to let user choose self.figure.bbox_inches?
-            fmt = self.get_default_filetype()
-
-        if fmt not in {'png', 'svg', 'jpg', 'pdf'}:
-            fmt = 'png' 
+        # Defer to IPython to handle html output if possible
+        if 'IPython' in sys.modules:
+            import IPython
+            ip = IPython.get_ipython()
+            # Check whether %matplotlib was run. Is there a better way?
+            ib_list = [c for c in ip.configurables 
+                       if 'InlineBackend' in type(c).__name__]
+            if ib_list:
+                return
+            
+        fmt = self.get_default_filetype()
 
         kw = {
             "format":fmt,
             "facecolor":self.figure.get_facecolor(),
             "edgecolor":self.figure.get_edgecolor(),
-            "dpi":dpi,
-            "bbox_inches":bbox_inches,
+            "dpi":self.figure.dpi,
+            "bbox_inches":self.figure.bbox_inches
         }
 
         bytes_io = io.BytesIO()
         self.print_figure(bytes_io, **kw)
         raw_bytes = bytes_io.getvalue()
 
-        from IPython.core.display import _pngxy, _jpegxy
-        
-        if fmt == 'svg':
-            return raw_bytes.decode()
-        elif fmt == 'png':
-            w, h = _pngxy(raw_bytes)
-        elif fmt == 'jpg':
-            w, h = _jpegxy(raw_bytes)
-        elif fmt == 'pdf':
-            w, h = self.figure.get_size_inches()
-            w, h = w * dpi, h * dpi
-
-        if is_retina:
-            w, h = w // 2, h // 2
-
         from base64 import b64encode
         data = b64encode(raw_bytes).decode()
 
-        if fmt == 'png':
-            return f'<img width="{w}" height="{h}"  src="data:image/png;base64, {data}" />'
+        if fmt == 'svg':
+            return raw_bytes.decode()
+        elif fmt == 'png':
+            return f'<img src="data:image/png;base64, {data}" />'
         elif fmt == 'pdf':
+            w, h = self.figure.get_size_inches()
+            w, h = w * self.figure.dpi, h * self.figure.dpi
             return f'<embed width="{w}" height="{h}" src="data:application/pdf;base64, {data}">'
         elif fmt == 'jpg':
-            return f'<img width="{w}" height="{h}" src="data:image/jpeg;base64, {data}" />'
+            return f'<img src="data:image/jpeg;base64, {data}" />'
 
     @classmethod
     @functools.lru_cache()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1596,41 +1596,71 @@ class FigureCanvasBase:
         self._is_idle_drawing = False
 
     def _repr_html_(self):
-        from base64 import b64encode
+        if not self.figure.axes and not self.figure.lines:
+            return
 
-        fmt = self.get_default_filetype()
         dpi = self.figure.dpi
-        if fmt == 'retina':
-            dpi = dpi * 2
-            fmt = 'png'
+        is_retina = False
+
+        import IPython
+        ip = IPython.get_ipython()
+        ib_list = [c for c in ip.configurables 
+                    if 'InlineBackend' in type(c).__name__]
+
+        # having an 'inline' backend doesn't mean '%matplotlib inline' has been run
+        # Running %matplotlib inline runs pylabtools.configure_inline_support
+        # which appends the InlineBackend to the list of configurables
+        if get_backend() == 'module://ipykernel.pylab.backend_inline' and ib_list:
+            ib = ib_list[0]
+            bbox_inches = ib.print_figure_kwargs['bbox_inches']
+            fmt = next(iter(ib.figure_formats))
+            if fmt == 'retina':
+                is_retina = True
+                dpi = dpi * 2
+                fmt = self.get_default_filetype()
+        else:
+            bbox_inches = 'tight' # how to let user choose self.figure.bbox_inches?
+            fmt = self.get_default_filetype()
+
+        if fmt not in {'png', 'svg', 'jpg', 'pdf'}:
+            fmt = 'png' 
 
         kw = {
             "format":fmt,
             "facecolor":self.figure.get_facecolor(),
             "edgecolor":self.figure.get_edgecolor(),
             "dpi":dpi,
-            "bbox_inches":self.figure.bbox_inches,
+            "bbox_inches":bbox_inches,
         }
 
         bytes_io = io.BytesIO()
         self.print_figure(bytes_io, **kw)
         raw_bytes = bytes_io.getvalue()
 
-        mimetype_dict = {'png': 'image/png', 'svg': 'image/svg+xml', 
-                         'jpg': 'image/jpeg', 'pdf': 'application/pdf'}
-        if fmt not in mimetype_dict:
-            fmt = 'png'
-        mimetype = mimetype_dict[fmt]
+        from IPython.core.display import _pngxy, _jpegxy
         
         if fmt == 'svg':
             return raw_bytes.decode()
+        elif fmt == 'png':
+            w, h = _pngxy(raw_bytes)
+        elif fmt == 'jpg':
+            w, h = _jpegxy(raw_bytes)
         elif fmt == 'pdf':
-            data = b64encode(raw_bytes).decode()
             w, h = self.figure.get_size_inches()
-            return f'<embed height="{h * dpi}" width="{w * dpi}" src="data:application/pdf;base64, {data}">'
-        else:
-            data = b64encode(raw_bytes).decode()
-        return f'<img src="data:{mimetype};base64, {data}" />'
+            w, h = w * dpi, h * dpi
+
+        if is_retina:
+            w, h = w // 2, h // 2
+
+        from base64 import b64encode
+        data = b64encode(raw_bytes).decode()
+
+        if fmt == 'png':
+            return f'<img width="{w}" height="{h}"  src="data:image/png;base64, {data}" />'
+        elif fmt == 'pdf':
+            return f'<embed width="{w}" height="{h}" src="data:application/pdf;base64, {data}">'
+        elif fmt == 'jpg':
+            return f'<img width="{w}" height="{h}" src="data:image/jpeg;base64, {data}" />'
 
     @classmethod
     @functools.lru_cache()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1595,6 +1595,43 @@ class FigureCanvasBase:
         self.toolbar = None  # NavigationToolbar2 will set me
         self._is_idle_drawing = False
 
+    def _repr_html_(self):
+        from base64 import b64encode
+
+        fmt = self.get_default_filetype()
+        dpi = self.figure.dpi
+        if fmt == 'retina':
+            dpi = dpi * 2
+            fmt = 'png'
+
+        kw = {
+            "format":fmt,
+            "facecolor":self.figure.get_facecolor(),
+            "edgecolor":self.figure.get_edgecolor(),
+            "dpi":self.figure.dpi,
+            "bbox_inches":self.figure.bbox_inches,
+        }
+
+        bytes_io = io.BytesIO()
+        self.print_figure(bytes_io, **kw)
+        raw_bytes = bytes_io.getvalue()
+
+        mimetype_dict = {'png': 'image/png', 'svg': 'image/svg+xml', 
+                         'jpg': 'image/jpeg', 'pdf': 'application/pdf'}
+        if fmt not in mimetype_dict:
+            fmt = 'png'
+        mimetype = mimetype_dict[fmt]
+        
+        if fmt == 'svg':
+            return raw_bytes.decode()
+        elif fmt == 'pdf':
+            data = b64encode(raw_bytes).decode()
+            w, h = self.figure.get_size_inches()
+            return f'<embed height="{h * dpi}" width="{w * dpi}" src="data:application/pdf;base64, {data}">'
+        else:
+            data = b64encode(raw_bytes).decode()
+        return f'<img src="data:{mimetype};base64, {data}" />'
+
     @classmethod
     @functools.lru_cache()
     def _fix_ipython_backend2gui(cls):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1608,7 +1608,7 @@ class FigureCanvasBase:
             "format":fmt,
             "facecolor":self.figure.get_facecolor(),
             "edgecolor":self.figure.get_edgecolor(),
-            "dpi":self.figure.dpi,
+            "dpi":dpi,
             "bbox_inches":self.figure.bbox_inches,
         }
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -51,6 +51,9 @@ webagg_server_thread = ServerThread()
 class FigureCanvasWebAgg(core.FigureCanvasWebAggCore):
     _timer_cls = TimerTornado
 
+    def _repr_html_(self):
+        return ipython_inline_display(self.figure)
+
     def show(self):
         # show the figure window
         global show  # placates pyflakes: created by @_Backend.export below

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -375,6 +375,15 @@ class Figure(Artist):
             from matplotlib.backends import backend_webagg
             return backend_webagg.ipython_inline_display(self)
 
+        if mpl.rcParams['backend'] == 'module://ipykernel.pylab.backend_inline':
+            from io import BytesIO
+            from base64 import b64encode
+            png_bytes = BytesIO()
+            self.canvas.print_figure(png_bytes, format='png')
+            s = png_bytes.getvalue()
+            s1 = b64encode(s).decode()
+            return f'<img src="data:image/png;base64, {s1}"/>'
+
     def show(self, warn=True):
         """
         If using a GUI backend with pyplot, display the figure window.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -369,20 +369,7 @@ class Figure(Artist):
     # use it, for some reason.
 
     def _repr_html_(self):
-        # We can't use "isinstance" here, because then we'd end up importing
-        # webagg unconditionally.
-        if 'WebAgg' in type(self.canvas).__name__:
-            from matplotlib.backends import backend_webagg
-            return backend_webagg.ipython_inline_display(self)
-
-        if mpl.rcParams['backend'] == 'module://ipykernel.pylab.backend_inline':
-            from io import BytesIO
-            from base64 import b64encode
-            png_bytes = BytesIO()
-            self.canvas.print_figure(png_bytes, format='png')
-            s = png_bytes.getvalue()
-            s1 = b64encode(s).decode()
-            return f'<img src="data:image/png;base64, {s1}"/>'
+        return self.canvas._repr_html_()
 
     def show(self, warn=True):
         """


### PR DESCRIPTION
## PR Summary

This will enable figures to be displayed in a jupyter notebook without ever having to run `%matplotlib inline` or `import matplotlib.pyplot`.

The initial issue was created here https://github.com/matplotlib/matplotlib/issues/16782.

I'm sure the code will need to be modified quite a bit to work with more cases, but I wanted to get the ball started on this important issue for me.

I don't know how to test this. Are there special tests for jupyter notebook output?

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


