### PR TITLE
Backport #15589 and #16693, fixes for check_figures_equal

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -389,18 +389,22 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         @pytest.mark.parametrize("ext", extensions)
         def wrapper(*args, ext, **kwargs):
-            fig_test = plt.figure("test")
-            fig_ref = plt.figure("reference")
-            func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
-            test_image_path = result_dir / (func.__name__ + "." + ext)
-            ref_image_path = result_dir / (
-                func.__name__ + "-expected." + ext
-            )
-            fig_test.savefig(test_image_path)
-            fig_ref.savefig(ref_image_path)
-            _raise_on_image_difference(
-                ref_image_path, test_image_path, tol=tol
-            )
+            try:
+                fig_test = plt.figure("test")
+                fig_ref = plt.figure("reference")
+                func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
+                test_image_path = result_dir / (func.__name__ + "." + ext)
+                ref_image_path = result_dir / (
+                    func.__name__ + "-expected." + ext
+                )
+                fig_test.savefig(test_image_path)
+                fig_ref.savefig(ref_image_path)
+                _raise_on_image_difference(
+                    ref_image_path, test_image_path, tol=tol
+                )
+            finally:
+                plt.close(fig_test)
+                plt.close(fig_ref)
 
         sig = inspect.signature(func)
         new_sig = sig.replace(

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -388,9 +388,17 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
         import pytest
 
         _, result_dir = _image_directories(func)
+        old_sig = inspect.signature(func)
 
         @pytest.mark.parametrize("ext", extensions)
-        def wrapper(*args, ext, request, **kwargs):
+        def wrapper(*args, **kwargs):
+            ext = kwargs['ext']
+            if 'ext' not in old_sig.parameters:
+                kwargs.pop('ext')
+            request = kwargs['request']
+            if 'request' not in old_sig.parameters:
+                kwargs.pop('request')
+
             file_name = "".join(c for c in request.node.name
                                 if c in ALLOWED_CHARS)
             try:
@@ -408,16 +416,16 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
                 plt.close(fig_test)
                 plt.close(fig_ref)
 
-        sig = inspect.signature(func)
-        new_sig = sig.replace(
-            parameters=([param
-                         for param in sig.parameters.values()
-                         if param.name not in {"fig_test", "fig_ref"}]
-                        + [
-                            inspect.Parameter("ext", KEYWORD_ONLY),
-                            inspect.Parameter("request", KEYWORD_ONLY),
-                        ])
-        )
+        parameters = [
+            param
+            for param in old_sig.parameters.values()
+            if param.name not in {"fig_test", "fig_ref"}
+        ]
+        if 'ext' not in old_sig.parameters:
+            parameters += [inspect.Parameter("ext", KEYWORD_ONLY)]
+        if 'request' not in old_sig.parameters:
+            parameters += [inspect.Parameter("request", KEYWORD_ONLY)]
+        new_sig = old_sig.replace(parameters=parameters)
         wrapper.__signature__ = new_sig
 
         # reach a bit into pytest internals to hoist the marks from

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -5,6 +5,7 @@ import inspect
 import os
 from pathlib import Path
 import shutil
+import string
 import sys
 import unittest
 import warnings
@@ -17,7 +18,7 @@ from matplotlib import cbook
 from matplotlib import ft2font
 from matplotlib import pyplot as plt
 from matplotlib import ticker
-from . import is_called_from_pytest
+
 from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 
@@ -381,22 +382,23 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             fig_test.subplots().plot([1, 3, 5])
             fig_ref.subplots().plot([0, 1, 2], [1, 3, 5])
     """
-    POSITIONAL_OR_KEYWORD = inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ALLOWED_CHARS = set(string.digits + string.ascii_letters + '_-[]()')
+    KEYWORD_ONLY = inspect.Parameter.KEYWORD_ONLY
     def decorator(func):
         import pytest
 
         _, result_dir = _image_directories(func)
 
         @pytest.mark.parametrize("ext", extensions)
-        def wrapper(*args, ext, **kwargs):
+        def wrapper(*args, ext, request, **kwargs):
+            file_name = "".join(c for c in request.node.name
+                                if c in ALLOWED_CHARS)
             try:
                 fig_test = plt.figure("test")
                 fig_ref = plt.figure("reference")
                 func(*args, fig_test=fig_test, fig_ref=fig_ref, **kwargs)
-                test_image_path = result_dir / (func.__name__ + "." + ext)
-                ref_image_path = result_dir / (
-                    func.__name__ + "-expected." + ext
-                )
+                test_image_path = result_dir / (file_name + "." + ext)
+                ref_image_path = result_dir / (file_name + "-expected." + ext)
                 fig_test.savefig(test_image_path)
                 fig_ref.savefig(ref_image_path)
                 _raise_on_image_difference(
@@ -411,7 +413,10 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
             parameters=([param
                          for param in sig.parameters.values()
                          if param.name not in {"fig_test", "fig_ref"}]
-                        + [inspect.Parameter("ext", POSITIONAL_OR_KEYWORD)])
+                        + [
+                            inspect.Parameter("ext", KEYWORD_ONLY),
+                            inspect.Parameter("request", KEYWORD_ONLY),
+                        ])
         )
         wrapper.__signature__ = new_sig
 


### PR DESCRIPTION
## PR Summary
* #15589: Make sure that figures are closed when check_figures_equal finishes
* #16693: TST: use pytest name in naming files for check_figures_equal

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way