### PR TITLE
Make the Qt interactive zoom rectangle black & white.

### DIFF
--- a/doc/users/next_whats_new/2020-03-16-qtzoom.rst
+++ b/doc/users/next_whats_new/2020-03-16-qtzoom.rst
@@ -1,0 +1,4 @@
+Qt zoom rectangle now black and white
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This makes it visible even over a dark background.

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -479,10 +479,15 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         # to be called at the end of paintEvent.
         if rect is not None:
             def _draw_rect_callback(painter):
-                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio,
-                                 QtCore.Qt.DotLine)
+                scaled_rect = [pt / self._dpi_ratio for pt in rect]
+                pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio)
+                pen.setDashPattern([3, 3])
                 painter.setPen(pen)
-                painter.drawRect(*(pt / self._dpi_ratio for pt in rect))
+                painter.drawRect(*scaled_rect)
+                pen.setDashOffset(3)
+                pen.setColor(QtCore.Qt.white)
+                painter.setPen(pen)
+                painter.drawRect(*scaled_rect)
         else:
             def _draw_rect_callback(painter):
                 return


### PR DESCRIPTION
Explicitly drawing white segments makes it visible even over dark
backgrounds.

before (but imagine even darker backgrounds (typically, an image using a black-to-white cmap)):
![old](https://user-images.githubusercontent.com/1322974/76808466-2a6bc180-67e8-11ea-832e-4e6ea54d16b7.png)
after:
![new](https://user-images.githubusercontent.com/1322974/76808467-2d66b200-67e8-11ea-8972-caf842616558.png)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
