### PR TITLE
Fix incorrect super class of VCentered.

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1978,7 +1978,7 @@ class HCentered(Hlist):
                        do_kern=False)
 
 
-class VCentered(Hlist):
+class VCentered(Vlist):
     """
     A convenience class to create a `Vlist` whose contents are
     centered within its enclosing box.


### PR DESCRIPTION
## PR Summary

It seems we don't ever use this class. I'm not sure if we should be, or if it's useful elsewhere, or it should just go away.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way