### PR TITLE
Fix some doc issues

### DIFF
--- a/examples/scales/log_bar.py
+++ b/examples/scales/log_bar.py
@@ -20,7 +20,8 @@ for i in range(len(data[0])):
     y = [d[i] for d in data]
     b = ax.bar(x + i * dimw, y, dimw, bottom=0.001)
 
-ax.set_xticks(x + dimw / 2, map(str, x))
+ax.set_xticks(x + dimw / 2)
+ax.set_xticklabels(map(str, x))
 ax.set_yscale('log')
 
 ax.set_xlabel('x')

--- a/examples/text_labels_and_annotations/text_rotation.py
+++ b/examples/text_labels_and_annotations/text_rotation.py
@@ -30,6 +30,7 @@ def addtext(ax, props):
     for x in range(0, 5):
         ax.scatter(x + 0.5, 0.5, color='r', alpha=0.5)
     ax.set_yticks([0, .5, 1])
+    ax.set_xticks(np.arange(0, 5.1, 0.5))
     ax.set_xlim(0, 5)
     ax.grid(True)
 
@@ -37,14 +38,12 @@ def addtext(ax, props):
 # the text bounding box
 bbox = {'fc': '0.8', 'pad': 0}
 
-fig, axs = plt.subplots(2, 1)
+fig, axs = plt.subplots(2, 1, sharex=True)
 
 addtext(axs[0], {'ha': 'center', 'va': 'center', 'bbox': bbox})
-axs[0].set_xticks(np.arange(0, 5.1, 0.5), [])
 axs[0].set_ylabel('center / center')
 
 addtext(axs[1], {'ha': 'left', 'va': 'bottom', 'bbox': bbox})
-axs[1].set_xticks(np.arange(0, 5.1, 0.5))
 axs[1].set_ylabel('left / bottom')
 
 plt.show()

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -225,7 +225,7 @@ for cmap_category, cmap_list in cmaps.items():
 plt.show()
 
 ###############################################################################
-# Lightness of matplotlib colormaps
+# Lightness of Matplotlib colormaps
 # =================================
 #
 # Here we examine the lightness values of the matplotlib colormaps.
@@ -308,10 +308,9 @@ for cmap_category, cmap_list in cmaps.items():
         formatter = mpl.ticker.FixedFormatter(cmap_list[i*dsub:(i+1)*dsub])
         ax.xaxis.set_major_formatter(formatter)
         ax.xaxis.set_tick_params(rotation=50)
+        ax.set_ylabel('Lightness $L^*$', fontsize=12)
 
     ax.set_xlabel(cmap_category + ' colormaps', fontsize=14)
-    fig.text(0.0, 0.55, 'Lightness $L^*$', fontsize=12,
-             transform=fig.transFigure, rotation=90)
 
     fig.tight_layout(h_pad=0.0, pad=1.5)
     plt.show()


### PR DESCRIPTION
## PR Summary

Fixes warnings when building docs, and an oddity in the colormaps tutorial.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way