### PR TITLE
Bezier/Path API Cleanup: fix circular import issue

### DIFF
--- a/doc/api/next_api_changes/removals.rst
+++ b/doc/api/next_api_changes/removals.rst
@@ -103,7 +103,7 @@ Classes, methods and attributes
 
 - ``image.BboxImage.interp_at_native`` property (no replacement)
 - ``lines.Line2D.verticalOffset`` property (no replacement)
-- ``bezier.find_r_to_boundary_of_closedpath()`` (no relacement)
+- ``bezier.find_r_to_boundary_of_closedpath()`` (no replacement)
 
 - ``quiver.Quiver.color()`` (use ``Quiver.get_facecolor()`` instead)
 - ``quiver.Quiver.keyvec`` property (no replacement)

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -7,11 +7,11 @@ import math
 import numpy as np
 
 import matplotlib.cbook as cbook
-from matplotlib.path import Path
 
 
 class NonIntersectingPathException(ValueError):
     pass
+
 
 # some functions
 
@@ -230,6 +230,7 @@ def split_path_inout(path, inside, tolerance=0.01, reorder_inout=False):
     Divide a path into two segments at the point where ``inside(x, y)`` becomes
     False.
     """
+    from .path import Path
     path_iter = path.iter_segments()
 
     ctl_points, command = next(path_iter)
@@ -486,6 +487,7 @@ def make_path_regular(p):
     with ``codes`` set to (MOVETO, LINETO, LINETO, ..., LINETO); otherwise
     return *p* itself.
     """
+    from .path import Path
     c = p.codes
     if c is None:
         c = np.full(len(p.vertices), Path.LINETO, dtype=Path.code_type)
@@ -498,6 +500,5 @@ def make_path_regular(p):
 @cbook.deprecated("3.3", alternative="Path.make_compound_path()")
 def concatenate_paths(paths):
     """Concatenate a list of paths into a single path."""
-    vertices = np.concatenate([p.vertices for p in paths])
-    codes = np.concatenate([make_path_regular(p).codes for p in paths])
-    return Path(vertices, codes)
+    from .path import Path
+    return Path.make_compound_path(*paths)

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -647,7 +647,8 @@ class Path:
     def unit_regular_polygon(cls, numVertices):
         """
         Return a :class:`Path` instance for a unit regular polygon with the
-        given *numVertices* and radius of 1.0, centered at (0, 0).
+        given *numVertices* such that the circumscribing circle has radius 1.0,
+        centered at (0, 0).
         """
         if numVertices <= 16:
             path = cls._unit_regular_polygons.get(numVertices)


### PR DESCRIPTION
## PR Summary

Roadmap:

(This PR) (\*) <- #16832 (\*) <- #16859 (\*) <- #16888 <- #16889 (\*) <- #16891 (MarkerStyle improvements!)

"<-" means "depends on", and "(\*)" marks PRs whose implementations are complete and fully ready for review. 

Currently, `bezier.py` depends on `path.py`. While it's easy to see how this could happen, this dependency should pretty obviously be reversed. `bezier.py` contains helper functions that are designed to help compute things about bezier curves. `path.py` defines a `Path`, and all computations that are "about paths" should be in `class Path`.

This became a show-stopper in #16607, #16832 and #16859) when I wanted to write methods that could compute things about paths (like their extrema, area, center of mass...all required for the marker size fixes proposed in #15703). I want to be able to define a member of `Path` that uses helper functions in `bezier.py` to help it compute bounds, etc., but currently cannot because that would cause a circular import (`path.py` - imports -> `bezier.py' - imports -> `path.py'). 

This is fixed here by moving a couple of functions from `bezier.py` that really compute things about *paths* (not about bezier curves necessarily) into `path.py`. 

EDIT: original list of functions to deprecate is now shorter, since @annzter deprecated `make_path_regular` and `concatenate_paths` in his own PR after my initial submission.

1) `bezier.split_path_inout` is now `Path.split_path_inout`, since its first argument is more naturally "self". This allows removing the import.
2) Bezier's "inside_circle" is only used by `patches.py` (not really anything to do with bezier curves) moved there.

The changes to the API I made seem likely to be internal-facing only, since `bezier.py` was obviously intended to be used internally by `matplotlib` to help with implementing `patches.py`, `path.py`, etc.

Per @tacaswell's suggestion, the original functions were kept around (as pass-thru/wrappers) and deprecated instead of removed.

No tests were added since no new code was added, only moved around.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
