### PR TITLE
DOC: Fix references to SymmetricalLogScale.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -312,10 +312,9 @@ longer necessary to import mplot3d to create 3d axes with ::
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously, `.SymLogNorm` had no *base* keyword argument and the base was
-hard-coded to ``base=np.e``. This was inconsistent with the default
-behavior of `.SymLogScale` (which defaults to ``base=10``) and the use
-of the word "decade" in the documentation.
+hard-coded to ``base=np.e``. This was inconsistent with the default behavior of
+`.SymmetricalLogScale` (which defaults to ``base=10``) and the use of the word
+"decade" in the documentation.
 
-In preparation for changing the default base to 10, calling
-`.SymLogNorm` without the new *base* kwarg emits a deprecation
-warning.
+In preparation for changing the default base to 10, calling `.SymLogNorm`
+without the new *base* keyword argument emits a deprecation warning.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -232,10 +232,11 @@ deprecated. Use an explicit list instead.
 
 Scales
 ~~~~~~
-Passing unsupported keyword arguments to `.ScaleBase` and its subclasses
-`.LinearScale`, and `.SymLogScale` is deprecated and will raise a `TypeError` in 3.3.
+Passing unsupported keyword arguments to `.ScaleBase`, and its subclasses
+`.LinearScale` and `.SymmetricalLogScale`, is deprecated and will raise a
+`TypeError` in 3.3.
 
-If extra kwargs are passed to `.LogScale`, `TypeError` will now be
+If extra keyword arguments are passed to `.LogScale`, `TypeError` will now be
 raised instead of `ValueError`.
 
 Testing

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -933,9 +933,6 @@
     "Locator.view_limits()": [
       "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:113"
     ],
-    "SymLogScale": [
-      "doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst:224"
-    ],
     "GraphicsContextBase": [
       "lib/matplotlib/backends/backend_agg.py:docstring of matplotlib.backends.backend_agg.RendererAgg.draw_text:8",
       "lib/matplotlib/backends/backend_cairo.py:docstring of matplotlib.backends.backend_cairo.RendererCairo.draw_image:8",


### PR DESCRIPTION
## PR Summary

Not sure why it didn't fail to build on this branch.

Note this PR is direct to the -doc branch so I can merge this all into master in #16816.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [n/a] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way