### PR TITLE
Destroy figures by manager instance, not by number.

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -45,14 +45,23 @@ class Gcf:
     @classmethod
     def destroy(cls, num):
         """
-        Destroy figure number *num*.
+        Destroy manager *num* -- either a manager instance or a manager number.
 
         In the interactive backends, this is bound to the window "destroy" and
         "delete" events.
+
+        It is recommended to pass a manager instance, to avoid confusion when
+        two managers share the same number.
         """
-        if not cls.has_fignum(num):
-            return
-        manager = cls.figs.pop(num)
+        if all(hasattr(num, attr) for attr in ["num", "_cidgcf", "destroy"]):
+            manager = num
+            if cls.figs.get(manager.num) is manager:
+                cls.figs.pop(manager.num)
+        else:
+            try:
+                manager = cls.figs.pop(num)
+            except KeyError:
+                return
         manager.canvas.mpl_disconnect(manager._cidgcf)
         manager.destroy()
         gc.collect(1)
@@ -62,8 +71,7 @@ class Gcf:
         """Destroy figure *fig*."""
         canvas = getattr(fig, "canvas", None)
         manager = getattr(canvas, "manager", None)
-        num = getattr(manager, "num", None)
-        cls.destroy(num)
+        cls.destroy(manager)
 
     @classmethod
     def destroy_all(cls):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -456,7 +456,7 @@ class FigureManagerTk(FigureManagerBase):
             if not self._shown:
                 def destroy(*args):
                     self.window = None
-                    Gcf.destroy(self.num)
+                    Gcf.destroy(self)
                 self.canvas._tkcanvas.bind("<Destroy>", destroy)
                 self.window.deiconify()
             else:

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -367,10 +367,8 @@ class FigureManagerGTK3(FigureManagerBase):
 
         self.window.set_default_size(w, h)
 
-        def destroy(*args):
-            Gcf.destroy(num)
-        self.window.connect("destroy", destroy)
-        self.window.connect("delete_event", destroy)
+        self.window.connect("destroy", lambda *args: Gcf.destroy(self))
+        self.window.connect("delete_event", lambda *args: Gcf.destroy(self))
         if mpl.is_interactive():
             self.window.show()
             self.canvas.draw_idle()

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -106,7 +106,7 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
             self.canvas.draw_idle()
 
     def close(self):
-        Gcf.destroy(self.num)
+        Gcf.destroy(self)
 
 
 class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -231,7 +231,7 @@ class _BackendNbAgg(_Backend):
         if is_interactive():
             manager.show()
             figure.canvas.draw_idle()
-        canvas.mpl_connect('close_event', lambda event: Gcf.destroy(num))
+        canvas.mpl_connect('close_event', lambda event: Gcf.destroy(manager))
         return manager
 
     @staticmethod

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -590,7 +590,7 @@ class FigureManagerQT(FigureManagerBase):
             return
         self.window._destroying = True
         try:
-            Gcf.destroy(self.num)
+            Gcf.destroy(self)
         except AttributeError:
             pass
             # It seems that when the python session is killed,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1007,7 +1007,7 @@ class FigureFrameWx(wx.Frame):
         _log.debug("%s - onClose()", type(self))
         self.canvas.close_event()
         self.canvas.stop_event_loop()
-        Gcf.destroy(self.num)
+        Gcf.destroy(self)
         # self.Destroy()
 
     def GetToolBar(self):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -690,7 +690,7 @@ def close(fig=None):
         if figManager is None:
             return
         else:
-            _pylab_helpers.Gcf.destroy(figManager.num)
+            _pylab_helpers.Gcf.destroy(figManager)
     elif fig == 'all':
         _pylab_helpers.Gcf.destroy_all()
     elif isinstance(fig, int):


### PR DESCRIPTION
This avoids destroying the wrong figure when two managers share the same
number.

(I don't think this can be easily tested as what really matters is UI
closing?)

Closes #15203.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
