### PR TITLE
fix bug where make_compound_path kept all STOPs

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -330,6 +330,7 @@ class Path:
         if not args:
             return Path(np.empty([0, 2], dtype=np.float32))
 
+        # concatenate paths
         vertices = np.concatenate([x.vertices for x in args])
         codes = np.empty(len(vertices), dtype=cls.code_type)
         i = 0
@@ -340,6 +341,16 @@ class Path:
             else:
                 codes[i:i + len(path.codes)] = path.codes
             i += len(path.vertices)
+
+        # remove internal STOP's, replace kinal stop if present
+        last_vert = None
+        if codes.size > 0 and codes[-1] == cls.STOP:
+            last_vert = vertices[-1]
+        vertices = vertices[codes != cls.STOP, :]
+        codes = codes[codes != cls.STOP]
+        if last_vert is not None:
+            vertices = np.append(vertices, [last_vert], axis=0)
+            codes = np.append(codes, cls.STOP)
 
         return cls(vertices, codes)
 

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -147,6 +147,13 @@ def test_make_compound_path_empty():
     assert r.vertices.shape == (0, 2)
 
 
+def test_make_compound_path_stops():
+    zero = [0, 0]
+    paths = 3*[Path([zero, zero], [Path.MOVETO, Path.STOP])]
+    compound_path = Path.make_compound_path(*paths)
+    assert np.sum(compound_path.codes == Path.STOP) == 1
+
+
 @image_comparison(['xkcd.png'], remove_text=True)
 def test_xkcd():
     np.random.seed(0)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -151,7 +151,9 @@ def test_make_compound_path_stops():
     zero = [0, 0]
     paths = 3*[Path([zero, zero], [Path.MOVETO, Path.STOP])]
     compound_path = Path.make_compound_path(*paths)
-    assert np.sum(compound_path.codes == Path.STOP) == 1
+    # the choice to not preserve the terminal STOP is arbitrary, but
+    # documented, so we test that it is in fact respected here
+    assert np.sum(compound_path.codes == Path.STOP) == 0
 
 
 @image_comparison(['xkcd.png'], remove_text=True)


### PR DESCRIPTION
## PR Summary

Fixes underlying issue in `make_compound_path` that would keep `.Path.cleaned` from being a drop-in replacement for `bezier.make_path_regular` (#14199).

A path we create by concatenating many paths should never have internal STOPs, as STOP is documented to mark the end of the *entire* path.

Long term solution is probably to deprecate `Path.STOP`, but then this code can be easily deleted as it is self-contained, and the new test will signal.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
