### PR TITLE
Fix warnings in doc examples

### DIFF
--- a/examples/color/custom_cmap.py
+++ b/examples/color/custom_cmap.py
@@ -155,7 +155,7 @@ cdict4 = {**cdict3,
 
 
 ###############################################################################
-# Now we will use this example to illustrate 3 ways of
+# Now we will use this example to illustrate 2 ways of
 # handling custom colormaps.
 # First, the most direct and explicit:
 
@@ -170,12 +170,8 @@ blue_red1 = LinearSegmentedColormap('BlueRed1', cdict1)
 blue_red2 = LinearSegmentedColormap('BlueRed2', cdict2)
 plt.register_cmap(cmap=blue_red2)
 
-###############################################################################
-# Third, for LinearSegmentedColormap only,
-# leave everything to register_cmap:
-
-plt.register_cmap(name='BlueRed3', data=cdict3)  # optional lut kwarg
-plt.register_cmap(name='BlueRedAlpha', data=cdict4)
+plt.register_cmap(cmap=LinearSegmentedColormap('BlueRed3', cdict3))
+plt.register_cmap(cmap=LinearSegmentedColormap('BlueRedAlpha', cdict4))
 
 ###############################################################################
 # Make the figure:

--- a/examples/event_handling/data_browser.py
+++ b/examples/event_handling/data_browser.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     fig, (ax, ax2) = plt.subplots(2, 1)
     ax.set_title('click on point to plot time series')
-    line, = ax.plot(xs, ys, 'o', picker=5)  # 5 points tolerance
+    line, = ax.plot(xs, ys, 'o', picker=True, pickradius=5)
 
     browser = PointBrowser()
 

--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -8,32 +8,27 @@ You can enable picking by setting the "picker" property of an artist
 (for example, a matplotlib Line2D, Text, Patch, Polygon, AxesImage,
 etc...)
 
-There are a variety of meanings of the picker property
+There are a variety of meanings of the picker property:
 
-    None -  picking is disabled for this artist (default)
+* *None* - picking is disabled for this artist (default)
 
-    boolean - if True then picking will be enabled and the
-      artist will fire a pick event if the mouse event is over
-      the artist
+* bool - if *True* then picking will be enabled and the artist will fire a pick
+  event if the mouse event is over the artist.
 
-    float - if picker is a number it is interpreted as an
-      epsilon tolerance in points and the artist will fire
-      off an event if it's data is within epsilon of the mouse
-      event.  For some artists like lines and patch collections,
-      the artist may provide additional data to the pick event
-      that is generated, for example, the indices of the data within
-      epsilon of the pick event
+  Setting ``pickradius`` will add an epsilon tolerance in points and the artist
+  will fire off an event if its data is within epsilon of the mouse event.  For
+  some artists like lines and patch collections, the artist may provide
+  additional data to the pick event that is generated, for example, the indices
+  of the data within epsilon of the pick event
 
-    function - if picker is callable, it is a user supplied
-      function which determines whether the artist is hit by the
-      mouse event.
+* function - if picker is callable, it is a user supplied function which
+  determines whether the artist is hit by the mouse event.
 
-         hit, props = picker(artist, mouseevent)
+     hit, props = picker(artist, mouseevent)
 
-      to determine the hit test.  If the mouse event is over the
-      artist, return hit=True and props is a dictionary of properties
-      you want added to the PickEvent attributes
-
+  to determine the hit test.  If the mouse event is over the artist, return
+  hit=True and props is a dictionary of properties you want added to the
+  PickEvent attributes.
 
 After you have enabled an artist for picking by setting the "picker"
 property, you need to connect to the figure canvas pick_event to get
@@ -80,7 +75,7 @@ def pick_simple():
     fig, (ax1, ax2) = plt.subplots(2, 1)
     ax1.set_title('click on points, rectangles or text', picker=True)
     ax1.set_ylabel('ylabel', picker=True, bbox=dict(facecolor='red'))
-    line, = ax1.plot(rand(100), 'o', picker=5)  # 5 points tolerance
+    line, = ax1.plot(rand(100), 'o', picker=True, pickradius=5)
 
     # pick the rectangle
     ax2.bar(range(10), rand(10), picker=True)

--- a/examples/event_handling/pick_event_demo2.py
+++ b/examples/event_handling/pick_event_demo2.py
@@ -17,7 +17,7 @@ ys = np.std(X, axis=1)
 
 fig, ax = plt.subplots()
 ax.set_title('click on point to plot time series')
-line, = ax.plot(xs, ys, 'o', picker=5)  # 5 points tolerance
+line, = ax.plot(xs, ys, 'o', picker=True, pickradius=5)
 
 
 def onpick(event):

--- a/examples/userdemo/pgf_preamble_sgskip.py
+++ b/examples/userdemo/pgf_preamble_sgskip.py
@@ -12,13 +12,13 @@ plt.rcParams.update({
     "font.family": "serif",  # use serif/main font for text elements
     "text.usetex": True,     # use inline math for ticks
     "pgf.rcfonts": False,    # don't setup fonts from rc parameters
-    "pgf.preamble": [
+    "pgf.preamble": "\n".join([
          "\\usepackage{units}",          # load additional packages
          "\\usepackage{metalogo}",
          "\\usepackage{unicode-math}",   # unicode math setup
          r"\setmathfont{xits-math.otf}",
          r"\setmainfont{DejaVu Serif}",  # serif font via preamble
-         ]
+    ])
 })
 
 plt.figure(figsize=(4.5, 2.5))

--- a/examples/userdemo/pgf_texsystem.py
+++ b/examples/userdemo/pgf_texsystem.py
@@ -8,11 +8,11 @@ Pgf Texsystem
 import matplotlib.pyplot as plt
 plt.rcParams.update({
     "pgf.texsystem": "pdflatex",
-    "pgf.preamble": [
+    "pgf.preamble": "\n".join([
          r"\usepackage[utf8x]{inputenc}",
          r"\usepackage[T1]{fontenc}",
          r"\usepackage{cmbright}",
-         ]
+    ]),
 })
 
 plt.figure(figsize=(4.5, 2.5))


### PR DESCRIPTION
## PR Summary

These are using things that have been deprecated.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way