### PR TITLE
Use more _setattr_cm, thus fix Text('').get_window_extent(dpi=...)

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -28,6 +28,7 @@ from itertools import cycle
 
 import numpy as np
 
+from matplotlib import cbook
 from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
 import matplotlib.collections as mcoll
@@ -607,18 +608,14 @@ class HandlerStem(HandlerNpointsYoffsets):
         if using_linecoll:
             # change the function used by update_prop() from the default
             # to one that handles LineCollection
-            orig_update_func = self._update_prop_func
-            self._update_prop_func = self._copy_collection_props
-
-            for line in leg_stemlines:
-                self.update_prop(line, stemlines, legend)
+            with cbook._setattr_cm(
+                    self, _update_prop_func=self._copy_collection_props):
+                for line in leg_stemlines:
+                    self.update_prop(line, stemlines, legend)
 
         else:
             for lm, m in zip(leg_stemlines, stemlines):
                 self.update_prop(lm, m, legend)
-
-        if using_linecoll:
-            self._update_prop_func = orig_update_func
 
         leg_baseline = Line2D([np.min(xdata), np.max(xdata)],
                               [bottom, bottom])

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -306,18 +306,15 @@ class QuiverKey(martist.Artist):
             if not self.Q._initialized:
                 self.Q._init()
             self._set_transform()
-            _pivot = self.Q.pivot
-            self.Q.pivot = self.pivot[self.labelpos]
-            # Hack: save and restore the Umask
-            _mask = self.Q.Umask
-            self.Q.Umask = ma.nomask
-            u = self.U * np.cos(np.radians(self.angle))
-            v = self.U * np.sin(np.radians(self.angle))
-            angle = self.Q.angles if isinstance(self.Q.angles, str) else 'uv'
-            self.verts = self.Q._make_verts(
-                np.array([u]), np.array([v]), angle)
-            self.Q.Umask = _mask
-            self.Q.pivot = _pivot
+            with cbook._setattr_cm(self.Q, pivot=self.pivot[self.labelpos],
+                                   # Hack: save and restore the Umask
+                                   Umask=ma.nomask):
+                u = self.U * np.cos(np.radians(self.angle))
+                v = self.U * np.sin(np.radians(self.angle))
+                angle = (self.Q.angles if isinstance(self.Q.angles, str)
+                         else 'uv')
+                self.verts = self.Q._make_verts(
+                    np.array([u]), np.array([v]), angle)
             kw = self.Q.polykw
             kw.update(self.kw)
             self.vector = mcollections.PolyCollection(

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -321,6 +321,22 @@ def test_set_position():
         assert a + shift_val == b
 
 
+@pytest.mark.parametrize('text', ['', 'O'], ids=['empty', 'non-empty'])
+def test_non_default_dpi(text):
+    fig, ax = plt.subplots()
+
+    t1 = ax.text(0.5, 0.5, text, ha='left', va='bottom')
+    fig.canvas.draw()
+    dpi = fig.dpi
+
+    bbox1 = t1.get_window_extent()
+    bbox2 = t1.get_window_extent(dpi=dpi * 10)
+    np.testing.assert_allclose(bbox2.get_points(), bbox1.get_points() * 10,
+                               rtol=5e-2)
+    # Text.get_window_extent should not permanently change dpi.
+    assert fig.dpi == dpi
+
+
 def test_get_rotation_string():
     assert mpl.text.get_rotation('horizontal') == 0.
     assert mpl.text.get_rotation('vertical') == 90.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -891,12 +891,12 @@ class Text(Artist):
         #return _unit_box
         if not self.get_visible():
             return Bbox.unit()
-        if dpi is not None:
-            dpi_orig = self.figure.dpi
-            self.figure.dpi = dpi
+        if dpi is None:
+            dpi = self.figure.dpi
         if self.get_text() == '':
-            tx, ty = self._get_xy_display()
-            return Bbox.from_bounds(tx, ty, 0, 0)
+            with cbook._setattr_cm(self.figure, dpi=dpi):
+                tx, ty = self._get_xy_display()
+                return Bbox.from_bounds(tx, ty, 0, 0)
 
         if renderer is not None:
             self._renderer = renderer
@@ -905,13 +905,12 @@ class Text(Artist):
         if self._renderer is None:
             raise RuntimeError('Cannot get window extent w/o renderer')
 
-        bbox, info, descent = self._get_layout(self._renderer)
-        x, y = self.get_unitless_position()
-        x, y = self.get_transform().transform((x, y))
-        bbox = bbox.translated(x, y)
-        if dpi is not None:
-            self.figure.dpi = dpi_orig
-        return bbox
+        with cbook._setattr_cm(self.figure, dpi=dpi):
+            bbox, info, descent = self._get_layout(self._renderer)
+            x, y = self.get_unitless_position()
+            x, y = self.get_transform().transform((x, y))
+            bbox = bbox.translated(x, y)
+            return bbox
 
     def set_backgroundcolor(self, color):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1151,10 +1151,8 @@ class SubplotTool(Widget):
 
         # During reset there can be a temporary invalid state depending on the
         # order of the reset so we turn off validation for the resetting
-        validate = toolfig.subplotpars.validate
-        toolfig.subplotpars.validate = False
-        self.buttonreset.on_clicked(self._on_reset)
-        toolfig.subplotpars.validate = validate
+        with cbook._setattr_cm(toolfig.subplotpars, validate=False):
+            self.buttonreset.on_clicked(self._on_reset)
 
     def _on_slider_changed(self, _):
         self.targetfig.subplots_adjust(


### PR DESCRIPTION
## PR Summary

This adds more `_setattr_cm`, and fixes a bug in `Text.get_window_extent` where if it contained an empty string, it would not reset the dpi of the figure.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way