### PR TITLE
Simplify interactive zoom handling.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2722,7 +2722,7 @@ class NavigationToolbar2:
         self._init_toolbar()
         self._id_drag = self.canvas.mpl_connect(
             'motion_notify_event', self.mouse_move)
-        self._id_zoom = None
+        self._zoom_info = None
 
         self._button_pressed = None  # determined by button pressed at start
 
@@ -2932,37 +2932,24 @@ class NavigationToolbar2:
 
     def press_zoom(self, event):
         """Callback for mouse button press in zoom to rect mode."""
-        # If we're already in the middle of a zoom, pressing another
-        # button works to "cancel"
-        if self._id_zoom is not None:
-            self.canvas.mpl_disconnect(self._id_zoom)
-            self.release(event)
-            self.draw()
-            self._xypress = None
-            self._button_pressed = None
-            self._id_zoom = None
+        if event.button not in [1, 3]:
             return
-
-        if event.button in [1, 3]:
-            self._button_pressed = event.button
-        else:
-            self._button_pressed = None
+        if event.x is None or event.y is None:
             return
-
+        axes = [a for a in self.canvas.figure.get_axes()
+                if a.in_axes(event) and a.get_navigate() and a.can_zoom()]
+        if not axes:
+            return
         if self._nav_stack() is None:
-            # set the home button to this view
-            self.push_current()
-
-        x, y = event.x, event.y
-        self._xypress = []
-        for a in self.canvas.figure.get_axes():
-            if (x is not None and y is not None and a.in_axes(event) and
-                    a.get_navigate() and a.can_zoom()):
-                self._xypress.append((x, y, a))
-
-        self._id_zoom = self.canvas.mpl_connect(
-            'motion_notify_event', self.drag_zoom)
-
+            self.push_current()  # set the home button to this view
+        id_zoom = self.canvas.mpl_connect(
+            "motion_notify_event", self.drag_zoom)
+        self._zoom_info = {
+            "direction": "in" if event.button == 1 else "out",
+            "start_xy": (event.x, event.y),
+            "axes": axes,
+            "cid": id_zoom,
+        }
         self.press(event)
 
     def push_current(self):
@@ -3007,65 +2994,53 @@ class NavigationToolbar2:
 
     def drag_zoom(self, event):
         """Callback for dragging in zoom mode."""
-        if self._xypress:
-            x, y = event.x, event.y
-            lastx, lasty, a = self._xypress[0]
-            (x1, y1), (x2, y2) = np.clip(
-                [[lastx, lasty], [x, y]], a.bbox.min, a.bbox.max)
-            if event.key == "x":
-                y1, y2 = a.bbox.intervaly
-            elif event.key == "y":
-                x1, x2 = a.bbox.intervalx
-            self.draw_rubberband(event, x1, y1, x2, y2)
+        start_xy = self._zoom_info["start_xy"]
+        ax = self._zoom_info["axes"][0]
+        (x1, y1), (x2, y2) = np.clip(
+            [start_xy, [event.x, event.y]], ax.bbox.min, ax.bbox.max)
+        if event.key == "x":
+            y1, y2 = ax.bbox.intervaly
+        elif event.key == "y":
+            x1, x2 = ax.bbox.intervalx
+        self.draw_rubberband(event, x1, y1, x2, y2)
 
     def release_zoom(self, event):
         """Callback for mouse button release in zoom to rect mode."""
-        if self._id_zoom is not None:
-            self.canvas.mpl_disconnect(self._id_zoom)
-        self._id_zoom = None
-
-        self.remove_rubberband()
-
-        if not self._xypress:
+        if self._zoom_info is None:
             return
 
-        last_a = []
+        # We don't check the event button here, so that zooms can be cancelled
+        # by (pressing and) releasing another mouse button.
+        self.canvas.mpl_disconnect(self._zoom_info["cid"])
+        self.remove_rubberband()
 
-        for lastx, lasty, a in self._xypress:
+        start_x, start_y = self._zoom_info["start_xy"]
+
+        for i, ax in enumerate(self._zoom_info["axes"]):
             x, y = event.x, event.y
             # ignore singular clicks - 5 pixels is a threshold
             # allows the user to "cancel" a zoom action
             # by zooming by less than 5 pixels
-            if ((abs(x - lastx) < 5 and event.key != "y") or
-                    (abs(y - lasty) < 5 and event.key != "x")):
+            if ((abs(x - start_x) < 5 and event.key != "y") or
+                    (abs(y - start_y) < 5 and event.key != "x")):
                 self._xypress = None
                 self.release(event)
                 self.draw()
                 return
 
-            # detect twinx, twiny axes and avoid double zooming
-            twinx, twiny = False, False
-            if last_a:
-                for la in last_a:
-                    if a.get_shared_x_axes().joined(a, la):
-                        twinx = True
-                    if a.get_shared_y_axes().joined(a, la):
-                        twiny = True
-            last_a.append(a)
+            # Detect whether this axes is twinned with an earlier axes in the
+            # list of zoomed axes, to avoid double zooming.
+            twinx = any(ax.get_shared_x_axes().joined(ax, prev)
+                        for prev in self._zoom_info["axes"][:i])
+            twiny = any(ax.get_shared_y_axes().joined(ax, prev)
+                        for prev in self._zoom_info["axes"][:i])
 
-            if self._button_pressed == 1:
-                direction = 'in'
-            elif self._button_pressed == 3:
-                direction = 'out'
-            else:
-                continue
-
-            a._set_view_from_bbox((lastx, lasty, x, y), direction,
-                                  event.key, twinx, twiny)
+            ax._set_view_from_bbox(
+                (start_x, start_y, x, y), self._zoom_info["direction"],
+                event.key, twinx, twiny)
 
         self.draw()
-        self._xypress = None
-        self._button_pressed = None
+        self._zoom_info = None
 
         self.push_current()
         self.release(event)


### PR DESCRIPTION
- Stash all the relevant variables (start click position, start click
  button, list of axes, callback id) into a single dict (`_zoom_info`).
- start_x/start_y is the same for all axes (it's in screen coordinates)
  so just store it once (under `start_xy`) instead of repeatedly.
- Immediatedly exit if no axes are selected (`not axes`) instead of
  later checking `self._xypress`.
- Remove the "cancel zoom if another button is pressed feature": that
  second button is going to get released anyways, so the release_event
  for that second button is going to handle the cancellation just fine.
  (More specifically, the second button press will throw away the first
  zoom and start a new zoom session from the new starting point, and
  then the button release will be detected as a zoom cancelled because
  <5px.)
- Simplify twinx/y detection.
- Resolve zoom direction from the beginning.


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
