### PR TITLE
Don't pretend to support old pythons in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,24 +3,8 @@ The matplotlib build options can be modified with a setup.cfg file. See
 setup.cfg.template for more information.
 """
 
-# NOTE: This file must remain Python 2 compatible for the foreseeable future,
-# to ensure that we error out properly for people with outdated setuptools
-# and/or pip.
-import sys
-
-min_version = (3, 6)
-
-if sys.version_info < min_version:
-    error = """
-Beginning with Matplotlib 3.1, Python {0} or above is required.
-
-This may be due to an out of date pip.
-
-Make sure you have pip >= 9.0.1.
-""".format('.'.join(str(n) for n in min_version)),
-    sys.exit(error)
-
 from pathlib import Path
+import sys
 import shutil
 from zipfile import ZipFile
 
@@ -256,7 +240,7 @@ if __name__ == '__main__':
         package_data=package_data,
         classifiers=classifiers,
 
-        python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
+        python_requires=">=3.6",
         setup_requires=[
             "numpy>=1.15",
         ],


### PR DESCRIPTION
setup.py uses f-strings, so it fails with SyntaxError on Py<3.6, so
let's not pretend to support older Pythons there (see also https://github.com/matplotlib/matplotlib/issues/16733).

(The alternative would be to only put the version check in setup.py and
then move *everything* else into setupext.py, which may not be silly
either?)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
