### PR TITLE
Inline some more kwargs into setup.py's setup() call.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,21 +73,6 @@ mpl_packages = [
     ]
 
 
-classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Framework :: Matplotlib',
-    'Intended Audience :: Science/Research',
-    'Intended Audience :: Education',
-    'License :: OSI Approved :: Python Software Foundation License',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Topic :: Scientific/Engineering :: Visualization',
-    ]
-
-
 class NoopTestCommand(TestCommand):
     def __init__(self, dist):
         print("Matplotlib does not support running tests with "
@@ -222,10 +207,6 @@ if __name__ == '__main__':
         with open('lib/matplotlib/mpl-data/matplotlibrc', 'w') as fd:
             fd.write(''.join(template_lines))
 
-    # Use Readme as long description
-    with open('README.rst', encoding='utf-8') as fd:
-        long_description = fd.read()
-
     # Finally, pass this all along to distutils to do the heavy lifting.
     setup(
         name="matplotlib",
@@ -242,10 +223,24 @@ if __name__ == '__main__':
             'Forum': 'https://discourse.matplotlib.org/',
             'Donate': 'https://numfocus.org/donate-to-matplotlib'
         },
-        long_description=long_description,
+        long_description=Path("README.rst").read_text(encoding="utf-8"),
         long_description_content_type="text/x-rst",
         license="PSF",
         platforms="any",
+        classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'Framework :: Matplotlib',
+            'Intended Audience :: Science/Research',
+            'Intended Audience :: Education',
+            'License :: OSI Approved :: Python Software Foundation License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+            'Topic :: Scientific/Engineering :: Visualization',
+        ],
+
         package_dir={"": "lib"},
         packages=find_packages("lib"),
         namespace_packages=["mpl_toolkits"],
@@ -254,7 +249,6 @@ if __name__ == '__main__':
         # real extensions that can depend on numpy for the build.
         ext_modules=[Extension("", [])],
         package_data=package_data,
-        classifiers=classifiers,
 
         python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
         setup_requires=[


### PR DESCRIPTION
- long_description can be defined right where it's used.
- It seems nicer to also define classifiers at the point of use
  (together with other "metadata"-like entries) rather than at the top
  of the file, far away from the point of use.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
