### PR TITLE
Deprecate is_pyqt5.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -535,3 +535,8 @@ These are unused and can be easily reproduced by other date tools.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``cbid`` and ``locator`` attribute are deprecated.  Use
 ``mappable.colorbar_cid`` and ``colorbar.locator``, as for standard colorbars.
+
+``qt_compat.is_pyqt5``
+~~~~~~~~~~~~~~~~~~~~~~
+This function is deprecated in prevision of the future release of PyQt6.  The
+Qt version can be checked using ``QtCore.QT_VERSION_STR``.

--- a/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -14,8 +14,8 @@ import time
 
 import numpy as np
 
-from matplotlib.backends.qt_compat import QtCore, QtWidgets, is_pyqt5
-if is_pyqt5():
+from matplotlib.backends.qt_compat import QtCore, QtWidgets
+if QtCore.QT_VERSION_STR >= "5.":
     from matplotlib.backends.backend_qt5agg import (
         FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
 else:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -105,7 +105,7 @@ def _create_qApp():
         app = QtWidgets.QApplication.instance()
         if app is None:
             # check for DISPLAY env variable on X11 build of Qt
-            if is_pyqt5():
+            if QtCore.QT_VERSION_STR >= "5.":
                 try:
                     importlib.import_module(
                         # i.e. PyQt5.QtX11Extras or PySide2.QtX11Extras.
@@ -130,11 +130,10 @@ def _create_qApp():
         else:
             qApp = app
 
-    if is_pyqt5():
-        try:
-            qApp.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
-        except AttributeError:
-            pass
+    try:
+        qApp.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+    except AttributeError:
+        pass
 
 
 def _allow_super_init(__init__):
@@ -332,7 +331,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             FigureCanvasBase.button_release_event(self, x, y, button,
                                                   guiEvent=event)
 
-    if is_pyqt5():
+    if QtCore.QT_VERSION_STR >= "5.":
         def wheelEvent(self, event):
             x, y = self.mouseEventCoords(event)
             # from QWheelEvent::delta doc
@@ -699,7 +698,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         return str(cbook._get_data_path('images'))
 
     def _icon(self, name, color=None):
-        if is_pyqt5():
+        if QtCore.QT_VERSION_STR >= '5.':
             name = name.replace('.png', '_large.png')
         pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))
         qt_compat._setDevicePixelRatio(pm, qt_compat._devicePixelRatio(self))
@@ -896,9 +895,7 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
 
     @property
     def _icon_extension(self):
-        if is_pyqt5():
-            return '_large.png'
-        return '.png'
+        return '_large.png' if QtCore.QT_VERSION_STR >= '5.' else '.png'
 
     def add_toolitem(
             self, name, group, position, image_file, description, toggle):

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -85,6 +85,7 @@ def _setup_pyqt5():
         raise ValueError("Unexpected value for the 'backend.qt5' rcparam")
     _getSaveFileName = QtWidgets.QFileDialog.getSaveFileName
 
+    @mpl.cbook.deprecated("3.3", alternative="QtCore.QT_VERSION_STR")
     def is_pyqt5():
         return True
 
@@ -144,6 +145,7 @@ def _setup_pyqt4():
         raise ValueError("Unexpected value for the 'backend.qt4' rcparam")
     QtWidgets = QtGui
 
+    @mpl.cbook.deprecated("3.3", alternative="QtCore.QT_VERSION_STR")
     def is_pyqt5():
         return False
 
@@ -183,7 +185,7 @@ else:  # We should not get there.
 # These globals are only defined for backcompatibility purposes.
 ETS = dict(pyqt=(QT_API_PYQTv2, 4), pyside=(QT_API_PYSIDE, 4),
            pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))
-QT_RC_MAJOR_VERSION = 5 if is_pyqt5() else 4
+QT_RC_MAJOR_VERSION = int(QtCore.qVersion().split(".")[0])
 
-if not is_pyqt5():
+if QT_RC_MAJOR_VERSION == 4:
     mpl.cbook.warn_deprecated("3.3", name="support for Qt4")


### PR DESCRIPTION
The function won't really make sense anymore after the release of
PyQt6.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
