### PR TITLE
fix example hist(density=...)

### DIFF
--- a/examples/statistics/histogram_features.py
+++ b/examples/statistics/histogram_features.py
@@ -35,7 +35,7 @@ num_bins = 50
 fig, ax = plt.subplots()
 
 # the histogram of the data
-n, bins, patches = ax.hist(x, num_bins, density=1)
+n, bins, patches = ax.hist(x, num_bins, density=True)
 
 # add a 'best fit' line
 y = ((1 / (np.sqrt(2 * np.pi) * sigma)) *


### PR DESCRIPTION
## PR Summary

While technically  `1` is accepted, the docs specify this to be `bool`.

Closes #16185 (all other documentation issues mentioned in that PR have already been fixed).

