### PR TITLE
Disconnect manager when resizing figure for animation saving.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -361,12 +361,10 @@ class MovieWriter(AbstractMovieWriter):
     def grab_frame(self, **savefig_kwargs):
         # docstring inherited
         _log.debug('MovieWriter.grab_frame: Grabbing frame.')
-        # re-adjust the figure size in case it has been changed by the
-        # user.  We must ensure that every frame is the same size or
-        # the movie will not save correctly.
+        # Readjust the figure size in case it has been changed by the user.
+        # All frames must have the same size to save the movie correctly.
         self.fig.set_size_inches(self._w, self._h)
-        # Tell the figure to save its data to the sink, using the
-        # frame format and dpi.
+        # Save the figure data to the sink, using the frame format and dpi.
         self.fig.savefig(self._frame_sink(), format=self.frame_format,
                          dpi=self.dpi, **savefig_kwargs)
 
@@ -1113,10 +1111,12 @@ class Animation:
                       "frame size to vary, which is inappropriate for "
                       "animation.")
         # canvas._is_saving = True makes the draw_event animation-starting
-        # callback a no-op.
+        # callback a no-op; canvas.manager = None prevents resizing the GUI
+        # widget (both are likewise done in savefig()).
         with mpl.rc_context({'savefig.bbox': None}), \
              writer.saving(self._fig, filename, dpi), \
-             cbook._setattr_cm(self._fig.canvas, _is_saving=True):
+             cbook._setattr_cm(self._fig.canvas,
+                               _is_saving=True, manager=None):
             for anim in all_anim:
                 anim._init_draw()  # Clear the initial frame
             frame_number = 0


### PR DESCRIPTION
This is similar to what's done in savefig() to prevent the GUI window
from being resized, and is also helpful as this code may trigger after
the GUI window has been closed.

Closes #16713.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
