### PR TITLE
Ticks are not markers

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -148,12 +148,12 @@ class Tick(martist.Artist):
         self.tick1line = mlines.Line2D(
             [], [],
             color=color, linestyle="none", zorder=zorder, visible=tick1On,
-            markersize=size, markeredgewidth=width,
+            markeredgecolor=color, markersize=size, markeredgewidth=width,
         )
         self.tick2line = mlines.Line2D(
             [], [],
             color=color, linestyle="none", zorder=zorder, visible=tick2On,
-            markersize=size, markeredgewidth=width,
+            markeredgecolor=color, markersize=size, markeredgewidth=width,
         )
         self.gridline = mlines.Line2D(
             [], [],
@@ -352,6 +352,8 @@ class Tick(martist.Artist):
             trans = self._get_text2_transform()[0]
             self.label2.set_transform(trans)
         tick_kw = {k: v for k, v in kw.items() if k in ['color', 'zorder']}
+        if 'color' in kw:
+            tick_kw['markeredgecolor'] = kw['color']
         self.tick1line.set(**tick_kw)
         self.tick2line.set(**tick_kw)
         for k, v in tick_kw.items():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6129,3 +6129,19 @@ def test_invisible_axes():
     assert fig.canvas.inaxes((200, 200)) is not None
     ax.set_visible(False)
     assert fig.canvas.inaxes((200, 200)) is None
+
+
+def test_xtickcolor_is_not_markercolor():
+    plt.rcParams['lines.markeredgecolor'] = 'white'
+    ax = plt.axes()
+    ticks = ax.xaxis.get_major_ticks()
+    for tick in ticks:
+        assert not tick.tick1line.get_markeredgecolor() == 'white'
+
+
+def test_ytickcolor_is_not_markercolor():
+    plt.rcParams['lines.markeredgecolor'] = 'white'
+    ax = plt.axes()
+    ticks = ax.yaxis.get_major_ticks()
+    for tick in ticks:
+        assert not tick.tick1line.get_markeredgecolor() == 'white'

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6136,7 +6136,7 @@ def test_xtickcolor_is_not_markercolor():
     ax = plt.axes()
     ticks = ax.xaxis.get_major_ticks()
     for tick in ticks:
-        assert not tick.tick1line.get_markeredgecolor() == 'white'
+        assert tick.tick1line.get_markeredgecolor() != 'white'
 
 
 def test_ytickcolor_is_not_markercolor():
@@ -6144,4 +6144,4 @@ def test_ytickcolor_is_not_markercolor():
     ax = plt.axes()
     ticks = ax.yaxis.get_major_ticks()
     for tick in ticks:
-        assert not tick.tick1line.get_markeredgecolor() == 'white'
+        assert tick.tick1line.get_markeredgecolor() != 'white'


### PR DESCRIPTION
## Setting markeredgecolor in rcParams should not affect color of ticks

When setting the `lines.markeredgecolor` in the rcParams, this changes the color of tickmarkers as well, while `xtick.color` and `ytick.color` leave the color of tickmarkers unaffected. This is unintuitive. This pull request should fix that.

## PR Checklist

- [x ] Has Pytest style unit tests
- [x ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related: **No new features**.
- [ ] Documentation is sphinx and numpydoc compliant: **No documentation**
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there): **No major new feature**
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way: **Backward compatible**.