### PR TITLE
use validate_[cap/join]style

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -16,7 +16,6 @@ import numpy as np
 import matplotlib as mpl
 from . import (_path, artist, cbook, cm, colors as mcolors, docstring,
                lines as mlines, path as mpath, transforms)
-from .rcsetup import validate_joinstyle, validate_capstyle
 import warnings
 
 
@@ -600,7 +599,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         cs : {'butt', 'round', 'projecting'}
             The capstyle
         """
-        validate_capstyle(cs)
+        mpl.rcsetup.validate_capstyle(cs)
         self._capstyle = cs
 
     def get_capstyle(self):
@@ -615,7 +614,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         js : {'miter', 'round', 'bevel'}
             The joinstyle
         """
-        validate_joinstyle(js)
+        mpl.rcsetup.validate_joinstyle(js)
         self._joinstyle = js
 
     def get_joinstyle(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -16,6 +16,7 @@ import numpy as np
 import matplotlib as mpl
 from . import (_path, artist, cbook, cm, colors as mcolors, docstring,
                lines as mlines, path as mpath, transforms)
+from .rcsetup import validate_joinstyle, validate_capstyle
 import warnings
 
 
@@ -599,7 +600,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         cs : {'butt', 'round', 'projecting'}
             The capstyle
         """
-        cbook._check_in_list(('butt', 'round', 'projecting'), capstyle=cs)
+        validate_capstyle(cs)
         self._capstyle = cs
 
     def get_capstyle(self):
@@ -614,7 +615,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         js : {'miter', 'round', 'bevel'}
             The joinstyle
         """
-        cbook._check_in_list(('miter', 'round', 'bevel'), joinstyle=js)
+        validate_joinstyle(js)
         self._joinstyle = js
 
     def get_joinstyle(self):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -16,7 +16,6 @@ from .cbook import (
     _to_unmasked_float_array, ls_mapper, ls_mapper_r, STEP_LOOKUP_MAP)
 from .markers import MarkerStyle
 from .path import Path
-from .rcsetup import validate_joinstyle, validate_capstyle
 from .transforms import (
     Affine2D, Bbox, BboxTransformFrom, BboxTransformTo, TransformedPath)
 
@@ -1353,7 +1352,7 @@ class Line2D(Artist):
         s : {'miter', 'round', 'bevel'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        validate_joinstyle(s)
+        mpl.rcsetup.validate_joinstyle(s)
         if self._dashjoinstyle != s:
             self.stale = True
         self._dashjoinstyle = s
@@ -1367,7 +1366,7 @@ class Line2D(Artist):
         s : {'miter', 'round', 'bevel'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        validate_joinstyle(s)
+        mpl.rcsetup.validate_joinstyle(s)
         if self._solidjoinstyle != s:
             self.stale = True
         self._solidjoinstyle = s
@@ -1397,7 +1396,7 @@ class Line2D(Artist):
         s : {'butt', 'round', 'projecting'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        validate_capstyle(s)
+        mpl.rcsetup.validate_capstyle(s)
         if self._dashcapstyle != s:
             self.stale = True
         self._dashcapstyle = s
@@ -1411,7 +1410,7 @@ class Line2D(Artist):
         s : {'butt', 'round', 'projecting'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        validate_capstyle(s)
+        mpl.rcsetup.validate_capstyle(s)
         if self._solidcapstyle != s:
             self.stale = True
         self._solidcapstyle = s

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -16,6 +16,7 @@ from .cbook import (
     _to_unmasked_float_array, ls_mapper, ls_mapper_r, STEP_LOOKUP_MAP)
 from .markers import MarkerStyle
 from .path import Path
+from .rcsetup import validate_joinstyle, validate_capstyle
 from .transforms import (
     Affine2D, Bbox, BboxTransformFrom, BboxTransformTo, TransformedPath)
 
@@ -1352,8 +1353,7 @@ class Line2D(Artist):
         s : {'miter', 'round', 'bevel'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validJoin, s=s)
+        validate_joinstyle(s)
         if self._dashjoinstyle != s:
             self.stale = True
         self._dashjoinstyle = s
@@ -1367,8 +1367,7 @@ class Line2D(Artist):
         s : {'miter', 'round', 'bevel'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validJoin, s=s)
+        validate_joinstyle(s)
         if self._solidjoinstyle != s:
             self.stale = True
         self._solidjoinstyle = s
@@ -1398,8 +1397,7 @@ class Line2D(Artist):
         s : {'butt', 'round', 'projecting'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validCap, s=s)
+        validate_capstyle(s)
         if self._dashcapstyle != s:
             self.stale = True
         self._dashcapstyle = s
@@ -1413,8 +1411,7 @@ class Line2D(Artist):
         s : {'butt', 'round', 'projecting'}
             For examples see :doc:`/gallery/lines_bars_and_markers/joinstyle`.
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validCap, s=s)
+        validate_capstyle(s)
         if self._solidcapstyle != s:
             self.stale = True
         self._solidcapstyle = s

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -14,6 +14,7 @@ from .bezier import (
     get_parallels, inside_circle, make_wedged_bezier2,
     split_bezier_intersecting_with_closedpath, split_path_inout)
 from .path import Path
+from .rcsetup import validate_joinstyle, validate_capstyle
 
 
 @cbook._define_aliases({
@@ -461,8 +462,7 @@ class Patch(artist.Artist):
         ----------
         s : {'butt', 'round', 'projecting'}
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validCap, capstyle=s)
+        validate_capstyle(s)
         self._capstyle = s
         self.stale = True
 
@@ -477,8 +477,7 @@ class Patch(artist.Artist):
         ----------
         s : {'miter', 'round', 'bevel'}
         """
-        s = mpl.rcsetup._deprecate_case_insensitive_join_cap(s)
-        cbook._check_in_list(self.validJoin, joinstyle=s)
+        validate_joinstyle(s)
         self._joinstyle = s
         self.stale = True
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -14,7 +14,6 @@ from .bezier import (
     get_parallels, inside_circle, make_wedged_bezier2,
     split_bezier_intersecting_with_closedpath, split_path_inout)
 from .path import Path
-from .rcsetup import validate_joinstyle, validate_capstyle
 
 
 @cbook._define_aliases({
@@ -462,7 +461,7 @@ class Patch(artist.Artist):
         ----------
         s : {'butt', 'round', 'projecting'}
         """
-        validate_capstyle(s)
+        mpl.rcsetup.validate_capstyle(s)
         self._capstyle = s
         self.stale = True
 
@@ -477,7 +476,7 @@ class Patch(artist.Artist):
         ----------
         s : {'miter', 'round', 'bevel'}
         """
-        validate_joinstyle(s)
+        mpl.rcsetup.validate_joinstyle(s)
         self._joinstyle = s
         self.stale = True
 


### PR DESCRIPTION
## PR Summary

Something trivial I found while scrolling around making sure I covered every join/capstyle we allow. Currently, `collections.py`, `rcparams.py`, and `lines.py` all have their own way of checking whether a cap/join-style is valid (`patches.py` uses the code from `lines.py`). These all boil down to a `cbook._check_in_list`, but some forget to warn that case-insensitivity is deprecated.

Since `rcparams.py` seems like the centralized place for checking that parameters are valid, I had them all call `rcparams.validate_[cap|join]style()` instead. This correctly warns for deprecated case-insensitivity.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
