### PR TITLE
Fix typo in deprecation warning

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1208,7 +1208,7 @@ default: 'top'
             cbook.warn_deprecated(
                 "3.3",
                 message="Calling add_axes() without argument is "
-                "deprecated. You may want to use add_suplot() "
+                "deprecated. You may want to use add_subplot() "
                 "instead.")
             return
 


### PR DESCRIPTION
Noticed this missing 'b' just now. Probably worth backporting.