### PR TITLE
Fix various numpydoc style issues

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1309,6 +1309,7 @@ def _add_data_doc(docstring, replace_names):
 
     Returns
     -------
+    str
         The augmented docstring.
     """
     if (docstring is None

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1296,7 +1296,8 @@ _DATA_DOC_APPENDIX = """
 
 
 def _add_data_doc(docstring, replace_names):
-    """Add documentation for a *data* field to the given docstring.
+    """
+    Add documentation for a *data* field to the given docstring.
 
     Parameters
     ----------

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -291,8 +291,8 @@ def _parse_composites(fh):
         list is a list of `.CompositePart` entries describing the parts of
         the composite.
 
-    Example
-    -------
+    Examples
+    --------
     A composite definition line::
 
       CC Aacute 2 ; PCC A 0 0 ; PCC acute 160 170 ;

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -286,7 +286,7 @@ def _parse_composites(fh):
 
     Returns
     -------
-    composites : dict
+    dict
         A dict mapping composite character names to a parts list. The parts
         list is a list of `.CompositePart` entries describing the parts of
         the composite.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -140,7 +140,7 @@ class MovieWriterRegistry:
 
         Returns
         -------
-        available : bool
+        bool
         """
         try:
             cls = self._registered[name]
@@ -1281,7 +1281,7 @@ class Animation:
 
         Returns
         -------
-        video_tag : str
+        str
             An HTML5 video tag with the animation embedded as base64 encoded
             h264 video.
             If the *embed_limit* is exceeded, this returns the string

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -274,7 +274,7 @@ class Artist:
 
         Returns
         -------
-        bbox : `.Bbox`
+        `.Bbox`
             The enclosing bounding box (in figure pixel coordinates).
         """
         bbox = self.get_window_extent(renderer)
@@ -305,7 +305,7 @@ class Artist:
 
         Returns
         -------
-        oid : int
+        int
             The observer id associated with the callback. This id can be
             used for removing the callback with `.remove_callback` later.
 
@@ -629,7 +629,7 @@ class Artist:
 
         Returns
         -------
-        sketch_params : tuple or None
+        tuple or None
 
             A 3-tuple with the following elements:
 
@@ -1109,7 +1109,7 @@ class Artist:
 
         Returns
         -------
-        artists : list of `.Artist`
+        list of `.Artist`
 
         """
         if match is None:  # always return True
@@ -1599,7 +1599,7 @@ def kwdoc(artist):
 
     Returns
     -------
-    string
+    str
         The settable properties of *artist*, as plain text if
         :rc:`docstring.hardcopy` is False and as a rst table (intended for
         use in Sphinx) if it is True.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -209,7 +209,7 @@ class Axes(_AxesBase):
         **kwargs : `.Text` properties
             `.Text` properties control the appearance of the label.
 
-        See also
+        See Also
         --------
         text : Documents the properties supported by `.Text`.
         """
@@ -262,7 +262,7 @@ class Axes(_AxesBase):
         **kwargs : `.Text` properties
             `.Text` properties control the appearance of the label.
 
-        See also
+        See Also
         --------
         text : Documents the properties supported by `.Text`.
         """
@@ -794,7 +794,7 @@ class Axes(_AxesBase):
 
             %(_Line2D_docstr)s
 
-        See also
+        See Also
         --------
         hlines : Add horizontal lines in data coordinates.
         axhspan : Add a horizontal span (rectangle) across the axis.
@@ -1103,7 +1103,7 @@ class Axes(_AxesBase):
         ----------------
         **kwargs :  `~matplotlib.collections.LineCollection` properties.
 
-        See also
+        See Also
         --------
         vlines : vertical lines
         axhline: horizontal line across the axes
@@ -1181,7 +1181,7 @@ class Axes(_AxesBase):
         ----------------
         **kwargs : `~matplotlib.collections.LineCollection` properties.
 
-        See also
+        See Also
         --------
         hlines : horizontal lines
         axvline: vertical line across the axes
@@ -2309,7 +2309,7 @@ class Axes(_AxesBase):
             *This is for internal use only.* Please use `barh` for
             horizontal bar plots. Default: 'vertical'.
 
-        See also
+        See Also
         --------
         barh: Plot a horizontal bar plot.
 
@@ -2578,7 +2578,7 @@ class Axes(_AxesBase):
         log : bool, default: False
             If ``True``, set the x-axis to be log scale.
 
-        See also
+        See Also
         --------
         bar: Plot a vertical bar plot.
 
@@ -5440,7 +5440,7 @@ default: :rc:`scatter.edgecolors`
             These parameters are passed on to the constructor of the
             `.AxesImage` artist.
 
-        See also
+        See Also
         --------
         matshow : Plot a matrix or an array as an image.
 
@@ -6471,7 +6471,7 @@ default: :rc:`scatter.edgecolors`
         **kwargs
             `~matplotlib.patches.Patch` properties
 
-        See also
+        See Also
         --------
         hist2d : 2D histograms
 
@@ -6832,7 +6832,7 @@ default: :rc:`scatter.edgecolors`
             `~.Axes.pcolormesh` method and `~matplotlib.collections.QuadMesh`
             constructor.
 
-        See also
+        See Also
         --------
         hist : 1D histogram plotting
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -104,7 +104,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        title : str
+        str
             The title text string.
 
         """
@@ -145,7 +145,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        text : `.Text`
+        `.Text`
             The matplotlib text instance representing the title
 
         Other Parameters
@@ -379,7 +379,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        legend : `~matplotlib.legend.Legend`
+        `~matplotlib.legend.Legend`
 
         Other Parameters
         ----------------
@@ -708,7 +708,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        text : `.Text`
+        `.Text`
             The created `.Text` instance.
 
         Other Parameters
@@ -784,7 +784,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        line : `~matplotlib.lines.Line2D`
+        `~matplotlib.lines.Line2D`
 
         Other Parameters
         ----------------
@@ -853,7 +853,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        line : `~matplotlib.lines.Line2D`
+        `~matplotlib.lines.Line2D`
 
         Other Parameters
         ----------------
@@ -984,7 +984,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        rectangle : `~matplotlib.patches.Polygon`
+        `~matplotlib.patches.Polygon`
             Horizontal span (rectangle) from (xmin, ymin) to (xmax, ymax).
 
         Other Parameters
@@ -1036,7 +1036,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        rectangle : `~matplotlib.patches.Polygon`
+        `~matplotlib.patches.Polygon`
             Vertical span (rectangle) from (xmin, ymin) to (xmax, ymax).
 
         Other Parameters
@@ -1097,7 +1097,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines : `~matplotlib.collections.LineCollection`
+        `~matplotlib.collections.LineCollection`
 
         Other Parameters
         ----------------
@@ -1175,7 +1175,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines : `~matplotlib.collections.LineCollection`
+        `~matplotlib.collections.LineCollection`
 
         Other Parameters
         ----------------
@@ -1311,7 +1311,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        list : list of `.EventCollection`
+        list of `.EventCollection`
             The `.EventCollection` that were added.
 
         Notes
@@ -1574,8 +1574,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `.Line2D`
+            A list of lines representing the plotted data.
 
         Other Parameters
         ----------------
@@ -2257,7 +2257,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        container : `.BarContainer`
+        `.BarContainer`
             Container with all the bars and optionally errorbars.
 
         Other Parameters
@@ -2530,7 +2530,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        container : `.BarContainer`
+        `.BarContainer`
             Container with all the bars and optionally errorbars.
 
         Other Parameters
@@ -2625,7 +2625,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        collection : `~.collections.BrokenBarHCollection`
+        `~.collections.BrokenBarHCollection`
 
         Other Parameters
         ----------------
@@ -2744,7 +2744,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        container : `.StemContainer`
+        `.StemContainer`
             The container may be treated like a tuple
             (*markerline*, *stemlines*, *baseline*)
 
@@ -3164,7 +3164,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        container : `.ErrorbarContainer`
+        `.ErrorbarContainer`
             The container contains:
 
             - plotline: `.Line2D` instance of x, y plot markers and/or line.
@@ -3603,7 +3603,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        result : dict
+        dict
           A dictionary mapping each component of the boxplot to a list
           of the `.Line2D` instances created. That dictionary has the
           following keys (assuming vertical boxplots):
@@ -3879,7 +3879,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        result : dict
+        dict
           A dictionary mapping each component of the boxplot to a list
           of the `.Line2D` instances created. That dictionary has the
           following keys (assuming vertical boxplots):
@@ -4364,7 +4364,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        paths : `~matplotlib.collections.PathCollection`
+        `~matplotlib.collections.PathCollection`
 
         Other Parameters
         ----------------
@@ -4552,7 +4552,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        polycollection : `~matplotlib.collections.PolyCollection`
+        `~matplotlib.collections.PolyCollection`
             A `.PolyCollection` defining the hexagonal bins.
 
             - `.PolyCollection.get_offset` contains a Mx2 array containing
@@ -4929,7 +4929,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        arrow : `.FancyArrow`
+        `.FancyArrow`
             The created `.FancyArrow` object.
 
         Notes
@@ -5432,7 +5432,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        image : `~matplotlib.image.AxesImage`
+        `~matplotlib.image.AxesImage`
 
         Other Parameters
         ----------------
@@ -5698,7 +5698,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        collection : `matplotlib.collections.Collection`
+        `matplotlib.collections.Collection`
 
         Other Parameters
         ----------------
@@ -5951,7 +5951,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        mesh : `matplotlib.collections.QuadMesh`
+        `matplotlib.collections.QuadMesh`
 
         Other Parameters
         ----------------
@@ -6164,7 +6164,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        image : `.AxesImage` or `.PcolorImage` or `.QuadMesh`
+        `.AxesImage` or `.PcolorImage` or `.QuadMesh`
             The return type depends on the type of grid:
 
             - `.AxesImage` for a regular rectangular grid.
@@ -7554,7 +7554,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        ret : `~matplotlib.image.AxesImage` or `.Line2D`
+        `~matplotlib.image.AxesImage` or `.Line2D`
             The return type depends on the plotting style (see above).
 
         Other Parameters
@@ -7648,7 +7648,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        image : `~matplotlib.image.AxesImage`
+        `~matplotlib.image.AxesImage`
 
         Other Parameters
         ----------------
@@ -7742,7 +7742,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        result : dict
+        dict
           A dictionary mapping each component of the violinplot to a
           list of the corresponding collection instances created. The
           dictionary has the following keys:
@@ -7842,7 +7842,7 @@ default: :rc:`scatter.edgecolors`
 
         Returns
         -------
-        result : dict
+        dict
           A dictionary mapping each component of the violinplot to a
           list of the corresponding collection instances created. The
           dictionary has the following keys:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -377,13 +377,13 @@ class Axes(_AxesBase):
             is shown in the legend and the automatic mechanism described above
             is not sufficient.
 
-        Other Parameters
-        ----------------
-        %(_legend_kw_doc)s
-
         Returns
         -------
         legend : `~matplotlib.legend.Legend`
+
+        Other Parameters
+        ----------------
+        %(_legend_kw_doc)s
 
         Notes
         -----
@@ -1572,6 +1572,11 @@ class Axes(_AxesBase):
                 You may suppress the warning by adding an empty format string
                 ``plot('n', 'o', '', data=obj)``.
 
+        Returns
+        -------
+        lines
+            A list of `.Line2D` objects representing the plotted data.
+
         Other Parameters
         ----------------
         scalex, scaley : bool, default: True
@@ -1592,11 +1597,6 @@ class Axes(_AxesBase):
             Here is a list of available `.Line2D` properties:
 
             %(_Line2D_docstr)s
-
-        Returns
-        -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
 
         See Also
         --------
@@ -2623,6 +2623,10 @@ class Axes(_AxesBase):
         yrange : (*ymin*, *yheight*)
             The y-position and extend for all the rectangles.
 
+        Returns
+        -------
+        collection : `~.collections.BrokenBarHCollection`
+
         Other Parameters
         ----------------
         **kwargs : `.BrokenBarHCollection` properties
@@ -2641,10 +2645,6 @@ class Axes(_AxesBase):
             Supported keywords:
 
             %(BrokenBarHCollection)s
-
-        Returns
-        -------
-        collection : `~.collections.BrokenBarHCollection`
         """
         # process the unit information
         if len(xranges):
@@ -3601,29 +3601,6 @@ class Axes(_AxesBase):
         zorder : scalar, default: None
             Sets the zorder of the boxplot.
 
-        Other Parameters
-        ----------------
-        showcaps : bool, default: True
-            Show the caps on the ends of whiskers.
-        showbox : bool, default: True
-            Show the central box.
-        showfliers : bool, default: True
-            Show the outliers beyond the caps.
-        showmeans : bool, default: False
-            Show the arithmetic means.
-        capprops : dict, default: None
-            The style of the caps.
-        boxprops : dict, default: None
-            The style of the box.
-        whiskerprops : dict, default: None
-            The style of the whiskers.
-        flierprops : dict, default: None
-            The style of the fliers.
-        medianprops : dict, default: None
-            The style of the median.
-        meanprops : dict, default: None
-            The style of the mean.
-
         Returns
         -------
         result : dict
@@ -3647,6 +3624,29 @@ class Axes(_AxesBase):
             the whiskers (fliers).
 
           - ``means``: points or lines representing the means.
+
+        Other Parameters
+        ----------------
+        showcaps : bool, default: True
+            Show the caps on the ends of whiskers.
+        showbox : bool, default: True
+            Show the central box.
+        showfliers : bool, default: True
+            Show the outliers beyond the caps.
+        showmeans : bool, default: False
+            Show the arithmetic means.
+        capprops : dict, default: None
+            The style of the caps.
+        boxprops : dict, default: None
+            The style of the box.
+        whiskerprops : dict, default: None
+            The style of the whiskers.
+        flierprops : dict, default: None
+            The style of the fliers.
+        medianprops : dict, default: None
+            The style of the median.
+        meanprops : dict, default: None
+            The style of the mean.
 
         """
 
@@ -4550,6 +4550,20 @@ default: :rc:`scatter.edgecolors`
 
             Order of scalars is (left, right, bottom, top).
 
+        Returns
+        -------
+        polycollection : `~matplotlib.collections.PolyCollection`
+            A `.PolyCollection` defining the hexagonal bins.
+
+            - `.PolyCollection.get_offset` contains a Mx2 array containing
+              the x, y positions of the M hexagon centers.
+            - `.PolyCollection.get_array` contains the values of the M
+              hexagons.
+
+            If *marginals* is *True*, horizontal
+            bar and vertical bar (both PolyCollections) will be attached
+            to the return collection as attributes *hbar* and *vbar*.
+
         Other Parameters
         ----------------
         cmap : str or `~matplotlib.colors.Colormap`, default: :rc:`image.cmap`
@@ -4599,20 +4613,6 @@ default: :rc:`scatter.edgecolors`
             All other keyword arguments are passed on to `.PolyCollection`:
 
             %(PolyCollection)s
-
-        Returns
-        -------
-        polycollection : `~matplotlib.collections.PolyCollection`
-            A `.PolyCollection` defining the hexagonal bins.
-
-            - `.PolyCollection.get_offset` contains a Mx2 array containing
-              the x, y positions of the M hexagon centers.
-            - `.PolyCollection.get_array` contains the values of the M
-              hexagons.
-
-            If *marginals* is *True*, horizontal
-            bar and vertical bar (both PolyCollections) will be attached
-            to the return collection as attributes *hbar* and *vbar*.
 
         """
         self._process_unit_info(xdata=x, ydata=y, kwargs=kwargs)
@@ -5119,6 +5119,11 @@ default: :rc:`scatter.edgecolors`
               value ``y[i]``.
             - 'mid': Steps occur half-way between the *x* positions.
 
+        Returns
+        -------
+        `.PolyCollection`
+            A `.PolyCollection` containing the plotted polygons.
+
         Other Parameters
         ----------------
         **kwargs
@@ -5126,11 +5131,6 @@ default: :rc:`scatter.edgecolors`
             They control the `.Polygon` properties:
 
             %(PolyCollection)s
-
-        Returns
-        -------
-        `.PolyCollection`
-            A `.PolyCollection` containing the plotted polygons.
 
         See Also
         --------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -863,6 +863,12 @@ class Axes(_AxesBase):
 
             %(_Line2D_docstr)s
 
+        See Also
+        --------
+        vlines : Add vertical lines in data coordinates.
+        axvspan : Add a vertical span (rectangle) across the axis.
+        axline : Add a line with an abritrary slope.
+
         Examples
         --------
         * draw a thick red vline at *x* = 0 that spans the yrange::
@@ -877,12 +883,6 @@ class Axes(_AxesBase):
           the yrange::
 
             >>> axvline(x=.5, ymin=0.25, ymax=0.75)
-
-        See also
-        --------
-        vlines : Add vertical lines in data coordinates.
-        axvspan : Add a vertical span (rectangle) across the axis.
-        axline : Add a line with an abritrary slope.
         """
 
         if "transform" in kwargs:
@@ -929,16 +929,16 @@ class Axes(_AxesBase):
 
             %(_Line2D_docstr)s
 
+        See Also
+        --------
+        axhline : for horizontal lines
+        axvline : for vertical lines
+
         Examples
         --------
         Draw a thick red line passing through (0, 0) and (1, 1)::
 
             >>> axline((0, 0), (1, 1), linewidth=4, color='r')
-
-        See Also
-        --------
-        axhline : for horizontal lines
-        axvline : for vertical lines
         """
 
         if "transform" in kwargs:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -415,7 +415,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        axes : `~.axes.Axes`
+        `~.axes.Axes`
             The new `~.axes.Axes` object.
         """
 
@@ -829,7 +829,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        pos : `.Bbox`
+        `.Bbox`
 
         """
         if original:
@@ -2759,7 +2759,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        axisbelow : bool or 'line'
+        bool or 'line'
 
         See Also
         --------
@@ -3388,7 +3388,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        labels : list
+        list
             List of `~matplotlib.text.Text` instances
         """
         return self.xaxis.get_majorticklabels()
@@ -3399,7 +3399,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        labels : list
+        list
             List of `~matplotlib.text.Text` instances
         """
         return self.xaxis.get_minorticklabels()
@@ -3421,7 +3421,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        ret : list
+        list
            List of `~matplotlib.text.Text` instances.
 
         Notes
@@ -3461,7 +3461,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        labels : list of `~.Text`
+        list of `~.Text`
             The labels.
 
         Other Parameters
@@ -3781,7 +3781,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        labels : list
+        list
             List of `~matplotlib.text.Text` instances
         """
         return self.yaxis.get_majorticklabels()
@@ -3792,7 +3792,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        labels : list
+        list
             List of `~matplotlib.text.Text` instances
         """
         return self.yaxis.get_minorticklabels()
@@ -3814,7 +3814,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        ret : list
+        list
            List of `~matplotlib.text.Text` instances.
 
         Notes
@@ -4376,8 +4376,8 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        bbox : `.BboxBase`
-            bounding box in figure pixel coordinates.
+        `.BboxBase`
+            Bounding box in figure pixel coordinates.
 
         See Also
         --------
@@ -4464,7 +4464,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        ax_twin : Axes
+        Axes
             The newly created Axes instance
 
         Notes
@@ -4494,7 +4494,7 @@ class _AxesBase(martist.Artist):
 
         Returns
         -------
-        ax_twin : Axes
+        Axes
             The newly created Axes instance
 
         Notes

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3465,7 +3465,7 @@ class _AxesBase(martist.Artist):
             The labels.
 
         Other Parameters
-        -----------------
+        ----------------
         **kwargs : `~.text.Text` properties.
         """
         if fontdict is not None:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1673,7 +1673,7 @@ class _AxesBase(martist.Artist):
         xmin, xmax, ymin, ymax : float
             The axis limits.
 
-        See also
+        See Also
         --------
         matplotlib.axes.Axes.set_xlim
         matplotlib.axes.Axes.set_ylim

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1175,6 +1175,13 @@ class _AxesBase(martist.Artist):
             Finite-length iterable of the property values. These values
             are validated and will raise a ValueError if invalid.
 
+        See Also
+        --------
+        matplotlib.rcsetup.cycler
+            Convenience function for creating validated cyclers for properties.
+        cycler.cycler
+            The original function for creating unvalidated cyclers.
+
         Examples
         --------
         Setting the property cycle for a single property:
@@ -1186,13 +1193,6 @@ class _AxesBase(martist.Artist):
 
         >>> ax.set_prop_cycle(color=['red', 'green', 'blue'],
         ...                   marker=['o', '+', 'x'])
-
-        See Also
-        --------
-        matplotlib.rcsetup.cycler
-            Convenience function for creating validated cyclers for properties.
-        cycler.cycler
-            The original function for creating unvalidated cyclers.
 
         """
         if args and kwargs:

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -374,14 +374,13 @@ functions : 2-tuple of func, or Transform with an inverse
     See :doc:`/gallery/subplots_axes_and_figures/secondary_axis`
     for examples of making these conversions.
 
+Returns
+-------
+ax : axes._secondary_axes.SecondaryAxis
 
 Other Parameters
 ----------------
 **kwargs : `~matplotlib.axes.Axes` properties.
     Other miscellaneous axes parameters.
-
-Returns
--------
-ax : axes._secondary_axes.SecondaryAxis
 '''
 docstring.interpd.update(_secax_docstring=_secax_docstring)

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -294,7 +294,7 @@ class SecondaryAxis(_AxesBase):
         **kwargs : `.Text` properties
             `.Text` properties control the appearance of the label.
 
-        See also
+        See Also
         --------
         text : Documents the properties supported by `.Text`.
         """
@@ -319,7 +319,7 @@ class SecondaryAxis(_AxesBase):
         **kwargs : `.Text` properties
             `.Text` properties control the appearance of the label.
 
-        See also
+        See Also
         --------
         text : Documents the properties supported by `.Text`.
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1211,7 +1211,7 @@ class Axis(martist.Artist):
 
         Returns
         -------
-        ret : list
+        list
            List of `~matplotlib.text.Text` instances.
         """
 
@@ -1626,7 +1626,7 @@ class Axis(martist.Artist):
 
         Returns
         -------
-        labels : list of `.Text`\s
+        list of `.Text`\s
             For each tick, includes ``tick.label1`` if it is visible, then
             ``tick.label2`` if it is visible, in that order.
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -986,7 +986,7 @@ class GraphicsContextBase:
 
         Returns
         -------
-        sketch_params : tuple or `None`
+        tuple or `None`
 
             A 3-tuple with the following elements:
 
@@ -1850,7 +1850,7 @@ class FigureCanvasBase:
 
         Returns
         -------
-        axes : `~matplotlib.axes.Axes` or None
+        `~matplotlib.axes.Axes` or None
             The topmost visible axes containing the point, or None if no axes.
         """
         axes_list = [a for a in self.figure.get_axes()

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -424,7 +424,7 @@ class ToolManager:
 
         Returns
         -------
-        tool : `.ToolBase` or None
+        `.ToolBase` or None
             The tool or None if no tool with the given name exists.
         """
         if isinstance(name, tools.ToolBase) and name.name in self._tools:

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -43,7 +43,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         Returns
         -------
-        mapped_value : float or ndarray[float]
+        float or ndarray[float]
         """
         if unit is None:
             raise ValueError(
@@ -75,7 +75,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         Returns
         -------
-        axisinfo : `~matplotlib.units.AxisInfo`
+        `~matplotlib.units.AxisInfo`
             Information to support default tick labeling
 
         .. note: axis is not used
@@ -99,7 +99,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         Returns
         -------
-        class : `.UnitData`
+        `.UnitData`
             object storing string to integer mapping
         """
         # the conversion call stack is default_units -> axis_info -> convert

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -101,7 +101,8 @@ class _StrongRef:
 
 
 class CallbackRegistry:
-    """Handle registering and disconnecting for a set of signals and callbacks:
+    """
+    Handle registering and disconnecting for a set of signals and callbacks:
 
         >>> def oneat(x):
         ...    print('eat', x)
@@ -1869,7 +1870,8 @@ other Matplotlib process is running, remove this file and try again.""".format(
 def _topmost_artist(
         artists,
         _cached_max=functools.partial(max, key=operator.attrgetter("zorder"))):
-    """Get the topmost artist of a list.
+    """
+    Get the topmost artist of a list.
 
     In case of a tie, return the *last* of the tied artists, as it will be
     drawn on top of the others. `max` returns the first maximum in case of
@@ -1879,7 +1881,8 @@ def _topmost_artist(
 
 
 def _str_equal(obj, s):
-    """Return whether *obj* is a string equal to string *s*.
+    """
+    Return whether *obj* is a string equal to string *s*.
 
     This helper solely exists to handle the case where *obj* is a numpy array,
     because in such cases, a naive ``obj == s`` would yield an array, which
@@ -1889,7 +1892,8 @@ def _str_equal(obj, s):
 
 
 def _str_lower_equal(obj, s):
-    """Return whether *obj* is a string equal, when lowercased, to string *s*.
+    """
+    Return whether *obj* is a string equal, when lowercased, to string *s*.
 
     This helper solely exists to handle the case where *obj* is a numpy array,
     because in such cases, a naive ``obj == s`` would yield an array, which
@@ -1899,7 +1903,8 @@ def _str_lower_equal(obj, s):
 
 
 def _define_aliases(alias_d, cls=None):
-    """Class decorator for defining property aliases.
+    """
+    Class decorator for defining property aliases.
 
     Use as ::
 
@@ -2094,7 +2099,8 @@ def _array_patch_perimeters(x, rstride, cstride):
 
 @contextlib.contextmanager
 def _setattr_cm(obj, **kwargs):
-    """Temporarily set some attributes; restore original state at context exit.
+    """
+    Temporarily set some attributes; restore original state at context exit.
     """
     sentinel = object()
     origs = [(attr, getattr(obj, attr, sentinel)) for attr in kwargs]

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -303,7 +303,7 @@ def local_over_kwdict(local_var, kwargs, *keys):
 
     Returns
     -------
-    out : any object
+    any object
         Either local_var or one of kwargs[key] for key in keys.
 
     Raises
@@ -1137,7 +1137,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
 
     Returns
     -------
-    bxpstats : list of dict
+    list of dict
         A list of dictionaries containing the results for each column
         of data. Keys of each dictionary are the following:
 
@@ -1461,7 +1461,7 @@ def violin_stats(X, method, points=100, quantiles=None):
 
     Returns
     -------
-    vpstats : list of dict
+    list of dict
         A list of dictionaries containing the results for each column of data.
         The dictionaries contain at least the following:
 
@@ -1540,7 +1540,7 @@ def pts_to_prestep(x, *args):
 
     Returns
     -------
-    out : array
+    array
         The x and y values converted to steps in the same order as the input;
         can be unpacked as ``x_out, y1_out, ..., yp_out``.  If the input is
         length ``N``, each of these arrays will be length ``2N + 1``. For
@@ -1578,7 +1578,7 @@ def pts_to_poststep(x, *args):
 
     Returns
     -------
-    out : array
+    array
         The x and y values converted to steps in the same order as the input;
         can be unpacked as ``x_out, y1_out, ..., yp_out``.  If the input is
         length ``N``, each of these arrays will be length ``2N + 1``. For
@@ -1615,7 +1615,7 @@ def pts_to_midstep(x, *args):
 
     Returns
     -------
-    out : array
+    array
         The x and y values converted to steps in the same order as the input;
         can be unpacked as ``x_out, y1_out, ..., yp_out``.  If the input is
         length ``N``, each of these arrays will be length ``2N``.
@@ -1963,7 +1963,7 @@ def _array_perimeter(arr):
 
     Returns
     -------
-    perimeter : ndarray, shape (2*(M - 1) + 2*(N - 1),)
+    ndarray, shape (2*(M - 1) + 2*(N - 1),)
         The elements on the perimeter of the array::
 
            [arr[0, 0], ..., arr[0, -1], ..., arr[-1, -1], ..., arr[-1, 0], ...]
@@ -2010,7 +2010,7 @@ def _unfold(arr, axis, size, step):
 
     Returns
     -------
-    windows : ndarray, shape (N_1, ..., 1 + (N_axis-size)/step, ..., N_k, size)
+    ndarray, shape (N_1, ..., 1 + (N_axis-size)/step, ..., N_k, size)
 
     Examples
     --------
@@ -2062,7 +2062,7 @@ def _array_patch_perimeters(x, rstride, cstride):
 
     Returns
     -------
-    patches : ndarray, shape (N/rstride * M/cstride, 2 * (rstride + cstride))
+    ndarray, shape (N/rstride * M/cstride, 2 * (rstride + cstride))
     """
     assert rstride > 0 and cstride > 0
     assert (x.shape[0] - 1) % rstride == 0

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1959,12 +1959,12 @@ def _define_aliases(alias_d, cls=None):
 
 def _array_perimeter(arr):
     """
-    Get the elements on the perimeter of ``arr``,
+    Get the elements on the perimeter of *arr*.
 
     Parameters
     ----------
     arr : ndarray, shape (M, N)
-        The input array
+        The input array.
 
     Returns
     -------

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -322,7 +322,7 @@ class ScalarMappable:
         """
         Returns
         -------
-        alpha : float
+        float
             Always returns 1.
         """
         # This method is intended to be overridden by Artist sub-classes

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -855,7 +855,7 @@ class _CollectionWithSizes(Collection):
 
         Returns
         -------
-        sizes : array
+        array
             The 'area' of each element.
         """
         return self._sizes
@@ -1398,7 +1398,7 @@ class LineCollection(Collection):
         """
         Returns
         -------
-        segments : list
+        list
             List of segments in the LineCollection. Each list item contains an
             array of vertices.
         """

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1703,7 +1703,7 @@ def colorbar_factory(cax, mappable, **kwargs):
 
     Returns
     -------
-    colorbar : `.Colorbar` or `.ColorbarPatch`
+    `.Colorbar` or `.ColorbarPatch`
         The created colorbar instance. `.ColorbarPatch` is only used if
         *mappable* is a `.ContourSet` with hatches.
     """

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -427,7 +427,7 @@ def _create_lookup_table(N, data, gamma=1.0):
 
     Returns
     -------
-    lut : array
+    array
         The lookup table where ``lut[x * (N-1)]`` gives the closest value
         for values of x between 0 and 1.
 
@@ -1478,7 +1478,7 @@ def rgb_to_hsv(arr):
 
     Returns
     -------
-    hsv : (..., 3) ndarray
+    (..., 3) ndarray
        Colors converted to hsv values in range [0, 1]
     """
     arr = np.asarray(arr)
@@ -1529,7 +1529,7 @@ def hsv_to_rgb(hsv):
 
     Returns
     -------
-    rgb : (..., 3) ndarray
+    (..., 3) ndarray
        Colors converted to RGB values in range [0, 1]
     """
     hsv = np.asarray(hsv)
@@ -1697,7 +1697,7 @@ class LightSource:
 
         Returns
         -------
-        intensity : ndarray
+        ndarray
             A 2d array of illumination values between 0-1, where 0 is
             completely in shadow and 1 is completely illuminated.
         """
@@ -1740,7 +1740,7 @@ class LightSource:
 
         Returns
         -------
-        intensity : ndarray
+        ndarray
             A 2d array of illumination values between 0-1, where 0 is
             completely in shadow and 1 is completely illuminated.
         """
@@ -1823,7 +1823,7 @@ class LightSource:
 
         Returns
         -------
-        rgba : ndarray
+        ndarray
             An MxNx4 array of floats ranging between 0-1.
         """
         if vmin is None:
@@ -1884,7 +1884,7 @@ class LightSource:
 
         Returns
         -------
-        shaded_rgb : ndarray
+        ndarray
             An (m, n, 3) array of floats ranging between 0-1.
         """
         # Calculate the "hillshade" intensity.
@@ -1950,7 +1950,7 @@ class LightSource:
 
         Returns
         -------
-        rgb : ndarray
+        ndarray
             An MxNx3 RGB array representing the combined images.
         """
         # Backward compatibility...
@@ -2000,7 +2000,7 @@ class LightSource:
 
         Returns
         -------
-        rgb : ndarray
+        ndarray
             An MxNx3 RGB array representing the combined images.
         """
         return 2 * intensity * rgb + (1 - 2 * intensity) * rgb**2
@@ -2018,7 +2018,7 @@ class LightSource:
 
         Returns
         -------
-        rgb : ndarray
+        ndarray
             An MxNx3 RGB array representing the combined images.
         """
         low = 2 * intensity * rgb

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1622,7 +1622,7 @@ class QuadContourSet(ContourSet):
 
         Returns
         -------
-        c : `~.contour.QuadContourSet`
+        `~.contour.QuadContourSet`
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -477,7 +477,7 @@ def drange(dstart, dend, delta):
 
     Returns
     -------
-    drange : `numpy.array`
+    `numpy.array`
         A list floats representing Matplotlib dates.
 
     """

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -985,7 +985,7 @@ def _parse_enc(path):
 
     Returns
     -------
-    encoding : list
+    list
         The nth entry of the list is the PostScript glyph name of the nth
         glyph.
     """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1142,6 +1142,14 @@ default: 'top'
         label : str
             A label for the returned axes.
 
+        Returns
+        -------
+        axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
+            The returned axes class depends on the projection used. It is
+            `~.axes.Axes` if rectilinear projection are used and
+            `.projections.polar.PolarAxes` if polar projection
+            are used.
+
         Other Parameters
         ----------------
         **kwargs
@@ -1153,14 +1161,6 @@ default: 'top'
             class.
 
             %(Axes)s
-
-        Returns
-        -------
-        axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
-            The returned axes class depends on the projection used. It is
-            `~.axes.Axes` if rectilinear projection are used and
-            `.projections.polar.PolarAxes` if polar projection
-            are used.
 
         Notes
         -----
@@ -1290,6 +1290,16 @@ default: 'top'
         label : str
             A label for the returned axes.
 
+        Returns
+        -------
+        axes : `.axes.SubplotBase`, or another subclass of `~.axes.Axes`
+
+            The axes of the subplot. The returned axes base class depends on
+            the projection used. It is `~.axes.Axes` if rectilinear projection
+            are used and `.projections.polar.PolarAxes` if polar projection
+            are used. The returned axes is then a subplot subclass of the
+            base class.
+
         Other Parameters
         ----------------
         **kwargs
@@ -1300,16 +1310,6 @@ default: 'top'
             arguments if another projection is used.
 
             %(Axes)s
-
-        Returns
-        -------
-        axes : `.axes.SubplotBase`, or another subclass of `~.axes.Axes`
-
-            The axes of the subplot. The returned axes base class depends on
-            the projection used. It is `~.axes.Axes` if rectilinear projection
-            are used and `.projections.polar.PolarAxes` if polar projection
-            are used. The returned axes is then a subplot subclass of the
-            base class.
 
         Notes
         -----
@@ -1788,13 +1788,13 @@ default: 'top'
             is shown in the legend and the automatic mechanism described above
             is not sufficient.
 
-        Other Parameters
-        ----------------
-        %(_legend_kw_doc)s
-
         Returns
         -------
         `~matplotlib.legend.Legend`
+
+        Other Parameters
+        ----------------
+        %(_legend_kw_doc)s
 
         Notes
         -----
@@ -1843,16 +1843,16 @@ default: 'top'
             the defaults are determined by :rc:`font.*`. Properties passed as
             *kwargs* override the corresponding ones given in *fontdict*.
 
+        Returns
+        -------
+        text : `~.text.Text`
+
         Other Parameters
         ----------------
         **kwargs : `~matplotlib.text.Text` properties
             Other miscellaneous text parameters.
 
             %(Text)s
-
-        Returns
-        -------
-        text : `~.text.Text`
 
         See Also
         --------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -890,7 +890,7 @@ default: 'top'
 
         Returns
         -------
-        size : ndarray
+        ndarray
            The size (width, height) of the figure in inches.
 
         See Also
@@ -1032,7 +1032,8 @@ default: 'top'
 
         Returns
         -------
-        artist : The added `~matplotlib.artist.Artist`
+        `~matplotlib.artist.Artist`
+            The added artist.
         """
         artist.set_figure(self)
         self.artists.append(artist)
@@ -1144,7 +1145,7 @@ default: 'top'
 
         Returns
         -------
-        axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
+        `~.axes.Axes` (or a subclass of `~.axes.Axes`)
             The returned axes class depends on the projection used. It is
             `~.axes.Axes` if rectilinear projection are used and
             `.projections.polar.PolarAxes` if polar projection
@@ -1292,7 +1293,7 @@ default: 'top'
 
         Returns
         -------
-        axes : `.axes.SubplotBase`, or another subclass of `~.axes.Axes`
+        `.axes.SubplotBase`, or another subclass of `~.axes.Axes`
 
             The axes of the subplot. The returned axes base class depends on
             the projection used. It is `~.axes.Axes` if rectilinear projection
@@ -1473,11 +1474,11 @@ default: 'top'
 
         Returns
         -------
-        ax : `~.axes.Axes` or array of Axes
-            *ax* can be either a single `~matplotlib.axes.Axes` object or
-            an array of Axes objects if more than one subplot was created. The
-            dimensions of the resulting array can be controlled with the
-            squeeze keyword, see above.
+        `~.axes.Axes` or array of Axes
+            Either a single `~matplotlib.axes.Axes` object or an array of Axes
+            objects if more than one subplot was created. The dimensions of the
+            resulting array can be controlled with the *squeeze* keyword, see
+            above.
 
         See Also
         --------
@@ -1845,7 +1846,7 @@ default: 'top'
 
         Returns
         -------
-        text : `~.text.Text`
+        `~.text.Text`
 
         Other Parameters
         ----------------
@@ -2286,7 +2287,7 @@ default: 'top'
 
         Returns
         -------
-        points : list of tuples
+        list of tuples
             A list of the clicked (x, y) coordinates.
 
         Notes
@@ -2343,7 +2344,7 @@ default: 'top'
 
         Returns
         -------
-        bbox : `.BboxBase`
+        `.BboxBase`
             containing the bounding box (in figure inches).
         """
 
@@ -2641,7 +2642,7 @@ default: 'top'
 
         Returns
         -------
-        gridspec : `.GridSpec`
+        `.GridSpec`
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1479,6 +1479,12 @@ default: 'top'
             dimensions of the resulting array can be controlled with the
             squeeze keyword, see above.
 
+        See Also
+        --------
+        .pyplot.subplots
+        .Figure.add_subplot
+        .pyplot.subplot
+
         Examples
         --------
         ::
@@ -1517,12 +1523,6 @@ default: 'top'
 
             # Note that this is the same as
             fig.subplots(2, 2, sharex=True, sharey=True)
-
-        See Also
-        --------
-        .pyplot.subplots
-        .Figure.add_subplot
-        .pyplot.subplot
         """
 
         if isinstance(sharex, bool):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1197,7 +1197,7 @@ class FontManager:
 
         Returns
         -------
-        fontfile : str
+        str
             The filename of the best matching font.
 
         Notes

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -255,8 +255,7 @@ def win32InstalledFonts(directory=None, fontext='ttf'):
 
 @lru_cache()
 def _call_fc_list():
-    """Cache and list the font filenames known to `fc-list`.
-    """
+    """Cache and list the font filenames known to `fc-list`."""
     # Delay the warning by 5s.
     timer = Timer(5, lambda: _log.warning(
         'Matplotlib is building the font cache using fc-list. '

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -907,15 +907,15 @@ def json_dump(data, filename):
     """
     Dump `FontManager` *data* as JSON to the file named *filename*.
 
+    See Also
+    --------
+    json_load
+
     Notes
     -----
     File paths that are children of the Matplotlib data path (typically, fonts
     shipped with Matplotlib) are stored relative to that data path (to remain
     valid across virtualenvs).
-
-    See Also
-    --------
-    json_load
     """
     with open(filename, 'w') as fh:
         try:

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -692,7 +692,7 @@ class SubplotSpec:
 
         Returns
         -------
-        gridspec : `.GridSpecFromSubplotSpec`
+        `.GridSpecFromSubplotSpec`
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1421,7 +1421,7 @@ def imread(fname, format=None):
 
     Returns
     -------
-    imagedata : :class:`numpy.array`
+    `numpy.array`
         The image data. The returned array has shape
 
         - (M, N) for grayscale images.
@@ -1656,7 +1656,7 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
 
     Returns
     -------
-    figure : `~.figure.Figure`
+    `~.figure.Figure`
         The figure instance containing the thumbnail.
     """
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -888,7 +888,8 @@ class Legend(Artist):
 
         Returns
         -------
-        `.BboxBase` : containing the bounding box in figure pixel coordinates.
+        `.BboxBase`
+            The bounding box in figure pixel coordinates.
         """
         return self._legend_box.get_window_extent(renderer)
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -3440,7 +3440,7 @@ class MathTextParser:
 
         Returns
         -------
-        depth : int
+        int
             Offset of the baseline from the bottom of the image, in pixels.
         """
         rgba, depth = self.to_rgba(
@@ -3459,7 +3459,7 @@ class MathTextParser:
 
         Returns
         -------
-        depth : int
+        int
             Offset of the baseline from the bottom of the image, in pixels.
         """
         assert self._output == "bitmap"

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -1076,7 +1076,7 @@ class GaussianKDE:
 
         Returns
         -------
-        values : (# of points,)-array
+        (# of points,)-array
             The values at each point.
 
         Raises

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1009,7 +1009,7 @@ class Polygon(Patch):
 
         Returns
         -------
-        path : Path
+        Path
            The `~.path.Path` object for the polygon.
         """
         return self._path
@@ -1020,7 +1020,7 @@ class Polygon(Patch):
 
         Returns
         -------
-        closed : bool
+        bool
             If the path is closed
         """
         return self._closed
@@ -1046,7 +1046,7 @@ class Polygon(Patch):
 
         Returns
         -------
-        vertices : (N, 2) numpy array
+        (N, 2) numpy array
             The coordinates of the vertices.
         """
         return self._path.vertices
@@ -1949,7 +1949,7 @@ class BoxStyle(_Style):
 
             Returns
             -------
-            path : `~matplotlib.path.Path`
+            `~matplotlib.path.Path`
             """
             # The __call__ method is a thin wrapper around the transmute method
             # and takes care of the aspect.
@@ -3968,7 +3968,7 @@ default: 'arc3'
 
         Returns
         -------
-        dpi_cor : scalar
+        scalar
         """
         return self._dpi_cor
 
@@ -4094,7 +4094,7 @@ default: 'arc3'
 
         Returns
         -------
-        scale : scalar
+        scalar
         """
         return self._mutation_scale
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -962,7 +962,7 @@ def get_path_collection_extents(
     master_transform : `~.Transform`
         Global transformation applied to all paths.
     paths : list of `Path`
-    transform : list of `~.Affine2D`
+    transforms : list of `~.Affine2D`
     offsets : (N, 2) array-like
     offset_transform : `~.Affine2D`
         Transform applied to the offsets before offsetting the path.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1298,8 +1298,11 @@ class PolarAxes(Axes):
 
         Returns
         -------
-        lines, labels : list of `.lines.Line2D`, list of `.text.Text`
-            *lines* are the theta gridlines and *labels* are the tick labels.
+        lines : list of `.lines.Line2D`
+            The theta gridlines.
+
+        labels : list of `.text.Text`
+            The tick labels.
 
         Other Parameters
         ----------------
@@ -1348,8 +1351,11 @@ class PolarAxes(Axes):
 
         Returns
         -------
-        lines, labels : list of `.lines.Line2D`, list of `.text.Text`
-            *lines* are the radial gridlines and *labels* are the tick labels.
+        lines : list of `.lines.Line2D`
+            The radial gridlines.
+
+        labels : list of `.text.Text`
+            The tick labels.
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1112,6 +1112,14 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         because for the latter it's not clear if it refers to a single
         `~.axes.Axes` instance or a collection of these.
 
+    See Also
+    --------
+    .pyplot.figure
+    .pyplot.subplot
+    .pyplot.axes
+    .Figure.subplots
+    .Figure.add_subplot
+
     Examples
     --------
     ::
@@ -1151,14 +1159,6 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         # Create figure number 10 with a single subplot
         # and clears it if it already exists.
         fig, ax = plt.subplots(num=10, clear=True)
-
-    See Also
-    --------
-    .pyplot.figure
-    .pyplot.subplot
-    .pyplot.axes
-    .Figure.subplots
-    .Figure.add_subplot
 
     """
     fig = figure(**fig_kw)
@@ -1570,6 +1570,13 @@ def rgrids(*args, **kwargs):
     **kwargs
         *kwargs* are optional `~.Text` properties for the labels.
 
+    See Also
+    --------
+    .pyplot.thetagrids
+    .projections.polar.PolarAxes.set_rgrids
+    .Axis.get_gridlines
+    .Axis.get_ticklabels
+
     Examples
     --------
     ::
@@ -1579,13 +1586,6 @@ def rgrids(*args, **kwargs):
 
       # set the locations and labels of the radial gridlines
       lines, labels = rgrids( (0.25, 0.5, 1.0), ('Tom', 'Dick', 'Harry' ))
-
-    See Also
-    --------
-    .pyplot.thetagrids
-    .projections.polar.PolarAxes.set_rgrids
-    .Axis.get_gridlines
-    .Axis.get_ticklabels
     """
     ax = gca()
     if not isinstance(ax, PolarAxes):
@@ -1634,6 +1634,13 @@ def thetagrids(*args, **kwargs):
     **kwargs
         *kwargs* are optional `~.Text` properties for the labels.
 
+    See Also
+    --------
+    .pyplot.rgrids
+    .projections.polar.PolarAxes.set_thetagrids
+    .Axis.get_gridlines
+    .Axis.get_ticklabels
+
     Examples
     --------
     ::
@@ -1643,13 +1650,6 @@ def thetagrids(*args, **kwargs):
 
       # set the locations and labels of the angular gridlines
       lines, labels = thetagrids(range(45, 360, 90), ('NE', 'NW', 'SW', 'SE'))
-
-    See Also
-    --------
-    .pyplot.rgrids
-    .projections.polar.PolarAxes.set_thetagrids
-    .Axis.get_gridlines
-    .Axis.get_ticklabels
     """
     ax = gca()
     if not isinstance(ax, PolarAxes):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -490,7 +490,7 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
 
     Returns
     -------
-    figure : `~matplotlib.figure.Figure`
+    `~matplotlib.figure.Figure`
         The `.Figure` instance returned will also be passed to
         new_figure_manager in the backends, which allows to hook custom
         `.Figure` classes into the pyplot interface. Additional kwargs will be
@@ -654,7 +654,7 @@ def get_current_fig_manager():
 
     Returns
     -------
-    manager : `.FigureManagerBase` or backend-dependent subclass thereof
+    `.FigureManagerBase` or backend-dependent subclass thereof
     """
     return gcf().canvas.manager
 
@@ -791,7 +791,7 @@ def axes(arg=None, **kwargs):
 
     Returns
     -------
-    axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
+    `~.axes.Axes` (or a subclass of `~.axes.Axes`)
         The returned axes class depends on the projection used. It is
         `~.axes.Axes` if rectilinear projection are used and
         `.projections.polar.PolarAxes` if polar projection
@@ -916,8 +916,8 @@ def subplot(*args, **kwargs):
 
     Returns
     -------
-    axes : an `.axes.SubplotBase` subclass of `~.axes.Axes` (or a subclass \
-    of `~.axes.Axes`)
+    an `.axes.SubplotBase` subclass of `~.axes.Axes` (or a subclass of \
+`~.axes.Axes`)
 
         The axes of the subplot. The returned axes base class depends on
         the projection used. It is `~.axes.Axes` if rectilinear projection
@@ -1562,8 +1562,11 @@ def rgrids(*args, **kwargs):
 
     Returns
     -------
-    lines, labels : list of `.lines.Line2D`, list of `.text.Text`
-        *lines* are the radial gridlines and *labels* are the tick labels.
+    lines : list of `.lines.Line2D`
+        The radial gridlines.
+
+    labels : list of `.text.Text`
+        The tick labels.
 
     Other Parameters
     ----------------
@@ -1626,8 +1629,11 @@ def thetagrids(*args, **kwargs):
 
     Returns
     -------
-    lines, labels : list of `.lines.Line2D`, list of `.text.Text`
-        *lines* are the theta gridlines and *labels* are the tick labels.
+    lines : list of `.lines.Line2D`
+        The theta gridlines.
+
+    labels : list of `.text.Text`
+        The tick labels.
 
     Other Parameters
     ----------------
@@ -2080,7 +2086,7 @@ def matshow(A, fignum=None, **kwargs):
 
     Returns
     -------
-    image : `~matplotlib.image.AxesImage`
+    `~matplotlib.image.AxesImage`
 
     Other Parameters
     ----------------

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -789,6 +789,14 @@ def axes(arg=None, **kwargs):
     label : str
         A label for the returned axes.
 
+    Returns
+    -------
+    axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
+        The returned axes class depends on the projection used. It is
+        `~.axes.Axes` if rectilinear projection are used and
+        `.projections.polar.PolarAxes` if polar projection
+        are used.
+
     Other Parameters
     ----------------
     **kwargs
@@ -800,14 +808,6 @@ def axes(arg=None, **kwargs):
         class.
 
         %(Axes)s
-
-    Returns
-    -------
-    axes : `~.axes.Axes` (or a subclass of `~.axes.Axes`)
-        The returned axes class depends on the projection used. It is
-        `~.axes.Axes` if rectilinear projection are used and
-        `.projections.polar.PolarAxes` if polar projection
-        are used.
 
     Notes
     -----
@@ -914,17 +914,6 @@ def subplot(*args, **kwargs):
     label : str
         A label for the returned axes.
 
-    Other Parameters
-    ----------------
-    **kwargs
-        This method also takes the keyword arguments for the returned axes
-        base class; except for the *figure* argument. The keyword arguments
-        for the rectilinear base class `~.axes.Axes` can be found in
-        the following table but there might also be other keyword
-        arguments if another projection is used.
-
-        %(Axes)s
-
     Returns
     -------
     axes : an `.axes.SubplotBase` subclass of `~.axes.Axes` (or a subclass \
@@ -935,6 +924,17 @@ def subplot(*args, **kwargs):
         are used and `.projections.polar.PolarAxes` if polar projection
         are used. The returned axes is then a subplot subclass of the
         base class.
+
+    Other Parameters
+    ----------------
+    **kwargs
+        This method also takes the keyword arguments for the returned axes
+        base class; except for the *figure* argument. The keyword arguments
+        for the rectilinear base class `~.axes.Axes` can be found in
+        the following table but there might also be other keyword
+        arguments if another projection is used.
+
+        %(Axes)s
 
     Notes
     -----

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -618,7 +618,7 @@ def validate_markevery(s):
 
     Returns
     -------
-    s : None, int, float, slice, length-2 tuple of ints,
+    None, int, float, slice, length-2 tuple of ints,
         length-2 tuple of floats, list of ints
 
     """
@@ -847,7 +847,7 @@ def cycler(*args, **kwargs):
 
     Returns
     -------
-    cycler : Cycler
+    Cycler
         A new :class:`~cycler.Cycler` for the given properties.
 
     Examples

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -54,7 +54,7 @@ def stackplot(axes, x, *args,
 
     Returns
     -------
-    list : list of `.PolyCollection`
+    list of `.PolyCollection`
         A list of `.PolyCollection` instances, one for each element in the
         stacked area plot.
     """

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -71,7 +71,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     Returns
     -------
-    stream_container : StreamplotSet
+    StreamplotSet
         Container object with attributes
 
         - ``lines``: `.LineCollection` of streamlines

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -726,17 +726,17 @@ def table(ax,
         The cell edges to be drawn with a line. See also
         `~.CustomCell.visible_edges`.
 
+    Returns
+    -------
+    table : `~matplotlib.table.Table`
+        The created table.
+
     Other Parameters
     ----------------
     **kwargs
         `.Table` properties.
 
     %(Table)s
-
-    Returns
-    -------
-    table : `~matplotlib.table.Table`
-        The created table.
     """
 
     if cellColours is None and cellText is None:

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -342,7 +342,7 @@ class Table(Artist):
 
         Returns
         -------
-        cell : `.CustomCell`
+        `.CustomCell`
             The created cell.
 
         """
@@ -728,7 +728,7 @@ def table(ax,
 
     Returns
     -------
-    table : `~matplotlib.table.Table`
+    `~matplotlib.table.Table`
         The created table.
 
     Other Parameters

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -240,7 +240,7 @@ def comparable_formats():
 
     Returns
     -------
-    supported_formats : list of str
+    list of str
         E.g. ``['png', 'pdf', 'svg', 'eps']``.
 
     """
@@ -335,7 +335,7 @@ def compare_images(expected, actual, tol, in_decorator=False):
 
     Returns
     -------
-    comparison_result : None or dict or str
+    None or dict or str
         Return *None* if the images are equal within the given tolerance.
 
         If the images differ, the return value depends on  *in_decorator*.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1308,7 +1308,7 @@ class OffsetFrom:
 
         Returns
         -------
-        transform : `Transform`
+        `Transform`
             Maps (x, y) in pixel or point units to screen units
             relative to the given artist.
         """
@@ -1705,7 +1705,7 @@ class Annotation(Text, _AnnotationBase):
 
         Returns
         -------
-        annotation : `.Annotation`
+        `.Annotation`
 
         See Also
         --------

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -107,9 +107,12 @@ class TextToPath:
 
         Returns
         -------
-        verts, codes : tuple of lists
-            *verts*  is a list of numpy arrays containing the x and y
-            coordinates of the vertices. *codes* is a list of path codes.
+        verts : list
+            A list of numpy arrays containing the x and y coordinates of the
+            vertices.
+
+        codes : list
+            A list of path codes.
 
         Examples
         --------

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1431,7 +1431,7 @@ class Transform(TransformNode):
 
         Returns
         -------
-        values : array
+        array
             The output values as NumPy array of length :attr:`input_dims` or
             shape (N x :attr:`output_dims`), depending on the input.
         """
@@ -1456,7 +1456,7 @@ class Transform(TransformNode):
 
         Returns
         -------
-        values : array
+        array
             The output values as NumPy array of length :attr:`input_dims` or
             shape (N x :attr:`output_dims`), depending on the input.
         """
@@ -1558,7 +1558,7 @@ class Transform(TransformNode):
 
         Returns
         -------
-        transformed_angles : (N,) array
+        (N,) array
         """
         # Must be 2D
         if self.input_dims != 2 or self.output_dims != 2:
@@ -2861,7 +2861,7 @@ def offset_copy(trans, fig=None, x=0.0, y=0.0, units='inches'):
 
     Returns
     -------
-    trans : `Transform` subclass
+    `Transform` subclass
         Transform with applied offset.
     """
     if units == 'dots':

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -72,7 +72,7 @@ class TriInterpolator:
 
         Returns
         -------
-        z : np.ma.array
+        np.ma.array
             Masked array of the same shape as *x* and *y*; values corresponding
             to (*x*, *y*) points outside of the triangulation are masked out.
 
@@ -149,7 +149,7 @@ class TriInterpolator:
 
         Returns
         -------
-        ret : list of arrays
+        list of arrays
             Each array-like contains the expected interpolated values in the
             order defined by *return_keys* parameter.
         """
@@ -223,7 +223,7 @@ class TriInterpolator:
 
         Returns
         -------
-        ret : 1-d array
+        1-d array
             Returned array of the same size as *tri_index*
         """
         raise NotImplementedError("TriInterpolator subclasses" +
@@ -464,7 +464,7 @@ class CubicTriInterpolator(TriInterpolator):
 
         Returns
         -------
-        dof : array-like, shape (npts, 2)
+        array-like, shape (npts, 2)
               Estimation of the gradient at triangulation nodes (stored as
               degree of freedoms of reduced-HCT triangle elements).
         """
@@ -497,7 +497,7 @@ class CubicTriInterpolator(TriInterpolator):
 
         Returns
         -------
-        alpha : array of dim 2 (shape (nx, 3))
+        array of dim 2 (shape (nx, 3))
             Barycentric coordinates of the points inside the containing
             triangles.
         """
@@ -534,7 +534,7 @@ class CubicTriInterpolator(TriInterpolator):
 
         Returns
         -------
-        J : array of dim 3 (shape (nx, 2, 2))
+        array of dim 3 (shape (nx, 2, 2))
             Barycentric coordinates of the points inside the containing
             triangles.
             J[itri, :, :] is the jacobian matrix at apex 0 of the triangle
@@ -562,7 +562,7 @@ class CubicTriInterpolator(TriInterpolator):
 
         Returns
         -------
-        ecc : array like of dim 2 (shape: (nx, 3))
+        array like of dim 2 (shape: (nx, 3))
             The so-called eccentricity parameters [1] needed for HCT triangular
             element.
         """

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -35,7 +35,7 @@ class TriAnalyzer:
 
         Returns
         -------
-        k : (float, float)
+        (float, float)
             Scaling factors (kx, ky) so that the triangulation
             ``[triangulation.x * kx, triangulation.y * ky]``
             fits exactly inside a unit square.
@@ -70,7 +70,7 @@ class TriAnalyzer:
 
         Returns
         -------
-        circle_ratios : masked array
+        masked array
             Ratio of the incircle radius over the circumcircle radius, for
             each 'rescaled' triangle of the encapsulated triangulation.
             Values corresponding to masked triangles are masked out.
@@ -144,7 +144,7 @@ class TriAnalyzer:
 
         Returns
         -------
-        new_mask : bool array-like
+        bool array-like
             Mask to apply to encapsulated triangulation.
             All the initially masked triangles remain masked in the
             *new_mask*.
@@ -273,7 +273,7 @@ class TriAnalyzer:
 
         Returns
         -------
-        renum : int array
+        int array
             array so that (`valid_array` being a compressed array
             based on a `masked_array` with mask *mask*):
 

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -325,7 +325,7 @@ class Type1Font:
 
         Returns
         -------
-        font : `Type1Font`
+        `Type1Font`
         """
         tokenizer = self._tokens(self.parts[0])
         transformed = self._transformer(tokenizer,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -473,7 +473,7 @@ class Slider(AxesWidget):
 
         Returns
         -------
-        cid : int
+        int
             Connection id (which can be used to disconnect *func*)
         """
         cid = self.cnt


### PR DESCRIPTION
## PR Summary

I'm trying out `numpydoc --validate` and I'm not sure it's quite ready to use in CI yet, but there are some issues we can fix right now.

The ordering of sections in the numpydoc example is prescriptive, so we this changes some incorrectly ordered docstrings. Return values don't need a name when there's only one returned item. The rest is just small typos, for details see the commit messages.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way