### PR TITLE
Document Quit All works only with toolmanager

### DIFF
--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -94,7 +94,7 @@ Zoom-to-rect                       **o**
 Save                               **ctrl** + **s**
 Toggle fullscreen                  **f** or **ctrl** + **f**
 Close plot                         **ctrl** + **w**
-Close all plots                    **shift** + **w**
+Close all plots                    **shift** + **w** (only when using toolmanager)
 Constrain pan/zoom to x axis       hold **x** when panning/zooming with mouse
 Constrain pan/zoom to y axis       hold **y** when panning/zooming with mouse
 Preserve aspect ratio              hold **CONTROL** when panning/zooming with mouse

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1462,6 +1462,7 @@ defaultParams = {
     'keymap.zoom':         [['o'], validate_stringlist],
     'keymap.save':         [['s', 'ctrl+s'], validate_stringlist],
     'keymap.quit':         [['ctrl+w', 'cmd+w', 'q'], validate_stringlist],
+    # quit_all is only supported in toolmanager (#14208)
     'keymap.quit_all':     [['W', 'cmd+W', 'Q'], validate_stringlist],
     'keymap.grid':         [['g'], validate_stringlist],
     'keymap.grid_minor':   [['G'], validate_stringlist],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -708,7 +708,7 @@
 #keymap.save: s, ctrl+s         # saving current figure
 #keymap.help: f1                # display help about active tools
 #keymap.quit: ctrl+w, cmd+w, q  # close the current figure
-#keymap.quit_all: W, cmd+W, Q   # close all figures
+#keymap.quit_all: W, cmd+W, Q   # close all figures (only when using toolmanager)
 #keymap.grid: g                 # switching on/off major grids in current axes
 #keymap.grid_minor: G           # switching on/off minor grids in current axes
 #keymap.yscale: l               # toggle scaling of y-axes ('log'/'linear')


### PR DESCRIPTION
## PR Summary

Closes #14208 by documenting the limitation.

I'm not particularly happy with this solution; see https://github.com/matplotlib/matplotlib/issues/14208#issuecomment-602025935. Therefore draft only.