### PR TITLE
Shortcut for closing all figures

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -122,3 +122,10 @@ This behavior is consistent with other figure saving methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This is consistent with other signature mismatch errors.  Previously a
 ValueError was raised.
+
+Shortcut for closing all figures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Shortcuts for closing all figures now also work for the classic toolbar.
+There is no default shortcut anymore because closing all figures by a key press
+might happen unintendedly too easy. You can configure the shortcut yourself
+using :rc:`keymap.quit_all`.

--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -126,6 +126,6 @@ ValueError was raised.
 Shortcut for closing all figures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Shortcuts for closing all figures now also work for the classic toolbar.
-There is no default shortcut anymore because closing all figures by a key press
-might happen unintendedly too easy. You can configure the shortcut yourself
+There is no default shortcut any more because unintentionally closing all figures by a key press
+might happen too easily. You can configure the shortcut yourself
 using :rc:`keymap.quit_all`.

--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -94,7 +94,7 @@ Zoom-to-rect                       **o**
 Save                               **ctrl** + **s**
 Toggle fullscreen                  **f** or **ctrl** + **f**
 Close plot                         **ctrl** + **w**
-Close all plots                    **shift** + **w**
+Close all plots                    *unassigned*
 Constrain pan/zoom to x axis       hold **x** when panning/zooming with mouse
 Constrain pan/zoom to y axis       hold **y** when panning/zooming with mouse
 Preserve aspect ratio              hold **CONTROL** when panning/zooming with mouse

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2329,6 +2329,7 @@ def key_press_handler(event, canvas, toolbar=None):
     zoom_keys = rcParams['keymap.zoom']
     save_keys = rcParams['keymap.save']
     quit_keys = rcParams['keymap.quit']
+    quit_all_keys = rcParams['keymap.quit']
     grid_keys = rcParams['keymap.grid']
     grid_minor_keys = rcParams['keymap.grid_minor']
     toggle_yscale_keys = rcParams['keymap.yscale']
@@ -2345,6 +2346,8 @@ def key_press_handler(event, canvas, toolbar=None):
     # quit the figure (default key 'ctrl+w')
     if event.key in quit_keys:
         Gcf.destroy_fig(canvas.figure)
+    if event.key in quit_all_keys:
+        Gcf.destroy_all()
 
     if toolbar is not None:
         # home or reset mnemonic  (default key 'h', 'home' and 'r')

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1462,7 +1462,7 @@ defaultParams = {
     'keymap.zoom':         [['o'], validate_stringlist],
     'keymap.save':         [['s', 'ctrl+s'], validate_stringlist],
     'keymap.quit':         [['ctrl+w', 'cmd+w', 'q'], validate_stringlist],
-    'keymap.quit_all':     [['W', 'cmd+W', 'Q'], validate_stringlist],
+    'keymap.quit_all':     [[], validate_stringlist],  # proposed values: 'W', 'cmd+W', 'Q'
     'keymap.grid':         [['g'], validate_stringlist],
     'keymap.grid_minor':   [['G'], validate_stringlist],
     'keymap.yscale':       [['l'], validate_stringlist],

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -708,7 +708,7 @@
 #keymap.save: s, ctrl+s         # saving current figure
 #keymap.help: f1                # display help about active tools
 #keymap.quit: ctrl+w, cmd+w, q  # close the current figure
-#keymap.quit_all: W, cmd+W, Q   # close all figures
+#keymap.quit_all:               # close all figures
 #keymap.grid: g                 # switching on/off major grids in current axes
 #keymap.grid_minor: G           # switching on/off minor grids in current axes
 #keymap.yscale: l               # toggle scaling of y-axes ('log'/'linear')


### PR DESCRIPTION
## PR Summary

as proposed in https://github.com/matplotlib/matplotlib/issues/14208#issuecomment-602028548:

- make 'quit_all' work for the classic toolbar
- do not assign a shortcut by default.

Closes #14208. Better solution than just documenting the current behavior (supersedes #16863).

