### PR TITLE
Check parameter type for legend(labels)

### DIFF
--- a/examples/text_labels_and_annotations/custom_legends.py
+++ b/examples/text_labels_and_annotations/custom_legends.py
@@ -33,10 +33,10 @@ rcParams['axes.prop_cycle'] = cycler(color=cmap(np.linspace(0, 1, N)))
 
 fig, ax = plt.subplots()
 lines = ax.plot(data)
-ax.legend(lines)
+ax.legend()
 
 ##############################################################################
-# Note that one legend item per line was created.
+# Note that no legend entries were created.
 # In this case, we can compose a legend using Matplotlib objects that aren't
 # explicitly tied to the data that was plotted. For example:
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1162,6 +1162,10 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     # One argument. User defined labels - automatic handle detection.
     elif len(args) == 1:
         labels, = args
+        if any(isinstance(l, Artist) for l in labels):
+            raise TypeError("A single argument passed to legend() must be a "
+                            "list of labels, but found an Artist in there.")
+
         # Get as many handles as there are labels.
         handles = [handle for handle, label
                    in zip(_get_legend_handles(axs, handlers), labels)]

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -234,6 +234,13 @@ class TestLegendFunction:
             plt.legend(lines, ['hello world'])
         Legend.assert_called_with(plt.gca(), lines, ['hello world'])
 
+    def test_legend_handles_only(self):
+        lines = plt.plot(range(10))
+        with pytest.raises(TypeError, match='but found an Artist'):
+            # a single arg is interpreted as labels
+            # it's a common error to just pass handles
+            plt.legend(lines)
+
     def test_legend_no_args(self):
         lines = plt.plot(range(10), label='hello world')
         with mock.patch('matplotlib.legend.Legend') as Legend:


### PR DESCRIPTION
## PR Summary

We support `legend(labels)`. However, it may happen that users think they can just pass in a list of handles (`legend(handles)`). This PR checks for the type of the first positional variable and raises a ValueError when the passed list contains an Artist.

Closes #16567. Supersedes #16771.
