### PR TITLE
Cleanup/update deprecations.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -227,19 +227,9 @@ The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_axes_titlelocation``, ``validate_toolbar``,
 ``validate_ps_papersize``, ``validate_legend_loc``,
 ``validate_bool_maybe_none``, ``validate_hinting``,
-``validate_movie_writers``.
+``validate_movie_writers``, ``validate_webagg_address``.
 To test whether an rcParam value would be acceptable, one can test e.g. ``rc =
 RcParams(); rc[k] = v`` raises an exception.
-||||||| constructed merge base
-``validate_ps_papersize``, ``validate_legend_log``.  To test whether an rcParam
-value would be acceptable, one can test e.g. ``rc = RcParams(); rc[k] = v``
-raises an exception.
-=======
-``validate_ps_papersize``, ``validate_legend_loc``,
-``validate_webagg_address``.
-To test whether an rcParam value would be acceptable, one can test e.g. ``rc =
-RcParams(); rc[k] = v`` raises an exception.
->>>>>>> Deprecate validate_webagg_address.
 
 Stricter rcParam validation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -481,7 +481,7 @@ def make_wedged_bezier2(bezier2, width, w1=1., wm=0.5, w2=0.):
 
 
 @cbook.deprecated(
-    "3.2", alternative="Path.cleaned() and remove the final STOP if needed")
+    "3.3", alternative="Path.cleaned() and remove the final STOP if needed")
 def make_path_regular(p):
     """
     If the ``codes`` attribute of `.Path` *p* is None, return a copy of *p*
@@ -497,7 +497,7 @@ def make_path_regular(p):
         return p
 
 
-@cbook.deprecated("3.2", alternative="Path.make_compound_path()")
+@cbook.deprecated("3.3", alternative="Path.make_compound_path()")
 def concatenate_paths(paths):
     """Concatenate a list of paths into a single path."""
     vertices = np.concatenate([p.vertices for p in paths])


### PR DESCRIPTION
- Fix messed up rebased in deprecations.rst.
- Fix version numbers in bezier.py deprecations (the PR missed 3.2 and
  only went in in 3.3).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
