### PR TITLE
BLD: Auto-trigger macOS/Linux wheels on tags.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,34 @@
+on: 
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+  trigger_wheel_builds:
+    runs-on: ubuntu-latest
+    name: Trigger macOS and manylinux wheel builds
+    if: github.repository == 'matplotlib/matplotlib'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: MacPython/matplotlib-wheels
+          ssh-key: ${{ secrets.WHEEL_DEPLOY_KEY }}
+          fetch-depth: 0
+      - name: Prepare build commit
+        id: commit
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          BRANCH="$(echo ${TAG} | sed 's/^v\([0-9]\+\.[0-9]\+\)\.[0-9]\+.*$/build-\1.x/')"
+          echo "${BRANCH}"
+          echo "##[set-output name=branch;]${BRANCH}"
+          git branch ${BRANCH} master || true
+          git checkout ${BRANCH}
+          sed -i -e "s/\(- BUILD_COMMIT=\).\+/\1${TAG}/g" .travis.yml
+          git add .travis.yml
+          git config --global user.name 'Matplotlib Actions Bot'
+          git config --global user.email 'matplotlib@users.noreply.github.com'
+          git commit -m "REL: $TAG"
+      - name: Push to matplotlib-wheels
+        run: |
+          git push origin ${{ steps.commit.outputs.branch }}


### PR DESCRIPTION
## PR Summary

I tested on my fork by pushing a bogus tag, [which worked except the push](https://github.com/QuLogic/matplotlib/runs/524531427?check_suite_focus=true), so I also added an `if` so it doesn't run on people's forks, [which skips running it](https://github.com/QuLogic/matplotlib/actions/runs/60471175). This took way too long for me to figure out.

We'll need to set the deploy key secret on this repo for this to work.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [n/a] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way