### PR TITLE
Unbreak CI by xfailing wxAgg test on macOS

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -40,6 +40,11 @@ def _get_testable_interactive_backends():
                 backend,
                 marks=pytest.mark.skip(
                     reason=f"Skipping {backend} because {reason}"))
+        elif backend == 'wxagg' and sys.platform == 'darwin':
+            # ignore on OSX because that's currently broken (github #16849)
+            backend = pytest.param(
+                backend,
+                marks=pytest.mark.xfail(reason='github #16849'))
         backends.append(backend)
     return backends
 


### PR DESCRIPTION
## PR Summary

This is a stopgap for #16849, which does not yet have a solution. We just xfail the test for now so that other PRs pass CI.
