### PR TITLE
Specialized path collection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1096,13 +1096,7 @@ class PolyCollection(_CollectionWithSizes):
         # Fast path for arrays
         if isinstance(verts, np.ndarray):
             verts_pad = np.concatenate((verts, verts[:, :1]), axis=1)
-            # Creating the codes once is much faster than having Path do it
-            # separately each time by passing closed=True.
-            codes = np.empty(verts_pad.shape[1], dtype=mpath.Path.code_type)
-            codes[:] = mpath.Path.LINETO
-            codes[0] = mpath.Path.MOVETO
-            codes[-1] = mpath.Path.CLOSEPOLY
-            self._paths = [mpath.Path(xy, codes) for xy in verts_pad]
+            self._paths = mpath.PathCollection(verts_pad, closed=True)
             return
 
         self._paths = []

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -19,6 +19,59 @@ from . import _path, cbook
 from .cbook import _to_unmasked_float_array, simple_linear_interpolation
 
 
+class PathCollection:
+    _is_uniform_path_collection = True
+
+    def __init__(self, vertices, codes=None, _interpolation_steps=1,
+                 closed=False):
+        # TODO: Should this support readonly??
+        vertices = _to_unmasked_float_array(vertices)
+        if vertices.ndim != 3 or vertices.shape[-1] != 2:
+            raise ValueError(
+                "'vertices' must be a 3D list or array with shape CxNx2")
+
+        if codes is not None:
+            codes = np.asarray(codes, Path.code_type)
+            if codes.shape != vertices.shape[:-1]:
+                raise ValueError("'codes' must be a 2D list or array with the "
+                                 "same length of 'vertices'")
+            if len(codes) and np.any(codes[0] != self.MOVETO):
+                raise ValueError("The first element of 'code' must be equal "
+                                 "to 'MOVETO' ({})".format(self.MOVETO))
+        elif closed and len(vertices):
+            codes = np.empty((1, vertices.shape[1]), dtype=Path.code_type)
+            codes[:, 0] = Path.MOVETO
+            codes[:, 1:-1] = Path.LINETO
+            codes[:, -1] = Path.CLOSEPOLY
+            codes = np.broadcast_to(codes, vertices.shape[:-1])
+
+        self._vertices = vertices
+        self._codes = codes
+        self._interpolation_steps = _interpolation_steps
+        self._example_path = Path(vertices[0], codes[0], _interpolation_steps)
+
+    def __len__(self):
+        return len(self._vertices)
+
+    def __getitem__(self, i):
+        pth = Path.__new__(Path)
+        pth._vertices = self._vertices[i]
+        pth._codes = self._codes[i]
+        pth._readonly = False
+        pth._should_simplify = self._example_path._should_simplify
+        pth._simplify_threshold = self._example_path._simplify_threshold
+        pth._interpolation_steps = self._example_path._interpolation_steps
+        return pth
+
+    @property
+    def should_simplify(self):
+        return self._example_path.should_simplify
+
+    @property
+    def simplify_threshold(self):
+        return self._example_path.simplify_threshold
+
+
 class Path:
     """
     A series of possibly disconnected, possibly closed, line and curve

--- a/src/py_adaptors.h
+++ b/src/py_adaptors.h
@@ -21,6 +21,84 @@ int convert_path(PyObject *obj, void *pathp);
 namespace py
 {
 
+template<typename T, size_t Dim>
+class StridedMemoryBase {
+protected:
+    char *m_data;
+    npy_intp *m_strides;
+
+    explicit StridedMemoryBase(char *data, npy_intp *strides)
+        : m_data(data), m_strides(strides)
+    {
+    }
+
+public:
+    StridedMemoryBase()
+        : m_data(nullptr), m_strides(nullptr)
+    {
+    }
+
+    explicit StridedMemoryBase(PyArrayObject *array)
+    {
+        if (PyArray_NDIM(array) != Dim) {
+            PyErr_SetString(PyExc_ValueError, "Invalid array dimensionality");
+            throw py::exception();
+        }
+        m_data = PyArray_BYTES(array);
+        m_strides = PyArray_STRIDES(array);
+    }
+
+    operator bool() const {
+        return m_data != nullptr;
+    }
+
+    void reset() {
+        m_data = nullptr;
+        m_strides = nullptr;
+    }
+
+    T* data() {
+        return reinterpret_cast<T*>(m_data);
+    }
+};
+
+#define INHERIT_CONSTRUCTORS(CLS, DIM)                                         \
+  CLS() {}                                                                     \
+  explicit CLS(char *data, npy_intp *strides): StridedMemoryBase<T, DIM>(data, strides) {} \
+  explicit CLS(PyArrayObject *array): StridedMemoryBase<T, DIM>(array) {}
+
+
+template<typename T>
+class StridedMemory1D : public StridedMemoryBase<T, 1> {
+public:
+    INHERIT_CONSTRUCTORS(StridedMemory1D, 1)
+    T operator[](size_t idx) const {
+        return *reinterpret_cast<T*>(this->m_data + *this->m_strides * idx);
+    }
+};
+
+template<typename T>
+class StridedMemory2D : public StridedMemoryBase<T, 2> {
+public:
+    INHERIT_CONSTRUCTORS(StridedMemory2D, 2)
+    StridedMemory1D<T> operator[](size_t idx) const {
+        return StridedMemory1D<T>(this->m_data + *this->m_strides * idx,
+                                  this->m_strides + 1);
+    }
+};
+
+template<typename T>
+class StridedMemory3D : public StridedMemoryBase<T, 3> {
+public:
+    INHERIT_CONSTRUCTORS(StridedMemory3D, 3)
+    StridedMemory2D<T> operator[](size_t idx) const {
+        return StridedMemory2D<T>(this->m_data + *this->m_strides * idx,
+                                  this->m_strides + 1);
+    }
+};
+
+#undef INHERIT_CONSTRUCTORS
+
 /************************************************************
  * py::PathIterator acts as a bridge between Numpy and Agg.  Given a
  * pair of Numpy arrays, vertices and codes, it iterates over
@@ -31,12 +109,12 @@ namespace py
  */
 class PathIterator
 {
-    /* We hold references to the Python objects, not just the
-       underlying data arrays, so that Python reference counting
-       can work.
+    /* XXX: This class does not own the data! It should really be used as an
+       iterator, where it is the container that manages the lifetime of the
+       paths.
     */
-    PyArrayObject *m_vertices;
-    PyArrayObject *m_codes;
+    StridedMemory2D<double> m_vertices;
+    StridedMemory1D<uint8_t> m_codes;
 
     unsigned m_iterator;
     unsigned m_total_vertices;
@@ -50,8 +128,8 @@ class PathIterator
 
   public:
     inline PathIterator()
-        : m_vertices(NULL),
-          m_codes(NULL),
+        : m_vertices(),
+          m_codes(),
           m_iterator(0),
           m_total_vertices(0),
           m_should_simplify(false),
@@ -63,14 +141,18 @@ class PathIterator
                         PyObject *codes,
                         bool should_simplify,
                         double simplify_threshold)
-        : m_vertices(NULL), m_codes(NULL), m_iterator(0)
+        : m_vertices(),
+          m_codes(),
+          m_iterator(0)
     {
         if (!set(vertices, codes, should_simplify, simplify_threshold))
             throw py::exception();
     }
 
     inline PathIterator(PyObject *vertices, PyObject *codes)
-        : m_vertices(NULL), m_codes(NULL), m_iterator(0)
+        : m_vertices(),
+          m_codes(),
+          m_iterator(0)
     {
         if (!set(vertices, codes))
             throw py::exception();
@@ -78,10 +160,7 @@ class PathIterator
 
     inline PathIterator(const PathIterator &other)
     {
-        Py_XINCREF(other.m_vertices);
         m_vertices = other.m_vertices;
-
-        Py_XINCREF(other.m_codes);
         m_codes = other.m_codes;
 
         m_iterator = 0;
@@ -91,39 +170,32 @@ class PathIterator
         m_simplify_threshold = other.m_simplify_threshold;
     }
 
-    ~PathIterator()
-    {
-        Py_XDECREF(m_vertices);
-        Py_XDECREF(m_codes);
-    }
-
     inline int
     set(PyObject *vertices, PyObject *codes, bool should_simplify, double simplify_threshold)
     {
         m_should_simplify = should_simplify;
         m_simplify_threshold = simplify_threshold;
 
-        Py_XDECREF(m_vertices);
-        m_vertices = (PyArrayObject *)PyArray_FromObject(vertices, NPY_DOUBLE, 2, 2);
-
-        if (!m_vertices || PyArray_DIM(m_vertices, 1) != 2) {
+        PyArrayObject *vertices_arr =
+            (PyArrayObject *)PyArray_FromObject(vertices, NPY_DOUBLE, 2, 2);
+        if (!vertices_arr || PyArray_DIM(vertices_arr, 1) != 2) {
             PyErr_SetString(PyExc_ValueError, "Invalid vertices array");
             return 0;
         }
-
-        Py_XDECREF(m_codes);
-        m_codes = NULL;
+        m_vertices = StridedMemory2D<double>(vertices_arr);
 
         if (codes != NULL && codes != Py_None) {
-            m_codes = (PyArrayObject *)PyArray_FromObject(codes, NPY_UINT8, 1, 1);
-
-            if (!m_codes || PyArray_DIM(m_codes, 0) != PyArray_DIM(m_vertices, 0)) {
+            PyArrayObject *codes_arr = (PyArrayObject *)PyArray_FromObject(codes, NPY_UINT8, 1, 1);
+            if (!codes_arr || PyArray_DIM(codes_arr, 0) != PyArray_DIM(vertices_arr, 0)) {
                 PyErr_SetString(PyExc_ValueError, "Invalid codes array");
                 return 0;
             }
+            m_codes = StridedMemory1D<uint8_t>(codes_arr);
+        } else {
+            m_codes.reset();
         }
 
-        m_total_vertices = (unsigned)PyArray_DIM(m_vertices, 0);
+        m_total_vertices = (unsigned)PyArray_DIM(vertices_arr, 0);
         m_iterator = 0;
 
         return 1;
@@ -144,12 +216,12 @@ class PathIterator
 
         const size_t idx = m_iterator++;
 
-        char *pair = (char *)PyArray_GETPTR2(m_vertices, idx, 0);
-        *x = *(double *)pair;
-        *y = *(double *)(pair + PyArray_STRIDE(m_vertices, 1));
+        StridedMemory1D<double> vertex = m_vertices[idx];
+        *x = vertex[0];
+        *y = vertex[1];
 
-        if (m_codes != NULL) {
-            return (unsigned)(*(char *)PyArray_GETPTR1(m_codes, idx));
+        if (m_codes) {
+            return static_cast<unsigned>(m_codes[idx]);
         } else {
             return idx == 0 ? agg::path_cmd_move_to : agg::path_cmd_line_to;
         }
@@ -177,12 +249,12 @@ class PathIterator
 
     inline bool has_curves() const
     {
-        return m_codes != NULL;
+        return m_codes;
     }
 
     inline void *get_id()
     {
-        return (void *)m_vertices;
+        return (void *)m_vertices.data();
     }
 };
 


### PR DESCRIPTION
## PR Summary

This PR adds an optimized path collection that can be used to store a set of paths of the same length without the need to create temporary `Path` objects. It still allows iterating over individual paths so that it is pretty much a drop-in replacement, but it also allows for using an optimized path in the renderer.

Note that this PR is a bit of a WIP that I'm putting out to gather feedback about the solution. It does introduce a bit of complexity, and I want to explore whether it would be possible to make `Collection._paths` use this data structure more often. In particular, I'm pretty sure it opens up more opportunities for vectorization which don't exist today. As for the performance, after all my previous PRs making a 400x400 surface plot takes around 0.7s, while with this patch applied this time drops to 0.4s. The breakdown now looks like this:

* 0.08s in `Axes3D.plot_surface` (0.04s if colormap is used instead of shading)
* 0.18s in `Poly3DCollection.do_3d_projection`
* 0.1s in the backend
* 0.04s saving the PNG (with Pillow-SIMD; regular Pillow needs 0.08s)

The fact that saving the PNG slowly starts to show up as a measurable portion of the plotting time makes me quite happy, as it means that matplotlib stops being the main reason for slowness as we start hitting some natural performance barriers.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way