### PR TITLE
More fixes to pydocstyle D403 (First word capitalization)

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -786,7 +786,7 @@ class Artist:
     def get_alpha(self):
         """
         Return the alpha value used for blending - not supported on all
-        backends
+        backends.
         """
         return self._alpha
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3327,8 +3327,8 @@ class Axes(_AxesBase):
 
         def xywhere(xs, ys, mask):
             """
-            return xs[mask], ys[mask] where mask is True but xs and
-            ys are not arrays
+            Return xs[mask], ys[mask] where mask is True but xs and
+            ys are not arrays.
             """
             assert len(xs) == len(ys)
             assert len(xs) == len(mask)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -867,10 +867,10 @@ class _AxesBase(martist.Artist):
 
     def _set_position(self, pos, which='both'):
         """
-        private version of set_position.  Call this internally
-        to get the same functionality of `get_position`, but not
-        to take the axis out of the constrained_layout
-        hierarchy.
+        Private version of set_position.
+
+        Call this internally to get the same functionality of `get_position`,
+        but not to take the axis out of the constrained_layout hierarchy.
         """
         if not isinstance(pos, mtransforms.BboxBase):
             pos = mtransforms.Bbox.from_bounds(*pos)
@@ -910,7 +910,7 @@ class _AxesBase(martist.Artist):
         return self._axes_locator
 
     def _set_artist_props(self, a):
-        """set the boilerplate props for artists added to axes"""
+        """Set the boilerplate props for artists added to axes."""
         a.set_figure(self.figure)
         if not a.is_transform_set():
             a.set_transform(self.transData)
@@ -1762,11 +1762,11 @@ class _AxesBase(martist.Artist):
         return self.legend_
 
     def get_images(self):
-        """return a list of Axes images contained by the Axes"""
+        r"""Return a list of `.AxesImage`\s contained by the Axes."""
         return cbook.silent_list('AxesImage', self.images)
 
     def get_lines(self):
-        """Return a list of lines contained by the Axes"""
+        """Return a list of lines contained by the Axes."""
         return cbook.silent_list('Line2D', self.lines)
 
     def get_xaxis(self):
@@ -1989,7 +1989,7 @@ class _AxesBase(martist.Artist):
         return p
 
     def _update_patch_limits(self, patch):
-        """update the data limits for patch *p*"""
+        """Update the data limits for the given patch."""
         # hist can add zero height Rectangles, which is useful to keep
         # the bins, counts and patches lined up, but it throws off log
         # scaling.  We'll ignore rects with zero height or width in

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -78,19 +78,19 @@ class SubplotBase:
         self.set_position(self.figbox)
 
     def get_subplotspec(self):
-        """get the SubplotSpec instance associated with the subplot"""
+        """Return the SubplotSpec instance associated with the subplot."""
         return self._subplotspec
 
     def set_subplotspec(self, subplotspec):
-        """set the SubplotSpec instance associated with the subplot"""
+        """Set the SubplotSpec instance associated with the subplot."""
         self._subplotspec = subplotspec
 
     def get_gridspec(self):
-        """get the GridSpec instance associated with the subplot"""
+        """Return the GridSpec instance associated with the subplot."""
         return self._subplotspec.get_gridspec()
 
     def update_params(self):
-        """update the subplot position from fig.subplotpars"""
+        """Update the subplot position from ``self.figure.subplotpars``."""
         self.figbox, _, _, self.numRows, self.numCols = \
             self.get_subplotspec().get_position(self.figure,
                                                 return_all=True)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -753,8 +753,8 @@ class GraphicsContextBase:
 
     def get_alpha(self):
         """
-        Return the alpha value used for blending - not supported on
-        all backends.
+        Return the alpha value used for blending - not supported on all
+        backends.
         """
         return self._alpha
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1214,7 +1214,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
 
 def get_bbox_header(lbrt, rotated=False):
     """
-    return a postscript header string for the given bbox lbrt=(l, b, r, t).
+    Return a postscript header string for the given bbox lbrt=(l, b, r, t).
     Optionally, return rotate command.
     """
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -417,7 +417,7 @@ class GraphicsContextWx(GraphicsContextBase):
         self.unselect()
 
     def get_wxcolour(self, color):
-        """return a wx.Colour from RGB format"""
+        """Convert the given RGB(A) color to a wx.Colour."""
         _log.debug("%s - get_wx_color()", type(self))
         if len(color) == 3:
             r, g, b = color
@@ -1407,7 +1407,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
 
 
 class StatusbarWx(StatusbarBase, wx.StatusBar):
-    """for use with ToolManager"""
+    """For use with ToolManager."""
     def __init__(self, parent, *args, **kwargs):
         StatusbarBase.__init__(self, *args, **kwargs)
         wx.StatusBar.__init__(self, parent, -1)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1631,15 +1631,11 @@ class EventCollection(LineCollection):
         self.switch_orientation()
 
     def get_linelength(self):
-        """
-        get the length of the lines used to mark each event
-        """
+        """Return the length of the lines used to mark each event."""
         return self._linelength
 
     def set_linelength(self, linelength):
-        """
-        set the length of the lines used to mark each event
-        """
+        """Set the length of the lines used to mark each event."""
         if linelength == self.get_linelength():
             return
         lineoffset = self.get_lineoffset()

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1294,7 +1294,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         return tlinestyles
 
     def get_alpha(self):
-        """returns alpha to be applied to all ContourSet artists"""
+        """Return alpha to be applied to all ContourSet artists."""
         return self.alpha
 
     def set_alpha(self, alpha):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -819,6 +819,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
 class AxesImage(_ImageBase):
     """
+    An image attached to an Axes.
+
     Parameters
     ----------
     ax : `~.axes.Axes`
@@ -1270,6 +1272,8 @@ class PcolorImage(AxesImage):
 
 
 class FigureImage(_ImageBase):
+    """An image attached to a figure."""
+
     zorder = 0
 
     _interpolation = 'nearest'

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1700,7 +1700,7 @@ def test_barh_tick_label():
 
 
 def test_bar_timedelta():
-    """smoketest that bar can handle width and height in delta units"""
+    """Smoketest that bar can handle width and height in delta units."""
     fig, ax = plt.subplots()
     ax.bar(datetime.datetime(2018, 1, 1), 1.,
            width=datetime.timedelta(hours=3))

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1073,7 +1073,7 @@ def test_image_cursor_formatting():
 
 @check_figures_equal()
 def test_image_array_alpha(fig_test, fig_ref):
-    """per-pixel alpha channel test"""
+    """Per-pixel alpha channel test."""
     x = np.linspace(0, 1)
     xx, yy = np.meshgrid(x, x)
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -356,7 +356,7 @@ class TestLegendFigureFunction:
 
 @image_comparison(['legend_stackplot.png'])
 def test_legend_stackplot():
-    """test legend for PolyCollection using stackplot"""
+    """Test legend for PolyCollection using stackplot."""
     # related to #1341, #1943, and PR #3303
     fig = plt.figure()
     ax = fig.add_subplot(111)

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -24,7 +24,7 @@ all_func_ids = ['plot_func']
 
 
 def test_compiletime_checks():
-    """test decorator invocations -> no replacements"""
+    """Test decorator invocations -> no replacements."""
 
     def func(ax, x, y): pass
     def func_args(ax, x, y, *args): pass
@@ -58,7 +58,7 @@ def test_compiletime_checks():
 
 @pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
 def test_function_call_without_data(func):
-    """test without data -> no replacements"""
+    """Test without data -> no replacements."""
     assert (func(None, "x", "y") ==
             "x: ['x'], y: ['y'], ls: x, w: xyz, label: None")
     assert (func(None, x="x", y="y") ==
@@ -93,7 +93,7 @@ def test_function_call_with_dict_data(func):
 
 @pytest.mark.parametrize('func', all_funcs, ids=all_func_ids)
 def test_function_call_with_dict_data_not_in_data(func):
-    """test the case that one var is not in data -> half replaces, half kept"""
+    """Test the case that one var is not in data -> half replaces, half kept"""
     data = {"a": [1, 2], "w": "NOT"}
     assert (func(None, "a", "b", data=data) ==
             "x: [1, 2], y: ['b'], ls: x, w: xyz, label: b")
@@ -131,7 +131,7 @@ def test_function_call_with_pandas_data(func, pd):
 
 
 def test_function_call_replace_all():
-    """Test without a "replace_names" argument, all vars should be replaced"""
+    """Test without a "replace_names" argument, all vars should be replaced."""
     data = {"a": [1, 2], "b": [8, 9], "x": "xyz"}
 
     @_preprocess_data(label_namer="y")
@@ -157,7 +157,7 @@ def test_function_call_replace_all():
 
 
 def test_no_label_replacements():
-    """Test with "label_namer=None" -> no label replacement at all"""
+    """Test with "label_namer=None" -> no label replacement at all."""
 
     @_preprocess_data(replace_names=["x", "y"], label_namer=None)
     def func_no_label(ax, x, y, ls="x", label=None, w="xyz"):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -649,7 +649,7 @@ class CheckButtons(AxesWidget):
         return cid
 
     def disconnect(self, cid):
-        """remove the observer with connection id *cid*"""
+        """Remove the observer with connection id *cid*."""
         try:
             del self.observers[cid]
         except KeyError:
@@ -1380,18 +1380,18 @@ class MultiCursor(Widget):
         self.connect()
 
     def connect(self):
-        """connect events"""
+        """Connect events."""
         self._cidmotion = self.canvas.mpl_connect('motion_notify_event',
                                                   self.onmove)
         self._ciddraw = self.canvas.mpl_connect('draw_event', self.clear)
 
     def disconnect(self):
-        """disconnect events"""
+        """Disconnect events."""
         self.canvas.mpl_disconnect(self._cidmotion)
         self.canvas.mpl_disconnect(self._ciddraw)
 
     def clear(self, event):
-        """clear the cursor"""
+        """Clear the cursor."""
         if self.ignore(event):
             return
         if self.useblit:
@@ -1471,7 +1471,7 @@ class _SelectorWidget(AxesWidget):
             self.update_background(None)
 
     def update_background(self, event):
-        """force an update of the background"""
+        """Force an update of the background."""
         # If you add a call to `ignore` here, you'll want to check edge case:
         # `release` can call a draw event even when `ignore` is True.
         if self.useblit:

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -198,9 +198,7 @@ class CbarAxesLocator:
         self.orientation = orientation
 
     def get_original_position(self, axes, renderer):
-        """
-        get the original position of the axes.
-        """
+        """Return the original position of the axes."""
         if self._locator is None:
             bbox = axes.get_position(original=True)
         else:
@@ -209,7 +207,8 @@ class CbarAxesLocator:
 
     def get_end_vertices(self):
         """
-        return a tuple of two vertices for the colorbar extended ends.
+        Return a tuple of two vertices for the colorbar extended ends.
+
         The first vertices is for the minimum end, and the second is for
         the maximum end.
         """
@@ -246,24 +245,18 @@ class CbarAxesLocator:
         return bottom, top
 
     def get_path_patch(self):
-        """
-        get the path for axes patch
-        """
+        """Return the path for axes patch."""
         end1, end2 = self.get_end_vertices()
         verts = [] + end1 + end2 + end1[:1]
         return Path(verts)
 
     def get_path_ends(self):
-        """
-        get the paths for extended ends
-        """
+        """Return the paths for extended ends."""
         end1, end2 = self.get_end_vertices()
         return Path(end1), Path(end2)
 
     def __call__(self, axes, renderer):
-        """
-        Return the adjusted position of the axes
-        """
+        """Return the adjusted position of the axes."""
         bbox0 = self.get_original_position(axes, renderer)
         bbox = bbox0
 
@@ -490,9 +483,7 @@ class ColorbarBase(cm.ScalarMappable):
         self.ax.add_artist(self.extension_patch2)
 
     def _set_label_text(self):
-        """
-        set label.
-        """
+        """Set the colorbar label."""
         self.cbar_axis.set_label_text(self._label, **self._labelkw)
 
     def set_label_text(self, label, **kw):
@@ -657,9 +648,7 @@ class ColorbarBase(cm.ScalarMappable):
         return X, Y
 
     def set_alpha(self, alpha):
-        """
-        set alpha value.
-        """
+        """Set the alpha value for transparency."""
         self.alpha = alpha
 
 

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -347,12 +347,7 @@ class ExtremeFinderCycle(ExtremeFinderSimple):
         self.lat_minmax = lat_minmax
 
     def __call__(self, transform_xy, x1, y1, x2, y2):
-        """
-        get extreme values.
-
-        x1, y1, x2, y2 in image coordinates (0-based)
-        nx, ny : number of divisions in each axis
-        """
+        # docstring inherited
         x_, y_ = np.linspace(x1, x2, self.nx), np.linspace(y1, y2, self.ny)
         x, y = np.meshgrid(x_, y_)
         lon, lat = transform_xy(np.ravel(x), np.ravel(y))

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -158,7 +158,7 @@ class AxisArtistHelper:
 
         def get_axislabel_pos_angle(self, axes):
             """
-            label reference position in transAxes.
+            Return the label reference position in transAxes.
 
             get_label_transform() returns a transform of (transAxes+offset)
             """
@@ -263,7 +263,7 @@ class AxisArtistHelperRectlinear:
 
         def get_axislabel_pos_angle(self, axes):
             """
-            label reference position in transAxes.
+            Return the label reference position in transAxes.
 
             get_label_transform() returns a transform of (transAxes+offset)
             """
@@ -418,7 +418,7 @@ class GridHelperRectlinear(GridHelperBase):
 
     def get_gridlines(self, which="major", axis="both"):
         """
-        return list of gridline coordinates in data coordinates.
+        Return list of gridline coordinates in data coordinates.
 
         *which* : "major" or "minor"
         *axis* : "both", "x" or "y"

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -147,12 +147,7 @@ class ExtremeFinderFixed(ExtremeFinderSimple):
         self._extremes = extremes
 
     def __call__(self, transform_xy, x1, y1, x2, y2):
-        """
-        get extreme values.
-
-        x1, y1, x2, y2 in image coordinates (0-based)
-        nx, ny : number of division in each axis
-        """
+        # docstring inherited
         return self._extremes
 
 
@@ -175,7 +170,7 @@ class GridHelperCurveLinear(grid_helper_curvelinear.GridHelperCurveLinear):
 
     def get_data_boundary(self, side):
         """
-        return v=0, nth=1
+        Return v=0, nth=1.
         """
         lon1, lon2, lat1, lat2 = self._extremes
         return dict(left=(lon1, 0),

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -23,7 +23,7 @@ class ExtremeFinderSimple:
 
     def __call__(self, transform_xy, x1, y1, x2, y2):
         """
-        get extreme values.
+        Return extreme values.
 
         x1, y1, x2, y2 in image coordinates (0-based)
         nx, ny : number of division in each axis

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -7,7 +7,8 @@ import numpy.linalg as linalg
 
 
 def _line2d_seg_dist(p1, p2, p0):
-    """distance(s) from line defined by p1 - p2 to point(s) p0
+    """
+    Return the distance(s) from line defined by p1 - p2 to point(s) p0.
 
     p0[0] = x(s)
     p0[1] = y(s)
@@ -32,8 +33,8 @@ def world_transformation(xmin, xmax,
                          ymin, ymax,
                          zmin, zmax, pb_aspect=None):
     """
-    produce a matrix that scales homogenous coords in the specified ranges
-    to [0, 1], or [0, pb_aspect[i]] if the plotbox aspect ratio is specified
+    Produce a matrix that scales homogenous coords in the specified ranges
+    to [0, 1], or [0, pb_aspect[i]] if the plotbox aspect ratio is specified.
     """
     dx = xmax - xmin
     dy = ymax - ymin

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -48,7 +48,7 @@ def issues2dict(issues):
     return idict
 
 def split_pulls(all_issues, project="matplotlib/matplotlib"):
-    """split a list of closed issues into non-PR Issues and Pull Requests"""
+    """Split a list of closed issues into non-PR Issues and Pull Requests."""
     pulls = []
     issues = []
     for i in all_issues:


### PR DESCRIPTION
## PR Summary

More fixes to pydocstyle D403 (First word of the first line should be properly capitalized); and general docstring improvement on the way.

Follow up to #14500 and #14513.
