### PR TITLE
Small cleanups to dviread.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -73,12 +73,12 @@ def _arg_raw(dvi, delta):
     return delta
 
 
-def _arg(bytes, signed, dvi, _):
+def _arg(nbytes, signed, dvi, _):
     """
-    Read *bytes* bytes, returning the bytes interpreted as a signed integer
+    Read *nbytes* bytes, returning the bytes interpreted as a signed integer
     if *signed* is true, unsigned otherwise.
     """
-    return dvi._arg(bytes, signed)
+    return dvi._arg(nbytes, signed)
 
 
 def _arg_slen(dvi, delta):
@@ -315,12 +315,12 @@ class Dvi:
         Read and return an integer argument *nbytes* long.
         Signedness is determined by the *signed* keyword.
         """
-        str = self.file.read(nbytes)
-        value = str[0]
+        buf = self.file.read(nbytes)
+        value = buf[0]
         if signed and value >= 0x80:
             value = value - 0x100
-        for i in range(1, nbytes):
-            value = 0x100*value + str[i]
+        for b in buf[1:]:
+            value = 0x100*value + b
         return value
 
     @_dispatch(min=0, max=127, state=_dvistate.inpage)


### PR DESCRIPTION
Don't use variables whose name shadow builtins (`bytes`, `str` -- the
latter is actually a bytes instance).  Also use a slightly more
idiomatic way to iterate over the bytestring.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
