### PR TITLE
Backport PR #16870: Unbreak CI by xfailing wxAgg test on macOS

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -35,6 +35,11 @@ def _get_testable_interactive_backends():
         if reason:
             backend = pytest.param(
                 backend, marks=pytest.mark.skip(reason=reason))
+        elif backend == 'wxagg' and sys.platform == 'darwin':
+            # ignore on OSX because that's currently broken (github #16849)
+            backend = pytest.param(
+                backend,
+                marks=pytest.mark.xfail(reason='github #16849'))
         backends.append(backend)
     return backends
 


### PR DESCRIPTION
Merge pull request #16870 from timhoffm/xfail

CI: Unbreak CI by xfailing wxAgg test on macOS

Conflicts:
  - lib/matplotlib/tests/test_backends_interactive.py
    - Other improvements to messages when skipping tests from
      bc155f09cf99334ffebe74c9dd7ce5f8c105a930 near by.  Did not
      implicitly backport other changes.
