### PR TITLE
Enables hatch alpha on SVG

### DIFF
--- a/doc/users/next_whats_new/2020-03-24-svg-hatch-alpha.rst
+++ b/doc/users/next_whats_new/2020-03-24-svg-hatch-alpha.rst
@@ -1,0 +1,6 @@
+The SVG backend can now render hatches with transparency
+--------------------------------------------------------
+
+The SVG backend now respects the hatch stroke alpha. Useful applications are,
+among others, semi-transparent hatches as a subtle way to differentiate columns
+in bar plots.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -391,16 +391,19 @@ class RendererSVG(RendererBase):
                 x="0", y="0", width=str(HATCH_SIZE+1),
                 height=str(HATCH_SIZE+1),
                 fill=fill)
-            writer.element(
-                'path',
-                d=path_data,
-                style=generate_css({
+            hatch_style = {
                     'fill': rgb2hex(stroke),
                     'stroke': rgb2hex(stroke),
                     'stroke-width': str(mpl.rcParams['hatch.linewidth']),
                     'stroke-linecap': 'butt',
                     'stroke-linejoin': 'miter'
-                    })
+                    }
+            if stroke[3] < 1.:
+                hatch_style['stroke-opacity'] = str(stroke[3])
+            writer.element(
+                'path',
+                d=path_data,
+                style=generate_css(hatch_style)
                 )
             writer.end('pattern')
         writer.end('defs')

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -398,7 +398,7 @@ class RendererSVG(RendererBase):
                     'stroke-linecap': 'butt',
                     'stroke-linejoin': 'miter'
                     }
-            if stroke[3] < 1.:
+            if stroke[3] < 1:
                 hatch_style['stroke-opacity'] = str(stroke[3])
             writer.element(
                 'path',

--- a/lib/matplotlib/tests/baseline_images/test_artist/clip_path_clipping.svg
+++ b/lib/matplotlib/tests/baseline_images/test_artist/clip_path_clipping.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<!-- Created with matplotlib (http://matplotlib.org/) -->
+<!-- Created with matplotlib (https://matplotlib.org/) -->
 <svg height="432pt" version="1.1" viewBox="0 0 576 432" width="576pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
  <defs>
   <style type="text/css">
@@ -27,7 +27,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="PathCollection_1">
-    <path clip-path="url(#p5833b729b6)" d="M 173.454545 66.24 
+    <path clip-path="url(#p3a3c58397e)" d="M 173.454545 66.24 
 L 151.472727 151.152018 
 L 97.307294 141.12 
 L 129.490909 216 
@@ -40,7 +40,7 @@ L 217.418182 216
 L 249.601797 141.12 
 L 195.436364 151.152018 
 z
-" style="fill:url(#h3d2475b8ea);fill-opacity:0.7;stroke:#0000ff;stroke-opacity:0.7;stroke-width:5;"/>
+" style="fill:url(#h95f2a3a954);fill-opacity:0.7;stroke:#0000ff;stroke-opacity:0.7;stroke-width:5;"/>
    </g>
    <g id="patch_3">
     <path d="M 72 388.8 
@@ -68,92 +68,92 @@ L 274.909091 43.2
       <defs>
        <path d="M 0 0 
 L 0 -4 
-" id="m39e13c1b86" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m368fc901b1" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_2">
       <defs>
        <path d="M 0 0 
 L 0 4 
-" id="m3d70fdc796" style="stroke:#000000;stroke-width:0.5;"/>
+" id="mc63e59a608" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_4">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="105.818182" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_6">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="139.636364" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_8">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="173.454545" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_10">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="207.272727" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_12">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="241.090909" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_14">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
@@ -164,92 +164,92 @@ L 0 4
       <defs>
        <path d="M 0 0 
 L 4 0 
-" id="m4a4f278297" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m556f96d829" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="388.8"/>
       </g>
      </g>
      <g id="line2d_16">
       <defs>
        <path d="M 0 0 
 L -4 0 
-" id="mc06ed8a296" style="stroke:#000000;stroke-width:0.5;"/>
+" id="m27e32ca04a" style="stroke:#000000;stroke-width:0.5;"/>
       </defs>
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_17">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="331.2"/>
       </g>
      </g>
      <g id="line2d_18">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="331.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_19">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="273.6"/>
       </g>
      </g>
      <g id="line2d_20">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_21">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="216"/>
       </g>
      </g>
      <g id="line2d_22">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="216"/>
       </g>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_23">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="158.4"/>
       </g>
      </g>
      <g id="line2d_24">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_25">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="100.8"/>
       </g>
      </g>
      <g id="line2d_26">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="100.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_27">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m4a4f278297" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="72" xlink:href="#m556f96d829" y="43.2"/>
       </g>
      </g>
      <g id="line2d_28">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#mc06ed8a296" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="274.909091" xlink:href="#m27e32ca04a" y="43.2"/>
       </g>
      </g>
     </g>
@@ -265,7 +265,7 @@ z
 " style="fill:#ffffff;"/>
    </g>
    <g id="patch_8">
-    <path clip-path="url(#p6741698e5c)" d="M 416.945455 66.24 
+    <path clip-path="url(#p0b645584cb)" d="M 416.945455 66.24 
 L 394.963636 151.152018 
 L 340.798203 141.12 
 L 372.981818 216 
@@ -278,7 +278,7 @@ L 460.909091 216
 L 493.092706 141.12 
 L 438.927273 151.152018 
 z
-" style="fill:url(#h3d2475b8ea);opacity:0.7;stroke:#0000ff;stroke-linejoin:miter;stroke-width:5;"/>
+" style="fill:url(#h95f2a3a954);opacity:0.7;stroke:#0000ff;stroke-linejoin:miter;stroke-width:5;"/>
    </g>
    <g id="patch_9">
     <path d="M 315.490909 388.8 
@@ -304,84 +304,84 @@ L 518.4 43.2
     <g id="xtick_8">
      <g id="line2d_29">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_30">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_9">
      <g id="line2d_31">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="349.309091" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="349.309091" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_32">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="349.309091" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="349.309091" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_10">
      <g id="line2d_33">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_34">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="383.127273" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_35">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="416.945455" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="416.945455" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_36">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="416.945455" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="416.945455" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_37">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_38">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="450.763636" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_13">
      <g id="line2d_39">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="484.581818" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="484.581818" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_40">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="484.581818" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="484.581818" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
     <g id="xtick_14">
      <g id="line2d_41">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m39e13c1b86" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m368fc901b1" y="388.8"/>
       </g>
      </g>
      <g id="line2d_42">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m3d70fdc796" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc63e59a608" y="43.2"/>
       </g>
      </g>
     </g>
@@ -390,84 +390,84 @@ L 518.4 43.2
     <g id="ytick_8">
      <g id="line2d_43">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="388.8"/>
       </g>
      </g>
      <g id="line2d_44">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="388.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="388.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_45">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="331.2"/>
       </g>
      </g>
      <g id="line2d_46">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="331.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="331.2"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_47">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="273.6"/>
       </g>
      </g>
      <g id="line2d_48">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="273.6"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="273.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_49">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="216"/>
       </g>
      </g>
      <g id="line2d_50">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="216"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="216"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_51">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="158.4"/>
       </g>
      </g>
      <g id="line2d_52">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="158.4"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="158.4"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_53">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="100.8"/>
       </g>
      </g>
      <g id="line2d_54">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="100.8"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="100.8"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_55">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m4a4f278297" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="315.490909" xlink:href="#m556f96d829" y="43.2"/>
       </g>
      </g>
      <g id="line2d_56">
       <g>
-       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#mc06ed8a296" y="43.2"/>
+       <use style="stroke:#000000;stroke-width:0.5;" x="518.4" xlink:href="#m27e32ca04a" y="43.2"/>
       </g>
      </g>
     </g>
@@ -475,7 +475,7 @@ L 518.4 43.2
   </g>
  </g>
  <defs>
-  <clipPath id="p5833b729b6">
+  <clipPath id="p3a3c58397e">
    <path d="M 105.818182 331.2 
 L 241.090909 331.2 
 L 241.090909 100.8 
@@ -493,7 +493,7 @@ C 197.367611 256.729351 191.025792 267.530901 182.423232 273.6
 z
 "/>
   </clipPath>
-  <clipPath id="p6741698e5c">
+  <clipPath id="p0b645584cb">
    <path d="M 349.309091 331.2 
 L 484.581818 331.2 
 L 484.581818 100.8 
@@ -513,7 +513,7 @@ z
   </clipPath>
  </defs>
  <defs>
-  <pattern height="72" id="h3d2475b8ea" patternUnits="userSpaceOnUse" width="72" x="0" y="0">
+  <pattern height="72" id="h95f2a3a954" patternUnits="userSpaceOnUse" width="72" x="0" y="0">
    <rect fill="#ff0000" height="73" width="73" x="0" y="0"/>
    <path d="M 0 68 
 L -1.175571 70.381966 
@@ -1021,7 +1021,7 @@ L 73.902113 0.618034
 L 75.804226 -1.236068 
 L 73.175571 -1.618034 
 L 72 -4 
-" style="fill:#0000ff;stroke:#0000ff;stroke-linecap:butt;stroke-linejoin:miter;stroke-width:1.0;"/>
+" style="fill:#0000ff;stroke:#0000ff;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.7;stroke-width:1.0;"/>
   </pattern>
  </defs>
 </svg>


### PR DESCRIPTION
## PR Summary
Partially addresses #16883 

Adds `stroke-opacity` to hatch, but only if it's set to anything less than 1.

Unsure if it warrants a new figure for test comparison (svgs are small, though). Alternatively, could be tested against the PNG output, which is correct now (but may miss future simultaneous breakage).

## PR Checklist

- [x] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way


