### PR TITLE
Robustify `AffineBase.__eq__` against comparing to other classes.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1685,8 +1685,7 @@ class TransformWrapper(Transform):
 
 class AffineBase(Transform):
     """
-    The base class of all affine transformations of any number of
-    dimensions.
+    The base class of all affine transformations of any number of dimensions.
     """
     is_affine = True
 
@@ -1699,7 +1698,7 @@ class AffineBase(Transform):
         return self.get_matrix()
 
     def __eq__(self, other):
-        if getattr(other, "is_affine", False):
+        if getattr(other, "is_affine", False) and hasattr(other, "get_matrix"):
             return np.all(self.get_matrix() == other.get_matrix())
         return NotImplemented
 


### PR DESCRIPTION
We already check whether `other` has an is_affine attribute, so we may
as well check whether it has a `get_matrix`.

Spun out of https://github.com/matplotlib/matplotlib/pull/14725#discussion_r304236904.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
