### PR TITLE
Remove optional returns from TriAnalyzer._get_compressed_triangulation.

### DIFF
--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -398,7 +398,7 @@ class CubicTriInterpolator(TriInterpolator):
         #    (used) node numbering.
         tri_analyzer = TriAnalyzer(self._triangulation)
         (compressed_triangles, compressed_x, compressed_y, tri_renum,
-         node_renum) = tri_analyzer._get_compressed_triangulation(True, True)
+         node_renum) = tri_analyzer._get_compressed_triangulation()
         self._triangles = compressed_triangles
         self._tri_renum = tri_renum
         # Taking into account the node renumbering in self._z:

--- a/lib/matplotlib/tri/tritools.py
+++ b/lib/matplotlib/tri/tritools.py
@@ -190,25 +190,13 @@ class TriAnalyzer:
 
         return np.ma.filled(current_mask, True)
 
-    def _get_compressed_triangulation(self, return_tri_renum=False,
-                                      return_node_renum=False):
+    def _get_compressed_triangulation(self):
         """
         Compress (if masked) the encapsulated triangulation.
 
         Returns minimal-length triangles array (*compressed_triangles*) and
         coordinates arrays (*compressed_x*, *compressed_y*) that can still
         describe the unmasked triangles of the encapsulated triangulation.
-
-        Parameters
-        ----------
-        return_tri_renum : bool, default: False
-            Indicates whether a renumbering table to translate the triangle
-            numbers from the encapsulated triangulation numbering into the
-            new (compressed) renumbering will be returned.
-        return_node_renum : bool, default: False
-            Indicates whether a renumbering table to translate the nodes
-            numbers from the encapsulated triangulation numbering into the
-            new (compressed) renumbering will be returned.
 
         Returns
         -------
@@ -222,12 +210,11 @@ class TriAnalyzer:
             renumbering table to translate the triangle numbers from the
             encapsulated triangulation into the new (compressed) renumbering.
             -1 for masked triangles (deleted from *compressed_triangles*).
-            Returned only if *return_tri_renum* is True.
         node_renum : int array
             renumbering table to translate the point numbers from the
             encapsulated triangulation into the new (compressed) renumbering.
             -1 for unused points (i.e. those deleted from *compressed_x* and
-            *compressed_y*). Returned only if *return_node_renum* is True.
+            *compressed_y*).
 
         """
         # Valid triangles and renumbering
@@ -246,20 +233,8 @@ class TriAnalyzer:
         # Now renumbering the valid triangles nodes
         compressed_triangles = node_renum[compressed_triangles]
 
-        # 4 cases possible for return
-        if not return_tri_renum:
-            if not return_node_renum:
-                return compressed_triangles, compressed_x, compressed_y
-            else:
-                return (compressed_triangles, compressed_x, compressed_y,
-                        node_renum)
-        else:
-            if not return_node_renum:
-                return (compressed_triangles, compressed_x, compressed_y,
-                        tri_renum)
-            else:
-                return (compressed_triangles, compressed_x, compressed_y,
-                        tri_renum, node_renum)
+        return (compressed_triangles, compressed_x, compressed_y, tri_renum,
+                node_renum)
 
     @staticmethod
     def _total_to_compress_renum(mask, n=None):


### PR DESCRIPTION
## PR Summary

It's only ever called once with `(True, True)`, and is not public, so drop the options to not return stuff.

## PR Checklist

- [?] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way