### PR TITLE
Shorten implementation of Axes methods that just wrap Axis methods.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -422,3 +422,7 @@ Setting the *orientation* of an ``eventplot()`` or `.EventCollection` to "none"
 or None is deprecated; set it to "horizontal" instead.  Moreover, the two
 orientations ("horizontal" and "vertical") will become case-sensitive in the
 future.
+
+*minor* kwarg to `.Axis.get_ticklocs` will become keyword-only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing this argument positionally is deprecated.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from contextlib import ExitStack
+import functools
 import itertools
 import logging
 import math
@@ -27,6 +28,37 @@ import matplotlib.image as mimage
 from matplotlib.rcsetup import cycler, validate_axisbelow
 
 _log = logging.getLogger(__name__)
+
+
+def _axis_method_wrapper(attr_name, method_name):
+    """
+    Helper to generate Axes methods wrapping Axis methods.
+
+    After ::
+
+        get_foo = _axis_method_wrapper("xaxis", "get_bar")
+
+    ``get_foo`` is a method that forwards it arguments to the ``get_bar``
+    method of the ``xaxis`` attribute, and gets its signature and docstring
+    from ``Axis.get_bar``.
+    """
+
+    method = getattr(maxis.Axis, method_name)
+    get_method = attrgetter(f"{attr_name}.{method_name}")
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        return get_method(self)(*args, **kwargs)
+
+    if wrapper.__doc__:
+        assert "this Axis" in wrapper.__doc__, \
+            (f"The docstring of wrapped Axis methods must contain "
+             f"'this Axis' as a substring, but this is not the case for "
+             f"{method_name}")
+        wrapper.__doc__ = wrapper.__doc__.replace(
+            "this Axis", f"the {attr_name}", 1)
+
+    return wrapper
 
 
 def _process_plot_format(fmt):
@@ -1761,25 +1793,14 @@ class _AxesBase(martist.Artist):
         """Return the XAxis instance."""
         return self.xaxis
 
-    def get_xgridlines(self):
-        """Get the x grid lines as a list of `.Line2D` instances."""
-        return self.xaxis.get_gridlines()
-
-    def get_xticklines(self):
-        """Get the x tick lines as a list of `.Line2D` instances."""
-        return self.xaxis.get_ticklines()
-
     def get_yaxis(self):
         """Return the YAxis instance."""
         return self.yaxis
 
-    def get_ygridlines(self):
-        """Get the y grid lines as a list of `.Line2D` instances."""
-        return self.yaxis.get_gridlines()
-
-    def get_yticklines(self):
-        """Get the y tick lines as a list of `.Line2D` instances."""
-        return self.yaxis.get_ticklines()
+    get_xgridlines = _axis_method_wrapper("xaxis", "get_gridlines")
+    get_xticklines = _axis_method_wrapper("xaxis", "get_ticklines")
+    get_ygridlines = _axis_method_wrapper("yaxis", "get_gridlines")
+    get_yticklines = _axis_method_wrapper("yaxis", "get_ticklines")
 
     # Adding and tracking artists
 
@@ -3065,19 +3086,7 @@ class _AxesBase(martist.Artist):
         """
         self.xaxis.set_inverted(not self.xaxis.get_inverted())
 
-    def xaxis_inverted(self):
-        """
-        Return whether the x-axis is inverted.
-
-        The axis is inverted if the left value is larger than the right value.
-
-        See Also
-        --------
-        invert_xaxis
-        get_xlim, set_xlim
-        get_xbound, set_xbound
-        """
-        return self.xaxis.get_inverted()
+    xaxis_inverted = _axis_method_wrapper("xaxis", "get_inverted")
 
     def get_xbound(self):
         """
@@ -3301,15 +3310,7 @@ class _AxesBase(martist.Artist):
         self.stale = True
         return left, right
 
-    def get_xscale(self):
-        """
-        Return the x-axis scale as string.
-
-        See Also
-        --------
-        set_xscale
-        """
-        return self.xaxis.get_scale()
+    get_xscale = _axis_method_wrapper("xaxis", "get_scale")
 
     def set_xscale(self, value, **kwargs):
         """
@@ -3350,77 +3351,11 @@ class _AxesBase(martist.Artist):
             # nonsingular() before it possibly gets swapped out by the user.
             self.autoscale_view(scaley=False)
 
-    @cbook._make_keyword_only("3.2", "minor")
-    def get_xticks(self, minor=False):
-        """Return the x ticks as a list of locations"""
-        return self.xaxis.get_ticklocs(minor=minor)
-
-    @cbook._make_keyword_only("3.2", "minor")
-    def set_xticks(self, ticks, minor=False):
-        """
-        Set the x ticks with list of *ticks*
-
-        Parameters
-        ----------
-        ticks : list
-            List of x-axis tick locations.
-        minor : bool, default: False
-            If ``False`` sets major ticks, if ``True`` sets minor ticks.
-        """
-        ret = self.xaxis.set_ticks(ticks, minor=minor)
-        self.stale = True
-        return ret
-
-    def get_xmajorticklabels(self):
-        """
-        Get the major x tick labels.
-
-        Returns
-        -------
-        list
-            List of `~matplotlib.text.Text` instances
-        """
-        return self.xaxis.get_majorticklabels()
-
-    def get_xminorticklabels(self):
-        """
-        Get the minor x tick labels.
-
-        Returns
-        -------
-        list
-            List of `~matplotlib.text.Text` instances
-        """
-        return self.xaxis.get_minorticklabels()
-
-    def get_xticklabels(self, minor=False, which=None):
-        """
-        Get the x tick labels as a list of `~matplotlib.text.Text` instances.
-
-        Parameters
-        ----------
-        minor : bool, optional
-           If True return the minor ticklabels,
-           else return the major ticklabels.
-
-        which : None, ('minor', 'major', 'both')
-           Overrides *minor*.
-
-           Selects which ticklabels to return
-
-        Returns
-        -------
-        list
-           List of `~matplotlib.text.Text` instances.
-
-        Notes
-        -----
-        The tick label strings are not populated until a ``draw``
-        method has been called.
-
-        See also: `~.pyplot.draw` and `~.FigureCanvasBase.draw`.
-        """
-        return self.xaxis.get_ticklabels(minor=minor, which=which)
+    get_xticks = _axis_method_wrapper("xaxis", "get_ticklocs")
+    set_xticks = _axis_method_wrapper("xaxis", "set_ticks")
+    get_xmajorticklabels = _axis_method_wrapper("xaxis", "get_majorticklabels")
+    get_xminorticklabels = _axis_method_wrapper("xaxis", "get_minorticklabels")
+    get_xticklabels = _axis_method_wrapper("xaxis", "get_ticklabels")
 
     @cbook._make_keyword_only("3.3", "fontdict")
     def set_xticklabels(self, labels, fontdict=None, minor=False, **kwargs):
@@ -3477,19 +3412,7 @@ class _AxesBase(martist.Artist):
         """
         self.yaxis.set_inverted(not self.yaxis.get_inverted())
 
-    def yaxis_inverted(self):
-        """
-        Return whether the y-axis is inverted.
-
-        The axis is inverted if the bottom value is larger than the top value.
-
-        See Also
-        --------
-        invert_yaxis
-        get_ylim, set_ylim
-        get_ybound, set_ybound
-        """
-        return self.yaxis.get_inverted()
+    yaxis_inverted = _axis_method_wrapper("yaxis", "get_inverted")
 
     def get_ybound(self):
         """
@@ -3696,15 +3619,7 @@ class _AxesBase(martist.Artist):
         self.stale = True
         return bottom, top
 
-    def get_yscale(self):
-        """
-        Return the y-axis scale as string.
-
-        See Also
-        --------
-        set_yscale
-        """
-        return self.yaxis.get_scale()
+    get_yscale = _axis_method_wrapper("yaxis", "get_scale")
 
     def set_yscale(self, value, **kwargs):
         """
@@ -3745,76 +3660,11 @@ class _AxesBase(martist.Artist):
             # nonsingular() before it possibly gets swapped out by the user.
             self.autoscale_view(scalex=False)
 
-    @cbook._make_keyword_only("3.2", "minor")
-    def get_yticks(self, minor=False):
-        """Return the y ticks as a list of locations"""
-        return self.yaxis.get_ticklocs(minor=minor)
-
-    @cbook._make_keyword_only("3.2", "minor")
-    def set_yticks(self, ticks, minor=False):
-        """
-        Set the y ticks with list of *ticks*
-
-        Parameters
-        ----------
-        ticks : list
-            List of y-axis tick locations
-        minor : bool, default: False
-            If ``False`` sets major ticks, if ``True`` sets minor ticks.
-        """
-        ret = self.yaxis.set_ticks(ticks, minor=minor)
-        return ret
-
-    def get_ymajorticklabels(self):
-        """
-        Get the major y tick labels.
-
-        Returns
-        -------
-        list
-            List of `~matplotlib.text.Text` instances
-        """
-        return self.yaxis.get_majorticklabels()
-
-    def get_yminorticklabels(self):
-        """
-        Get the minor y tick labels.
-
-        Returns
-        -------
-        list
-            List of `~matplotlib.text.Text` instances
-        """
-        return self.yaxis.get_minorticklabels()
-
-    def get_yticklabels(self, minor=False, which=None):
-        """
-        Get the y tick labels as a list of `~matplotlib.text.Text` instances.
-
-        Parameters
-        ----------
-        minor : bool
-           If True return the minor ticklabels,
-           else return the major ticklabels
-
-        which : None, ('minor', 'major', 'both')
-           Overrides *minor*.
-
-           Selects which ticklabels to return
-
-        Returns
-        -------
-        list
-           List of `~matplotlib.text.Text` instances.
-
-        Notes
-        -----
-        The tick label strings are not populated until a ``draw``
-        method has been called.
-
-        See also: `~.pyplot.draw` and `~.FigureCanvasBase.draw`.
-        """
-        return self.yaxis.get_ticklabels(minor=minor, which=which)
+    get_yticks = _axis_method_wrapper("yaxis", "get_ticklocs")
+    set_yticks = _axis_method_wrapper("yaxis", "set_ticks")
+    get_ymajorticklabels = _axis_method_wrapper("yaxis", "get_majorticklabels")
+    get_yminorticklabels = _axis_method_wrapper("yaxis", "get_minorticklabels")
+    get_yticklabels = _axis_method_wrapper("yaxis", "get_ticklabels")
 
     @cbook._make_keyword_only("3.3", "fontdict")
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from contextlib import ExitStack
 import functools
+import inspect
 import itertools
 import logging
 import math
@@ -44,7 +45,8 @@ def _axis_method_wrapper(attr_name, method_name, *, doc_sub=None):
 
     The docstring of ``get_foo`` is built by replacing "this Axis" by "the
     {attr_name}" ("the xaxis", "the yaxis") in the wrapped method's docstring;
-    additional replacements can by given in *doc_sub*.
+    additional replacements can by given in *doc_sub*.  The docstring is also
+    dedented to simplify further manipulations.
     """
 
     method = getattr(maxis.Axis, method_name)
@@ -62,7 +64,7 @@ def _axis_method_wrapper(attr_name, method_name, *, doc_sub=None):
                 (f"The docstring of wrapped Axis method {method_name!r} must "
                  f"contain {k!r} as a substring.")
             doc = doc.replace(k, v)
-        wrapper.__doc__ = doc
+        wrapper.__doc__ = inspect.cleandoc(doc)
 
     return wrapper
 
@@ -3635,29 +3637,8 @@ class _AxesBase(martist.Artist):
         "yaxis", "_set_ticklabels",
         doc_sub={"Axis.set_ticks": "Axes.set_yticks"})
 
-    def xaxis_date(self, tz=None):
-        """
-        Sets up x-axis ticks and labels that treat the x data as dates.
-
-        Parameters
-        ----------
-        tz : str or `datetime.tzinfo`, default: :rc:`timezone`
-            Timezone.
-        """
-        # should be enough to inform the unit conversion interface
-        # dates are coming in
-        self.xaxis.axis_date(tz)
-
-    def yaxis_date(self, tz=None):
-        """
-        Sets up y-axis ticks and labels that treat the y data as dates.
-
-        Parameters
-        ----------
-        tz : str or `datetime.tzinfo`, default: :rc:`timezone`
-            Timezone.
-        """
-        self.yaxis.axis_date(tz)
+    xaxis_date = _axis_method_wrapper("xaxis", "axis_date")
+    yaxis_date = _axis_method_wrapper("yaxis", "axis_date")
 
     def format_xdata(self, x):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1647,6 +1647,48 @@ class Axis(martist.Artist):
         self.stale = True
         return ret
 
+    # Wrapper around set_ticklabels used to generate Axes.set_x/ytickabels; can
+    # go away once the API of Axes.set_x/yticklabels becomes consistent.
+    @cbook._make_keyword_only("3.3", "fontdict")
+    def _set_ticklabels(self, labels, fontdict=None, minor=False, **kwargs):
+        """
+        Set this Axis' labels with list of string labels.
+
+        .. warning::
+            This method should only be used after fixing the tick positions
+            using `.Axis.set_ticks`. Otherwise, the labels may end up in
+            unexpected positions.
+
+        Parameters
+        ----------
+        labels : list of str
+            The label texts.
+
+        fontdict : dict, optional
+            A dictionary controlling the appearance of the ticklabels.
+            The default *fontdict* is::
+
+               {'fontsize': rcParams['axes.titlesize'],
+                'fontweight': rcParams['axes.titleweight'],
+                'verticalalignment': 'baseline',
+                'horizontalalignment': loc}
+
+        minor : bool, default: False
+            Whether to set the minor ticklabels rather than the major ones.
+
+        Returns
+        -------
+        list of `~.Text`
+            The labels.
+
+        Other Parameters
+        ----------------
+        **kwargs : `~.text.Text` properties.
+        """
+        if fontdict is not None:
+            kwargs.update(fontdict)
+        return self.set_ticklabels(labels, minor=minor, **kwargs)
+
     @cbook._make_keyword_only("3.2", "minor")
     def set_ticks(self, ticks, minor=False):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1752,11 +1752,11 @@ class Axis(martist.Artist):
 
     def axis_date(self, tz=None):
         """
-        Sets up axis ticks and labels treating data along this axis as dates.
+        Sets up axis ticks and labels to treat data along this Axis as dates.
 
         Parameters
         ----------
-        tz : tzinfo or str or None
+        tz : str or `datetime.tzinfo`, default: :rc:`timezone`
             The timezone used to create date labels.
         """
         # By providing a sample datetime instance with the desired timezone,

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -732,6 +732,7 @@ class Axis(martist.Artist):
         return self._scale.get_transform()
 
     def get_scale(self):
+        """Return this Axis' scale (as a str)."""
         return self._scale.name
 
     def _set_scale(self, value, **kwargs):
@@ -924,7 +925,7 @@ class Axis(martist.Artist):
 
     def get_inverted(self):
         """
-        Return whether the axis is oriented in the "inverse" direction.
+        Return whether this Axis is oriented in the "inverse" direction.
 
         The "normal" direction is increasing to the right for the x-axis and to
         the top for the y-axis; the "inverse" direction is increasing to the
@@ -935,7 +936,7 @@ class Axis(martist.Artist):
 
     def set_inverted(self, inverted):
         """
-        Set whether the axis is oriented in the "inverse" direction.
+        Set whether this Axis is oriented in the "inverse" direction.
 
         The "normal" direction is increasing to the right for the x-axis and to
         the top for the y-axis; the "inverse" direction is increasing to the
@@ -1149,7 +1150,7 @@ class Axis(martist.Artist):
         self.stale = False
 
     def get_gridlines(self):
-        """Return the grid lines as a list of Line2D instance."""
+        r"""Return this Axis' grid lines as a list of `.Line2D`\s."""
         ticks = self.get_major_ticks()
         return cbook.silent_list('Line2D gridline',
                                  [tick.gridline for tick in ticks])
@@ -1167,14 +1168,14 @@ class Axis(martist.Artist):
         return self.pickradius
 
     def get_majorticklabels(self):
-        """Return a list of Text instances for the major ticklabels."""
+        """Return this Axis' major tick labels, as a list of `~.text.Text`."""
         ticks = self.get_major_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]
         return cbook.silent_list('Text major ticklabel', labels1 + labels2)
 
     def get_minorticklabels(self):
-        """Return a list of Text instances for the minor ticklabels."""
+        """Return this Axis' minor tick labels, as a list of `~.text.Text`."""
         ticks = self.get_minor_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]
@@ -1182,13 +1183,12 @@ class Axis(martist.Artist):
 
     def get_ticklabels(self, minor=False, which=None):
         """
-        Get the tick labels as a list of `~matplotlib.text.Text` instances.
+        Get this Axis' tick labels.
 
         Parameters
         ----------
         minor : bool
-           If True return the minor ticklabels,
-           else return the major ticklabels
+           Whether to return the minor or the major ticklabels.
 
         which : None, ('minor', 'major', 'both')
            Overrides *minor*.
@@ -1197,10 +1197,15 @@ class Axis(martist.Artist):
 
         Returns
         -------
-        list
-           List of `~matplotlib.text.Text` instances.
-        """
+        list of `~matplotlib.text.Text`
 
+        Notes
+        -----
+        The tick label strings are not populated until a ``draw`` method has
+        been called.
+
+        See also: `~.pyplot.draw` and `~.FigureCanvasBase.draw`.
+        """
         if which is not None:
             if which == 'minor':
                 return self.get_minorticklabels()
@@ -1215,7 +1220,7 @@ class Axis(martist.Artist):
         return self.get_majorticklabels()
 
     def get_majorticklines(self):
-        """Return the major tick lines as a list of Line2D instances."""
+        r"""Return this Axis' major tick lines as a list of `.Line2D`\s."""
         lines = []
         ticks = self.get_major_ticks()
         for tick in ticks:
@@ -1224,7 +1229,7 @@ class Axis(martist.Artist):
         return cbook.silent_list('Line2D ticklines', lines)
 
     def get_minorticklines(self):
-        """Return the minor tick lines as a list of Line2D instances."""
+        r"""Return this Axis' minor tick lines as a list of `.Line2D`\s."""
         lines = []
         ticks = self.get_minor_ticks()
         for tick in ticks:
@@ -1233,17 +1238,17 @@ class Axis(martist.Artist):
         return cbook.silent_list('Line2D ticklines', lines)
 
     def get_ticklines(self, minor=False):
-        """Return the tick lines as a list of Line2D instances."""
+        r"""Return this Axis' tick lines as a list of `.Line2D`\s."""
         if minor:
             return self.get_minorticklines()
         return self.get_majorticklines()
 
     def get_majorticklocs(self):
-        """Get the array of major tick locations in data coordinates."""
+        """Return this Axis' major tick locations in data coordinates."""
         return self.major.locator()
 
     def get_minorticklocs(self):
-        """Get the array of minor tick locations in data coordinates."""
+        """Return this Axis' minor tick locations in data coordinates."""
         # Remove minor ticks duplicating major ticks.
         major_locs = self.major.locator()
         minor_locs = self.minor.locator()
@@ -1260,8 +1265,9 @@ class Axis(martist.Artist):
                 if ~np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any()]
         return minor_locs
 
+    @cbook._make_keyword_only("3.3", "minor")
     def get_ticklocs(self, minor=False):
-        """Get the array of tick locations in data coordinates."""
+        """Return this Axis' tick locations in data coordinates."""
         return self.get_minorticklocs() if minor else self.get_majorticklocs()
 
     def get_ticks_direction(self, minor=False):
@@ -1644,12 +1650,14 @@ class Axis(martist.Artist):
     @cbook._make_keyword_only("3.2", "minor")
     def set_ticks(self, ticks, minor=False):
         """
-        Set the locations of the tick marks from sequence ticks
+        Set this Axis' tick locations.
 
         Parameters
         ----------
-        ticks : sequence of floats
-        minor : bool
+        ticks : list of floats
+            List of tick locations.
+        minor : bool, default: False
+            If ``False``, set the major ticks; if ``True``, the minor ticks.
         """
         # XXX if the user changes units, the information will be lost here
         ticks = self.convert_units(ticks)
@@ -1659,6 +1667,7 @@ class Axis(martist.Artist):
                 self.set_view_interval(min(ticks), max(ticks))
             else:
                 self.set_view_interval(max(ticks), min(ticks))
+        self.axes.stale = True
         if minor:
             self.set_minor_locator(mticker.FixedLocator(ticks))
             return self.get_minor_ticks(len(ticks))

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -13,6 +13,7 @@ Module containing Axes3D, an object which can plot 3D objects on a
 from collections import defaultdict
 from functools import reduce
 import math
+import textwrap
 
 import numpy as np
 
@@ -827,23 +828,15 @@ class Axes3D(Axes):
         "zaxis", "_set_ticklabels",
         doc_sub={"Axis.set_ticks": "Axes.set_zticks"})
 
-    def zaxis_date(self, tz=None):
-        """
-        Sets up z-axis ticks and labels that treat the z data as dates.
+    zaxis_date = _axis_method_wrapper("zaxis", "axis_date")
+    if zaxis_date.__doc__:
+        zaxis_date.__doc__ += textwrap.dedent("""
 
-        .. note::
-            This function is merely provided for completeness.
-            Axes3D objects do not officially support dates for ticks,
-            and so this may or may not work as expected.
-
-        .. versionadded:: 1.1.0
-            This function was added, but not tested. Please report any bugs.
-
-        Parameters
-        ----------
-        tz : `datetime.tzinfo`, default: :rc:`timezone`
-        """
-        self.zaxis.axis_date(tz)
+        Notes
+        -----
+        This function is merely provided for completeness, but 3d axes do not
+        support dates for ticks, and so this may not work as expected.
+        """)
 
     def clabel(self, *args, **kwargs):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -823,15 +823,9 @@ class Axes3D(Axes):
     get_zmajorticklabels = _axis_method_wrapper("zaxis", "get_majorticklabels")
     get_zminorticklabels = _axis_method_wrapper("zaxis", "get_minorticklabels")
     get_zticklabels = _axis_method_wrapper("zaxis", "get_ticklabels")
-
-    def set_zticklabels(self, *args, **kwargs):
-        """
-        Set z-axis tick labels.
-        See :meth:`matplotlib.axes.Axes.set_yticklabels` for more details.
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.set_ticklabels(*args, **kwargs)
+    set_zticklabels = _axis_method_wrapper(
+        "zaxis", "_set_ticklabels",
+        doc_sub={"Axis.set_ticks": "Axes.set_zticks"})
 
     def zaxis_date(self, tz=None):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -24,6 +24,7 @@ import matplotlib.colors as mcolors
 import matplotlib.docstring as docstring
 import matplotlib.scale as mscale
 from matplotlib.axes import Axes, rcParams
+from matplotlib.axes._base import _axis_method_wrapper
 from matplotlib.transforms import Bbox
 from matplotlib.tri.triangulation import Triangulation
 
@@ -201,6 +202,9 @@ class Axes3D(Axes):
     def get_zaxis(self):
         """Return the ``ZAxis`` (`~.axis3d.Axis`) instance."""
         return self.zaxis
+
+    get_zgridlines = _axis_method_wrapper("zaxis", "get_gridlines")
+    get_zticklines = _axis_method_wrapper("zaxis", "get_ticklines")
 
     @cbook.deprecated("3.1", alternative="xaxis", pending=True)
     @property
@@ -814,40 +818,11 @@ class Axes3D(Axes):
         """.format,
         ["x", "y", "z"])
 
-    def set_zticks(self, *args, **kwargs):
-        """
-        Set z-axis tick locations.
-        See :meth:`matplotlib.axes.Axes.set_yticks` for more details.
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.set_ticks(*args, **kwargs)
-
-    @cbook._make_keyword_only("3.2", "minor")
-    def get_zticks(self, minor=False):
-        """
-        Return the z ticks as a list of locations
-        See :meth:`matplotlib.axes.Axes.get_yticks` for more details.
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.get_ticklocs(minor=minor)
-
-    def get_zmajorticklabels(self):
-        """
-        Get the ztick labels as a list of Text instances
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.get_majorticklabels()
-
-    def get_zminorticklabels(self):
-        """
-        Get the ztick labels as a list of Text instances
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.get_minorticklabels()
+    get_zticks = _axis_method_wrapper("zaxis", "get_ticklocs")
+    set_zticks = _axis_method_wrapper("zaxis", "set_ticks")
+    get_zmajorticklabels = _axis_method_wrapper("zaxis", "get_majorticklabels")
+    get_zminorticklabels = _axis_method_wrapper("zaxis", "get_minorticklabels")
+    get_zticklabels = _axis_method_wrapper("zaxis", "get_ticklabels")
 
     def set_zticklabels(self, *args, **kwargs):
         """
@@ -857,15 +832,6 @@ class Axes3D(Axes):
         .. versionadded:: 1.1.0
         """
         return self.zaxis.set_ticklabels(*args, **kwargs)
-
-    def get_zticklabels(self, minor=False):
-        """
-        Get ztick labels as a list of Text instances.
-        See :meth:`matplotlib.axes.Axes.get_yticklabels` for more details.
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.get_ticklabels(minor=minor)
 
     def zaxis_date(self, tz=None):
         """
@@ -884,16 +850,6 @@ class Axes3D(Axes):
         tz : `datetime.tzinfo`, default: :rc:`timezone`
         """
         self.zaxis.axis_date(tz)
-
-    def get_zticklines(self):
-        """
-        Get ztick lines as a list of Line2D instances.
-        Note that this function is provided merely for completeness.
-        These lines are re-calculated as the display changes.
-
-        .. versionadded:: 1.1.0
-        """
-        return self.zaxis.get_ticklines()
 
     def clabel(self, *args, **kwargs):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -826,7 +826,7 @@ class Axes3D(Axes):
     get_zticklabels = _axis_method_wrapper("zaxis", "get_ticklabels")
     set_zticklabels = _axis_method_wrapper(
         "zaxis", "_set_ticklabels",
-        doc_sub={"Axis.set_ticks": "Axes.set_zticks"})
+        doc_sub={"Axis.set_ticks": "Axes3D.set_zticks"})
 
     zaxis_date = _axis_method_wrapper("zaxis", "axis_date")
     if zaxis_date.__doc__:


### PR DESCRIPTION
... by autogenerating wrappers that forward to the Axis methods.

Admittedly docstring search/replace is a bit ugly, but this has to be
compared with having 4 copies of the docstrings for each method (Axis,
xaxis, yaxis, zaxis) each to be kept in sync.

(As an anecdote, the ability to do this templatization for mplot3d was what originally motivated me to check whether minor ticks could easily be fixed for 3d axes...)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
