### PR TITLE
Turn fontdict & minor into kwonly parameters for set_{x,y}ticklabels.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -395,3 +395,6 @@ This method is deprecated.  Use the ``GridSpec.nrows``, ``GridSpec.ncols``,
 Qt4-based backends
 ~~~~~~~~~~~~~~~~~~
 The qt4agg and qt4cairo backends are deprecated.
+
+*fontdict* and *minor* parameters of `.Axes.set_xticklabels` and `.Axes.set_yticklabels` will become keyword-only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3422,6 +3422,7 @@ class _AxesBase(martist.Artist):
         """
         return self.xaxis.get_ticklabels(minor=minor, which=which)
 
+    @cbook._make_keyword_only("3.3", "fontdict")
     def set_xticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
         Set the x-tick labels with list of string labels.
@@ -3815,6 +3816,7 @@ class _AxesBase(martist.Artist):
         """
         return self.yaxis.get_ticklabels(minor=minor, which=which)
 
+    @cbook._make_keyword_only("3.3", "fontdict")
     def set_yticklabels(self, labels, fontdict=None, minor=False, **kwargs):
         """
         Set the y-tick labels with list of string labels.


### PR DESCRIPTION
This is consistent with the general trend of making "minor" a kwonly
param, and will help in making set_{x,y}ticklabels just a thin wrapper
around Axis.set_ticklabels (#16903).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
