### PR TITLE
update FAQ on how to register pandas converters

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -21,20 +21,12 @@ Plot `numpy.datetime64` values
 As of Matplotlib 2.2, `numpy.datetime64` objects are handled the same way
 as `datetime.datetime` objects.
 
-If you prefer the pandas converters and locators, you can register their
-converter with the `matplotlib.units` module::
+If you prefer the pandas converters and locators, you can register them.  This
+is done automatically when calling a pandas plot function and may be
+unnecessary when using pandas instead of Matplotlib directly. ::
 
-  from pandas.tseries import converter as pdtc
-  pdtc.register()
-
-If you only want to use the `pandas` converter for `numpy.datetime64` values ::
-
-  from pandas.tseries import converter as pdtc
-  import matplotlib.units as munits
-  import numpy as np
-
-  munits.registry[np.datetime64] = pdtc.DatetimeConverter()
-
+  from pandas.plotting import register_matplotlib_converters
+  register_matplotlib_converters()
 
 
 .. _howto-figure-empty:


### PR DESCRIPTION
## PR Summary

`pandas.tseries.converter` no longer exists, and the individual converters are not part of the public API so this change updates the documentation to reflect how to properly register the pandas converters with matplotlib.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way