### PR TITLE
Fix use of psfrags in ps backend + usetex.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1098,18 +1098,20 @@ def convert_psfrags(tmpfile, psfrags, font_preamble, custom_preamble,
     with mpl.rc_context({
             "text.latex.preamble":
             mpl.rcParams["text.latex.preamble"] +
-            r"\usepackage{psfrag,color}"
-            r"\usepackage[dvips]{graphicx}"
-            r"\PassOptionsToPackage{dvips}{geometry}"}):
+            r"\usepackage{psfrag,color}""\n"
+            r"\usepackage[dvips]{graphicx}""\n"
+            r"\geometry{papersize={%(width)sin,%(height)sin},"
+            r"body={%(width)sin,%(height)sin},margin=0in}"
+            % {"width": paper_width, "height": paper_height}
+    }):
         dvifile = TexManager().make_dvi(
-            r"\newgeometry{papersize={%(width)sin,%(height)sin},"
-            r"body={%(width)sin,%(height)sin}, margin={0in,0in}}""\n"
-            r"\begin{figure}"
-            r"\centering\leavevmode%(psfrags)s"
-            r"\includegraphics*[angle=%(angle)s]{%(epsfile)s}"
+            "\n"
+            r"\begin{figure}""\n"
+            r"  \centering\leavevmode""\n"
+            r"  %(psfrags)s""\n"
+            r"  \includegraphics*[angle=%(angle)s]{%(epsfile)s}""\n"
             r"\end{figure}"
             % {
-                "width": paper_width, "height": paper_height,
                 "psfrags": "\n".join(psfrags),
                 "angle": 90 if orientation == 'landscape' else 0,
                 "epsfile": pathlib.Path(tmpfile).resolve().as_posix(),

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -186,6 +186,9 @@ class TexManager:
             self._font_preamble,
             r"\usepackage[utf8]{inputenc}",
             r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
+            # Needs to come early so that the custom preamble can change the
+            # geometry, e.g. in convert_psfrags.
+            r"\usepackage[papersize=72in,body=70in,margin=1in]{geometry}",
             self.get_custom_preamble(),
         ])
 
@@ -204,7 +207,6 @@ class TexManager:
         Path(texfile).write_text(
             r"""
 %s
-\usepackage[papersize={72in,72in},body={70in,70in},margin={1in,1in}]{geometry}
 \pagestyle{empty}
 \begin{document}
 \fontsize{%f}{%f}%s
@@ -239,7 +241,6 @@ class TexManager:
             r"""
 %s
 \usepackage[active,showbox,tightpage]{preview}
-\usepackage[papersize={72in,72in},body={70in,70in},margin={1in,1in}]{geometry}
 
 %% we override the default showbox as it is treated as an error and makes
 %% the exit status not zero


### PR DESCRIPTION
Looks like psfrags interacts badly with `\newgeometry`, so we need to
use `\geometry` instead in the custom preamble to set the paper size.

In turn this means that `\usepackage{geometry}` needs to move to before
the custom preamble into `TexManager._get_preamble()`, and thus we
can't pass the dvips option to it anymore, but fortunately dvips is
documented as the default driver anyways (section 5.6 of `geometry`
docs).  Also, in order to keep everything under 79 characters wide,
change `{72in,72in}` to just `72in` (which is synonymous per section
4.3.3 of `geometry` docs).

Also insert some extra newlines in the generated tex file for ease of
debugging.

Closes #16898; sorry I don't have a test for now.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
