### PR TITLE
Tighten/cleanup wx backend.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -398,3 +398,7 @@ The qt4agg and qt4cairo backends are deprecated.
 
 *fontdict* and *minor* parameters of `.Axes.set_xticklabels` and `.Axes.set_yticklabels` will become keyword-only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``RendererWx.get_gc``
+~~~~~~~~~~~~~~~~~~~~~
+This method is deprecated.  Access the ``gc`` attribute directly instead.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -56,9 +56,7 @@ IDLE_DELAY = 5  # Documented as deprecated as of Matplotlib 3.1.
 
 
 def error_msg_wx(msg, parent=None):
-    """
-    Signal an error condition -- in a GUI, popup a error dialog
-    """
+    """Signal an error condition with a popup error dialog."""
     dialog = wx.MessageDialog(parent=parent,
                               message=msg,
                               caption='Matplotlib backend_wx error',
@@ -240,7 +238,6 @@ class RendererWx(RendererBase):
             h = self.height
         rows, cols = im.shape[:2]
         bitmap = wx.Bitmap.FromBufferRGBA(cols, rows, im.tostring())
-        gc = self.get_gc()
         gc.select()
         gc.gfx_ctx.DrawBitmap(bitmap, int(l), int(self.height - b),
                               int(w), int(-h))
@@ -282,6 +279,7 @@ class RendererWx(RendererBase):
         self.gc.unselect()
         return self.gc
 
+    @cbook.deprecated("3.3", alternative=".gc")
     def get_gc(self):
         """
         Fetch the locally cached gc.
@@ -417,7 +415,7 @@ class GraphicsContextWx(GraphicsContextBase):
         self.unselect()
 
     def get_wxcolour(self, color):
-        """Convert the given RGB(A) color to a wx.Colour."""
+        """Convert a RGB(A) color to a wx.Colour."""
         _log.debug("%s - get_wx_color()", type(self))
         if len(color) == 3:
             r, g, b = color
@@ -914,14 +912,6 @@ class FigureCanvasWx(_FigureCanvasWxBase):
         self.Refresh()
 
 
-########################################################################
-#
-# The following functions and classes are for pylab compatibility
-# mode (matplotlib.pylab) and implement figure managers, etc...
-#
-########################################################################
-
-
 class FigureFrameWx(wx.Frame):
     def __init__(self, num, fig):
         # On non-Windows platform, explicitly set the position - fix
@@ -1047,7 +1037,6 @@ class FigureManagerWx(FigureManagerBase):
         a FigureCanvasWx(wx.Panel) instance
     window : wxFrame
         a wxFrame instance - wxpython.org/Phoenix/docs/html/Frame.html
-
     """
 
     def __init__(self, canvas, num, frame):
@@ -1060,12 +1049,14 @@ class FigureManagerWx(FigureManagerBase):
         self.toolbar = frame.GetToolBar()
 
     def show(self):
+        # docstring inherited
         self.frame.Show()
         self.canvas.draw()
         if mpl.rcParams['figure.raise_window']:
             self.frame.Raise()
 
     def destroy(self, *args):
+        # docstring inherited
         _log.debug("%s - destroy()", type(self))
         self.frame.Close()
         wxapp = wx.GetApp()
@@ -1073,13 +1064,15 @@ class FigureManagerWx(FigureManagerBase):
             wxapp.Yield()
 
     def get_window_title(self):
+        # docstring inherited
         return self.window.GetTitle()
 
     def set_window_title(self, title):
+        # docstring inherited
         self.window.SetTitle(title)
 
     def resize(self, width, height):
-        """Set the canvas size in pixels."""
+        # docstring inherited
         self.canvas.SetInitialSize(wx.Size(width, height))
         self.window.GetSizer().Fit(self.window)
 


### PR DESCRIPTION
- Deprecate get_gc, which doesn't exist in other backends, is just
  accessing the .gc attribute, and is not necessary anyways (draw_image
  gets the gc as argument, so doesn't need to get it separately).
- Inherit/cleanup more docstrings.
- Remove outdated comment.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
