### PR TITLE
Add test for close_event.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -367,6 +367,7 @@ class FigureManagerGTK3(FigureManagerBase):
 
         self.window.set_default_size(w, h)
 
+        self._destroying = False
         self.window.connect("destroy", lambda *args: Gcf.destroy(self))
         self.window.connect("delete_event", lambda *args: Gcf.destroy(self))
         if mpl.is_interactive():
@@ -376,6 +377,13 @@ class FigureManagerGTK3(FigureManagerBase):
         self.canvas.grab_focus()
 
     def destroy(self, *args):
+        if self._destroying:
+            # Otherwise, this can be called twice when the user presses 'q',
+            # which calls Gcf.destroy(self), then this destroy(), then triggers
+            # Gcf.destroy(self) once again via
+            # `connect("destroy", lambda *args: Gcf.destroy(self))`.
+            return
+        self._destroying = True
         self.vbox.destroy()
         self.window.destroy()
         self.canvas.destroy()

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1008,7 +1008,8 @@ class FigureFrameWx(wx.Frame):
         self.canvas.close_event()
         self.canvas.stop_event_loop()
         Gcf.destroy(self)
-        # self.Destroy()
+        if self:
+            self.Destroy()
 
     def GetToolBar(self):
         """Override wxFrame::GetToolBar as we don't have managed toolbar"""
@@ -1066,7 +1067,7 @@ class FigureManagerWx(FigureManagerBase):
 
     def destroy(self, *args):
         _log.debug("%s - destroy()", type(self))
-        self.frame.Destroy()
+        self.frame.Close()
         wxapp = wx.GetApp()
         if wxapp:
             wxapp.Yield()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -111,6 +111,7 @@ timer = fig.canvas.new_timer(1)
 timer.add_callback(FigureCanvasBase.key_press_event, fig.canvas, "q")
 # Trigger quitting upon draw.
 fig.canvas.mpl_connect("draw_event", lambda event: timer.start())
+fig.canvas.mpl_connect("close_event", print)
 
 plt.show()
 """
@@ -120,12 +121,14 @@ _test_timeout = 10  # Empirically, 1s is not enough on Travis.
 @pytest.mark.parametrize("backend", _get_testable_interactive_backends())
 @pytest.mark.flaky(reruns=3)
 def test_interactive_backend(backend):
-    proc = subprocess.run([sys.executable, "-c", _test_script],
-                          env={**os.environ, "MPLBACKEND": backend},
-                          timeout=_test_timeout)
+    proc = subprocess.run(
+        [sys.executable, "-c", _test_script],
+        env={**os.environ, "MPLBACKEND": backend}, timeout=_test_timeout,
+        stdout=subprocess.PIPE, universal_newlines=True)
     if proc.returncode:
         pytest.fail("The subprocess returned with non-zero exit status "
                     f"{proc.returncode}.")
+    assert proc.stdout.count("CloseEvent") == 1
 
 
 @pytest.mark.skipif('SYSTEM_TEAMFOUNDATIONCOLLECTIONURI' in os.environ,


### PR DESCRIPTION
Test that a single close_event is triggered when a window is closed.

This caught a bug in the gtk3 backends, which used to emit *two*
close_events (see comment there; a better fix would be welcome); and
another in the wx backends (which emit *no* close_events when the window
is closed by pressing "q" -- now fixed per https://github.com/matplotlib/matplotlib/issues/16919#issuecomment-604532327).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
