### PR TITLE
Remove unused _read_ppm_image from macosx.m.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -458,46 +458,6 @@ FigureCanvas_remove_rubberband(FigureCanvas* self)
     Py_RETURN_NONE;
 }
 
-static NSImage* _read_ppm_image(PyObject* obj)
-{
-    int width;
-    int height;
-    const char* data;
-    int n;
-    int i;
-    NSBitmapImageRep* bitmap;
-    unsigned char* bitmapdata;
-
-    if (!obj) return NULL;
-    if (!PyTuple_Check(obj)) return NULL;
-    if (!PyArg_ParseTuple(obj, "iit#", &width, &height, &data, &n)) return NULL;
-    if (width*height*3 != n) return NULL; /* RGB image uses 3 colors / pixel */
-
-    bitmap = [[NSBitmapImageRep alloc]
-                  initWithBitmapDataPlanes: NULL
-                                pixelsWide: width
-                                pixelsHigh: height
-                             bitsPerSample: 8
-                           samplesPerPixel: 3
-                                  hasAlpha: NO
-                                  isPlanar: NO
-                            colorSpaceName: NSDeviceRGBColorSpace
-                              bitmapFormat: 0
-                               bytesPerRow: width*3
-                               bitsPerPixel: 24];
-    if (!bitmap) return NULL;
-    bitmapdata = [bitmap bitmapData];
-    for (i = 0; i < n; i++) bitmapdata[i] = data[i];
-
-    NSSize size = NSMakeSize(width, height);
-    NSImage* image = [[NSImage alloc] initWithSize: size];
-    if (image) [image addRepresentation: bitmap];
-
-    [bitmap release];
-
-    return image;
-}
-
 static PyObject*
 FigureCanvas_start_event_loop(FigureCanvas* self, PyObject* args, PyObject* keywords)
 {


### PR DESCRIPTION
It's not used anywhere since d8a08bc

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
