### PR TITLE
update units.ConversionInterface to have `to_numeric` and `from_numeric`

### DIFF
--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -144,7 +144,9 @@ Units
    :toctree: _as_gen
    :nosignatures:
 
+   Artist.convert_x_to_numeric
    Artist.convert_xunits
+   Artist.convert_y_to_numeric
    Artist.convert_yunits
    Artist.have_units
 

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -424,7 +424,9 @@ Units
    :template: autosummary.rst
    :nosignatures:
 
+   Axes.convert_x_to_numeric
    Axes.convert_xunits
+   Axes.convert_y_to_numeric
    Axes.convert_yunits
    Axes.have_units
 

--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -159,6 +159,8 @@ Units
    :template: autosummary.rst
    :nosignatures:
 
+   Axis.convert_from_numeric
+   Axis.convert_to_numeric
    Axis.convert_units
    Axis.set_units
    Axis.get_units
@@ -330,6 +332,8 @@ XAxis
    XAxis.OFFSETTEXTPAD
    XAxis.axis_date
    XAxis.cla
+   XAxis.convert_from_numeric
+   XAxis.convert_to_numeric
    XAxis.convert_units
    XAxis.get_data_interval
    XAxis.get_gridlines
@@ -395,6 +399,8 @@ YAxis
    YAxis.OFFSETTEXTPAD
    YAxis.axis_date
    YAxis.cla
+   YAxis.convert_from_numeric
+   YAxis.convert_to_numeric
    YAxis.convert_units
    YAxis.get_data_interval
    YAxis.get_gridlines
@@ -464,7 +470,9 @@ Ticks
    Tick.add_callback
    Tick.axes
    Tick.contains
+   Tick.convert_x_to_numeric
    Tick.convert_xunits
+   Tick.convert_y_to_numeric
    Tick.convert_yunits
    Tick.draw
    Tick.findobj
@@ -529,7 +537,9 @@ Ticks
    XTick.add_callback
    XTick.axes
    XTick.contains
+   XTick.convert_x_to_numeric
    XTick.convert_xunits
+   XTick.convert_y_to_numeric
    XTick.convert_yunits
    XTick.draw
    XTick.findobj
@@ -594,7 +604,9 @@ Ticks
    YTick.add_callback
    YTick.axes
    YTick.contains
+   YTick.convert_x_to_numeric
    YTick.convert_xunits
+   YTick.convert_y_to_numeric
    YTick.convert_yunits
    YTick.draw
    YTick.findobj
@@ -669,7 +681,9 @@ Axis
    Axis.add_callback
    Axis.axes
    Axis.contains
+   Axis.convert_x_to_numeric
    Axis.convert_xunits
+   Axis.convert_y_to_numeric
    Axis.convert_yunits
    Axis.draw
    Axis.findobj
@@ -734,7 +748,9 @@ Axis
    XAxis.add_callback
    XAxis.axes
    XAxis.contains
+   XAxis.convert_x_to_numeric
    XAxis.convert_xunits
+   XAxis.convert_y_to_numeric
    XAxis.convert_yunits
    XAxis.draw
    XAxis.findobj
@@ -799,7 +815,9 @@ Axis
    YAxis.add_callback
    YAxis.axes
    YAxis.contains
+   YAxis.convert_x_to_numeric
    YAxis.convert_xunits
+   YAxis.convert_y_to_numeric
    YAxis.convert_yunits
    YAxis.draw
    YAxis.findobj

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -313,8 +313,8 @@ def rad_fn(x, pos=None):
 
 
 class BasicUnitConverter(units.ConversionInterface):
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """Return AxisInfo instance for x and unit."""
 
         if unit == radians:
@@ -336,9 +336,9 @@ class BasicUnitConverter(units.ConversionInterface):
                 return units.AxisInfo(label=unit.unit.fullname)
         return None
 
-    @staticmethod
-    def convert(val, unit, axis):
-        if units.ConversionInterface.is_numlike(val):
+    @classmethod
+    def to_numeric(cls, val, unit, axis):
+        if cls.is_numlike(val):
             return val
         if np.iterable(val):
             if isinstance(val, np.ma.MaskedArray):
@@ -358,8 +358,8 @@ class BasicUnitConverter(units.ConversionInterface):
         else:
             return val.convert_to(unit).get_value()
 
-    @staticmethod
-    def default_units(x, axis):
+    @classmethod
+    def default_units(cls, x, axis):
         """Return the default unit for x or None."""
         if np.iterable(x):
             for thisx in x:

--- a/examples/units/evans_test.py
+++ b/examples/units/evans_test.py
@@ -28,8 +28,8 @@ class Foo:
 
 
 class FooConverter(units.ConversionInterface):
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """Return the Foo AxisInfo."""
         if unit == 1.0 or unit == 2.0:
             return units.AxisInfo(
@@ -41,14 +41,14 @@ class FooConverter(units.ConversionInterface):
         else:
             return None
 
-    @staticmethod
-    def convert(obj, unit, axis):
+    @classmethod
+    def to_numeric(cls, obj, unit, axis):
         """
         Convert *obj* using *unit*.
 
         If *obj* is a sequence, return the converted sequence.
         """
-        if units.ConversionInterface.is_numlike(obj):
+        if cls.is_numlike(obj):
             return obj
 
         if np.iterable(obj):
@@ -56,8 +56,8 @@ class FooConverter(units.ConversionInterface):
         else:
             return obj.value(unit)
 
-    @staticmethod
-    def default_units(x, axis):
+    @classmethod
+    def default_units(cls, x, axis):
         """Return the default unit for *x* or None."""
         if np.iterable(x):
             for thisx in x:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -164,7 +164,7 @@ class Artist:
         ax = self.axes
         return ax and any(axis.have_units() for axis in ax._get_axis_list())
 
-    def convert_xunits(self, x):
+    def convert_x_to_numeric(self, x):
         """
         Convert *x* using the unit type of the xaxis.
 
@@ -174,9 +174,13 @@ class Artist:
         ax = getattr(self, 'axes', None)
         if ax is None or ax.xaxis is None:
             return x
-        return ax.xaxis.convert_units(x)
+        return ax.xaxis.convert_to_numeric(x)
 
-    def convert_yunits(self, y):
+    @cbook.deprecated("3.3", pending=True, alternative="convert_x_to_numeric")
+    def convert_xunits(self, x):
+        return self.convert_x_to_numeric(x)
+
+    def convert_y_to_numeric(self, y):
         """
         Convert *y* using the unit type of the yaxis.
 
@@ -186,7 +190,11 @@ class Artist:
         ax = getattr(self, 'axes', None)
         if ax is None or ax.yaxis is None:
             return y
-        return ax.yaxis.convert_units(y)
+        return ax.yaxis.convert_to_numeric(y)
+
+    @cbook.deprecated("3.3", pending=True, alternative="convert_y_to_numeric")
+    def convert_yunits(self, y):
+        return self.convert_y_to_numeric(y)
 
     @property
     def axes(self):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -825,7 +825,7 @@ class Axes(_AxesBase):
         # We need to strip away the units for comparison with
         # non-unitized bounds
         self._process_unit_info(ydata=y, kwargs=kwargs)
-        yy = self.convert_yunits(y)
+        yy = self.convert_y_to_numeric(y)
         scaley = (yy < ymin) or (yy > ymax)
 
         trans = self.get_yaxis_transform(which='grid')
@@ -895,7 +895,7 @@ class Axes(_AxesBase):
         # We need to strip away the units for comparison with
         # non-unitized bounds
         self._process_unit_info(xdata=x, kwargs=kwargs)
-        xx = self.convert_xunits(x)
+        xx = self.convert_x_to_numeric(x)
         scalex = (xx < xmin) or (xx > xmax)
 
         trans = self.get_xaxis_transform(which='grid')
@@ -1004,8 +1004,8 @@ class Axes(_AxesBase):
         self._process_unit_info([xmin, xmax], [ymin, ymax], kwargs=kwargs)
 
         # first we need to strip away the units
-        xmin, xmax = self.convert_xunits([xmin, xmax])
-        ymin, ymax = self.convert_yunits([ymin, ymax])
+        xmin, xmax = self.convert_x_to_numeric([xmin, xmax])
+        ymin, ymax = self.convert_y_to_numeric([ymin, ymax])
 
         verts = (xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)
         p = mpatches.Polygon(verts, **kwargs)
@@ -1064,8 +1064,8 @@ class Axes(_AxesBase):
         self._process_unit_info([xmin, xmax], [ymin, ymax], kwargs=kwargs)
 
         # first we need to strip away the units
-        xmin, xmax = self.convert_xunits([xmin, xmax])
-        ymin, ymax = self.convert_yunits([ymin, ymax])
+        xmin, xmax = self.convert_x_to_numeric([xmin, xmax])
+        ymin, ymax = self.convert_y_to_numeric([ymin, ymax])
 
         verts = [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)]
         p = mpatches.Polygon(verts, **kwargs)
@@ -1113,9 +1113,9 @@ class Axes(_AxesBase):
         # We do the conversion first since not all unitized data is uniform
         # process the unit information
         self._process_unit_info([xmin, xmax], y, kwargs=kwargs)
-        y = self.convert_yunits(y)
-        xmin = self.convert_xunits(xmin)
-        xmax = self.convert_xunits(xmax)
+        y = self.convert_y_to_numeric(y)
+        xmin = self.convert_x_to_numeric(xmin)
+        xmax = self.convert_x_to_numeric(xmax)
 
         if not np.iterable(y):
             y = [y]
@@ -1195,9 +1195,9 @@ class Axes(_AxesBase):
         self._process_unit_info(xdata=x, ydata=[ymin, ymax], kwargs=kwargs)
 
         # We do the conversion first since not all unitized data is uniform
-        x = self.convert_xunits(x)
-        ymin = self.convert_yunits(ymin)
-        ymax = self.convert_yunits(ymax)
+        x = self.convert_x_to_numeric(x)
+        ymin = self.convert_y_to_numeric(ymin)
+        ymax = self.convert_y_to_numeric(ymax)
 
         if not np.iterable(x):
             x = [x]
@@ -1339,9 +1339,9 @@ class Axes(_AxesBase):
                                 kwargs=kwargs)
 
         # We do the conversion first since not all unitized data is uniform
-        positions = self.convert_xunits(positions)
-        lineoffsets = self.convert_yunits(lineoffsets)
-        linelengths = self.convert_yunits(linelengths)
+        positions = self.convert_x_to_numeric(positions)
+        lineoffsets = self.convert_y_to_numeric(lineoffsets)
+        linelengths = self.convert_y_to_numeric(linelengths)
 
         if not np.iterable(positions):
             positions = [positions]
@@ -2389,16 +2389,16 @@ class Axes(_AxesBase):
         # subtracted uniformly
         if self.xaxis is not None:
             x0 = x
-            x = np.asarray(self.convert_xunits(x))
-            width = self._convert_dx(width, x0, x, self.convert_xunits)
+            x = np.asarray(self.convert_x_to_numeric(x))
+            width = self._convert_dx(width, x0, x, self.convert_x_to_numeric)
             if xerr is not None:
-                xerr = self._convert_dx(xerr, x0, x, self.convert_xunits)
+                xerr = self._convert_dx(xerr, x0, x, self.convert_x_to_numeric)
         if self.yaxis is not None:
             y0 = y
-            y = np.asarray(self.convert_yunits(y))
-            height = self._convert_dx(height, y0, y, self.convert_yunits)
+            y = np.asarray(self.convert_y_to_numeric(y))
+            height = self._convert_dx(height, y0, y, self.convert_y_to_numeric)
             if yerr is not None:
-                yerr = self._convert_dx(yerr, y0, y, self.convert_yunits)
+                yerr = self._convert_dx(yerr, y0, y, self.convert_y_to_numeric)
 
         x, height, width, y, linewidth = np.broadcast_arrays(
             # Make args iterable too.
@@ -2673,11 +2673,12 @@ class Axes(_AxesBase):
                 raise ValueError('each range in xrange must be a sequence '
                                  'with two elements (i.e. an Nx2 array)')
             # convert the absolute values, not the x and dx...
-            x_conv = np.asarray(self.convert_xunits(xr[0]))
-            x1 = self._convert_dx(xr[1], xr[0], x_conv, self.convert_xunits)
+            x_conv = np.asarray(self.convert_x_to_numeric(xr[0]))
+            x1 = self._convert_dx(
+                xr[1], xr[0], x_conv, self.convert_x_to_numeric)
             xranges_conv.append((x_conv, x1))
 
-        yrange_conv = self.convert_yunits(yrange)
+        yrange_conv = self.convert_y_to_numeric(yrange)
 
         col = mcoll.BrokenBarHCollection(xranges_conv, yrange_conv, **kwargs)
         self.add_collection(col, autolim=True)
@@ -2776,8 +2777,8 @@ class Axes(_AxesBase):
             x, y, *args = args
 
         self._process_unit_info(xdata=x, ydata=y)
-        x = self.convert_xunits(x)
-        y = self.convert_yunits(y)
+        x = self.convert_x_to_numeric(x)
+        y = self.convert_y_to_numeric(y)
 
         # defaults for formats
         if linefmt is None:
@@ -4112,7 +4113,7 @@ class Axes(_AxesBase):
             axis_name = "x" if vert else "y"
             interval = getattr(self.dataLim, f"interval{axis_name}")
             axis = getattr(self, f"{axis_name}axis")
-            positions = axis.convert_units(positions)
+            positions = axis.convert_to_numeric(positions)
             # The 0.5 additional padding ensures reasonable-looking boxes
             # even when drawing a single box.  We set the sticky edge to
             # prevent margins expansion, in order to match old behavior (back
@@ -4402,8 +4403,8 @@ default: :rc:`scatter.edgecolors`
         # Process **kwargs to handle aliases, conflicts with explicit kwargs:
 
         self._process_unit_info(xdata=x, ydata=y, kwargs=kwargs)
-        x = self.convert_xunits(x)
-        y = self.convert_yunits(y)
+        x = self.convert_x_to_numeric(x)
+        y = self.convert_y_to_numeric(y)
 
         # np.ma.ravel yields an ndarray, not a masked array,
         # unless its argument is a masked array.
@@ -4954,10 +4955,10 @@ default: :rc:`scatter.edgecolors`
         """
         # Strip away units for the underlying patch since units
         # do not make sense to most patch-like code
-        x = self.convert_xunits(x)
-        y = self.convert_yunits(y)
-        dx = self.convert_xunits(dx)
-        dy = self.convert_yunits(dy)
+        x = self.convert_x_to_numeric(x)
+        y = self.convert_y_to_numeric(y)
+        dx = self.convert_x_to_numeric(dx)
+        dy = self.convert_y_to_numeric(dy)
 
         a = mpatches.FancyArrow(x, y, dx, dy, **kwargs)
         self.add_patch(a)
@@ -4975,8 +4976,8 @@ default: :rc:`scatter.edgecolors`
         if len(args) > 3:
             x, y = args[0:2]
             self._process_unit_info(xdata=x, ydata=y, kwargs=kw)
-            x = self.convert_xunits(x)
-            y = self.convert_yunits(y)
+            x = self.convert_x_to_numeric(x)
+            y = self.convert_y_to_numeric(y)
             return (x, y) + args[2:]
         return args
 
@@ -5168,11 +5169,12 @@ default: :rc:`scatter.edgecolors`
             **{f"{dep_dir}data": dep2})
 
         # Convert the arrays so we can work with them
-        ind = ma.masked_invalid(getattr(self, f"convert_{ind_dir}units")(ind))
+        ind = ma.masked_invalid(
+            getattr(self, f"convert_{ind_dir}_to_numeric")(ind))
         dep1 = ma.masked_invalid(
-            getattr(self, f"convert_{dep_dir}units")(dep1))
+            getattr(self, f"convert_{dep_dir}_to_numeric")(dep1))
         dep2 = ma.masked_invalid(
-            getattr(self, f"convert_{dep_dir}units")(dep2))
+            getattr(self, f"convert_{dep_dir}_to_numeric")(dep2))
 
         for name, array in [
                 (ind_dir, ind), (f"{dep_dir}1", dep1), (f"{dep_dir}2", dep2)]:
@@ -5760,8 +5762,8 @@ default: :rc:`scatter.edgecolors`
 
         # unit conversion allows e.g. datetime objects as axis values
         self._process_unit_info(xdata=X, ydata=Y, kwargs=kwargs)
-        X = self.convert_xunits(X)
-        Y = self.convert_yunits(Y)
+        X = self.convert_x_to_numeric(X)
+        Y = self.convert_y_to_numeric(Y)
 
         # convert to MA, if necessary.
         C = ma.asarray(C)
@@ -6037,8 +6039,8 @@ default: :rc:`scatter.edgecolors`
         Y = Y.ravel()
         # unit conversion allows e.g. datetime objects as axis values
         self._process_unit_info(xdata=X, ydata=Y, kwargs=kwargs)
-        X = self.convert_xunits(X)
-        Y = self.convert_yunits(Y)
+        X = self.convert_x_to_numeric(X)
+        Y = self.convert_y_to_numeric(Y)
 
         # convert to one dimensional arrays
         C = C.ravel()
@@ -6520,13 +6522,13 @@ default: :rc:`scatter.edgecolors`
         # Process unit information
         # Unit conversion is done individually on each dataset
         self._process_unit_info(xdata=x[0], kwargs=kwargs)
-        x = [self.convert_xunits(xi) for xi in x]
+        x = [self.convert_x_to_numeric(xi) for xi in x]
 
         if bin_range is not None:
-            bin_range = self.convert_xunits(bin_range)
+            bin_range = self.convert_x_to_numeric(bin_range)
 
         if not cbook.is_scalar_or_string(bins):
-            bins = self.convert_xunits(bins)
+            bins = self.convert_x_to_numeric(bins)
 
         # We need to do to 'weights' what was done to 'x'
         if weights is not None:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -255,8 +255,8 @@ class _process_plot_var_args:
 
     def _makefill(self, x, y, kw, kwargs):
         # Polygon doesn't directly support unitized inputs.
-        x = self.axes.convert_xunits(x)
-        y = self.axes.convert_yunits(y)
+        x = self.axes.convert_x_to_numeric(x)
+        y = self.axes.convert_y_to_numeric(y)
 
         kw = kw.copy()  # Don't modify the original kw.
         kwargs = kwargs.copy()
@@ -3247,8 +3247,10 @@ class _AxesBase(martist.Artist):
             right = xmax
 
         self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        left = self._validate_converted_limits(
+            left, self.convert_x_to_numeric)
+        right = self._validate_converted_limits(
+            right, self.convert_x_to_numeric)
 
         if left is None or right is None:
             # Axes init calls set_xlim(0, 1) before get_xlim() can be called,
@@ -3641,8 +3643,9 @@ class _AxesBase(martist.Artist):
             top = ymax
 
         self._process_unit_info(ydata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        bottom = self._validate_converted_limits(
+            bottom, self.convert_y_to_numeric)
+        top = self._validate_converted_limits(top, self.convert_y_to_numeric)
 
         if bottom is None or top is None:
             # Axes init calls set_ylim(0, 1) before get_ylim() can be called,

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -24,8 +24,8 @@ _log = logging.getLogger(__name__)
 
 
 class StrCategoryConverter(units.ConversionInterface):
-    @staticmethod
-    def convert(value, unit, axis):
+    @classmethod
+    def to_numeric(cls, value, unit, axis):
         """
         Convert strings in *value* to floats using mapping information stored
         in the *unit* object.
@@ -53,7 +53,7 @@ class StrCategoryConverter(units.ConversionInterface):
         # dtype = object preserves numerical pass throughs
         values = np.atleast_1d(np.array(value, dtype=object))
         # pass through sequence of non binary numbers
-        if all(units.ConversionInterface.is_numlike(v)
+        if all(cls.is_numlike(v)
                and not isinstance(v, (str, bytes))
                for v in values):
             return np.asarray(values, dtype=float)
@@ -61,8 +61,8 @@ class StrCategoryConverter(units.ConversionInterface):
         unit.update(values)
         return np.vectorize(unit._mapping.__getitem__, otypes=[float])(values)
 
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """
         Set the default axis ticks and labels.
 
@@ -86,8 +86,8 @@ class StrCategoryConverter(units.ConversionInterface):
         majfmt = StrCategoryFormatter(unit._mapping)
         return units.AxisInfo(majloc=majloc, majfmt=majfmt)
 
-    @staticmethod
-    def default_units(data, axis):
+    @classmethod
+    def default_units(cls, data, axis):
         """
         Set and update the `~matplotlib.axis.Axis` units.
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -262,12 +262,12 @@ class Collection(artist.Artist, cm.ScalarMappable):
             for path in self.get_paths():
                 vertices = path.vertices
                 xs, ys = vertices[:, 0], vertices[:, 1]
-                xs = self.convert_xunits(xs)
-                ys = self.convert_yunits(ys)
+                xs = self.convert_x_to_numeric(xs)
+                ys = self.convert_y_to_numeric(ys)
                 paths.append(mpath.Path(np.column_stack([xs, ys]), path.codes))
             if offsets.size:
-                xs = self.convert_xunits(offsets[:, 0])
-                ys = self.convert_yunits(offsets[:, 1])
+                xs = self.convert_x_to_numeric(offsets[:, 0])
+                ys = self.convert_y_to_numeric(offsets[:, 1])
                 offsets = np.column_stack([xs, ys])
 
         if not transform.is_affine:
@@ -2036,8 +2036,8 @@ class QuadMesh(Collection):
 
         if self.have_units():
             if len(self._offsets):
-                xs = self.convert_xunits(self._offsets[:, 0])
-                ys = self.convert_yunits(self._offsets[:, 1])
+                xs = self.convert_x_to_numeric(self._offsets[:, 0])
+                ys = self.convert_y_to_numeric(self._offsets[:, 1])
                 offsets = np.column_stack([xs, ys])
 
         self.update_scalarmappable()

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1503,8 +1503,8 @@ class QuadContourSet(ContourSet):
         """
         x, y = args[:2]
         kwargs = self.ax._process_unit_info(xdata=x, ydata=y, kwargs=kwargs)
-        x = self.ax.convert_xunits(x)
-        y = self.ax.convert_yunits(y)
+        x = self.ax.convert_x_to_numeric(x)
+        y = self.ax.convert_y_to_numeric(y)
 
         x = np.asarray(x, dtype=np.float64)
         y = np.asarray(y, dtype=np.float64)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -657,12 +657,12 @@ class Line2D(Artist):
 
     def recache(self, always=False):
         if always or self._invalidx:
-            xconv = self.convert_xunits(self._xorig)
+            xconv = self.convert_x_to_numeric(self._xorig)
             x = _to_unmasked_float_array(xconv).ravel()
         else:
             x = self._x
         if always or self._invalidy:
-            yconv = self.convert_yunits(self._yorig)
+            yconv = self.convert_y_to_numeric(self._yorig)
             y = _to_unmasked_float_array(yconv).ravel()
         else:
             y = self._y

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -603,10 +603,10 @@ class Patch(artist.Artist):
     def get_window_extent(self, renderer=None):
         return self.get_path().get_extents(self.get_transform())
 
-    def _convert_xy_units(self, xy):
+    def _convert_xy_to_numeric(self, xy):
         """Convert x and y units for a tuple (x, y)."""
-        x = self.convert_xunits(xy[0])
-        y = self.convert_yunits(xy[1])
+        x = self.convert_x_to_numeric(xy[0])
+        y = self.convert_y_to_numeric(xy[1])
         return x, y
 
 
@@ -765,7 +765,7 @@ class Rectangle(Patch):
         call the accessor method and not directly access the transformation
         member variable.
         """
-        x0, y0, x1, y1 = self._convert_units()
+        x0, y0, x1, y1 = self._convert_to_numeric()
         bbox = transforms.Bbox.from_extents(x0, y0, x1, y1)
         rot_trans = transforms.Affine2D()
         rot_trans.rotate_deg_around(x0, y0, self.angle)
@@ -778,12 +778,10 @@ class Rectangle(Patch):
     def _update_y1(self):
         self._y1 = self._y0 + self._height
 
-    def _convert_units(self):
+    def _convert_to_numeric(self):
         """Convert bounds of the rectangle."""
-        x0 = self.convert_xunits(self._x0)
-        y0 = self.convert_yunits(self._y0)
-        x1 = self.convert_xunits(self._x1)
-        y1 = self.convert_yunits(self._y1)
+        x0, x1 = self.convert_x_to_numeric([self._x0, self._x1])
+        y0, y1 = self.convert_y_to_numeric([self._y0, self._y1])
         return x0, y0, x1, y1
 
     def get_patch_transform(self):
@@ -872,7 +870,7 @@ class Rectangle(Patch):
 
     def get_bbox(self):
         """Return the `.Bbox`."""
-        x0, y0, x1, y1 = self._convert_units()
+        x0, y0, x1, y1 = self._convert_to_numeric()
         return transforms.Bbox.from_extents(x0, y0, x1, y1)
 
     xy = property(get_xy, set_xy)
@@ -1403,10 +1401,10 @@ class Ellipse(Patch):
         call the accessor method and not directly access the transformation
         member variable.
         """
-        center = (self.convert_xunits(self._center[0]),
-                  self.convert_yunits(self._center[1]))
-        width = self.convert_xunits(self._width)
-        height = self.convert_yunits(self._height)
+        center = (self.convert_x_to_numeric(self._center[0]),
+                  self.convert_y_to_numeric(self._center[1]))
+        width = self.convert_x_to_numeric(self._width)
+        height = self.convert_y_to_numeric(self._height)
         self._patch_transform = transforms.Affine2D() \
             .scale(width * 0.5, height * 0.5) \
             .rotate_deg(self.angle) \
@@ -1649,8 +1647,8 @@ class Arc(Ellipse):
 
         self._recompute_transform()
 
-        width = self.convert_xunits(self.width)
-        height = self.convert_yunits(self.height)
+        width = self.convert_x_to_numeric(self.width)
+        height = self.convert_y_to_numeric(self.height)
 
         # If the width and height of ellipse are not equal, take into account
         # stretching when calculating angles to draw between
@@ -4128,8 +4126,8 @@ default: 'arc3'
         dpi_cor = self.get_dpi_cor()
 
         if self._posA_posB is not None:
-            posA = self._convert_xy_units(self._posA_posB[0])
-            posB = self._convert_xy_units(self._posA_posB[1])
+            posA = self._convert_xy_to_numeric(self._posA_posB[0])
+            posB = self._convert_xy_to_numeric(self._posA_posB[1])
             (posA, posB) = self.get_transform().transform((posA, posB))
             _path = self.get_connectionstyle()(posA, posB,
                                                patchA=self.patchA,
@@ -4292,8 +4290,8 @@ class ConnectionPatch(FancyArrowPatch):
 
         if s == 'data':
             trans = axes.transData
-            x = float(self.convert_xunits(x))
-            y = float(self.convert_yunits(y))
+            x = float(self.convert_x_to_numeric(x))
+            y = float(self.convert_y_to_numeric(y))
             return trans.transform((x, y))
         elif s == 'offset points':
             # convert the data point

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1317,7 +1317,7 @@ class PolarAxes(Axes):
         """
 
         # Make sure we take into account unitized data
-        angles = self.convert_yunits(angles)
+        angles = self.convert_y_to_numeric(angles)
         angles = np.deg2rad(angles)
         self.set_xticks(angles)
         if labels is not None:
@@ -1369,7 +1369,7 @@ class PolarAxes(Axes):
         .Axis.get_ticklabels
         """
         # Make sure we take into account unitized data
-        radii = self.convert_xunits(radii)
+        radii = self.convert_x_to_numeric(radii)
         radii = np.asarray(radii)
 
         self.set_yticks(radii)

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -138,10 +138,10 @@ class Spine(mpatches.Patch):
         member variable.
         """
         assert self._patch_type in ('arc', 'circle')
-        center = (self.convert_xunits(self._center[0]),
-                  self.convert_yunits(self._center[1]))
-        width = self.convert_xunits(self._width)
-        height = self.convert_yunits(self._height)
+        center = (self.convert_x_to_numeric(self._center[0]),
+                  self.convert_y_to_numeric(self._center[1]))
+        width = self.convert_x_to_numeric(self._width)
+        height = self.convert_y_to_numeric(self._height)
         self._patch_transform = mtransforms.Affine2D() \
             .scale(width * 0.5, height * 0.5) \
             .translate(*center)

--- a/lib/matplotlib/testing/jpl_units/StrConverter.py
+++ b/lib/matplotlib/testing/jpl_units/StrConverter.py
@@ -18,8 +18,8 @@ class StrConverter(units.ConversionInterface):
     - 'sorted-inverted' :  A combination of 'sorted' and 'inverted'
     """
 
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """: Returns information on how to handle an axis that has string data.
 
         = INPUT VARIABLES
@@ -34,8 +34,8 @@ class StrConverter(units.ConversionInterface):
 
         return None
 
-    @staticmethod
-    def convert(value, unit, axis):
+    @classmethod
+    def to_numeric(cls, value, unit, axis):
         """: Convert value using unit to a float.  If value is a sequence, return
         the converted sequence.
 
@@ -48,7 +48,7 @@ class StrConverter(units.ConversionInterface):
         - Returns the value parameter converted to floats.
         """
 
-        if units.ConversionInterface.is_numlike(value):
+        if cls.is_numlike(value):
             return value
 
         if value == []:
@@ -114,8 +114,8 @@ class StrConverter(units.ConversionInterface):
         ax.viewLim.ignore(-1)
         return result
 
-    @staticmethod
-    def default_units(value, axis):
+    @classmethod
+    def default_units(cls, value, axis):
         """: Return the default unit for value, or None.
 
         = INPUT VARIABLES

--- a/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
@@ -38,8 +38,8 @@ class UnitDblConverter(units.ConversionInterface):
        "time": 'sec',
        }
 
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """: Returns information on how to handle an axis that has Epoch data.
 
         = INPUT VARIABLES
@@ -69,8 +69,8 @@ class UnitDblConverter(units.ConversionInterface):
 
         return units.AxisInfo(majfmt=majfmt, label=label)
 
-    @staticmethod
-    def convert(value, unit, axis):
+    @classmethod
+    def to_numeric(cls, value, unit, axis):
         """: Convert value using unit to a float.  If value is a sequence, return
         the converted sequence.
 
@@ -82,23 +82,23 @@ class UnitDblConverter(units.ConversionInterface):
         - Returns the value parameter converted to floats.
         """
         if not cbook.is_scalar_or_string(value):
-            return [UnitDblConverter.convert(x, unit, axis) for x in value]
+            return [cls.to_numeric(x, unit, axis) for x in value]
         # If the incoming value behaves like a number,
         # then just return it because we don't know how to convert it
         # (or it is already converted)
-        if units.ConversionInterface.is_numlike(value):
+        if cls.is_numlike(value):
             return value
         # If no units were specified, then get the default units to use.
         if unit is None:
-            unit = UnitDblConverter.default_units(value, axis)
+            unit = cls.default_units(value, axis)
         # Convert the incoming UnitDbl value/values to float/floats
         if isinstance(axis.axes, polar.PolarAxes) and value.type() == "angle":
             # Guarantee that units are radians for polar plots.
             return value.convert("rad")
         return value.convert(unit)
 
-    @staticmethod
-    def default_units(value, axis):
+    @classmethod
+    def default_units(cls, value, axis):
         """: Return the default unit for value, or None.
 
         = INPUT VARIABLES
@@ -111,6 +111,6 @@ class UnitDblConverter(units.ConversionInterface):
         # Determine the default units based on the user preferences set for
         # default units when printing a UnitDbl.
         if cbook.is_scalar_or_string(value):
-            return UnitDblConverter.defaults[value.type()]
+            return cls.defaults[value.type()]
         else:
-            return UnitDblConverter.default_units(value[0], axis)
+            return cls.default_units(value[0], axis)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -89,27 +89,27 @@ class TestStrCategoryConverter:
 
     @pytest.mark.parametrize("vals", values, ids=ids)
     def test_convert(self, vals):
-        np.testing.assert_allclose(self.cc.convert(vals, self.ax.units,
-                                                   self.ax),
+        np.testing.assert_allclose(self.cc.to_numeric(
+                                        vals, self.ax.units, self.ax),
                                    range(len(vals)))
 
     @pytest.mark.parametrize("value", ["hi", "мир"], ids=["ascii", "unicode"])
     def test_convert_one_string(self, value):
-        assert self.cc.convert(value, self.unit, self.ax) == 0
+        assert self.cc.to_numeric(value, self.unit, self.ax) == 0
 
     def test_convert_one_number(self):
-        actual = self.cc.convert(0.0, self.unit, self.ax)
+        actual = self.cc.to_numeric(0.0, self.unit, self.ax)
         np.testing.assert_allclose(actual, np.array([0.]))
 
     def test_convert_float_array(self):
         data = np.array([1, 2, 3], dtype=float)
-        actual = self.cc.convert(data, self.unit, self.ax)
+        actual = self.cc.to_numeric(data, self.unit, self.ax)
         np.testing.assert_allclose(actual, np.array([1., 2., 3.]))
 
     @pytest.mark.parametrize("fvals", fvalues, ids=fids)
     def test_convert_fail(self, fvals):
         with pytest.raises(TypeError):
-            self.cc.convert(fvals, self.unit, self.ax)
+            self.cc.to_numeric(fvals, self.unit, self.ax)
 
     def test_axisinfo(self):
         axis = self.cc.axisinfo(self.unit, self.ax)

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -44,7 +44,7 @@ def quantity_converter():
     # mock so we can check methods called
     qc = munits.ConversionInterface()
 
-    def convert(value, unit, axis):
+    def to_numeric(value, unit, axis):
         if hasattr(value, 'units'):
             return value.to(unit).magnitude
         elif np.iterable(value):
@@ -65,7 +65,7 @@ def quantity_converter():
                     return v.units
             return None
 
-    qc.convert = MagicMock(side_effect=convert)
+    qc.to_numeric = MagicMock(side_effect=to_numeric)
     qc.axisinfo = MagicMock(side_effect=lambda u, a: munits.AxisInfo(label=u))
     qc.default_units = MagicMock(side_effect=default_units)
     return qc
@@ -94,7 +94,7 @@ def test_numpy_facade(quantity_converter):
     ax.yaxis.set_units('inches')
     ax.xaxis.set_units('seconds')
 
-    assert quantity_converter.convert.called
+    assert quantity_converter.to_numeric.called
     assert quantity_converter.axisinfo.called
     assert quantity_converter.default_units.called
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -498,8 +498,8 @@ class Text(Artist):
 
             # don't use self.get_unitless_position here, which refers to text
             # position in Text:
-            posx = float(self.convert_xunits(self._x))
-            posy = float(self.convert_yunits(self._y))
+            posx = float(self.convert_x_to_numeric(self._x))
+            posy = float(self.convert_y_to_numeric(self._y))
 
             posx, posy = trans.transform((posx, posy))
 
@@ -690,8 +690,8 @@ class Text(Artist):
 
             # don't use textobj.get_position here, which refers to text
             # position in Text:
-            posx = float(textobj.convert_xunits(textobj._x))
-            posy = float(textobj.convert_yunits(textobj._y))
+            posx = float(textobj.convert_x_to_numeric(textobj._x))
+            posy = float(textobj.convert_y_to_numeric(textobj._y))
             posx, posy = trans.transform((posx, posy))
             if not np.isfinite(posx) or not np.isfinite(posy):
                 _log.warning("posx and posy should be finite values")
@@ -828,8 +828,8 @@ class Text(Artist):
         """Return the (x, y) unitless position of the text."""
         # This will get the position with all unit information stripped away.
         # This is here for convenience since it is done in several locations.
-        x = float(self.convert_xunits(self._x))
-        y = float(self.convert_yunits(self._y))
+        x = float(self.convert_x_to_numeric(self._x))
+        y = float(self.convert_y_to_numeric(self._y))
         return x, y
 
     def get_position(self):
@@ -1349,9 +1349,9 @@ class _AnnotationBase:
         else:
             s1, s2 = s, s
         if s1 == 'data':
-            x = float(self.convert_xunits(x))
+            x = float(self.convert_x_to_numeric(x))
         if s2 == 'data':
-            y = float(self.convert_yunits(y))
+            y = float(self.convert_y_to_numeric(y))
         return self._get_xy_transform(renderer, s).transform((x, y))
 
     def _get_xy_transform(self, renderer, s):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -262,7 +262,7 @@ class Formatter(TickHelper):
         Return the full string representation of the value with the
         position unspecified.
         """
-        return self.__call__(value)
+        return self(value)
 
     def format_data_short(self, value):
         """
@@ -961,7 +961,7 @@ class LogFormatter(Formatter):
 
     def format_data(self, value):
         with cbook._setattr_cm(self, labelOnlyBase=False):
-            return cbook.strip_math(self.__call__(value))
+            return cbook.strip_math(self(value))
 
     def format_data_short(self, value):
         # docstring inherited

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -18,7 +18,7 @@ datetime objects::
     class DateConverter(units.ConversionInterface):
 
         @staticmethod
-        def convert(value, unit, axis):
+        def to_numeric(value, unit, axis):
             'Convert a datetime value to a scalar or array'
             return dates.date2num(value)
 
@@ -51,7 +51,7 @@ from numpy import ma
 from matplotlib import cbook
 
 
-class ConversionError(TypeError):
+class ConversionError(ValueError):
     pass
 
 
@@ -113,52 +113,69 @@ class ConversionInterface:
     sequences) and convert them to values Matplotlib can use.
     """
 
-    @staticmethod
-    def axisinfo(unit, axis):
+    @classmethod
+    def axisinfo(cls, unit, axis):
         """
         Return an `~units.AxisInfo` for the axis with the specified units.
         """
         return None
 
-    @staticmethod
-    def default_units(x, axis):
+    @classmethod
+    def default_units(cls, x, axis):
         """
         Return the default unit for *x* or ``None`` for the given axis.
         """
         return None
 
-    @staticmethod
-    def convert(obj, unit, axis):
+    @classmethod
+    def to_numeric(cls, obj, unit, axis):
         """
-        Convert *obj* using *unit* for the specified *axis*.
+        Convert *obj* using *unit* to a numeric value for the specified *axis*.
 
         If *obj* is a sequence, return the converted sequence.  The output must
         be a sequence of scalars that can be used by the numpy array layer.
         """
         return obj
 
-    @staticmethod
-    def is_numlike(x):
+    @classmethod
+    def from_numeric(cls, x, unit, axis):
+        """
+        Convert numeric *x* using *unit* for the specified *axis*.
+
+        If *x* is a sequence, return the converted sequence.
+        """
+        return x
+
+    @classmethod
+    def is_numlike(cls, x):
         """
         The Matplotlib datalim, autoscaling, locators etc work with scalars
         which are the units converted to floats given the current unit.  The
         converter may be passed these floats, or arrays of them, even when
         units are set.
         """
+        return cls.is_like(x, Number)
+
+    @classmethod
+    def is_like(cls, x, types):
+        """
+        A helper which checks if a value is either a container of the
+        specified types or of the specified types itself.
+        """
         if np.iterable(x):
             for thisx in x:
                 if thisx is ma.masked:
                     continue
-                return isinstance(thisx, Number)
+                return isinstance(thisx, types)
         else:
-            return isinstance(x, Number)
+            return isinstance(x, types)
 
 
 class DecimalConverter(ConversionInterface):
     """Converter for decimal.Decimal data to float."""
 
     @staticmethod
-    def convert(value, unit, axis):
+    def to_numeric(value, unit, axis):
         """
         Convert Decimals to floats.
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -142,7 +142,7 @@ class Axes3D(Axes):
         self._axis3don = True
         self.stale = True
 
-    def convert_zunits(self, z):
+    def convert_z_to_numeric(self, z):
         """
         For artists in an axes, if the zaxis has units support,
         convert *z* using zaxis unit type
@@ -150,7 +150,11 @@ class Axes3D(Axes):
         .. versionadded:: 1.2.1
 
         """
-        return self.zaxis.convert_units(z)
+        return self.zaxis.convert_to_numeric(z)
+
+    @cbook.deprecated("3.3", pending=True, alternative="convert_z_to_numeric")
+    def convert_zunits(self, z):
+        return self.convert_z_to_numeric(z)
 
     def _process_unit_info(self, xdata=None, ydata=None, zdata=None,
                            kwargs=None):
@@ -606,8 +610,9 @@ class Axes3D(Axes):
             right = xmax
 
         self._process_unit_info(xdata=(left, right))
-        left = self._validate_converted_limits(left, self.convert_xunits)
-        right = self._validate_converted_limits(right, self.convert_xunits)
+        left = self._validate_converted_limits(left, self.convert_x_to_numeric)
+        right = self._validate_converted_limits(
+            right, self.convert_x_to_numeric)
 
         old_left, old_right = self.get_xlim()
         if left is None:
@@ -660,8 +665,9 @@ class Axes3D(Axes):
             top = ymax
 
         self._process_unit_info(ydata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_yunits)
-        top = self._validate_converted_limits(top, self.convert_yunits)
+        bottom = self._validate_converted_limits(
+            bottom, self.convert_y_to_numeric)
+        top = self._validate_converted_limits(top, self.convert_y_to_numeric)
 
         old_bottom, old_top = self.get_ylim()
         if bottom is None:
@@ -715,8 +721,9 @@ class Axes3D(Axes):
             top = zmax
 
         self._process_unit_info(zdata=(bottom, top))
-        bottom = self._validate_converted_limits(bottom, self.convert_zunits)
-        top = self._validate_converted_limits(top, self.convert_zunits)
+        bottom = self._validate_converted_limits(
+            bottom, self.convert_z_to_numeric)
+        top = self._validate_converted_limits(top, self.convert_z_to_numeric)
 
         old_bottom, old_top = self.get_zlim()
         if bottom is None:


### PR DESCRIPTION
This change updates `matplotlib.units.ConversionInterface` to have a `to_numeric` instead of a `convert` method, and adds a `from_numeric` method. The method `convert` is renamed to `to_numeric` and similarly named methods are updated accordingly. The renaming is done to make `convert` less ambiguous with a forward and backward conversion on the `ConversionInterface`.

Adding a `from_numeric` method standardizes the way to convert back to a native object from an internal numeric value. This allows registered converters to provide more specific conversions which will allow formatters and locators to provide an implementation which is not as tied to the internal values Matplotlib uses.

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way