### PR TITLE
Test flakiness

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
-                 --cov-report= --cov=lib --log-level=DEBUG -k 'mhi-pdf-False'
+                 --cov-report= --cov=lib --log-level=DEBUG -k determinism
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
-                 --cov-report= --cov=lib --log-level=DEBUG
+                 --cov-report= --cov=lib --log-level=DEBUG -k 'mhi-pdf-False' lib\matplotlib\tests\test_determinism.py
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct
@@ -41,7 +41,6 @@ cache:
 
 init:
   - echo %PYTHON_VERSION% %CONDA_INSTALL_LOCN%
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
@@ -86,7 +85,29 @@ test_script:
   - python -c "import matplotlib as m; m.use('tkagg'); import matplotlib.pyplot as plt; print(plt.get_backend())"
   # tests
   - echo The following args are passed to pytest %PYTEST_ARGS%
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
+  - pytest %PYTEST_ARGS%
   - pytest %PYTEST_ARGS%
 
 after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,10 +23,6 @@ environment:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct
     # the envs anyway. But using one for the right python version hopefully
     # making things faster due to package caching.
-    - PYTHON_VERSION: "3.6"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
-      TEST_ALL: "no"
-      EXTRAREQS: "-r requirements/testing/travis_extra.txt"
     - PYTHON_VERSION: "3.7"
       CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
       TEST_ALL: "no"
@@ -45,6 +41,7 @@ cache:
 
 init:
   - echo %PYTHON_VERSION% %CONDA_INSTALL_LOCN%
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
   - set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%;
@@ -89,6 +86,7 @@ test_script:
   - python -c "import matplotlib as m; m.use('tkagg'); import matplotlib.pyplot as plt; print(plt.get_backend())"
   # tests
   - echo The following args are passed to pytest %PYTEST_ARGS%
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - pytest %PYTEST_ARGS%
 
 after_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
-                 --cov-report= --cov=lib --log-level=DEBUG -k 'mhi-pdf-False' lib\matplotlib\tests\test_determinism.py
+                 --cov-report= --cov=lib --log-level=DEBUG -k 'mhi-pdf-False'
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,7 +70,7 @@ install:
 test_script:
   # Now build the thing..
   - set LINK=/LIBPATH:%cd%\lib
-  - pip install -ve .
+  - pip install -e .
   # this should show no freetype dll...
   - set "DUMPBIN=%VS140COMNTOOLS%\..\..\VC\bin\dumpbin.exe"
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ environment:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
-                 --cov-report= --cov=lib --log-level=DEBUG -k determinism
+                 --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -103,6 +103,7 @@ def test_determinism_check(objects, fmt, usetex):
             env={**os.environ, "SOURCE_DATE_EPOCH": "946684800"})
         for _ in range(3)
     ]
+    print(*[repr(p) for p in plots])
     for p in plots[1:]:
         if fmt == "ps" and usetex:
             if p != plots[0]:


### PR DESCRIPTION
## PR Summary
I've tried running this a few times over, but it's still not triggering the issue: https://ci.appveyor.com/project/QuLogic/matplotlib

So I'm trying here if maybe there's something in the cache that causes it.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way