### PR TITLE
tk: Resize the canvas, not the figure.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -446,7 +446,7 @@ class FigureManagerTk(FigureManagerBase):
         return toolmanager
 
     def resize(self, width, height):
-        self.canvas._tkcanvas.master.geometry("%dx%d" % (width, height))
+        self.canvas._tkcanvas.configure(width=width, height=height)
 
         if self.toolbar is not None:
             self.toolbar.configure(width=width)


### PR DESCRIPTION
## PR Summary

Resizing the figure directly does not account for the toolbar, so figures are actually a little shorter than they should be. The recent change to `Text.get_window_extent` some how causes this to actually get reflected in the Matplotlib figure size, which cycles back to Tk and shrinks the window. However, this can be triggered by other calls to `Figure.set_size_inches` as noted in the linked issues.

Fixes #10083.
Fixes #10566.
Fixes #16926.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way