### PR TITLE
Make it easier to improve UI event metadata.

### DIFF
--- a/doc/api/next_api_changes/deprecations/16931-AL.rst
+++ b/doc/api/next_api_changes/deprecations/16931-AL.rst
@@ -1,0 +1,11 @@
+Event handlers
+~~~~~~~~~~~~~~
+The ``draw_event``, ``resize_event``, ``close_event``, ``key_press_event``,
+``key_release_event``, ``pick_event``, ``scroll_event``,
+``button_press_event``, ``button_release_event``, ``motion_notify_event``,
+``enter_notify_event`` and ``leave_notify_event`` methods of `.FigureCanvasBase`
+are deprecated.  They had inconsistent signatures across backends, and made it
+difficult to improve event metadata.
+
+In order to trigger an event on a canvas, directly construct an `.Event` object
+of the correct class and call ``canvas.callbacks.process(event.name, event)``.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -498,6 +498,7 @@ class Artist:
         --------
         set_picker, get_picker, pickable
         """
+        from .backend_bases import PickEvent  # Circular import.
         # Pick self
         if self.pickable():
             picker = self.get_picker()
@@ -506,7 +507,8 @@ class Artist:
             else:
                 inside, prop = self.contains(mouseevent)
             if inside:
-                self.figure.canvas.pick_event(mouseevent, self, **prop)
+                PickEvent("pick_event", self.figure.canvas,
+                          mouseevent, self, **prop)._process()
 
         # Pick children
         for a in self.get_children():

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1277,10 +1277,6 @@ class ResizeEvent(Event):
         super().__init__(name, canvas)
         self.width, self.height = canvas.get_width_height()
 
-    def _process(self):
-        super()._process()
-        self.canvas.draw_idle()
-
 
 class CloseEvent(Event):
     """An event triggered by a figure being closed."""

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1405,6 +1405,7 @@ class MouseEvent(LocationEvent):
 
     def __init__(self, name, canvas, x, y, button=None, key=None,
                  step=0, dblclick=False, guiEvent=None):
+        super().__init__(name, canvas, x, y, guiEvent=guiEvent)
         if button in MouseButton.__members__.values():
             button = MouseButton(button)
         if name == "scroll_event" and button is None:
@@ -1416,10 +1417,6 @@ class MouseEvent(LocationEvent):
         self.key = key
         self.step = step
         self.dblclick = dblclick
-
-        # super-init is deferred to the end because it calls back on
-        # 'axes_enter_event', which requires a fully initialized event.
-        super().__init__(name, canvas, x, y, guiEvent=guiEvent)
 
     def _process(self):
         if self.name == "button_press_event":
@@ -1521,9 +1518,8 @@ class KeyEvent(LocationEvent):
     """
 
     def __init__(self, name, canvas, key, x=0, y=0, guiEvent=None):
-        self.key = key
-        # super-init deferred to the end: callback errors if called before
         super().__init__(name, canvas, x, y, guiEvent=guiEvent)
+        self.key = key
 
     def _process(self):
         if self.name == "key_press_event":

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1285,15 +1285,6 @@ class ResizeEvent(Event):
 class CloseEvent(Event):
     """An event triggered by a figure being closed."""
 
-    def _process(self):
-        try:
-            super()._process()
-        except (AttributeError, TypeError):
-            pass
-            # Suppress AttributeError/TypeError that occur when the python
-            # session is being killed.  It may be that a better solution would
-            # be a mechanism to disconnect all callbacks upon shutdown.
-
 
 class LocationEvent(Event):
     """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1344,22 +1344,6 @@ class LocationEvent(Event):
                 self.xdata = xdata
                 self.ydata = ydata
 
-    def _process(self):
-        last = LocationEvent.lastevent
-        last_axes = last.inaxes if last is not None else None
-        if last_axes != self.inaxes:
-            if last_axes is not None:
-                try:
-                    last.canvas.callbacks.process("axes_leave_event", last)
-                except Exception:
-                    # The last canvas may already have been torn down.
-                    pass
-            if self.inaxes is not None:
-                self.canvas.callbacks.process("axes_enter_event", self)
-        LocationEvent.lastevent = (
-            None if self.name == "figure_leave_event" else self)
-        super()._process()
-
 
 class MouseButton(IntEnum):
     LEFT = 1
@@ -1547,6 +1531,22 @@ class KeyEvent(LocationEvent):
         elif self.name == "key_release_event":
             self.canvas._key = None
         super()._process()
+
+
+def _axes_enter_leave_emitter(event):
+    last = LocationEvent.lastevent
+    last_axes = last.inaxes if last is not None else None
+    if last_axes != event.inaxes:
+        if last_axes is not None:
+            try:
+                last.canvas.callbacks.process("axes_leave_event", last)
+            except Exception:
+                # The last canvas may already have been torn down.
+                pass
+        if event.inaxes is not None:
+            event.canvas.callbacks.process("axes_enter_event", event)
+    LocationEvent.lastevent = (
+        None if event.name == "figure_leave_event" else event)
 
 
 def _get_renderer(figure, print_method=None):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -17,7 +17,8 @@ import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook, _c_internal_utils
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    TimerBase, ToolContainerBase, cursors, _Mode)
+    TimerBase, ToolContainerBase, cursors, _Mode,
+    CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 from matplotlib._pylab_helpers import Gcf
 from . import _tkagg
 
@@ -206,7 +207,7 @@ class FigureCanvasTk(FigureCanvasBase):
         # to the window and filter.
         def filter_destroy(event):
             if event.widget is self._tkcanvas:
-                self.close_event()
+                CloseEvent("close_event", self)._process()
         root.bind("<Destroy>", filter_destroy, "+")
 
         self._tkcanvas.focus_set()
@@ -239,7 +240,7 @@ class FigureCanvasTk(FigureCanvasBase):
             master=self._tkcanvas, width=int(width), height=int(height))
         self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
-        self.resize_event()
+        ResizeEvent("resize_event", self)._process()
 
     def draw_idle(self):
         # docstring inherited
@@ -271,12 +272,19 @@ class FigureCanvasTk(FigureCanvasBase):
                 self.figure.bbox.height - self._tkcanvas.canvasy(event.y))
 
     def motion_notify_event(self, event):
-        super().motion_notify_event(
-            *self._event_mpl_coords(event), guiEvent=event)
+        MouseEvent("motion_notify_event", self,
+                   *self._event_mpl_coords(event),
+                   guiEvent=event)._process()
 
     def enter_notify_event(self, event):
-        super().enter_notify_event(
-            guiEvent=event, xy=self._event_mpl_coords(event))
+        LocationEvent("figure_enter_event", self,
+                      *self._event_mpl_coords(event),
+                      guiEvent=event)._process()
+
+    def leave_notify_event(self, event):
+        LocationEvent("figure_leave_event", self,
+                      *self._event_mpl_coords(event),
+                      guiEvent=event)._process()
 
     def button_press_event(self, event, dblclick=False):
         # set focus to the canvas so that it can receive keyboard events
@@ -285,9 +293,9 @@ class FigureCanvasTk(FigureCanvasBase):
         num = getattr(event, 'num', None)
         if sys.platform == 'darwin':  # 2 and 3 are reversed.
             num = {2: 3, 3: 2}.get(num, num)
-        super().button_press_event(
-            *self._event_mpl_coords(event), num, dblclick=dblclick,
-            guiEvent=event)
+        MouseEvent("button_press_event", self,
+                   *self._event_mpl_coords(event), num, dblclick=dblclick,
+                   guiEvent=event)._process()
 
     def button_dblclick_event(self, event):
         self.button_press_event(event, dblclick=True)
@@ -296,25 +304,29 @@ class FigureCanvasTk(FigureCanvasBase):
         num = getattr(event, 'num', None)
         if sys.platform == 'darwin':  # 2 and 3 are reversed.
             num = {2: 3, 3: 2}.get(num, num)
-        super().button_release_event(
-            *self._event_mpl_coords(event), num, guiEvent=event)
+        MouseEvent("button_release_event", self,
+                   *self._event_mpl_coords(event), num,
+                   guiEvent=event)._process()
 
     def scroll_event(self, event):
         num = getattr(event, 'num', None)
         step = 1 if num == 4 else -1 if num == 5 else 0
-        super().scroll_event(
-            *self._event_mpl_coords(event), step, guiEvent=event)
+        MouseEvent("scroll_event", self,
+                   *self._event_mpl_coords(event), step=step,
+                   guiEvent=event)._process()
 
     def scroll_event_windows(self, event):
         """MouseWheel event processor"""
         # need to find the window that contains the mouse
         w = event.widget.winfo_containing(event.x_root, event.y_root)
-        if w == self._tkcanvas:
-            x = self._tkcanvas.canvasx(event.x_root - w.winfo_rootx())
-            y = (self.figure.bbox.height
-                 - self._tkcanvas.canvasy(event.y_root - w.winfo_rooty()))
-            step = event.delta/120.
-            FigureCanvasBase.scroll_event(self, x, y, step, guiEvent=event)
+        if w != self._tkcanvas:
+            return
+        x = self._tkcanvas.canvasx(event.x_root - w.winfo_rootx())
+        y = (self.figure.bbox.height
+             - self._tkcanvas.canvasy(event.y_root - w.winfo_rooty()))
+        step = event.delta / 120
+        MouseEvent("scroll_event", self,
+                   x, y, step=step, guiEvent=event)._process()
 
     def _get_key(self, event):
         unikey = event.char
@@ -356,12 +368,14 @@ class FigureCanvasTk(FigureCanvasBase):
         return key
 
     def key_press(self, event):
-        key = self._get_key(event)
-        FigureCanvasBase.key_press_event(self, key, guiEvent=event)
+        KeyEvent("key_press_event", self,
+                 self._get_key(event), *self._event_mpl_coords(event),
+                 guiEvent=event)._process()
 
     def key_release(self, event):
-        key = self._get_key(event)
-        FigureCanvasBase.key_release_event(self, key, guiEvent=event)
+        KeyEvent("key_release_event", self,
+                 self._get_key(event), *self._event_mpl_coords(event),
+                 guiEvent=event)._process()
 
     def new_timer(self, *args, **kwargs):
         # docstring inherited

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -241,6 +241,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
         ResizeEvent("resize_event", self)._process()
+        self.draw_idle()
 
     def draw_idle(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -4,7 +4,9 @@ import os
 
 import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
-from matplotlib.backend_bases import FigureCanvasBase, ToolContainerBase
+from matplotlib.backend_bases import (
+    FigureCanvasBase, ToolContainerBase,
+    CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 try:
     import gi
@@ -86,9 +88,10 @@ class FigureCanvasGTK4(FigureCanvasBase, Gtk.DrawingArea):
         # docstring inherited
         self.set_cursor_from_name(_backend_gtk.mpl_to_gtk_cursor_name(cursor))
 
-    def _mouse_event_coords(self, x, y):
+    def _mpl_coords(self, xy=None):
         """
-        Calculate mouse coordinates in physical pixels.
+        Convert the *xy* position of a GTK event, or of the current cursor
+        position if *xy* is None, to Matplotlib coordinates.
 
         GTK use logical pixels, but the figure is scaled to physical pixels for
         rendering.  Transform to physical pixels so that all of the down-stream
@@ -96,46 +99,56 @@ class FigureCanvasGTK4(FigureCanvasBase, Gtk.DrawingArea):
 
         Also, the origin is different and needs to be corrected.
         """
+        if xy is None:
+            surface = self.get_native().get_surface()
+            is_over, x, y, mask = surface.get_device_position(
+                self.get_display().get_default_seat().get_pointer())
+        else:
+            x, y = xy
         x = x * self.device_pixel_ratio
         # flip y so y=0 is bottom of canvas
         y = self.figure.bbox.height - y * self.device_pixel_ratio
         return x, y
 
     def scroll_event(self, controller, dx, dy):
-        FigureCanvasBase.scroll_event(self, 0, 0, dy)
+        MouseEvent("scroll_event", self,
+                   *self._mpl_coords(), step=dy)._process()
         return True
 
     def button_press_event(self, controller, n_press, x, y):
-        x, y = self._mouse_event_coords(x, y)
-        FigureCanvasBase.button_press_event(self, x, y,
-                                            controller.get_current_button())
+        MouseEvent("button_press_event", self,
+                   *self._mpl_coords((x, y)), controller.get_current_button()
+                   )._process()
         self.grab_focus()
 
     def button_release_event(self, controller, n_press, x, y):
-        x, y = self._mouse_event_coords(x, y)
-        FigureCanvasBase.button_release_event(self, x, y,
-                                              controller.get_current_button())
+        MouseEvent("button_release_event", self,
+                   *self._mpl_coords((x, y)), controller.get_current_button()
+                   )._process()
 
     def key_press_event(self, controller, keyval, keycode, state):
-        key = self._get_key(keyval, keycode, state)
-        FigureCanvasBase.key_press_event(self, key)
+        KeyEvent("key_press_event", self,
+                 self._get_key(keyval, keycode, state), *self._mpl_coords()
+                 )._process()
         return True
 
     def key_release_event(self, controller, keyval, keycode, state):
-        key = self._get_key(keyval, keycode, state)
-        FigureCanvasBase.key_release_event(self, key)
+        KeyEvent("key_release_event", self,
+                 self._get_key(keyval, keycode, state), *self._mpl_coords()
+                 )._process()
         return True
 
     def motion_notify_event(self, controller, x, y):
-        x, y = self._mouse_event_coords(x, y)
-        FigureCanvasBase.motion_notify_event(self, x, y)
+        MouseEvent("motion_notify_event", self,
+                   *self._mpl_coords((x, y)))._process()
 
     def leave_notify_event(self, controller):
-        FigureCanvasBase.leave_notify_event(self)
+        LocationEvent("figure_leave_event", self,
+                      *self._mpl_coords())._process()
 
     def enter_notify_event(self, controller, x, y):
-        x, y = self._mouse_event_coords(x, y)
-        FigureCanvasBase.enter_notify_event(self, xy=(x, y))
+        LocationEvent("figure_enter_event", self,
+                      *self._mpl_coords((x, y)))._process()
 
     def resize_event(self, area, width, height):
         self._update_device_pixel_ratio()
@@ -143,7 +156,7 @@ class FigureCanvasGTK4(FigureCanvasBase, Gtk.DrawingArea):
         winch = width * self.device_pixel_ratio / dpi
         hinch = height * self.device_pixel_ratio / dpi
         self.figure.set_size_inches(winch, hinch, forward=False)
-        FigureCanvasBase.resize_event(self)
+        ResizeEvent("resize_event", self)._process()
         self.draw_idle()
 
     def _get_key(self, keyval, keycode, state):

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -7,7 +7,7 @@ from . import _macosx
 from .backend_agg import FigureCanvasAgg
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    TimerBase)
+    ResizeEvent, TimerBase)
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
 
@@ -28,10 +28,8 @@ class FigureCanvasMac(FigureCanvasAgg, _macosx.FigureCanvas, FigureCanvasBase):
     # and we can just as well lift the FCBase base up one level, keeping it *at
     # the end* to have the right method resolution order.
 
-    # Events such as button presses, mouse movements, and key presses
-    # are handled in the C code and the base class methods
-    # button_press_event, button_release_event, motion_notify_event,
-    # key_press_event, and key_release_event are called from there.
+    # Events such as button presses, mouse movements, and key presses are
+    # handled in C and events (MouseEvent, etc.) are triggered from there.
 
     required_interactive_framework = "macosx"
     _timer_cls = TimerMac
@@ -100,7 +98,7 @@ class FigureCanvasMac(FigureCanvasAgg, _macosx.FigureCanvas, FigureCanvasBase):
         width /= scale
         height /= scale
         self.figure.set_size_inches(width, height, forward=False)
-        FigureCanvasBase.resize_event(self)
+        ResizeEvent("resize_event", self)._process()
         self.draw_idle()
 
 

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -348,6 +348,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         QtWidgets.QWidget.resizeEvent(self, event)
         # emit our resize events
         ResizeEvent("resize_event", self)._process()
+        self.draw_idle()
 
     def sizeHint(self):
         w, h = self.get_width_height()

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -343,6 +343,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         self._png_is_old = True
         self.manager.resize(*fig.bbox.size, forward=False)
         ResizeEvent('resize_event', self)._process()
+        self.draw_idle()
 
     def handle_send_image_mode(self, event):
         # The client requests notification of what the current image mode is.

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -23,7 +23,8 @@ from PIL import Image
 
 from matplotlib import _api, backend_bases, backend_tools
 from matplotlib.backends import backend_agg
-from matplotlib.backend_bases import _Backend
+from matplotlib.backend_bases import (
+    _Backend, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 _log = logging.getLogger(__name__)
 
@@ -162,23 +163,21 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         # Set to True when the renderer contains data that is newer
         # than the PNG buffer.
         self._png_is_old = True
-
         # Set to True by the `refresh` message so that the next frame
         # sent to the clients will be a full frame.
         self._force_full = True
-
         # The last buffer, for diff mode.
         self._last_buff = np.empty((0, 0))
-
         # Store the current image mode so that at any point, clients can
         # request the information. This should be changed by calling
         # self.set_image_mode(mode) so that the notification can be given
         # to the connected clients.
         self._current_image_mode = 'full'
+        # Track mouse events to fill in the x, y position of key events.
+        self._last_mouse_xy = (None, None)
 
     def show(self):
         # show the figure window
@@ -285,40 +284,35 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         x = event['x']
         y = event['y']
         y = self.get_renderer().height - y
-
-        # JavaScript button numbers and matplotlib button numbers are
-        # off by 1
+        self._last_mouse_xy = x, y
+        # JavaScript button numbers and Matplotlib button numbers are off by 1.
         button = event['button'] + 1
 
         e_type = event['type']
-        guiEvent = event.get('guiEvent', None)
-        if e_type == 'button_press':
-            self.button_press_event(x, y, button, guiEvent=guiEvent)
+        guiEvent = event.get('guiEvent')
+        if e_type in ['button_press', 'button_release']:
+            MouseEvent(e_type + '_event', self, x, y, button,
+                       guiEvent=guiEvent)._process()
         elif e_type == 'dblclick':
-            self.button_press_event(x, y, button, dblclick=True,
-                                    guiEvent=guiEvent)
-        elif e_type == 'button_release':
-            self.button_release_event(x, y, button, guiEvent=guiEvent)
-        elif e_type == 'motion_notify':
-            self.motion_notify_event(x, y, guiEvent=guiEvent)
-        elif e_type == 'figure_enter':
-            self.enter_notify_event(xy=(x, y), guiEvent=guiEvent)
-        elif e_type == 'figure_leave':
-            self.leave_notify_event()
+            MouseEvent('button_press_event', self, x, y, button, dblclick=True,
+                       guiEvent=guiEvent)._process()
         elif e_type == 'scroll':
-            self.scroll_event(x, y, event['step'], guiEvent=guiEvent)
+            MouseEvent('scroll_event', self, x, y, step=event['step'],
+                       guiEvent=guiEvent)._process()
+        elif e_type == 'motion_notify':
+            MouseEvent(e_type + '_event', self, x, y,
+                       guiEvent=guiEvent)._process()
+        elif e_type in ['figure_enter', 'figure_leave']:
+            LocationEvent(e_type + '_event', self, x, y,
+                          guiEvent=guiEvent)._process()
     handle_button_press = handle_button_release = handle_dblclick = \
         handle_figure_enter = handle_figure_leave = handle_motion_notify = \
         handle_scroll = _handle_mouse
 
     def _handle_key(self, event):
-        key = _handle_key(event['key'])
-        e_type = event['type']
-        guiEvent = event.get('guiEvent', None)
-        if e_type == 'key_press':
-            self.key_press_event(key, guiEvent=guiEvent)
-        elif e_type == 'key_release':
-            self.key_release_event(key, guiEvent=guiEvent)
+        KeyEvent(event['type'] + '_event', self,
+                 _handle_key(event['key']), *self._last_mouse_xy,
+                 guiEvent=event.get('guiEvent'))._process()
     handle_key_press = handle_key_release = _handle_key
 
     def handle_toolbar_button(self, event):
@@ -348,7 +342,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         # identical or within a pixel or so).
         self._png_is_old = True
         self.manager.resize(*fig.bbox.size, forward=False)
-        self.resize_event()
+        ResizeEvent('resize_event', self)._process()
 
     def handle_send_image_mode(self, event):
         # The client requests notification of what the current image mode is.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -705,6 +705,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # the whole background is repainted.
         self.Refresh(eraseBackground=False)
         ResizeEvent("resize_event", self)._process()
+        self.draw_idle()
 
     def _get_key(self, event):
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -19,9 +19,10 @@ import PIL
 
 import matplotlib as mpl
 from matplotlib.backend_bases import (
-    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
-    MouseButton, NavigationToolbar2, RendererBase, TimerBase,
-    ToolContainerBase, cursors)
+    _Backend, FigureCanvasBase, FigureManagerBase,
+    GraphicsContextBase, MouseButton, NavigationToolbar2, RendererBase,
+    TimerBase, ToolContainerBase, cursors,
+    CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 from matplotlib import _api, cbook, backend_tools
 from matplotlib._pylab_helpers import Gcf
@@ -529,8 +530,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         self.Bind(wx.EVT_MOUSE_AUX2_DCLICK, self._on_mouse_button)
         self.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
         self.Bind(wx.EVT_MOTION, self._on_motion)
-        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
         self.Bind(wx.EVT_ENTER_WINDOW, self._on_enter)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
 
         self.Bind(wx.EVT_MOUSE_CAPTURE_CHANGED, self._on_capture_lost)
         self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self._on_capture_lost)
@@ -703,7 +704,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # so no need to do anything here except to make sure
         # the whole background is repainted.
         self.Refresh(eraseBackground=False)
-        FigureCanvasBase.resize_event(self)
+        ResizeEvent("resize_event", self)._process()
 
     def _get_key(self, event):
 
@@ -730,17 +731,32 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
 
         return key
 
+    def _mpl_coords(self, pos=None):
+        """
+        Convert a wx position, defaulting to the current cursor position, to
+        Matplotlib coordinates.
+        """
+        if pos is None:
+            pos = wx.GetMouseState()
+            x, y = self.ScreenToClient(pos.X, pos.Y)
+        else:
+            x, y = pos.X, pos.Y
+        # flip y so y=0 is bottom of canvas
+        return x, self.figure.bbox.height - y
+
     def _on_key_down(self, event):
         """Capture key press."""
-        key = self._get_key(event)
-        FigureCanvasBase.key_press_event(self, key, guiEvent=event)
+        KeyEvent("key_press_event", self,
+                 self._get_key(event), *self._mpl_coords(),
+                 guiEvent=event)._process()
         if self:
             event.Skip()
 
     def _on_key_up(self, event):
         """Release key."""
-        key = self._get_key(event)
-        FigureCanvasBase.key_release_event(self, key, guiEvent=event)
+        KeyEvent("key_release_event", self,
+                 self._get_key(event), *self._mpl_coords(),
+                 guiEvent=event)._process()
         if self:
             event.Skip()
 
@@ -773,8 +789,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         """Start measuring on an axis."""
         event.Skip()
         self._set_capture(event.ButtonDown() or event.ButtonDClick())
-        x = event.X
-        y = self.figure.bbox.height - event.Y
+        x, y = self._mpl_coords(event)
         button_map = {
             wx.MOUSE_BTN_LEFT: MouseButton.LEFT,
             wx.MOUSE_BTN_MIDDLE: MouseButton.MIDDLE,
@@ -785,18 +800,18 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         button = event.GetButton()
         button = button_map.get(button, button)
         if event.ButtonDown():
-            self.button_press_event(x, y, button, guiEvent=event)
+            MouseEvent("button_press_event", self,
+                       x, y, button, guiEvent=event)._process()
         elif event.ButtonDClick():
-            self.button_press_event(x, y, button, dblclick=True,
-                                    guiEvent=event)
+            MouseEvent("button_press_event", self,
+                       x, y, button, dblclick=True, guiEvent=event)._process()
         elif event.ButtonUp():
-            self.button_release_event(x, y, button, guiEvent=event)
+            MouseEvent("button_release_event", self,
+                       x, y, button, guiEvent=event)._process()
 
     def _on_mouse_wheel(self, event):
         """Translate mouse wheel events into matplotlib events"""
-        # Determine mouse location
-        x = event.GetX()
-        y = self.figure.bbox.height - event.GetY()
+        x, y = self._mpl_coords(event)
         # Convert delta/rotation/rate into a floating point step size
         step = event.LinesPerAction * event.WheelRotation / event.WheelDelta
         # Done handling event
@@ -810,26 +825,29 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
                 return  # Return without processing event
             else:
                 self._skipwheelevent = True
-        FigureCanvasBase.scroll_event(self, x, y, step, guiEvent=event)
+        MouseEvent("scroll_event", self,
+                   x, y, step=step, guiEvent=event)._process()
 
     def _on_motion(self, event):
         """Start measuring on an axis."""
-        x = event.GetX()
-        y = self.figure.bbox.height - event.GetY()
         event.Skip()
-        FigureCanvasBase.motion_notify_event(self, x, y, guiEvent=event)
+        MouseEvent("motion_notify_event", self,
+                   *self._mpl_coords(event),
+                   guiEvent=event)._process()
+
+    def _on_enter(self, event):
+        """Mouse has entered the window."""
+        event.Skip()
+        LocationEvent("figure_enter_event", self,
+                      *self._mpl_coords(event),
+                      guiEvent=event)._process()
 
     def _on_leave(self, event):
         """Mouse has left the window."""
         event.Skip()
-        FigureCanvasBase.leave_notify_event(self, guiEvent=event)
-
-    def _on_enter(self, event):
-        """Mouse has entered the window."""
-        x = event.GetX()
-        y = self.figure.bbox.height - event.GetY()
-        event.Skip()
-        FigureCanvasBase.enter_notify_event(self, guiEvent=event, xy=(x, y))
+        LocationEvent("figure_leave_event", self,
+                      *self._mpl_coords(event),
+                      guiEvent=event)._process()
 
 
 class FigureCanvasWx(_FigureCanvasWxBase):
@@ -945,7 +963,7 @@ class FigureFrameWx(wx.Frame):
 
     def _on_close(self, event):
         _log.debug("%s - on_close()", type(self))
-        self.canvas.close_event()
+        CloseEvent("close_event", self.canvas)._process()
         self.canvas.stop_event_loop()
         # set FigureManagerWx.frame to None to prevent repeated attempts to
         # close this frame from FigureManagerWx.destroy()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2376,8 +2376,16 @@ class Figure(FigureBase):
             'button_press_event', self.pick)
         self._scroll_pick_id = self._canvas_callbacks._connect_picklable(
             'scroll_event', self.pick)
-        self._axes_enter_leave_id = self._canvas_callbacks.connect(
-            'motion_notify_event', backend_bases._axes_enter_leave_emitter)
+        connect = self._canvas_callbacks._connect_picklable
+        self._mouse_key_ids = [
+            connect('key_press_event', backend_bases._key_handler),
+            connect('key_release_event', backend_bases._key_handler),
+            connect('key_release_event', backend_bases._key_handler),
+            connect('button_press_event', backend_bases._mouse_handler),
+            connect('button_release_event', backend_bases._mouse_handler),
+            connect('scroll_event', backend_bases._mouse_handler),
+            connect('motion_notify_event', backend_bases._mouse_handler),
+        ]
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -27,7 +27,7 @@ from matplotlib import _blocking_input, _docstring, projections
 from matplotlib.artist import (
     Artist, allow_rasterization, _finalize_rasterization)
 from matplotlib.backend_bases import (
-    FigureCanvasBase, NonGuiException, MouseButton, _get_renderer)
+    DrawEvent, FigureCanvasBase, NonGuiException, MouseButton, _get_renderer)
 import matplotlib._api as _api
 import matplotlib.cbook as cbook
 import matplotlib.colorbar as cbar
@@ -2979,7 +2979,7 @@ class Figure(FigureBase):
         finally:
             self.stale = False
 
-        self.canvas.draw_event(renderer)
+        DrawEvent("draw_event", self.canvas, renderer)._process()
 
     def draw_without_rendering(self):
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -23,7 +23,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _blocking_input, _docstring, projections
+from matplotlib import _blocking_input, backend_bases, _docstring, projections
 from matplotlib.artist import (
     Artist, allow_rasterization, _finalize_rasterization)
 from matplotlib.backend_bases import (
@@ -2376,6 +2376,8 @@ class Figure(FigureBase):
             'button_press_event', self.pick)
         self._scroll_pick_id = self._canvas_callbacks._connect_picklable(
             'scroll_event', self.pick)
+        self._axes_enter_leave_id = self._canvas_callbacks.connect(
+            'motion_notify_event', backend_bases._axes_enter_leave_emitter)
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -82,6 +82,7 @@ _test_timeout = 60  # A reasonably safe value for slower architectures.
 # early.  Also, gtk3 redefines key_press_event with a different signature, so
 # we directly invoke it from the superclass instead.
 def _test_interactive_impl():
+    import importlib
     import importlib.util
     import io
     import json
@@ -90,8 +91,7 @@ def _test_interactive_impl():
 
     import matplotlib as mpl
     from matplotlib import pyplot as plt, rcParams
-    from matplotlib.backend_bases import FigureCanvasBase
-
+    from matplotlib.backend_bases import KeyEvent
     rcParams.update({
         "webagg.open_in_browser": False,
         "webagg.port_retries": 1,
@@ -140,8 +140,8 @@ def _test_interactive_impl():
     if fig.canvas.toolbar:  # i.e toolbar2.
         fig.canvas.toolbar.draw_rubberband(None, 1., 1, 2., 2)
 
-    timer = fig.canvas.new_timer(1.)  # Test floats casting to int as needed.
-    timer.add_callback(FigureCanvasBase.key_press_event, fig.canvas, "q")
+    timer = fig.canvas.new_timer(1.)  # Test that floats are cast to int.
+    timer.add_callback(KeyEvent("key_press_event", fig.canvas, "q")._process)
     # Trigger quitting upon draw.
     fig.canvas.mpl_connect("draw_event", lambda event: timer.start())
     fig.canvas.mpl_connect("close_event", print)

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -9,7 +9,7 @@ from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.lines as mlines
-from matplotlib.backend_bases import MouseButton
+from matplotlib.backend_bases import MouseButton, MouseEvent
 
 from matplotlib.offsetbox import (
     AnchoredOffsetbox, AnnotationBbox, AnchoredText, DrawingArea, OffsetBox,
@@ -228,7 +228,8 @@ def test_picking(child_type, boxcoords):
         x, y = ax.transAxes.transform_point((0.5, 0.5))
     fig.canvas.draw()
     calls.clear()
-    fig.canvas.button_press_event(x, y, MouseButton.LEFT)
+    MouseEvent(
+        "button_press_event", fig.canvas, x, y, MouseButton.LEFT)._process()
     assert len(calls) == 1 and calls[0].artist == ab
 
     # Annotation should *not* be picked by an event at its original center
@@ -237,7 +238,8 @@ def test_picking(child_type, boxcoords):
     ax.set_ylim(-1, 0)
     fig.canvas.draw()
     calls.clear()
-    fig.canvas.button_press_event(x, y, MouseButton.LEFT)
+    MouseEvent(
+        "button_press_event", fig.canvas, x, y, MouseButton.LEFT)._process()
     assert len(calls) == 0
 
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,6 +1,7 @@
 import functools
 
 from matplotlib._api.deprecation import MatplotlibDeprecationWarning
+from matplotlib.backend_bases import MouseEvent
 import matplotlib.colors as mcolors
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
@@ -1486,16 +1487,22 @@ def test_polygon_selector_box(ax):
     canvas = ax.figure.canvas
 
     # Scale to half size using the top right corner of the bounding box
-    canvas.button_press_event(*t.transform((40, 40)), 1)
-    canvas.motion_notify_event(*t.transform((20, 20)))
-    canvas.button_release_event(*t.transform((20, 20)), 1)
+    MouseEvent(
+        "button_press_event", canvas, *t.transform((40, 40)), 1)._process()
+    MouseEvent(
+        "motion_notify_event", canvas, *t.transform((20, 20)))._process()
+    MouseEvent(
+        "button_release_event", canvas, *t.transform((20, 20)), 1)._process()
     np.testing.assert_allclose(
         tool.verts, [(10, 0), (0, 10), (10, 20), (20, 10)])
 
     # Move using the center of the bounding box
-    canvas.button_press_event(*t.transform((10, 10)), 1)
-    canvas.motion_notify_event(*t.transform((30, 30)))
-    canvas.button_release_event(*t.transform((30, 30)), 1)
+    MouseEvent(
+        "button_press_event", canvas, *t.transform((10, 10)), 1)._process()
+    MouseEvent(
+        "motion_notify_event", canvas, *t.transform((30, 30)))._process()
+    MouseEvent(
+        "button_release_event", canvas, *t.transform((30, 30)), 1)._process()
     np.testing.assert_allclose(
         tool.verts, [(30, 20), (20, 30), (30, 40), (40, 30)])
 
@@ -1503,8 +1510,10 @@ def test_polygon_selector_box(ax):
     np.testing.assert_allclose(
         tool._box.extents, (20.0, 40.0, 20.0, 40.0))
 
-    canvas.button_press_event(*t.transform((30, 20)), 3)
-    canvas.button_release_event(*t.transform((30, 20)), 3)
+    MouseEvent(
+        "button_press_event", canvas, *t.transform((30, 20)), 3)._process()
+    MouseEvent(
+        "button_release_event", canvas, *t.transform((30, 20)), 3)._process()
     np.testing.assert_allclose(
         tool.verts, [(20, 30), (30, 40), (40, 30)])
     np.testing.assert_allclose(


### PR DESCRIPTION
## PR Summary

Currently, UI events (MouseEvent, KeyEvent, etc.) are generated by
letting the GUI-specific backends massage the native event objects into
a list of args/kwargs and then call
`FigureCanvasBase.motion_notify_event`/`.key_press_event`/etc.  This
makes it a bit tricky to improve the metadata on the events, because one
needs to change the signature on both the `FigureCanvasBase` method and
the event class.  Moreover, the `motion_notify_event`/etc. methods are
directly bound as event handlers in the gtk3 and tk backends, and thus
have incompatible signatures there.

Instead, the native GUI handlers can directly construct the relevant
event objects and trigger the events themselves; a new `Event.process`
helper method makes this even shorter (and allows to keep factoring some
common functionality e.g. for tracking the last pressed button or key).

As an example, this PR also updates figure_leave_event to always
correctly set the event location based on the *current* cursor position,
instead of the last triggered location event (which may be outdated);
this can now easily be done on a backend-by-backend basis, instead of
coordinating the change with FigureCanvasBase.figure_leave_event.

This also exposed another (minor) issue, in that resize events often
trigger *two* calls to draw_idle -- one in the GUI-specific handler, and
one in FigureCanvasBase.draw_idle (now moved to ResizeEvent.process, but
should perhaps instead be a callback autoconnected to "resize_event") --
could probably be fixed later.

---

As an example, this strategy would have made the change at #9814 easier (by just passing the correct additional arguments to LocationEvent).

This would also make #6159 easier (right now #6159 only fixes modifiers for button_press_event, but it would also nice to have it for motion_notify_event and button_release_event).

Also closes https://github.com/matplotlib/matplotlib/issues/8715 (by deprecating the relevant handlers).

---

Another small commit updates .gitattributes so that diffs in _macosx.m get the correct context when displayed locally.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
