### PR TITLE
Making sure to keep over/under/bad in cmap resample/reverse.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -790,7 +790,12 @@ class LinearSegmentedColormap(Colormap):
 
     def _resample(self, lutsize):
         """Return a new color map with *lutsize* entries."""
-        return LinearSegmentedColormap(self.name, self._segmentdata, lutsize)
+        new_cmap = LinearSegmentedColormap(self.name, self._segmentdata,
+                                           lutsize)
+        new_cmap._rgba_over = self._rgba_over
+        new_cmap._rgba_under = self._rgba_under
+        new_cmap._rgba_bad = self._rgba_bad
+        return new_cmap
 
     # Helper ensuring picklability of the reversed cmap.
     @staticmethod
@@ -821,7 +826,12 @@ class LinearSegmentedColormap(Colormap):
                         [(1.0 - x, y1, y0) for x, y0, y1 in reversed(data)])
                   for key, data in self._segmentdata.items()}
 
-        return LinearSegmentedColormap(name, data_r, self.N, self._gamma)
+        new_cmap = LinearSegmentedColormap(name, data_r, self.N, self._gamma)
+        # Reverse the over/under values too
+        new_cmap._rgba_over = self._rgba_under
+        new_cmap._rgba_under = self._rgba_over
+        new_cmap._rgba_bad = self._rgba_bad
+        return new_cmap
 
 
 class ListedColormap(Colormap):
@@ -885,7 +895,12 @@ class ListedColormap(Colormap):
     def _resample(self, lutsize):
         """Return a new color map with *lutsize* entries."""
         colors = self(np.linspace(0, 1, lutsize))
-        return ListedColormap(colors, name=self.name)
+        new_cmap = ListedColormap(colors, name=self.name)
+        # Keep the over/under values too
+        new_cmap._rgba_over = self._rgba_over
+        new_cmap._rgba_under = self._rgba_under
+        new_cmap._rgba_bad = self._rgba_bad
+        return new_cmap
 
     def reversed(self, name=None):
         """
@@ -906,7 +921,12 @@ class ListedColormap(Colormap):
             name = self.name + "_r"
 
         colors_r = list(reversed(self.colors))
-        return ListedColormap(colors_r, name=name, N=self.N)
+        new_cmap = ListedColormap(colors_r, name=name, N=self.N)
+        # Reverse the over/under values too
+        new_cmap._rgba_over = self._rgba_under
+        new_cmap._rgba_under = self._rgba_over
+        new_cmap._rgba_bad = self._rgba_bad
+        return new_cmap
 
 
 class Normalize:

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -39,6 +39,11 @@ def test_resample():
     colorlist[:, 3] = 0.7
     lsc = mcolors.LinearSegmentedColormap.from_list('lsc', colorlist)
     lc = mcolors.ListedColormap(colorlist)
+    # Set some bad values for testing too
+    for cmap in [lsc, lc]:
+        cmap.set_under('r')
+        cmap.set_over('g')
+        cmap.set_bad('b')
     lsc3 = lsc._resample(3)
     lc3 = lc._resample(3)
     expected = np.array([[0.0, 0.2, 1.0, 0.7],
@@ -46,6 +51,13 @@ def test_resample():
                          [1.0, 0.2, 0.0, 0.7]], float)
     assert_array_almost_equal(lsc3([0, 0.5, 1]), expected)
     assert_array_almost_equal(lc3([0, 0.5, 1]), expected)
+    # Test over/under was copied properly
+    assert_array_almost_equal(lsc(np.inf), lsc3(np.inf))
+    assert_array_almost_equal(lsc(-np.inf), lsc3(-np.inf))
+    assert_array_almost_equal(lsc(np.nan), lsc3(np.nan))
+    assert_array_almost_equal(lc(np.inf), lc3(np.inf))
+    assert_array_almost_equal(lc(-np.inf), lc3(-np.inf))
+    assert_array_almost_equal(lc(np.nan), lc3(np.nan))
 
 
 def test_register_cmap():
@@ -818,6 +830,10 @@ def test_colormap_reversing(name):
         cmap._init()
         cmap_r._init()
     assert_array_almost_equal(cmap._lut[:-3], cmap_r._lut[-4::-1])
+    # Test the bad, over, under values too
+    assert_array_almost_equal(cmap(-np.inf), cmap_r(np.inf))
+    assert_array_almost_equal(cmap(np.inf), cmap_r(-np.inf))
+    assert_array_almost_equal(cmap(np.nan), cmap_r(np.nan))
 
 
 def test_cn():


### PR DESCRIPTION
## PR Summary

Setting the over/under/bad when calling _resample or reverse on the colormaps.

Fixes part of #16296
Addresses bullet 3 of this comment: https://github.com/matplotlib/matplotlib/issues/16296#issuecomment-597113684

Could possibly be made a little more elegant using #14645
However, when I was working through this it isn't quite so simple as calling `set_over()` on the new_cmap object because you're calling it with None which can't be converted to a color on the other side. You also can't update the`new_cmap. _lut` directly because when generating the `cmap_d` the `_lut` of all colormaps is not populated initially and it is still calling reverse().

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
