### PR TITLE
Cleanup/tighten axes_grid.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -402,3 +402,10 @@ The qt4agg and qt4cairo backends are deprecated.
 ``RendererWx.get_gc``
 ~~~~~~~~~~~~~~~~~~~~~
 This method is deprecated.  Access the ``gc`` attribute directly instead.
+
+*add_all* parameter in ``axes_grid``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *add_all* parameter of `.axes_grid1.axes_grid.Grid`,
+`.axes_grid1.axes_grid.ImageGrid`, `.axes_grid1.axes_rgb.make_rgb_axes` and
+`.axes_grid1.axes_rgb.RGBAxes` is deprecated.  Axes are now always added to the
+parent figure, though they can be later removed with ``ax.remove()``.

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -68,12 +68,8 @@ class Divider:
         return [s.get_size(renderer) for s in self.get_vertical()]
 
     def get_vsize_hsize(self):
-
-        from .axes_size import AddList
-
-        vsize = AddList(self.get_vertical())
-        hsize = AddList(self.get_horizontal())
-
+        vsize = Size.AddList(self.get_vertical())
+        hsize = Size.AddList(self.get_horizontal())
         return vsize, hsize
 
     @staticmethod

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -93,6 +93,7 @@ class Grid:
 
     _defaultAxesClass = Axes
 
+    @cbook._delete_parameter("3.3", "add_all")
     def __init__(self, fig,
                  rect,
                  nrows_ncols,
@@ -128,6 +129,7 @@ class Grid:
             inches.
         add_all : bool, default: True
             Whether to add the axes to the figure using `.Figure.add_axes`.
+            This parameter is deprecated.
         share_all : bool, default: False
             Whether all axes share their x- and y-axis.  Overrides *share_x*
             and *share_y*.
@@ -343,6 +345,7 @@ class ImageGrid(Grid):
 
     _defaultCbarAxesClass = CbarAxes
 
+    @cbook._delete_parameter("3.3", "add_all")
     def __init__(self, fig,
                  rect,
                  nrows_ncols,
@@ -381,6 +384,7 @@ class ImageGrid(Grid):
             inches.
         add_all : bool, default: True
             Whether to add the axes to the figure using `.Figure.add_axes`.
+            This parameter is deprecated.
         share_all : bool, default: False
             Whether all axes share their x- and y-axis.
         aspect : bool, default: True
@@ -415,11 +419,18 @@ class ImageGrid(Grid):
         self._colorbar_size = cbar_size
         # The colorbar axes are created in _init_locators().
 
-        super().__init__(
-            fig, rect, nrows_ncols, ngrids,
-            direction=direction, axes_pad=axes_pad, add_all=add_all,
-            share_all=share_all, share_x=True, share_y=True, aspect=aspect,
-            label_mode=label_mode, axes_class=axes_class)
+        if add_all:
+            super().__init__(
+                fig, rect, nrows_ncols, ngrids,
+                direction=direction, axes_pad=axes_pad,
+                share_all=share_all, share_x=True, share_y=True, aspect=aspect,
+                label_mode=label_mode, axes_class=axes_class)
+        else:  # Only show deprecation in that case.
+            super().__init__(
+                fig, rect, nrows_ncols, ngrids,
+                direction=direction, axes_pad=axes_pad, add_all=add_all,
+                share_all=share_all, share_x=True, share_y=True, aspect=aspect,
+                label_mode=label_mode, axes_class=axes_class)
 
         if add_all:
             for ax in self.cbar_axes:

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -335,14 +335,7 @@ class Grid:
         return self._divider.get_locator()
 
     def get_vsize_hsize(self):
-
         return self._divider.get_vsize_hsize()
-#         from axes_size import AddList
-
-#         vsize = AddList(self._divider.get_vertical())
-#         hsize = AddList(self._divider.get_horizontal())
-
-#         return vsize, hsize
 
 
 class ImageGrid(Grid):

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -5,6 +5,7 @@ from .axes_divider import make_axes_locatable, Size
 from .mpl_axes import Axes
 
 
+@cbook._delete_parameter("3.3", "add_all")
 def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True, **kwargs):
     """
     Parameters
@@ -89,6 +90,7 @@ class RGBAxes:
 
     _defaultAxesClass = Axes
 
+    @cbook._delete_parameter("3.3", "add_all")
     def __init__(self, *args, pad=0, add_all=True, **kwargs):
         """
         Parameters
@@ -96,7 +98,8 @@ class RGBAxes:
         pad : float, default: 0
             fraction of the axes height to put as padding.
         add_all : bool, default: True
-            Whether to add the {rgb, r, g, b} axes to the figure
+            Whether to add the {rgb, r, g, b} axes to the figure.
+            This parameter is deprecated.
         axes_class : matplotlib.axes.Axes
 
         *args
@@ -108,8 +111,10 @@ class RGBAxes:
         self.RGB = ax = axes_class(*args, **kwargs)
         if add_all:
             ax.get_figure().add_axes(ax)
+        else:
+            kwargs["add_all"] = add_all  # only show deprecation in that case
         self.R, self.G, self.B = make_rgb_axes(
-            ax, pad=pad, axes_class=axes_class, add_all=add_all, **kwargs)
+            ax, pad=pad, axes_class=axes_class, **kwargs)
         self._config_axes()
 
     def _config_axes(self, line_color='w', marker_edge_color='w'):


### PR DESCRIPTION
## PR Summary

First commit: Remove commented-out implementation and in-function import.
    
The commented out code in Grid.get_vsize_hsize is the same as
Divider.get_vsize_hsize.


Second commit:  Deprecate add_all parameter.
    
I'm not really sure there's a use case for not adding axes to the parent
figure (it was never used in the history of the library), and in any
case axes can always be removed with `ax.remove()`.


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
