### PR TITLE
Cleanup and avoid refleaks OSX Timer__timer_start.

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -55,10 +55,8 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
 
     def _draw(self):
         renderer = self.get_renderer(cleared=self.figure.stale)
-
         if self.figure.stale:
             self.figure.draw(renderer)
-
         return renderer
 
     def draw(self):


### PR DESCRIPTION
Reference leaks where occurring with early `return NULL`, e.g. if
`PyObject_IsTrue(attribute)` or `PyMethod_Check(attribute)` failed.

Also there's plenty of cases where one doesn't need to set the error
message, as PyObject_GetAttrString (for example) will set the correct
exception.

Also apply similar cleanups to drawRect, even though it doesn't actually
suffer from refleaks.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
