### PR TITLE
Changing get_cmap to return copies of the registered colormaps.

### DIFF
--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -147,9 +147,9 @@ The parameter ``s`` to `.Axes.annotate` and  `.pyplot.annotate` is renamed to
 The old parameter name remains supported, but
 support for it will be dropped in a future Matplotlib release.
 
-`pyplot.get_cmap()` now returns a copy of the colormap
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Previously, calling ``.pyplot.get_cmap()`` would return a pointer to
+``get_cmap()`` now returns a copy of the colormap
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, calling ``get_cmap()`` would return
 the built-in Colormap. If you made modifications to that colormap, the
 changes would be propagated in the global state. This function now
 returns a copy of all registered colormaps to keep the built-in

--- a/doc/api/next_api_changes/behaviour.rst
+++ b/doc/api/next_api_changes/behaviour.rst
@@ -98,9 +98,9 @@ deprecation warning.
 `~.Axes.errorbar` now color cycles when only errorbar color is set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously setting the *ecolor* would turn off automatic color cycling for the plot, leading to the 
-the lines and markers defaulting to whatever the first color in the color cycle was in the case of 
-multiple plot calls. 
+Previously setting the *ecolor* would turn off automatic color cycling for the plot, leading to the
+the lines and markers defaulting to whatever the first color in the color cycle was in the case of
+multiple plot calls.
 
 `.rcsetup.validate_color_for_prop_cycle` now always raises TypeError for bytes input
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,4 +146,12 @@ The parameter ``s`` to `.Axes.annotate` and  `.pyplot.annotate` is renamed to
 
 The old parameter name remains supported, but
 support for it will be dropped in a future Matplotlib release.
+
+`pyplot.get_cmap()` now returns a copy of the colormap
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, calling ``.pyplot.get_cmap()`` would return a pointer to
+the built-in Colormap. If you made modifications to that colormap, the
+changes would be propagated in the global state. This function now
+returns a copy of all registered colormaps to keep the built-in
+colormaps untouched.
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -15,6 +15,7 @@ Builtin colormaps, colormap handling utilities, and the `ScalarMappable` mixin.
   normalization.
 """
 
+import copy
 import functools
 
 import numpy as np
@@ -70,7 +71,7 @@ def _gen_cmap_d():
 
 
 cmap_d = _gen_cmap_d()
-locals().update(cmap_d)
+locals().update(copy.deepcopy(cmap_d))
 
 
 # Continue with definitions ...
@@ -95,6 +96,9 @@ def register_cmap(name=None, cmap=None, data=None, lut=None):
     and the resulting colormap is registered. Instead of this implicit
     colormap creation, create a `.LinearSegmentedColormap` and use the first
     case: ``register_cmap(cmap=LinearSegmentedColormap(name, data, lut))``.
+
+    If *name* is the same as a built-in colormap this will replace the
+    built-in Colormap of the same name.
     """
     cbook._check_isinstance((str, None), name=name)
     if name is None:
@@ -124,15 +128,16 @@ def get_cmap(name=None, lut=None):
     """
     Get a colormap instance, defaulting to rc values if *name* is None.
 
-    Colormaps added with :func:`register_cmap` take precedence over
-    built-in colormaps.
+    Colormaps added with :func:`register_cmap` with the same name as
+    built-in colormaps will replace them.
 
     Parameters
     ----------
     name : `matplotlib.colors.Colormap` or str or None, default: None
-        If a `.Colormap` instance, it will be returned.  Otherwise, the name of
-        a colormap known to Matplotlib, which will be resampled by *lut*.  The
-        default, None, means :rc:`image.cmap`.
+        If a `.Colormap` instance, a copy of it will be returned.
+        Otherwise, the name of a colormap known to Matplotlib, which will
+        be resampled by *lut*. A copy of the requested Colormap is always
+        returned. The default, None, means :rc:`image.cmap`.
     lut : int or None, default: None
         If *name* is not already a Colormap instance and *lut* is not None, the
         colormap will be resampled to have *lut* entries in the lookup table.
@@ -140,10 +145,10 @@ def get_cmap(name=None, lut=None):
     if name is None:
         name = mpl.rcParams['image.cmap']
     if isinstance(name, colors.Colormap):
-        return name
+        return copy.copy(name)
     cbook._check_in_list(sorted(cmap_d), name=name)
     if lut is None:
-        return cmap_d[name]
+        return copy.copy(cmap_d[name])
     else:
         return cmap_d[name]._resample(lut)
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -601,6 +601,18 @@ class Colormap:
             cmapobject._lut = np.copy(self._lut)
         return cmapobject
 
+    def __eq__(self, other):
+        if isinstance(other, Colormap):
+            # To compare lookup tables the Colormaps have to be initialized
+            if not self._isinit:
+                self._init()
+            if not other._isinit:
+                other._init()
+            if self._lut.shape != other._lut.shape:
+                return False
+            return np.all(self._lut == other._lut)
+        return False
+
     def set_bad(self, color='k', alpha=None):
         """Set the color for masked values."""
         self._rgba_bad = to_rgba(color, alpha)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -515,6 +515,8 @@ class Colormap:
         self._i_over = self.N + 1
         self._i_bad = self.N + 2
         self._isinit = False
+        # This is to aid in deprecation transition for v3.3
+        self._global_changed = False
 
         #: When this colormap exists on a scalar mappable and colorbar_extend
         #: is not False, colorbar creation will pick up ``colorbar_extend`` as
@@ -599,6 +601,7 @@ class Colormap:
         cmapobject.__dict__.update(self.__dict__)
         if self._isinit:
             cmapobject._lut = np.copy(self._lut)
+        cmapobject._global_changed = False
         return cmapobject
 
     def __eq__(self, other):
@@ -618,6 +621,7 @@ class Colormap:
         self._rgba_bad = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        self._global_changed = True
 
     def set_under(self, color='k', alpha=None):
         """
@@ -626,6 +630,7 @@ class Colormap:
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        self._global_changed = True
 
     def set_over(self, color='k', alpha=None):
         """
@@ -634,6 +639,7 @@ class Colormap:
         self._rgba_over = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        self._global_changed = True
 
     def _set_extremes(self):
         if self._rgba_under:
@@ -2110,6 +2116,7 @@ def from_levels_and_colors(levels, colors, extend='neither'):
         cmap.set_over('none')
 
     cmap.colorbar_extend = extend
+    cmap._global_changed = False
 
     norm = BoundaryNorm(levels, ncolors=n_data_colors)
     return cmap, norm

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -61,13 +61,25 @@ def test_resample():
 
 
 def test_register_cmap():
-    new_cm = copy.copy(plt.cm.viridis)
+    new_cm = plt.get_cmap('viridis')
     cm.register_cmap('viridis2', new_cm)
     assert plt.get_cmap('viridis2') == new_cm
 
     with pytest.raises(ValueError,
                        match='Arguments must include a name or a Colormap'):
         cm.register_cmap()
+
+
+def test_colormap_builtin_immutable():
+    new_cm = plt.get_cmap('viridis')
+    new_cm.set_over('b')
+    # Make sure that this didn't mess with the original viridis cmap
+    assert new_cm != plt.get_cmap('viridis')
+
+    # Also test that pyplot access doesn't mess the original up
+    new_cm = plt.cm.viridis
+    new_cm.set_over('b')
+    assert new_cm != plt.get_cmap('viridis')
 
 
 def test_colormap_copy():


### PR DESCRIPTION
This is an alternative proposal compared to making Colormap objects themselves immutable as mentioned in https://github.com/matplotlib/matplotlib/issues/16296#issuecomment-597113684. I expect this to have some discussion about extensibility and future directions, so I consider this a proposal/idea PR. Previous discussion can be found in issues #16296 and #14645 

Note that this isn't really deprecating anything, but it is changing some pretty significant behavior. I wasn't sure if it would need any deprecation/warnings put in somewhere, but figured that could wait until after some discussion as well.

## PR Summary

Previously, calling `plt.get_cmap()` would return a pointer to the object, which would allow you to modify the built-ins unknowingly.

```python
cmap = plt.get_cmap('viridis').set_over('b')
```
Previously, a second call to get the viridis colormap would return the modified colormap.
`cmap == plt.get_cmap('viridis') # True`
Now, it will return the original viridis built-in colormap.
`cmap == plt.get_cmap('viridis') # False`

## Implications

* Accessing colormaps through the pyplot interface could still mess people up since it is a single object still.
```python
cmap = plt.cm.viridis
cmap.set_over('b')
cmap == plt.cm.viridis # True
cmap == plt.cm.get_cmap('viridis') # False
```

* This also means that there are two copies of the colormap objects created initially now (one in `cmap_d` and a second deepcopy that I made for `locals()` to use with the pyplot interface.

* Is there a way to make the `plt.cm.viridis` object point to the function `plt.get_cmap('viridis')`? That may be and even nicer touch, but I couldn't think of anything quick off the top of my head.

* I had to add an equals method to Colormaps to compare lookup tables rather than object pointers that were done before. This will initialize the lookup table if it wasn't already previously, possibly leading to a little more overhead if people are comparing lots of colormaps.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
