### PR TITLE
TST: update default junit_family

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -7,8 +7,8 @@ from matplotlib import cbook
 def pytest_configure(config):
     # config is initialized here rather than in pytest.ini so that `pytest
     # --pyargs matplotlib` (which would not find pytest.ini) works.  The only
-    # entries in pytest.ini set minversion (which is checked earlier) and
-    # testpaths/python_files, as they are required to properly find the tests.
+    # entries in pytest.ini set minversion (which is checked earlier),
+    # testpaths/python_files, as they are required to properly find the tests
     for key, value in [
         ("markers", "flaky: (Provided by pytest-rerunfailures.)"),
         ("markers", "timeout: (Provided by pytest-timeout.)"),

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ minversion = 3.6
 
 testpaths = lib
 python_files = test_*.py
+junit_family = xunit2


### PR DESCRIPTION
## PR Summary

pytest 6 will be moving to this by default and azure supports this
format so might as well move to the future now.