### PR TITLE
CI: add a 'git status' line to appveyor for debugging

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,7 @@ test_script:
   # tests
   - echo The following args are passed to pytest %PYTEST_ARGS%
   - pytest %PYTEST_ARGS%
+  - git status
 
 after_test:
   # After the tests were a success, build wheels.


### PR DESCRIPTION
As suggested in #16941  something is happening that is making versioneer think there are uncommitted changes to git, add a `git status` to try and see what that change might be.