### PR TITLE
Fix missing parameter initialization in Axes.specgram()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7649,6 +7649,8 @@ default: :rc:`scatter.edgecolors`
         Z = np.flipud(Z)
 
         if xextent is None:
+            if Fs is None:
+                Fs = freqs[-1] * 2  # default set in mlab._spectral_helper()
             # padding is needed for first and last segment:
             pad_xextent = (NFFT-noverlap) / Fs / 2
             xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7617,6 +7617,8 @@ default: :rc:`scatter.edgecolors`
             Fc = 0  # same default as in mlab._spectral_helper()
         if noverlap is None:
             noverlap = 128  # same default as in mlab.specgram()
+        if Fs is None:
+            Fs = 2  # same default as in mlab._spectral_helper()
 
         if mode == 'complex':
             raise ValueError('Cannot plot a complex specgram')
@@ -7649,8 +7651,6 @@ default: :rc:`scatter.edgecolors`
         Z = np.flipud(Z)
 
         if xextent is None:
-            if Fs is None:
-                Fs = freqs[-1] * 2  # default set in mlab._spectral_helper()
             # padding is needed for first and last segment:
             pad_xextent = (NFFT-noverlap) / Fs / 2
             xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4166,6 +4166,17 @@ def test_specgram_angle():
                                 scale="dB")
 
 
+def test_specgram_fs_none():
+    """ Test axes.specgram when Fs is None, should not throw error """
+    try:
+        spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None)
+    except Exception as e:
+        raise pytest.fail("DID RAISE {0}".format(e))
+
+    xmin, xmax, freq0, freq1 = im.get_extent()
+    assert xmin == 32 and xmax == 96
+
+
 @image_comparison(
     ["psd_freqs.png", "csd_freqs.png", "psd_noise.png", "csd_noise.png"],
     remove_text=True, tol=0.002)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4167,7 +4167,8 @@ def test_specgram_angle():
 
 
 def test_specgram_fs_none():
-    """ Test axes.specgram when Fs is None, should not throw error """
+    """Test axes.specgram when Fs is None, should not throw error."""
+
     try:
         spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None)
     except Exception as e:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4168,12 +4168,7 @@ def test_specgram_angle():
 
 def test_specgram_fs_none():
     """Test axes.specgram when Fs is None, should not throw error."""
-
-    try:
-        spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None)
-    except Exception as e:
-        raise pytest.fail("DID RAISE {0}".format(e))
-
+    spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None)
     xmin, xmax, freq0, freq1 = im.get_extent()
     assert xmin == 32 and xmax == 96
 


### PR DESCRIPTION
## PR Summary
Added check to set Fs in _axes.specgram() to be Fs = freq[-1] * 2.
Added a test to test_axes.py to check if Fs is None that it won't throw an error.

Closes #9100

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
