### PR TITLE
solution: All subclasses of LocationEvent could be used in cbook.callbacks before being fully initialized - issue 15139

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1394,13 +1394,15 @@ class MouseEvent(LocationEvent):
         (*x*, *y*) in figure coords ((0, 0) = bottom left)
         button pressed None, 1, 2, 3, 'up', 'down'
         """
-        LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
         if button in MouseButton.__members__.values():
             button = MouseButton(button)
         self.button = button
         self.key = key
         self.step = step
         self.dblclick = dblclick
+
+        LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
+
 
     def __str__(self):
         return (f"{self.name}: "

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1401,7 +1401,8 @@ class MouseEvent(LocationEvent):
         self.step = step
         self.dblclick = dblclick
 
-        # super-init deferred to the end: callback errors if called before
+        # super-init is deferred to the end because it calls back on
+        # 'axes_enter_event', which requires a fully initialized event.
         LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
 
     def __str__(self):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1401,6 +1401,7 @@ class MouseEvent(LocationEvent):
         self.step = step
         self.dblclick = dblclick
 
+        # super-init deferred to the end: callback errors if called before
         LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
 
     def __str__(self):
@@ -1487,6 +1488,7 @@ class KeyEvent(LocationEvent):
     """
     def __init__(self, name, canvas, key, x=0, y=0, guiEvent=None):
         self.key = key
+        # super-init deferred to the end: callback errors if called before
         LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
 
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1486,8 +1486,8 @@ class KeyEvent(LocationEvent):
         cid = fig.canvas.mpl_connect('key_press_event', on_key)
     """
     def __init__(self, name, canvas, key, x=0, y=0, guiEvent=None):
-        LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
         self.key = key
+        LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
 
 
 def _get_renderer(figure, print_method):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1403,7 +1403,6 @@ class MouseEvent(LocationEvent):
 
         LocationEvent.__init__(self, name, canvas, x, y, guiEvent=guiEvent)
 
-
     def __str__(self):
         return (f"{self.name}: "
                 f"xy=({self.x}, {self.y}) xydata=({self.xdata}, {self.ydata}) "


### PR DESCRIPTION
## PR Summary
Modified the call to LocationEvent.__init__() to be after MouseButton initialization in MouseEvent.init(). The reason for this is the error occurs because callback.process is invoked before the initialization.

MouseEvent is a subclass of LocationEvent, so it is safe to say that motion_notify_event() can be called by a child class of LocationEvent.

Issue Ref: matplotlib#15139

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
