### PR TITLE
TST: Don't modify actual pyplot file for boilerplate test.

### DIFF
--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -10,31 +10,32 @@ from matplotlib import pyplot as plt
 from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
-def test_pyplot_up_to_date():
+def test_pyplot_up_to_date(tmpdir):
     gen_script = Path(mpl.__file__).parents[2] / "tools/boilerplate.py"
     if not gen_script.exists():
         pytest.skip("boilerplate.py not found")
     orig_contents = Path(plt.__file__).read_text()
-    try:
-        subprocess.run([sys.executable, str(gen_script)], check=True)
-        new_contents = Path(plt.__file__).read_text()
+    plt_file = tmpdir.join('pyplot.py')
+    plt_file.write_text(orig_contents, 'utf-8')
 
-        if orig_contents != new_contents:
-            diff_msg = '\n'.join(
-                difflib.unified_diff(
-                    orig_contents.split('\n'), new_contents.split('\n'),
-                    fromfile='found pyplot.py',
-                    tofile='expected pyplot.py',
-                    n=0, lineterm=''))
-            pytest.fail(
-                "pyplot.py is not up-to-date. Please run "
-                "'python tools/boilerplate.py' to update pyplot.py. "
-                "This needs to be done from an environment where your "
-                "current working copy is installed (e.g. 'pip install -e'd). "
-                "Here is a diff of unexpected differences:\n%s" % diff_msg
-            )
-    finally:
-        Path(plt.__file__).write_text(orig_contents)
+    subprocess.run([sys.executable, str(gen_script), str(plt_file)],
+                   check=True)
+    new_contents = plt_file.read_text('utf-8')
+
+    if orig_contents != new_contents:
+        diff_msg = '\n'.join(
+            difflib.unified_diff(
+                orig_contents.split('\n'), new_contents.split('\n'),
+                fromfile='found pyplot.py',
+                tofile='expected pyplot.py',
+                n=0, lineterm=''))
+        pytest.fail(
+            "pyplot.py is not up-to-date. Please run "
+            "'python tools/boilerplate.py' to update pyplot.py. "
+            "This needs to be done from an environment where your "
+            "current working copy is installed (e.g. 'pip install -e'd). "
+            "Here is a diff of unexpected differences:\n%s" % diff_msg
+        )
 
 
 def test_copy_docstring_and_deprecators(recwarn):

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -17,6 +17,7 @@ from enum import Enum
 import inspect
 from inspect import Parameter
 from pathlib import Path
+import sys
 import textwrap
 
 # This line imports the installed copy of matplotlib, and not the local copy.
@@ -337,9 +338,7 @@ def boilerplate_gen():
     yield '_setup_pyplot_info_docstrings()'
 
 
-def build_pyplot():
-    pyplot_path = Path(__file__).parent / "../lib/matplotlib/pyplot.py"
-
+def build_pyplot(pyplot_path):
     pyplot_orig = pyplot_path.read_text().splitlines(keepends=True)
     try:
         pyplot_orig = pyplot_orig[:pyplot_orig.index(PYPLOT_MAGIC_HEADER) + 1]
@@ -355,4 +354,8 @@ def build_pyplot():
 
 if __name__ == '__main__':
     # Write the matplotlib.pyplot file.
-    build_pyplot()
+    if len(sys.argv) > 1:
+        pyplot_path = Path(sys.argv[1])
+    else:
+        pyplot_path = Path(__file__).parent / "../lib/matplotlib/pyplot.py"
+    build_pyplot(pyplot_path)


### PR DESCRIPTION
## PR Summary

This should prevent git/versioneer from thinking the working tree is dirty if some parallel test happens to run while this one is mid-write.

Maybe will help to fix up #16941.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way