### PR TITLE
Improve error for quoted values in matplotlibrc.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -72,8 +72,14 @@ class ValidateInStrings:
             s = s.lower()
         if s in self.valid:
             return self.valid[s]
-        raise ValueError('Unrecognized %s string %r: valid strings are %s'
-                         % (self.key, s, list(self.valid.values())))
+        msg = (f"{s!r} is not a valid value for {self.key}; supported values "
+               f"are {[*self.valid.values()]}")
+        if (isinstance(s, str)
+                and (s.startswith('"') and s.endswith('"')
+                     or s.startswith("'") and s.endswith("'"))
+                and s[1:-1] in self.valid):
+            msg += "; remove quotes surrounding your string"
+        raise ValueError(msg)
 
 
 def _listify_validator(scalar_validator, allow_stringlist=False, *, doc=None):


### PR DESCRIPTION
... as the need for unquoted values in the matplotlibrc is slightly
confusing.

Also reword the error message to match the one in
_check_in_list/_check_getitem.

Closes #16952.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
