### PR TITLE
Simplify animation writer fallback.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1087,17 +1087,13 @@ class Animation:
         # If we have the name of a writer, instantiate an instance of the
         # registered class.
         if isinstance(writer, str):
-            if writers.is_available(writer):
-                writer = writers[writer](fps, **writer_kwargs)
-            else:
-                alt_writer = next(iter(writers), None)
-                if alt_writer is None:
-                    raise ValueError("Cannot save animation: no writers are "
-                                     "available. Please install ffmpeg to "
-                                     "save animations.")
-                _log.warning("MovieWriter %s unavailable; trying to use %s "
-                             "instead.", writer, alt_writer)
-                writer = alt_writer(fps, **writer_kwargs)
+            try:
+                writer_cls = writers[writer]
+            except RuntimeError:  # Raised if not available.
+                writer_cls = PillowWriter  # Always available.
+                _log.warning("MovieWriter %s unavailable; using Pillow "
+                             "instead.", writer)
+            writer = writer_cls(fps, **writer_kwargs)
         _log.info('Animation.save using %s', type(writer))
 
         if 'bbox_inches' in savefig_kwargs:


### PR DESCRIPTION
The fallback now always returns PillowWriter, which is the first
registered writer and is always available, so we may just as well be
more explicit.

(Not all writers support all output formats, but we don't have machinery
to select writers based on the output format right now anyways.)

Slightly more complex than https://github.com/matplotlib/matplotlib/pull/16966 so I'm milestoning this one to 3.3.0 instead, but we could also backport it to 3.2.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
