### PR TITLE
tk: Don't resize toolbar during resize event.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -448,9 +448,6 @@ class FigureManagerTk(FigureManagerBase):
     def resize(self, width, height):
         self.canvas._tkcanvas.configure(width=width, height=height)
 
-        if self.toolbar is not None:
-            self.toolbar.configure(width=width)
-
     def show(self):
         with _restore_foreground_window_at_end():
             if not self._shown:


### PR DESCRIPTION
## PR Summary

It is already resized by Tk due to its packing mode, and doing it manually causes the window to grow erratically during resize. This came about since #16929 stopped resizing the figure, so it needs to be backported as well.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way