### PR TITLE
Don't change Figure DPI if value unchanged

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -442,11 +442,12 @@ class Figure(Artist):
         forward : bool
             Passed on to `~.Figure.set_size_inches`
         """
-        self._dpi = dpi
-        self.dpi_scale_trans.clear().scale(dpi)
-        w, h = self.get_size_inches()
-        self.set_size_inches(w, h, forward=forward)
-        self.callbacks.process('dpi_changed', self)
+        if self._dpi != dpi:
+            self._dpi = dpi
+            self.dpi_scale_trans.clear().scale(dpi)
+            w, h = self.get_size_inches()
+            self.set_size_inches(w, h, forward=forward)
+            self.callbacks.process('dpi_changed', self)
 
     dpi = property(_get_dpi, _set_dpi, doc="The resolution in dots per inch.")
 


### PR DESCRIPTION
So while digging into #15131, I noticed a change in how much we call resize. Here is the sample code I'm running:
```python
import matplotlib
matplotlib.use('macosx')
import matplotlib.pyplot as plt
fig1, ax = plt.subplots()
plt.show()
```

When I run that  3.2.1, I see the following set of print outs of calls of various resize-related methods:
```
_macosx.View.windowDidResize
FigureCanvasMac.resize: 640 480 1.0
Figure.set_size_inches: False [6.4 4.8] 100.0
Figure._set_dpi 200.0 True
Figure.set_size_inches: True [6.4 4.8] 200.0
FigureManagerBase.resize
```

That looks reasonable. This is what the same code does on current master:
```
_macosx.View.windowDidResize
FigureCanvasMac.resize: 640 480 1.0
Figure.set_size_inches: False [6.4 4.8] 100.0
Figure._set_dpi 200.0 True
Figure.set_size_inches: True [6.4 4.8] 200.0
FigureManagerBase.resize
Figure._set_dpi 200.0 True
Figure.set_size_inches: True [6.4 4.8] 200.0
FigureManagerBase.resize
Figure._set_dpi 200.0 True
Figure.set_size_inches: True [6.4 4.8] 200.0
FigureManagerBase.resize
...[repeat last 3 lines 50 more times]
```

It looks like this change came in #16828. Prevously when `Text.get_window_extent` got a DPI of `None`, the function did not set `figure.dpi`. Now:

https://github.com/matplotlib/matplotlib/blob/e702edd1aa467fef05f83fbf93248026ad686d0c/lib/matplotlib/text.py#L894-L913

If DPI comes in as  `None`, the current DPI is grabbed and then reset on `Figure`. The change I've implemented here is to make setting `Figure.dpi` a no-op if the value isn't different. This gets us back to:
```
_macosx.View.windowDidResize
FigureCanvasMac.resize: 640 480 1.0
Figure.set_size_inches: False [6.4 4.8] 100.0
Figure._set_dpi 200.0 True
Figure.set_size_inches: True [6.4 4.8] 200.0
FigureManagerBase.resize
```