### PR TITLE
Fix resize bugs in GTK

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -436,10 +436,21 @@ class FigureManagerGTK3(FigureManagerBase):
 
     def resize(self, width, height):
         """Set the canvas size in pixels."""
-        #_, _, cw, ch = self.canvas.allocation
-        #_, _, ww, wh = self.window.allocation
-        #self.window.resize (width-cw+ww, height-ch+wh)
-        self.window.resize(width, height)
+        if self.toolbar:
+            toolbar_size = self.toolbar.size_request()
+            height += toolbar_size.height
+        if self.statusbar:
+            statusbar_size = self.statusbar.size_request()
+            height += statusbar_size.height
+        canvas_size = self.canvas.get_allocation()
+        if canvas_size.width == canvas_size.height == 1:
+            # A canvas size of (1, 1) cannot exist in most cases, because
+            # window decorations would prevent such a small window. This call
+            # must be before the window has been mapped and widgets have been
+            # sized, so just change the window's starting size.
+            self.window.set_default_size(width, height)
+        else:
+            self.window.resize(width, height)
 
 
 class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -442,6 +442,9 @@ class Figure(Artist):
         forward : bool
             Passed on to `~.Figure.set_size_inches`
         """
+        if dpi == self._dpi:
+            # We don't want to cause undue events in backends.
+            return
         self._dpi = dpi
         self.dpi_scale_trans.clear().scale(dpi)
         w, h = self.get_size_inches()

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -271,4 +271,5 @@ def test_canvas_reinit():
     fig.stale_callback = crashing_callback
     # this should not raise
     canvas = FigureCanvasQTAgg(fig)
+    fig.stale = True
     assert called


### PR DESCRIPTION
## PR Summary

This fixes #16934 by essentially reverting the `Text.get_window_extent` change, but in a more general way. Avoiding redundant event signals for changing DPI is somewhat safer for all backends as we can't really control whether a backend will trigger another draw on resize or not (ok, we could block their signals, but this is simpler). By doing it in the `Figure.set_dpi` method, it covers all cases that might come up in the future, and not just the `Text` one.

The second commit also fixes #10083 and #10566 for GTK.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way