### PR TITLE
Fix "out of bounds" undefined behavior

### DIFF
--- a/extern/agg24-svn/include/agg_pixfmt_gray.h
+++ b/extern/agg24-svn/include/agg_pixfmt_gray.h
@@ -136,14 +136,13 @@ namespace agg
         typedef typename color_type::calc_type    calc_type;
         enum 
         {
-            num_components = 1,
             pix_width = sizeof(value_type) * Step,
             pix_step = Step,
             pix_offset = Offset,
         };
         struct pixel_type
         {
-            value_type c[num_components];
+            value_type c[pix_step];
 
             void set(value_type v)
             {
@@ -167,22 +166,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return this + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return this + n;
             }
         };
 

--- a/extern/agg24-svn/include/agg_pixfmt_rgb.h
+++ b/extern/agg24-svn/include/agg_pixfmt_rgb.h
@@ -192,14 +192,13 @@ namespace agg
         typedef typename color_type::calc_type calc_type;
         enum 
         {
-            num_components = 3,
             pix_step = Step,
             pix_offset = Offset,
             pix_width = sizeof(value_type) * pix_step
         };
         struct pixel_type
         {
-            value_type c[num_components];
+            value_type c[pix_step];
 
             void set(value_type r, value_type g, value_type b)
             {
@@ -230,22 +229,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return this + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return this + n;
             }
         };
 

--- a/extern/agg24-svn/include/agg_pixfmt_rgba.h
+++ b/extern/agg24-svn/include/agg_pixfmt_rgba.h
@@ -1515,13 +1515,12 @@ namespace agg
         typedef typename color_type::calc_type calc_type;
         enum 
         {
-            num_components = 4,
             pix_step = 4,
             pix_width = sizeof(value_type) * pix_step,
         };
         struct pixel_type
         {
-            value_type c[num_components];
+            value_type c[pix_step];
 
             void set(value_type r, value_type g, value_type b, value_type a)
             {
@@ -1555,22 +1554,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return this + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return this + n;
             }
         };
 
@@ -2193,13 +2192,12 @@ namespace agg
         typedef typename color_type::calc_type calc_type;
         enum 
         {
-            num_components = 4,
             pix_step = 4,
             pix_width  = sizeof(value_type) * pix_step,
         };
         struct pixel_type
         {
-            value_type c[num_components];
+            value_type c[pix_step];
 
             void set(value_type r, value_type g, value_type b, value_type a)
             {
@@ -2233,22 +2231,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return this + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return this + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return this + n;
             }
         };
 


### PR DESCRIPTION
This is detected with clang and -fsanitizer=bounds.
    
Out-of-bound addressing array of fixed size is undefined
behavior in both C and C++. It is so even if underlying
memory is properly allocated.
    
Easy fix here is to iterate with this pointer instead of
pixel_type::c array.