### PR TITLE
Correctly disable more drawing methods in tight_bboxing renderer.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1500,7 +1500,7 @@ def _get_renderer(figure, print_method, *, draw_disabled=False):
     Get the renderer that would be used to save a `~.Figure`, and cache it on
     the figure.
 
-    If *draw_disabled* is True, additionally replace draw_foo methods on
+    If *draw_disabled* is True, additionally replace drawing methods on
     *renderer* by no-ops.  This is used by the tight-bbox-saving renderer,
     which needs to walk through the artist tree to compute the tight-bbox, but
     for which the output file may be closed early.
@@ -1521,7 +1521,8 @@ def _get_renderer(figure, print_method, *, draw_disabled=False):
 
     if draw_disabled:
         for meth_name in dir(RendererBase):
-            if meth_name.startswith("draw_"):
+            if (meth_name.startswith("draw_")
+                    or meth_name in ["open_group", "close_group"]):
                 setattr(renderer, meth_name, lambda *args, **kwargs: None)
 
     return renderer

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -207,3 +207,9 @@ def test_gid():
     for gid, obj in gdic.items():
         if include(gid, obj):
             assert gid in buf
+
+
+def test_savefig_tight():
+    # Check that the draw-disabled renderer correctly disables open/close_group
+    # as well.
+    plt.savefig(BytesIO(), format="svgz", bbox_inches="tight")


### PR DESCRIPTION
These methods also try to write to the output file.

Closes https://github.com/matplotlib/matplotlib/issues/16978.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
