### PR TITLE
Adds normalize kwarg to pie function

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -172,6 +172,12 @@ values are displayed with an appropriate number of significant digits even if
 they are much smaller or much bigger than 1.  To restore the old behavior,
 explicitly pass a "%1.2f" as the *valfmt* parameter to `.Slider`.
 
+Add *normalize*  keyword argument to ``Axes.pie``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``pie()`` used to draw a partial pie if the sum of the values was < 1. This behavior 
+is deprecated and will change to always normalizing the values to a full pie by default. 
+If you want to draw a partial pie, please pass ``normalize=False`` explicitly.
+
 ``table.CustomCell`` is now an alias for `.table.Cell`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 All the functionality of ``CustomCell`` has been moved to its base class

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2943,15 +2943,15 @@ class Axes(_AxesBase):
             Draw a shadow beneath the pie.
 
         normalize: None or bool, default: None
-            ``pie()`` used to draw a partial pie if ``sum(x) < 1``. This
-            behavior is deprecated and will change to always normalizing the
-            values to a full pie by default. If you want to draw a partial pie,
-            please pass ``normalize=False`` explicitly.
             When *True*, always make a full pie by normalizing x so that
             ``sum(x) == 1``. When *False*, make a partial pie.
             When *None*, gives the current behavior and warns if
             ``sum(x) < 1``. Please note that passing None to this parameter is
             deprecated.
+            ``pie()`` used to draw a partial pie if ``sum(x) < 1``. This
+            behavior is deprecated and will change to always normalizing the
+            values to a full pie by default. If you want to draw a partial pie,
+            please pass ``normalize=False`` explicitly.
 
         labeldistance : float or None, default: 1.1
             The radial distance at which the pie labels are drawn.
@@ -3025,11 +3025,11 @@ class Axes(_AxesBase):
         if normalize is None:
             if sx < 1:
                 cbook.warn_deprecated(
-                    "3.1", message="normalize=None does not normalize if "
-                    "the sum is less than 1 "
-                    "but this behavior is deprecated "
-                    "since %(since)s. After the deprecation period "
-                    "the default value will be normalize=True. "
+                    "3.3", message="normalize=None does not normalize "
+                    "if the sum is less than 1 but this behavior"
+                    "is deprecated since %(since)s until %(removal)s. "
+                    "After the deprecation "
+                    "period the default value will be normalize=True. "
                     "To prevent normalization pass normalize=False ")
             else:
                 normalize = True

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2944,7 +2944,8 @@ class Axes(_AxesBase):
 
         normalize: None or bool, default: None
             When *True*, always make a full pie by normalizing x so that
-            ``sum(x) == 1``. When *False*, make a partial (or overfull) pie.
+            ``sum(x) == 1``. *False* makes a partial pie if ``sum(x) <= 1``
+            and raises a `ValueError` for ``sum(x) > 1``.
 
             When *None*, defaults to *True* if ``sum(x) > 0`` and *False* if
             ``sum(x) < 1``.
@@ -3036,6 +3037,8 @@ class Axes(_AxesBase):
                 normalize = True
         if normalize:
             x = x / sx
+        elif sx > 1:
+            raise ValueError('Cannot plot an unnormalized pie with sum(x) > 1')
         if labels is None:
             labels = [''] * len(x)
         if explode is None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2949,12 +2949,10 @@ class Axes(_AxesBase):
             When *None*, defaults to *True* if ``sum(x) > 0`` and *False* if
             ``sum(x) < 1``.
 
-            Please note that passing None to this parameter is deprecated.
-
-            ``pie()`` used to draw a partial pie if ``sum(x) < 1``. This
-            behavior is deprecated and will change to always normalizing the
-            values to a full pie by default. If you want to draw a partial pie,
-            please pass ``normalize=False`` explicitly.
+            Please note that the previous default value of *None* is now
+            deprecated, and the default will change to *True* in the next
+            release. Please pass ``normalize=False`` explicitly if you want to
+            draw a partial pie.
 
         labeldistance : float or None, default: 1.1
             The radial distance at which the pie labels are drawn.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2901,7 +2901,7 @@ class Axes(_AxesBase):
             autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
             startangle=0, radius=1, counterclock=True,
             wedgeprops=None, textprops=None, center=(0, 0),
-            frame=False, rotatelabels=False):
+            frame=False, rotatelabels=False, *, normalize=None):
         """
         Plot a pie chart.
 
@@ -2941,6 +2941,17 @@ class Axes(_AxesBase):
 
         shadow : bool, default: False
             Draw a shadow beneath the pie.
+
+        normalize: None or bool, default: None
+            ``pie()`` used to draw a partial pie if ``sum(x) < 1``. This
+            behavior is deprecated and will change to always normalizing the
+            values to a full pie by default. If you want to draw a partial pie,
+            please pass ``normalize=False`` explicitly.
+            When *True*, always make a full pie by normalizing x so that
+            ``sum(x) == 1``. When *False*, make a partial pie.
+            When *None*, gives the current behavior and warns if
+            ``sum(x) < 1``. Please note that passing None to this parameter is
+            deprecated.
 
         labeldistance : float or None, default: 1.1
             The radial distance at which the pie labels are drawn.
@@ -3010,9 +3021,20 @@ class Axes(_AxesBase):
             raise ValueError("Wedge sizes 'x' must be non negative values")
 
         sx = x.sum()
-        if sx > 1:
-            x = x / sx
 
+        if normalize is None:
+            if sx < 1:
+                cbook.warn_deprecated(
+                    "3.1", message="normalize=None does not normalize if "
+                    "the sum is less than 1 "
+                    "but this behavior is deprecated "
+                    "since %(since)s. After the deprecation period "
+                    "the default value will be normalize=True. "
+                    "To prevent normalization pass normalize=False ")
+            else:
+                normalize = True
+        if normalize:
+            x = x / sx
         if labels is None:
             labels = [''] * len(x)
         if explode is None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2946,7 +2946,7 @@ class Axes(_AxesBase):
             When *True*, always make a full pie by normalizing x so that
             ``sum(x) == 1``. When *False*, make a partial (or overfull) pie.
 
-            When *None*, gives the normalize if ``sum(x) > 0`` and warn if
+            When *None*, defaults to *True* if ``sum(x) > 0`` and *False* if
             ``sum(x) < 1``.
 
             Please note that passing None to this parameter is deprecated.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2944,10 +2944,13 @@ class Axes(_AxesBase):
 
         normalize: None or bool, default: None
             When *True*, always make a full pie by normalizing x so that
-            ``sum(x) == 1``. When *False*, make a partial pie.
-            When *None*, gives the current behavior and warns if
-            ``sum(x) < 1``. Please note that passing None to this parameter is
-            deprecated.
+            ``sum(x) == 1``. When *False*, make a partial (or overfull) pie.
+
+            When *None*, gives the normalize if ``sum(x) > 0`` and warn if
+            ``sum(x) < 1``.
+
+            Please note that passing None to this parameter is deprecated.
+
             ``pie()`` used to draw a partial pie if ``sum(x) < 1``. This
             behavior is deprecated and will change to always normalizing the
             values to a full pie by default. If you want to draw a partial pie,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2639,14 +2639,14 @@ def pie(
         pctdistance=0.6, shadow=False, labeldistance=1.1,
         startangle=0, radius=1, counterclock=True, wedgeprops=None,
         textprops=None, center=(0, 0), frame=False,
-        rotatelabels=False, *, data=None):
+        rotatelabels=False, *, normalize=None, data=None):
     return gca().pie(
         x, explode=explode, labels=labels, colors=colors,
         autopct=autopct, pctdistance=pctdistance, shadow=shadow,
         labeldistance=labeldistance, startangle=startangle,
         radius=radius, counterclock=counterclock,
         wedgeprops=wedgeprops, textprops=textprops, center=center,
-        frame=frame, rotatelabels=rotatelabels,
+        frame=frame, rotatelabels=rotatelabels, normalize=normalize,
         **({"data": data} if data is not None else {}))
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6145,3 +6145,26 @@ def test_ytickcolor_is_not_markercolor():
     ticks = ax.yaxis.get_major_ticks()
     for tick in ticks:
         assert tick.tick1line.get_markeredgecolor() != 'white'
+
+
+@check_figures_equal(extensions=["png"])
+def test_polar_interpolation_steps_variable_r(fig_test, fig_ref):
+    l, = fig_test.add_subplot(projection="polar").plot([0, np.pi/2], [1, 2])
+    l.get_path()._interpolation_steps = 100
+    fig_ref.add_subplot(projection="polar").plot(
+        np.linspace(0, np.pi/2, 101), np.linspace(1, 2, 101))
+
+
+def test_normalize_kwarg_warn_pie():
+    fig, ax = plt.subplots()
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ax.pie(x=[0], normalize=None)
+
+
+def test_normalize_kwarg_pie():
+    fig, ax = plt.subplots()
+    x = [0.3, 0.3, 0.1]
+    t1 = ax.pie(x=x, normalize=True)
+    assert abs(t1[0][-1].theta2 - 360.) < 1e-3
+    t2 = ax.pie(x=x, normalize=False)
+    assert abs(t2[0][-1].theta2 - 360.) > 1e-3


### PR DESCRIPTION
## PR Summary
pie() used to draw a partial pie if the sum of the values was < 1 and already normalized the values if the sum was > 1. I added a kwarg normalize into pie function and deprecated the previous behaviour. Now, the function will always normalize the values to a full pie by default. If one wants to draw a partial pie, one should pass normalize=False explicitly.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
