### PR TITLE
update tox.ini to match pythons supported and allow flags for pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py35, py36
+envlist = py36, py37, py38
 
 [testenv]
 changedir = /tmp
@@ -14,7 +14,7 @@ setenv =
     PIP_ISOLATED = 1
 usedevelop = True
 commands =
-    pytest --pyargs matplotlib
+    pytest --pyargs matplotlib {posargs}
 deps =
     pytest
 


### PR DESCRIPTION
## PR Summary

Pulling tox.ini change out of #16922

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way