### PR TITLE
Deprecate case-insensitive properties.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -426,3 +426,10 @@ future.
 *minor* kwarg to `.Axis.get_ticklocs` will become keyword-only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Passing this argument positionally is deprecated.
+
+Case-insensitive properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Normalization of upper or mixed-case property names to lowercase in
+`.Artist.set` and `.Artist.update` is deprecated.  In the future, property
+names will be passed as is, allowing one to pass names such as *patchA* or
+*UVC*.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -980,7 +980,12 @@ class Artist:
         ret = []
         with cbook._setattr_cm(self, eventson=False):
             for k, v in props.items():
-                k = k.lower()
+                if k != k.lower():
+                    cbook.warn_deprecated(
+                        "3.3", message="Case-insensitive properties were "
+                        "deprecated in %(since)s and support will be removed "
+                        "%(removal)s")
+                    k = k.lower()
                 # White list attributes we want to be able to update through
                 # art.update, art.set, setp.
                 if k == "axes":


### PR DESCRIPTION
As a real case, incorrectly passing "axA" instead of "axesA" to
ConnectionPatch currently triggers a slightly confusing warning
regarding the non-existence of the "axa" property.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
