### PR TITLE
Begin warning on modifying global state of colormaps

### DIFF
--- a/examples/images_contours_and_fields/demo_bboximage.py
+++ b/examples/images_contours_and_fields/demo_bboximage.py
@@ -38,7 +38,7 @@ a = np.linspace(0, 1, 256).reshape(1, -1)
 a = np.vstack((a, a))
 
 # List of all colormaps; skip reversed colormaps.
-maps = sorted(m for m in plt.cm.cmap_d if not m.endswith("_r"))
+maps = sorted(m for m in plt.colormaps() if not m.endswith("_r"))
 
 ncol = 2
 nrow = len(maps)//ncol + 1

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -140,11 +140,11 @@ def figure_edit(axes, parent=None):
         mappabledict[label] = mappable
     mappablelabels = sorted(mappabledict, key=cmp_key)
     mappables = []
-    cmaps = [(cmap, name) for name, cmap in sorted(cm.cmap_d.items())]
+    cmaps = [(cmap, name) for name, cmap in sorted(cm._cmap_registry.items())]
     for label in mappablelabels:
         mappable = mappabledict[label]
         cmap = mappable.get_cmap()
-        if cmap not in cm.cmap_d.values():
+        if cmap not in cm._cmap_registry.values():
             cmaps = [(cmap, cmap.name), *cmaps]
         low, high = mappable.get_clim()
         mappabledata = [

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -484,6 +484,21 @@ def makeMappingArray(N, data, gamma=1.0):
     return _create_lookup_table(N, data, gamma)
 
 
+def _deprecate_global_cmap(cmap):
+    if hasattr(cmap, '_global') and cmap._global:
+        cbook.warn_deprecated(
+            "3.3",
+            message="You are modifying the state of a globally registered "
+                    "colormap. In future versions, you will not be able "
+                    "to modify a globally registered colormap directly. "
+                    "To eliminate this warning until then, you can make "
+                    "a copy of the requested colormap before modifying it. ",
+            alternative="To modify a colormap without overwriting the "
+                        "global state, you can make a copy of the colormap "
+                        f"first. cmap = copy.copy(mpl.cm.get_cmap({cmap.name})"
+        )
+
+
 class Colormap:
     """
     Baseclass for all scalar to RGBA mappings.
@@ -599,6 +614,7 @@ class Colormap:
         cmapobject.__dict__.update(self.__dict__)
         if self._isinit:
             cmapobject._lut = np.copy(self._lut)
+        cmapobject._global = False
         return cmapobject
 
     def set_bad(self, color='k', alpha=None):
@@ -606,6 +622,7 @@ class Colormap:
         self._rgba_bad = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        _deprecate_global_cmap(self)
 
     def set_under(self, color='k', alpha=None):
         """
@@ -614,6 +631,7 @@ class Colormap:
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        _deprecate_global_cmap(self)
 
     def set_over(self, color='k', alpha=None):
         """
@@ -622,6 +640,7 @@ class Colormap:
         self._rgba_over = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+        _deprecate_global_cmap(self)
 
     def _set_extremes(self):
         if self._rgba_under:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -484,18 +484,15 @@ def makeMappingArray(N, data, gamma=1.0):
     return _create_lookup_table(N, data, gamma)
 
 
-def _deprecate_global_cmap(cmap):
-    if hasattr(cmap, '_global') and cmap._global:
+def _warn_if_global_cmap_modified(cmap):
+    if getattr(cmap, '_global', False):
         cbook.warn_deprecated(
             "3.3",
             message="You are modifying the state of a globally registered "
-                    "colormap. In future versions, you will not be able "
-                    "to modify a globally registered colormap directly. "
-                    "To eliminate this warning until then, you can make "
-                    "a copy of the requested colormap before modifying it. ",
-            alternative="To modify a colormap without overwriting the "
-                        "global state, you can make a copy of the colormap "
-                        f"first. cmap = copy.copy(mpl.cm.get_cmap({cmap.name})"
+                    "colormap. In future versions, you will not be able to "
+                    "modify a registered colormap in-place. To remove this "
+                    "warning, you can make a copy of the colormap first. "
+                    f"cmap = mpl.cm.get_cmap({cmap.name}).copy()"
         )
 
 
@@ -619,28 +616,28 @@ class Colormap:
 
     def set_bad(self, color='k', alpha=None):
         """Set the color for masked values."""
+        _warn_if_global_cmap_modified(self)
         self._rgba_bad = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
-        _deprecate_global_cmap(self)
 
     def set_under(self, color='k', alpha=None):
         """
         Set the color for low out-of-range values when ``norm.clip = False``.
         """
+        _warn_if_global_cmap_modified(self)
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
-        _deprecate_global_cmap(self)
 
     def set_over(self, color='k', alpha=None):
         """
         Set the color for high out-of-range values when ``norm.clip = False``.
         """
+        _warn_if_global_cmap_modified(self)
         self._rgba_over = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
-        _deprecate_global_cmap(self)
 
     def _set_extremes(self):
         if self._rgba_under:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1948,7 +1948,7 @@ def colormaps():
       <https://www.mathworks.com/matlabcentral/fileexchange/2662-cmrmap-m>`_
       by Carey Rappaport
     """
-    return sorted(cm.cmap_d)
+    return sorted(cm._cmap_registry)
 
 
 def _setup_pyplot_info_docstrings():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -70,38 +70,6 @@ def test_register_cmap():
         cm.register_cmap()
 
 
-@pytest.mark.skipif(matplotlib.__version__ < "3.5",
-                    reason="This test modifies the global state of colormaps.")
-def test_colormap_global_unchanged_state():
-    new_cm = plt.get_cmap('viridis')
-    new_cm.set_over('b')
-    # Make sure that this didn't mess with the original viridis cmap
-    assert new_cm != plt.get_cmap('viridis')
-
-    # Also test that pyplot access doesn't mess the original up
-    new_cm = plt.cm.viridis
-    new_cm.set_over('b')
-    assert new_cm != plt.get_cmap('viridis')
-
-
-@pytest.mark.skipif(matplotlib.__version__ < "3.4",
-                    reason="This test modifies the global state of colormaps.")
-def test_colormap_global_get_warn():
-    new_cm = plt.get_cmap('viridis')
-    # Store the old value so we don't override the state later on.
-    orig_cmap = copy.copy(new_cm)
-    new_cm.set_under('k')
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
-                      match="You are modifying the state of a globally"):
-        # This should warn now because we've modified the global state
-        # without registering it
-        plt.get_cmap('viridis')
-
-    # Test that re-registering the original cmap clears the warning
-    plt.register_cmap(cmap=orig_cmap)
-    plt.get_cmap('viridis')
-
-
 def test_colormap_global_set_warn():
     new_cm = plt.get_cmap('viridis')
     # Store the old value so we don't override the state later on.
@@ -124,6 +92,17 @@ def test_colormap_global_set_warn():
 
     # Re-register the original
     plt.register_cmap(cmap=orig_cmap)
+
+
+def test_colormap_dict_deprecate():
+    # Make sure we warn on get and set access into cmap_d
+    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+                      match="The global colormaps dictionary is no longer"):
+        cm = plt.cm.cmap_d['viridis']
+
+    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+                      match="The global colormaps dictionary is no longer"):
+        plt.cm.cmap_d['test'] = cm
 
 
 def test_colormap_copy():
@@ -874,7 +853,7 @@ def test_pandas_iterable(pd):
     assert_array_equal(cm1.colors, cm2.colors)
 
 
-@pytest.mark.parametrize('name', sorted(cm.cmap_d))
+@pytest.mark.parametrize('name', sorted(plt.colormaps()))
 def test_colormap_reversing(name):
     """
     Check the generated _lut data of a colormap and corresponding reversed

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -190,7 +190,7 @@ def test_shared():
     assert fig.axes[1].get_xlim() == (10, 20)
 
 
-@pytest.mark.parametrize("cmap", cm.cmap_d.values())
+@pytest.mark.parametrize("cmap", cm._cmap_registry.values())
 def test_cmap(cmap):
     pickle.dumps(cmap)
 


### PR DESCRIPTION
## PR Summary

This is the start of deprecating global state access for built-in colormaps. It doesn't implement any solutions yet, just begins to warn users about what will happen.

Returning a copy of colormaps is implemented in #16943 

Per the dev call, the tentative plan forward is:
### 3.3
- [x] still return global
- [x] warn on set_*
- [x] make cmap_d private and warn on read/write

### 3.4:
- [ ] return a copy
- [ ] don’t warn on set_*
- [ ] warn on re-accessing a color map that would have been changed

### 3.5:
- [ ] either return a copy or make colormaps immutable

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way