### PR TITLE
Implement FigureManager.resize for macosx backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -46,12 +46,14 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         FigureCanvasBase.__init__(self, figure)
         width, height = self.get_width_height()
         _macosx.FigureCanvas.__init__(self, width, height)
-        self._device_scale = 1.0
+        self._dpi_ratio = 1.0
 
     def _set_device_scale(self, value):
-        if self._device_scale != value:
-            self.figure.dpi = self.figure.dpi / self._device_scale * value
-            self._device_scale = value
+        if self._dpi_ratio != value:
+            # Need the new value in place before setting figure.dpi, which
+            # will trigger a resize
+            self._dpi_ratio, old_value = value, self._dpi_ratio
+            self.figure.dpi = self.figure.dpi / old_value * self._dpi_ratio
 
     def _draw(self):
         renderer = self.get_renderer(cleared=self.figure.stale)
@@ -77,8 +79,8 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         dpi = self.figure.dpi
         width /= dpi
         height /= dpi
-        self.figure.set_size_inches(width * self._device_scale,
-                                    height * self._device_scale,
+        self.figure.set_size_inches(width * self._dpi_ratio,
+                                    height * self._dpi_ratio,
                                     forward=False)
         FigureCanvasBase.resize_event(self)
         self.draw_idle()

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -337,6 +337,13 @@ FigureCanvas_init(FigureCanvas *self, PyObject *args, PyObject *kwds)
 
     NSRect rect = NSMakeRect(0.0, 0.0, width, height);
     self->view = [self->view initWithFrame: rect];
+    int opts = (NSTrackingMouseEnteredAndExited |
+                NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect);
+    [self->view addTrackingArea: [
+        [NSTrackingArea alloc] initWithRect: rect
+                                    options: opts
+                                      owner: self->view
+                                   userInfo: nil]];
     [self->view setCanvas: (PyObject*)self];
     return 0;
 }
@@ -1565,7 +1572,6 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     self = [super initWithFrame: rect];
     rubberband = NSZeroRect;
     inside = false;
-    tracking = 0;
     device_scale = 1;
     return self;
 }
@@ -1574,7 +1580,6 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
 {
     FigureCanvas* fc = (FigureCanvas*)canvas;
     if (fc) fc->view = NULL;
-    [self removeTrackingRect: tracking];
     [super dealloc];
 }
 
@@ -1713,11 +1718,6 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     else
         PyErr_Print();
     PyGILState_Release(gstate);
-    if (tracking) [self removeTrackingRect: tracking];
-    tracking = [self addTrackingRect: [self bounds]
-                               owner: self
-                            userData: nil
-                        assumeInside: NO];
     [self setNeedsDisplay: YES];
 }
 

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -810,6 +810,22 @@ FigureManager_get_window_title(FigureManager* self)
     }
 }
 
+static PyObject*
+FigureManager_resize(FigureManager* self, PyObject *args, PyObject *kwds)
+{
+    int width, height;
+    if (!PyArg_ParseTuple(args, "ii", &width, &height)) {
+        return NULL;
+    }
+    Window* window = self->window;
+    if(window)
+    {
+        // 36 comes from hard-coded size of toolbar later in code
+        [window setContentSize: NSMakeSize(width, height + 36.)];
+    }
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef FigureManager_methods[] = {
     {"show",
      (PyCFunction)FigureManager_show,
@@ -830,6 +846,11 @@ static PyMethodDef FigureManager_methods[] = {
      (PyCFunction)FigureManager_get_window_title,
      METH_NOARGS,
      "Returns the title of the window associated with the figure manager."
+    },
+    {"resize",
+     (PyCFunction)FigureManager_resize,
+     METH_VARARGS,
+     "Resize the window (in pixels)."
     },
     {NULL}  /* Sentinel */
 };

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -337,6 +337,7 @@ FigureCanvas_init(FigureCanvas *self, PyObject *args, PyObject *kwds)
 
     NSRect rect = NSMakeRect(0.0, 0.0, width, height);
     self->view = [self->view initWithFrame: rect];
+    self->view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     int opts = (NSTrackingMouseEnteredAndExited |
                 NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect);
     [self->view addTrackingArea: [
@@ -1707,8 +1708,6 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     size.height -= rect.origin.y;
     width = size.width;
     height = size.height;
-
-    [self setFrameSize: size];
 
     PyGILState_STATE gstate = PyGILState_Ensure();
     PyObject* result = PyObject_CallMethod(


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

Fixes #15131. In addition to implementing the missing method there are also a few clean-ups here for the macosx backend. This also depends on fixing handling of `Figure.dpi` changes in #16971 or #16972.
