### PR TITLE
 Clean up get_proj() docstring (used view_init docstring as reference)

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -914,7 +914,7 @@ class Axes3D(Axes):
         'elev' stores the elevation angle in the z plane (in degrees).
         'azim' stores the azimuth angle in the (x, y) plane (in degrees).
 
-        if elev or azim are None (default), then the initial value
+        if 'elev' or 'azim' are None (default), then the initial value
         is used which was specified in the :class:`Axes3D` constructor.
         """
 
@@ -947,10 +947,10 @@ class Axes3D(Axes):
         """
         Create the projection matrix from the current viewing position.
 
-        elev stores the elevation angle in the z plane
-        azim stores the azimuth angle in the (x, y) plane
+        'elev' stores the elevation angle in the z plane.
+        'azim' stores the azimuth angle in the (x, y) plane.
 
-        dist is the distance of the eye viewing point from the object point.
+        'dist' is the distance of the eye viewing point from the object point.
         """
         # chosen for similarity with the initial view before gh-8896
         pb_aspect = np.array([4, 4, 3]) / 3.5

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -154,10 +154,7 @@ class Axes3D(Axes):
 
     def _process_unit_info(self, xdata=None, ydata=None, zdata=None,
                            kwargs=None):
-        """
-        Look for unit *kwargs* and update the axis instances as necessary
-
-        """
+        """Look for unit *kwargs* and update the axis instances as necessary."""
         super()._process_unit_info(xdata=xdata, ydata=ydata, kwargs=kwargs)
 
         if self.xaxis is None or self.yaxis is None or self.zaxis is None:
@@ -944,10 +941,7 @@ class Axes3D(Axes):
         }, proj_type=proj_type)
 
     def get_proj(self):
-        """
-        Create the projection matrix from the current viewing position.
-        
-        """
+        """Create the projection matrix from the current viewing position."""
         # chosen for similarity with the initial view before gh-8896
         pb_aspect = np.array([4, 4, 3]) / 3.5
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -946,11 +946,7 @@ class Axes3D(Axes):
     def get_proj(self):
         """
         Create the projection matrix from the current viewing position.
-
-        'elev' stores the elevation angle in the z plane.
-        'azim' stores the azimuth angle in the (x, y) plane.
-
-        'dist' is the distance of the eye viewing point from the object point.
+        
         """
         # chosen for similarity with the initial view before gh-8896
         pb_aspect = np.array([4, 4, 3]) / 3.5

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -154,7 +154,7 @@ class Axes3D(Axes):
 
     def _process_unit_info(self, xdata=None, ydata=None, zdata=None,
                            kwargs=None):
-        """Look for unit *kwargs* and update the axis instances as necessary."""
+        """Update the axis instances based on unit *kwargs* if given."""
         super()._process_unit_info(xdata=xdata, ydata=ydata, kwargs=kwargs)
 
         if self.xaxis is None or self.yaxis is None or self.zaxis is None:


### PR DESCRIPTION
## PR Summary

Clean up the get_proj() docstring so that it follows the same format as view_init(elev=None, azim=None).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
