### PR TITLE
More stringent eventplot orientations.

### DIFF
--- a/doc/api/next_api_changes/deprecations.rst
+++ b/doc/api/next_api_changes/deprecations.rst
@@ -415,3 +415,10 @@ parent figure, though they can be later removed with ``ax.remove()``.
 
 ``.BboxBase.inverse_transformed`` is deprecated (call `.BboxBase.transformed`
 on the `~.Transform.inverted()` transform instead).
+
+*orientation* of ``eventplot()`` and `.EventCollection`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting the *orientation* of an ``eventplot()`` or `.EventCollection` to "none"
+or None is deprecated; set it to "horizontal" instead.  Moreover, the two
+orientations ("horizontal" and "vertical") will become case-sensitive in the
+future.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1264,7 +1264,7 @@ class Axes(_AxesBase):
             row corresponds to a row or a column of lines (depending on the
             *orientation* parameter).
 
-        orientation : {'horizontal', 'vertical'}, optional
+        orientation : {'horizontal', 'vertical'}, default: 'horizontal'
             The direction of the event collections:
 
             - 'horizontal': the lines are arranged horizontally in rows,

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1455,8 +1455,8 @@ class EventCollection(LineCollection):
     _edge_default = True
 
     def __init__(self,
-                 positions,     # Cannot be None.
-                 orientation=None,
+                 positions,  # Cannot be None.
+                 orientation='horizontal',
                  lineoffset=0,
                  linelength=1,
                  linewidth=None,
@@ -1471,10 +1471,9 @@ class EventCollection(LineCollection):
         positions : 1D array-like
             Each value is an event.
 
-        orientation : {None, 'horizontal', 'vertical'}, optional
+        orientation : {'horizontal', 'vertical'}, default: 'horizontal'
             The orientation of the **collection** (the event bars are along
-            the orthogonal direction). Defaults to 'horizontal' if not
-            specified or None.
+            the orthogonal direction).
 
         lineoffset : scalar, default: 0
             The offset of the center of the markers from the origin, in the
@@ -1584,17 +1583,26 @@ class EventCollection(LineCollection):
 
         Parameters
         ----------
-        orientation: {'horizontal', 'vertical'} or None
-            Defaults to 'horizontal' if not specified or None.
+        orientation : {'horizontal', 'vertical'}
         """
-        if (orientation is None or orientation.lower() == 'none' or
-                orientation.lower() == 'horizontal'):
-            is_horizontal = True
-        elif orientation.lower() == 'vertical':
-            is_horizontal = False
-        else:
-            cbook._check_in_list(['horizontal', 'vertical'],
-                                 orientation=orientation)
+        try:
+            is_horizontal = cbook._check_getitem(
+                {"horizontal": True, "vertical": False},
+                orientation=orientation)
+        except ValueError:
+            if (orientation is None or orientation.lower() == "none"
+                    or orientation.lower() == "horizontal"):
+                is_horizontal = True
+            elif orientation.lower() == "vertical":
+                is_horizontal = False
+            else:
+                raise
+            normalized = "horizontal" if is_horizontal else "vertical"
+            cbook.warn_deprecated(
+                "3.3", message="Support for setting the orientation of "
+                f"EventCollection to {orientation!r} is deprecated since "
+                f"%(since)s and will be removed %(removal)s; please set it to "
+                f"{normalized!r} instead.")
         if is_horizontal == self.is_horizontal():
             return
         self.switch_orientation()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3848,14 +3848,16 @@ def test_empty_eventplot():
     plt.draw()
 
 
-@pytest.mark.parametrize('data, orientation', product(
-    ([[]], [[], [0, 1]], [[0, 1], []]),
-    ('_empty', 'vertical', 'horizontal', None, 'none')))
+@pytest.mark.parametrize('data', [[[]], [[], [0, 1]], [[0, 1], []]])
+@pytest.mark.parametrize(
+    'orientation', ['_empty', 'vertical', 'horizontal', None, 'none'])
 def test_eventplot_orientation(data, orientation):
     """Introduced when fixing issue #6412."""
     opts = {} if orientation == "_empty" else {'orientation': orientation}
     fig, ax = plt.subplots(1, 1)
-    ax.eventplot(data, **opts)
+    with (pytest.warns(MatplotlibDeprecationWarning)
+          if orientation in [None, 'none'] else nullcontext()):
+        ax.eventplot(data, **opts)
     plt.draw()
 
 


### PR DESCRIPTION
Supporting `eventplot(..., orientation="none")` or `set_orientation()`
(no arguments) doesn't make much sense, especially compared to
`orientation="horizontal"` (which they are synonym to).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
