### PR TITLE
Cleanup imshow_extent tutorial.

### DIFF
--- a/tutorials/intermediate/imshow_extent.py
+++ b/tutorials/intermediate/imshow_extent.py
@@ -148,21 +148,15 @@ def generate_imshow_demo_grid(extents, xlim=None, ylim=None):
         for ax, extent in zip(columns[origin], extents):
             plot_imshow_with_labels(ax, data, extent, origin, xlim, ylim)
 
+    columns['label'][0].set_title('extent=')
     for ax, extent in zip(columns['label'], extents):
-        text_kwargs = {'ha': 'right',
-                       'va': 'center',
-                       'xycoords': 'axes fraction',
-                       'xy': (1, .5)}
         if extent is None:
-            ax.annotate('None', **text_kwargs)
-            ax.set_title('extent=')
+            text = 'None'
         else:
             left, right, bottom, top = extent
-            text = ('left: {left:0.1f}\nright: {right:0.1f}\n' +
-                    'bottom: {bottom:0.1f}\ntop: {top:0.1f}\n').format(
-                        left=left, right=right, bottom=bottom, top=top)
-
-            ax.annotate(text, **text_kwargs)
+            text = (f'left: {left:0.1f}\nright: {right:0.1f}\n'
+                    f'bottom: {bottom:0.1f}\ntop: {top:0.1f}\n')
+        ax.text(1., .5, text, transform=ax.transAxes, ha='right', va='center')
         ax.axis('off')
     return columns
 
@@ -263,3 +257,5 @@ set_extent_None_text(columns['lower'][0])
 
 generate_imshow_demo_grid(extents=[None] + extents,
                           xlim=(-2, 8), ylim=(-1, 6))
+
+plt.show()


### PR DESCRIPTION
- Move title-setting out to make it hopefully clearer (it's the first
  row that matters, not the one with `extent=None`).
- Define the kwargs to annotate() at a single call site rather than in a
  separate dict.
- Add show() to make the example runnable from the command-line.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
