### PR TITLE
Fix AnnotationBbox picking and a bit of cleanup

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1430,7 +1430,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
 
         xybox : (float, float), default: *xy*
             The position *(x, y)* to place the text at. The coordinate system
-            is determined by *textcoords*.
+            is determined by *boxcoords*.
 
         xycoords : str or `.Artist` or `.Transform` or callable or \
 (float, float), default: 'data'

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1360,24 +1360,6 @@ class OffsetImage(OffsetBox):
     def get_zoom(self):
         return self._zoom
 
-#     def set_axes(self, axes):
-#         self.image.set_axes(axes)
-#         martist.Artist.set_axes(self, axes)
-
-#     def set_offset(self, xy):
-#         """
-#         Set the offset of the container.
-#
-#         Parameters
-#         ----------
-#         xy : (float, float)
-#             The (x, y) coordinates of the offset in display units.
-#         """
-#         self._offset = xy
-
-#         self.offset_transform.clear()
-#         self.offset_transform.translate(xy[0], xy[1])
-
     def get_offset(self):
         """Return offset of the container."""
         return self._offset

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1523,6 +1523,11 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         inside, info = self._default_contains(mouseevent)
         if inside is not None:
             return inside, info
+
+        xy_pixel = self._get_position_xy(None)
+        if not self._check_xy(None, xy_pixel):
+            return False, {}
+
         t, tinfo = self.offsetbox.contains(mouseevent)
         #if self.arrow_patch is not None:
         #    a, ainfo=self.arrow_patch.contains(event)
@@ -1641,7 +1646,6 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             return
 
         xy_pixel = self._get_position_xy(renderer)
-
         if not self._check_xy(renderer, xy_pixel):
             return
 


### PR DESCRIPTION
## PR Summary

Fixes picking when the `AnnotationBbox` goes out of view, and cleanup some old code.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way