### PR TITLE
Optimize extensions with LTO and hidden visibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,16 @@ class BuildExtraLibraries(BuildExtCommand):
         ]
         super().finalize_options()
 
-    def add_optional_flags(self):
+    def add_optimization_flags(self):
+        """
+        Add optional optimization flags to extension.
+
+        This adds flags for LTO and hidden visibility to both compiled
+        extensions, and to the environment variables so that vendored libraries
+        will also use them. If the compiler does not support these flags, then
+        none are added.
+        """
+
         env = os.environ.copy()
         if sys.platform == 'win32':
             return env
@@ -162,7 +171,7 @@ class BuildExtraLibraries(BuildExtCommand):
         except (ValueError, AttributeError):
             pass
 
-        env = self.add_optional_flags()
+        env = self.add_optimization_flags()
         for package in good_packages:
             package.do_custom_build(env)
         return super().build_extensions()

--- a/setup.py
+++ b/setup.py
@@ -102,13 +102,23 @@ class BuildExtraLibraries(BuildExtCommand):
         cppflags = []
         if 'CPPFLAGS' in os.environ:
             cppflags.append(os.environ['CPPFLAGS'])
+        cxxflags = []
+        if 'CXXFLAGS' in os.environ:
+            cxxflags.append(os.environ['CXXFLAGS'])
 
         if has_flag(self.compiler, '-fvisibility=hidden'):
             for ext in self.extensions:
                 ext.extra_compile_args.append('-fvisibility=hidden')
             cppflags.append('-fvisibility=hidden')
+        if has_flag(self.compiler, '-fvisibility-inlines-hidden'):
+            for ext in self.extensions:
+                if self.compiler.detect_language(ext.sources) != 'cpp':
+                    continue
+                ext.extra_compile_args.append('-fvisibility-inlines-hidden')
+            cxxflags.append('-fvisibility-inlines-hidden')
 
         env['CPPFLAGS'] = ' '.join(cppflags)
+        env['CXXFLAGS'] = ' '.join(cxxflags)
 
         return env
 

--- a/setupext.py
+++ b/setupext.py
@@ -262,7 +262,7 @@ class SetupPackage:
         """
         return []
 
-    def do_custom_build(self):
+    def do_custom_build(self, env):
         """
         If a package needs to do extra custom things, such as building a
         third-party library, before building an extension, it should
@@ -538,7 +538,7 @@ class FreeType(SetupPackage):
                 0, str(src_path / 'objs' / '.libs' / libfreetype))
             ext.define_macros.append(('FREETYPE_BUILD_TYPE', 'local'))
 
-    def do_custom_build(self):
+    def do_custom_build(self, env):
         # We're using a system freetype
         if options.get('system_freetype'):
             return
@@ -586,8 +586,7 @@ class FreeType(SetupPackage):
 
         print(f"Building freetype in {src_path}")
         if sys.platform != 'win32':  # compilation on non-windows
-            env = {**os.environ,
-                   "CFLAGS": "{} -fPIC".format(os.environ.get("CFLAGS", ""))}
+            env = {**env, "CFLAGS": "{} -fPIC".format(env.get("CFLAGS", ""))}
             subprocess.check_call(
                 ["./configure", "--with-zlib=no", "--with-bzip2=no",
                  "--with-png=no", "--with-harfbuzz=no"],

--- a/setupext.py
+++ b/setupext.py
@@ -589,7 +589,8 @@ class FreeType(SetupPackage):
             env = {**env, "CFLAGS": "{} -fPIC".format(env.get("CFLAGS", ""))}
             subprocess.check_call(
                 ["./configure", "--with-zlib=no", "--with-bzip2=no",
-                 "--with-png=no", "--with-harfbuzz=no"],
+                 "--with-png=no", "--with-harfbuzz=no", "--enable-static",
+                 "--disable-shared"],
                 env=env, cwd=src_path)
             subprocess.check_call(["make"], env=env, cwd=src_path)
         else:  # compilation on windows

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -672,6 +672,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__backend_agg(void)
 {
     PyObject *m;
@@ -694,3 +696,5 @@ PyMODINIT_FUNC PyInit__backend_agg(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -164,6 +164,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__contour(void)
 {
     PyObject *m;
@@ -182,3 +184,5 @@ PyMODINIT_FUNC PyInit__contour(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -456,6 +456,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__image(void)
 {
     PyObject *m;
@@ -491,3 +493,5 @@ PyMODINIT_FUNC PyInit__image(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2531,6 +2531,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyObject* PyInit__macosx(void)
 {
     PyObject *module;
@@ -2556,3 +2558,5 @@ PyObject* PyInit__macosx(void)
 
     return module;
 }
+
+#pragma GCC visibility pop

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -853,6 +853,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__path(void)
 {
     PyObject *m;
@@ -866,3 +868,5 @@ PyMODINIT_FUNC PyInit__path(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -226,6 +226,8 @@ static PyModuleDef _tkagg_module = {
     PyModuleDef_HEAD_INIT, "_tkagg", "", -1, functions, NULL, NULL, NULL, NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__tkagg(void)
 {
     load_tkinter_funcs();
@@ -240,3 +242,5 @@ PyMODINIT_FUNC PyInit__tkagg(void)
     }
     return PyModule_Create(&_tkagg_module);
 }
+
+#pragma GCC visibility pop

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -276,6 +276,8 @@ static PyModuleDef ttconv_module = {
     NULL, NULL, NULL, NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC
 PyInit_ttconv(void)
 {
@@ -285,3 +287,5 @@ PyInit_ttconv(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -43,7 +43,7 @@
 FT_Library _ft2Library;
 
 void throw_ft_error(std::string message, FT_Error error) {
-    std::ostringstream os;
+    std::ostringstream os("");
     os << message << " (error code 0x" << std::hex << error << ")";
     throw std::runtime_error(os.str());
 }

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1632,6 +1632,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit_ft2font(void)
 {
     PyObject *m;
@@ -1722,3 +1724,5 @@ PyMODINIT_FUNC PyInit_ft2font(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/qhull_wrap.c
+++ b/src/qhull_wrap.c
@@ -337,6 +337,8 @@ static struct PyModuleDef qhull_module = {
     NULL, NULL, NULL, NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC
 PyInit__qhull(void)
 {
@@ -352,3 +354,5 @@ PyInit__qhull(void)
 
     return m;
 }
+
+#pragma GCC visibility pop

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -504,6 +504,8 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
+#pragma GCC visibility push(default)
+
 PyMODINIT_FUNC PyInit__tri(void)
 {
     PyObject *m;
@@ -528,3 +530,5 @@ PyMODINIT_FUNC PyInit__tri(void)
 
     return m;
 }
+
+#pragma GCC visibility pop


### PR DESCRIPTION
## PR Summary

I've been trying this for a while, but only just figured out the right incantation to get both settings working together. The main reason for hidden visibility is to fix #7537 (I hope; I don't have a way to reproduce), but I threw LTO in to make some nice space savings. That being said, LTO took some time to get into a working state, and it's possible that the `manylinux1` images won't be able to do it. So this will need some extra testing to ensure it's actually usable.

This table shows the effect on _stripped_ binary size. The first row is the original size on master, and the subsequent rows show the size change for each commit. However, note that some of the visibility changes only really had an effect on the LTO build, so they appear as 0. Overall, this would save 17% on shared libraries size, maybe more with newer gcc.
<details>
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: right;">
      <th></th>
      <th>backend_agg</th>
      <th>contour</th>
      <th>image</th>
      <th>path</th>
      <th>qhull</th>
      <th>tkagg</th>
      <th>tri</th>
      <th>ft2font</th>
      <th>ttconv</th>
      <th>total</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>0</th>
      <td>373480.0</td>
      <td>85760.0</td>
      <td>278440.0</td>
      <td>205464.0</td>
      <td>395096.0</td>
      <td>31696.0</td>
      <td>107120.0</td>
      <td>913072.0</td>
      <td>71360.0</td>
      <td>2461488.0</td>
    </tr>
    <tr>
      <th>1</th>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
    </tr>
    <tr>
      <th>2</th>
      <td>-25632.0</td>
      <td>-4608.0</td>
      <td>-25312.0</td>
      <td>-17152.0</td>
      <td>9376.0</td>
      <td>-32.0</td>
      <td>-17408.0</td>
      <td>-38432.0</td>
      <td>-8512.0</td>
      <td>-127712.0</td>
    </tr>
    <tr>
      <th>3</th>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
    </tr>
    <tr>
      <th>4</th>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
      <td>0.0</td>
    </tr>
    <tr>
      <th>5</th>
      <td>-69712.0</td>
      <td>-28928.0</td>
      <td>-69808.0</td>
      <td>-33024.0</td>
      <td>-28768.0</td>
      <td>-16664.0</td>
      <td>-20688.0</td>
      <td>-24944.0</td>
      <td>1840.0</td>
      <td>-290696.0</td>
    </tr>
  </tbody>
</table>
</details>
The savings for _unstripped_ binaries are even bigger at ~54%, but unless we start shipping debug nightly builds or something, it's probably not as impactful. It might be nice for binary distros that ship debug symbols though.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way