### PR TITLE
Change the description of Rectangle's xy parameter

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -720,7 +720,7 @@ class Rectangle(Patch):
         Parameters
         ----------
         xy : (float, float)
-            The anchor coordinates
+            The rectangle extends from xy[0] to xy[0] + width in x-direction and from xy[1] to xy[1] + height in y-direction.
         width : float
             Rectangle width
         height : float

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -720,7 +720,8 @@ class Rectangle(Patch):
         Parameters
         ----------
         xy : (float, float)
-            The rectangle extends from xy[0] to xy[0] + width in x-direction and from xy[1] to xy[1] + height in y-direction.
+            The rectangle extends from xy[0] to xy[0] + width in
+            x-direction and from xy[1] to xy[1] + height in y-direction.
         width : float
             Rectangle width
         height : float

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -720,7 +720,7 @@ class Rectangle(Patch):
         Parameters
         ----------
         xy : (float, float)
-            The bottom and left rectangle coordinates
+            The anchor coordinates
         width : float
             Rectangle width
         height : float


### PR DESCRIPTION
## PR Summary

matplotlib.patches.Rectangle's first parameter, xy, is previously only documented for data plotting functions in which xy means left and bottom coordinates. However, in imshow(), the vertical axis's direction is inverted, and xy means left and top coordinates. See #15401.

In this PR, a fix is made to explain xy as starting coordinates so as to make it suitable for both cases
Closes #15433

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
