### PR TITLE
ci: Publish result images as Azure artifacts.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,3 +120,7 @@ steps:
     testResultsFiles: '**/test-results.xml'
     testRunTitle: 'Python $(python.version)'
   condition: succeededOrFailed()
+
+- publish: $(System.DefaultWorkingDirectory)/result_images
+  artifact: $(Agent.JobName)-result_images
+  condition: and(failed(), ne(variables['python.version'], 'Pre'))


### PR DESCRIPTION
This should allow us to debug result images if they're failing on Azure.