### PR TITLE
Ensure name in set_cmap is contained in cmap_d

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -56,7 +56,7 @@ from matplotlib.cm import get_cmap, register_cmap
 import numpy as np
 
 # We may not need the following imports here:
-from matplotlib.colors import Normalize
+from matplotlib.colors import Normalize, Colormap
 from matplotlib.lines import Line2D
 from matplotlib.text import Text, Annotation
 from matplotlib.patches import Polygon, Rectangle, Circle, Arrow
@@ -2069,11 +2069,17 @@ def set_cmap(cmap):
     matplotlib.cm.register_cmap
     matplotlib.cm.get_cmap
     """
-    cmap = cm.get_cmap(cmap)
+    cbook._check_isinstance((str, Colormap), cmap=cmap)
+    if isinstance(cmap, str):
+        name = cmap
+        cmap = cm.get_cmap(name)
+        rc('image',cmap=name)
+    elif isinstance(cmap, Colormap):
+        if not cmap.name in cm.cmap_d.keys():
+            cm.register_cmap(cmap.name, cmap)
+        rc('image', cmap=cmap.name)
 
-    rc('image', cmap=cmap.name)
     im = gci()
-
     if im is not None:
         im.set_cmap(cmap)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2072,11 +2072,11 @@ def set_cmap(cmap):
     cbook._check_isinstance((str, Colormap), cmap=cmap)
     if isinstance(cmap, str):
         name = cmap
-        cmap = cm.get_cmap(name)
-        rc('image',cmap=name)
+        cmap = get_cmap(name)
+        rc('image', cmap=name)
     elif isinstance(cmap, Colormap):
-        if not cmap.name in cm.cmap_d.keys():
-            cm.register_cmap(cmap.name, cmap)
+        if cmap.name not in cm.cmap_d.keys():
+            register_cmap(cmap.name, cmap)
         rc('image', cmap=cmap.name)
 
     im = gci()


### PR DESCRIPTION
## PR Summary
Fixes: https://github.com/matplotlib/matplotlib/issues/5087

Colormaps have their own name attribute, but this is not necessarily the name that they are registered with in `cm.cmap_d`. This becomes a problem when using `set_cm` followed by `plt.imshow` because `imshow` expects the name in the rcParams to also be present in the keys of `cmap_d`. In the linked issue the poster noted that this can happen when using a colormap from a library. 

With this change `set_cmap` tries to obtain the cmap from `cmap_d` only if passed a string, and if passed a Colormap it will check if the cmap is registered, and if not register it using `cmap.name`.

I believe that this PR is backwards-compatible.
## PR Checklist

- [ ] - N/A - Has Pytest style unit tests 
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] - N/A -  New features are documented, with examples if plot related
- [ ] - N/A - Documentation is sphinx and numpydoc compliant
- [ ] - N/A - Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] - N/A - Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
