### PR TITLE
Add return field to documentation of 'get_major_ticks'

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1334,7 +1334,7 @@ class Axis(martist.Artist):
         return self.majorTicks[:numticks]
 
     def get_minor_ticks(self, numticks=None):
-        """Get the minor tick instances; grow as necessary."""
+        r"""Return the list of minor `.Tick`\s."""
         if numticks is None:
             numticks = len(self.get_minorticklocs())
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1320,7 +1320,13 @@ class Axis(martist.Artist):
         return self.minor.formatter
 
     def get_major_ticks(self, numticks=None):
-        """Get the tick instances; grow as necessary."""
+        """
+        Get the tick instances; grow as necessary.
+        
+        Returns
+        -------
+        list of `.Tick` objects 
+        """
         if numticks is None:
             numticks = len(self.get_majorticklocs())
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1320,13 +1320,7 @@ class Axis(martist.Artist):
         return self.minor.formatter
 
     def get_major_ticks(self, numticks=None):
-        """
-        Get the tick instances; grow as necessary.
-        
-        Returns
-        -------
-        list of `.Tick` objects 
-        """
+        r"""Return the list of major `.Tick`\s."""
         if numticks is None:
             numticks = len(self.get_majorticklocs())
 


### PR DESCRIPTION
## PR Summary 
The documentation of axis.Axis.get_major_ticks is updated to list its return type, which is a list of Tick objects. Reference is added to the Tick object documentation. See #17015 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
