### PR TITLE
ENH: add rcParam for ConciseDate and interval_multiples

### DIFF
--- a/doc/users/next_whats_new/rcparams_dates.rst
+++ b/doc/users/next_whats_new/rcparams_dates.rst
@@ -1,0 +1,31 @@
+New rcParams for dates: set converter and whether to use interval_multiples
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :rc:`date.converter` allows toggling between
+`matplotlib.dates.DateConverter` and `matplotlib.dates.ConciseDateConverter`
+using the strings 'auto' and 'concise' respectively.
+
+The new :rc:`date.interval_multiples` allows toggling between the dates
+locator trying to pick ticks at set intervals (i.e. day 1 and 15 of the
+month), versus evenly spaced ticks that start where ever the
+timeseries starts:
+
+.. plot::
+    :include-source: True
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    dates = np.arange('2001-01-10', '2001-05-23', dtype='datetime64[D]')
+    y = np.sin(dates.astype(float) / 10)
+    fig, axs = plt.subplots(nrows=2, constrained_layout=True)
+
+    plt.rcParams['date.converter'] = 'concise'
+    plt.rcParams['date.interval_multiples'] = True
+    ax = axs[0]
+    ax.plot(dates, y)
+
+    plt.rcParams['date.converter'] = 'auto'
+    plt.rcParams['date.interval_multiples'] = False
+    ax = axs[1]
+    ax.plot(dates, y)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -20,6 +20,7 @@ from numbers import Number
 import operator
 import os
 import re
+import sys
 
 import numpy as np
 
@@ -172,6 +173,23 @@ def validate_bool_maybe_none(b):
         return False
     else:
         raise ValueError('Could not convert "%s" to bool' % b)
+
+
+def _validate_date_converter(s):
+    s = validate_string(s)
+    mdates = sys.modules.get("matplotlib.dates")
+    if mdates:
+        mdates._rcParam_helper.set_converter(s)
+
+
+def _validate_date_int_mult(s):
+    if s is None:
+        return
+    s = validate_bool(s)
+    # only do this if dates is already imported...
+    mdates = sys.modules.get("matplotlib.dates")
+    if mdates:
+        mdates._rcParam_helper.set_int_mult(s)
 
 
 def _validate_tex_preamble(s):
@@ -1271,6 +1289,11 @@ _validators = {
     "date.autoformatter.second":      validate_string,
     "date.autoformatter.microsecond": validate_string,
 
+    # 'auto', 'concise', 'auto-noninterval'
+    'date.converter': _validate_date_converter,
+    # for auto date locator, choose interval_multiples
+    'date.interval_multiples': _validate_date_int_mult,
+
     # legend properties
     "legend.fancybox": validate_bool,
     "legend.loc": _ignorecase([
@@ -1278,6 +1301,7 @@ _validators = {
         "upper right", "upper left", "lower left", "lower right", "right",
         "center left", "center right", "lower center", "upper center",
         "center"]),
+
     # the number of points in the legend line
     "legend.numpoints":      validate_int,
     # the number of points in the legend line for scatter

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -958,3 +958,41 @@ def test_warn_notintervals():
                               mdates.date2num(dates[-1]))
     with pytest.warns(UserWarning, match="AutoDateLocator was unable") as rec:
         locs = locator()
+
+
+def test_change_converter():
+    plt.rcParams['date.converter'] = 'concise'
+    dates = np.arange('2020-01-01', '2020-05-01', dtype='datetime64[D]')
+    fig, ax = plt.subplots()
+
+    ax.plot(dates, np.arange(len(dates)))
+    fig.canvas.draw()
+    assert ax.get_xticklabels()[0].get_text() == 'Jan'
+    assert ax.get_xticklabels()[1].get_text() == '15'
+
+    plt.rcParams['date.converter'] = 'auto'
+    fig, ax = plt.subplots()
+
+    ax.plot(dates, np.arange(len(dates)))
+    fig.canvas.draw()
+    assert ax.get_xticklabels()[0].get_text() == 'Jan 01 2020'
+    assert ax.get_xticklabels()[1].get_text() == 'Jan 15 2020'
+
+
+def test_change_interval_multiples():
+    plt.rcParams['date.interval_multiples'] = False
+    dates = np.arange('2020-01-10', '2020-05-01', dtype='datetime64[D]')
+    fig, ax = plt.subplots()
+
+    ax.plot(dates, np.arange(len(dates)))
+    fig.canvas.draw()
+    assert ax.get_xticklabels()[0].get_text() == 'Jan 10 2020'
+    assert ax.get_xticklabels()[1].get_text() == 'Jan 24 2020'
+
+    plt.rcParams['date.interval_multiples'] = 'True'
+    fig, ax = plt.subplots()
+
+    ax.plot(dates, np.arange(len(dates)))
+    fig.canvas.draw()
+    assert ax.get_xticklabels()[0].get_text() == 'Jan 15 2020'
+    assert ax.get_xticklabels()[1].get_text() == 'Feb 01 2020'

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -442,10 +442,13 @@
 #date.autoformatter.minute:      %d %H:%M
 #date.autoformatter.second:      %H:%M:%S
 #date.autoformatter.microsecond: %M:%S.%f
-
 ## The reference date for Matplotlib's internal date representation
 ## See https://matplotlib.org/examples/ticks_and_spines/date_precision_and_epochs.py
 #date.epoch: 1970-01-01T00:00:00
+## 'auto', 'concise':
+#date.converter:                  auto
+## For auto converter whether to use interval_multiples:
+#date.interval_multiples:         True
 
 ## ***************************************************************************
 ## * TICKS                                                                   *


### PR DESCRIPTION
## PR Summary

This is a proposal for two new `date` rcParam entries:

`date.converter` which takes a string.   If its `'concise'` then `mdates.ConciseDateConverter` is used for dates, otherwise `mdates.AutoDateConverter` is used (as before). Default is the same as before: 'auto'

`date.interval_multiples` sets whether 'interval_multiples' is used (True by default) for the auto locators.  

~Note this needs a new `mdates.register_converters` to work after `matplotlib.dates` has been imported by `matplotlib.pyplot`.~ EDIT: fixed to allow automatic changing of the rcParams....

```python
import matplotlib
import datetime
import matplotlib.pyplot as plt
import matplotlib.dates as mdates


y = range(43)
datex = [datetime.date(2020,2,21)+datetime.timedelta(x) for x in range(43)]
fig, axs = plt.subplots(2, 2, constrained_layout=True, figsize=(6,7))

for m, converter in enumerate(['auto', 'concise']):
    for n, interval_multiples in enumerate([True, False]):

        plt.rcParams['date.converter'] = converter
        plt.rcParams['date.interval_multiples'] = interval_multiples
        ax = axs[m, n]
        ax.plot(datex, y)
        if m == 0:
            ax.xaxis.set_tick_params(rotation=45)
plt.show()
```

![Dates](https://user-images.githubusercontent.com/1562854/78412692-218d3500-75c9-11ea-9422-d0385b1daf26.png)


Needs tests and a what's new...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
