### PR TITLE
Fix RecursionError when closing nbAgg figures.

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -57,6 +57,8 @@ class Gcf:
             manager = num
             if cls.figs.get(manager.num) is manager:
                 cls.figs.pop(manager.num)
+            else:
+                return
         else:
             try:
                 manager = cls.figs.pop(num)


### PR DESCRIPTION
## PR Summary

Previously, if a figure number was not in the list of managed figures, the destroy would be skipped, but now that only happens if a figure number is passed. If a figure manager is passed, then the destroy happens regardless. In nbAgg, this loops around closing/close_event and eventually calls destroy again, leading to a RecursionError.

This broke in 9e6f112a783753c112253b222d4bff69d2328876; cc @anntzer.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way