### PR TITLE
Fix saving nbAgg figure after a partial blit

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -33,7 +33,7 @@ mpl.mpl_figure_comm = function (comm, msg) {
     var ws_proxy = comm_websocket_adapter(comm);
 
     function ondownload(figure, _format) {
-        window.open(figure.imageObj.src);
+        window.open(figure.canvas.toDataURL());
     }
 
     var fig = new mpl.figure(id, ws_proxy, ondownload, element.get(0));


### PR DESCRIPTION
## PR Summary

While testing out #13971, I realized that it was making an empty blit on click, and that if I hit Save after that, the result would be empty. Also, hitting the Home button would create an image that was a weird mix of the old and new views (whatever the blit looked like.)

Fortunately, this is already [fixed in ipympl](https://github.com/matplotlib/ipympl/pull/93), so I can just grab the fix from there. This seems to have been broken since forever.

Waiting on the JS re-formatting PR.

## PR Checklist

- [ ] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way