### PR TITLE
Fix table.Cell docstrings.

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -31,32 +31,9 @@ class Cell(Rectangle):
     """
     A cell is a `.Rectangle` with some associated `.Text`.
 
-    .. note:
-        As a user, you'll most likely not creates cells yourself. Instead, you
-        should use either the `~matplotlib.table.table` factory function or
-        `.Table.add_cell`.
-
-    Parameters
-    ----------
-    xy : 2-tuple
-        The position of the bottom left corner of the cell.
-    width : float
-        The cell width.
-    height : float
-        The cell height.
-    edgecolor : color
-        The color of the cell border.
-    facecolor : color
-        The cell facecolor.
-    fill : bool
-        Whether the cell background is filled.
-    text : str
-        The cell text.
-    loc : {'left', 'center', 'right'}, default: 'right'
-        The alignment of the text within the cell.
-    fontproperties : dict
-        A dict defining the font properties of the text. Supported keys and
-        values are the keyword arguments accepted by `.FontProperties`.
+    As a user, you'll most likely not creates cells yourself. Instead, you
+    should use either the `~matplotlib.table.table` factory function or
+    `.Table.add_cell`.
     """
 
     PAD = 0.1
@@ -69,6 +46,29 @@ class Cell(Rectangle):
                  loc=None,
                  fontproperties=None
                  ):
+        """
+        Parameters
+        ----------
+        xy : 2-tuple
+            The position of the bottom left corner of the cell.
+        width : float
+            The cell width.
+        height : float
+            The cell height.
+        edgecolor : color
+            The color of the cell border.
+        facecolor : color
+            The cell facecolor.
+        fill : bool
+            Whether the cell background is filled.
+        text : str
+            The cell text.
+        loc : {'left', 'center', 'right'}, default: 'right'
+            The alignment of the text within the cell.
+        fontproperties : dict
+            A dict defining the font properties of the text. Supported keys and
+            values are the keyword arguments accepted by `.FontProperties`.
+        """
 
         # Call base
         Rectangle.__init__(self, xy, width=width, height=height, fill=fill,


### PR DESCRIPTION
- Previously the "note" would be treated as a comment (it needs *two*
  end colons); we can just make it plain text anyways.
- Moving the doc for the parameters to `__init__` avoids `__init__`
  inheriting the docstring of the parent `Rectangle.__init__` and thus
  the rendered docs getting two copies of the parameter list, with only
  one being correct.

See https://matplotlib.org/api/table_api.html#matplotlib.table.Cell.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
