### PR TITLE
Move widget functions into matplotlib.testing.widgets.

### DIFF
--- a/lib/matplotlib/testing/widgets.py
+++ b/lib/matplotlib/testing/widgets.py
@@ -1,0 +1,57 @@
+"""
+========================
+Widget testing utilities
+========================
+Functions that are useful for testing widgets.
+See also matplotlib.tests.test_widgets
+"""
+import matplotlib.pyplot as plt
+from unittest import mock
+
+
+def get_ax():
+    """Creates plot and returns its axes"""
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([0, 200], [0, 200])
+    ax.set_aspect(1.0)
+    ax.figure.canvas.draw()
+    return ax
+
+
+def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
+    """
+    Trigger an event
+
+    Parameters
+    ----------
+    tool : a matplotlib.widgets.RectangleSelector instance
+    etype
+        the event to trigger
+    xdata : int
+        x coord of mouse in data coords
+    ydata : int
+        y coord of mouse in data coords
+    button : int or str
+        button pressed None, 1, 2, 3, 'up', 'down' (up and down are used
+        for scroll events)
+    key
+        the key depressed when the mouse event triggered (see
+        :class:`KeyEvent`)
+    step : int
+        number of scroll steps (positive for 'up', negative for 'down')
+    """
+    event = mock.Mock()
+    event.button = button
+    ax = tool.ax
+    event.x, event.y = ax.transData.transform([(xdata, ydata),
+                                               (xdata, ydata)])[00]
+    event.xdata, event.ydata = xdata, ydata
+    event.inaxes = ax
+    event.canvas = ax.figure.canvas
+    event.key = key
+    event.step = step
+    event.guiEvent = None
+    event.name = 'Custom'
+
+    func = getattr(tool, etype)
+    func(event)

--- a/lib/matplotlib/testing/widgets.py
+++ b/lib/matplotlib/testing/widgets.py
@@ -44,7 +44,7 @@ def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
     event.button = button
     ax = tool.ax
     event.x, event.y = ax.transData.transform([(xdata, ydata),
-                                               (xdata, ydata)])[00]
+                                               (xdata, ydata)])[0]
     event.xdata, event.ydata = xdata, ydata
     event.inaxes = ax
     event.canvas = ax.figure.canvas

--- a/lib/matplotlib/testing/widgets.py
+++ b/lib/matplotlib/testing/widgets.py
@@ -24,7 +24,7 @@ def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
 
     Parameters
     ----------
-    tool : a matplotlib.widgets.RectangleSelector instance
+    tool : matplotlib.widgets.RectangleSelector
     etype
         the event to trigger
     xdata : int

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,74 +1,11 @@
-from types import SimpleNamespace
-
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.widgets import do_event, get_ax
 
 from numpy.testing import assert_allclose
 
 import pytest
-
-
-def get_ax():
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([0, 200], [0, 200])
-    ax.set_aspect(1.0)
-    ax.figure.canvas.draw()
-    return ax
-
-
-def do_event(tool, etype, button=1, xdata=0, ydata=0, key=None, step=1):
-    """
-     *name*
-        the event name
-
-    *canvas*
-        the FigureCanvas instance generating the event
-
-    *guiEvent*
-        the GUI event that triggered the matplotlib event
-
-    *x*
-        x position - pixels from left of canvas
-
-    *y*
-        y position - pixels from bottom of canvas
-
-    *inaxes*
-        the :class:`~matplotlib.axes.Axes` instance if mouse is over axes
-
-    *xdata*
-        x coord of mouse in data coords
-
-    *ydata*
-        y coord of mouse in data coords
-
-     *button*
-        button pressed None, 1, 2, 3, 'up', 'down' (up and down are used
-        for scroll events)
-
-    *key*
-        the key depressed when the mouse event triggered (see
-        :class:`KeyEvent`)
-
-    *step*
-        number of scroll steps (positive for 'up', negative for 'down')
-    """
-    event = SimpleNamespace()
-    event.button = button
-    ax = tool.ax
-    event.x, event.y = ax.transData.transform([(xdata, ydata),
-                                               (xdata, ydata)])[00]
-    event.xdata, event.ydata = xdata, ydata
-    event.inaxes = ax
-    event.canvas = ax.figure.canvas
-    event.key = key
-    event.step = step
-    event.guiEvent = None
-    event.name = 'Custom'
-
-    func = getattr(tool, etype)
-    func(event)
 
 
 def check_rectangle(**kwargs):


### PR DESCRIPTION
## PR Summary

Fixes #7372, move widget functions into matplotlib.testing.widgets.

Co-authored-by: @dakotablair
Closes #9905

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
