### PR TITLE
Fix missing-references.json.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,7 +102,9 @@ if sphinx.version_info < (1, 8):
 else:
     autodoc_default_options = {'members': None, 'undoc-members': None}
 
-nitpicky = True
+# missing-references names matches sphinx>=3 behavior, so we can't be nitpicky
+# for older sphinxes.
+nitpicky = sphinx.version_info >= (3,)
 # change this to True to update the allowed failures
 missing_references_write_json = False
 missing_references_warn_unused_ignores = False

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -24,8 +24,8 @@
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:338"
     ],
     "cbar_axes": [
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:48",
-      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:48"
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:49",
+      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:49"
     ],
     "dividers": [
       "lib/mpl_toolkits/axes_grid1/colorbar.py:docstring of mpl_toolkits.axes_grid1.colorbar.ColorbarBase:29"
@@ -41,8 +41,8 @@
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.Bbox.bounds:2"
     ],
     "input_dims": [
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:4",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:7",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:14",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:8",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform_affine:15",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform_non_affine:14",
@@ -51,8 +51,8 @@
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.CompositeGenericTransform.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.CompositeGenericTransform.transform_non_affine:14",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.CompositeGenericTransform.transform_non_affine:20",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:4",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:7",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:14",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:8",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_affine:15",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_non_affine:14",
@@ -69,16 +69,16 @@
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
     ],
     "matplotlib.axes.Axes.lines": [
-      "doc/tutorials/intermediate/artists.rst:406",
-      "doc/tutorials/intermediate/artists.rst:90"
+      "doc/tutorials/intermediate/artists.rst:408",
+      "doc/tutorials/intermediate/artists.rst:92"
     ],
     "matplotlib.axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:172",
-      "doc/tutorials/intermediate/artists.rst:390"
+      "doc/tutorials/intermediate/artists.rst:174",
+      "doc/tutorials/intermediate/artists.rst:392"
     ],
     "matplotlib.axes.Axes.patches": [
-      "doc/tutorials/intermediate/artists.rst:429"
+      "doc/tutorials/intermediate/artists.rst:431"
     ],
     "matplotlib.axes.Axes.transAxes": [
       "lib/mpl_toolkits/axes_grid1/anchored_artists.py:docstring of mpl_toolkits.axes_grid1.anchored_artists.AnchoredDirectionArrows:8"
@@ -92,17 +92,13 @@
       "doc/api/prev_api_changes/api_changes_0.99.x.rst:23"
     ],
     "matplotlib.axes.Axes.xaxis": [
-      "doc/tutorials/intermediate/artists.rst:528"
+      "doc/tutorials/intermediate/artists.rst:530"
     ],
     "matplotlib.axes.Axes.yaxis": [
-      "doc/tutorials/intermediate/artists.rst:528"
+      "doc/tutorials/intermediate/artists.rst:530"
     ],
     "matplotlib.axis.Axis.label": [
-      "doc/tutorials/intermediate/artists.rst:575"
-    ],
-    "matplotlib.cm.ScalarMappable._A": [
-      "lib/matplotlib/collections.py:docstring of matplotlib.collections.LineCollection:100",
-      "lib/mpl_toolkits/mplot3d/art3d.py:docstring of mpl_toolkits.mplot3d.art3d.Line3DCollection:94"
+      "doc/tutorials/intermediate/artists.rst:577"
     ],
     "matplotlib.cm.ScalarMappable.callbacksSM": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
@@ -115,11 +111,11 @@
     ],
     "matplotlib.figure.Figure.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:172",
-      "doc/tutorials/intermediate/artists.rst:287"
+      "doc/tutorials/intermediate/artists.rst:174",
+      "doc/tutorials/intermediate/artists.rst:289"
     ],
     "matplotlib.figure.Figure.transFigure": [
-      "doc/tutorials/intermediate/artists.rst:337"
+      "doc/tutorials/intermediate/artists.rst:339"
     ],
     "max": [
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.Bbox.p1:4"
@@ -134,14 +130,12 @@
       "lib/matplotlib/scale.py:docstring of matplotlib.scale.ScaleBase:8"
     ],
     "output_dims": [
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:4",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:7",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform:14",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.AffineBase.transform_non_affine:20",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.CompositeGenericTransform.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.CompositeGenericTransform.transform_non_affine:20",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:4",
-      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:7",
+      "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform:14",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_affine:21",
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.IdentityTransform.transform_non_affine:20"
     ],
@@ -175,10 +169,10 @@
       "doc/api/prev_api_changes/api_changes_2.2.0.rst:215"
     ],
     "Patch3DCollection": [
-      "doc/api/toolkits/mplot3d.rst:92:<autosummary>:1"
+      "doc/api/toolkits/mplot3d.rst:83:<autosummary>:1"
     ],
     "Path3DCollection": [
-      "doc/api/toolkits/mplot3d.rst:92:<autosummary>:1"
+      "doc/api/toolkits/mplot3d.rst:83:<autosummary>:1"
     ],
     "_FancyAxislineStyle.FilledArrow": [
       "<unknown>:1"
@@ -202,8 +196,8 @@
       "lib/matplotlib/dviread.py:docstring of matplotlib.dviread.DviFont:20"
     ],
     "matplotlib.axes.Subplot": [
-      "doc/tutorials/intermediate/artists.rst:34",
-      "doc/tutorials/intermediate/artists.rst:57"
+      "doc/tutorials/intermediate/artists.rst:36",
+      "doc/tutorials/intermediate/artists.rst:59"
     ],
     "matplotlib.axes._axes.Axes": [
       "doc/api/artist_api.rst:189",
@@ -219,13 +213,13 @@
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes:1"
     ],
     "matplotlib.backend_bases.FigureCanvas": [
-      "doc/tutorials/intermediate/artists.rst:18",
       "doc/tutorials/intermediate/artists.rst:20",
-      "doc/tutorials/intermediate/artists.rst:26"
+      "doc/tutorials/intermediate/artists.rst:22",
+      "doc/tutorials/intermediate/artists.rst:28"
     ],
     "matplotlib.backend_bases.Renderer": [
-      "doc/tutorials/intermediate/artists.rst:20",
-      "doc/tutorials/intermediate/artists.rst:26"
+      "doc/tutorials/intermediate/artists.rst:22",
+      "doc/tutorials/intermediate/artists.rst:28"
     ],
     "matplotlib.backend_bases._Backend": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ShowBase:1"
@@ -235,10 +229,6 @@
     ],
     "matplotlib.backend_tools._ToolEnableNavigation": [
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolEnableNavigation:1"
-    ],
-    "matplotlib.backend_tools._ToolGridBase": [
-      "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolGrid:1",
-      "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolMinorGrid:1"
     ],
     "matplotlib.backends._backend_pdf_ps.RendererPDFPSBase": [
       "lib/matplotlib/backends/backend_pdf.py:docstring of matplotlib.backends.backend_pdf.RendererPdf:1",
@@ -288,36 +278,18 @@
       "lib/matplotlib/image.py:docstring of matplotlib.image.BboxImage:1",
       "lib/matplotlib/image.py:docstring of matplotlib.image.FigureImage:1"
     ],
-    "matplotlib.patches.LArrow": [
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.RArrow:1"
-    ],
-    "matplotlib.patches.Sawtooth": [
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Roundtooth:1"
-    ],
-    "matplotlib.patches._Base": [
+    "matplotlib.patches.ArrowStyle._Base": [
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.Fancy:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.Simple:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.Wedge:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Circle:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.DArrow:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.LArrow:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Round4:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Round:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Sawtooth:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Square:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Angle3:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Angle:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Arc3:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Arc:1",
-      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Bar:1"
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.Wedge:1"
     ],
-    "matplotlib.patches._Bracket": [
+    "matplotlib.patches.ArrowStyle._Bracket": [
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.BarAB:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.BracketA:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.BracketAB:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.BracketB:1"
     ],
-    "matplotlib.patches._Curve": [
+    "matplotlib.patches.ArrowStyle._Curve": [
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.Curve:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.CurveA:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.CurveAB:1",
@@ -325,6 +297,22 @@
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.CurveFilledA:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.CurveFilledAB:1",
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle.CurveFilledB:1"
+    ],
+    "matplotlib.patches.BoxStyle._Base": [
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Circle:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.DArrow:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.LArrow:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Round4:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Round:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Sawtooth:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.BoxStyle.Square:1"
+    ],
+    "matplotlib.patches.ConnectionStyle._Base": [
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Angle3:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Angle:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Arc3:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Arc:1",
+      "lib/matplotlib/patches.py:docstring of matplotlib.patches.ConnectionStyle.Bar:1"
     ],
     "matplotlib.patches._Style": [
       "lib/matplotlib/patches.py:docstring of matplotlib.patches.ArrowStyle:1",
@@ -380,8 +368,6 @@
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.Fixed:1",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.Fraction:1",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.MaxExtent:1",
-      "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.MaxHeight:1",
-      "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.MaxWidth:1",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.Padded:1",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.Scaled:1",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size.SizeFromFunc:1"
@@ -402,31 +388,16 @@
       "doc/api/toolkits/axisartist.rst:5",
       "doc/api/toolkits/axisartist.rst:6"
     ],
-    "mpl_toolkits.axisartist.axisline_style.SimpleArrow": [
-      "lib/mpl_toolkits/axisartist/axisline_style.py:docstring of mpl_toolkits.axisartist.axisline_style.AxislineStyle.FilledArrow:1"
-    ],
-    "mpl_toolkits.axisartist.axisline_style._Base": [
+    "mpl_toolkits.axisartist.axisline_style.AxislineStyle._Base": [
       "lib/mpl_toolkits/axisartist/axisline_style.py:docstring of mpl_toolkits.axisartist.axisline_style.AxislineStyle.SimpleArrow:1"
     ],
-    "mpl_toolkits.axisartist.axislines.Fixed": [
-      "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelperRectlinear.Fixed:1",
-      "lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py:docstring of mpl_toolkits.axisartist.grid_helper_curvelinear.FixedAxisArtistHelper:1"
-    ],
-    "mpl_toolkits.axisartist.axislines.Floating": [
-      "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelperRectlinear.Floating:1",
-      "lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py:docstring of mpl_toolkits.axisartist.grid_helper_curvelinear.FloatingAxisArtistHelper:1"
-    ],
-    "mpl_toolkits.axisartist.axislines._Base": [
+    "mpl_toolkits.axisartist.axislines.AxisArtistHelper._Base": [
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelper.Fixed:1",
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelper.Floating:1"
     ],
     "mpl_toolkits.axisartist.floating_axes.Floating AxesHostAxes": [
       "<unknown>:1",
       "doc/api/_as_gen/mpl_toolkits.axisartist.floating_axes.rst:31:<autosummary>:1"
-    ],
-    "numpy.array": [
-      "lib/matplotlib/image.py:docstring of matplotlib.image.imread:35",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.imread:35"
     ],
     "numpy.uint8": [
       "<unknown>:1"
@@ -446,7 +417,7 @@
   },
   "py:func": {
     "log.debug": [
-      "doc/devel/contributing.rst:434"
+      "doc/devel/contributing.rst:450"
     ],
     "matplotlib.Axis.set_ticks_position": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:141"
@@ -468,7 +439,7 @@
     "AbstractPathEffect._update_gc": [
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimpleLineShadow:43",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:42",
-      "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:43"
+      "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:51"
     ],
     "Colormap.__call__": [
       "lib/matplotlib/colors.py:docstring of matplotlib.colors.BoundaryNorm:44"
@@ -537,8 +508,8 @@
       "doc/users/event_handling.rst:164"
     ],
     "matplotlib.text.Text.__init__": [
-      "doc/devel/contributing.rst:384",
-      "doc/devel/contributing.rst:392"
+      "doc/devel/contributing.rst:400",
+      "doc/devel/contributing.rst:408"
     ],
     "option_scale_image": [
       "lib/matplotlib/backends/backend_cairo.py:docstring of matplotlib.backends.backend_cairo.RendererCairo.draw_image:22",
@@ -590,7 +561,7 @@
   },
   "py:obj": {
     "./gallery/index.html": [
-      "doc/devel/contributing.rst:546"
+      "doc/devel/contributing.rst:562"
     ],
     "Artist.sticky_edges": [
       "doc/api/axes_api.rst:357:<autosummary>:1",
@@ -663,15 +634,11 @@
       "doc/devel/MEP/MEP22.rst:60",
       "doc/devel/MEP/MEP23.rst:70"
     ],
-    "ClabelText": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.clabel:68",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.clabel:68"
-    ],
     "ConnectionPatch": [
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:178"
     ],
     "FT2Font": [
-      "doc/gallery/misc/ftface_props.rst:14",
+      "doc/gallery/misc/ftface_props.rst:16",
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager.ttfFontProperty:8"
     ],
     "FigureCanvas": [
@@ -695,7 +662,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.violinplot:46"
     ],
     "Glyph": [
-      "doc/gallery/misc/ftface_props.rst:14"
+      "doc/gallery/misc/ftface_props.rst:16"
     ],
     "GraphicsContext": [
       "doc/devel/MEP/MEP26.rst:68"
@@ -741,10 +708,10 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.hexbin:71"
     ],
     "QuadContourSet.changed()": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.contour:130",
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.contourf:130",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.contour:130",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.contourf:130"
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.contour:131",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.contourf:131",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.contour:131",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.contourf:131"
     ],
     "Quit": [
       "doc/devel/MEP/MEP22.rst:78"
@@ -753,8 +720,8 @@
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:44"
     ],
     "Size.from_any": [
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:60",
-      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:60"
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:61",
+      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:61"
     ],
     "Style": [
       "doc/devel/MEP/MEP26.rst:68"
@@ -917,10 +884,10 @@
       "doc/devel/MEP/MEP23.rst:40"
     ],
     "cbook._warn_external": [
-      "doc/devel/contributing.rst:477",
-      "doc/devel/contributing.rst:492",
-      "doc/devel/contributing.rst:501",
-      "doc/devel/contributing.rst:526"
+      "doc/devel/contributing.rst:493",
+      "doc/devel/contributing.rst:508",
+      "doc/devel/contributing.rst:517",
+      "doc/devel/contributing.rst:542"
     ],
     "cbook.deprecated": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:1073",
@@ -930,7 +897,7 @@
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:766"
     ],
     "cbook.warn_deprecated()": [
-      "doc/devel/contributing.rst:314"
+      "doc/devel/contributing.rst:330"
     ],
     "cleanup": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.setup:19"
@@ -958,7 +925,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:128"
     ],
     "floating_axes.FloatingSubplot": [
-      "doc/gallery/axisartist/demo_floating_axes.rst:20"
+      "doc/gallery/axisartist/demo_floating_axes.rst:22"
     ],
     "fmt_xdata": [
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes.Axes.format_xdata:4"
@@ -977,12 +944,6 @@
     ],
     "get_canvas_title": [
       "doc/devel/MEP/MEP23.rst:68"
-    ],
-    "get_contains": [
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend.contains:29",
-      "lib/matplotlib/offsetbox.py:docstring of matplotlib.offsetbox.AnnotationBbox.contains:29",
-      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.QuiverKey.contains:29",
-      "lib/matplotlib/table.py:docstring of matplotlib.table.Table.contains:29"
     ],
     "get_ps": [
       "doc/devel/MEP/MEP14.rst:376"
@@ -1003,18 +964,8 @@
     "h_pad": [
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.set_constrained_layout:5"
     ],
-    "handler_map": [
-      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:242",
-      "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:206",
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:201",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:206",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:242"
-    ],
     "image": [
-      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:72"
-    ],
-    "images": [
-      "lib/matplotlib/image.py:docstring of matplotlib.image.composite_images:2"
+      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:73"
     ],
     "interactive": [
       "lib/matplotlib/backends/backend_nbagg.py:docstring of matplotlib.backends.backend_nbagg.show:4"
@@ -1048,11 +999,11 @@
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.PolygonSelector:27"
     ],
     "load_char": [
-      "doc/gallery/misc/ftface_props.rst:14"
+      "doc/gallery/misc/ftface_props.rst:16"
     ],
     "logging.WARNING": [
-      "doc/devel/contributing.rst:452",
-      "doc/devel/contributing.rst:489"
+      "doc/devel/contributing.rst:468",
+      "doc/devel/contributing.rst:505"
     ],
     "ls_mapper": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:11"
@@ -1279,9 +1230,6 @@
     "matplotlib.animation.FuncAnimation.to_jshtml": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.FuncAnimation.new_frame_seq:1:<autosummary>:1"
     ],
-    "matplotlib.animation.HTMLWriter.args_key": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
-    ],
     "matplotlib.animation.HTMLWriter.bin_path": [
       "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
     ],
@@ -1289,16 +1237,16 @@
       "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.HTMLWriter.clear_temp": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.args_key:1:<autosummary>:1"
     ],
     "matplotlib.animation.HTMLWriter.exec_key": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.args_key:1:<autosummary>:1"
     ],
     "matplotlib.animation.HTMLWriter.frame_format": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.args_key:1:<autosummary>:1"
     ],
     "matplotlib.animation.HTMLWriter.frame_size": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.finish:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.args_key:1:<autosummary>:1"
     ],
     "matplotlib.animation.HTMLWriter.saving": [
       "doc/api/_as_gen/matplotlib.animation.HTMLWriter.rst:28:<autosummary>:1"
@@ -1428,13 +1376,13 @@
       "lib/matplotlib/tri/tricontour.py:docstring of matplotlib.axes.Axes.tricontourf:57"
     ],
     "matplotlib.dates.rrulewrapper": [
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates:105"
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates:103"
     ],
     "matplotlib.docstring.dedent_interpd": [
-      "doc/devel/documenting_mpl.rst:638"
+      "doc/devel/documenting_mpl.rst:663"
     ],
     "matplotlib.patches.Patch.__init__": [
-      "doc/devel/documenting_mpl.rst:671"
+      "doc/devel/documenting_mpl.rst:696"
     ],
     "matplotlib.pyplot.get_scale_docs()": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:853"
@@ -1485,10 +1433,9 @@
       "doc/api/prev_api_changes/api_changes_2.1.0.rst:95",
       "doc/faq/howto_faq.rst:18",
       "doc/faq/howto_faq.rst:21",
-      "doc/faq/howto_faq.rst:30",
-      "doc/gallery/recipes/common_date_problems.rst:34",
-      "doc/gallery/text_labels_and_annotations/date.rst:18",
-      "doc/tutorials/text/text_intro.rst:580",
+      "doc/gallery/recipes/common_date_problems.rst:36",
+      "doc/gallery/text_labels_and_annotations/date.rst:20",
+      "doc/tutorials/text/text_intro.rst:582",
       "doc/users/prev_whats_new/whats_new_2.2.rst:155",
       "lib/matplotlib/dates.py:docstring of matplotlib.dates.date2num:8"
     ],
@@ -1504,10 +1451,11 @@
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:135"
     ],
     "plot": [
+      "doc/tutorials/introductory/customizing.rst:195",
       "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:4"
     ],
     "plot_include_source": [
-      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:51"
+      "lib/matplotlib/sphinxext/plot_directive.py:docstring of matplotlib.sphinxext.plot_directive:52"
     ],
     "print_xyz": [
       "lib/matplotlib/backends/backend_template.py:docstring of matplotlib.backends.backend_template:22"
@@ -1519,7 +1467,7 @@
       "doc/devel/MEP/MEP23.rst:63"
     ],
     "rrulewrapper": [
-      "lib/matplotlib/dates.py:docstring of matplotlib.dates:105"
+      "lib/matplotlib/dates.py:docstring of matplotlib.dates:103"
     ],
     "scipy.stats.norm.pdf": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:565",
@@ -1537,12 +1485,6 @@
     "set_canvas_title": [
       "doc/devel/MEP/MEP23.rst:66"
     ],
-    "set_contains": [
-      "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend.contains:29",
-      "lib/matplotlib/offsetbox.py:docstring of matplotlib.offsetbox.AnnotationBbox.contains:29",
-      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.QuiverKey.contains:29",
-      "lib/matplotlib/table.py:docstring of matplotlib.table.Table.contains:29"
-    ],
     "set_size": [
       "doc/users/prev_whats_new/whats_new_1.4.rst:223"
     ],
@@ -1555,7 +1497,7 @@
     "shadow_rgbFace": [
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimpleLineShadow:39",
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimplePatchShadow:38",
-      "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:39"
+      "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.withSimplePatchShadow:47"
     ],
     "sharex": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.subplots:13"
@@ -1580,7 +1522,7 @@
     ],
     "style.available": [
       "lib/matplotlib/style/__init__.py:docstring of matplotlib.style.context:12",
-      "lib/matplotlib/style/__init__.py:docstring of matplotlib.style.use:14"
+      "lib/matplotlib/style/__init__.py:docstring of matplotlib.style.use:19"
     ],
     "tight_bbox.adjust_bbox": [
       "doc/api/prev_api_changes/api_changes_1.4.x.rst:152"
@@ -1624,7 +1566,7 @@
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.set_constrained_layout:5"
     ],
     "warn": [
-      "doc/devel/contributing.rst:501"
+      "doc/devel/contributing.rst:517"
     ],
     "whats_new.rst": [
       "doc/users/next_whats_new/README.rst:6"


### PR DESCRIPTION
I think what happened is that the way nested classes are referred to in
inheritance diagrams has improved (the qualified name is more correct
now), which caused missing-references.json to go out of sync.
Unfortunately this means missing-references.json can either be
compatible with sphinx<3.0 or with sphinx>3.0, but to be compatible with
both we'd likely need to generate one with both versions and merge the
two json files, which seems not worth it.  Instead, just drop nitpicky
mode for older sphixes (sphinges?).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
