### PR TITLE
Replace most jQuery with vanilla JavaScript

### DIFF
--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -71,7 +71,15 @@ html_content = """
         window.open('download.' + format, '_blank');
       };
 
-      $(document).ready(
+      function ready(fn) {
+        if (document.readyState != "loading") {
+          fn();
+        } else {
+          document.addEventListener("DOMContentLoaded", fn);
+        }
+      }
+
+      ready(
         function() {
           /* It is up to the application to provide a websocket that the figure
              will use to communicate to the server.  This websocket object can
@@ -89,7 +97,7 @@ html_content = """
               // A function called when a file type is selected for download
               ondownload,
               // The HTML element in which to place the figure
-              $('div#figure'));
+              document.getElementById("figure"));
         }
       );
     </script>

--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -35,7 +35,7 @@
       };
 
       {% for (fig_id, fig_manager) in figures %}
-        ready(figure_ready({{ repr(str(fig_id)) }}));
+        ready(figure_ready({{ str(fig_id) }}));
       {% end %}
     </script>
 

--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -10,25 +10,33 @@
     <script src="{{ prefix }}/js/mpl.js"></script>
 
     <script>
-      {% for (fig_id, fig_manager) in figures %}
-        $(document).ready(
-        function() {
-          var main_div = $('div#figures');
-          var figure_div = $('<div id="figure-div"/>')
-          main_div.append(figure_div);
+      function ready(fn) {
+        if (document.readyState != "loading") {
+          fn();
+        } else {
+          document.addEventListener("DOMContentLoaded", fn);
+        }
+      }
+
+      function figure_ready(fig_id) {
+        return function () {
+          var main_div = document.querySelector("div#figures");
+          var figure_div = document.createElement("div");
+          figure_div.id = "figure-div";
+          main_div.appendChild(figure_div);
           var websocket_type = mpl.get_websocket_type();
-          var websocket = new websocket_type(
-              "{{ ws_uri }}" + "{{ fig_id }}" + "/ws");
-          var fig = new mpl.figure(
-              "{{ fig_id }}", websocket, mpl_ondownload, figure_div);
+          var websocket = new websocket_type("{{ ws_uri }}" + fig_id + "/ws");
+          var fig = new mpl.figure(fig_id, websocket, mpl_ondownload, figure_div);
 
           fig.focus_on_mouseover = true;
 
-          $(fig.canvas).attr('tabindex', {{ fig_id }});
-          }
-        );
+          fig.canvas.setAttribute("tabindex", fig_id);
+        }
+      };
 
-	{% end %}
+      {% for (fig_id, fig_manager) in figures %}
+        ready(figure_ready({{ repr(str(fig_id)) }}));
+      {% end %}
     </script>
 
   <title>MPL | WebAgg current figures</title>

--- a/lib/matplotlib/backends/web_backend/ipython_inline_figure.html
+++ b/lib/matplotlib/backends/web_backend/ipython_inline_figure.html
@@ -12,7 +12,7 @@
   function init_figure{{ fig_id }}(e) {
     $('div.output').off('resize');
 
-    var output_div = $(e.target).find('div.output_subarea');
+    var output_div = e.target.querySelector('div.output_subarea');
     var websocket_type = mpl.get_websocket_type();
     var websocket = new websocket_type(
         "ws://" + window.location.hostname + ":{{ port }}{{ prefix}}/" +

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -45,11 +45,11 @@ mpl.figure = function (figure_id, websocket, ondownload, parent_element) {
 
     this.image_mode = 'full';
 
-    this.root = $('<div/>');
+    this.root = document.createElement('div');
     this._root_extra_style(this.root);
-    this.root.attr('style', 'display: inline-block');
+    this.root.setAttribute('style', 'display: inline-block');
 
-    $(parent_element).append(this.root);
+    parent_element.appendChild(this.root);
 
     this._init_header(this);
     this._init_canvas(this);
@@ -88,17 +88,18 @@ mpl.figure = function (figure_id, websocket, ondownload, parent_element) {
 };
 
 mpl.figure.prototype._init_header = function () {
-    var titlebar = $(
-        '<div class="ui-dialog-titlebar ui-widget-header ui-corner-all ' +
-            'ui-helper-clearfix"/>'
+    var titlebar = document.createElement('div');
+    titlebar.classList =
+        'ui-dialog-titlebar ui-widget-header ui-corner-all ui-helper-clearfix';
+    var titletext = document.createElement('div');
+    titletext.classList = 'ui-dialog-title';
+    titletext.setAttribute(
+        'style',
+        'width: 100%; text-align: center; padding: 3px;'
     );
-    var titletext = $(
-        '<div class="ui-dialog-title" style="width: 100%; ' +
-            'text-align: center; padding: 3px;"/>'
-    );
-    titlebar.append(titletext);
-    this.root.append(titlebar);
-    this.header = titletext[0];
+    titlebar.appendChild(titletext);
+    this.root.appendChild(titlebar);
+    this.header = titletext;
 };
 
 mpl.figure.prototype._canvas_extra_style = function (_canvas_div) {};
@@ -108,26 +109,35 @@ mpl.figure.prototype._root_extra_style = function (_canvas_div) {};
 mpl.figure.prototype._init_canvas = function () {
     var fig = this;
 
-    var canvas_div = $('<div/>');
+    var canvas_div = (this.canvas_div = document.createElement('div'));
+    canvas_div.setAttribute(
+        'style',
+        'position: relative; clear: both; outline: 0'
+    );
 
-    canvas_div.attr('style', 'position: relative; clear: both; outline: 0');
-
-    function canvas_keyboard_event(event) {
-        return fig.key_event(event, event['data']);
+    function on_keyboard_event_closure(name) {
+        return function (event) {
+            return fig.key_event(event, name);
+        };
     }
 
-    canvas_div.keydown('key_press', canvas_keyboard_event);
-    canvas_div.keyup('key_release', canvas_keyboard_event);
-    this.canvas_div = canvas_div;
+    canvas_div.addEventListener(
+        'keydown',
+        on_keyboard_event_closure('key_press')
+    );
+    canvas_div.addEventListener(
+        'keyup',
+        on_keyboard_event_closure('key_release')
+    );
+
     this._canvas_extra_style(canvas_div);
-    this.root.append(canvas_div);
+    this.root.appendChild(canvas_div);
 
-    var canvas = $('<canvas/>');
-    canvas.addClass('mpl-canvas');
-    canvas.attr('style', 'left: 0; top: 0; z-index: 0; outline: 0');
+    var canvas = (this.canvas = document.createElement('canvas'));
+    canvas.classList.add('mpl-canvas');
+    canvas.setAttribute('style', 'left: 0; top: 0; z-index: 0; outline: 0');
 
-    this.canvas = canvas[0];
-    this.context = canvas[0].getContext('2d');
+    this.context = canvas.getContext('2d');
 
     var backingStore =
         this.context.backingStorePixelRatio ||
@@ -140,15 +150,17 @@ mpl.figure.prototype._init_canvas = function () {
 
     mpl.ratio = (window.devicePixelRatio || 1) / backingStore;
 
-    var rubberband = $('<canvas/>');
-    rubberband.attr(
+    var rubberband_canvas = (this.rubberband_canvas = document.createElement(
+        'canvas'
+    ));
+    rubberband_canvas.setAttribute(
         'style',
         'position: absolute; left: 0; top: 0; z-index: 1;'
     );
 
     var pass_mouse_events = true;
 
-    canvas_div.resizable({
+    $(canvas_div).resizable({
         start: function (_event, _ui) {
             pass_mouse_events = false;
         },
@@ -161,54 +173,67 @@ mpl.figure.prototype._init_canvas = function () {
         },
     });
 
-    function mouse_event_fn(event) {
-        if (pass_mouse_events) {
-            return fig.mouse_event(event, event['data']);
-        }
+    function on_mouse_event_closure(name) {
+        return function (event) {
+            if (pass_mouse_events) {
+                return fig.mouse_event(event, name);
+            }
+        };
     }
 
-    rubberband.mousedown('button_press', mouse_event_fn);
-    rubberband.mouseup('button_release', mouse_event_fn);
+    rubberband_canvas.addEventListener(
+        'mousedown',
+        on_mouse_event_closure('button_press')
+    );
+    rubberband_canvas.addEventListener(
+        'mouseup',
+        on_mouse_event_closure('button_release')
+    );
     // Throttle sequential mouse events to 1 every 20ms.
-    rubberband.mousemove('motion_notify', mouse_event_fn);
+    rubberband_canvas.addEventListener(
+        'mousemove',
+        on_mouse_event_closure('motion_notify')
+    );
 
-    rubberband.mouseenter('figure_enter', mouse_event_fn);
-    rubberband.mouseleave('figure_leave', mouse_event_fn);
+    rubberband_canvas.addEventListener(
+        'mouseenter',
+        on_mouse_event_closure('figure_enter')
+    );
+    rubberband_canvas.addEventListener(
+        'mouseleave',
+        on_mouse_event_closure('figure_leave')
+    );
 
-    canvas_div.on('wheel', function (event) {
-        event = event.originalEvent;
-        event['data'] = 'scroll';
+    canvas_div.addEventListener('wheel', function (event) {
         if (event.deltaY < 0) {
             event.step = 1;
         } else {
             event.step = -1;
         }
-        mouse_event_fn(event);
+        on_mouse_event_closure('scroll')(event);
     });
 
-    canvas_div.append(canvas);
-    canvas_div.append(rubberband);
+    canvas_div.appendChild(canvas);
+    canvas_div.appendChild(rubberband_canvas);
 
-    this.rubberband = rubberband;
-    this.rubberband_canvas = rubberband[0];
-    this.rubberband_context = rubberband[0].getContext('2d');
+    this.rubberband_context = rubberband_canvas.getContext('2d');
     this.rubberband_context.strokeStyle = '#000000';
 
     this._resize_canvas = function (width, height) {
         // Keep the size of the canvas, canvas container, and rubber band
         // canvas in synch.
-        canvas_div.css('width', width);
-        canvas_div.css('height', height);
+        canvas_div.style.width = width;
+        canvas_div.style.height = height;
 
-        canvas.attr('width', width * mpl.ratio);
-        canvas.attr('height', height * mpl.ratio);
-        canvas.attr(
+        canvas.setAttribute('width', width * mpl.ratio);
+        canvas.setAttribute('height', height * mpl.ratio);
+        canvas.setAttribute(
             'style',
             'width: ' + width + 'px; height: ' + height + 'px;'
         );
 
-        rubberband.attr('width', width);
-        rubberband.attr('height', height);
+        rubberband_canvas.setAttribute('width', width);
+        rubberband_canvas.setAttribute('height', height);
     };
 
     // Set the figure to an initial 600x600px, this will subsequently be updated
@@ -216,7 +241,7 @@ mpl.figure.prototype._init_canvas = function () {
     this._resize_canvas(600, 600);
 
     // Disable right mouse context menu.
-    $(this.rubberband_canvas).bind('contextmenu', function (_e) {
+    this.rubberband_canvas.addEventListener('contextmenu', function (_e) {
         return false;
     });
 
@@ -231,16 +256,20 @@ mpl.figure.prototype._init_canvas = function () {
 mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
-    var toolbar = $('<div/>');
-    toolbar.attr('style', 'width: 100%');
-    this.root.append(toolbar);
+    var toolbar = document.createElement('div');
+    toolbar.setAttribute('style', 'width: 100%');
+    this.root.appendChild(toolbar);
 
-    // Define a callback function for later on.
-    function toolbar_event(event) {
-        return fig.toolbar_button_onclick(event['data']);
+    function on_click_closure(name) {
+        return function (_event) {
+            return fig.toolbar_button_onclick(name);
+        };
     }
-    function toolbar_mouse_event(event) {
-        return fig.toolbar_button_onmouseover(event['data']);
+
+    function on_mouseover_closure(tooltip) {
+        return function (_event) {
+            return fig.toolbar_button_onmouseover(tooltip);
+        };
     }
 
     for (var toolbar_ind in mpl.toolbar_items) {
@@ -253,50 +282,48 @@ mpl.figure.prototype._init_toolbar = function () {
             // put a spacer in here.
             continue;
         }
-        var button = $('<button/>');
-        button.addClass(
-            'ui-button ui-widget ui-state-default ui-corner-all ' +
-                'ui-button-icon-only'
-        );
-        button.attr('role', 'button');
-        button.attr('aria-disabled', 'false');
-        button.click(method_name, toolbar_event);
-        button.mouseover(tooltip, toolbar_mouse_event);
+        var button = document.createElement('button');
+        button.classList =
+            'ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only';
+        button.setAttribute('role', 'button');
+        button.setAttribute('aria-disabled', 'false');
+        button.addEventListener('click', on_click_closure(method_name));
+        button.addEventListener('mouseover', on_mouseover_closure(tooltip));
 
-        var icon_img = $('<span/>');
-        icon_img.addClass('ui-button-icon-primary ui-icon');
-        icon_img.addClass(image);
-        icon_img.addClass('ui-corner-all');
+        var icon_img = document.createElement('span');
+        icon_img.classList =
+            'ui-button-icon-primary ui-icon ' + image + ' ui-corner-all';
 
-        var tooltip_span = $('<span/>');
-        tooltip_span.addClass('ui-button-text');
-        tooltip_span.html(tooltip);
+        var tooltip_span = document.createElement('span');
+        tooltip_span.classList = 'ui-button-text';
+        tooltip_span.innerHTML = tooltip;
 
-        button.append(icon_img);
-        button.append(tooltip_span);
+        button.appendChild(icon_img);
+        button.appendChild(tooltip_span);
 
-        toolbar.append(button);
+        toolbar.appendChild(button);
     }
 
-    var fmt_picker_span = $('<span/>');
+    var fmt_picker_span = document.createElement('span');
 
-    var fmt_picker = $('<select/>');
-    fmt_picker.addClass('mpl-toolbar-option ui-widget ui-widget-content');
-    fmt_picker_span.append(fmt_picker);
-    toolbar.append(fmt_picker_span);
-    this.format_dropdown = fmt_picker[0];
+    var fmt_picker = document.createElement('select');
+    fmt_picker.classList = 'mpl-toolbar-option ui-widget ui-widget-content';
+    fmt_picker_span.appendChild(fmt_picker);
+    toolbar.appendChild(fmt_picker_span);
+    this.format_dropdown = fmt_picker;
 
     for (var ind in mpl.extensions) {
         var fmt = mpl.extensions[ind];
-        var option = $('<option/>', {
-            selected: fmt === mpl.default_extension,
-        }).html(fmt);
-        fmt_picker.append(option);
+        var option = document.createElement('option');
+        option.selected = fmt === mpl.default_extension;
+        option.innerHTML = fmt;
+        fmt_picker.appendChild(option);
     }
 
-    var status_bar = $('<span class="mpl-message"/>');
-    toolbar.append(status_bar);
-    this.message = status_bar[0];
+    var status_bar = document.createElement('span');
+    status_bar.classList = 'mpl-message';
+    toolbar.appendChild(status_bar);
+    this.message = status_bar;
 };
 
 mpl.figure.prototype.request_resize = function (x_pixels, y_pixels) {
@@ -480,11 +507,10 @@ mpl.findpos = function (e) {
         targ = targ.parentNode;
     }
 
-    // jQuery normalizes the pageX and pageY
     // pageX,Y are the mouse positions relative to the document
-    // offset() returns the position of the element relative to the document
-    var x = e.pageX - $(targ).offset().left;
-    var y = e.pageY - $(targ).offset().top;
+    var boundingRect = targ.getBoundingClientRect();
+    var x = e.pageX - (boundingRect.left + document.body.scrollLeft);
+    var y = e.pageY - (boundingRect.top + document.body.scrollTop);
 
     return { x: x, y: y };
 };

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -294,16 +294,6 @@ mpl.figure.prototype._init_toolbar = function () {
         fmt_picker.append(option);
     }
 
-    // Add hover states to the ui-buttons
-    $('.ui-button').hover(
-        function () {
-            $(this).addClass('ui-state-hover');
-        },
-        function () {
-            $(this).removeClass('ui-state-hover');
-        }
-    );
-
     var status_bar = $('<span class="mpl-message"/>');
     toolbar.append(status_bar);
     this.message = status_bar[0];

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -231,9 +231,9 @@ mpl.figure.prototype._init_canvas = function () {
 mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
-    var nav_element = $('<div/>');
-    nav_element.attr('style', 'width: 100%');
-    this.root.append(nav_element);
+    var toolbar = $('<div/>');
+    toolbar.attr('style', 'width: 100%');
+    this.root.append(toolbar);
 
     // Define a callback function for later on.
     function toolbar_event(event) {
@@ -275,7 +275,7 @@ mpl.figure.prototype._init_toolbar = function () {
         button.append(icon_img);
         button.append(tooltip_span);
 
-        nav_element.append(button);
+        toolbar.append(button);
     }
 
     var fmt_picker_span = $('<span/>');
@@ -283,7 +283,7 @@ mpl.figure.prototype._init_toolbar = function () {
     var fmt_picker = $('<select/>');
     fmt_picker.addClass('mpl-toolbar-option ui-widget ui-widget-content');
     fmt_picker_span.append(fmt_picker);
-    nav_element.append(fmt_picker_span);
+    toolbar.append(fmt_picker_span);
     this.format_dropdown = fmt_picker[0];
 
     for (var ind in mpl.extensions) {
@@ -305,7 +305,7 @@ mpl.figure.prototype._init_toolbar = function () {
     );
 
     var status_bar = $('<span class="mpl-message"/>');
-    nav_element.append(status_bar);
+    toolbar.append(status_bar);
     this.message = status_bar[0];
 };
 

--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -94,9 +94,9 @@ mpl.figure.prototype.updated_canvas_event = function () {
 mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
-    var nav_element = $('<div/>');
-    nav_element.attr('style', 'width: 100%');
-    this.root.append(nav_element);
+    var toolbar = $('<div/>');
+    toolbar.attr('style', 'width: 100%');
+    this.root.append(toolbar);
 
     // Define a callback function for later on.
     function toolbar_event(event) {
@@ -126,14 +126,14 @@ mpl.figure.prototype._init_toolbar = function () {
         );
         button.click(method_name, toolbar_event);
         button.mouseover(tooltip, toolbar_mouse_event);
-        nav_element.append(button);
+        toolbar.append(button);
     }
 
     // Add the status bar.
     var status_bar = $(
         '<span class="mpl-message" style="text-align:right; float: right;"/>'
     );
-    nav_element.append(status_bar);
+    toolbar.append(status_bar);
     this.message = status_bar[0];
 
     // Add the close button to the window.

--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -29,20 +29,20 @@ mpl.mpl_figure_comm = function (comm, msg) {
     var id = msg.content.data.id;
     // Get hold of the div created by the display call when the Comm
     // socket was opened in Python.
-    var element = $('#' + id);
+    var element = document.getElementById(id);
     var ws_proxy = comm_websocket_adapter(comm);
 
     function ondownload(figure, _format) {
         window.open(figure.canvas.toDataURL());
     }
 
-    var fig = new mpl.figure(id, ws_proxy, ondownload, element.get(0));
+    var fig = new mpl.figure(id, ws_proxy, ondownload, element);
 
     // Call onopen now - mpl needs it, as it is assuming we've passed it a real
     // web socket which is closed, not our websocket->open comm proxy.
     ws_proxy.onopen();
 
-    fig.parent_element = element.get(0);
+    fig.parent_element = element;
     fig.cell_info = mpl.find_output_cell("<div id='" + id + "'></div>");
     if (!fig.cell_info) {
         console.error('Failed to find cell for figure', id, fig);
@@ -52,7 +52,7 @@ mpl.mpl_figure_comm = function (comm, msg) {
 
 mpl.figure.prototype.handle_close = function (fig, msg) {
     var width = fig.canvas.width / mpl.ratio;
-    fig.root.unbind('remove');
+    fig.root.removeEventListener('remove', this._remove_fig_handler);
 
     // Update the output cell to use the data from the current canvas.
     fig.push_to_output();
@@ -60,9 +60,8 @@ mpl.figure.prototype.handle_close = function (fig, msg) {
     // Re-enable the keyboard manager in IPython - without this line, in FF,
     // the notebook keyboard shortcuts fail.
     IPython.keyboard_manager.enable();
-    $(fig.parent_element).html(
-        '<img src="' + dataURL + '" width="' + width + '">'
-    );
+    fig.parent_element.innerHTML =
+        '<img src="' + dataURL + '" width="' + width + '">';
     fig.close_ws(fig, msg);
 };
 
@@ -94,16 +93,20 @@ mpl.figure.prototype.updated_canvas_event = function () {
 mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
-    var toolbar = $('<div/>');
-    toolbar.attr('style', 'width: 100%');
-    this.root.append(toolbar);
+    var toolbar = document.createElement('div');
+    toolbar.setAttribute('style', 'width: 100%');
+    this.root.appendChild(toolbar);
 
-    // Define a callback function for later on.
-    function toolbar_event(event) {
-        return fig.toolbar_button_onclick(event['data']);
+    function on_click_closure(name) {
+        return function (_event) {
+            return fig.toolbar_button_onclick(name);
+        };
     }
-    function toolbar_mouse_event(event) {
-        return fig.toolbar_button_onmouseover(event['data']);
+
+    function on_mouseover_closure(tooltip) {
+        return function (_event) {
+            return fig.toolbar_button_onmouseover(tooltip);
+        };
     }
 
     var button;
@@ -117,49 +120,54 @@ mpl.figure.prototype._init_toolbar = function () {
             continue;
         }
 
-        button = $(
-            '<button class="btn btn-default" href="#" title="' +
-                name +
-                '"><i class="fa ' +
-                image +
-                ' fa-lg"></i></button>'
-        );
-        button.click(method_name, toolbar_event);
-        button.mouseover(tooltip, toolbar_mouse_event);
-        toolbar.append(button);
+        button = document.createElement('button');
+        button.classList = 'btn btn-default';
+        button.href = '#';
+        button.title = name;
+        button.innerHTML = '<i class="fa ' + image + ' fa-lg"></i>';
+        button.addEventListener('click', on_click_closure(method_name));
+        button.addEventListener('mouseover', on_mouseover_closure(tooltip));
+        toolbar.appendChild(button);
     }
 
     // Add the status bar.
-    var status_bar = $(
-        '<span class="mpl-message" style="text-align:right; float: right;"/>'
-    );
-    toolbar.append(status_bar);
-    this.message = status_bar[0];
+    var status_bar = document.createElement('span');
+    status_bar.classList = 'mpl-message';
+    status_bar.setAttribute('style', 'text-align:right; float: right;');
+    toolbar.appendChild(status_bar);
+    this.message = status_bar;
 
     // Add the close button to the window.
-    var buttongrp = $('<div class="btn-group inline pull-right"></div>');
-    button = $(
-        '<button class="btn btn-mini btn-primary" href="#" title="Stop Interaction"><i class="fa fa-power-off icon-remove icon-large"></i></button>'
-    );
-    button.click(function (_evt) {
+    var buttongrp = document.createElement('div');
+    buttongrp.classList = 'btn-group inline pull-right';
+    button = document.createElement('button');
+    button.classList = 'btn btn-mini btn-primary';
+    button.href = '#';
+    button.title = 'Stop Interaction';
+    button.innerHTML = '<i class="fa fa-power-off icon-remove icon-large"></i>';
+    button.addEventListener('click', function (_evt) {
         fig.handle_close(fig, {});
     });
-    button.mouseover('Stop Interaction', toolbar_mouse_event);
-    buttongrp.append(button);
-    var titlebar = this.root.find($('.ui-dialog-titlebar'));
-    titlebar.prepend(buttongrp);
+    button.addEventListener(
+        'mouseover',
+        on_mouseover_closure('Stop Interaction')
+    );
+    buttongrp.appendChild(button);
+    var titlebar = this.root.querySelector('.ui-dialog-titlebar');
+    titlebar.insertBefore(buttongrp, titlebar.firstChild);
+};
+
+mpl.figure.prototype._remove_fig_handler = function () {
+    this.close_ws(this, {});
 };
 
 mpl.figure.prototype._root_extra_style = function (el) {
-    var fig = this;
-    el.on('remove', function () {
-        fig.close_ws(fig, {});
-    });
+    el.addEventListener('remove', this._remove_fig_handler);
 };
 
 mpl.figure.prototype._canvas_extra_style = function (el) {
     // this is important to make the div 'focusable
-    el.attr('tabindex', 0);
+    el.setAttribute('tabindex', 0);
     // reach out to IPython and tell the keyboard manager to turn it's self
     // off when our div gets focus
 

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -21,9 +21,9 @@
         function () {
           var websocket_type = mpl.get_websocket_type();
           var websocket = new websocket_type(
-              "{{ ws_uri }}" + {{ repr(str(fig_id)) }} + "/ws");
+              "{{ ws_uri }}" + {{ str(fig_id) }} + "/ws");
           var fig = new mpl.figure(
-              {{repr(str(fig_id))}}, websocket, mpl_ondownload,
+              {{ str(fig_id) }}, websocket, mpl_ondownload,
               document.getElementById("figure"));
         }
       );

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -9,13 +9,22 @@
     <script src="{{ prefix }}/_static/js/mpl_tornado.js"></script>
     <script src="{{ prefix }}/js/mpl.js"></script>
     <script>
-      $(document).ready(
-        function() {
+      function ready(fn) {
+        if (document.readyState != "loading") {
+          fn();
+        } else {
+          document.addEventListener("DOMContentLoaded", fn);
+        }
+      }
+
+      ready(
+        function () {
           var websocket_type = mpl.get_websocket_type();
           var websocket = new websocket_type(
               "{{ ws_uri }}" + {{ repr(str(fig_id)) }} + "/ws");
-	  var fig = new mpl.figure(
-              {{repr(str(fig_id))}}, websocket, mpl_ondownload, $('div#figure'));
+          var fig = new mpl.figure(
+              {{repr(str(fig_id))}}, websocket, mpl_ondownload,
+              document.getElementById("figure"));
         }
       );
     </script>


### PR DESCRIPTION
## PR Summary

This is a mix of the change in ipympl, plus the same thing for our original version of other stuff, using stuff like http://youmightnotneedjquery.com/ and [this cheat sheet](https://tobiasahlin.com/blog/move-from-jquery-to-vanilla-javascript/). Unfortunately, we can't just remove jQuery, because we have jquery-ui for the CSS and resizable handles. CSS is easy, and we can replace the handles without too much code (since we don't need its full flexibility), but this was large enough already.

Fixes #14596. ~~Waiting on the JS style fix PR.~~

## PR Checklist

- [x] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way