### PR TITLE
Simplify subgridspec example/tutorial.

### DIFF
--- a/examples/userdemo/demo_gridspec06.py
+++ b/examples/userdemo/demo_gridspec06.py
@@ -7,9 +7,7 @@ This example demonstrates the use of nested `.GridSpec`\s.
 """
 
 import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
 import numpy as np
-from itertools import product
 
 
 def squiggle_xy(a, b, c, d):
@@ -18,35 +16,23 @@ def squiggle_xy(a, b, c, d):
 
 
 fig = plt.figure(figsize=(8, 8))
+outer_grid = fig.add_gridspec(4, 4, wspace=0, hspace=0)
 
-# gridspec inside gridspec
-outer_grid = gridspec.GridSpec(4, 4, wspace=0.0, hspace=0.0)
-
-for i in range(16):
-    inner_grid = gridspec.GridSpecFromSubplotSpec(
-        3, 3, subplot_spec=outer_grid[i], wspace=0.0, hspace=0.0)
-    a = i // 4 + 1
-    b = i % 4 + 1
-    for j, (c, d) in enumerate(product(range(1, 4), repeat=2)):
-        ax = fig.add_subplot(inner_grid[j])
-        ax.plot(*squiggle_xy(a, b, c, d))
-        ax.set_xticks([])
-        ax.set_yticks([])
-        fig.add_subplot(ax)
-
-all_axes = fig.get_axes()
+for a in range(4):
+    for b in range(4):
+        # gridspec inside gridspec
+        inner_grid = outer_grid[a, b].subgridspec(3, 3, wspace=0, hspace=0)
+        for c in range(3):
+            for d in range(3):
+                ax = fig.add_subplot(inner_grid[c, d])
+                ax.plot(*squiggle_xy(a + 1, b + 1, c + 1, d + 1))
+                ax.set(xticks=[], yticks=[])
 
 # show only the outside spines
-for ax in all_axes:
-    for sp in ax.spines.values():
-        sp.set_visible(False)
-    if ax.is_first_row():
-        ax.spines['top'].set_visible(True)
-    if ax.is_last_row():
-        ax.spines['bottom'].set_visible(True)
-    if ax.is_first_col():
-        ax.spines['left'].set_visible(True)
-    if ax.is_last_col():
-        ax.spines['right'].set_visible(True)
+for ax in fig.get_axes():
+    ax.spines['top'].set_visible(ax.is_first_row())
+    ax.spines['bottom'].set_visible(ax.is_last_row())
+    ax.spines['left'].set_visible(ax.is_first_col())
+    ax.spines['right'].set_visible(ax.is_last_col())
 
 plt.show()

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -226,7 +226,6 @@ for a in range(2):
 # spines in each of the inner 3x3 grids.
 
 import numpy as np
-from itertools import product
 
 
 def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
@@ -234,34 +233,24 @@ def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
 
 
 fig11 = plt.figure(figsize=(8, 8), constrained_layout=False)
+outer_grid = fig11.add_gridspec(4, 4, wspace=0, hspace=0)
 
-# gridspec inside gridspec
-outer_grid = fig11.add_gridspec(4, 4, wspace=0.0, hspace=0.0)
-
-for i in range(16):
-    inner_grid = outer_grid[i].subgridspec(3, 3, wspace=0.0, hspace=0.0)
-    a, b = int(i/4)+1, i % 4+1
-    for j, (c, d) in enumerate(product(range(1, 4), repeat=2)):
-        ax = fig11.add_subplot(inner_grid[j])
-        ax.plot(*squiggle_xy(a, b, c, d))
-        ax.set_xticks([])
-        ax.set_yticks([])
-        fig11.add_subplot(ax)
-
-all_axes = fig11.get_axes()
+for a in range(4):
+    for b in range(4):
+        # gridspec inside gridspec
+        inner_grid = outer_grid[a, b].subgridspec(3, 3, wspace=0, hspace=0)
+        for c in range(3):
+            for d in range(3):
+                ax = fig11.add_subplot(inner_grid[c, d])
+                ax.plot(*squiggle_xy(a + 1, b + 1, c + 1, d + 1))
+                ax.set(xticks=[], yticks=[])
 
 # show only the outside spines
-for ax in all_axes:
-    for sp in ax.spines.values():
-        sp.set_visible(False)
-    if ax.is_first_row():
-        ax.spines['top'].set_visible(True)
-    if ax.is_last_row():
-        ax.spines['bottom'].set_visible(True)
-    if ax.is_first_col():
-        ax.spines['left'].set_visible(True)
-    if ax.is_last_col():
-        ax.spines['right'].set_visible(True)
+for ax in fig11.get_axes():
+    ax.spines['top'].set_visible(ax.is_first_row())
+    ax.spines['bottom'].set_visible(ax.is_last_row())
+    ax.spines['left'].set_visible(ax.is_first_col())
+    ax.spines['right'].set_visible(ax.is_last_col())
 
 plt.show()
 


### PR DESCRIPTION
- Use add_gridspec to construct the gridspec and subgridspec to
  construct the subgridspec, saving an import.
- Use nested loops rather than itertools.product, which is nice but
  not really the point of the tutorial.
- Index gridspecs with two indices rather than a single flat index,
  again matching "standard" use.
- Set spine visiibility to the right value directly, rather than first
  toggling them all off and then a few on again.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
