### PR TITLE
Fix to "exported SVG files blurred in viewers"

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -874,6 +874,8 @@ class RendererSVG(RendererBase):
 
             attrib['transform'] = generate_transform(
                 [('matrix', flipped.frozen())])
+            attrib['preserveAspectRatio'] = 'none'
+            attrib['style'] = 'image-rendering:optimizeSpeed'
             self.writer.element(
                 'image',
                 width=short_float_fmt(w), height=short_float_fmt(h),

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -874,8 +874,7 @@ class RendererSVG(RendererBase):
 
             attrib['transform'] = generate_transform(
                 [('matrix', flipped.frozen())])
-            attrib['preserveAspectRatio'] = 'none'
-            attrib['style'] = 'image-rendering:pixelated'
+            attrib['style'] = 'image-rendering:crisp-edges;image-rendering:pixelated'
             self.writer.element(
                 'image',
                 width=short_float_fmt(w), height=short_float_fmt(h),

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -875,7 +875,7 @@ class RendererSVG(RendererBase):
             attrib['transform'] = generate_transform(
                 [('matrix', flipped.frozen())])
             attrib['preserveAspectRatio'] = 'none'
-            attrib['style'] = 'image-rendering:optimizeSpeed'
+            attrib['style'] = 'image-rendering:pixelated'
             self.writer.element(
                 'image',
                 width=short_float_fmt(w), height=short_float_fmt(h),


### PR DESCRIPTION
## PR Summary
As mentioned in [#12065](https://github.com/matplotlib/matplotlib/issues/12065)  and [#10112](https://github.com/matplotlib/matplotlib/issues/10112), SVG viewers (Chrome, Inkscape...) perform interpolation (blurring) by default. However, for files generated by `imshow(interpolation='none')`, there shouldn't be any interpolation on the viewer's side. `image-rendering:pixelated` disable the blurred-interpolation in SVG viewers.

`'preserveAspectRatio':'none'` allow pixels to be rectangles in SVG viewers. Otherwise, pixels may be rendered as squares only, leading to problems if the image is not 1:1 scaled.

SVG is important because the text of PNG in Jupyter notebooks inline mode looks blurred.

## PR Checklist

Just a change of two lines. 
