### PR TITLE
Cleanups to Qt backend.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -366,11 +366,12 @@ The ``Fil``, ``Fill``, ``Filll``, ``NegFil``, ``NegFill``, ``NegFilll``, and
 ``SsGlue`` classes in the :mod:`matplotlib.mathtext` module are deprecated.
 As an alternative, directly construct glue instances with ``Glue("fil")``, etc.
 
-NavigationToolbar2QT.parent
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This attribute is deprecated.  In order to access the parent window, use
+NavigationToolbar2QT.parent and .basedir
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These attributes are deprecated.  In order to access the parent window, use
 ``toolbar.canvas.parent()``.  Once the deprecation period is elapsed, it will
-also be accessible as ``toolbar.parent()``.
+also be accessible as ``toolbar.parent()``.  The base directory to the icons
+is ``os.path.join(mpl.get_data_path(), "images")``.
 
 Path helpers in :mod:`.bezier`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -67,7 +67,7 @@ else:
 
 def _setup_pyqt5():
     global QtCore, QtGui, QtWidgets, __version__, is_pyqt5, \
-        _isdeleted, _getSaveFileName
+        _isdeleted, _devicePixelRatio, _setDevicePixelRatio, _getSaveFileName
 
     if QT_API == QT_API_PYQT5:
         from PyQt5 import QtCore, QtGui, QtWidgets
@@ -88,10 +88,14 @@ def _setup_pyqt5():
     def is_pyqt5():
         return True
 
+    # self.devicePixelRatio() returns 0 in rare cases
+    def _devicePixelRatio(obj): return obj.devicePixelRatio() or 1
+    def _setDevicePixelRatio(obj, factor): obj.setDevicePixelRatio(factor)
+
 
 def _setup_pyqt4():
     global QtCore, QtGui, QtWidgets, __version__, is_pyqt5, \
-        _isdeleted, _getSaveFileName
+        _isdeleted, _devicePixelRatio, _setDevicePixelRatio, _getSaveFileName
 
     def _setup_pyqt4_internal(api):
         global QtCore, QtGui, QtWidgets, \
@@ -142,6 +146,9 @@ def _setup_pyqt4():
 
     def is_pyqt5():
         return False
+
+    def _devicePixelRatio(obj): return 1
+    def _setDevicePixelRatio(obj, factor): pass
 
 
 if QT_API in [QT_API_PYQT5, QT_API_PYSIDE2]:


### PR DESCRIPTION
- Move Qt4/Qt5-dependent logic re: devicePixelRatio to qt_compat;
  these functions are documented to have existed ever since Qt5 was
  released.
- In Toolbar, no need to set `.canvas` (the base class init does it)
  or `._parent` (one can just return the canvas' `.parent()`);
  `.basedir` is just a small helper which doesn't exist in other
  backends and doesn't warrant being public.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
