### PR TITLE
Fix SyntaxErrors when running setup in old Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,13 @@ min_version = (3, 6)
 if sys.version_info < min_version:
     error = """
 Beginning with Matplotlib 3.1, Python {0} or above is required.
+You are using Python {1}.
 
 This may be due to an out of date pip.
 
 Make sure you have pip >= 9.0.1.
-""".format('.'.join(str(n) for n in min_version))
+""".format('.'.join(str(n) for n in min_version),
+           '.'.join(str(n) for n in sys.version_info[:3]))
     sys.exit(error)
 
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Beginning with Matplotlib 3.1, Python {0} or above is required.
 This may be due to an out of date pip.
 
 Make sure you have pip >= 9.0.1.
-""".format('.'.join(str(n) for n in min_version)),
+""".format('.'.join(str(n) for n in min_version))
     sys.exit(error)
 
 from pathlib import Path
@@ -112,8 +112,9 @@ def _download_jquery_to(dest):
         try:
             buff = download_or_cache(url, sha)
         except Exception:
-            raise IOError(f"Failed to download jquery-ui.  Please download "
-                          f"{url} and extract it to {dest}.")
+            raise IOError(
+                "Failed to download jquery-ui.  Please download "
+                "{url} and extract it to {dest}.".format(url=url, dest=dest))
         with ZipFile(buff) as zf:
             zf.extractall(dest)
 
@@ -154,7 +155,7 @@ if __name__ == '__main__':
     # If the user just queries for information, don't bother figuring out which
     # packages to build or install.
     if not (any('--' + opt in sys.argv
-                for opt in [*Distribution.display_option_names, 'help'])
+                for opt in Distribution.display_option_names + ['help'])
             or 'clean' in sys.argv):
         # Go through all of the packages and figure out which ones we are
         # going to build/install.
@@ -169,10 +170,11 @@ if __name__ == '__main__':
             try:
                 message = package.check()
             except setupext.Skipped as e:
-                print_status(package.name, f"no  [{e}]")
+                print_status(package.name, "no  [{e}]".format(e=e))
                 continue
             if message is not None:
-                print_status(package.name, f"yes [{message}]")
+                print_status(package.name,
+                             "yes [{message}]".format(message=message))
             good_packages.append(package)
 
         print_raw()


### PR DESCRIPTION
## PR Summary

We just got another report about this, so that tells me we're not ready to remove the Python version check in `setup.py`. I know the suggestion in #16837 is to move the jQuery stuff, but soon I'll be removing it entirely, so I didn't bother.

Fixes #17075.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way