### PR TITLE
Improve default formatter for Slider values.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -155,3 +155,11 @@ support for it will be dropped in a future Matplotlib release.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Previously, keyword arguments were silently ignored when no positional
 arguments were given.
+
+Default slider formatter
+~~~~~~~~~~~~~~~~~~~~~~~~
+The default method used to format `.Slider` values has been changed to use a
+`.ScalarFormatter` adapted the slider values limits.  This should ensure that
+values are displayed with an appropriate number of significant digits even if
+they are much smaller or much bigger than 1.  To restore the old behavior,
+explicitly pass a "%1.2f" as the *valfmt* parameter to `.Slider`.


### PR DESCRIPTION
Using a ScalarFormatter works both for very small and for very large
values.  We try to keep a user-configured ScalarFormatter if there's
already one (not that this was likely at all given that the formatter
is otherwise discarded by the call to `set_x/yticks([])`).

See https://discourse.matplotlib.org/t/matplotlib-slider-labels-stop-responding-with-very-small-numbers/21064/1 for an example of user confused by the default format string.

No tests, but one can try with e.g.
```
from matplotlib.widgets import Slider
from pylab import *

ax = plt.axes([.1, .5, .7, .1])
sl1 = Slider(ax, "foo", 2e8, 3e8)
ax = plt.axes([.1, .4, .7, .1])
sl2 = Slider(ax, "bar", 2e-8, 3e-8)
plt.show()
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
