### PR TITLE
Improve nbAgg & WebAgg toolbars

### DIFF
--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -59,6 +59,7 @@ html_content = """
     <link rel="stylesheet" href="_static/css/boilerplate.css"
           type="text/css" />
     <link rel="stylesheet" href="_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="_static/css/mpl.css" type="text/css">
     <link rel="stylesheet" href="_static/jquery-ui-1.12.1/jquery-ui.min.css" />
     <script src="_static/jquery-ui-1.12.1/external/jquery/jquery.js"></script>
     <script src="_static/jquery-ui-1.12.1/jquery-ui.min.js"></script>

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -12,7 +12,9 @@ The framework being used must support web sockets.
 """
 
 import io
+import json
 import mimetypes
+from pathlib import Path
 
 try:
     import tornado
@@ -24,13 +26,12 @@ import tornado.ioloop
 import tornado.websocket
 
 
+import matplotlib as mpl
 from matplotlib.backends.backend_webagg_core import (
     FigureManagerWebAgg, new_figure_manager_given_figure)
 from matplotlib.figure import Figure
 
 import numpy as np
-
-import json
 
 
 def create_figure():
@@ -218,6 +219,11 @@ class MyApplication(tornado.web.Application):
             (r'/_static/(.*)',
              tornado.web.StaticFileHandler,
              {'path': FigureManagerWebAgg.get_static_file_path()}),
+
+            # Static images for the toolbar
+            (r'/_images/(.*)',
+             tornado.web.StaticFileHandler,
+             {'path': Path(mpl.get_data_path(), 'images')}),
 
             # The page that contains all of the pieces
             ('/', self.MainPage),

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -33,7 +33,6 @@ import tornado.ioloop
 import tornado.websocket
 
 import matplotlib as mpl
-from matplotlib import cbook
 from matplotlib.backend_bases import _Backend
 from matplotlib._pylab_helpers import Gcf
 from . import backend_webagg_core as core
@@ -64,8 +63,8 @@ class WebAggApplication(tornado.web.Application):
     class FavIcon(tornado.web.RequestHandler):
         def get(self):
             self.set_header('Content-Type', 'image/png')
-            self.write(
-                cbook._get_data_path('images/matplotlib.png').read_bytes())
+            self.write(Path(mpl.get_data_path(),
+                            'images/matplotlib.png').read_bytes())
 
     class SingleFigurePage(tornado.web.RequestHandler):
         def __init__(self, application, request, *, url_prefix='', **kwargs):
@@ -169,6 +168,11 @@ class WebAggApplication(tornado.web.Application):
                 (url_prefix + r'/_static/(.*)',
                  tornado.web.StaticFileHandler,
                  {'path': core.FigureManagerWebAgg.get_static_file_path()}),
+
+                # Static images for the toolbar
+                (url_prefix + r'/_images/(.*)',
+                 tornado.web.StaticFileHandler,
+                 {'path': Path(mpl.get_data_path(), 'images')}),
 
                 # A Matplotlib favicon
                 (url_prefix + r'/favicon.ico', self.FavIcon),

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -398,6 +398,14 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
         """Save the current figure"""
         self.canvas.send_event('save')
 
+    def pan(self):
+        super().pan()
+        self.canvas.send_event('navigate_mode', mode=self.mode.name)
+
+    def zoom(self):
+        super().zoom()
+        self.canvas.send_event('navigate_mode', mode=self.mode.name)
+
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0
         can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -345,26 +345,27 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             self.manager._send_event(event_type, **kwargs)
 
 
-_JQUERY_ICON_CLASSES = {
-    'home': 'ui-icon ui-icon-home',
-    'back': 'ui-icon ui-icon-circle-arrow-w',
-    'forward': 'ui-icon ui-icon-circle-arrow-e',
-    'zoom_to_rect': 'ui-icon ui-icon-search',
-    'move': 'ui-icon ui-icon-arrow-4',
-    'download': 'ui-icon ui-icon-disk',
-    None: None,
+_ALLOWED_TOOL_ITEMS = {
+    'home',
+    'back',
+    'forward',
+    'pan',
+    'zoom',
+    'download',
+    None,
 }
 
 
 class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
 
     # Use the standard toolbar items + download button
-    toolitems = [(text, tooltip_text, _JQUERY_ICON_CLASSES[image_file],
-                  name_of_method)
-                 for text, tooltip_text, image_file, name_of_method
-                 in (backend_bases.NavigationToolbar2.toolitems +
-                     (('Download', 'Download plot', 'download', 'download'),))
-                 if image_file in _JQUERY_ICON_CLASSES]
+    toolitems = [
+        (text, tooltip_text, image_file, name_of_method)
+        for text, tooltip_text, image_file, name_of_method
+        in (*backend_bases.NavigationToolbar2.toolitems,
+            ('Download', 'Download plot', 'filesave', 'download'))
+        if name_of_method in _ALLOWED_TOOL_ITEMS
+    ]
 
     def _init_toolbar(self):
         self.message = ''

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -308,6 +308,10 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             figure_label = "Figure {0}".format(self.manager.num)
         self.send_event('figure_label', label=figure_label)
         self._force_full = True
+        if self.toolbar:
+            # Normal toolbar init would refresh this, but it happens before the
+            # browser canvas is set up.
+            self.toolbar.set_history_buttons()
         self.draw_idle()
 
     def handle_resize(self, event):
@@ -393,6 +397,12 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
     def save_figure(self, *args):
         """Save the current figure"""
         self.canvas.send_event('save')
+
+    def set_history_buttons(self):
+        can_backward = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
+        self.canvas.send_event('history_buttons',
+                               Back=can_backward, Forward=can_forward)
 
 
 class FigureManagerWebAgg(backend_bases.FigureManagerBase):

--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -3,6 +3,7 @@
     <link rel="stylesheet" href="{{ prefix }}/_static/css/page.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css" />
     <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/mpl.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/jquery-ui-1.12.1/jquery-ui.min.css" >
     <script src="{{ prefix }}/_static/jquery-ui-1.12.1/external/jquery/jquery.js"></script>
     <script src="{{ prefix }}/_static/jquery-ui-1.12.1/jquery-ui.min.js"></script>

--- a/lib/matplotlib/backends/web_backend/css/mpl.css
+++ b/lib/matplotlib/backends/web_backend/css/mpl.css
@@ -34,6 +34,11 @@
   filter: contrast(0%);
 }
 
+.mpl-widget.active img {
+  /* Convert black to tab:blue, approximately */
+  filter: invert(34%) sepia(97%) saturate(468%) hue-rotate(162deg) brightness(96%) contrast(91%);
+}
+
 button.mpl-widget:focus,
 button.mpl-widget:hover {
   background-color: #ddd;

--- a/lib/matplotlib/backends/web_backend/css/mpl.css
+++ b/lib/matplotlib/backends/web_backend/css/mpl.css
@@ -21,6 +21,19 @@
   vertical-align: middle;
 }
 
+.mpl-widget:disabled,
+.mpl-widget[disabled] {
+  background-color: #ddd;
+  border-color: #ddd !important;
+  cursor: not-allowed;
+}
+
+.mpl-widget:disabled img,
+.mpl-widget[disabled] img {
+  /* Convert black to grey */
+  filter: contrast(0%);
+}
+
 button.mpl-widget:focus,
 button.mpl-widget:hover {
   background-color: #ddd;

--- a/lib/matplotlib/backends/web_backend/css/mpl.css
+++ b/lib/matplotlib/backends/web_backend/css/mpl.css
@@ -1,0 +1,45 @@
+/* Toolbar and items */
+.mpl-toolbar {
+  width: 100%;
+}
+
+.mpl-toolbar div.mpl-button-group {
+  display: inline-block;
+}
+
+.mpl-button-group + .mpl-button-group {
+  margin-left: 0.5em;
+}
+
+.mpl-widget {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  display: inline-block;
+  cursor: pointer;
+  color: #333;
+  padding: 6px;
+  vertical-align: middle;
+}
+
+button.mpl-widget:focus,
+button.mpl-widget:hover {
+  background-color: #ddd;
+  border-color: #aaa;
+}
+
+.mpl-button-group button.mpl-widget {
+  margin-left: -1px;
+}
+.mpl-button-group button.mpl-widget:first-child {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  margin-left: 0px;
+}
+.mpl-button-group button.mpl-widget:last-child {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+
+select.mpl-widget {
+  cursor: default;
+}

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -283,23 +283,18 @@ mpl.figure.prototype._init_toolbar = function () {
             continue;
         }
         var button = document.createElement('button');
-        button.classList =
-            'ui-button ui-widget ui-state-default ui-corner-all ui-button-icon-only';
+        button.classList = 'ui-button ui-widget ui-state-default ui-corner-all';
         button.setAttribute('role', 'button');
         button.setAttribute('aria-disabled', 'false');
         button.addEventListener('click', on_click_closure(method_name));
         button.addEventListener('mouseover', on_mouseover_closure(tooltip));
 
-        var icon_img = document.createElement('span');
-        icon_img.classList =
-            'ui-button-icon-primary ui-icon ' + image + ' ui-corner-all';
-
-        var tooltip_span = document.createElement('span');
-        tooltip_span.classList = 'ui-button-text';
-        tooltip_span.innerHTML = tooltip;
+        var icon_img = document.createElement('img');
+        icon_img.src = '_images/' + image + '.png';
+        icon_img.srcset = '_images/' + image + '_large.png 2x';
+        icon_img.alt = tooltip;
 
         button.appendChild(icon_img);
-        button.appendChild(tooltip_span);
 
         toolbar.appendChild(button);
     }

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -267,11 +267,14 @@ mpl.figure.prototype._init_toolbar = function () {
     }
 
     function on_mouseover_closure(tooltip) {
-        return function (_event) {
-            return fig.toolbar_button_onmouseover(tooltip);
+        return function (event) {
+            if (!event.currentTarget.disabled) {
+                return fig.toolbar_button_onmouseover(tooltip);
+            }
         };
     }
 
+    fig.buttons = {};
     var buttonGroup = document.createElement('div');
     buttonGroup.classList = 'mpl-button-group';
     for (var toolbar_ind in mpl.toolbar_items) {
@@ -290,7 +293,7 @@ mpl.figure.prototype._init_toolbar = function () {
             continue;
         }
 
-        var button = document.createElement('button');
+        var button = (fig.buttons[name] = document.createElement('button'));
         button.classList = 'mpl-widget';
         button.setAttribute('role', 'button');
         button.setAttribute('aria-disabled', 'false');
@@ -421,6 +424,16 @@ mpl.figure.prototype.handle_draw = function (fig, _msg) {
 
 mpl.figure.prototype.handle_image_mode = function (fig, msg) {
     fig.image_mode = msg['mode'];
+};
+
+mpl.figure.prototype.handle_history_buttons = function (fig, msg) {
+    for (var key in msg) {
+        if (!(key in fig.buttons)) {
+            continue;
+        }
+        fig.buttons[key].disabled = !msg[key];
+        fig.buttons[key].setAttribute('aria-disabled', !msg[key]);
+    }
 };
 
 mpl.figure.prototype.updated_canvas_event = function () {

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -257,7 +257,7 @@ mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
     var toolbar = document.createElement('div');
-    toolbar.setAttribute('style', 'width: 100%');
+    toolbar.classList = 'mpl-toolbar';
     this.root.appendChild(toolbar);
 
     function on_click_closure(name) {
@@ -272,6 +272,8 @@ mpl.figure.prototype._init_toolbar = function () {
         };
     }
 
+    var buttonGroup = document.createElement('div');
+    buttonGroup.classList = 'mpl-button-group';
     for (var toolbar_ind in mpl.toolbar_items) {
         var name = mpl.toolbar_items[toolbar_ind][0];
         var tooltip = mpl.toolbar_items[toolbar_ind][1];
@@ -279,11 +281,17 @@ mpl.figure.prototype._init_toolbar = function () {
         var method_name = mpl.toolbar_items[toolbar_ind][3];
 
         if (!name) {
-            // put a spacer in here.
+            /* Instead of a spacer, we start a new button group. */
+            if (buttonGroup.hasChildNodes()) {
+                toolbar.appendChild(buttonGroup);
+            }
+            buttonGroup = document.createElement('div');
+            buttonGroup.classList = 'mpl-button-group';
             continue;
         }
+
         var button = document.createElement('button');
-        button.classList = 'ui-button ui-widget ui-state-default ui-corner-all';
+        button.classList = 'mpl-widget';
         button.setAttribute('role', 'button');
         button.setAttribute('aria-disabled', 'false');
         button.addEventListener('click', on_click_closure(method_name));
@@ -293,18 +301,18 @@ mpl.figure.prototype._init_toolbar = function () {
         icon_img.src = '_images/' + image + '.png';
         icon_img.srcset = '_images/' + image + '_large.png 2x';
         icon_img.alt = tooltip;
-
         button.appendChild(icon_img);
 
-        toolbar.appendChild(button);
+        buttonGroup.appendChild(button);
     }
 
-    var fmt_picker_span = document.createElement('span');
+    if (buttonGroup.hasChildNodes()) {
+        toolbar.appendChild(buttonGroup);
+    }
 
     var fmt_picker = document.createElement('select');
-    fmt_picker.classList = 'mpl-toolbar-option ui-widget ui-widget-content';
-    fmt_picker_span.appendChild(fmt_picker);
-    toolbar.appendChild(fmt_picker_span);
+    fmt_picker.classList = 'mpl-widget';
+    toolbar.appendChild(fmt_picker);
     this.format_dropdown = fmt_picker;
 
     for (var ind in mpl.extensions) {

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -436,6 +436,19 @@ mpl.figure.prototype.handle_history_buttons = function (fig, msg) {
     }
 };
 
+mpl.figure.prototype.handle_navigate_mode = function (fig, msg) {
+    if (msg['mode'] === 'PAN') {
+        fig.buttons['Pan'].classList.add('active');
+        fig.buttons['Zoom'].classList.remove('active');
+    } else if (msg['mode'] === 'ZOOM') {
+        fig.buttons['Pan'].classList.remove('active');
+        fig.buttons['Zoom'].classList.add('active');
+    } else {
+        fig.buttons['Pan'].classList.remove('active');
+        fig.buttons['Zoom'].classList.remove('active');
+    }
+};
+
 mpl.figure.prototype.updated_canvas_event = function () {
     // Called whenever the canvas gets updated.
     this.send_message('ack', {});

--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -94,7 +94,7 @@ mpl.figure.prototype._init_toolbar = function () {
     var fig = this;
 
     var toolbar = document.createElement('div');
-    toolbar.setAttribute('style', 'width: 100%');
+    toolbar.classList = 'btn-toolbar';
     this.root.appendChild(toolbar);
 
     function on_click_closure(name) {
@@ -109,6 +109,8 @@ mpl.figure.prototype._init_toolbar = function () {
         };
     }
 
+    var buttonGroup = document.createElement('div');
+    buttonGroup.classList = 'btn-group';
     var button;
     for (var toolbar_ind in mpl.toolbar_items) {
         var name = mpl.toolbar_items[toolbar_ind][0];
@@ -117,6 +119,12 @@ mpl.figure.prototype._init_toolbar = function () {
         var method_name = mpl.toolbar_items[toolbar_ind][3];
 
         if (!name) {
+            /* Instead of a spacer, we start a new button group. */
+            if (buttonGroup.hasChildNodes()) {
+                toolbar.appendChild(buttonGroup);
+            }
+            buttonGroup = document.createElement('div');
+            buttonGroup.classList = 'btn-group';
             continue;
         }
 
@@ -127,13 +135,16 @@ mpl.figure.prototype._init_toolbar = function () {
         button.innerHTML = '<i class="fa ' + image + ' fa-lg"></i>';
         button.addEventListener('click', on_click_closure(method_name));
         button.addEventListener('mouseover', on_mouseover_closure(tooltip));
-        toolbar.appendChild(button);
+        buttonGroup.appendChild(button);
+    }
+
+    if (buttonGroup.hasChildNodes()) {
+        toolbar.appendChild(buttonGroup);
     }
 
     // Add the status bar.
     var status_bar = document.createElement('span');
-    status_bar.classList = 'mpl-message';
-    status_bar.setAttribute('style', 'text-align:right; float: right;');
+    status_bar.classList = 'mpl-message pull-right';
     toolbar.appendChild(status_bar);
     this.message = status_bar;
 

--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -104,11 +104,14 @@ mpl.figure.prototype._init_toolbar = function () {
     }
 
     function on_mouseover_closure(tooltip) {
-        return function (_event) {
-            return fig.toolbar_button_onmouseover(tooltip);
+        return function (event) {
+            if (!event.currentTarget.disabled) {
+                return fig.toolbar_button_onmouseover(tooltip);
+            }
         };
     }
 
+    fig.buttons = {};
     var buttonGroup = document.createElement('div');
     buttonGroup.classList = 'btn-group';
     var button;
@@ -128,7 +131,7 @@ mpl.figure.prototype._init_toolbar = function () {
             continue;
         }
 
-        button = document.createElement('button');
+        button = fig.buttons[name] = document.createElement('button');
         button.classList = 'btn btn-default';
         button.href = '#';
         button.title = name;

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -3,6 +3,7 @@
     <link rel="stylesheet" href="{{ prefix }}/_static/css/page.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css" />
     <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/mpl.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/jquery-ui-1.12.1/jquery-ui.min.css" >
     <script src="{{ prefix }}/_static/jquery-ui-1.12.1/external/jquery/jquery.js"></script>
     <script src="{{ prefix }}/_static/jquery-ui-1.12.1/jquery-ui.min.js"></script>


### PR DESCRIPTION
## PR Summary

This tweaks the nbAgg and WebAgg toolbars to look a little better. Using button groups, we can emulate the spacer setup that other GUIs have. For WebAgg, start using Matplotlib's icons and try to move away from jQuery UI's CSS. Additionally, implement `set_history_buttons`, so the back/forward buttons disable themselves, and add a style for active button, to show pan/zoom state.

Previously, nbAgg looked like:
![Screenshot_2020-04-09 Untitled](https://user-images.githubusercontent.com/302469/78861448-cca35180-7a02-11ea-8da2-42e723ce6a97.png)
and now it looks like:
![Screenshot_2020-04-20 Untitled](https://user-images.githubusercontent.com/302469/79820590-9ba81280-835a-11ea-8dd5-5eef86248cd6.png)

Previously, WebAgg looked like:
![Screenshot_2020-04-09 matplotlib](https://user-images.githubusercontent.com/302469/78861508-ea70b680-7a02-11ea-8c30-b3d2f3e40090.png)
and now it looks like:
![Screenshot_2020-04-20 matplotlib](https://user-images.githubusercontent.com/302469/79820638-b1b5d300-835a-11ea-816b-f516094884e3.png)

~~Waiting for #17053.~~

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way