### PR TITLE
Removed Summary from Tutorials/Introductory/Usage_Guide

### DIFF
--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -613,22 +613,6 @@ my_plotter(ax2, data3, data4, {'marker': 'o'})
 # which makes three plots, one at a time. I.e. the second plot will show up,
 # once the first plot is closed.
 #
-# Summary
-# -------
-#
-# In interactive mode, pyplot functions automatically draw
-# to the screen.
-#
-# When plotting interactively, if using
-# object method calls in addition to pyplot functions, then
-# call :func:`~matplotlib.pyplot.draw` whenever you want to
-# refresh the plot.
-#
-# Use non-interactive mode in scripts in which you want to
-# generate one or more figures and display them before ending
-# or generating a new set of figures.  In that case, use
-# :func:`~matplotlib.pyplot.show` to display the figure(s) and
-# to block execution until you have manually destroyed them.
 #
 # .. _performance:
 #


### PR DESCRIPTION
## PR Summary

No other sub-topic in tutorials/introductory has `Summary` as sub-sub heading except `Interactive mode` sub-topic in `Usage Guide` topic. It looks inconsistent from the readers' viewpoint. The reader expects either summary for all OR summary for none. As no other place has `Summary` I preferred to remove it to make layout consistent. Also, the summary has introduced redundancy in the `interactive mode` sub-topic, as it is clearly explained above.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
