### PR TITLE
Update animation_api.rst

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -223,7 +223,7 @@ strongly encouraged to use the `~MovieWriter.saving` context manager ::
 
   with moviewriter.saving(fig, 'myfile.mp4', dpi=100):
       for j in range(n):
-          update_figure(n)
+          update_figure(j)
           moviewriter.grab_frame()
 
 to ensures that setup and cleanup are performed as necessary.

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -212,9 +212,9 @@ at a time and ``finish()`` finalizes the movie and writes the output
 file to disk.  For example ::
 
    moviewriter = MovieWriter(...)
-   moviewriter.setup(fig=fig, 'my_movie.ext', dpi=100)
+   moviewriter.setup(fig, 'my_movie.ext', dpi=100)
    for j in range(n):
-       update_figure(n)
+       update_figure(j)
        moviewriter.grab_frame()
    moviewriter.finish()
 


### PR DESCRIPTION
## PR Summary
syntax fix and bugfix in animation example code , see issue #17066

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
