### PR TITLE
Cleanup TextBox implementation.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -190,8 +190,6 @@ class Button(AxesWidget):
         self.color = color
         self.hovercolor = hovercolor
 
-        self._lastcolor = color
-
     def _click(self, event):
         if (self.ignore(event)
                 or event.inaxes != self.ax
@@ -706,50 +704,41 @@ class TextBox(AxesWidget):
 
         self.DIST_FROM_LEFT = .05
 
-        self.text = initial
-        self.label = ax.text(-label_pad, 0.5, label,
-                             verticalalignment='center',
-                             horizontalalignment='right',
-                             transform=ax.transAxes)
-        self.text_disp = self._make_text_disp(self.text)
+        self.label = ax.text(
+            -label_pad, 0.5, label, transform=ax.transAxes,
+            verticalalignment='center', horizontalalignment='right')
+        self.text_disp = self.ax.text(
+            self.DIST_FROM_LEFT, 0.5, initial, transform=self.ax.transAxes,
+            verticalalignment='center', horizontalalignment='left')
 
         self.cnt = 0
         self.change_observers = {}
         self.submit_observers = {}
 
-        # If these lines are removed, the cursor won't appear the first
-        # time the box is clicked:
-        self.ax.set_xlim(0, 1)
-        self.ax.set_ylim(0, 1)
+        ax.set(
+            xlim=(0, 1), ylim=(0, 1),  # s.t. cursor appears from first click.
+            navigate=False, facecolor=color,
+            xticks=[], yticks=[])
 
         self.cursor_index = 0
 
-        # Because this is initialized, _render_cursor
-        # can assume that cursor exists.
-        self.cursor = self.ax.vlines(0, 0, 0)
-        self.cursor.set_visible(False)
+        self.cursor = ax.vlines(0, 0, 0, visible=False,
+                                transform=mpl.transforms.IdentityTransform())
 
         self.connect_event('button_press_event', self._click)
         self.connect_event('button_release_event', self._release)
         self.connect_event('motion_notify_event', self._motion)
         self.connect_event('key_press_event', self._keypress)
         self.connect_event('resize_event', self._resize)
-        ax.set_navigate(False)
-        ax.set_facecolor(color)
-        ax.set_xticks([])
-        ax.set_yticks([])
+
         self.color = color
         self.hovercolor = hovercolor
 
-        self._lastcolor = color
-
         self.capturekeystrokes = False
 
-    def _make_text_disp(self, string):
-        return self.ax.text(self.DIST_FROM_LEFT, 0.5, string,
-                            verticalalignment='center',
-                            horizontalalignment='left',
-                            transform=self.ax.transAxes)
+    @property
+    def text(self):
+        return self.text_disp.get_text()
 
     def _rendercursor(self):
         # this is a hack to figure out where the cursor should go.
@@ -757,25 +746,16 @@ class TextBox(AxesWidget):
         # and save its dimensions, draw the real text, then put the cursor
         # at the saved dimensions
 
-        widthtext = self.text[:self.cursor_index]
-        no_text = False
-        if widthtext in ["", " ", "  "]:
-            no_text = widthtext == ""
-            widthtext = ","
+        text = self.text_disp.get_text()  # Save value before overwriting it.
+        widthtext = text[:self.cursor_index]
+        self.text_disp.set_text(widthtext or ",")
+        bb = self.text_disp.get_window_extent()
+        if not widthtext:  # Use the comma for the height, but keep width to 0.
+            bb.x1 = bb.x0
+        self.cursor.set(
+            segments=[[(bb.x1, bb.y0), (bb.x1, bb.y1)]], visible=True)
+        self.text_disp.set_text(text)
 
-        wt_disp = self._make_text_disp(widthtext)
-
-        self.ax.figure.canvas.draw()
-        bb = wt_disp.get_window_extent()
-        inv = self.ax.transData.inverted()
-        bb = inv.transform(bb)
-        wt_disp.set_visible(False)
-        if no_text:
-            bb[1, 0] = bb[0, 0]
-        # hack done
-        self.cursor.set_visible(False)
-
-        self.cursor = self.ax.vlines(bb[1, 0], bb[0, 1], bb[1, 1])
         self.ax.figure.canvas.draw()
 
     def _notify_submit_observers(self):
@@ -795,13 +775,13 @@ class TextBox(AxesWidget):
             return
         if self.capturekeystrokes:
             key = event.key
-
+            text = self.text
             if len(key) == 1:
-                self.text = (self.text[:self.cursor_index] + key +
-                             self.text[self.cursor_index:])
+                text = (text[:self.cursor_index] + key +
+                        text[self.cursor_index:])
                 self.cursor_index += 1
             elif key == "right":
-                if self.cursor_index != len(self.text):
+                if self.cursor_index != len(text):
                     self.cursor_index += 1
             elif key == "left":
                 if self.cursor_index != 0:
@@ -809,19 +789,17 @@ class TextBox(AxesWidget):
             elif key == "home":
                 self.cursor_index = 0
             elif key == "end":
-                self.cursor_index = len(self.text)
+                self.cursor_index = len(text)
             elif key == "backspace":
                 if self.cursor_index != 0:
-                    self.text = (self.text[:self.cursor_index - 1] +
-                                 self.text[self.cursor_index:])
+                    text = (text[:self.cursor_index - 1] +
+                            text[self.cursor_index:])
                     self.cursor_index -= 1
             elif key == "delete":
                 if self.cursor_index != len(self.text):
-                    self.text = (self.text[:self.cursor_index] +
-                                 self.text[self.cursor_index + 1:])
-
-            self.text_disp.remove()
-            self.text_disp = self._make_text_disp(self.text)
+                    text = (text[:self.cursor_index] +
+                            text[self.cursor_index + 1:])
+            self.text_disp.set_text(text)
             self._rendercursor()
             self._notify_change_observers()
             if key == "enter":
@@ -831,9 +809,7 @@ class TextBox(AxesWidget):
         newval = str(val)
         if self.text == newval:
             return
-        self.text = newval
-        self.text_disp.remove()
-        self.text_disp = self._make_text_disp(self.text)
+        self.text_disp.set_text(newval)
         self._rendercursor()
         self._notify_change_observers()
         self._notify_submit_observers()
@@ -885,23 +861,8 @@ class TextBox(AxesWidget):
             self.cursor_index = 0
         else:
             bb = self.text_disp.get_window_extent()
-
-            trans = self.ax.transData
-            inv = self.ax.transData.inverted()
-            bb = trans.transform(inv.transform(bb))
-
-            text_start = bb[0, 0]
-            text_end = bb[1, 0]
-
-            ratio = (x - text_start) / (text_end - text_start)
-
-            if ratio < 0:
-                ratio = 0
-            if ratio > 1:
-                ratio = 1
-
+            ratio = np.clip((x - bb.x0) / bb.width, 0, 1)
             self.cursor_index = int(len(self.text) * ratio)
-
         self._rendercursor()
 
     def _click(self, event):
@@ -924,13 +885,9 @@ class TextBox(AxesWidget):
     def _motion(self, event):
         if self.ignore(event):
             return
-        if event.inaxes == self.ax:
-            c = self.hovercolor
-        else:
-            c = self.color
-        if c != self._lastcolor:
+        c = self.hovercolor if event.inaxes == self.ax else self.color
+        if c != self.ax.get_facecolor():
             self.ax.set_facecolor(c)
-            self._lastcolor = c
             if self.drawon:
                 self.ax.figure.canvas.draw()
 


### PR DESCRIPTION
- Reuse a single Text instance to measure cursor width and display text,
  instead of creating a new one every time the text is edited.
- Likewise, reuse a single LineCollection for the cursor (I guess a
  Line2D would be more efficient but I'm too lazy to go through the API
  change here).  Also, putting the LineCollection in pixel coordinates
  (`transforms=IdentityTransform()`) makes things much simpler.
- Auto-sync `.text` and the contents of the text field.
- `._lastcolor` is just the current axes color.
- Misc. cleanups.

Closes #17044, but there's no tests for TextBox :/ just one example at widgets/textbox.py.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
