### PR TITLE
Cleanup some imports in tests

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -1,6 +1,5 @@
 import copy
 import signal
-import sys
 from unittest import mock
 
 import matplotlib

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -1,9 +1,9 @@
-import numpy as np
 from io import BytesIO
 import re
 import tempfile
 import xml.parsers.expat
 
+import numpy as np
 import pytest
 
 import matplotlib as mpl

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -1,5 +1,6 @@
-import numpy as np
 from io import BytesIO
+
+import numpy as np
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -8,7 +8,6 @@ import sys
 import urllib.request
 
 import numpy as np
-from numpy import ma
 from numpy.testing import assert_array_equal
 from PIL import Image
 
@@ -820,7 +819,7 @@ def test_mask_image_over_under():
     palette.set_over('r', 1.0)
     palette.set_under('g', 1.0)
     palette.set_bad('b', 1.0)
-    Zm = ma.masked_where(Z > 1.2, Z)
+    Zm = np.ma.masked_where(Z > 1.2, Z)
     fig, (ax1, ax2) = plt.subplots(1, 2)
     im = ax1.imshow(Zm, interpolation='bilinear',
                     cmap=palette,

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -5,7 +5,6 @@ import re
 import numpy as np
 import pytest
 
-import matplotlib
 import matplotlib as mpl
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.pyplot as plt
@@ -181,7 +180,7 @@ def baseline_images(request, fontset, index):
 @pytest.mark.parametrize('baseline_images', ['mathtext'], indirect=True)
 @image_comparison(baseline_images=None)
 def test_mathtext_rendering(baseline_images, fontset, index, test):
-    matplotlib.rcParams['mathtext.fontset'] = fontset
+    mpl.rcParams['mathtext.fontset'] = fontset
     fig = plt.figure(figsize=(5.25, 0.75))
     fig.text(0.5, 0.5, test,
              horizontalalignment='center', verticalalignment='center')
@@ -195,7 +194,7 @@ def test_mathtext_rendering(baseline_images, fontset, index, test):
 @pytest.mark.parametrize('baseline_images', ['mathfont'], indirect=True)
 @image_comparison(baseline_images=None, extensions=['png'])
 def test_mathfont_rendering(baseline_images, fontset, index, test):
-    matplotlib.rcParams['mathtext.fontset'] = fontset
+    mpl.rcParams['mathtext.fontset'] = fontset
     fig = plt.figure(figsize=(5.25, 0.75))
     fig.text(0.5, 0.5, test,
              horizontalalignment='center', verticalalignment='center')

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
-import numpy.testing as nptest
+
+from numpy.testing import assert_allclose
 import pytest
+
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -143,7 +145,7 @@ _Params = namedtuple('_params', 'wd_list, total, sep, expected')
 def test_get_packed_offsets_fixed(wd_list, total, sep, expected):
     result = _get_packed_offsets(wd_list, total, sep, mode='fixed')
     assert result[0] == expected[0]
-    nptest.assert_allclose(result[1], expected[1])
+    assert_allclose(result[1], expected[1])
 
 
 @pytest.mark.parametrize('wd_list, total, sep, expected', [
@@ -157,7 +159,7 @@ def test_get_packed_offsets_fixed(wd_list, total, sep, expected):
 def test_get_packed_offsets_expand(wd_list, total, sep, expected):
     result = _get_packed_offsets(wd_list, total, sep, mode='expand')
     assert result[0] == expected[0]
-    nptest.assert_allclose(result[1], expected[1])
+    assert_allclose(result[1], expected[1])
 
 
 @pytest.mark.parametrize('wd_list, total, sep, expected', [
@@ -174,7 +176,7 @@ def test_get_packed_offsets_expand(wd_list, total, sep, expected):
 def test_get_packed_offsets_equal(wd_list, total, sep, expected):
     result = _get_packed_offsets(wd_list, total, sep, mode='equal')
     assert result[0] == expected[0]
-    nptest.assert_allclose(result[1], expected[1])
+    assert_allclose(result[1], expected[1])
 
 
 def test_get_packed_offsets_equal_total_none_sep_none():

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -1,7 +1,7 @@
 """Tests for tinypages build using sphinx extensions."""
 
 import filecmp
-from os.path import join as pjoin, dirname, isdir
+from pathlib import Path
 from subprocess import Popen, PIPE
 import sys
 
@@ -12,11 +12,13 @@ pytest.importorskip('sphinx')
 
 
 def test_tinypages(tmpdir):
-    html_dir = pjoin(str(tmpdir), 'html')
-    doctree_dir = pjoin(str(tmpdir), 'doctrees')
+    tmp_path = Path(tmpdir)
+    html_dir = tmp_path / 'html'
+    doctree_dir = tmp_path / 'doctrees'
     # Build the pages with warnings turned into errors
-    cmd = [sys.executable, '-msphinx', '-W', '-b', 'html', '-d', doctree_dir,
-           pjoin(dirname(__file__), 'tinypages'), html_dir]
+    cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
+           '-d', str(doctree_dir),
+           str(Path(__file__).parent / 'tinypages'), str(html_dir)]
     proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = proc.communicate()
     assert proc.returncode == 0, \
@@ -25,10 +27,10 @@ def test_tinypages(tmpdir):
         pytest.fail("sphinx build emitted the following warnings:\n{}"
                     .format(err))
 
-    assert isdir(html_dir)
+    assert html_dir.is_dir()
 
     def plot_file(num):
-        return pjoin(html_dir, 'some_plots-{0}.png'.format(num))
+        return html_dir / f'some_plots-{num}.png'
 
     range_10, range_6, range_4 = [plot_file(i) for i in range(1, 4)]
     # Plot 5 is range(6) plot
@@ -43,11 +45,10 @@ def test_tinypages(tmpdir):
     # Plot 13 shows close-figs in action
     assert filecmp.cmp(range_4, plot_file(13))
     # Plot 14 has included source
-    with open(pjoin(html_dir, 'some_plots.html'), 'rb') as fobj:
-        html_contents = fobj.read()
+    html_contents = (html_dir / 'some_plots.html').read_bytes()
     assert b'# Only a comment' in html_contents
     # check plot defined in external file.
-    assert filecmp.cmp(range_4, pjoin(html_dir, 'range4.png'))
-    assert filecmp.cmp(range_6, pjoin(html_dir, 'range6.png'))
+    assert filecmp.cmp(range_4, html_dir / 'range4.png')
+    assert filecmp.cmp(range_6, html_dir / 'range6.png')
     # check if figure caption made it into html file
     assert b'This is the caption for plot 15.' in html_contents

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -1,10 +1,10 @@
 import itertools
 
-import numpy
+import numpy as np
+import pytest
+
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
-
-import pytest
 
 
 def check_shared(axs, x_shared, y_shared):
@@ -38,14 +38,14 @@ def check_visible(axs, x_visible, y_visible):
 def test_shared():
     rdim = (4, 4, 2)
     share = {
-            'all': numpy.ones(rdim[:2], dtype=bool),
-            'none': numpy.zeros(rdim[:2], dtype=bool),
-            'row': numpy.array([
+            'all': np.ones(rdim[:2], dtype=bool),
+            'none': np.zeros(rdim[:2], dtype=bool),
+            'row': np.array([
                 [False, True, False, False],
                 [True, False, False, False],
                 [False, False, False, True],
                 [False, False, True, False]]),
-            'col': numpy.array([
+            'col': np.array([
                 [False, False, True, False],
                 [False, False, False, True],
                 [True, False, False, False],
@@ -151,8 +151,8 @@ def test_exceptions():
 
 @image_comparison(['subplots_offset_text'], remove_text=False)
 def test_subplots_offsettext():
-    x = numpy.arange(0, 1e10, 1e9)
-    y = numpy.arange(0, 100, 10)+1e4
+    x = np.arange(0, 1e10, 1e9)
+    y = np.arange(0, 100, 10)+1e4
     fig, axs = plt.subplots(2, 2, sharex='col', sharey='all')
     axs[0, 0].plot(x, x)
     axs[1, 0].plot(x, x)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -6,7 +6,6 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 import pytest
 
-import matplotlib
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.patches as mpatches
@@ -15,7 +14,7 @@ from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 
 needs_usetex = pytest.mark.skipif(
-    not matplotlib.checkdep_usetex(True),
+    not mpl.checkdep_usetex(True),
     reason="This test needs a TeX installation")
 
 
@@ -24,7 +23,7 @@ def test_font_styles():
 
     def find_matplotlib_font(**kw):
         prop = FontProperties(**kw)
-        path = findfont(prop, directory=matplotlib.get_data_path())
+        path = findfont(prop, directory=mpl.get_data_path())
         return FontProperties(fname=path)
 
     from matplotlib.font_manager import FontProperties, findfont
@@ -182,7 +181,7 @@ def test_multiline2():
 
 @image_comparison(['antialiased.png'])
 def test_antialiasing():
-    matplotlib.rcParams['text.antialiased'] = True
+    mpl.rcParams['text.antialiased'] = True
 
     fig = plt.figure(figsize=(5.25, 0.75))
     fig.text(0.5, 0.75, "antialiased", horizontalalignment='center',
@@ -477,17 +476,17 @@ def test_agg_text_clip():
 
 
 def test_text_size_binding():
-    matplotlib.rcParams['font.size'] = 10
+    mpl.rcParams['font.size'] = 10
     fp = mpl.font_manager.FontProperties(size='large')
     sz1 = fp.get_size_in_points()
-    matplotlib.rcParams['font.size'] = 100
+    mpl.rcParams['font.size'] = 100
 
     assert sz1 == fp.get_size_in_points()
 
 
 @image_comparison(['font_scaling.pdf'])
 def test_font_scaling():
-    matplotlib.rcParams['pdf.fonttype'] = 42
+    mpl.rcParams['pdf.fonttype'] = 42
     fig, ax = plt.subplots(figsize=(6.4, 12.4))
     ax.xaxis.set_major_locator(plt.NullLocator())
     ax.yaxis.set_major_locator(plt.NullLocator())
@@ -575,7 +574,7 @@ def test_text_as_path_opacity():
 
 @image_comparison(['text_as_text_opacity.svg'])
 def test_text_as_text_opacity():
-    matplotlib.rcParams['svg.fonttype'] = 'none'
+    mpl.rcParams['svg.fonttype'] = 'none'
     plt.figure()
     plt.gca().set_axis_off()
     plt.text(0.25, 0.25, '50% using `color`', color=(0, 0, 0, 0.5))


### PR DESCRIPTION
## PR Summary

I noticed some cases where imports were using a different name, or double-imported in one file, so clean that up a bit.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way