### PR TITLE
Don't create a statusbar in Qt, wx backends.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -274,3 +274,9 @@ instead of ::
 
     <a list of 3 Lists of Patches objects>  # "bar", "barstacked"
     <a list of 3 Lists of Patches objects>  # "step", "stepfilled"
+
+Qt and wx backends no longer create a status bar by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The coordinates information is now displayed in the toolbar, consistently with
+the other backends.  This is intended to simplify embedding of Matplotlib in
+larger GUIs, where Matplotlib may control the toolbar but not the status bar.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2893,6 +2893,7 @@ class NavigationToolbar2:
                             if data_str is not None:
                                 s = s + ' ' + data_str
 
+                s = s.rstrip()
                 if len(self.mode):
                     self.set_message('%s, %s' % (self.mode, s))
                 else:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2881,23 +2881,18 @@ class NavigationToolbar2:
             except (ValueError, OverflowError):
                 pass
             else:
+                s = s.rstrip()
                 artists = [a for a in event.inaxes._mouseover_set
                            if a.contains(event)[0] and a.get_visible()]
-
                 if artists:
                     a = cbook._topmost_artist(artists)
                     if a is not event.inaxes.patch:
                         data = a.get_cursor_data(event)
                         if data is not None:
-                            data_str = a.format_cursor_data(data)
-                            if data_str is not None:
-                                s = s + ' ' + data_str
-
-                s = s.rstrip()
-                if len(self.mode):
-                    self.set_message('%s, %s' % (self.mode, s))
-                else:
-                    self.set_message(s)
+                            data_str = a.format_cursor_data(data).rstrip()
+                            if data_str:
+                                s = s + '\n' + data_str
+                self.set_message(s)
         else:
             self.set_message(self.mode)
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -550,14 +550,12 @@ class FigureManagerQT(FigureManagerBase):
             if self.toolbar:
                 backend_tools.add_tools_to_container(self.toolbar)
                 self.statusbar = StatusbarQt(self.window, self.toolmanager)
+                sbs_height = self.statusbar.sizeHint().height()
+        else:
+            sbs_height = 0
 
         if self.toolbar is not None:
             self.window.addToolBar(self.toolbar)
-            if not self.toolmanager:
-                # add text label to status bar
-                statusbar_label = QtWidgets.QLabel()
-                self.window.statusBar().addWidget(statusbar_label)
-                self.toolbar.message.connect(statusbar_label.setText)
             tbs_height = self.toolbar.sizeHint().height()
         else:
             tbs_height = 0
@@ -565,8 +563,8 @@ class FigureManagerQT(FigureManagerBase):
         # resize the main window so it will display the canvas with the
         # requested size:
         cs = canvas.sizeHint()
-        sbs = self.window.statusBar().sizeHint()
-        height = cs.height() + tbs_height + sbs.height()
+        cs_height = cs.height()
+        height = cs_height + tbs_height + sbs_height
         self.window.resize(cs.width(), height)
 
         self.window.setCentralWidget(self.canvas)
@@ -599,7 +597,7 @@ class FigureManagerQT(FigureManagerBase):
         # must be inited after the window, drawingArea and figure
         # attrs are set
         if matplotlib.rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2QT(canvas, parent, False)
+            toolbar = NavigationToolbar2QT(canvas, parent, True)
         elif matplotlib.rcParams['toolbar'] == 'toolmanager':
             toolbar = ToolbarQt(self.toolmanager, self.window)
         else:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -677,7 +677,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         if self.coordinates:
             self.locLabel = QtWidgets.QLabel("", self)
             self.locLabel.setAlignment(
-                    QtCore.Qt.AlignRight | QtCore.Qt.AlignTop)
+                QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
             self.locLabel.setSizePolicy(
                 QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding,
                                       QtWidgets.QSizePolicy.Ignored))

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -928,13 +928,11 @@ class FigureFrameWx(wx.Frame):
 
         self.figmgr = FigureManagerWx(self.canvas, num, self)
 
-        statusbar = (StatusbarWx(self, self.toolmanager)
-                     if self.toolmanager else StatusBarWx(self))
-        self.SetStatusBar(statusbar)
         self.toolbar = self._get_toolbar()
 
-        if self.toolmanager:
-            backend_tools.add_tools_to_manager(self.toolmanager)
+        if self.figmgr.toolmanager:
+            self.SetStatusBar(StatusbarWx(self, self.figmgr.toolmanager))
+            backend_tools.add_tools_to_manager(self.figmgr.toolmanager)
             if self.toolbar:
                 backend_tools.add_tools_to_container(self.toolbar)
 
@@ -1122,6 +1120,10 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             self.Bind(wx.EVT_TOOL, getattr(self, callback),
                       id=self.wx_ids[text])
 
+        self.AddStretchableSpace()
+        self._label_text = wx.StaticText(self)
+        self.AddControl(self._label_text)
+
         self.Realize()
 
         NavigationToolbar2.__init__(self, canvas)
@@ -1300,9 +1302,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         return self.GetTopLevelParent().GetStatusBar()
 
     def set_message(self, s):
-        status_bar = self.GetTopLevelParent().GetStatusBar()
-        if status_bar is not None:
-            status_bar.set_function(s)
+        self._label_text.SetLabel(s)
 
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0


### PR DESCRIPTION
Display the coordinates text on the right of the toolbar, consistently
with the GTK3, wx, and (I think?) macosx backends.  This helps when
embedding Matplotlib in larger GUIs, because Matplotlib may not
necessarily control the statusbar (which is typically global for the
whole window) but controls the toolbar if there's one.

If we decide to go this route we could probably also kill the status bar
for toolmanager.

xref https://github.com/matplotlib/matplotlib/issues/17085.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
