### PR TITLE
DOC: drop the experimental tag constrained_layout and tight_layout

### DIFF
--- a/doc/users/next_whats_new/2020-04-11-constrainedlayout-not-exp.rst
+++ b/doc/users/next_whats_new/2020-04-11-constrainedlayout-not-exp.rst
@@ -1,0 +1,7 @@
+Constrained layout is no longer marked as experimental
+------------------------------------------------------
+
+The *constrained_layout* option for figures and gridspecs was introduced
+in Matplotlib 2.2, and is no longer considered experimental.  For an
+overview of the feature, please see
+:doc:`/tutorials/intermediate/constrainedlayout_guide`.

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -30,12 +30,11 @@ Those are described in detail throughout the following sections.
 
 .. warning::
 
-    Currently Constrained Layout is **experimental**.  The
-    behaviour and API are subject to change, or the whole functionality
-    may be removed without a deprecation period.  If you *require* your
-    plots to be absolutely reproducible, get the Axes positions after
-    running Constrained Layout and use ``ax.set_position()`` in your code
-    with ``constrained_layout=False``.
+    Constrained layout can lead to irreproducible plots
+    as the solver sometimes returns slightly different results.
+    If you *require* your plots to be absolutely reproducible, get the
+    Axes positions after running Constrained Layout and use
+    ``ax.set_position()`` in your code with ``constrained_layout=False``.
 
 Simple Example
 ==============

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -6,9 +6,9 @@ Tight Layout guide
 How to use tight-layout to fit plots within your figure cleanly.
 
 *tight_layout* automatically adjusts subplot params so that the
-subplot(s) fits in to the figure area. This is an experimental
-feature and may not work for some cases. It only checks the extents
-of ticklabels, axis labels, and titles.
+subplot(s) fits in to the figure area. This feature may not work
+for some cases. It only checks the extents of ticklabels, axis labels,
+and titles.
 
 An alternative to *tight_layout* is :doc:`constrained_layout
 </tutorials/intermediate/constrainedlayout_guide>`.


### PR DESCRIPTION
## PR Summary

`constrained_layout` was marked experimental.  Its been around for a couple of years with no indication that the API will change, and no complete show-stoppers so I propose to drop the experimental tag.  

Interestingly, as I grepped for "experimental" `tight_layout` was deemed experimental as well.  

Both tutorials had useful information in the same clause as the experimental designation, so I tried to maintain that info in the rewrite.  

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
