### PR TITLE
Add conda environment.yml for developers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,58 @@
+# To set up a development environment using conda run:
+#
+#   conda env create -f environment.yml
+#   conda activate mpl-dev
+#   pip install -e .
+#
+name: mpl-dev
+channels:
+  - conda-forge
+dependencies:
+  - cairocffi
+  - cycler>=0.10.0
+  - fonttools>=4.22.0
+  - kiwisolver>=1.0.1
+  - numpy>=1.17
+  - pillow>=6.2
+  - pygobject
+  - pyparsing
+  - pyqt
+  - python-dateutil>=2.1
+  - setuptools
+  - setuptools_scm
+  - wxpython
+  # building documentation
+  - colorspacious
+  - graphviz
+  - ipython
+  - ipywidgets
+  - numpydoc>=0.8
+  - pydata-sphinx-theme
+  - scipy
+  - sphinx>=1.8.1,!=2.0.0
+  - sphinx-copybutton
+  - pip
+  - pip:
+    - sphinxcontrib-svg2pdfconverter
+    # b41e328 is PR 808 which adds the image_srcset directive.  When this is
+    # released with sphinx gallery, we can change to the last release w/o this feature:
+    # sphinx-gallery>0.9
+    - git+git://github.com/sphinx-gallery/sphinx-gallery@b41e328#egg=sphinx-gallery
+  # testing
+  - coverage
+  - flake8>=3.8
+  - flake8-docstrings>=1.4.0
+  - gtk3
+  - ipykernel
+  - nbconvert[execute]!=6.0.0,!=6.0.1
+  - nbformat!=5.0.0,!=5.0.1
+  - pandas!=0.25.0
+  - pikepdf
+  - pydocstyle>=5.1.0
+  - pytest!=4.6.0,!=5.4.0
+  - pytest-cov
+  - pytest-rerunfailures
+  - pytest-timeout
+  - pytest-xdist
+  - tornado
+  - pytz


### PR DESCRIPTION
## PR Summary

This should make it much easier to set up a development environment. Essentially one should be up and running with

~~~
git clone https://github.com/matplotlib/matplotlib.git
cd matplotlib
conda env create -f environment-dev.yml
conda activate mpl-dev
pip install -ve .
~~~

This must still be added to the docs.

I've copied the dependencies together from the requirements files and https://matplotlib.org/devdocs/users/installing.html#dependencies. Not sure what to do about the optional dependencies ffmpeg, ImageMagick, LaTeX and fontconfig.

