### PR TITLE
Deprecate BBox.ignore()

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -433,3 +433,12 @@ Normalization of upper or mixed-case property names to lowercase in
 `.Artist.set` and `.Artist.update` is deprecated.  In the future, property
 names will be passed as is, allowing one to pass names such as *patchA* or
 *UVC*.
+
+``Bbox.ignore``
+~~~~~~~~~~~~~~~
+The persistent ignore state for `.Bbox` is deprecated and *ignore* should be
+explicitly passed to the relevant functions if needed. The method
+``Bbox.ignore()`` is deprecated. The parameter *ignore* of
+``Bbox.update_from_path()`` and ``Bbox.update_from_data_xy()`` will not accept
+None anymore and default to ``True`` instead, which was the default persistent
+ignore state.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1836,7 +1836,7 @@ class TriMesh(Collection):
         # was rewritten.
         xy = np.hstack((triangulation.x.reshape(-1, 1),
                         triangulation.y.reshape(-1, 1)))
-        self._bbox.update_from_data_xy(xy)
+        self._bbox.update_from_data_xy(xy, ignore=True)
 
     def get_paths(self):
         if self._paths is None:
@@ -1924,7 +1924,7 @@ class QuadMesh(Collection):
 
         self._bbox = transforms.Bbox.unit()
         self._bbox.update_from_data_xy(coordinates.reshape(
-            ((meshWidth + 1) * (meshHeight + 1), 2)))
+            ((meshWidth + 1) * (meshHeight + 1), 2)), ignore=True)
 
     def get_paths(self):
         if self._paths is None:

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -759,7 +759,7 @@ class _WedgeBbox(mtransforms.Bbox):
             wedge = mpatches.Wedge(self._center, points[1, 1],
                                    points[0, 0], points[1, 0],
                                    width=width)
-            self.update_from_path(wedge.get_path())
+            self.update_from_path(wedge.get_path(), ignore=True)
 
             # Ensure equal aspect ratio.
             w, h = self._points[1] - self._points[0]

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -759,6 +759,9 @@ class Bbox(BboxBase):
     def __repr__(self):
         return 'Bbox([[{0.x0}, {0.y0}], [{0.x1}, {0.y1}]])'.format(self)
 
+    @cbook.deprecated("3.3", message="The ignore state is deprecated. Please"
+                                     "Please pass *ignore* explicitly to "
+                                     "update_fom_data_xy().")
     def ignore(self, value):
         """
         Set whether the existing bounds of the box should be ignored
@@ -788,10 +791,23 @@ class Bbox(BboxBase):
            - when ``False``, include the existing bounds of the `Bbox`.
            - when ``None``, use the last value passed to :meth:`ignore`.
 
+             *Deprecated*: The persistent ignore state is deprecated and
+             *ignore* will default to True in the future. Please pass
+             ``ignore=False`` explicitly if needed.
+
         updatex, updatey : bool, optional
             When ``True``, update the x/y values.
         """
         if ignore is None:
+            # Note: When removing this deprecation and changing the default
+            # to True, grep through the codebase to remove some explicit
+            # ignore=True usages, which were introduced in internal calls to
+            # prevent the warning.
+            cbook.warn_deprecated(
+                "3.3", message="The persistent ignore state is deprecated and "
+                               "will default to True in the future. Please "
+                               "please pass ignore=False explicitly if"
+                               "needed.")
             ignore = self._ignore
 
         if path.vertices.size == 0:
@@ -825,11 +841,27 @@ class Bbox(BboxBase):
            - When ``False``, include the existing bounds of the `Bbox`.
            - When ``None``, use the last value passed to :meth:`ignore`.
 
+             *Deprecated*: The persistent ignore state is deprecated and
+             *ignore* will default to True in the future. Please pass
+             ``ignore=False`` explicitly if needed.
+
         updatex, updatey : bool, optional
             When ``True``, update the x/y values.
         """
         if len(xy) == 0:
             return
+
+        if ignore is None:
+            # Note: When removing this deprecation and changing the default
+            # to True, grep through the codebase to remove some explicit
+            # ignore=True usages, which were introduced in internal calls to
+            # prevent the warning.
+            cbook.warn_deprecated(
+                "3.3", message="The persistent ignore state is deprecated and "
+                               "will default to True in the future. Please "
+                               "please pass ignore=False explicitly if"
+                               "needed.")
+            ignore = self._ignore
 
         path = Path(xy)
         self.update_from_path(path, ignore=ignore,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -510,11 +510,11 @@ class Axes3D(Axes):
         X = np.reshape(X, -1)
         Y = np.reshape(Y, -1)
         self.xy_dataLim.update_from_data_xy(
-            np.column_stack([X, Y]), not had_data)
+            np.column_stack([X, Y]), ignore=not had_data)
         if Z is not None:
             Z = np.reshape(Z, -1)
             self.zz_dataLim.update_from_data_xy(
-                np.column_stack([Z, Z]), not had_data)
+                np.column_stack([Z, Z]), ignore=not had_data)
         # Let autoscale_view figure out how to use this data.
         self.autoscale_view()
 


### PR DESCRIPTION
## PR Summary

**The code in the PR is preliminary. The deprecation may not be viable, pending discussion below.**

Identified through the discussion in #17090.

`Bbox.ignore()` introduces a persistent state that affects whether `Bbox.update_from_path()` and `Bbox.update_from_data_xy()` will set the box extents to their arguments or join the argument extents with the existing extents. This hidden state can be confusing and is dangerous because it might be changed by other parts of the program without knowing.

However,
https://github.com/matplotlib/matplotlib/blob/065769b79abece7771dec779587e46a03900a3b1/lib/matplotlib/axes/_base.py#L2115 and 
https://github.com/matplotlib/matplotlib/blob/065769b79abece7771dec779587e46a03900a3b1/lib/matplotlib/testing/jpl_units/StrConverter.py#L114
made me think, if this feature is needed for ignoring data limits (which IMHO would be a questionable design). If so, we'd need a different approach.

Comments welcome.

