### PR TITLE
Deprecate NavigationToolbar2._init_toolbar.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -366,6 +366,16 @@ The ``Fil``, ``Fill``, ``Filll``, ``NegFil``, ``NegFill``, ``NegFilll``, and
 ``SsGlue`` classes in the :mod:`matplotlib.mathtext` module are deprecated.
 As an alternative, directly construct glue instances with ``Glue("fil")``, etc.
 
+NavigationToolbar2._init_toolbar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Overriding this method to initialize third-party toolbars is deprecated.
+Instead, the toolbar should be initialized in the ``__init__`` method of the
+subclass (which should call the base-class' ``__init__`` as appropriate).  To
+keep back-compatibility with earlier versions of Matplotlib (which *required*
+``_init_toolbar`` to be overridden), a fully empty implementation (``def
+_init_toolbar(self): pass``) may be kept and will not trigger the deprecation
+warning.
+
 NavigationToolbar2QT.parent and .basedir
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These attributes are deprecated.  In order to access the parent window, use

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2668,11 +2668,11 @@ class _Mode(str, Enum):
 
 class NavigationToolbar2:
     """
-    Base class for the navigation cursor, version 2
+    Base class for the navigation cursor, version 2.
 
-    backends must implement a canvas that handles connections for
+    Backends must implement a canvas that handles connections for
     'button_press_event' and 'button_release_event'.  See
-    :meth:`FigureCanvasBase.mpl_connect` for more information
+    :meth:`FigureCanvasBase.mpl_connect` for more information.
 
     They must also define
 
@@ -2681,9 +2681,6 @@ class NavigationToolbar2:
 
       :meth:`set_cursor`
          if you want the pointer icon to change
-
-      :meth:`_init_toolbar`
-         create your toolbar widget
 
       :meth:`draw_rubberband` (optional)
          draw the zoom to rect "rubberband" rectangle
@@ -2694,6 +2691,12 @@ class NavigationToolbar2:
       :meth:`set_history_buttons` (optional)
          you can change the history back / forward buttons to
          indicate disabled / enabled state.
+
+    and override ``__init__`` to set up the toolbar -- without forgetting to
+    call the base-class init.  Typically, ``__init__`` needs to set up toolbar
+    buttons connected to the `home`, `back`, `forward`, `pan`, `zoom`, and
+    `save_figure` methods and using standard icons in the "images" subdirectory
+    of the data path.
 
     That's it, we'll do the rest!
     """
@@ -2724,7 +2727,15 @@ class NavigationToolbar2:
         self._xypress = None  # location and axis info at the time of the press
         # This cursor will be set after the initial draw.
         self._lastCursor = cursors.POINTER
-        self._init_toolbar()
+
+        init = cbook._deprecate_method_override(
+            __class__._init_toolbar, self, allow_empty=True, since="3.3",
+            addendum="Please fully initialize the toolbar in your subclass' "
+            "__init__; a fully empty _init_toolbar implementation may be kept "
+            "for compatibility with earlier versions of Matplotlib.")
+        if init:
+            init()
+
         self._id_press = self.canvas.mpl_connect(
             'button_press_event', self._zoom_pan_handler)
         self._id_release = self.canvas.mpl_connect(
@@ -2787,6 +2798,7 @@ class NavigationToolbar2:
         self.set_history_buttons()
         self._update_view()
 
+    @cbook.deprecated("3.3", alternative="__init__")
     def _init_toolbar(self):
         """
         This is where you actually build the GUI widgets (called by

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -451,43 +451,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
     def __init__(self, canvas, window):
         self.win = window
         GObject.GObject.__init__(self)
-        NavigationToolbar2.__init__(self, canvas)
 
-    @cbook.deprecated("3.3")
-    @property
-    def ctx(self):
-        return self.canvas.get_property("window").cairo_create()
-
-    def set_message(self, s):
-        self.message.set_label(s)
-
-    def set_cursor(self, cursor):
-        self.canvas.get_property("window").set_cursor(cursord[cursor])
-        Gtk.main_iteration()
-
-    def draw_rubberband(self, event, x0, y0, x1, y1):
-        # adapted from
-        # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/189744
-        ctx = self.canvas.get_property("window").cairo_create()
-
-        # todo: instead of redrawing the entire figure, copy the part of
-        # the figure that was covered by the previous rubberband rectangle
-        self.canvas.draw()
-
-        height = self.canvas.figure.bbox.height
-        y1 = height - y1
-        y0 = height - y0
-        w = abs(x1 - x0)
-        h = abs(y1 - y0)
-        rect = [int(val) for val in (min(x0, x1), min(y0, y1), w, h)]
-
-        ctx.new_path()
-        ctx.set_line_width(0.5)
-        ctx.rectangle(*rect)
-        ctx.set_source_rgb(0, 0, 0)
-        ctx.stroke()
-
-    def _init_toolbar(self):
         self.set_style(Gtk.ToolbarStyle.ICONS)
 
         self._gtk_ids = {}
@@ -520,6 +484,42 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         toolitem.add(self.message)
 
         self.show_all()
+
+        NavigationToolbar2.__init__(self, canvas)
+
+    @cbook.deprecated("3.3")
+    @property
+    def ctx(self):
+        return self.canvas.get_property("window").cairo_create()
+
+    def set_message(self, s):
+        self.message.set_label(s)
+
+    def set_cursor(self, cursor):
+        self.canvas.get_property("window").set_cursor(cursord[cursor])
+        Gtk.main_iteration()
+
+    def draw_rubberband(self, event, x0, y0, x1, y1):
+        # adapted from
+        # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/189744
+        self.ctx = self.canvas.get_property("window").cairo_create()
+
+        # todo: instead of redrawing the entire figure, copy the part of
+        # the figure that was covered by the previous rubberband rectangle
+        self.canvas.draw()
+
+        height = self.canvas.figure.bbox.height
+        y1 = height - y1
+        y0 = height - y0
+        w = abs(x1 - x0)
+        h = abs(y1 - y0)
+        rect = [int(val) for val in (min(x0, x1), min(y0, y1), w, h)]
+
+        self.ctx.new_path()
+        self.ctx.set_line_width(0.5)
+        self.ctx.rectangle(rect[0], rect[1], rect[2], rect[3])
+        self.ctx.set_source_rgb(0, 0, 0)
+        self.ctx.stroke()
 
     def _update_buttons_checked(self):
         for name, active in [("Pan", "PAN"), ("Zoom", "ZOOM")]:

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -110,11 +110,10 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
 class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
 
     def __init__(self, canvas):
-        NavigationToolbar2.__init__(self, canvas)
-
-    def _init_toolbar(self):
+        self.canvas = canvas  # Needed by the _macosx __init__.
         _macosx.NavigationToolbar2.__init__(
             self, str(cbook._get_data_path('images')))
+        NavigationToolbar2.__init__(self, canvas)
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         self.canvas.set_rubberband(int(x0), int(y0), int(x1), int(y1))

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -639,36 +639,12 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
     def __init__(self, canvas, parent, coordinates=True):
         """coordinates: should we show the coordinates on the right?"""
+        QtWidgets.QToolBar.__init__(self, parent)
+
         self._parent = parent
         self.coordinates = coordinates
         self._actions = {}  # mapping of toolitem method names to QActions.
-        QtWidgets.QToolBar.__init__(self, parent)
-        NavigationToolbar2.__init__(self, canvas)
 
-    @cbook.deprecated("3.3", alternative="self.canvas.parent()")
-    @property
-    def parent(self):
-        return self._parent
-
-    @cbook.deprecated(
-        "3.3", alternative="os.path.join(mpl.get_data_path(), 'images')")
-    @property
-    def basedir(self):
-        return str(cbook._get_data_path('images'))
-
-    def _icon(self, name, color=None):
-        if is_pyqt5():
-            name = name.replace('.png', '_large.png')
-        pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))
-        qt_compat._setDevicePixelRatio(pm, self.canvas._dpi_ratio)
-        if color is not None:
-            mask = pm.createMaskFromColor(QtGui.QColor('black'),
-                                          QtCore.Qt.MaskOutColor)
-            pm.fill(color)
-            pm.setMask(mask)
-        return QtGui.QIcon(pm)
-
-    def _init_toolbar(self):
         background_color = self.palette().color(self.backgroundRole())
         foreground_color = self.palette().color(self.foregroundRole())
         icon_color = (foreground_color
@@ -698,6 +674,31 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
                                       QtWidgets.QSizePolicy.Ignored))
             labelAction = self.addWidget(self.locLabel)
             labelAction.setVisible(True)
+
+        NavigationToolbar2.__init__(self, canvas)
+
+    @cbook.deprecated("3.3", alternative="self.canvas.parent()")
+    @property
+    def parent(self):
+        return self._parent
+
+    @cbook.deprecated(
+        "3.3", alternative="os.path.join(mpl.get_data_path(), 'images')")
+    @property
+    def basedir(self):
+        return str(cbook._get_data_path('images'))
+
+    def _icon(self, name, color=None):
+        if is_pyqt5():
+            name = name.replace('.png', '_large.png')
+        pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))
+        qt_compat._setDevicePixelRatio(pm, qt_compat._devicePixelRatio(self))
+        if color is not None:
+            mask = pm.createMaskFromColor(QtGui.QColor('black'),
+                                          QtCore.Qt.MaskOutColor)
+            pm.fill(color)
+            pm.setMask(mask)
+        return QtGui.QIcon(pm)
 
     def edit_parameters(self):
         axes = self.canvas.figure.get_axes()

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -367,9 +367,10 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
         if name_of_method in _ALLOWED_TOOL_ITEMS
     ]
 
-    def _init_toolbar(self):
+    def __init__(self, canvas):
         self.message = ''
         self.cursor = 0
+        super().__init__(canvas)
 
     def set_message(self, message):
         if message != self.message:

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1104,22 +1104,6 @@ cursord = {
 class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def __init__(self, canvas):
         wx.ToolBar.__init__(self, canvas.GetParent(), -1)
-        NavigationToolbar2.__init__(self, canvas)
-        self._idle = True
-        self.prevZoomRect = None
-        # for now, use alternate zoom-rectangle drawing on all
-        # Macs. N.B. In future versions of wx it may be possible to
-        # detect Retina displays with window.GetContentScaleFactor()
-        # and/or dc.GetContentScaleFactor()
-        self.retinaFix = 'wxMac' in wx.PlatformInfo
-
-    def get_canvas(self, frame, fig):
-        return type(self.canvas)(frame, -1, fig)
-
-    def _init_toolbar(self):
-        _log.debug("%s - _init_toolbar", type(self))
-
-        self._parent = self.canvas.GetParent()
 
         self.wx_ids = {}
         for text, tooltip_text, image_file, callback in self.toolitems:
@@ -1139,6 +1123,18 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                       id=self.wx_ids[text])
 
         self.Realize()
+
+        NavigationToolbar2.__init__(self, canvas)
+        self._idle = True
+        self.prevZoomRect = None
+        # for now, use alternate zoom-rectangle drawing on all
+        # Macs. N.B. In future versions of wx it may be possible to
+        # detect Retina displays with window.GetContentScaleFactor()
+        # and/or dc.GetContentScaleFactor()
+        self.retinaFix = 'wxMac' in wx.PlatformInfo
+
+    def get_canvas(self, frame, fig):
+        return type(self.canvas)(frame, -1, fig)
 
     def zoom(self, *args):
         self.ToggleTool(self.wx_ids['Pan'], False)

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -107,10 +107,7 @@ def test_interactive_zoom():
     fig, ax = plt.subplots()
     ax.set(xscale="logit")
 
-    class NT2(NavigationToolbar2):
-        def _init_toolbar(self): pass
-
-    tb = NT2(fig.canvas)
+    tb = NavigationToolbar2(fig.canvas)
     tb.zoom()
 
     xlim0 = ax.get_xlim()


### PR DESCRIPTION
As argued elsewhere, a customization point which requires third-party
libraries to override a private method is awkward from the PoV of
documentation and of required API stability.  In fact _init_toolbar is
not needed as a customization point; third-party libraries can simply
override `__init__` and call `super().__init__` as appropriate.

Moreover, *requiring* that `_init_toolbar` be overridden is actually
overkill, e.g. for `test_backend_bases.py::test_interactive_zoom`:
there, the base class NavigationToolbar2 is perfectly suitable -- see
change there.

In order to let third-parties write code that supports both pre- and
post-deprecation versions of mpl, allow them to keep a fully empty
`_init_toolbar` (an override is required by earlier versions of mpl)
without triggering a deprecation warning.

-----

Note that git(hub) may show the diff a bit weirdly, but for the GUI backend implementations, this is basically just moving the body of `_init_toolbar` into `__init__` (it's just that git instead shows that as the code between `__init__` and `_init_toolbar` moving down.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
