### PR TITLE
TextBox improvements.

### DIFF
--- a/examples/widgets/textbox.py
+++ b/examples/widgets/textbox.py
@@ -16,12 +16,13 @@ static elements: :doc:`/tutorials/text/annotations` and
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import TextBox
+
+
 fig, ax = plt.subplots()
-plt.subplots_adjust(bottom=0.2)
+fig.subplots_adjust(bottom=0.2)
+
 t = np.arange(-2.0, 2.0, 0.001)
-s = t ** 2
-initial_text = "t ** 2"
-l, = plt.plot(t, s, lw=2)  # make a plot for the math expression "t ** 2"
+l, = ax.plot(t, np.zeros_like(t), lw=2)
 
 
 def submit(expression):
@@ -33,12 +34,15 @@ def submit(expression):
     """
     ydata = eval(expression)
     l.set_ydata(ydata)
-    ax.set_ylim(np.min(ydata), np.max(ydata))
+    ax.relim()
+    ax.autoscale_view()
     plt.draw()
 
-axbox = plt.axes([0.1, 0.05, 0.8, 0.075])
-text_box = TextBox(axbox, 'Evaluate', initial=initial_text)
+
+axbox = fig.add_axes([0.1, 0.05, 0.8, 0.075])
+text_box = TextBox(axbox, "Evaluate")
 text_box.on_submit(submit)
+text_box.set_val("t ** 2")  # Trigger `submit` with the initial string.
 
 plt.show()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -767,6 +767,12 @@ class TextBox(AxesWidget):
         # and save its dimensions, draw the real text, then put the cursor
         # at the saved dimensions
 
+        # This causes a single extra draw if the figure has never been rendered
+        # yet, which should be fine as we're going to repeatedly re-render the
+        # figure later anyways.
+        if self.ax.figure._cachedRenderer is None:
+            self.ax.figure.canvas.draw()
+
         text = self.text_disp.get_text()  # Save value before overwriting it.
         widthtext = text[:self.cursor_index]
         self.text_disp.set_text(widthtext or ",")


### PR DESCRIPTION
Cleanup textbox example: 1) handling the initial text through the normal
`submit` callback seems simpler; 2) use "normal" autoscaling methods,
which correctly apply margins and would also work if other artists were
involved.  This revealed that `TextBox.set_val` throws an exception due
to no cached renderer if the figure has never been rendered before.
Given that TextBox is going to trigger a bunch of redraws anyways for
user edits, we may as well trigger a first draw if needed to cache a
renderer first.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
