### PR TITLE
Cleanup/Simplify Cell._set_text_position.

### DIFF
--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -79,9 +79,9 @@ class Cell(Rectangle):
         if loc is None:
             loc = 'right'
         self._loc = loc
-        self._text = Text(x=xy[0], y=xy[1], text=text,
-                          fontproperties=fontproperties)
-        self._text.set_clip_on(False)
+        self._text = Text(x=xy[0], y=xy[1], clip_on=False,
+                          text=text, fontproperties=fontproperties,
+                          horizontalalignment=loc, verticalalignment='center')
 
     def set_transform(self, trans):
         Rectangle.set_transform(self, trans)
@@ -122,35 +122,24 @@ class Cell(Rectangle):
             return
         # draw the rectangle
         Rectangle.draw(self, renderer)
-
         # position the text
         self._set_text_position(renderer)
         self._text.draw(renderer)
         self.stale = False
 
     def _set_text_position(self, renderer):
-        """Set text up so it draws in the right place.
-
-        Currently support 'left', 'center' and 'right'
-        """
+        """Set text up so it is drawn in the right place."""
         bbox = self.get_window_extent(renderer)
-        l, b, w, h = bbox.bounds
-
-        # draw in center vertically
-        self._text.set_verticalalignment('center')
-        y = b + (h / 2.0)
-
-        # now position horizontally
-        if self._loc == 'center':
-            self._text.set_horizontalalignment('center')
-            x = l + (w / 2.0)
-        elif self._loc == 'left':
-            self._text.set_horizontalalignment('left')
-            x = l + (w * self.PAD)
-        else:
-            self._text.set_horizontalalignment('right')
-            x = l + (w * (1.0 - self.PAD))
-
+        # center vertically
+        y = bbox.y0 + bbox.height / 2
+        # position horizontally
+        loc = self._text.get_horizontalalignment()
+        if loc == 'center':
+            x = bbox.x0 + bbox.width / 2
+        elif loc == 'left':
+            x = bbox.x0 + bbox.width * self.PAD
+        else:  # right.
+            x = bbox.x0 + bbox.width * (1 - self.PAD)
         self._text.set_position((x, y))
 
     def get_text_bounds(self, renderer):


### PR DESCRIPTION
Directly pass *loc* to the text `horizontalalignment` in the
constructor, which will avoid handling anything-but-"center"-and-"left"
as "right", but error out (from the constructor, rather than at draw
time) instead.  Also, this means that changing the text alignment from
`set_text_props` will work "as expected".

Make the docstring style-compliant.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
