### PR TITLE
Widgets cleanup.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -69,13 +69,11 @@ class Widget:
     _active = True
 
     def set_active(self, active):
-        """Set whether the widget is active.
-        """
+        """Set whether the widget is active."""
         self._active = active
 
     def get_active(self):
-        """Get whether the widget is active.
-        """
+        """Get whether the widget is active."""
         return self._active
 
     # set_active is overridden by SelectorWidgets.
@@ -1491,9 +1489,7 @@ class _SelectorWidget(AxesWidget):
                 event.button != self.eventpress.button)
 
     def update(self):
-        """
-        Draw using blit() or draw_idle() depending on ``self.useblit``.
-        """
+        """Draw using blit() or draw_idle(), depending on ``self.useblit``."""
         if not self.ax.get_visible():
             return False
         if self.useblit:
@@ -1507,35 +1503,31 @@ class _SelectorWidget(AxesWidget):
         return False
 
     def _get_data(self, event):
-        """Get the xdata and ydata for event, with limits"""
+        """Get the xdata and ydata for event, with limits."""
         if event.xdata is None:
             return None, None
-        x0, x1 = self.ax.get_xbound()
-        y0, y1 = self.ax.get_ybound()
-        xdata = max(x0, event.xdata)
-        xdata = min(x1, xdata)
-        ydata = max(y0, event.ydata)
-        ydata = min(y1, ydata)
+        xdata = np.clip(event.xdata, *self.ax.get_xbound())
+        ydata = np.clip(event.ydata, *self.ax.get_ybound())
         return xdata, ydata
 
     def _clean_event(self, event):
-        """Clean up an event
+        """
+        Preprocess an event:
 
-        Use prev event if there is no xdata
-        Limit the xdata and ydata to the axes limits
-        Set the prev event
+        - Replace *event* by the previous event if *event* has no ``xdata``.
+        - Clip ``xdata`` and ``ydata`` to the axes limits.
+        - Update the previous event.
         """
         if event.xdata is None:
             event = self._prev_event
         else:
             event = copy.copy(event)
         event.xdata, event.ydata = self._get_data(event)
-
         self._prev_event = event
         return event
 
     def press(self, event):
-        """Button press handler and validator"""
+        """Button press handler and validator."""
         if not self.ignore(event):
             event = self._clean_event(event)
             self.eventpress = event
@@ -1550,10 +1542,10 @@ class _SelectorWidget(AxesWidget):
         return False
 
     def _press(self, event):
-        """Button press handler"""
+        """Button press handler."""
 
     def release(self, event):
-        """Button release event handler and validator"""
+        """Button release event handler and validator."""
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
             self.eventrelease = event
@@ -1565,10 +1557,10 @@ class _SelectorWidget(AxesWidget):
         return False
 
     def _release(self, event):
-        """Button release event handler"""
+        """Button release event handler."""
 
     def onmove(self, event):
-        """Cursor move event handler and validator"""
+        """Cursor move event handler and validator."""
         if not self.ignore(event) and self.eventpress:
             event = self._clean_event(event)
             self._onmove(event)
@@ -1576,18 +1568,18 @@ class _SelectorWidget(AxesWidget):
         return False
 
     def _onmove(self, event):
-        """Cursor move event handler"""
+        """Cursor move event handler."""
 
     def on_scroll(self, event):
-        """Mouse scroll event handler and validator"""
+        """Mouse scroll event handler and validator."""
         if not self.ignore(event):
             self._on_scroll(event)
 
     def _on_scroll(self, event):
-        """Mouse scroll event handler"""
+        """Mouse scroll event handler."""
 
     def on_key_press(self, event):
-        """Key press event handler and validator for all selection widgets"""
+        """Key press event handler and validator for all selection widgets."""
         if self.active:
             key = event.key or ''
             key = key.replace('ctrl', 'control')


### PR DESCRIPTION
Mostly docstring cleanups, but also a small simplification to
_SelectorWidget._get_data.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
