### PR TITLE
Remove Python2/3 info box

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -265,8 +265,10 @@ html_index = 'index.html'
 
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
-    'index': ['sidebar_announcement.html', 'sidebar_versions.html',
-              'donate_sidebar.html'],
+    'index': [
+        # 'sidebar_announcement.html',
+        'sidebar_versions.html',
+        'donate_sidebar.html'],
     '**': ['localtoc.html', 'relations.html', 'pagesource.html']
 }
 


### PR DESCRIPTION
## PR Summary

Because of #16253 we don't need an explicit version announcement anymore. The "Last release for Python 2" segment in there already expresses all relevant information from the box: Last py2 compatible release is stated, which means all newer releases are Py3. The transition date is not relevant anymore.

I've just removed the info box via sphinx `conf.py`, because we might want to reactivate it for other announcements.