### PR TITLE
In docs remove 'optional' if 'default' can be given

### DIFF
--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -92,7 +92,7 @@ def stack_hist(ax, stacked_data, sty_cycle, bottoms=None,
     sty_cycle : Cycler or operable of dict
         Style to apply to each set
 
-    bottoms : array, optional, default: 0
+    bottoms : array, default: 0
         The initial positions of the bottoms.
 
     hist_func : callable, optional

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -208,7 +208,7 @@ class AbstractMovieWriter(abc.ABC):
             The figure object that contains the information for frames.
         outfile : str
             The filename of the resulting movie file.
-        dpi : float, optional, default: ``fig.dpi``
+        dpi : float, default: ``fig.dpi``
             The DPI (or resolution) for the file.  This controls the size
             in pixels of the resulting movie file.
         """
@@ -989,7 +989,7 @@ class Animation:
             Controls the dots per inch for the movie frames.  Together with
             the figure's size in inches, this controls the size of the movie.
 
-        codec : str, optional, default: :rc:`animation.codec`.
+        codec : str, default: :rc:`animation.codec`.
             The video codec to use.  Not all codecs are supported by a given
             `MovieWriter`.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6833,12 +6833,12 @@ default: :rc:`scatter.edgecolors`
         weights : array-like, shape (n, ), optional
             An array of values w_i weighing each sample (x_i, y_i).
 
-        cmin : scalar, optional, default: None
+        cmin : scalar, default: None
             All bins that has count less than cmin will not be displayed (set
             to NaN before passing to imshow) and these count values in the
             return value count histogram will also be set to nan upon return.
 
-        cmax : scalar, optional, default: None
+        cmax : scalar, default: None
             All bins that has count more than cmax will not be displayed (set
             to NaN before passing to imshow) and these count values in the
             return value count histogram will also be set to nan upon return.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -455,8 +455,8 @@ class _AxesBase(martist.Artist):
             The x or y `~.matplotlib.axis` is shared with the x or
             y axis in the input `~.axes.Axes`.
 
-        frameon : bool, optional
-            True means that the axes frame is visible.
+        frameon : bool, default: True
+            Whether the axes frame is visible.
 
         box_aspect : None, or a number, optional
             Sets the aspect of the axes box. See `~.axes.Axes.set_box_aspect`
@@ -906,7 +906,7 @@ class _AxesBase(martist.Artist):
         pos : [left, bottom, width, height] or `~matplotlib.transforms.Bbox`
             The new position of the in `.Figure` coordinates.
 
-        which : {'both', 'active', 'original'}, optional
+        which : {'both', 'active', 'original'}, default: 'both'
             Determines which position variables to change.
 
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2315,11 +2315,11 @@ def key_press_handler(event, canvas=None, toolbar=None):
     ----------
     event : `KeyEvent`
         A key press/release event.
-    canvas : `FigureCanvasBase`, optional, default: ``event.canvas``
+    canvas : `FigureCanvasBase`, default: ``event.canvas``
         The backend-specific canvas instance.  This parameter is kept for
         back-compatibility, but, if set, should always be equal to
         ``event.canvas``.
-    toolbar : `NavigationToolbar2`, optional, default: ``event.canvas.toolbar``
+    toolbar : `NavigationToolbar2`, default: ``event.canvas.toolbar``
         The navigation cursor toolbar.  This parameter is kept for
         back-compatibility, but, if set, should always be equal to
         ``event.canvas.toolbar``.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -1004,7 +1004,7 @@ class PdfPages:
         filename : str or path-like
             Plots using `PdfPages.savefig` will be written to a file at this
             location. Any older file with the same name is overwritten.
-        keep_empty : bool, optional
+        keep_empty : bool, default: True
             If set to False, then empty pdf files will be deleted automatically
             when closed.
         metadata : dict, optional

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -218,7 +218,7 @@ class FormWidget(QtWidgets.QWidget):
             The data to be edited in the form.
         comment : str, optional
 
-        with_margin : bool, optional, default: False
+        with_margin : bool, default: False
             If False, the form elements reach to the border of the widget.
             This is the desired behavior if the FormWidget is used as a widget
             alongside with other widgets such as a QComboBox, which also do

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1299,7 +1299,7 @@ class LineCollection(Collection):
         antialiaseds : sequence, optional
             A sequence of ones or zeros.
 
-        linestyles : str or tuple, optional
+        linestyles : str or tuple, default: 'solid'
             Either one of {'solid', 'dashed', 'dashdot', 'dotted'}, or
             a dash tuple. The dash tuple is::
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1957,7 +1957,7 @@ class LightSource:
             An MxNx1 array of floats ranging from 0 to 1 (grayscale image).
         hsv_max_sat : number, default: 1
             The maximum saturation value that the *intensity* map can shift the
-            output image to. Defaults to 1.
+            output image to.
         hsv_min_sat : number, optional
             The minimum saturation value that the *intensity* map can shift the
             output image to. Defaults to 0.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1955,7 +1955,7 @@ class LightSource:
             An MxNx3 RGB array of floats ranging from 0 to 1 (color image).
         intensity : ndarray
             An MxNx1 array of floats ranging from 0 to 1 (grayscale image).
-        hsv_max_sat : number, optional, default: 1
+        hsv_max_sat : number, default: 1
             The maximum saturation value that the *intensity* map can shift the
             output image to. Defaults to 1.
         hsv_min_sat : number, optional

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -217,7 +217,7 @@ class MarkerStyle:
             See the descriptions of possible markers in the module docstring.
 
         fillstyle : str, default: 'full'
-            One of 'full', 'left", 'right', 'bottom', 'top', 'none'.
+            One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
         """
         self._marker_function = None
         self.set_fillstyle(fillstyle)

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -213,11 +213,11 @@ class MarkerStyle:
 
         Parameters
         ----------
-        marker : str or array-like, optional, default: None
+        marker : str or array-like, default: None
             See the descriptions of possible markers in the module docstring.
 
-        fillstyle : str, optional, default: 'full'
-            'full', 'left", 'right', 'bottom', 'top', 'none'
+        fillstyle : str, default: 'full'
+            One of 'full', 'left", 'right', 'bottom', 'top', 'none'.
         """
         self._marker_function = None
         self.set_fillstyle(fillstyle)

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -640,7 +640,7 @@ detrend : {'none', 'mean', 'linear'} or callable, default 'none'
     choose one of the functions: 'none' calls `.detrend_none`. 'mean' calls
     `.detrend_mean`. 'linear' calls `.detrend_linear`.
 
-scale_by_freq : bool, optional, default: True
+scale_by_freq : bool, default: True
     Whether the resulting density values should be scaled by the scaling
     frequency, which gives density in units of Hz^-1.  This allows for
     integration over the returned frequency values.  The default is True for
@@ -850,7 +850,7 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
     noverlap : int, optional
         The number of points of overlap between blocks.  The default
         value is 128.
-    mode : str, optional, default: 'psd'
+    mode : str, default: 'psd'
         What sort of spectrum to use:
             'psd'
                 Returns the power spectral density.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1386,7 +1386,7 @@ class Ellipse(Patch):
             Total length (diameter) of horizontal axis.
         height : float
             Total length (diameter) of vertical axis.
-        angle : scalar, optional
+        angle : float, default: 0
             Rotation in degrees anti-clockwise.
 
         Notes
@@ -1579,7 +1579,7 @@ class Arc(Ellipse):
         angle : float
             Rotation of the ellipse in degrees (counterclockwise).
 
-        theta1, theta2 : float, optional
+        theta1, theta2 : float, default: 0, 360
             Starting and ending angles of the arc in degrees. These values
             are relative to *angle*, e.g. if *angle* = 45 and *theta1* = 90
             the absolute starting angle is 135.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1069,7 +1069,7 @@ class PolarAxes(Axes):
         loc : str
             May be one of "N", "NW", "W", "SW", "S", "SE", "E", or "NE".
 
-        offset : float, optional
+        offset : float, default: 0
             An offset in degrees to apply from the specified *loc*. **Note:**
             this offset is *always* applied counter-clockwise regardless of
             the direction setting.

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -858,7 +858,7 @@ class Bbox(BboxBase):
            - when ``False``, include the existing bounds of the `Bbox`.
            - when ``None``, use the last value passed to :meth:`ignore`.
 
-        updatex, updatey : bool, optional
+        updatex, updatey : bool, default: True
             When ``True``, update the x/y values.
         """
         if ignore is None:
@@ -895,7 +895,7 @@ class Bbox(BboxBase):
            - When ``False``, include the existing bounds of the `Bbox`.
            - When ``None``, use the last value passed to :meth:`ignore`.
 
-        updatex, updatey : bool, optional
+        updatex, updatey : bool, default: True
             When ``True``, update the x/y values.
         """
         if len(xy) == 0:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2482,7 +2482,7 @@ class PolygonSelector(_SelectorWidget):
         When a polygon is completed or modified after completion,
         the *onselect* function is called and passed a list of the vertices as
         ``(xdata, ydata)`` tuples.
-    useblit : bool, optional
+    useblit : bool, default: False
     lineprops : dict, default: \
 ``dict(color='k', linestyle='-', linewidth=2, alpha=0.5)``.
         Artist properties for the line representing the edges of the polygon.

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -42,16 +42,16 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
                 'upper center' : 9,
                 'center'       : 10
 
-        pad : float, optional, default: 0.4
+        pad : float, default: 0.4
             Padding around the child objects, in fraction of the font size.
 
-        borderpad : float, optional, default: 0.5
+        borderpad : float, default: 0.5
             Border padding, in fraction of the font size.
 
         prop : `matplotlib.font_manager.FontProperties`, optional
             Font property used as a reference for paddings.
 
-        frameon : bool, optional, default: True
+        frameon : bool, default: True
             If True, draw a box around this artists.
 
         **kwargs
@@ -113,16 +113,16 @@ class AnchoredAuxTransformBox(AnchoredOffsetbox):
                 'upper center' : 9,
                 'center'       : 10
 
-        pad : float, optional, default: 0.4
+        pad : float, default: 0.4
             Padding around the child objects, in fraction of the font size.
 
-        borderpad : float, optional, default: 0.5
+        borderpad : float, default: 0.5
             Border padding, in fraction of the font size.
 
         prop : `matplotlib.font_manager.FontProperties`, optional
             Font property used as a reference for paddings.
 
-        frameon : bool, optional, default: True
+        frameon : bool, default: True
             If True, draw a box around this artists.
 
         **kwargs
@@ -190,10 +190,10 @@ class AnchoredEllipse(AnchoredOffsetbox):
             Padding around the ellipse, in fraction of the font size. Defaults
             to 0.1.
 
-        borderpad : float, optional, default: 0.1
+        borderpad : float, default: 0.1
             Border padding, in fraction of the font size.
 
-        frameon : bool, optional, default: True
+        frameon : bool, default: True
             If True, draw a box around the ellipse.
 
         prop : `matplotlib.font_manager.FontProperties`, optional
@@ -254,27 +254,27 @@ class AnchoredSizeBar(AnchoredOffsetbox):
                 'upper center' : 9,
                 'center'       : 10
 
-        pad : float, optional, default: 0.1
+        pad : float, default: 0.1
             Padding around the label and size bar, in fraction of the font
             size.
 
-        borderpad : float, optional, default: 0.1
+        borderpad : float, default: 0.1
             Border padding, in fraction of the font size.
 
-        sep : float, optional, default: 2
+        sep : float, default: 2
             Separation between the label and the size bar, in points.
 
-        frameon : bool, optional, default: True
+        frameon : bool, default: True
             If True, draw a box around the horizontal bar and label.
 
-        size_vertical : float, optional, default: 0
+        size_vertical : float, default: 0
             Vertical length of the size bar, given in coordinates of
             *transform*.
 
-        color : str, optional, default: 'black'
+        color : str, default: 'black'
             Color for the size bar and label.
 
-        label_top : bool, optional, default: False
+        label_top : bool, default: False
             If True, the label will be over the size bar.
 
         fontproperties : `matplotlib.font_manager.FontProperties`, optional
@@ -381,13 +381,13 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
         label_x, label_y : str
             Label text for the x and y arrows
 
-        length : float, optional, default: 0.15
+        length : float, default: 0.15
             Length of the arrow, given in coordinates of *transform*.
 
-        fontsize : float, optional, default: 0.08
+        fontsize : float, default: 0.08
             Size of label strings, given in coordinates of *transform*.
 
-        loc : int, optional, default: 2
+        loc : int, default: 2
             Location of the direction arrows. Valid location codes are::
 
                 'upper right'  : 1,
@@ -401,45 +401,45 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
                 'upper center' : 9,
                 'center'       : 10
 
-        angle : float, optional, default: 0
+        angle : float, default: 0
             The angle of the arrows in degrees.
 
-        aspect_ratio : float, optional, default: 1
+        aspect_ratio : float, default: 1
             The ratio of the length of arrow_x and arrow_y.
             Negative numbers can be used to change the direction.
 
-        pad : float, optional, default: 0.4
+        pad : float, default: 0.4
             Padding around the labels and arrows, in fraction of the font size.
 
-        borderpad : float, optional, default: 0.4
+        borderpad : float, default: 0.4
             Border padding, in fraction of the font size.
 
-        frameon : bool, optional, default: False
+        frameon : bool, default: False
             If True, draw a box around the arrows and labels.
 
-        color : str, optional, default: 'white'
+        color : str, default: 'white'
             Color for the arrows and labels.
 
-        alpha : float, optional, default: 1
+        alpha : float, default: 1
             Alpha values of the arrows and labels
 
-        sep_x, sep_y : float, optional, default: 0.01 and 0 respectively
+        sep_x, sep_y : float, default: 0.01 and 0 respectively
             Separation between the arrows and labels in coordinates of
             *transform*.
 
         fontproperties : `matplotlib.font_manager.FontProperties`, optional
             Font properties for the label text.
 
-        back_length : float, optional, default: 0.15
+        back_length : float, default: 0.15
             Fraction of the arrow behind the arrow crossing.
 
-        head_width : float, optional, default: 10
+        head_width : float, default: 10
             Width of arrow head, sent to ArrowStyle.
 
-        head_length : float, optional, default: 15
+        head_length : float, default: 15
             Length of arrow head, sent to ArrowStyle.
 
-        tail_width : float, optional, default: 2
+        tail_width : float, default: 2
             Width of arrow tail, sent to ArrowStyle.
 
         text_props, arrow_props : dict

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -408,7 +408,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
         are relative to the parent_axes. Otherwise they are to be understood
         relative to the bounding box provided via *bbox_to_anchor*.
 
-    loc : int or str, optional, default: 1
+    loc : int or str, default: 1
         Location to place the inset axes. The valid locations are::
 
             'upper right'  : 1,
@@ -455,7 +455,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
 
         %(Axes)s
 
-    borderpad : float, optional, default: 0.5
+    borderpad : float, default: 0.5
         Padding between inset axes and the bbox_to_anchor.
         The units are axes font size, i.e. for a default font size of 10 points
         *borderpad = 0.5* is equivalent to a padding of 5 points.
@@ -527,7 +527,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
         coordinates (i.e., "zoomed in"), while *zoom* < 1 will shrink the
         coordinates (i.e., "zoomed out").
 
-    loc : int or str, optional, default: 'upper right'
+    loc : int or str, default: 'upper right'
         Location to place the inset axes. The valid locations are::
 
             'upper right'  : 1,
@@ -573,7 +573,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
 
         %(Axes)s
 
-    borderpad : float, optional, default: 0.5
+    borderpad : float, default: 0.5
         Padding between inset axes and the bbox_to_anchor.
         The units are axes font size, i.e. for a default font size of 10 points
         *borderpad = 0.5* is equivalent to a padding of 5 points.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -60,9 +60,9 @@ class Axes3D(Axes):
             The parent figure.
         rect : (float, float, float, float)
             The ``(left, bottom, width, height)`` axes position.
-        azim : float, optional, default: -60
+        azim : float, default: -60
             Azimuthal viewing angle.
-        elev : float, optional, default: 30
+        elev : float, default: 30
             Elevation viewing angle.
         sharez : Axes3D, optional
             Other axes to share z-limits with.
@@ -1766,7 +1766,7 @@ class Axes3D(Axes):
             A colormap for the surface patches.
         norm : Normalize
             An instance of Normalize to map values to colors.
-        vmin, vmax : scalar, optional, default: None
+        vmin, vmax : scalar, default: None
             Minimum and maximum value to map.
         shade : bool, default: True
             Whether to shade the facecolors.  Shading is always disabled when
@@ -2121,17 +2121,17 @@ class Axes3D(Axes):
         ----------
         xs, ys : array-like
              The data positions.
-        zs : float or array-like, optional, default: 0
+        zs : float or array-like, default: 0
             The z-positions. Either an array of the same length as *xs* and
             *ys* or a single value to place all points in the same plane.
-        zdir : {'x', 'y', 'z', '-x', '-y', '-z'}, optional, default: 'z'
+        zdir : {'x', 'y', 'z', '-x', '-y', '-z'}, default: 'z'
             The axis direction for the *zs*. This is useful when plotting 2D
             data on a 3D Axes. The data must be passed as *xs*, *ys*. Setting
             *zdir* to 'y' then plots the data to the x-z-plane.
 
             See also :doc:`/gallery/mplot3d/2dcollections3d`.
 
-        s : scalar or array-like, optional, default: 20
+        s : scalar or array-like, default: 20
             The marker size in points**2. Either an array of the same length
             as *xs* and *ys* or a single value to make all markers the same
             size.
@@ -2145,7 +2145,7 @@ class Axes3D(Axes):
             - A 2-D array in which the rows are RGB or RGBA.
 
             For more details see the *c* argument of `~.axes.Axes.scatter`.
-        depthshade : bool, optional, default: True
+        depthshade : bool, default: True
             Whether to shade the scatter markers to give the appearance of
             depth. Each call to ``scatter()`` will perform its depthshading
             independently.
@@ -2274,7 +2274,7 @@ class Axes3D(Axes):
         zsort : str, optional
             The z-axis sorting scheme passed onto `~.art3d.Poly3DCollection`
 
-        shade : bool, optional, default: True
+        shade : bool, default: True
             When true, this shades the dark sides of the bars (relative
             to the plot's source of light).
 


### PR DESCRIPTION
## PR Summary

Following our convention to omit "optional" for parameters if a default value can be given (#15824).
