### PR TITLE
BUG: Fix formatting error in GridSpec.__repr__

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -48,9 +48,9 @@ class GridSpecBase:
         self.set_width_ratios(width_ratios)
 
     def __repr__(self):
-        height_arg = (', height_ratios=%r' % self._row_height_ratios
+        height_arg = (', height_ratios=%r' % (self._row_height_ratios,)
                       if self._row_height_ratios is not None else '')
-        width_arg = (', width_ratios=%r' % self._col_width_ratios
+        width_arg = (', width_ratios=%r' % (self._col_width_ratios,)
                      if self._col_width_ratios is not None else '')
         return '{clsname}({nrows}, {ncols}{optionals})'.format(
             clsname=self.__class__.__name__,

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -29,3 +29,9 @@ def test_height_ratios():
 def test_repr():
     ss = gridspec.GridSpec(3, 3)[2, 1:3]
     assert repr(ss) == "GridSpec(3, 3)[2:3, 1:3]"
+
+    ss = gridspec.GridSpec(2, 2,
+                           height_ratios=(3, 1),
+                           width_ratios=(1, 3))
+    assert repr(ss) == \
+        "GridSpec(2, 2, height_ratios=(3, 1), width_ratios=(1, 3))"


### PR DESCRIPTION
Fix this error in `GridSpec.__repr__` when formatting the
`width_ratios` or `height_ratios` arguments:

    TypeError: not all arguments converted during string formatting