### PR TITLE
Fix Button widget motion callback.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -212,13 +212,9 @@ class Button(AxesWidget):
     def _motion(self, event):
         if self.ignore(event):
             return
-        if event.inaxes == self.ax:
-            c = self.hovercolor
-        else:
-            c = self.color
-        if c != self._lastcolor:
+        c = self.hovercolor if event.inaxes == self.ax else self.color
+        if c != self.ax.get_facecolor():
             self.ax.set_facecolor(c)
-            self._lastcolor = c
             if self.drawon:
                 self.ax.figure.canvas.draw()
 


### PR DESCRIPTION
## PR Summary

`Button._lastcolor` was removed in #17082, but one instance was missed, so the `Button` was broken. Can be reproduced by using the subplot parameter editor in Tk.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way