### PR TITLE
Simplify pan/zoom toggling.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -528,7 +528,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
             button = self._gtk_ids.get(name)
             if button:
                 with button.handler_block(button._signal_handler):
-                    button.set_active(self._active == active)
+                    button.set_active(self.mode.name == active)
 
     def pan(self, *args):
         super().pan(*args)

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -745,9 +745,9 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
     def _update_buttons_checked(self):
         # sync button checkstates to match active mode
         if 'pan' in self._actions:
-            self._actions['pan'].setChecked(self._active == 'PAN')
+            self._actions['pan'].setChecked(self.mode.name == 'PAN')
         if 'zoom' in self._actions:
-            self._actions['zoom'].setChecked(self._active == 'ZOOM')
+            self._actions['zoom'].setChecked(self.mode.name == 'ZOOM')
 
     def pan(self, *args):
         super().pan(*args)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1209,7 +1209,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self.canvas.Update()
 
     def press(self, event):
-        if self._active == 'ZOOM':
+        if self.mode.name == 'ZOOM':
             if not self.retinaFix:
                 self.wxoverlay = wx.Overlay()
             else:
@@ -1221,7 +1221,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                     self.zoomAxes = event.inaxes
 
     def release(self, event):
-        if self._active == 'ZOOM':
+        if self.mode.name == 'ZOOM':
             # When the mouse is released we reset the overlay and it
             # restores the former content to the window.
             if not self.retinaFix:


### PR DESCRIPTION
- Store current active tool just in the .mode attribute, rather than
  both in .mode and ._active; use a "StrEnum" (like an IntEnum, but for
  strs...) for backcompat.
- Connect a single handler which will dispatch to the correct
  sub-handler depending on the active tool, rather than having to
  disconnect and reconnect handlers every time a tool is changed.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
