### PR TITLE
Move linting to GitHub Actions with reviewdog.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,28 @@
+name: Linting
+on: [pull_request]
+
+jobs:
+  flake8:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install flake8
+        run: pip3 install -r requirements/testing/flake8.txt
+
+      - name: Set up reviewdog
+        run: |
+          mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
+          echo ::add-path::$HOME/bin
+
+      - name: Run flake8
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          flake8 --docstring-convention=all | reviewdog -f=pep8 -name=flake8 -reporter=github-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,17 +62,9 @@ env:
     - NO_AT_BRIDGE=1  # Necessary for GTK3 interactive test.
     - OPENBLAS_NUM_THREADS=1
     - PYTHONFAULTHANDLER=1
-    - RUN_PYTEST=1
-    - RUN_FLAKE8=
 
 matrix:
   include:
-    - name: flake8
-      python: 3.6
-      env:
-        - RUN_PYTEST=
-        - RUN_FLAKE8=1
-        - EXTRAREQS='-r requirements/testing/travis_flake8.txt'
     - python: 3.6
       env:
         - PINNEDVERS='-c requirements/testing/travis36minver.txt'
@@ -165,13 +157,13 @@ install:
 
   # Set flag in a delayed manner to avoid issues with installing other packages
   - |
-    if [[ $TRAVIS_OS_NAME != 'osx' ]] && [[ $RUN_PYTEST == 1 ]]; then
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
       export CPPFLAGS=--coverage
     fi
   - |
     python -mpip install -ve .  # Install Matplotlib.
   - |
-    if [[ $TRAVIS_OS_NAME != 'osx' ]] && [[ $RUN_PYTEST == 1 ]]; then
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
       unset CPPFLAGS
     fi
 
@@ -184,16 +176,10 @@ script:
   # Each script we want to run need to go in its own section and the program
   # you want to fail travis needs to be the last thing called.
   - |
-    if [[ $RUN_PYTEST == 1 ]]; then
-      # The number of processes is hardcoded (-n2), because using too many
-      # causes the Travis VM to run out of memory (since so many copies of
-      # inkscape and ghostscript are running at the same time).
-      python -mpytest -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n2 --log-level=DEBUG
-    fi
-  - |
-    if [[ $RUN_FLAKE8 == 1 ]]; then
-      flake8 --docstring-convention=all --statistics && echo "Flake8 passed without any issues!"
-    fi
+    # The number of processes is hardcoded (-n2), because using too many
+    # causes the Travis VM to run out of memory (since so many copies of
+    # inkscape and ghostscript are running at the same time).
+    python -mpytest -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n2 --log-level=DEBUG
 
 before_cache: |
   rm -rf $HOME/.cache/matplotlib/tex.cache

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -188,14 +188,14 @@ Automated tests
 Whenever a pull request is created or updated, various automated test tools
 will run on all supported platforms and versions of Python.
 
-* Make sure the Travis, Appveyor, CircleCI, and Azure pipelines are passing
-  before merging (All checks are listed at the bottom of the GitHub page of
-  your pull request). Here are some tips for finding the cause of the test
-  failure:
+* Make sure the Linting, Travis, AppVeyor, CircleCI, and Azure pipelines are
+  passing before merging (All checks are listed at the bottom of the GitHub
+  page of your pull request). Here are some tips for finding the cause of the
+  test failure:
 
-  - If *Travis flake8* fails, you have a code style issue, which will be listed
-    near the bottom of the *Travis flake8* log.
-  - If any other Travis run fails, search the log for ``FAILURES``. The
+  - If *Linting* fails, you have a code style issue, which will be listed
+    as annotations on the pull request's diff.
+  - If a Travis or AppVeyor run fails, search the log for ``FAILURES``. The
     subsequent section will contain information on the failed tests.
   - If CircleCI fails, likely you have some reStructuredText style issue in
     the docs. Search the CircleCI log for ``WARNING``.

--- a/requirements/testing/flake8.txt
+++ b/requirements/testing/flake8.txt
@@ -1,0 +1,5 @@
+# Extra pip requirements for the GitHub Actions flake8 build
+
+flake8>=3.7
+pydocstyle<4.0
+flake8-docstrings

--- a/requirements/testing/travis_flake8.txt
+++ b/requirements/testing/travis_flake8.txt
@@ -1,5 +1,0 @@
-# Extra pip requirements for the travis flake8 build
-
-flake8>=3.7
-pydocstyle<4.0
-flake8-docstrings


### PR DESCRIPTION
## PR Summary

This moves `flake8` from Travis to GitHub Actions using [reviewdog](https://github.com/reviewdog/reviewdog) to post it to the GitHub Checks. It runs a bit faster now (basically all time is running `flake8` vs ~0 install time) at ~1m vs ~5.5m on Travis.

Linting will appear as a section separate from Travis now in the Checks section of the PR, but I could switch the config to post a review.

[Here is the PR](https://github.com/QuLogic/matplotlib/pull/3) I'm using to test out the results.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way