### PR TITLE
DOCS: include how to reproduce CI in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,41 +1,63 @@
 ## PR Summary
 
-## PR Checklist
+<!--
+Thank you so much for your PR! To help us review your contribution, please
+summarize the purpose of this PR here.
 
-- [ ] Has Pytest style unit tests
-- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
-- [ ] New features are documented, with examples if plot related
-- [ ] Documentation is sphinx and numpydoc compliant
-- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
-- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
+- The summary should provide at least 1-2 sentences describing the pull request
+  in detail (Why is this change required? What problem does it solve?) and
+  link to any relevant issues.
+-->
+
+
+## PR Checklists
+
+<!-- Feel free to delete any checklists that do not apply to this PR -->
+
+For new code:
+
+- [ ] Has Pytest style unit tests (and `pytest lib/matplotlib/tests` passes)
+- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
+- [ ] New code is documented, with examples if plot related
+
+For new documentation:
+
+- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
+- [ ] New documentation conforms to matplotlib style conventions. (If you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
+
+For new features:
+
+- [ ] Added an entry to `doc/users/next_whats_new/` if major new feature (follow instructions in `README.rst` there)
+
+For API changes:
+
+- [ ] Documented in `doc/api/api_changes_[VERSION]` if API changed in a backward-incompatible way (follow instructions in `README.rst` there)
 
 <!--
-Thank you so much for your PR!  To help us review your contribution, please
-consider the following points:
+A few other common gotchas:
 
-- A development guide is available at
+- Do not create the PR out of master, but out of a separate branch.
+
+- The PR title should summarize the changes, for example "Raise ValueError on
+  non-numeric input to set_xlim". Avoid non-descriptive titles such as
+  "Addresses issue #8576".
+
+- If you are contributing fixes to docstrings, please pay attention to
+  http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
+  note the difference between using single backquotes, double backquotes, and
+  asterisks in the markup.
+
+
+If you have further questions:
+
+- A more complete development guide is available at
   https://matplotlib.org/devdocs/devel/index.html.
 
 - Help with git and github is available at
   https://matplotlib.org/devel/gitwash/development_workflow.html.
 
-- Do not create the PR out of master, but out of a separate branch.
-
-- The PR title should summarize the changes, for example "Raise ValueError on
-  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
-  "Addresses issue #8576".
-
-- The summary should provide at least 1-2 sentences describing the pull request
-  in detail (Why is this change required?  What problem does it solve?) and
-  link to any relevant issues.
-
-- If you are contributing fixes to docstrings, please pay attention to
-  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
-  note the difference between using single backquotes, double backquotes, and
-  asterisks in the markup.
-
 We understand that PRs can sometimes be overwhelming, especially as the
-reviews start coming in.  Please let us know if the reviews are unclear or
+reviews start coming in. Please let us know if the reviews are unclear or
 the recommended next step seems overly demanding, if you would like help in
 addressing a reviewer's comments, or if you have been waiting too long to hear
 back on your PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,12 @@ New documentation:
 
 - [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
 - [ ] Documentation conforms to matplotlib style conventions. (If you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
+<!--
+- If you are contributing fixes to docstrings, please pay attention to
+  http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
+  note the difference between using single backquotes, double backquotes, and
+  asterisks in the markup.
+-->
 
 New features:
 
@@ -28,20 +34,16 @@ API changes:
 
 - [ ] Documented in `doc/api/api_changes_[NEXT_VERSION]` if API changed in a backward-incompatible way (follow instructions in `doc/api/api_changes_[NEXT_VERSION]/README.rst`)
 
+<!--
 Meta:
 
-- [ ] PR title summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" instead of "Addresses issue #8576").
-- [ ] PR has at least 1-2 sentence summary.
-- [ ] PR is not out of master, but out of a separate branch (e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`)
-- [ ] Optional: PR cross-links related issues.
+- PR title summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" instead of "Addresses issue #8576").
+- PR has at least 1-2 sentence summary.
+- PR is not out of master, but out of a separate branch (e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`)
+- Optional: PR cross-links related issues.
+-->
 
 <!--
-- If you are contributing fixes to docstrings, please pay attention to
-  http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
-  note the difference between using single backquotes, double backquotes, and
-  asterisks in the markup.
-
-
 If you have further questions:
 
 - A more complete development guide is available at

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,47 +1,41 @@
 ## PR Summary
 
 <!--
-Thank you so much for your PR! To help us review your contribution, please
-summarize the purpose of this PR here.
-
-- The summary should provide at least 1-2 sentences describing the pull request
-  in detail (Why is this change required? What problem does it solve?) and
-  link to any relevant issues.
+Please provide at least a 1-2 sentence summary of the purpose of the PR.
 -->
 
 
 ## PR Checklists
 
-<!-- Feel free to delete any checklists that do not apply to this PR -->
+<!-- Feel free to delete any checkboxes that do not apply to this PR. -->
 
-For new code:
+New code:
 
 - [ ] Has Pytest style unit tests (and `pytest lib/matplotlib/tests` passes)
 - [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
-- [ ] New code is documented, with examples if plot related
+- [ ] Code is documented, with examples if plot related
 
-For new documentation:
+New documentation:
 
 - [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
-- [ ] New documentation conforms to matplotlib style conventions. (If you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
+- [ ] Documentation conforms to matplotlib style conventions. (If you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
 
-For new features:
+New features:
 
-- [ ] Added an entry to `doc/users/next_whats_new/` if major new feature (follow instructions in `README.rst` there)
+- [ ] Added an entry to `doc/users/next_whats_new/` if major new feature (follow instructions in `doc/users/next_whats_new/README.rst`)
 
-For API changes:
+API changes:
 
-- [ ] Documented in `doc/api/api_changes_[VERSION]` if API changed in a backward-incompatible way (follow instructions in `README.rst` there)
+- [ ] Documented in `doc/api/api_changes_[NEXT_VERSION]` if API changed in a backward-incompatible way (follow instructions in `doc/api/api_changes_[NEXT_VERSION]/README.rst`)
+
+Meta:
+
+- [ ] PR title summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" instead of "Addresses issue #8576").
+- [ ] PR has at least 1-2 sentence summary.
+- [ ] PR is not out of master, but out of a separate branch (e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`)
+- [ ] Optional: PR cross-links related issues.
 
 <!--
-A few other common gotchas:
-
-- Do not create the PR out of master, but out of a separate branch.
-
-- The PR title should summarize the changes, for example "Raise ValueError on
-  non-numeric input to set_xlim". Avoid non-descriptive titles such as
-  "Addresses issue #8576".
-
 - If you are contributing fixes to docstrings, please pay attention to
   http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
   note the difference between using single backquotes, double backquotes, and

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,21 @@
 ## PR Summary
 
 <!--
-Please provide at least a 1-2 sentence summary of the purpose of the PR.
--->
+Thank you so much for your PR! Please summarize the purpose of the PR here
+using at least 1-2 sentences.
 
+To help us review your pull request, make sure:
+
+- The PR title descriptively summarizes the changes.
+    - e.g. "Raise `ValueError` on non-numeric input to `set_xlim`"
+    - Please don't use non-descriptive titles such as "Addresses issue #8576".
+- The PR summary includes:
+    - How the PR implements any changes.
+    - Why these changes are necessary.
+- The PR is not out of master, but out of a separate branch.
+    - e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`
+- Optional: PR cross-links related issues.
+-->
 
 ## PR Checklists
 
@@ -11,14 +23,14 @@ Please provide at least a 1-2 sentence summary of the purpose of the PR.
 
 New code:
 
-- [ ] Has Pytest style unit tests (and `pytest lib/matplotlib/tests` passes)
-- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
-- [ ] Code is documented, with examples if plot related
+- [ ] has Pytest style unit tests (and `pytest lib/matplotlib/tests` passes)
+- [ ] is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
+- [ ] is documented, with examples if plot related
 
 New documentation:
 
-- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
-- [ ] Documentation conforms to matplotlib style conventions. (If you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
+- [ ] is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
+- [ ] conforms to matplotlib style conventions (if you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
 <!--
 - If you are contributing fixes to docstrings, please pay attention to
   http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
@@ -28,20 +40,11 @@ New documentation:
 
 New features:
 
-- [ ] Have an entry in `doc/users/next_whats_new/` (follow instructions in `doc/users/next_whats_new/README.rst`)
+- [ ] have an entry in `doc/users/next_whats_new/` (follow instructions in `doc/users/next_whats_new/README.rst`)
 
 API changes:
 
-- [ ] Documented in `doc/api/api_changes_[NEXT_VERSION]` if API changed in a backward-incompatible way (follow instructions in `doc/api/api_changes_[NEXT_VERSION]/README.rst`)
-
-<!--
-Meta:
-
-- PR title descriptively summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" to "Addresses issue #8576").
-- PR has at least a 1-2 sentence summary.
-- PR is not out of master, but out of a separate branch (e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`)
-- Optional: PR cross-links related issues.
--->
+- [ ] are documented in `doc/api/api_changes_[NEXT_VERSION]` if API changed in a backward-incompatible way (follow instructions in `doc/api/api_changes_[NEXT_VERSION]/README.rst`)
 
 <!--
 If you have further questions:
@@ -53,7 +56,7 @@ If you have further questions:
   https://matplotlib.org/devel/gitwash/development_workflow.html.
 
 We understand that PRs can sometimes be overwhelming, especially as the
-reviews start coming in. Please let us know if the reviews are unclear,  
+reviews start coming in. Please let us know if the reviews are unclear,
 the recommended next step seems overly demanding, you would like help in
 addressing a reviewer's comments, or you have been waiting too long to hear
 back on your PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ New documentation:
 
 New features:
 
-- [ ] Added an entry to `doc/users/next_whats_new/` if major new feature (follow instructions in `doc/users/next_whats_new/README.rst`)
+- [ ] Have an entry in `doc/users/next_whats_new/` (follow instructions in `doc/users/next_whats_new/README.rst`)
 
 API changes:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,8 +37,8 @@ API changes:
 <!--
 Meta:
 
-- PR title summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" instead of "Addresses issue #8576").
-- PR has at least 1-2 sentence summary.
+- PR title descriptively summarizes the changes. (For example, prefer "Raise `ValueError` on non-numeric input to `set_xlim`" to "Addresses issue #8576").
+- PR has at least a 1-2 sentence summary.
 - PR is not out of master, but out of a separate branch (e.g. `your-user-name:non-numeric-xlim -> matplotlib:master`)
 - Optional: PR cross-links related issues.
 -->
@@ -53,8 +53,8 @@ If you have further questions:
   https://matplotlib.org/devel/gitwash/development_workflow.html.
 
 We understand that PRs can sometimes be overwhelming, especially as the
-reviews start coming in. Please let us know if the reviews are unclear or
-the recommended next step seems overly demanding, if you would like help in
-addressing a reviewer's comments, or if you have been waiting too long to hear
+reviews start coming in. Please let us know if the reviews are unclear,  
+the recommended next step seems overly demanding, you would like help in
+addressing a reviewer's comments, or you have been waiting too long to hear
 back on your PR.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,8 @@
 Thank you so much for your PR!  To help us review your contribution, please
 consider the following points:
 
-- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.
+- A development guide is available at
+  https://matplotlib.org/devdocs/devel/index.html.
 
 - Help with git and github is available at
   https://matplotlib.org/devel/gitwash/development_workflow.html.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,17 +23,17 @@ To help us review your pull request, make sure:
 
 New code:
 
-- [ ] has Pytest style unit tests (and `pytest lib/matplotlib/tests` passes)
-- [ ] is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
+- [ ] has pytest style unit tests (and `pytest` passes)
+- [ ] is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check)
 - [ ] is documented, with examples if plot related
 
 New documentation:
 
-- [ ] is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
-- [ ] conforms to matplotlib style conventions (if you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
+- [ ] is Sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error)
+- [ ] conforms to Matplotlib style conventions (if you have `flake8-docstrings` and `pydocstyle<4` installed, run `flake8 --docstring-convention=all` on changed files to check).
 <!--
 - If you are contributing fixes to docstrings, please pay attention to
-  http://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
+  https://matplotlib.org/devel/documenting_mpl.html#formatting. In particular,
   note the difference between using single backquotes, double backquotes, and
   asterisks in the markup.
 -->
@@ -52,7 +52,7 @@ If you have further questions:
 - A more complete development guide is available at
   https://matplotlib.org/devdocs/devel/index.html.
 
-- Help with git and github is available at
+- Help with Git and GitHub is available at
   https://matplotlib.org/devel/gitwash/development_workflow.html.
 
 We understand that PRs can sometimes be overwhelming, especially as the


### PR DESCRIPTION
## PR Summary

Implement the suggestions to the PR checklist described in (https://discourse.matplotlib.org/t/how-to-engage-more-contributors-to-matplotlib/21059/11) and discussed in the last call.

Basically, gives users explicit instructions for how to "check" that each of the checkboxes is actually ready to check.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
