### PR TITLE
DOC: Fix some warning and unreproducibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ mpl-run: &mpl-install
 doc-run: &doc-build
   name: Build documentation
   command: |
+    # Set epoch to date of latest tag.
+    export SOURCE_DATE_EPOCH="$(git log -1 --format=%at $(git describe --abbrev=0))"
     make html O=-T
     rm -r build/html/_sources
   working_directory: doc

--- a/examples/axes_grid1/demo_anchored_direction_arrows.py
+++ b/examples/axes_grid1/demo_anchored_direction_arrows.py
@@ -9,6 +9,10 @@ import numpy as np
 from mpl_toolkits.axes_grid1.anchored_artists import AnchoredDirectionArrows
 import matplotlib.font_manager as fm
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 fig, ax = plt.subplots()
 ax.imshow(np.random.random((10, 10)))
 

--- a/examples/event_handling/image_slices_viewer.py
+++ b/examples/event_handling/image_slices_viewer.py
@@ -10,6 +10,10 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
+
 class IndexTracker:
     def __init__(self, ax, X):
         self.ax = ax

--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -70,6 +70,10 @@ import numpy as np
 from numpy.random import rand
 
 
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
+
 def pick_simple():
     # simple picking, lines, rectangles and text
     fig, (ax1, ax2) = plt.subplots(2, 1)

--- a/examples/event_handling/pick_event_demo2.py
+++ b/examples/event_handling/pick_event_demo2.py
@@ -11,6 +11,9 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 X = np.random.rand(100, 1000)
 xs = np.mean(X, axis=1)
 ys = np.std(X, axis=1)

--- a/examples/event_handling/zoom_window.py
+++ b/examples/event_handling/zoom_window.py
@@ -17,6 +17,10 @@ their size is independent of the zoom.
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 figsrc, axsrc = plt.subplots()
 figzoom, axzoom = plt.subplots()
 axsrc.set(xlim=(0, 1), ylim=(0, 1), autoscale_on=False,

--- a/examples/images_contours_and_fields/image_demo.py
+++ b/examples/images_contours_and_fields/image_demo.py
@@ -17,6 +17,10 @@ import matplotlib.cbook as cbook
 from matplotlib.path import Path
 from matplotlib.patches import PathPatch
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 ###############################################################################
 # First we'll generate a simple bivariate normal distribution.
 

--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -12,6 +12,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 ###############################################################################
 # A simple pcolor demo
 # --------------------

--- a/examples/images_contours_and_fields/spy_demos.py
+++ b/examples/images_contours_and_fields/spy_demos.py
@@ -9,6 +9,10 @@ Plot the sparsity pattern of arrays.
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 fig, axs = plt.subplots(2, 2)
 ax1 = axs[0, 0]
 ax2 = axs[0, 1]

--- a/examples/lines_bars_and_markers/scatter_custom_symbol.py
+++ b/examples/lines_bars_and_markers/scatter_custom_symbol.py
@@ -9,6 +9,10 @@ Creating a custom ellipse symbol in scatter plot.
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 # unit area ellipse
 rx, ry = 3., 1.
 area = rx * ry * np.pi

--- a/examples/lines_bars_and_markers/stackplot_demo.py
+++ b/examples/lines_bars_and_markers/stackplot_demo.py
@@ -12,6 +12,10 @@ show some examples to accomplish this with Matplotlib.
 import numpy as np
 import matplotlib.pyplot as plt
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 x = [1, 2, 3, 4, 5]
 y1 = [1, 1, 2, 3, 5]
 y2 = [0, 4, 2, 6, 8]

--- a/examples/lines_bars_and_markers/vline_hline_demo.py
+++ b/examples/lines_bars_and_markers/vline_hline_demo.py
@@ -10,6 +10,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 t = np.arange(0.0, 5.0, 0.1)
 s = np.exp(-t) + np.sin(2 * np.pi * t) + 1
 nse = np.random.normal(0.0, 0.3, t.shape) * s

--- a/examples/recipes/create_subplots.py
+++ b/examples/recipes/create_subplots.py
@@ -11,6 +11,10 @@ code.  e.g.
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 x = np.random.randn(50)
 
 # old style

--- a/examples/recipes/fill_between_alpha.py
+++ b/examples/recipes/fill_between_alpha.py
@@ -16,6 +16,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.cbook as cbook
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 # load up some sample financial data
 with cbook.get_sample_data('goog.npz') as datafile:
     r = np.load(datafile)['price_data'].view(np.recarray)

--- a/examples/scales/power_norm.py
+++ b/examples/scales/power_norm.py
@@ -14,7 +14,7 @@ from numpy.random import multivariate_normal
 
 data = np.vstack([
     multivariate_normal([10, 10], [[3, 2], [2, 3]], size=100000),
-    multivariate_normal([30, 20], [[2, 3], [1, 3]], size=1000)
+    multivariate_normal([30, 20], [[3, 1], [1, 3]], size=1000)
 ])
 
 gammas = [0.8, 0.5, 0.3]

--- a/examples/scales/power_norm.py
+++ b/examples/scales/power_norm.py
@@ -12,6 +12,10 @@ import matplotlib.colors as mcolors
 import numpy as np
 from numpy.random import multivariate_normal
 
+
+# Fixing random state for reproducibility.
+np.random.seed(19680801)
+
 data = np.vstack([
     multivariate_normal([10, 10], [[3, 2], [2, 3]], size=100000),
     multivariate_normal([30, 20], [[3, 1], [1, 3]], size=1000)

--- a/examples/scales/scales.py
+++ b/examples/scales/scales.py
@@ -87,7 +87,7 @@ def inverse(a):
 
 ax = axs[2, 1]
 
-t = np.arange(-170.0, 170.0, 0.1)
+t = np.arange(0, 170.0, 0.1)
 s = t / 2.
 
 ax.plot(t, s, '-', lw=2)
@@ -95,9 +95,9 @@ ax.plot(t, s, '-', lw=2)
 ax.set_yscale('function', functions=(forward, inverse))
 ax.set_title('function: Mercator')
 ax.grid(True)
-ax.set_xlim([-180, 180])
+ax.set_xlim([0, 180])
 ax.yaxis.set_minor_formatter(NullFormatter())
-ax.yaxis.set_major_locator(FixedLocator(np.arange(-90, 90, 30)))
+ax.yaxis.set_major_locator(FixedLocator(np.arange(0, 90, 10)))
 
 plt.show()
 

--- a/examples/shapes_and_collections/ellipse_demo.py
+++ b/examples/shapes_and_collections/ellipse_demo.py
@@ -11,6 +11,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Ellipse
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 NUM = 250
 
 ells = [Ellipse(xy=np.random.rand(2) * 10,

--- a/examples/style_sheets/bmh.py
+++ b/examples/style_sheets/bmh.py
@@ -9,16 +9,19 @@ This example demonstrates the style used in the Bayesian Methods for Hackers
 .. [1] http://camdavidsonpilon.github.io/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/
 
 """
-from numpy.random import beta
+import numpy as np
 import matplotlib.pyplot as plt
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
 
 plt.style.use('bmh')
 
 
 def plot_beta_hist(ax, a, b):
-    ax.hist(beta(a, b, size=10000), histtype="stepfilled",
-            bins=25, alpha=0.8, density=True)
+    ax.hist(np.random.beta(a, b, size=10000),
+            histtype="stepfilled", bins=25, alpha=0.8, density=True)
 
 
 fig, ax = plt.subplots()

--- a/examples/style_sheets/plot_solarizedlight2.py
+++ b/examples/style_sheets/plot_solarizedlight2.py
@@ -23,6 +23,11 @@ ToDo:
 """
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 x = np.linspace(0, 10)
 with plt.style.context('Solarize_Light2'):
     plt.plot(x, np.sin(x) + x + np.random.randn(50))

--- a/examples/subplots_axes_and_figures/axes_box_aspect.py
+++ b/examples/subplots_axes_and_figures/axes_box_aspect.py
@@ -80,6 +80,7 @@ plt.show()
 
 fig4, (ax, ax2) = plt.subplots(ncols=2, constrained_layout=True)
 
+np.random.seed(19680801)  # Fixing random state for reproducibility
 im = np.random.rand(16, 27)
 ax.imshow(im)
 
@@ -106,6 +107,7 @@ axs[0, 0].set_box_aspect(1/3)
 axs[1, 0].set_box_aspect(1)
 axs[1, 1].set_box_aspect(3/1)
 
+np.random.seed(19680801)  # Fixing random state for reproducibility
 x, y = np.random.randn(2, 400) * [[.5], [180]]
 axs[1, 0].scatter(x, y)
 axs[0, 0].hist(x)

--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -11,6 +11,10 @@ The simplest case is just attaching a colorbar to each axes:
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 fig, axs = plt.subplots(2, 2)
 cm = ['RdBu_r', 'viridis']
 for col in range(2):

--- a/examples/subplots_axes_and_figures/subplot_toolbar.py
+++ b/examples/subplots_axes_and_figures/subplot_toolbar.py
@@ -8,6 +8,10 @@ Matplotlib has a toolbar available for adjusting subplot spacing.
 import matplotlib.pyplot as plt
 import numpy as np
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 fig, axs = plt.subplots(2, 2)
 
 axs[0, 0].imshow(np.random.random((100, 100)))

--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -64,7 +64,7 @@ def test_rotation_mode(fig, mode, subplot_location):
         # highlight bbox
         fig.canvas.draw()
         for ax, tx in zip(grid, texts):
-            bb = tx.get_window_extent().inverse_transformed(ax.transData)
+            bb = tx.get_window_extent().transformed(ax.transData.inverted())
             rect = plt.Rectangle((bb.x0, bb.y0), bb.width, bb.height,
                                  facecolor="C1", alpha=0.3, zorder=2)
             ax.add_patch(rect)

--- a/examples/ticks_and_spines/colorbar_tick_labelling_demo.py
+++ b/examples/ticks_and_spines/colorbar_tick_labelling_demo.py
@@ -13,6 +13,10 @@ import numpy as np
 from matplotlib import cm
 from numpy.random import randn
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 ###############################################################################
 # Make plot with vertical (default) colorbar
 

--- a/examples/userdemo/annotate_text_arrow.py
+++ b/examples/userdemo/annotate_text_arrow.py
@@ -8,6 +8,10 @@ Annotate Text Arrow
 import numpy as np
 import matplotlib.pyplot as plt
 
+
+# Fixing random state for reproducibility
+np.random.seed(19680801)
+
 fig, ax = plt.subplots(figsize=(5, 5))
 ax.set_aspect(1)
 

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -37,7 +37,6 @@ from matplotlib import cm
 from matplotlib.colors import ListedColormap, LinearSegmentedColormap
 
 viridis = cm.get_cmap('viridis', 8)
-print(viridis)
 
 ##############################################################################
 # The object ``viridis`` is a callable, that when passed a float between
@@ -74,7 +73,6 @@ print('viridis(np.linspace(0, 1, 12))', viridis(np.linspace(0, 1, 12)))
 # float array between 0 and 1.
 
 copper = cm.get_cmap('copper', 8)
-print(copper)
 
 print('copper(range(8))', copper(range(8)))
 print('copper(np.linspace(0, 1, 8))', copper(np.linspace(0, 1, 8)))


### PR DESCRIPTION
## PR Summary

Fix some warnings (see commit message for details) and some unreproducible parts. For doc CI, it sets `SOURCE_DATE_EPOCH` to the date of the latest tag, in order to reduce any possible timestamp changes.

If you build docs with `SOURCE_DATE_EPOCH` set twice in a row, the only differences are now the example runtimes inserted by sphinx-gallery and one plot in the constrained layout tutorial (which warns that it may be unreproducible.)

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way