### PR TITLE
Deprecate text.latex.preview rcParam.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -388,6 +388,12 @@ instead.
 The unused ``animation.html_args`` rcParam and ``animation.HTMLWriter.args_key``
 attribute are deprecated.
 
+``text.latex.preview`` rcParam
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This rcParam, which controlled the use of the preview.sty LaTeX package to
+align TeX string baselines, is deprecated, as Matplotlib's own dvi parser now
+computes baselines just as well as preview.sty.
+
 ``SubplotSpec.get_rows_columns``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This method is deprecated.  Use the ``GridSpec.nrows``, ``GridSpec.ncols``,

--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -3,6 +3,11 @@
 Usetex Baseline Test
 ====================
 
+A test for :rc:`text.latex.preview`, a deprecated feature which relied
+on the preview.sty LaTeX package to properly align TeX baselines.  This
+feature has been deprecated as Matplotlib's dvi parser now computes baselines
+just as well as preview.sty; this example will be removed together with
+:rc:`text.latex.preview` after the deprecation elapses.
 """
 
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -624,6 +624,7 @@ _deprecated_remain_as_none = {
     'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
     'savefig.jpeg_quality': ('3.3',),
+    'text.latex.preview': ('3.3',),
 }
 
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -477,7 +477,7 @@ translate
         tex = r'\color[rgb]{%s} %s' % (color, s)
 
         corr = 0  # w/2*(fontsize-10)/10
-        if mpl.rcParams['text.latex.preview']:
+        if dict.__getitem__(mpl.rcParams, 'text.latex.preview'):
             # use baseline alignment!
             pos = _nums_to_str(x-corr, y)
             self.psfrag.append(

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -214,7 +214,7 @@ class Dvi:
         self.baseline = self._get_baseline(filename)
 
     def _get_baseline(self, filename):
-        if rcParams['text.latex.preview']:
+        if dict.__getitem__(rcParams, 'text.latex.preview'):
             baseline = Path(filename).with_suffix(".baseline")
             if baseline.exists():
                 height, depth, width = baseline.read_bytes().split()

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -122,7 +122,6 @@ text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURE
                            # beware of package collisions: color, geometry, graphicx,
                            # type1cm, textcomp. Adobe Postscript (PSSNFS) font packages
                            # may also be loaded, depending on your font settings
-text.latex.preview : False
 
 text.hinting : auto   # May be one of the following:
                       #   'none': Perform no hinting

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -219,6 +219,7 @@ class TexManager:
     _re_vbox = re.compile(
         r"MatplotlibBox:\(([\d.]+)pt\+([\d.]+)pt\)x([\d.]+)pt")
 
+    @cbook.deprecated("3.3")
     def make_tex_preview(self, tex, fontsize):
         """
         Generate a tex file to render the tex string at a specific font size.
@@ -286,7 +287,7 @@ class TexManager:
         Return the file name.
         """
 
-        if rcParams['text.latex.preview']:
+        if dict.__getitem__(rcParams, 'text.latex.preview'):
             return self.make_dvi_preview(tex, fontsize)
 
         basefile = self.get_basefile(tex, fontsize)
@@ -306,6 +307,7 @@ class TexManager:
 
         return dvifile
 
+    @cbook.deprecated("3.3")
     def make_dvi_preview(self, tex, fontsize):
         """
         Generate a dvi file containing latex's layout of tex string.
@@ -397,7 +399,7 @@ class TexManager:
 
         dpi_fraction = renderer.points_to_pixels(1.) if renderer else 1
 
-        if rcParams['text.latex.preview']:
+        if dict.__getitem__(rcParams, 'text.latex.preview'):
             # use preview.sty
             basefile = self.get_basefile(tex, fontsize)
             baselinefile = '%s.baseline' % basefile

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -291,7 +291,6 @@
                         # type1cm, textcomp.
                         # Adobe Postscript (PSSNFS) font packages may also be
                         # loaded, depending on your font settings.
-#text.latex.preview: False
 
 #text.hinting: auto  # May be one of the following:
                      #     - none: Perform no hinting


### PR DESCRIPTION
It is now unneeded; see changelog note.

Followup to #16476.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
