### PR TITLE
Correctly go through property setter when init'ing Timer interval.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -176,3 +176,8 @@ explicitly pass a "%1.2f" as the *valfmt* parameter to `.Slider`.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 All the functionality of ``CustomCell`` has been moved to its base class
 `~.table.Cell`.
+
+wx Timer interval
+~~~~~~~~~~~~~~~~~
+Setting the timer interval on a not-yet-started ``TimerWx`` won't start it
+anymore.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1059,10 +1059,9 @@ class TimerBase:
             `remove_callback` can be used.
         """
         self.callbacks = [] if callbacks is None else callbacks.copy()
-        self._interval = 1000 if interval is None else interval
-        self._single = False
-        # Default attribute for holding the GUI-specific timer object
-        self._timer = None
+        # Set .interval and not ._interval to go through the property setter.
+        self.interval = 1000 if interval is None else interval
+        self.single_shot = False
 
     def __del__(self):
         """Need to stop timer and possibly disconnect timer."""

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -82,9 +82,9 @@ class TimerTk(TimerBase):
     """Subclass of `backend_bases.TimerBase` using Tk timer events."""
 
     def __init__(self, parent, *args, **kwargs):
+        self._timer = None
         TimerBase.__init__(self, *args, **kwargs)
         self.parent = parent
-        self._timer = None
 
     def _timer_start(self):
         self._timer_stop()
@@ -97,7 +97,6 @@ class TimerTk(TimerBase):
 
     def _on_timer(self):
         TimerBase._on_timer(self)
-
         # Tk after() is only a single shot, so we need to add code here to
         # reset the timer if we're not operating in single shot mode.  However,
         # if _timer is None, this means that _timer_stop has been called; so

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -52,6 +52,10 @@ except TypeError as exc:
 class TimerGTK3(TimerBase):
     """Subclass of `.TimerBase` using GTK3 timer events."""
 
+    def __init__(self, *args, **kwargs):
+        self._timer = None
+        TimerBase.__init__(self, *args, **kwargs)
+
     def _timer_start(self):
         # Need to stop it, otherwise we potentially leak a timer id that will
         # never be stopped.

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -180,12 +180,11 @@ class TimerQT(TimerBase):
     """Subclass of `.TimerBase` using QTimer events."""
 
     def __init__(self, *args, **kwargs):
-        TimerBase.__init__(self, *args, **kwargs)
         # Create a new timer and connect the timeout() signal to the
         # _on_timer method.
         self._timer = QtCore.QTimer()
         self._timer.timeout.connect(self._on_timer)
-        self._timer_set_interval()
+        TimerBase.__init__(self, *args, **kwargs)
 
     def __del__(self):
         # The check for deletedness is needed to avoid an error at animation

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -489,6 +489,10 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
 
 
 class TimerTornado(backend_bases.TimerBase):
+    def __init__(self, *args, **kwargs):
+        self._timer = None
+        super().__init__(*args, **kwargs)
+
     def _timer_start(self):
         self._timer_stop()
         if self._single:
@@ -510,7 +514,6 @@ class TimerTornado(backend_bases.TimerBase):
             ioloop.remove_timeout(self._timer)
         else:
             self._timer.stop()
-
         self._timer = None
 
     def _timer_set_interval(self):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -70,9 +70,9 @@ class TimerWx(TimerBase):
     """Subclass of `.TimerBase` using wx.Timer events."""
 
     def __init__(self, *args, **kwargs):
-        TimerBase.__init__(self, *args, **kwargs)
         self._timer = wx.Timer()
         self._timer.Notify = self._on_timer
+        TimerBase.__init__(self, *args, **kwargs)
 
     def _timer_start(self):
         self._timer.Start(self._interval, self._single)
@@ -81,7 +81,8 @@ class TimerWx(TimerBase):
         self._timer.Stop()
 
     def _timer_set_interval(self):
-        self._timer_start()
+        if self._timer.IsRunning():
+            self._timer_start()  # Restart with new interval.
 
     def _timer_set_single_shot(self):
         self._timer.Start()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -114,7 +114,7 @@ assert_equal(
 
 ax.plot([0, 1], [2, 3])
 
-timer = fig.canvas.new_timer(1)
+timer = fig.canvas.new_timer(1.)  # Test that floats are cast to int as needed.
 timer.add_callback(FigureCanvasBase.key_press_event, fig.canvas, "q")
 # Trigger quitting upon draw.
 fig.canvas.mpl_connect("draw_event", lambda event: timer.start())


### PR DESCRIPTION
The setter casts the interval to an int, which is required at least by
the tk backend.

Closes https://github.com/matplotlib/matplotlib/issues/17149#issuecomment-614876614.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
