### PR TITLE
Fix Figure.add_axes(rect=...).

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1211,6 +1211,11 @@ default: 'top'
                 "deprecated. You may want to use add_subplot() "
                 "instead.")
             return
+        elif 'rect' in kwargs:
+            if len(args):
+                raise TypeError(
+                    "add_axes() got multiple values for argument 'rect'")
+            args = (kwargs.pop('rect'), )
 
         # shortcut the projection "key" modifications later on, if an axes
         # with the exact args/kwargs exists, return it immediately.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -150,7 +150,11 @@ def test_gca():
         # empty call to add_axes() will throw deprecation warning
         assert fig.add_axes() is None
 
-    ax1 = fig.add_axes([0, 0, 1, 1])
+    ax0 = fig.add_axes([0, 0, 1, 1])
+    assert fig.gca(projection='rectilinear') is ax0
+    assert fig.gca() is ax0
+
+    ax1 = fig.add_axes(rect=[0.1, 0.1, 0.8, 0.8])
     assert fig.gca(projection='rectilinear') is ax1
     assert fig.gca() is ax1
 
@@ -386,6 +390,9 @@ def test_invalid_figure_add_axes():
     fig = plt.figure()
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
+
+    with pytest.raises(TypeError, match="multiple values for argument 'rect'"):
+        fig.add_axes([0, 0, 1, 1], rect=[0, 0, 1, 1])
 
 
 def test_subplots_shareax_loglabels():


### PR DESCRIPTION
## PR Summary

This makes it behave as if the signature was actually `add_axes(rect, **kwargs)` instead of `*args`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way