### PR TITLE
Small optimizations to scale and translate of Affine2D

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -43,8 +43,8 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import (
-    backend_tools as tools, cbook, colors, textpath, tight_bbox, transforms,
-    widgets, get_backend, is_interactive, rcParams)
+    backend_tools as tools, cbook, colors, textpath, tight_bbox,
+    transforms, widgets, get_backend, is_interactive, rcParams)
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_managers import ToolManager
 from matplotlib.transforms import Affine2D
@@ -220,18 +220,17 @@ class RendererBase:
         recommended to use those generators, so that changes to the
         behavior of :meth:`draw_path_collection` can be made globally.
         """
-        path_ids = [
-            (path, transforms.Affine2D(transform))
-            for path, transform in self._iter_collection_raw_paths(
-                    master_transform, paths, all_transforms)]
+        path_ids = self._iter_collection_raw_paths(master_transform,
+                                                   paths, all_transforms)
 
         for xo, yo, path_id, gc0, rgbFace in self._iter_collection(
-                gc, master_transform, all_transforms, path_ids, offsets,
+                gc, master_transform, all_transforms, list(path_ids), offsets,
                 offsetTrans, facecolors, edgecolors, linewidths, linestyles,
                 antialiaseds, urls, offset_position):
             path, transform = path_id
-            transform = transforms.Affine2D(
-                            transform.get_matrix()).translate(xo, yo)
+            if xo != 0 or yo != 0:
+                transform = transform.frozen()
+                transform.translate(xo, yo)
             self.draw_path(gc0, path, transform, rgbFace)
 
     def draw_quad_mesh(self, gc, master_transform, meshWidth, meshHeight,

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -228,7 +228,12 @@ class RendererBase:
                 offsetTrans, facecolors, edgecolors, linewidths, linestyles,
                 antialiaseds, urls, offset_position):
             path, transform = path_id
+            # Only apply another translation if we have an offset, else we
+            # resuse the inital transform.
             if xo != 0 or yo != 0:
+                # The transformation can be used by multiple paths. Since
+                # translate is a inplace operation, we need to copy the
+                # transformation by .frozen() before applying the translation.
                 transform = transform.frozen()
                 transform.translate(xo, yo)
             self.draw_path(gc0, path, transform, rgbFace)

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -14,7 +14,7 @@ import pytest
 def test_uses_per_path():
     id = transforms.Affine2D()
     paths = [path.Path.unit_regular_polygon(i) for i in range(3, 7)]
-    tforms = [id.rotate(i) for i in range(1, 5)]
+    tforms_matrices = [id.rotate(i).get_matrix().copy() for i in range(1, 5)]
     offsets = np.arange(20).reshape((10, 2))
     facecolors = ['red', 'green']
     edgecolors = ['red', 'green']
@@ -37,17 +37,18 @@ def test_uses_per_path():
             seen = np.bincount(ids, minlength=len(raw_paths))
             assert set(seen).issubset([uses - 1, uses])
 
-    check(id, paths, tforms, offsets, facecolors, edgecolors)
-    check(id, paths[0:1], tforms, offsets, facecolors, edgecolors)
-    check(id, [], tforms, offsets, facecolors, edgecolors)
-    check(id, paths, tforms[0:1], offsets, facecolors, edgecolors)
+    check(id, paths, tforms_matrices, offsets, facecolors, edgecolors)
+    check(id, paths[0:1], tforms_matrices, offsets, facecolors, edgecolors)
+    check(id, [], tforms_matrices, offsets, facecolors, edgecolors)
+    check(id, paths, tforms_matrices[0:1], offsets, facecolors, edgecolors)
     check(id, paths, [], offsets, facecolors, edgecolors)
     for n in range(0, offsets.shape[0]):
-        check(id, paths, tforms, offsets[0:n, :], facecolors, edgecolors)
-    check(id, paths, tforms, offsets, [], edgecolors)
-    check(id, paths, tforms, offsets, facecolors, [])
-    check(id, paths, tforms, offsets, [], [])
-    check(id, paths, tforms, offsets, facecolors[0:1], edgecolors)
+        check(id, paths, tforms_matrices, offsets[0:n, :],
+              facecolors, edgecolors)
+    check(id, paths, tforms_matrices, offsets, [], edgecolors)
+    check(id, paths, tforms_matrices, offsets, facecolors, [])
+    check(id, paths, tforms_matrices, offsets, [], [])
+    check(id, paths, tforms_matrices, offsets, facecolors[0:1], edgecolors)
 
 
 def test_get_default_filename(tmpdir):


### PR DESCRIPTION
## PR Summary
Instead of building a transformation matrix and do the matrix multiplication, just change the matrix directly. This change also exposed a bug in draw_path_collection where Affine2D was called with the wrong argument.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
