### PR TITLE
Deprecate ScalarMappable.check_update and associated machinery.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -450,3 +450,8 @@ needed.
 The associated helper methods ``NavigationToolbar2.draw()`` and
 ``ToolViewsPositions.refresh_locators()`` are deprecated, and should be
 replaced by calls to ``draw_idle()`` on the corresponding canvas.
+
+`.ScalarMappable` checkers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``add_checker`` and ``check_update`` methods and ``update_dict`` attribute
+of `.ScalarMappable` are deprecated.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -177,7 +177,7 @@ class ScalarMappable:
         #: The last colorbar associated with this ScalarMappable. May be None.
         self.colorbar = None
         self.callbacksSM = cbook.CallbackRegistry()
-        self.update_dict = {'array': False}
+        self._update_dict = {'array': False}
 
     def _scale_norm(self, norm, vmin, vmax):
         """
@@ -279,7 +279,7 @@ class ScalarMappable:
         A : ndarray
         """
         self._A = A
-        self.update_dict['array'] = True
+        self._update_dict['array'] = True
 
     def get_array(self):
         """Return the data array."""
@@ -386,30 +386,39 @@ class ScalarMappable:
         self.norm.autoscale_None(self._A)
         self.changed()
 
-    def add_checker(self, checker):
+    def _add_checker(self, checker):
         """
         Add an entry to a dictionary of boolean flags
         that are set to True when the mappable is changed.
         """
-        self.update_dict[checker] = False
+        self._update_dict[checker] = False
 
-    def check_update(self, checker):
-        """
-        If mappable has changed since the last check,
-        return True; else return False
-        """
-        if self.update_dict[checker]:
-            self.update_dict[checker] = False
+    def _check_update(self, checker):
+        """Return whether mappable has changed since the last check."""
+        if self._update_dict[checker]:
+            self._update_dict[checker] = False
             return True
         return False
 
     def changed(self):
         """
         Call this whenever the mappable is changed to notify all the
-        callbackSM listeners to the 'changed' signal
+        callbackSM listeners to the 'changed' signal.
         """
         self.callbacksSM.process('changed', self)
-
-        for key in self.update_dict:
-            self.update_dict[key] = True
+        for key in self._update_dict:
+            self._update_dict[key] = True
         self.stale = True
+
+    @cbook.deprecated("3.3")
+    @property
+    def update_dict(self):
+        return self._update_dict
+
+    @cbook.deprecated("3.3")
+    def add_checker(self, checker):
+        return self._add_checker(checker)
+
+    @cbook.deprecated("3.3")
+    def check_update(self, checker):
+        return self.check_update(checker)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -768,7 +768,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
     def set_alpha(self, alpha):
         # docstring inherited
         super().set_alpha(alpha)
-        self.update_dict['array'] = True
+        self._update_dict['array'] = True
         self._set_facecolor(self._original_facecolor)
         self._set_edgecolor(self._original_edgecolor)
 
@@ -784,7 +784,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             return
         if self._A.ndim > 1:
             raise ValueError('Collections can only map rank 1 arrays')
-        if not self.check_update("array"):
+        if not self._check_update("array"):
             return
         if self._is_filled:
             self._facecolors = self.to_rgba(self._A, self._alpha)
@@ -815,7 +815,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._A = other._A
         self.norm = other.norm
         self.cmap = other.cmap
-        # self.update_dict = other.update_dict # do we need to copy this? -JJL
+        # do we need to copy self._update_dict? -JJL
         self.stale = True
 
 


### PR DESCRIPTION
It's a rather complex machinery that's ultimately just used by
Collection to know whether the alpha array has been updated so that the
value-to-rgba mapping needs to be updated.  Users can't connect to it to
know whether the mapped values have been updated, and they can't even
use it to check whether the *alpha* values have been updated because
this unsets the marker and thus would mess up Collection's own use of
it.  For now, just deprecate its public use to ultimately make it
private and perhaps replace it later by something less brittle (e.g.,
normal a normal callback registry).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
