### PR TITLE
Fixes issue where toolbar tools wouldn't shown when selected - wxpython and macOS v2

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1128,7 +1128,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self._parent = self.canvas.GetParent()
 
         self.wx_ids = {}
-        self.bitmaps = {}
+        self._bitmaps = {}
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:
                 self.AddSeparator()
@@ -1136,7 +1136,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
             bitmap = _load_bitmap(f"{image_file}.png")
             if text in ["Pan", "Zoom"]:
-                self.bitmaps[text] = {"Normal": bitmap,
+                self._bitmaps[text] = {"Normal": bitmap,
                     "Toggled": self._make_toggled_bitmap(bitmap)}
 
             self.wx_ids[text] = (
@@ -1169,33 +1169,32 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
         return bmp
 
+    def _fake_toggle_group(self, elements, active):
+        for name in elements:
+            self.SetToolNormalBitmap(self.wx_ids[name],
+                self._bitmaps[name]["Toggled" if name == active else "Normal"])
+
     def zoom(self, *args):
         evt = args[0]
         self.ToggleTool(self.wx_ids['Pan'], False)
         NavigationToolbar2.zoom(self, *args)
         if 'wxMac' in wx.PlatformInfo:
-            self.SetToolNormalBitmap(self.wx_ids["Pan"],
-                self.bitmaps["Pan"]["Normal"])
             if evt.IsChecked():
-                self.SetToolNormalBitmap(self.wx_ids["Zoom"],
-                    self.bitmaps["Zoom"]["Toggled"])
+                active = "Zoom"
             else:
-                self.SetToolNormalBitmap(self.wx_ids["Zoom"],
-                    self.bitmaps["Zoom"]["Normal"])
+                active = None
+            self._fake_toggle_group(["Zoom", "Pan"], active)
 
     def pan(self, *args):
         evt = args[0]
         self.ToggleTool(self.wx_ids['Zoom'], False)
         NavigationToolbar2.pan(self, *args)
         if 'wxMac' in wx.PlatformInfo:
-            self.SetToolNormalBitmap(self.wx_ids["Zoom"],
-                self.bitmaps["Zoom"]["Normal"])
             if evt.IsChecked():
-                self.SetToolNormalBitmap(self.wx_ids["Pan"],
-                    self.bitmaps["Pan"]["Toggled"])
+                active = "Pan"
             else:
-                self.SetToolNormalBitmap(self.wx_ids["Pan"],
-                    self.bitmaps["Pan"]["Normal"])
+                active = None
+            self._fake_toggle_group(["Zoom", "Pan"], active)
 
     def configure_subplots(self, *args):
         global FigureManager  # placates pyflakes: created by @_Backend.export


### PR DESCRIPTION
## PR Summary
This fixes the bug identified in issue #16701: "When using the WxAgg backend on MacOS, if you select a tool in the toolbar you essentially can't tell that the tool is selected. There is only a very small change in the appearance. On other platforms (linux, windows) it is very obvious that the tool is selected."

A previous version of the fix (pr #17138) used `wx.lib.agw.buttonpanel`. This resulted in a changed API and non-native like display on Windows and Linux. This version of the fix makes custom bitmaps for MacOS, while continuing to use `wx.Toolbar`. Behavior on Windows and Linux is unchanged.

The are two concerns with this fix. First, if a user adds custom toggle tools they'll have to do the same workaround. Second, if a user toggles the pan or zoom tool programmatically it won't properly update the image. However, it was suggested that these were acceptable tradeoffs for not breaking backwards compatibility and preserving native display on Linux and Windows.

Here's the old behavior (zoom selected):
<img width="497" alt="mac_mpl_toolbar_old" src="https://user-images.githubusercontent.com/23534688/79581395-fbb76400-808f-11ea-8209-1c05d31099bc.png">

Here's the new behavior (zoom selected):
<img width="498" alt="mac_mpl_toolbar_new2" src="https://user-images.githubusercontent.com/23534688/79581366-f3f7bf80-808f-11ea-8197-3df9daf5d2af.png">

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
