### PR TITLE
Inline RGBAxes._config_axes to its only call site.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -115,20 +115,10 @@ class RGBAxes:
             kwargs["add_all"] = add_all  # only show deprecation in that case
         self.R, self.G, self.B = make_rgb_axes(
             ax, pad=pad, axes_class=axes_class, **kwargs)
-        self._config_axes()
-
-    def _config_axes(self, line_color='w', marker_edge_color='w'):
-        """
-        Set the line color and ticks for the axes.
-
-        Parameters
-        ----------
-        line_color : color
-        marker_edge_color : color
-        """
+        # Set the line color and ticks for the axes.
         for ax1 in [self.RGB, self.R, self.G, self.B]:
-            ax1.axis[:].line.set_color(line_color)
-            ax1.axis[:].major_ticks.set_markeredgecolor(marker_edge_color)
+            ax1.axis[:].line.set_color("w")
+            ax1.axis[:].major_ticks.set_markeredgecolor("w")
 
     @cbook.deprecated("3.3")
     def add_RGB_to_figure(self):


### PR DESCRIPTION
This is not called from anywhere else, and inlining avoids confusion
with other unrelated methods called _config_axes in other classes.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
