### PR TITLE
Further sync axes_grid colorbars with standard colorbars.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -515,3 +515,8 @@ experimental and may change in the future.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These are unused and can be easily reproduced by other date tools.
 `.get_epoch` will return Matplotlib's epoch.
+
+``axes_grid1.CbarAxes`` attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``cbid`` and ``locator`` attribute are deprecated.  Use
+``mappable.colorbar_cid`` and ``colorbar.locator``, as for standard colorbars.

--- a/lib/mpl_toolkits/axisartist/axes_grid.py
+++ b/lib/mpl_toolkits/axisartist/axes_grid.py
@@ -3,15 +3,7 @@ from .axislines import Axes
 
 
 class CbarAxes(axes_grid_orig.CbarAxesBase, Axes):
-    def __init__(self, *args, orientation, **kwargs):
-        self.orientation = orientation
-        self._default_label_on = False
-        self.locator = None
-        super().__init__(*args, **kwargs)
-
-    def cla(self):
-        super().cla()
-        self._config_axes()
+    pass
 
 
 class Grid(axes_grid_orig.Grid):


### PR DESCRIPTION
Remap the cbid and locator attributes to the ones of standard colorbars.
Move most functionality of CbarAxes to CbarAxesBase, leaving only the
multiple-inheritance part, so that axisartist.axes_grid.CbarAxes can
likewise just limit itself to multiple-inheritance.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
