### PR TITLE
Fix handling single contour level out of data range

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1161,7 +1161,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             inside = (self.levels > self.zmin) & (self.levels < self.zmax)
             levels_in = self.levels[inside]
             if len(levels_in) == 0:
-                self.levels = [self.zmin]
+                self.levels = [np.nan]
                 cbook._warn_external(
                     "No contour levels were found within the data range.")
 


### PR DESCRIPTION
## PR Summary

Previously, the behavior of ContourSet was special when a single contour
level was specified that was out of range of the given z array.

In that case, instead of the given value the minimum of the dataset was
contoured, instead. This is very unexpected, in my opinion.

This simple change simply makes no contour line at all, instead.

## PR Checklist
The change is so simple and small, I believe none of the entries in the checklist is really applicable. I tested, of course, that with `[np.nan]` in place `plt.contour()` still works. I am unsure, however, in what other places that change could have unintended side-effects, so I would be glad for some review.

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
