### PR TITLE
Inline some private helper methods in ColorbarBase + small refactors.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -221,7 +221,7 @@ docstring.interpd.update(colorbar_doc=colorbar_doc)
 
 def _set_ticks_on_axis_warn(*args, **kw):
     # a top level function which gets put in at the axes'
-    # set_xticks set_yticks by _patch_ax
+    # set_xticks and set_yticks by ColorbarBase.__init__.
     cbook._warn_external("Use the colorbar set_ticks() method instead.")
 
 
@@ -419,8 +419,12 @@ class ColorbarBase:
             ticklocation=ticklocation)
         cbook._check_in_list(
             ['uniform', 'proportional'], spacing=spacing)
+
         self.ax = ax
-        self._patch_ax()
+        # Bind some methods to the axes to warn users against using them.
+        ax.set_xticks = ax.set_yticks = _set_ticks_on_axis_warn
+        ax.set(frame_on=False, navigate=False)
+
         if cmap is None:
             cmap = cm.get_cmap()
         if norm is None:
@@ -487,12 +491,6 @@ class ColorbarBase:
         """Return whether the upper limit is open ended."""
         return self.extend in ('both', 'max')
 
-    def _patch_ax(self):
-        # bind some methods to the axes to warn users
-        # against using those methods.
-        self.ax.set_xticks = _set_ticks_on_axis_warn
-        self.ax.set_yticks = _set_ticks_on_axis_warn
-
     def draw_all(self):
         """
         Calculate any free parameters based on the current cmap and norm,
@@ -501,17 +499,23 @@ class ColorbarBase:
         # sets self._boundaries and self._values in real data units.
         # takes into account extend values:
         self._process_values()
-        # sets self.vmin and vmax in data units, but just for
-        # the part of the colorbar that is not part of the extend
-        # patch:
+        # sets self.vmin and vmax in data units, but just for the part of the
+        # colorbar that is not part of the extend patch:
         self._find_range()
-        # returns the X and Y mesh, *but* this was/is in normalized
-        # units:
+        # returns the X and Y mesh, *but* this was/is in normalized units:
         X, Y = self._mesh()
         C = self._values[:, np.newaxis]
-        # decide minor/major axis
-        self._config_axis()
-        self._config_axes(X, Y)
+
+        self._config_axis()  # Inline it after deprecation elapses.
+        # Configure axes limits, patch, and outline.
+        xy = self._outline(X, Y)
+        xmin, ymin = xy.min(axis=0)
+        xmax, ymax = xy.max(axis=0)
+        self.ax.set(xlim=(xmin, xmax), ylim=(ymin, ymax))
+        self.outline.set_xy(xy)
+        self.patch.set_xy(xy)
+        self.update_ticks()
+
         if self.filled:
             self._add_solids(X, Y, C)
 
@@ -520,9 +524,8 @@ class ColorbarBase:
         self._config_axis()
 
     def _config_axis(self):
-        """Configure the ticks, ticklabels and label of the underlying Axes."""
+        """Set up long and short axis."""
         ax = self.ax
-
         if self.orientation == 'vertical':
             long_axis, short_axis = ax.yaxis, ax.xaxis
             if mpl.rcParams['ytick.minor.visible']:
@@ -531,9 +534,8 @@ class ColorbarBase:
             long_axis, short_axis = ax.xaxis, ax.yaxis
             if mpl.rcParams['xtick.minor.visible']:
                 self.minorticks_on()
-
-        long_axis.set_label_position(self.ticklocation)
-        long_axis.set_ticks_position(self.ticklocation)
+        long_axis.set(label_position=self.ticklocation,
+                      ticks_position=self.ticklocation)
         short_axis.set_ticks([])
         short_axis.set_ticks([], minor=True)
         self._set_label()
@@ -716,20 +718,6 @@ class ColorbarBase:
         long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
 
         long_axis.set_minor_locator(ticker.NullLocator())
-
-    def _config_axes(self, X, Y):
-        """Create an axes patch and outline."""
-        ax = self.ax
-        ax.set_frame_on(False)
-        ax.set_navigate(False)
-        xy = self._outline(X, Y)
-        ax.ignore_existing_data_limits = True
-        ax.update_datalim(xy)
-        ax.set_xlim(*ax.dataLim.intervalx)
-        ax.set_ylim(*ax.dataLim.intervaly)
-        self.outline.set_xy(xy)
-        self.patch.set_xy(xy)
-        self.update_ticks()
 
     def _set_label(self):
         if self.orientation == 'vertical':


### PR DESCRIPTION
I think _patch_ax, _config_axis, and _config_axes are short enough that
inlining them improve readability by avoiding having to scroll through
to find the helper's implementation.

Also:
- Disable axes frame_on and navigability in the constructor -- no
  need to do it again and again when drawing.
- Instead of going through the datalim machinery to compute the colorbar
  axes limits, directly compute them from the patch/outline coordinates.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
