### PR TITLE
Update configuration of CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,18 +35,18 @@ commands:
 
   fonts-install:
     steps:
+      - restore_cache:
+          key: fonts-2
       - run:
           name: Install custom fonts
           command: |
             mkdir -p ~/.local/share/fonts
             wget -nc https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O ~/.local/share/fonts/Felipa-Regular.ttf || true
             fc-cache -f -v
-          save_cache:
-            key: fonts-2
-            paths:
-              - ~/.local/share/fonts/
-          restore_cache:
-            key: fonts-2
+      - save_cache:
+          key: fonts-2
+          paths:
+            - ~/.local/share/fonts/
 
   pip-install:
     description: Upgrade pip and setuptools and wheel to get as clean an install as possible

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,76 +4,95 @@
 version: 2.1
 
 
-###########################################
-# Define some common steps as YAML anchors.
+#######################################
+# Define some common steps as commands.
 #
 
-apt-run:  &apt-install
-  name: Install apt packages
-  command: |
-    sudo apt -qq update
-    sudo apt install -y \
-      inkscape \
-      ffmpeg \
-      dvipng \
-      lmodern \
-      cm-super \
-      texlive-latex-base \
-      texlive-latex-extra \
-      texlive-fonts-recommended \
-      texlive-latex-recommended \
-      texlive-pictures \
-      texlive-xetex \
-      graphviz \
-      fonts-crosextra-carlito \
-      fonts-freefont-otf \
-      fonts-humor-sans \
-      optipng
+commands:
+  apt-install:
+    steps:
+      - run:
+          name: Install apt packages
+          command: |
+            sudo apt -qq update
+            sudo apt install -y \
+              inkscape \
+              ffmpeg \
+              dvipng \
+              lmodern \
+              cm-super \
+              texlive-latex-base \
+              texlive-latex-extra \
+              texlive-fonts-recommended \
+              texlive-latex-recommended \
+              texlive-pictures \
+              texlive-xetex \
+              graphviz \
+              fonts-crosextra-carlito \
+              fonts-freefont-otf \
+              fonts-humor-sans \
+              optipng
 
-fonts-run:  &fonts-install
-  name: Install custom fonts
-  command: |
-    mkdir -p ~/.local/share/fonts
-    wget -nc https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O ~/.local/share/fonts/Felipa-Regular.ttf || true
-    fc-cache -f -v
-  save_cache:
-    key: fonts-2
-    paths:
-      - ~/.local/share/fonts/
-  restore_cache:
-    key: fonts-2
+  fonts-install:
+    steps:
+      - run:
+          name: Install custom fonts
+          command: |
+            mkdir -p ~/.local/share/fonts
+            wget -nc https://github.com/google/fonts/blob/master/ofl/felipa/Felipa-Regular.ttf?raw=true -O ~/.local/share/fonts/Felipa-Regular.ttf || true
+            fc-cache -f -v
+          save_cache:
+            key: fonts-2
+            paths:
+              - ~/.local/share/fonts/
+          restore_cache:
+            key: fonts-2
 
-pip-run:  &pip-install
-  # Upgrade pip and setuptools and wheel to get as clean an install as possible
-  name: Upgrade pip, setuptools, wheel
-  command: |
-    python -mpip install --upgrade --user pip
-    python -mpip install --upgrade --user wheel
-    python -mpip install --upgrade --user setuptools
+  pip-install:
+    description: Upgrade pip and setuptools and wheel to get as clean an install as possible
+    steps:
+      - run:
+          name: Upgrade pip, setuptools, wheel
+          command: |
+            python -mpip install --upgrade --user pip
+            python -mpip install --upgrade --user wheel
+            python -mpip install --upgrade --user setuptools
 
-deps-run: &deps-install
-  name: Install Python dependencies
-  command: |
-    python -mpip install --user numpy${NUMPY_VERSION} codecov coverage
-    python -mpip install --user -r requirements/doc/doc-requirements.txt
+  deps-install:
+    parameters:
+      numpy_version:
+        type: string
+        default: ""
+    steps:
+      - run:
+          name: Install Python dependencies
+          command: |
+            python -mpip install --user numpy<< parameters.numpy_version >> codecov coverage
+            python -mpip install --user -r requirements/doc/doc-requirements.txt
 
-mpl-run: &mpl-install
-  name: Install Matplotlib
-  command: python -mpip install --user -ve .
+  mpl-install:
+    steps:
+      - run:
+          name: Install Matplotlib
+          command: python -mpip install --user -ve .
 
-doc-run: &doc-build
-  name: Build documentation
-  command: |
-    # Set epoch to date of latest tag.
-    export SOURCE_DATE_EPOCH="$(git log -1 --format=%at $(git describe --abbrev=0))"
-    make html O=-T
-    rm -r build/html/_sources
-  working_directory: doc
+  doc-build:
+    steps:
+      - run:
+          name: Build documentation
+          command: |
+            # Set epoch to date of latest tag.
+            export SOURCE_DATE_EPOCH="$(git log -1 --format=%at $(git describe --abbrev=0))"
+            make html O=-T
+            rm -r build/html/_sources
+          working_directory: doc
 
-doc-bundle-run: &doc-bundle
-  name: Bundle sphinx-gallery documentation artifacts
-  command: tar cf doc/build/sphinx-gallery-files.tar.gz doc/api/_as_gen doc/gallery doc/tutorials
-  when: always
+  doc-bundle:
+    steps:
+      - run:
+          name: Bundle sphinx-gallery documentation artifacts
+          command: tar cf doc/build/sphinx-gallery-files.tar.gz doc/api/_as_gen doc/gallery doc/tutorials
+          when: always
 
 
 ##########################################
@@ -87,18 +106,16 @@ jobs:
     steps:
       - checkout
 
-      - run: *apt-install
-      - run: *fonts-install
-      - run: *pip-install
-      - run:
-           <<: *deps-install
-           environment:
-             NUMPY_VERSION: "==1.13.0"
-      - run: *mpl-install
+      - apt-install
+      - fonts-install
+      - pip-install
+      - deps-install:
+          numpy_version: "==1.13.0"
+      - mpl-install
 
-      - run: *doc-build
+      - doc-build
 
-      - run: *doc-bundle
+      - doc-bundle
       - store_artifacts:
           path: doc/build/sphinx-gallery-files.tar.gz
 
@@ -111,16 +128,16 @@ jobs:
     steps:
       - checkout
 
-      - run: *apt-install
-      - run: *fonts-install
-      - run: *pip-install
+      - apt-install
+      - fonts-install
+      - pip-install
 
-      - run: *deps-install
-      - run: *mpl-install
+      - deps-install
+      - mpl-install
 
-      - run: *doc-build
+      - doc-build
 
-      - run: *doc-bundle
+      - doc-bundle
       - store_artifacts:
           path: doc/build/sphinx-gallery-files.tar.gz
 
@@ -133,16 +150,16 @@ jobs:
     steps:
       - checkout
 
-      - run: *apt-install
-      - run: *fonts-install
-      - run: *pip-install
+      - apt-install
+      - fonts-install
+      - pip-install
 
-      - run: *deps-install
-      - run: *mpl-install
+      - deps-install
+      - mpl-install
 
-      - run: *doc-build
+      - doc-build
 
-      - run: *doc-bundle
+      - doc-bundle
       - store_artifacts:
           path: doc/build/sphinx-gallery-files.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,10 @@ commands:
 
   doc-build:
     steps:
+      - restore_cache:
+          keys:
+            - sphinx-env-v1-{{ .BuildNum }}-{{ .Environment.CIRCLE_JOB }}
+            - sphinx-env-v1-{{ .Environment.CIRCLE_PREVIOUS_BUILD_NUM }}-{{ .Environment.CIRCLE_JOB }}
       - run:
           name: Build documentation
           command: |
@@ -86,6 +90,10 @@ commands:
             make html O=-T
             rm -r build/html/_sources
           working_directory: doc
+      - save_cache:
+          key: sphinx-env-v1-{{ .BuildNum }}-{{ .Environment.CIRCLE_JOB }}
+          paths:
+            - doc/build/doctrees
 
   doc-bundle:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,8 @@ commands:
           name: Bundle sphinx-gallery documentation artifacts
           command: tar cf doc/build/sphinx-gallery-files.tar.gz doc/api/_as_gen doc/gallery doc/tutorials
           when: always
+      - store_artifacts:
+          path: doc/build/sphinx-gallery-files.tar.gz
 
 
 ##########################################
@@ -116,8 +118,6 @@ jobs:
       - doc-build
 
       - doc-bundle
-      - store_artifacts:
-          path: doc/build/sphinx-gallery-files.tar.gz
 
       - store_artifacts:
           path: doc/build/html
@@ -138,8 +138,6 @@ jobs:
       - doc-build
 
       - doc-bundle
-      - store_artifacts:
-          path: doc/build/sphinx-gallery-files.tar.gz
 
       - store_artifacts:
           path: doc/build/html
@@ -160,8 +158,6 @@ jobs:
       - doc-build
 
       - doc-bundle
-      - store_artifacts:
-          path: doc/build/sphinx-gallery-files.tar.gz
 
       - store_artifacts:
           path: doc/build/html


### PR DESCRIPTION
## PR Summary

I noticed that CircleCI didn't seem to be doing any caching. This was because `save_cache` and `restore_cache` were _on_ the `run` step, but really should have been separate steps.

Before doing that however, I re-wrote the config to use CircleCI's new re-usable command style (as opposed to using YAML anchors). Since this allows multiple steps in each named command, it allows removing some duplicated steps and putting the cache in the right place. Finally, I added a cache for Sphinx's doctrees. This is not intended to provide much speedup (it's about 30s out of 7m for me), but rather to hold on to the intersphinx mappings because we seem to fail to download them periodically.

These are in separate commits for _slightly_ easier review.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way