### PR TITLE
Backport PR #16958: MAINT: Replace uses of tostring with tobytes

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1394,7 +1394,7 @@ end"""
             streamarr['points'] = (flat_points - points_min) * factor
             streamarr['colors'] = flat_colors[:, :colordim] * 255.0
 
-            self.write(streamarr.tostring())
+            self.write(streamarr.tobytes())
             self.endStream()
         self.writeObject(self.gouraudObject, gouraudDict)
 
@@ -1487,7 +1487,7 @@ end"""
         if png:
             self._writePng(data)
         else:
-            self.currentstream.write(data.tostring())
+            self.currentstream.write(data.tobytes())
         self.endStream()
 
     def writeImages(self):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -694,7 +694,7 @@ grestore
         streamarr['points'] = (flat_points - points_min) * factor
         streamarr['colors'] = flat_colors[:, :3] * 255.0
 
-        stream = quote_ps_string(streamarr.tostring())
+        stream = quote_ps_string(streamarr.tobytes())
 
         self._pswriter.write(f"""\
 gsave

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -288,7 +288,7 @@ class RendererWx(RendererBase):
             w = self.width
             h = self.height
         rows, cols = im.shape[:2]
-        bitmap = wx.Bitmap.FromBufferRGBA(cols, rows, im.tostring())
+        bitmap = wx.Bitmap.FromBufferRGBA(cols, rows, im.tobytes())
         gc = self.get_gc()
         gc.select()
         gc.gfx_ctx.DrawBitmap(bitmap, int(l), int(self.height - b),


### PR DESCRIPTION
## PR Summary

Backport PR #16958: MAINT: Replace uses of tostring with tobytes
