### PR TITLE
Make all parameters of ColorbarBase, except `ax`, keyword-only.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -455,3 +455,8 @@ replaced by calls to ``draw_idle()`` on the corresponding canvas.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``add_checker`` and ``check_update`` methods and ``update_dict`` attribute
 of `.ScalarMappable` are deprecated.
+
+``ColorbarBase`` parameters will become keyword-only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+All parameters of ``ColorbarBase``, except for the first (*ax*), will become
+keyword-only, consistently with ``Colorbar``.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -394,6 +394,7 @@ class ColorbarBase:
 
     n_rasterize = 50  # rasterize solids if number of colors >= n_rasterize
 
+    @cbook._make_keyword_only("3.3", "cmap")
     def __init__(self, ax, cmap=None,
                  norm=None,
                  alpha=None,

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -226,7 +226,7 @@ def test_remove_from_figure(use_gridspec):
 def test_colorbarbase():
     # smoke test from #3805
     ax = plt.gca()
-    ColorbarBase(ax, plt.cm.bone)
+    ColorbarBase(ax, cmap=plt.cm.bone)
 
 
 @image_comparison(['colorbar_closed_patch'], remove_text=True)


### PR DESCRIPTION
This is consistent with Colorbar.  Moreover, this will make it possibly
to ultimately merge Colorbar into ColorbarBase -- currently, they only
differ by the fact that a ColorbarBase doesn't have an associated
ScalarMappable, but we can just construct an empty ScalarMappable in
that case (this is already what we document as recommended approach to
construct colorbars not attached to an artist --
`fig.colorbar(ScalarMappable(norm=..., cmap=...))`.  Right now this
merging is *nearly* possible except for the fact that the constructors'
signatures are a pain to combine.

---

An alternative strategy may be to just deprecate ColorbarBase and move it all into Colorbar, but I guess that would be more disruptive.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
