### PR TITLE
Small cleanups/simplifications/fixes to pie().

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -460,3 +460,8 @@ of `.ScalarMappable` are deprecated.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 All parameters of ``ColorbarBase``, except for the first (*ax*), will become
 keyword-only, consistently with ``Colorbar``.
+
+`.Axes.pie` radius and startangle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing ``None`` as either the ``radius`` or ``startangle`` of an `.Axes.pie`
+is deprecated; use the explicit defaults of 1 and 0, respectively, instead.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2648,8 +2648,8 @@ def phase_spectrum(
 def pie(
         x, explode=None, labels=None, colors=None, autopct=None,
         pctdistance=0.6, shadow=False, labeldistance=1.1,
-        startangle=None, radius=None, counterclock=True,
-        wedgeprops=None, textprops=None, center=(0, 0), frame=False,
+        startangle=0, radius=1, counterclock=True, wedgeprops=None,
+        textprops=None, center=(0, 0), frame=False,
         rotatelabels=False, *, data=None):
     return gca().pie(
         x, explode=explode, labels=labels, colors=colors,


### PR DESCRIPTION
- Change the default values of `startangle` and `radius` from "None" to
  the more explicit 0 and 1.
- Apply wedgeprops and textprops separately after the corresponding
  artist has already been instantiated.  This avoids conflicts in case
  e.g. `textprops` contains an "ha" entry (the dict merge won't notice
  that this needs to override "horizontalalignment", but applying the
  user-supplied properties in a second step will "just work".
- Misc. small cleanups.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
