### PR TITLE
Fix polar tests.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1061,7 +1061,7 @@ class PolarAxes(Axes):
 
         if thetamin is not None and thetamax is not None:
             if abs(thetamax - thetamin) > 2 * np.pi:
-                raise ValueError('The angle range must be<= 360 degrees')
+                raise ValueError('The angle range must be <= 360 degrees')
         return tuple(np.rad2deg(self.set_xlim(left=left, right=right,
                                               xmin=thetamin, xmax=thetamax)))
 

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from matplotlib import pyplot as plt
+
+
+def test_thetalim_valid_invalid():
+    ax = plt.subplot(projection='polar')
+    ax.set_thetalim(0, 2 * np.pi)  # doesn't raise.
+    ax.set_thetalim(thetamin=800, thetamax=440)  # doesn't raise.
+    with pytest.raises(ValueError, match='The angle range must be <= 2 pi'):
+        ax.set_thetalim(0, 3 * np.pi)
+    with pytest.raises(ValueError,
+                       match='The angle range must be <= 360 degrees'):
+        ax.set_thetalim(thetamin=800, thetamax=400)

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -173,26 +173,3 @@ def test_dont_mutate_kwargs():
                            gridspec_kw=gridspec_kw)
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
-
-
-def test_subplot_theta_min_max_raise():
-    with pytest.raises(ValueError, match='The angle range ' +
-                                         'must be<= 360 degrees'):
-        ax = plt.subplot(111, projection='polar')
-        ax.set_thetalim(thetamin=800, thetamax=400)
-
-
-def test_subplot_theta_min_max_non_raise():
-    ax = plt.subplot(111, projection='polar')
-    ax.set_thetalim(thetamin=800, thetamax=440)
-
-
-def test_subplot_theta_range_raise():
-    with pytest.raises(ValueError, match='The angle range must be <= 2 pi'):
-        ax = plt.subplot(111, projection='polar')
-        ax.set_thetalim(0, 3 * numpy.pi)
-
-
-def test_subplot_theta_range_normal_non_raise():
-    ax = plt.subplot(111, projection='polar')
-    ax.set_thetalim(0, 2 * numpy.pi)


### PR DESCRIPTION
The `numpy` import went away, breaking the tests.  Also move them out of
test_subplots.py given that they have nothing to do with subplots; we
could move them to test_axes.py but a new test_polar.py seems better (we
could also later move polar tests from test_axes to test_polar).  Also
some test refactoring and fix an error message.

Fix following https://github.com/matplotlib/matplotlib/pull/16717.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
