### PR TITLE
Implement set_history_buttons for Tk toolbar.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -620,6 +620,16 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         except Exception as e:
             tkinter.messagebox.showerror("Error saving file", str(e))
 
+    def set_history_buttons(self):
+        if self._nav_stack._pos > 0:
+            self._buttons['Back']['state'] = tk.NORMAL
+        else:
+            self._buttons['Back']['state'] = tk.DISABLED
+        if self._nav_stack._pos < len(self._nav_stack._elements) - 1:
+            self._buttons['Forward']['state'] = tk.NORMAL
+        else:
+            self._buttons['Forward']['state'] = tk.DISABLED
+
 
 class ToolTip:
     """


### PR DESCRIPTION
## PR Summary

This makes the backward/forward buttons change enabled state based on whether there are actually old/new views available.

This depends on #17111 because otherwise `self._buttons` is not initialized early enough.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way