### PR TITLE
Draw unfilled hist()s with the zorder of lines.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -181,3 +181,8 @@ wx Timer interval
 ~~~~~~~~~~~~~~~~~
 Setting the timer interval on a not-yet-started ``TimerWx`` won't start it
 anymore.
+
+"step"-type histograms default to the zorder of `.Line2D`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This ensures that they go above gridlines by default.  The old ``zorder`` can
+be kept by passing it as a keyword argument to `.Axes.hist`.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6769,7 +6769,8 @@ default: :rc:`scatter.edgecolors`
                     closed=True if fill else None,
                     facecolor=c,
                     edgecolor=None if fill else c,
-                    fill=fill if fill else None))
+                    fill=fill if fill else None,
+                    zorder=None if fill else mlines.Line2D.zorder))
             for patch_list in patches:
                 for patch in patch_list:
                     if orientation == 'vertical':

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1903,6 +1903,18 @@ def test_hist_with_empty_input(data, expected_number_of_hists):
         assert hists.shape[0] == expected_number_of_hists
 
 
+@pytest.mark.parametrize("histtype, zorder",
+                         [("bar", mpl.patches.Patch.zorder),
+                          ("step", mpl.lines.Line2D.zorder),
+                          ("stepfilled", mpl.patches.Patch.zorder)])
+def test_hist_zorder(histtype, zorder):
+    ax = plt.figure().add_subplot()
+    ax.hist([1, 2], histtype=histtype)
+    assert ax.patches
+    for patch in ax.patches:
+        assert patch.get_zorder() == zorder
+
+
 def contour_dat():
     x = np.linspace(-3, 5, 150)
     y = np.linspace(-3, 5, 120)


### PR DESCRIPTION
Unfilled hist()s (`histtype="step"`) are technically drawn as Patches
with `fill=False`, but they are effectively lines and should therefore
be drawn above gridlines (like Line2D), not below (like Patch).  Change
their default zorder accordingly.

```python
from pylab import *
np.random.seed(0)
hist(np.random.randint(10, size=20), bins=range(10), histtype="step")
grid()
```

before:
![old](https://user-images.githubusercontent.com/1322974/79911512-c492db00-8420-11ea-9750-287cacf4151b.png)
after:
![new](https://user-images.githubusercontent.com/1322974/79911507-c2308100-8420-11ea-8a2c-95100f87a7c4.png)


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
