### PR TITLE
FIX: bypass inverse in collection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -211,8 +211,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # we may have transform.contains_branch(transData) but not
             # transforms.get_affine().contains_branch(transData).  But later,
             # be careful to only apply the affine part that remains.
-        if not transOffset.is_affine:
-            offsets = transOffset.transform_non_affine(offsets)
 
         if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
@@ -226,7 +224,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 # also use this algorithm (like streamplot).
                 result = mpath.get_path_collection_extents(
                     transform.get_affine(), paths, self.get_transforms(),
-                    offsets, transOffset.get_affine().frozen())
+                    transOffset.transform_non_affine(offsets),
+                    transOffset.get_affine().frozen())
                 return result.transformed(transData.inverted())
             if not self._offsetsNone:
                 # this is for collections that have their paths (shapes)
@@ -234,11 +233,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 # (i.e. like scatter). We can't uniquely set limits based on
                 # those shapes, so we just set the limits based on their
                 # location.
-                if not (transOffset.is_affine and (transOffset == transData)):
-                    # Finish the transform started above, but only
-                    # if we have to (to save floating point precision)
-                    offsets = (transOffset.get_affine() +
-                               transData.inverted()).transform(offsets)
+
+                offsets = (transOffset - transData).transform(offsets)
+                # note A-B means A B^{-1}
                 offsets = np.ma.masked_invalid(offsets)
                 if not offsets.mask.all():
                     points = np.row_stack((offsets.min(axis=0),

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -234,9 +234,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 # (i.e. like scatter). We can't uniquely set limits based on
                 # those shapes, so we just set the limits based on their
                 # location.
-                # Finish the transform:
-                offsets = (transOffset.get_affine() +
-                           transData.inverted()).transform(offsets)
+                if not (transOffset.is_affine and (transOffset == transData)):
+                    # Finish the transform started above, but only
+                    # if we have to (to save floating point precision)
+                    offsets = (transOffset.get_affine() +
+                               transData.inverted()).transform(offsets)
                 offsets = np.ma.masked_invalid(offsets)
                 if not offsets.mask.all():
                     points = np.row_stack((offsets.min(axis=0),

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -630,3 +630,10 @@ def test_blended_collection_autolim():
     ax.add_collection(LineCollection(line_segs, transform=trans))
     ax.autoscale_view(scalex=True, scaley=False)
     np.testing.assert_allclose(ax.get_xlim(), [1., 4.])
+
+
+def test_singleton_autolim():
+    fig, ax = plt.subplots()
+    ax.scatter(0, 0)
+    np.testing.assert_allclose(ax.get_ylim(), [-0.06, 0.06])
+    np.testing.assert_allclose(ax.get_xlim(), [-0.06, 0.06])


### PR DESCRIPTION
## PR Summary

I think this fixes #17203.  If anyone has a dev environment where #17203 is triggered can you test this?  It bypasses transforming the offsets if the offset transform and the data transform are the same.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
