### PR TITLE
Deprecate support for running svg converter from path contaning newline.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -487,3 +487,7 @@ of all renderer classes is deprecated.
 
 `.transforms.AffineDeltaTransform` can be used as a replacement.  This API is
 experimental and may change in the future.
+
+``testing.compare.make_external_conversion_command``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -1,6 +1,5 @@
 """
-Provides a collection of utilities for comparing (image) results.
-
+Utilities for comparing image results.
 """
 
 import atexit
@@ -17,6 +16,7 @@ import numpy as np
 import PIL
 
 import matplotlib as mpl
+from matplotlib import cbook
 from matplotlib.testing.exceptions import ImageComparisonFailure
 
 __all__ = ['compare_images', 'comparable_formats']
@@ -55,6 +55,7 @@ def get_file_hash(path, block_size=2 ** 20):
     return md5.hexdigest()
 
 
+@cbook.deprecated("3.3")
 def make_external_conversion_command(cmd):
     def convert(old, new):
         cmdline = cmd(old, new)
@@ -194,6 +195,10 @@ class _SVGConverter(_Converter):
             # our encoding is even ASCII compatible...  Just fall back on the
             # slow solution (Inkscape uses `fgets` so it will always stop at a
             # newline).
+            cbook.warn_deprecated(
+                "3.3", message="Support for converting files from paths "
+                "containing a newline is deprecated since %(since)s and "
+                "support will be removed %(removal)s")
             return make_external_conversion_command(lambda old, new: [
                 'inkscape', '-z', old, '--export-png', new])(orig, dest)
         self._proc.stdin.write(orig_b + b" --export-png=" + dest_b + b"\n")


### PR DESCRIPTION
Inkscape's batch mode doesn't handle newlines(!) in file names, which
tbh doesn't seem to be a too big restriction in practice.  Right now we
fallback on a specific path to handle that case, but I doubt that it is
really hit, given that the batch ghostscript converter likely has the
same limitation (since #9454) and no one complained about it for two years.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
