### PR TITLE
Replace use of Bbox.bounds by appropriate properties.

### DIFF
--- a/examples/event_handling/viewlims.py
+++ b/examples/event_handling/viewlims.py
@@ -31,7 +31,7 @@ class MandelbrotDisplay:
         self.radius = radius
         self.power = power
 
-    def __call__(self, xstart, xend, ystart, yend):
+    def compute_image(self, xstart, xend, ystart, yend):
         self.x = np.linspace(xstart, xend, self.width)
         self.y = np.linspace(ystart, yend, self.height).reshape(-1, 1)
         c = self.x + 1.0j * self.y
@@ -46,25 +46,21 @@ class MandelbrotDisplay:
 
     def ax_update(self, ax):
         ax.set_autoscale_on(False)  # Otherwise, infinite loop
-
         # Get the number of points from the number of pixels in the window
-        dims = ax.patch.get_window_extent().bounds
-        self.width = int(dims[2] + 0.5)
-        self.height = int(dims[2] + 0.5)
-
+        self.width, self.height = \
+            np.round(ax.patch.get_window_extent().size).astype(int)
         # Get the range for the new area
-        xstart, ystart, xdelta, ydelta = ax.viewLim.bounds
-        xend = xstart + xdelta
-        yend = ystart + ydelta
-
+        vl = ax.viewLim
+        extent = vl.x0, vl.x1, vl.y0, vl.y1
         # Update the image object with our new data and extent
         im = ax.images[-1]
-        im.set_data(self.__call__(xstart, xend, ystart, yend))
-        im.set_extent((xstart, xend, ystart, yend))
+        im.set_data(self.compute_image(*extent))
+        im.set_extent(extent)
         ax.figure.canvas.draw_idle()
 
+
 md = MandelbrotDisplay()
-Z = md(-2., 0.5, -1.25, 1.25)
+Z = md.compute_image(-2., 0.5, -1.25, 1.25)
 
 fig1, (ax1, ax2) = plt.subplots(1, 2)
 ax1.imshow(Z, origin='lower',

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -167,7 +167,7 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
         if do_suptitle:
             bbox = invTransFig(
                 suptitle.get_window_extent(renderer=renderer))
-            height = bbox.y1 - bbox.y0
+            height = bbox.height
             if np.isfinite(height):
                 # reserve at top of figure include an h_pad above and below
                 suptitle._layoutbox.edit_height(height + h_pad * 2)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1642,8 +1642,7 @@ class _AxesBase(martist.Artist):
         xsize = max(abs(xmax - xmin), 1e-30)
         ysize = max(abs(ymax - ymin), 1e-30)
 
-        l, b, w, h = position.bounds
-        box_aspect = fig_aspect * (h / w)
+        box_aspect = fig_aspect * (position.height / position.width)
         data_ratio = box_aspect / aspect
 
         y_expander = data_ratio * xsize / ysize - 1

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -178,8 +178,7 @@ class FigureCanvasTk(FigureCanvasBase):
         super(FigureCanvasTk, self).__init__(figure)
         self._idle = True
         self._idle_callback = None
-        t1, t2, w, h = self.figure.bbox.bounds
-        w, h = int(w), int(h)
+        w, h = self.figure.bbox.size.astype(int)
         self._tkcanvas = tk.Canvas(
             master=master, background="white",
             width=w, height=h, borderwidth=0, highlightthickness=0)

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -385,7 +385,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             super().draw()
 
     def get_renderer(self, cleared=False):
-        l, b, w, h = self.figure.bbox.bounds
+        w, h = self.figure.bbox.size
         key = w, h, self.figure.dpi
         reuse_renderer = (hasattr(self, "renderer")
                           and getattr(self, "_lastKey", None) == key)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -312,9 +312,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
 
         clip = []
         if bbox is not None:
-            clipx, clipy, clipw, cliph = bbox.bounds
-            clip.append(
-                '%s clipbox' % _nums_to_str(clipw, cliph, clipx, clipy))
+            clip.append('%s clipbox' % _nums_to_str(*bbox.size, *bbox.p0))
         if clippath is not None:
             id = self._get_clip_path(clippath, clippath_trans)
             clip.append('%s' % id)
@@ -690,8 +688,8 @@ grestore
 
         cliprect = gc.get_clip_rectangle()
         if cliprect:
-            x, y, w, h = cliprect.bounds
-            write('%1.4g %1.4g %1.4g %1.4g clipbox\n' % (w, h, x, y))
+            write('%1.4g %1.4g %1.4g %1.4g clipbox\n'
+                  % (*cliprect.size, *cliprect.p0))
         clippath, clippath_trans = gc.get_clip_path()
         if clippath:
             id = self._get_clip_path(clippath, clippath_trans)
@@ -846,11 +844,10 @@ class FigureCanvasPS(FigureCanvasBase):
         xo = 72 * 0.5 * (paper_width - width)
         yo = 72 * 0.5 * (paper_height - height)
 
-        l, b, w, h = self.figure.bbox.bounds
         llx = xo
         lly = yo
-        urx = llx + w
-        ury = lly + h
+        urx = llx + self.figure.bbox.width
+        ury = lly + self.figure.bbox.height
         rotation = 0
         if orientation is _Orientation.landscape:
             llx, lly, urx, ury = lly, llx, ury, urx
@@ -1004,11 +1001,10 @@ class FigureCanvasPS(FigureCanvasBase):
         xo = 0
         yo = 0
 
-        l, b, w, h = self.figure.bbox.bounds
         llx = xo
         lly = yo
-        urx = llx + w
-        ury = lly + h
+        urx = llx + self.figure.bbox.width
+        ury = lly + self.figure.bbox.height
         bbox = (llx, lly, urx, ury)
 
         if dryrun:

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -206,11 +206,9 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             return buf.getvalue()
 
     def get_renderer(self, cleared=None):
-        # Mirrors super.get_renderer, but caches the old one
-        # so that we can do things such as produce a diff image
-        # in get_diff_image
-        _, _, w, h = self.figure.bbox.bounds
-        w, h = int(w), int(h)
+        # Mirrors super.get_renderer, but caches the old one so that we can do
+        # things such as produce a diff image in get_diff_image.
+        w, h = self.figure.bbox.size.astype(int)
         key = w, h, self.figure.dpi
         try:
             self._lastKey, self._renderer
@@ -316,13 +314,11 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         fig = self.figure
         # An attempt at approximating the figure size in pixels.
         fig.set_size_inches(x / fig.dpi, y / fig.dpi, forward=False)
-
-        _, _, w, h = self.figure.bbox.bounds
         # Acknowledge the resize, and force the viewer to update the
         # canvas size to the figure's new size (which is hopefully
         # identical or within a pixel or so).
         self._png_is_old = True
-        self.manager.resize(w, h)
+        self.manager.resize(*fig.bbox.size)
         self.resize_event()
 
     def handle_send_image_mode(self, event):
@@ -424,11 +420,8 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
     def add_web_socket(self, web_socket):
         assert hasattr(web_socket, 'send_binary')
         assert hasattr(web_socket, 'send_json')
-
         self.web_sockets.add(web_socket)
-
-        _, _, w, h = self.canvas.figure.bbox.bounds
-        self.resize(w, h)
+        self.resize(*self.canvas.figure.bbox.size)
         self._send_event('refresh')
 
     def remove_web_socket(self, web_socket):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -519,14 +519,9 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         """
 
         FigureCanvasBase.__init__(self, figure)
-        # Set preferred window size hint - helps the sizer (if one is
-        # connected)
-        l, b, w, h = figure.bbox.bounds
-        w = math.ceil(w)
-        h = math.ceil(h)
-
+        w, h = map(math.ceil, figure.bbox.size)
+        # Set preferred window size hint - helps the sizer, if one is connected
         wx.Panel.__init__(self, parent, id, size=wx.Size(w, h))
-
         # Create the drawing bitmap
         self.bitmap = wx.Bitmap(w, h)
         _log.debug("%s - __init__() - bitmap w:%d h:%d", type(self), w, h)
@@ -864,16 +859,11 @@ class FigureCanvasWx(_FigureCanvasWxBase):
     def _print_image(self, filename, filetype, *args, **kwargs):
         origBitmap = self.bitmap
 
-        l, b, width, height = self.figure.bbox.bounds
-        width = math.ceil(width)
-        height = math.ceil(height)
-
-        self.bitmap = wx.Bitmap(width, height)
-
+        self.bitmap = wx.Bitmap(math.ceil(self.figure.bbox.width),
+                                math.ceil(self.figure.bbox.height))
         renderer = RendererWx(self.bitmap, self.figure.dpi)
 
         gc = renderer.new_gc()
-
         self.figure.draw(renderer)
 
         # image is the object that we call SaveFile on.

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -39,12 +39,6 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
             self.gui_repaint()
             return
 
-        l, b, w, h = bbox.bounds
-        r = l + w
-        t = b + h
-        x = int(l)
-        y = int(self.bitmap.GetHeight() - t)
-
         srcBmp = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
         srcDC = wx.MemoryDC()
         srcDC.SelectObject(srcBmp)
@@ -52,7 +46,9 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
         destDC = wx.MemoryDC()
         destDC.SelectObject(self.bitmap)
 
-        destDC.Blit(x, y, int(w), int(h), srcDC, x, y)
+        x = int(bbox.x0)
+        y = int(self.bitmap.GetHeight() - bbox.y1)
+        destDC.Blit(x, y, int(bbox.width), int(bbox.height), srcDC, x, y)
 
         destDC.SelectObject(wx.NullBitmap)
         srcDC.SelectObject(wx.NullBitmap)
@@ -71,22 +67,18 @@ def _convert_agg_to_wx_bitmap(agg, bbox):
                                         agg.buffer_rgba())
     else:
         # agg => rgba buffer -> bitmap => clipped bitmap
-        l, b, width, height = bbox.bounds
-        r = l + width
-        t = b + height
-
         srcBmp = wx.Bitmap.FromBufferRGBA(int(agg.width), int(agg.height),
                                           agg.buffer_rgba())
         srcDC = wx.MemoryDC()
         srcDC.SelectObject(srcBmp)
 
-        destBmp = wx.Bitmap(int(width), int(height))
+        destBmp = wx.Bitmap(int(bbox.width), int(bbox.height))
         destDC = wx.MemoryDC()
         destDC.SelectObject(destBmp)
 
-        x = int(l)
-        y = int(int(agg.height) - t)
-        destDC.Blit(0, 0, int(width), int(height), srcDC, x, y)
+        x = int(bbox.x0)
+        y = int(int(agg.height) - bbox.y1)
+        destDC.Blit(0, 0, int(bbox.width), int(bbox.height), srcDC, x, y)
 
         srcDC.SelectObject(wx.NullBitmap)
         destDC.SelectObject(wx.NullBitmap)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1033,7 +1033,7 @@ class NonUniformImage(AxesImage):
                 B[:, :, 3] = 255
                 A = B
             self._is_grayscale = False
-        x0, y0, v_width, v_height = self.axes.viewLim.bounds
+        vl = self.axes.viewLim
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
         height = (round(t) + 0.5) - (round(b) - 0.5)
@@ -1041,7 +1041,7 @@ class NonUniformImage(AxesImage):
         height *= magnification
         im = _image.pcolor(self._Ax, self._Ay, A,
                            int(height), int(width),
-                           (x0, x0+v_width, y0, y0+v_height),
+                           (vl.x0, vl.x1, vl.y0, vl.y1),
                            _interpd_[self._interpolation])
         return im, l, b, IdentityTransform()
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1764,18 +1764,10 @@ def bbox_artist(artist, renderer, props=None, fill=True):
     pad = props.pop('pad', 4)
     pad = renderer.points_to_pixels(pad)
     bbox = artist.get_window_extent(renderer)
-    l, b, w, h = bbox.bounds
-    l -= pad / 2.
-    b -= pad / 2.
-    w += pad
-    h += pad
-    r = Rectangle(xy=(l, b),
-                  width=w,
-                  height=h,
-                  fill=fill,
-                  )
-    r.set_transform(transforms.IdentityTransform())
-    r.set_clip_on(False)
+    r = Rectangle(
+        xy=(bbox.x0 - pad / 2, bbox.y0 - pad / 2),
+        width=bbox.width + pad, height=bbox.height + pad,
+        fill=fill, transform=transforms.IdentityTransform(), clip_on=False)
     r.update(props)
     r.draw(renderer)
 
@@ -1786,17 +1778,10 @@ def draw_bbox(bbox, renderer, color='k', trans=None):
     box returned by an artist's `.Artist.get_window_extent`
     to test whether the artist is returning the correct bbox.
     """
-
-    l, b, w, h = bbox.bounds
-    r = Rectangle(xy=(l, b),
-                  width=w,
-                  height=h,
-                  edgecolor=color,
-                  fill=False,
-                  )
+    r = Rectangle(xy=(bbox.x0, bbox.y0), width=bbox.width, height=bbox.height,
+                  edgecolor=color, fill=False, clip_on=False)
     if trans is not None:
         r.set_transform(trans)
-    r.set_clip_on(False)
     r.draw(renderer)
 
 

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -96,15 +96,14 @@ class AnchoredSizeLocator(AnchoredLocatorBase):
         self.y_size = Size.from_any(y_size)
 
     def get_extent(self, renderer):
-        x, y, w, h = self.get_bbox_to_anchor().bounds
-
+        bbox = self.get_bbox_to_anchor()
         dpi = renderer.points_to_pixels(72.)
 
         r, a = self.x_size.get_size(renderer)
-        width = w * r + a * dpi
-
+        width = bbox.width * r + a * dpi
         r, a = self.y_size.get_size(renderer)
-        height = h * r + a * dpi
+        height = bbox.height * r + a * dpi
+
         xd, yd = 0, 0
 
         fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
@@ -120,21 +119,18 @@ class AnchoredZoomLocator(AnchoredLocatorBase):
                  bbox_transform=None):
         self.parent_axes = parent_axes
         self.zoom = zoom
-
         if bbox_to_anchor is None:
             bbox_to_anchor = parent_axes.bbox
-
         super().__init__(
             bbox_to_anchor, None, loc, borderpad=borderpad,
             bbox_transform=bbox_transform)
 
     def get_extent(self, renderer):
-        bb = TransformedBbox(self.axes.viewLim,
-                             self.parent_axes.transData)
-        x, y, w, h = bb.bounds
+        bb = TransformedBbox(self.axes.viewLim, self.parent_axes.transData)
         fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
         pad = self.pad * fontsize
-        return (abs(w * self.zoom) + 2 * pad, abs(h * self.zoom) + 2 * pad,
+        return (abs(bb.width * self.zoom) + 2 * pad,
+                abs(bb.height * self.zoom) + 2 * pad,
                 pad, pad)
 
 


### PR DESCRIPTION
It's much easier to just use `bbox.y1` instead of `x0, y0, w, h =
bbox.bounds; y0 + h`, for example.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
