### PR TITLE
Small cleanups.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -446,14 +446,12 @@ newpath
                 linewidths, linestyles, antialiaseds, urls,
                 offset_position)
 
-        write = self._pswriter.write
-
         path_codes = []
         for i, (path, transform) in enumerate(self._iter_collection_raw_paths(
                 master_transform, paths, all_transforms)):
             name = 'p%x_%x' % (self._path_collection_id, i)
             path_bytes = self._convert_path(path, transform, simplify=False)
-            write(f"""\
+            self._pswriter.write(f"""\
 /{name} {{
 newpath
 translate
@@ -510,10 +508,8 @@ grestore
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         # docstring inherited
 
-        # local to avoid repeated attribute lookups
-        write = self._pswriter.write
         if debugPS:
-            write("% text\n")
+            self._pswriter.write("% text\n")
 
         if _is_transparent(gc.get_rgb()):
             return  # Special handling for fully transparent.
@@ -941,10 +937,7 @@ class FigureCanvasPS(FigureCanvasBase):
                   file=fh)
 
             # write the figure
-            content = self._pswriter.getvalue()
-            if not isinstance(content, str):
-                content = content.decode('ascii')
-            print(content, file=fh)
+            print(self._pswriter.getvalue(), file=fh)
 
             # write the trailer
             print("end", file=fh)

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -1,8 +1,8 @@
 r"""
-`~matplotlib.mathtext` is a module for parsing a subset of the
-TeX math syntax and drawing them to a matplotlib backend.
+A module for parsing a subset of the TeX math syntax and rendering it to a
+Matplotlib backend.
 
-For a tutorial of its usage see :doc:`/tutorials/text/mathtext`.  This
+For a tutorial of its usage, see :doc:`/tutorials/text/mathtext`.  This
 document is primarily concerned with implementation details.
 
 The module uses pyparsing_ to parse the TeX expression.
@@ -231,8 +231,7 @@ class MathtextBackendPs(MathtextBackend):
     def render_glyph(self, ox, oy, info):
         oy = self.height - oy + info.offset
         postscript_name = info.postscript_name
-        fontsize        = info.fontsize
-        symbol_name     = info.symbol_name
+        fontsize = info.fontsize
 
         if (postscript_name, fontsize) != self.lastfont:
             self.lastfont = postscript_name, fontsize
@@ -243,7 +242,7 @@ class MathtextBackendPs(MathtextBackend):
 
         self.pswriter.write(
             f"{ox:f} {oy:f} moveto\n"
-            f"/{symbol_name} glyphshow\n")
+            f"/{info.symbol_name} glyphshow\n")
 
     def render_rect_filled(self, x1, y1, x2, y2):
         ps = "%f %f %f %f rectfill\n" % (


### PR DESCRIPTION
- Saving a couple of attribute lookups in backend_ps is unlikely to
  matter re: performance.
- _pswriter is a StringIO, not a BytesIO (and the whole module is
  writing strs to it...) so its value will always be a str, not bytes.
- Trivial cleanups to mathtext.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
