### PR TITLE
Add support for suptitle() in tight_layout().

### DIFF
--- a/doc/users/next_whats_new/2020-04-22-suptitle-tl.rst
+++ b/doc/users/next_whats_new/2020-04-22-suptitle-tl.rst
@@ -1,0 +1,2 @@
+tight_layout now supports suptitle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -308,3 +308,11 @@ def test_collapsed():
     # test that passing a rect doesn't crash...
     with pytest.warns(UserWarning):
         plt.tight_layout(rect=[0, 0, 0.8, 0.8])
+
+
+def test_suptitle():
+    fig, ax = plt.subplots(tight_layout=True)
+    st = fig.suptitle("foo")
+    t = ax.set_title("bar")
+    fig.canvas.draw()
+    assert st.get_window_extent().y0 > t.get_window_extent().y1

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -107,9 +107,15 @@ def auto_adjust_subplotpars(
     if not margin_top:
         margin_top = (max(vspaces[0, :].max(), 0)
                       + pad_inches / fig_height_inch)
+        suptitle = fig._suptitle
+        if suptitle and suptitle.get_in_layout():
+            rel_suptitle_height = fig.transFigure.inverted().transform_bbox(
+                suptitle.get_window_extent(renderer)).height
+            margin_top += rel_suptitle_height + pad_inches / fig_height_inch
     if not margin_bottom:
         margin_bottom = (max(vspaces[-1, :].max(), 0)
                          + pad_inches / fig_height_inch)
+
     if margin_left + margin_right >= 1:
         cbook._warn_external('Tight layout not applied. The left and right '
                              'margins cannot be made large enough to '


### PR DESCRIPTION
## PR Summary

The padding between the suptitle and the axes is the same as around all
axes, which is consistent with the behavior of constrained_layout.

~~Depends on #17205.~~

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
