### PR TITLE
Simplify Annotation and Text bbox drawing.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1507,19 +1507,13 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         inside, info = self._default_contains(mouseevent)
         if inside is not None:
             return inside, info
-
-        xy_pixel = self._get_position_xy(None)
-        if not self._check_xy(None, xy_pixel):
+        if not self._check_xy(None):
             return False, {}
-
-        t, tinfo = self.offsetbox.contains(mouseevent)
+        return self.offsetbox.contains(mouseevent)
         #if self.arrow_patch is not None:
         #    a, ainfo=self.arrow_patch.contains(event)
         #    t = t or a
-
         # self.arrow_patch is currently not checked as this can be a line - JJ
-
-        return t, tinfo
 
     def get_children(self):
         children = [self.offsetbox, self.patch]
@@ -1528,7 +1522,6 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         return children
 
     def set_figure(self, fig):
-
         if self.arrow_patch is not None:
             self.arrow_patch.set_figure(fig)
         self.offsetbox.set_figure(fig)
@@ -1623,23 +1616,15 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
 
     def draw(self, renderer):
         # docstring inherited
-
         if renderer is not None:
             self._renderer = renderer
-        if not self.get_visible():
+        if not self.get_visible() or not self._check_xy(renderer):
             return
-
-        xy_pixel = self._get_position_xy(renderer)
-        if not self._check_xy(renderer, xy_pixel):
-            return
-
         self.update_positions(renderer)
-
         if self.arrow_patch is not None:
             if self.arrow_patch.figure is None and self.figure is not None:
                 self.arrow_patch.figure = self.figure
             self.arrow_patch.draw(renderer)
-
         self.patch.draw(renderer)
         self.offsetbox.draw(renderer)
         self.stale = False


### PR DESCRIPTION
Currently Annotation.draw goes through _check_xy to check whether the
annotation should be drawn at all, and then through
_update_position_xytext to position itself.  In order to save a single
call to _get_position_xy, it first calls _get_position_xy itself and
then passes it down to the helper functions, making them harder to
follow.  Instead, just let _check_xy call _get_position_xy itself (and
even then, this is only needed for some values of annotation_clip), and
likewise for _update_position_xytext (which just becomes a call to
update_positions).

Also a small shortening of Text.update_bbox_position_size.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
