### PR TITLE
Remove Patch visibility tracking by Legend & OffsetBox.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -186,3 +186,9 @@ anymore.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This ensures that they go above gridlines by default.  The old ``zorder`` can
 be kept by passing it as a keyword argument to `.Axes.hist`.
+
+`.Legend` and `.OffsetBox` visibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.Legend` and `.OffsetBox` subclasses (`.PaddedBox`, `.AnchoredOffsetbox`, and
+`.AnnotationBbox`) no longer directly keep track of the visibility of their
+underlying `.Patch` artist, but instead pass that flag down to the `.Patch`.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -499,11 +499,10 @@ class Legend(Artist):
                       else "square,pad=0"),
             mutation_scale=self._fontsize,
             snap=True,
+            visible=(frameon if frameon is not None
+                     else mpl.rcParams["legend.frameon"])
         )
         self._set_artist_props(self.legendPatch)
-
-        self._drawFrame = (frameon if frameon is not None
-                           else mpl.rcParams["legend.frameon"])
 
         # init with null renderer
         self._init_legend_box(handles, labels, markerfirst)
@@ -580,17 +579,13 @@ class Legend(Artist):
         # update the location and size of the legend. This needs to
         # be done in any case to clip the figure right.
         bbox = self._legend_box.get_window_extent(renderer)
-        self.legendPatch.set_bounds(bbox.x0, bbox.y0,
-                                    bbox.width, bbox.height)
+        self.legendPatch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
         self.legendPatch.set_mutation_scale(fontsize)
 
-        if self._drawFrame:
-            if self.shadow:
-                shadow = Shadow(self.legendPatch, 2, -2)
-                shadow.draw(renderer)
+        if self.shadow:
+            Shadow(self.legendPatch, 2, -2).draw(renderer)
 
-            self.legendPatch.draw(renderer)
-
+        self.legendPatch.draw(renderer)
         self._legend_box.draw(renderer)
 
         renderer.close_group('legend')
@@ -895,7 +890,7 @@ class Legend(Artist):
 
     def get_frame_on(self):
         """Get whether the legend box patch is drawn."""
-        return self._drawFrame
+        return self.legendPatch.get_visible()
 
     def set_frame_on(self, b):
         """
@@ -905,7 +900,7 @@ class Legend(Artist):
         ----------
         b : bool
         """
-        self._drawFrame = b
+        self.legendPatch.set_visible(b)
         self.stale = True
 
     draw_frame = set_frame_on  # Backcompat alias.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -592,23 +592,18 @@ class PaddedBox(OffsetBox):
             Additional parameters passed to the contained `.FancyBboxPatch`.
         """
         super().__init__()
-
         self.pad = pad
         self._children = [child]
-
         self.patch = FancyBboxPatch(
             xy=(0.0, 0.0), width=1., height=1.,
             facecolor='w', edgecolor='k',
             mutation_scale=1,  # self.prop.get_size_in_points(),
-            snap=True
-            )
-
-        self.patch.set_boxstyle("square", pad=0)
-
+            snap=True,
+            visible=draw_frame,
+            boxstyle="square,pad=0",
+        )
         if patch_attrs is not None:
             self.patch.update(patch_attrs)
-
-        self._drawFrame = draw_frame
 
     def get_extent_offsets(self, renderer):
         # docstring inherited.
@@ -637,20 +632,15 @@ class PaddedBox(OffsetBox):
         self.stale = False
 
     def update_frame(self, bbox, fontsize=None):
-        self.patch.set_bounds(bbox.x0, bbox.y0,
-                              bbox.width, bbox.height)
-
+        self.patch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
         if fontsize:
             self.patch.set_mutation_scale(fontsize)
         self.stale = True
 
     def draw_frame(self, renderer):
         # update the location and size of the legend
-        bbox = self.get_window_extent(renderer)
-        self.update_frame(bbox)
-
-        if self._drawFrame:
-            self.patch.draw(renderer)
+        self.update_frame(self.get_window_extent(renderer))
+        self.patch.draw(renderer)
 
 
 class DrawingArea(OffsetBox):
@@ -1110,10 +1100,10 @@ class AnchoredOffsetbox(OffsetBox):
             xy=(0.0, 0.0), width=1., height=1.,
             facecolor='w', edgecolor='k',
             mutation_scale=self.prop.get_size_in_points(),
-            snap=True
-            )
-        self.patch.set_boxstyle("square", pad=0)
-        self._drawFrame = frameon
+            snap=True,
+            visible=frameon,
+            boxstyle="square,pad=0",
+        )
 
     def set_child(self, child):
         """Set the child to be anchored."""
@@ -1210,26 +1200,22 @@ class AnchoredOffsetbox(OffsetBox):
         self.set_offset(_offset)
 
     def update_frame(self, bbox, fontsize=None):
-        self.patch.set_bounds(bbox.x0, bbox.y0,
-                              bbox.width, bbox.height)
-
+        self.patch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
         if fontsize:
             self.patch.set_mutation_scale(fontsize)
 
     def draw(self, renderer):
         # docstring inherited
-
         if not self.get_visible():
             return
 
         fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
         self._update_offset_func(renderer, fontsize)
 
-        if self._drawFrame:
-            # update the location and size of the legend
-            bbox = self.get_window_extent(renderer)
-            self.update_frame(bbox, fontsize)
-            self.patch.draw(renderer)
+        # update the location and size of the legend
+        bbox = self.get_window_extent(renderer)
+        self.update_frame(bbox, fontsize)
+        self.patch.draw(renderer)
 
         width, height, xdescent, ydescent = self.get_extent(renderer)
 
@@ -1512,12 +1498,12 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             xy=(0.0, 0.0), width=1., height=1.,
             facecolor='w', edgecolor='k',
             mutation_scale=self.prop.get_size_in_points(),
-            snap=True
-            )
+            snap=True,
+            visible=frameon,
+        )
         self.patch.set_boxstyle("square", pad=pad)
         if bboxprops:
             self.patch.set(**bboxprops)
-        self._drawFrame = frameon
 
     @property
     def xyann(self):
@@ -1670,9 +1656,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
                 self.arrow_patch.figure = self.figure
             self.arrow_patch.draw(renderer)
 
-        if self._drawFrame:
-            self.patch.draw(renderer)
-
+        self.patch.draw(renderer)
         self.offsetbox.draw(renderer)
         self.stale = False
 


### PR DESCRIPTION
Instead of having a separate _drawFrame attribute on Legend/OffsetBox,
just set the visibility attribute on the underlying Patch.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
