### PR TITLE
Shorten and privatize qt's UiSubplotTool.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -184,6 +184,11 @@ variables is deprecated.  Additional fonts may be registered using
 ~~~~~~~~~~~~~~~~~~~~~
 This module is deprecated.
 
+``matplotlib.backends.qt_editor.formsubplottool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This module is deprecated.  Use ``matplotlib.backends.backend_qt5.SubplotToolQt``
+instead.
+
 AVConv animation writer deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``AVConvBase``, ``AVConvWriter`` and ``AVConvFileWriter`` classes, and the

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -14,7 +14,7 @@ from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     TimerBase, cursors, ToolContainerBase, StatusbarBase, MouseButton)
 import matplotlib.backends.qt_editor.figureoptions as figureoptions
-from matplotlib.backends.qt_editor.formsubplottool import UiSubplotTool
+from matplotlib.backends.qt_editor._formsubplottool import UiSubplotTool
 from . import qt_compat
 from .qt_compat import (
     QtCore, QtGui, QtWidgets, _isdeleted, is_pyqt5, __version__, QT_API)

--- a/lib/matplotlib/backends/qt_editor/_formsubplottool.py
+++ b/lib/matplotlib/backends/qt_editor/_formsubplottool.py
@@ -1,0 +1,40 @@
+from matplotlib.backends.qt_compat import QtWidgets
+
+
+class UiSubplotTool(QtWidgets.QDialog):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setObjectName("SubplotTool")
+        self._widgets = {}
+
+        main_layout = QtWidgets.QHBoxLayout()
+        self.setLayout(main_layout)
+
+        for group, spinboxes, buttons in [
+                ("Borders",
+                 ["top", "bottom", "left", "right"], ["Export values"]),
+                ("Spacings",
+                 ["hspace", "wspace"], ["Tight layout", "Reset", "Close"]),
+        ]:
+            layout = QtWidgets.QVBoxLayout()
+            main_layout.addLayout(layout)
+            box = QtWidgets.QGroupBox(group)
+            layout.addWidget(box)
+            inner = QtWidgets.QFormLayout(box)
+            for name in spinboxes:
+                self._widgets[name] = widget = QtWidgets.QDoubleSpinBox()
+                widget.setMinimum(0)
+                widget.setMaximum(1)
+                widget.setDecimals(3)
+                widget.setSingleStep(0.005)
+                widget.setKeyboardTracking(False)
+                inner.addRow(name, widget)
+            layout.addStretch(1)
+            for name in buttons:
+                self._widgets[name] = widget = QtWidgets.QPushButton(name)
+                # Don't trigger on <enter>, which is used to input values.
+                widget.setAutoDefault(False)
+                layout.addWidget(widget)
+
+        self._widgets["Close"].setFocus()

--- a/lib/matplotlib/backends/qt_editor/formsubplottool.py
+++ b/lib/matplotlib/backends/qt_editor/formsubplottool.py
@@ -1,56 +1,8 @@
-from matplotlib.backends.qt_compat import QtWidgets
+from matplotlib import cbook
+from ._formsubplottool import UiSubplotTool
 
 
-class UiSubplotTool(QtWidgets.QDialog):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.setObjectName("SubplotTool")
-        self._widgets = {}
-
-        layout = QtWidgets.QHBoxLayout()
-        self.setLayout(layout)
-
-        left = QtWidgets.QVBoxLayout()
-        layout.addLayout(left)
-        right = QtWidgets.QVBoxLayout()
-        layout.addLayout(right)
-
-        box = QtWidgets.QGroupBox("Borders")
-        left.addWidget(box)
-        inner = QtWidgets.QFormLayout(box)
-        for side in ["top", "bottom", "left", "right"]:
-            self._widgets[side] = widget = QtWidgets.QDoubleSpinBox()
-            widget.setMinimum(0)
-            widget.setMaximum(1)
-            widget.setDecimals(3)
-            widget.setSingleStep(.005)
-            widget.setKeyboardTracking(False)
-            inner.addRow(side, widget)
-        left.addStretch(1)
-
-        box = QtWidgets.QGroupBox("Spacings")
-        right.addWidget(box)
-        inner = QtWidgets.QFormLayout(box)
-        for side in ["hspace", "wspace"]:
-            self._widgets[side] = widget = QtWidgets.QDoubleSpinBox()
-            widget.setMinimum(0)
-            widget.setMaximum(1)
-            widget.setDecimals(3)
-            widget.setSingleStep(.005)
-            widget.setKeyboardTracking(False)
-            inner.addRow(side, widget)
-        right.addStretch(1)
-
-        widget = QtWidgets.QPushButton("Export values")
-        self._widgets["Export values"] = widget
-        # Don't trigger on <enter>, which is used to input values.
-        widget.setAutoDefault(False)
-        left.addWidget(widget)
-
-        for action in ["Tight layout", "Reset", "Close"]:
-            self._widgets[action] = widget = QtWidgets.QPushButton(action)
-            widget.setAutoDefault(False)
-            right.addWidget(widget)
-
-        self._widgets["Close"].setFocus()
+cbook.warn_deprecated(
+    "3.3", obj_type="module", name=__name__,
+    alternative="matplotlib.backends.backend_qt5.SubplotToolQt")
+__all__ = ["UiSubplotTool"]


### PR DESCRIPTION
- Loop over the left and right groups to avoid some repetition.
- Move towards making UiSubplotTool and its module private -- the public
  API is SubplotToolQt; just having an UI with no connected slots is not
  useful.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
