### PR TITLE
More axisartist cleanups

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -362,10 +362,10 @@ class AxisLabel(AttributeCopier, LabelBase):
 
     def __init__(self, *args, axis_direction="bottom", axis=None, **kwargs):
         self._axis = axis
-        LabelBase.__init__(self, *args, **kwargs)
-        self.set_axis_direction(axis_direction)
         self._pad = 5
         self._extra_pad = 0
+        LabelBase.__init__(self, *args, **kwargs)
+        self.set_axis_direction(axis_direction)
 
     def set_pad(self, pad):
         """
@@ -728,17 +728,15 @@ class AxisArtist(martist.Artist):
             + self.axes.figure.dpi_scale_trans)
 
         if axis_direction in ["left", "right"]:
-            axis_name = "ytick"
             self.axis = axes.yaxis
         else:
-            axis_name = "xtick"
             self.axis = axes.xaxis
 
         self._axisline_style = None
         self._axis_direction = axis_direction
 
         self._init_line()
-        self._init_ticks(axis_name, **kwargs)
+        self._init_ticks(**kwargs)
         self._init_offsetText(axis_direction)
         self._init_label()
 
@@ -899,46 +897,40 @@ class AxisArtist(martist.Artist):
             self.line.set_line_mutation_scale(self.major_ticklabels.get_size())
         self.line.draw(renderer)
 
-    def _init_ticks(self, axis_name, **kwargs):
+    def _init_ticks(self, **kwargs):
+        axis_name = self.axis.axis_name
 
         trans = (self._axis_artist_helper.get_tick_transform(self.axes)
                  + self.offset_transform)
 
-        major_tick_size = kwargs.get("major_tick_size",
-                                     rcParams[f'{axis_name}.major.size'])
-        major_tick_pad = kwargs.get("major_tick_pad",
-                                    rcParams[f'{axis_name}.major.pad'])
-        minor_tick_size = kwargs.get("minor_tick_size",
-                                     rcParams[f'{axis_name}.minor.size'])
-        minor_tick_pad = kwargs.get("minor_tick_pad",
-                                    rcParams[f'{axis_name}.minor.pad'])
+        self.major_ticks = Ticks(
+            kwargs.get(
+                "major_tick_size", rcParams[f"{axis_name}tick.major.size"]),
+            axis=self.axis, transform=trans)
+        self.minor_ticks = Ticks(
+            kwargs.get(
+                "minor_tick_size", rcParams[f"{axis_name}tick.minor.size"]),
+            axis=self.axis, transform=trans)
 
-        self.major_ticks = Ticks(major_tick_size,
-                                 axis=self.axis,
-                                 transform=trans)
-        self.minor_ticks = Ticks(minor_tick_size,
-                                 axis=self.axis,
-                                 transform=trans)
-
-        if axis_name == "xaxis":
-            size = rcParams['xtick.labelsize']
-        else:
-            size = rcParams['ytick.labelsize']
-
-        self.major_ticklabels = TickLabels(size=size, axis=self.axis,
-                                           axis_direction=self._axis_direction)
-        self.minor_ticklabels = TickLabels(size=size, axis=self.axis,
-                                           axis_direction=self._axis_direction)
-
-        self.major_ticklabels.set(figure=self.axes.figure,
-                                  transform=trans,
-                                  fontsize=size)
-        self.major_ticklabels.set_pad(major_tick_pad)
-
-        self.minor_ticklabels.set(figure=self.axes.figure,
-                                  transform=trans,
-                                  fontsize=size)
-        self.minor_ticklabels.set_pad(minor_tick_pad)
+        size = rcParams[f"{axis_name}tick.labelsize"]
+        self.major_ticklabels = TickLabels(
+            axis=self.axis,
+            axis_direction=self._axis_direction,
+            figure=self.axes.figure,
+            transform=trans,
+            fontsize=size,
+            pad=kwargs.get(
+                "major_tick_pad", rcParams[f"{axis_name}tick.major.pad"]),
+        )
+        self.minor_ticklabels = TickLabels(
+            axis=self.axis,
+            axis_direction=self._axis_direction,
+            figure=self.axes.figure,
+            transform=trans,
+            fontsize=size,
+            pad=kwargs.get(
+                "minor_tick_pad", rcParams[f"{axis_name}tick.minor.pad"]),
+        )
 
     def _get_tick_info(self, tick_iter):
         """

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -691,7 +691,7 @@ class AxisArtist(martist.Artist):
     is constant) line, ticks, ticklabels, and axis label.
     """
 
-    ZORDER = 2.5
+    zorder = ZORDER = 2.5  # ZORDER is a backcompat alias.
 
     @property
     def LABELPAD(self):
@@ -740,12 +740,7 @@ class AxisArtist(martist.Artist):
         self._init_offsetText(axis_direction)
         self._init_label()
 
-        self.set_zorder(self.ZORDER)
-
-        self._rotate_label_along_line = False
-
         # axis direction
-        self._tick_add_angle = 180.
         self._ticklabel_add_angle = 0.
         self._axislabel_add_angle = 0.
         self.set_axis_direction(axis_direction)

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -361,9 +361,6 @@ class GridHelperCurveLinear(GridHelperBase):
         # axisline.major_ticklabels.set_visible(True)
         # axisline.minor_ticklabels.set_visible(False)
 
-        # axisline.major_ticklabels.set_rotate_along_line(True)
-        # axisline.set_rotate_label_along_line(True)
-
         return axisline
 
     def _update_grid(self, x1, y1, x2, y2):


### PR DESCRIPTION
## PR Summary

1) Cleanup AxisArtist._init_ticks.

- Directly get the axis_name from the underlying Axis object, which
  makes the name "x" or "y".  This caught a bug where there was an
  invalid check `if axis_name == "xaxis"` which should have been (in
  the old code) `== "xtick"`, causing x labels to also use the y
  labelsize.
- Don't pass size to TickLabels twice (as `size` and as `fontsize`,
  which are aliases of one another); pass all properties to TickLabels
  at once.  To do so, fix a bug in AxisLabel where a `pad` passed as
  kwargs would get overwritten by the constructor.

2) Delete some unused attributes.  Use normal zorder defaulting.
    
(i.e., just set the default zorder as a class attribute, like for all
other artists.)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
