### PR TITLE
Add the "contour.linewidths" configuration option

### DIFF
--- a/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidth.rst
+++ b/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidth.rst
@@ -1,7 +1,7 @@
-Add :rc:`contour.linewidths` to rcParams
-----------------------------------------
+Add :rc:`contour.linewidth` to rcParams
+---------------------------------------
 
-The new config option :rc:`contour.linewidths` allows to control the default
+The new config option :rc:`contour.linewidth` allows to control the default
 linewidth of contours as a float. When set to ``None``, the linewidths fall
 back to :rc:`lines.linewidth`. The config value is overidden as usual
 by the ``linewidths`` argument passed to `~.axes.Axes.contour` when

--- a/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidths.rst
+++ b/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidths.rst
@@ -1,7 +1,7 @@
 Add :rc:`contour.linewidths` to rcParams
 ----------------------------------------
 
-The new config option :rc:`contour.linewidth` allows to control the default
+The new config option :rc:`contour.linewidths` allows to control the default
 linewidth of contours as a float. When set to ``None``, the linewidths fall
 back to :rc:`lines.linewidth`. The config value is overidden as usual
 by the ``linewidths`` argument passed to `~.axes.Axes.contour` when

--- a/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidths.rst
+++ b/doc/users/next_whats_new/2020-05-04-add-rcparams-contour-linewidths.rst
@@ -1,0 +1,9 @@
+Add :rc:`contour.linewidths` to rcParams
+----------------------------------------
+
+The new config option :rc:`contour.linewidth` allows to control the default
+linewidth of contours as a float. When set to ``None``, the linewidths fall
+back to :rc:`lines.linewidth`. The config value is overidden as usual
+by the ``linewidths`` argument passed to `~.axes.Axes.contour` when
+it is not set to ``None``.
+

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1752,7 +1752,7 @@ class QuadContourSet(ContourSet):
             however introduce rendering artifacts at chunk boundaries depending
             on the backend, the *antialiased* flag and value of *alpha*.
 
-        linewidths : float or sequence of float, default: :rc:`contour.linewidths`
+        linewidths : float or array-like, default: :rc:`contour.linewidths`
             *Only applies to* `.contour`.
 
             The line width of the contour lines.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1257,7 +1257,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         linewidths = self.linewidths
         Nlev = len(self.levels)
         if linewidths is None:
-            default_linewidth = mpl.rcParams['contour.linewidths']
+            default_linewidth = mpl.rcParams['contour.linewidth']
             if default_linewidth is None:
                 default_linewidth = mpl.rcParams['lines.linewidth']
             tlinewidths = [(default_linewidth,)] * Nlev
@@ -1752,7 +1752,7 @@ class QuadContourSet(ContourSet):
             however introduce rendering artifacts at chunk boundaries depending
             on the backend, the *antialiased* flag and value of *alpha*.
 
-        linewidths : float or array-like, default: :rc:`contour.linewidths`
+        linewidths : float or array-like, default: :rc:`contour.linewidth`
             *Only applies to* `.contour`.
 
             The line width of the contour lines.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1752,7 +1752,7 @@ class QuadContourSet(ContourSet):
             however introduce rendering artifacts at chunk boundaries depending
             on the backend, the *antialiased* flag and value of *alpha*.
 
-        linewidths : float or sequence of float
+        linewidths : float or sequence of float, default: :rc:`contour.linewidths`
             *Only applies to* `.contour`.
 
             The line width of the contour lines.
@@ -1762,8 +1762,7 @@ class QuadContourSet(ContourSet):
             If a sequence, the levels in ascending order will be plotted with
             the linewidths in the order specified.
 
-            Defaults to :rc:`contour.linewidths`. If this value is None,
-            it falls back to :rc:`lines.linewidth`.
+            If None, this falls back to :rc:`lines.linewidth`.
 
         linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, optional
             *Only applies to* `.contour`.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1257,7 +1257,10 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         linewidths = self.linewidths
         Nlev = len(self.levels)
         if linewidths is None:
-            tlinewidths = [(mpl.rcParams['lines.linewidth'],)] * Nlev
+            default_linewidth = mpl.rcParams['contour.linewidths']
+            if default_linewidth is None:
+                default_linewidth = mpl.rcParams['lines.linewidth']
+            tlinewidths = [(default_linewidth,)] * Nlev
         else:
             if not np.iterable(linewidths):
                 linewidths = [linewidths] * Nlev
@@ -1749,7 +1752,7 @@ class QuadContourSet(ContourSet):
             however introduce rendering artifacts at chunk boundaries depending
             on the backend, the *antialiased* flag and value of *alpha*.
 
-        linewidths : float or sequence of float, default: :rc:`lines.linewidth`
+        linewidths : float or sequence of float
             *Only applies to* `.contour`.
 
             The line width of the contour lines.
@@ -1758,6 +1761,9 @@ class QuadContourSet(ContourSet):
 
             If a sequence, the levels in ascending order will be plotted with
             the linewidths in the order specified.
+
+            Defaults to :rc:`contour.linewidths`. If this value is None,
+            it falls back to :rc:`lines.linewidth`.
 
         linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, optional
             *Only applies to* `.contour`.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1195,7 +1195,7 @@ defaultParams = {
     # contour props
     'contour.negative_linestyle': ['dashed', _validate_linestyle],
     'contour.corner_mask':        [True, validate_bool],
-    'contour.linewidths':        [None, validate_float_or_None],
+    'contour.linewidth':          [None, validate_float_or_None],
 
     # errorbar props
     'errorbar.capsize':      [0, validate_float],

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1195,6 +1195,7 @@ defaultParams = {
     # contour props
     'contour.negative_linestyle': ['dashed', _validate_linestyle],
     'contour.corner_mask':        [True, validate_bool],
+    'contour.linewidths':        [None, validate_float_or_None],
 
     # errorbar props
     'errorbar.capsize':      [0, validate_float],

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -377,15 +377,18 @@ def test_contour_uneven():
     fig.colorbar(cs, ax=ax, spacing='uniform')
 
 
-@pytest.mark.parametrize("rcll, rccl, fcl, expected", [
-    (1.23, None, None, 1.23),
-    (1.23, 4.24, None, 4.24),
-    (1.23, 4.24, 5.02, 5.02)
-])
-def test_contour_linewidths(rcll, rccl, fcl, expected):
+@pytest.mark.parametrize(
+    "rc_lines_linewidth, rc_contour_linewidths, call_linewidths, expected", [
+        (1.23, None, None, 1.23),
+        (1.23, 4.24, None, 4.24),
+        (1.23, 4.24, 5.02, 5.02)
+        ])
+def test_contour_linewidths(
+        rc_lines_linewidth, rc_contour_linewidths, call_linewidths, expected):
 
-    with rc_context(rc={"lines.linewidth": rcll, "contour.linewidths": rccl}):
+    with rc_context(rc={"lines.linewidth": rc_lines_linewidth,
+                        "contour.linewidths": rc_contour_linewidths}):
         fig, ax = plt.subplots()
         X = np.arange(4*3).reshape(4, 3)
-        cs = ax.contour(X, linewidths=fcl)
+        cs = ax.contour(X, linewidths=call_linewidths)
         assert cs.tlinewidths[0][0] == expected

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -5,7 +5,7 @@ import numpy as np
 from numpy.testing import assert_array_almost_equal
 import matplotlib as mpl
 from matplotlib.testing.decorators import image_comparison
-from matplotlib import pyplot as plt
+from matplotlib import pyplot as plt, rc_context
 from matplotlib.colors import LogNorm
 import pytest
 
@@ -375,3 +375,17 @@ def test_contour_uneven():
     ax = axs[1]
     cs = ax.contourf(z, levels=[2, 4, 6, 10, 20])
     fig.colorbar(cs, ax=ax, spacing='uniform')
+
+
+@pytest.mark.parametrize("rcll, rccl, fcl, expected", [
+    (1.23, None, None, 1.23),
+    (1.23, 4.24, None, 4.24),
+    (1.23, 4.24, 5.02, 5.02)
+])
+def test_contour_linewidths(rcll, rccl, fcl, expected):
+
+    with rc_context(rc={"lines.linewidth": rcll, "contour.linewidths": rccl}):
+        fig, ax = plt.subplots()
+        X = np.arange(4*3).reshape(4, 3)
+        cs = ax.contour(X, linewidths=fcl)
+        assert cs.tlinewidths[0][0] == expected

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -378,16 +378,16 @@ def test_contour_uneven():
 
 
 @pytest.mark.parametrize(
-    "rc_lines_linewidth, rc_contour_linewidths, call_linewidths, expected", [
+    "rc_lines_linewidth, rc_contour_linewidth, call_linewidths, expected", [
         (1.23, None, None, 1.23),
         (1.23, 4.24, None, 4.24),
         (1.23, 4.24, 5.02, 5.02)
         ])
-def test_contour_linewidths(
-        rc_lines_linewidth, rc_contour_linewidths, call_linewidths, expected):
+def test_contour_linewidth(
+        rc_lines_linewidth, rc_contour_linewidth, call_linewidths, expected):
 
     with rc_context(rc={"lines.linewidth": rc_lines_linewidth,
-                        "contour.linewidths": rc_contour_linewidths}):
+                        "contour.linewidth": rc_contour_linewidth}):
         fig, ax = plt.subplots()
         X = np.arange(4*3).reshape(4, 3)
         cs = ax.contour(X, linewidths=call_linewidths)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -352,7 +352,7 @@
 #axes.titleweight:   normal  # font weight of title
 #axes.titlecolor:    auto    # color of the axes title, auto falls back to
                              # text.color as default value
-#axes.titley:        None    # position title (axes relative units).  None implies auto 
+#axes.titley:        None    # position title (axes relative units).  None implies auto
 #axes.titlepad:      6.0     # pad between axes and title in points
 #axes.labelsize:     medium  # fontsize of the x any y labels
 #axes.labelpad:      4.0     # space between label and axis
@@ -574,6 +574,9 @@
 ## ***************************************************************************
 #contour.negative_linestyle: dashed  # string or on-off ink sequence
 #contour.corner_mask:        True    # {True, False, legacy}
+#contour.linewidths :        None    # {float, None} Size of the contour
+                                     # linewidths. If set to None,
+                                     # it falls back to `line.linewidth`.
 
 
 ## ***************************************************************************

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -574,7 +574,7 @@
 ## ***************************************************************************
 #contour.negative_linestyle: dashed  # string or on-off ink sequence
 #contour.corner_mask:        True    # {True, False, legacy}
-#contour.linewidths :        None    # {float, None} Size of the contour
+#contour.linewidth:          None    # {float, None} Size of the contour
                                      # linewidths. If set to None,
                                      # it falls back to `line.linewidth`.
 


### PR DESCRIPTION
## PR Summary

Contours plots are often more beautiful when line widths are smaller
than line widths that are generally used for curves.
This is especially true when ``contour`` is used with ``contourf``, or when
the number of levels if high.

With this PR, one can change default value for contour linewidths independently from normal line widths. The new options is ``"contour.linewidths"``, which defaults to ``None``.  When value is ``None``, it falls back to  ``"lines.linewidth"`` like before.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

