### PR TITLE
Remove deprecations that expire in 3.3

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -192,3 +192,11 @@ be kept by passing it as a keyword argument to `.Axes.hist`.
 `.Legend` and `.OffsetBox` subclasses (`.PaddedBox`, `.AnchoredOffsetbox`, and
 `.AnnotationBbox`) no longer directly keep track of the visibility of their
 underlying `.Patch` artist, but instead pass that flag down to the `.Patch`.
+
+`.Legend` and `.Table` no longer allow invalid locations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This affects legends produced on an Axes (`.Axes.legend` and `.pyplot.legend`)
+and on a Figure (`.Figure.legend` and `.pyplot.figlegend`).  Figure legends also
+no longer accept the unsupported ``'best'`` location.  Previously, invalid Axes
+locations would use ``'best'`` and invalid Figure locations would used ``'upper
+right'``.

--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -200,3 +200,11 @@ and on a Figure (`.Figure.legend` and `.pyplot.figlegend`).  Figure legends also
 no longer accept the unsupported ``'best'`` location.  Previously, invalid Axes
 locations would use ``'best'`` and invalid Figure locations would used ``'upper
 right'``.
+
+
+Passing Line2D's *drawstyle* together with *linestyle* is removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Instead of ``plt.plot(..., linestyle="steps--")``, use ``plt.plot(...,
+linestyle="--", drawstyle="steps")``. ``ds`` is also an alias for
+``drawstyle``.

--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -208,3 +208,9 @@ Passing Line2D's *drawstyle* together with *linestyle* is removed
 Instead of ``plt.plot(..., linestyle="steps--")``, use ``plt.plot(...,
 linestyle="--", drawstyle="steps")``. ``ds`` is also an alias for
 ``drawstyle``.
+
+Upper case color strings
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Support for passing single-letter colors (one of "rgbcmykw") as UPPERCASE
+characters is removed; these colors are now case-sensitive (lowercase).

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -13,6 +13,8 @@ Classes, methods and attributes
 
 - ``axis.Axis.iter_ticks`` (no replacement)
 
+- Support for custom backends that do not provide a
+  ``backend_bases.GraphicsContextBase.set_hatch_color`` method
 - ``backend_bases.RendererBase.strip_math()``
   (use ``cbook.strip_math()`` instead)
 

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -195,6 +195,10 @@ Arguments
   other than ``ticklabels``.
 - ``mpl_toolkits.mplot3d.art3d.Poly3DCollection.set_zsort`` does not accept
   the value ``True`` anymore. Pass the equivalent value 'average' instead.
+- `~.ConnectionPatch` no longer accepts the ``arrow_transmuter`` and
+  ``connector`` keyword arguments, which did nothing since 3.0.
+- `~.FancyArrowPatch` no longer accepts the ``arrow_transmuter`` and
+  ``connector`` keyword arguments, which did nothing since 3.0.
 
 rcParams
 ~~~~~~~~

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -176,7 +176,8 @@ Arguments
 - The unused parameter ``interp_at_native`` of `.BboxImage` has been removed.
 - The parameter ``usetex`` of `.TextToPath.get_text_path` has been removed.
   Use ``ismath='TeX'`` instead.
-- The parameter ``block`` of ``show()`` is now keyword-only.
+- The parameter ``block`` of ``show()`` is now keyword-only, and arbitrary
+  arguments or keyword arguments are no longer accepted.
 - The parameter ``frameon`` of `.Figure.savefig` has been removed.  Use
   ``facecolor="none"`` to get a transparent background.
 - Passing a ``wx.EvtHandler`` as the first argument to ``backend_wx.TimerWx``
@@ -195,10 +196,14 @@ Arguments
   other than ``ticklabels``.
 - ``mpl_toolkits.mplot3d.art3d.Poly3DCollection.set_zsort`` does not accept
   the value ``True`` anymore. Pass the equivalent value 'average' instead.
-- `~.ConnectionPatch` no longer accepts the ``arrow_transmuter`` and
+- `.AnchoredText` no longer accepts ``horizontalalignment`` or
+  ``verticalalignment`` keyword arguments.
+- `.ConnectionPatch` no longer accepts the ``arrow_transmuter`` and
   ``connector`` keyword arguments, which did nothing since 3.0.
-- `~.FancyArrowPatch` no longer accepts the ``arrow_transmuter`` and
+- `.FancyArrowPatch` no longer accepts the ``arrow_transmuter`` and
   ``connector`` keyword arguments, which did nothing since 3.0.
+- `.TextPath` no longer accepts arbitrary positional or keyword arguments.
+- `.MaxNLocator.set_params()` no longer accepts arbitrary keyword arguments.
 
 rcParams
 ~~~~~~~~

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -87,6 +87,8 @@ Classes, methods and attributes
 
 - ``path.get_paths_extents()``
   (use ``path.get_path_collection_extents()`` instead)
+- ``path.Path.has_nonfinite()`` (use ``not np.isfinite(self.vertices).all()``
+  instead)
 
 - ``projections.process_projection_requirements()`` (no replacement)
 
@@ -111,6 +113,7 @@ Classes, methods and attributes
 - ``scale.InvertedLog2Transform`` (use ``scale.InvertedLogTransform`` instead)
 - ``scale.NaturalLogTransform`` (use ``scale.LogTransform`` instead)
 - ``scale.InvertedNaturalLogTransform`` (use ``scale.InvertedLogTransform`` instead)
+- ``scale.get_scale_docs()`` (no replacement)
 
 - ``sphinxext.plot_directive.plot_directive()``
   (use the class ``PlotDirective`` instead)
@@ -119,11 +122,17 @@ Classes, methods and attributes
 
 - ``spines.Spine.is_frame_like()`` (no replacement)
 
+- ``testing.decorators.switch_backend()`` (use ``@pytest.mark.backend``
+  decorator instead)
+
 - ``text.Text.is_math_text()`` (use ``cbook.is_math_text()`` instead)
 - ``text.TextWithDash()`` (use ``text.Annotation`` instead)
 - ``textpath.TextPath.is_math_text()`` (use ``cbook.is_math_text()`` instead)
 - ``textpath.TextPath.text_get_vertices_codes()``
   (use ``textpath.text_to_path.get_text_path()`` instead)
+
+- ``textpath.TextToPath.glyph_to_path()`` (use ``font.get_path()`` and manual
+  translation of the vertices instead)
 
 - ``ticker.OldScalarFormatter.pprint_val()`` (no replacement)
 - ``ticker.ScalarFormatter.pprint_val()`` (no replacement)

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -219,6 +219,8 @@ Arguments
   ``connector`` keyword arguments, which did nothing since 3.0.
 - `.TextPath` no longer accepts arbitrary positional or keyword arguments.
 - `.MaxNLocator.set_params()` no longer accepts arbitrary keyword arguments.
+- `~.Axes.pie` no longer accepts and squeezes non-1D inputs; pass 1D input to
+  the ``x`` argument.
 
 rcParams
 ~~~~~~~~

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -221,6 +221,8 @@ Arguments
 - `.MaxNLocator.set_params()` no longer accepts arbitrary keyword arguments.
 - `~.Axes.pie` no longer accepts and squeezes non-1D inputs; pass 1D input to
   the ``x`` argument.
+- Passing (n, 1)-shaped error arrays to `.Axes.errorbar()` is no longer
+  supported; pass a 1D array instead.
 
 rcParams
 ~~~~~~~~

--- a/doc/api/api_changes_3.3/removals.rst
+++ b/doc/api/api_changes_3.3/removals.rst
@@ -9,6 +9,10 @@ Modules
 
 Classes, methods and attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- ``artist.Artist.aname`` property (no replacement)
+
+- ``axis.Axis.iter_ticks`` (no replacement)
+
 - ``backend_bases.RendererBase.strip_math()``
   (use ``cbook.strip_math()`` instead)
 
@@ -39,6 +43,8 @@ Classes, methods and attributes
 - ``backend_qt5.NavigationToolbar2QT.buttons`` property (no replacement)
 - ``backend_qt5.NavigationToolbar2QT.adj_window`` property (no replacement)
 
+- ``bezier.find_r_to_boundary_of_closedpath()`` (no replacement)
+
 - ``cbook.dedent()`` (use `inspect.cleandoc` instead)
 - ``cbook.get_label()`` (no replacement)
 - ``cbook.is_hashable()`` (use ``isinstance(..., collections.abc.Hashable)``
@@ -46,10 +52,29 @@ Classes, methods and attributes
 - ``cbook.iterable()`` (use ``numpy.iterable()`` instead)
 - ``cbook.safezip()`` (no replacement)
 
+- ``colorbar.ColorbarBase.get_cmap`` (use ``ScalarMappable.get_cmap`` instead)
+- ``colorbar.ColorbarBase.set_cmap`` (use ``ScalarMappable.set_cmap`` instead)
+- ``colorbar.ColorbarBase.get_clim`` (use ``ScalarMappable.get_clim`` instead)
+- ``colorbar.ColorbarBase.set_clim`` (use ``ScalarMappable.set_clim`` instead)
+- ``colorbar.ColorbarBase.set_norm`` (use ``ScalarMappable.set_norm`` instead)
+
+- ``dates.seconds()`` (no replacement)
+- ``dates.minutes()`` (no replacement)
+- ``dates.hours()`` (no replacement)
+- ``dates.weeks()`` (no replacement)
+- ``dates.strpdate2num`` and ``dates.bytespdate2num`` (use `time.strptime` or
+  `dateutil.parser.parse` or `.dates.datestr2num` instead)
+
 - ``docstring.Appender`` (no replacement)
 - ``docstring.dedent()`` (use `inspect.getdoc` instead)
 - ``docstring.copy_dedent()``
   (use ``docstring.copy()`` and `inspect.getdoc` instead)
+
+- ``font_manager.OSXInstalledFonts()`` (no replacement)
+
+- ``image.BboxImage.interp_at_native`` property (no replacement)
+
+- ``lines.Line2D.verticalOffset`` property (no replacement)
 
 - ``matplotlib.checkdep_dvipng`` (no replacement)
 - ``matplotlib.checkdep_ghostscript`` (no replacement)
@@ -58,18 +83,25 @@ Classes, methods and attributes
 - ``matplotlib.get_py2exe_datafiles`` (no replacement)
 - ``matplotlib.tk_window_focus`` (use ``rcParams['tk.window_focus']`` instead)
 
+- ``mlab.demean()`` (use ``mlab.detrend_mean()`` instead)
+
+- ``path.get_paths_extents()``
+  (use ``path.get_path_collection_extents()`` instead)
+
+- ``projections.process_projection_requirements()`` (no replacement)
+
 - ``pyplot.plotfile()`` (Instead, load the data using
   `pandas.read_csv` or `numpy.loadtxt` or similar and use regular pyplot
   functions to plot the loaded data.)
+
+- ``quiver.Quiver.color()`` (use ``Quiver.get_facecolor()`` instead)
+- ``quiver.Quiver.keyvec`` property (no replacement)
+- ``quiver.Quiver.keytext`` property (no replacement)
+
 - ``rcsetup.validate_qt4()`` (no replacement)
 - ``rcsetup.validate_qt5()`` (no replacement)
 - ``rcsetup.validate_verbose()`` (no replacement)
 - ``rcsetup.ValidateInterval`` (no replacement)
-
-- ``sphinxext.plot_directive.plot_directive()``
-  (use the class ``PlotDirective`` instead)
-- ``sphinxext.mathmpl.math_directive()``
-  (use the class ``MathDirective`` instead)
 
 - ``scale.LogTransformBase`` (use ``scale.LogTransform`` instead)
 - ``scale.InvertedLogTransformBase`` (use ``scale.InvertedLogTransform`` instead)
@@ -79,6 +111,11 @@ Classes, methods and attributes
 - ``scale.InvertedLog2Transform`` (use ``scale.InvertedLogTransform`` instead)
 - ``scale.NaturalLogTransform`` (use ``scale.LogTransform`` instead)
 - ``scale.InvertedNaturalLogTransform`` (use ``scale.InvertedLogTransform`` instead)
+
+- ``sphinxext.plot_directive.plot_directive()``
+  (use the class ``PlotDirective`` instead)
+- ``sphinxext.mathmpl.math_directive()``
+  (use the class ``MathDirective`` instead)
 
 - ``spines.Spine.is_frame_like()`` (no replacement)
 
@@ -98,38 +135,7 @@ Classes, methods and attributes
   ``Tick.tick1line``, ``Tick.tick2line``, ``Tick.label1``,  ``Tick.label2``
   instead)
 
-- ``Artist.aname`` property (no replacement)
-- ``Axis.iter_ticks`` (no replacement)
-
-- ``image.BboxImage.interp_at_native`` property (no replacement)
-- ``lines.Line2D.verticalOffset`` property (no replacement)
-- ``bezier.find_r_to_boundary_of_closedpath()`` (no replacement)
-
-- ``quiver.Quiver.color()`` (use ``Quiver.get_facecolor()`` instead)
-- ``quiver.Quiver.keyvec`` property (no replacement)
-- ``quiver.Quiver.keytext`` property (no replacement)
-
-- ``colorbar.ColorbarBase.get_cmap`` (use ``ScalarMappable.get_cmap`` instead)
-- ``colorbar.ColorbarBase.set_cmap`` (use ``ScalarMappable.set_cmap`` instead)
-- ``colorbar.ColorbarBase.get_clim`` (use ``ScalarMappable.get_clim`` instead)
-- ``colorbar.ColorbarBase.set_clim`` (use ``ScalarMappable.set_clim`` instead)
-- ``colorbar.ColorbarBase.set_norm`` (use ``ScalarMappable.set_norm`` instead)
-
-- ``dates.seconds()`` (no replacement)
-- ``dates.minutes()`` (no replacement)
-- ``dates.hours()`` (no replacement)
-- ``dates.weeks()`` (no replacement)
-- ``dates.strpdate2num`` and ``dates.bytespdate2num`` (use `time.strptime` or
-  `dateutil.parser.parse` or `.dates.datestr2num` instead)
-
-- ``font_manager.OSXInstalledFonts()`` (no replacement)
-
-- ``mlab.demean()`` (use ``mlab.detrend_mean()`` instead)
-
-- ``projections.process_projection_requirements()`` (no replacement)
-
-- ``path.get_paths_extents()``
-  (use ``path.get_path_collection_extents()`` instead)
+- ``widgets.SpanSelector.buttonDown`` property (no replacement)
 
 - ``mplot3d.proj3d.line2d()`` (no replacement)
 - ``mplot3d.proj3d.line2d_dist()`` (no replacement)
@@ -158,8 +164,6 @@ Classes, methods and attributes
   (use ``axis_grid1.mpl_axes.SimpleChainedObjects`` instead)
 - ``axisartist.axislines.Axes.AxisDict``
   (use ``axis_grid1.mpl_axes.Axes.AxisDict`` instead)
-
-- ``widgets.SpanSelector.buttonDown`` property (no replacement)
 
 Arguments
 ~~~~~~~~~

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -849,8 +849,8 @@ Use the standard library's docstring manipulation tools instead, such as
 
 
 
-- `matplotlib.scale.get_scale_docs()`
-- `matplotlib.pyplot.get_scale_docs()`
+- ``matplotlib.scale.get_scale_docs()``
+- ``matplotlib.pyplot.get_scale_docs()``
 
 These are considered internal and will be removed from the public API in a
 future version.
@@ -905,7 +905,8 @@ Font Handling
 - ``backend_pdf.RendererPdf.afm_font_cache``
 - ``backend_ps.RendererPS.afmfontd``
 - ``font_manager.OSXInstalledFonts``
-- `.TextToPath.glyph_to_path` (Instead call ``font.get_path()`` and manually transform the path.)
+- ``.TextToPath.glyph_to_path`` (Instead call ``font.get_path()`` and manually
+  transform the path.)
 
 
 Date related functions
@@ -1011,7 +1012,7 @@ Path tools
 
 Use `~.path.get_path_collection_extents` instead.
 
-- `.Path.has_nonfinite` attribute
+- ``.Path.has_nonfinite`` attribute
 
 Use ``not np.isfinite(path.vertices).all()`` instead.
 

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -1369,9 +1369,6 @@
     "matplotlib.patches.Patch.__init__": [
       "doc/devel/documenting_mpl.rst:696"
     ],
-    "matplotlib.pyplot.get_scale_docs()": [
-      "doc/api/prev_api_changes/api_changes_3.1.0.rst:853"
-    ],
     "matplotlib.sphinxext.mathmpl": [
       "doc/users/prev_whats_new/whats_new_3.0.rst:225"
     ],

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3368,7 +3368,7 @@ class Axes(_AxesBase):
             ys = [thisy for thisy, b in zip(ys, mask) if b]
             return xs, ys
 
-        def extract_err(err, data):
+        def extract_err(name, err, data):
             """
             Private function to parse *err* and subtract/add it to *data*.
 
@@ -3380,20 +3380,9 @@ class Axes(_AxesBase):
                 iter(b)
             except (TypeError, ValueError):
                 a = b = err  # Symmetric error: 1D iterable.
-            # This could just be `np.ndim(a) > 1 and np.ndim(b) > 1`, except
-            # for the (undocumented, but tested) support for (n, 1) arrays.
-            a_sh = np.shape(a)
-            b_sh = np.shape(b)
-            if (len(a_sh) > 2 or (len(a_sh) == 2 and a_sh[1] != 1)
-                    or len(b_sh) > 2 or (len(b_sh) == 2 and b_sh[1] != 1)):
+            if np.ndim(a) > 1 or np.ndim(b) > 1:
                 raise ValueError(
-                    "err must be a scalar or a 1D or (2, n) array-like")
-            if len(a_sh) == 2 or len(b_sh) == 2:
-                cbook.warn_deprecated(
-                    "3.1", message="Support for passing a (n, 1)-shaped error "
-                    "array to errorbar() is deprecated since Matplotlib "
-                    "%(since)s and will be removed %(removal)s; pass a 1D "
-                    "array instead.")
+                    f"{name}err must be a scalar or a 1D or (2, n) array-like")
             # Using list comprehensions rather than arrays to preserve units.
             for e in [a, b]:
                 if len(data) != len(e):
@@ -3405,7 +3394,7 @@ class Axes(_AxesBase):
             return low, high
 
         if xerr is not None:
-            left, right = extract_err(xerr, x)
+            left, right = extract_err('x', xerr, x)
             # select points without upper/lower limits in x and
             # draw normal errorbars for these points
             noxlims = ~(xlolims | xuplims)
@@ -3454,7 +3443,7 @@ class Axes(_AxesBase):
                                                   **eb_cap_style))
 
         if yerr is not None:
-            lower, upper = extract_err(yerr, y)
+            lower, upper = extract_err('y', yerr, y)
             # select points without upper/lower limits in y and
             # draw normal errorbars for these points
             noylims = ~(lolims | uplims)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2915,7 +2915,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x : array-like
+        x : 1D array-like
             The wedge sizes.
 
         explode : array-like, default: None
@@ -2999,12 +2999,8 @@ class Axes(_AxesBase):
         # The use of float32 is "historical", but can't be changed without
         # regenerating the test baselines.
         x = np.asarray(x, np.float32)
-        if x.ndim != 1 and x.squeeze().ndim <= 1:
-            cbook.warn_deprecated(
-                "3.1", message="Non-1D inputs to pie() are currently "
-                "squeeze()d, but this behavior is deprecated since %(since)s "
-                "and will be removed %(removal)s; pass a 1D array instead.")
-            x = np.atleast_1d(x.squeeze())
+        if x.ndim > 1:
+            raise ValueError("x must be 1D")
 
         if np.any(x < 0):
             raise ValueError("Wedge sizes 'x' must be non negative values")

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -239,13 +239,7 @@ class _BackendNbAgg(_Backend):
         manager.show()
 
     @staticmethod
-    def show(*args, block=None, **kwargs):
-        if args or kwargs:
-            cbook.warn_deprecated(
-                "3.1", message="Passing arguments to show(), other than "
-                "passing 'block' by keyword, is deprecated %(since)s, and "
-                "support for it will be removed %(removal)s.")
-
+    def show(block=None):
         ## TODO: something to do when keyword block==False ?
         from matplotlib._pylab_helpers import Gcf
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -302,14 +302,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         if self._hatch:
             gc.set_hatch(self._hatch)
-            try:
-                gc.set_hatch_color(self._hatch_color)
-            except AttributeError:
-                # if we end up with a GC that does not have this method
-                cbook.warn_deprecated(
-                    "3.1", message="Your backend does not support setting the "
-                    "hatch color; such backends will become unsupported in "
-                    "Matplotlib 3.3.")
+            gc.set_hatch_color(self._hatch_color)
 
         if self.get_sketch_params() is not None:
             gc.set_sketch_params(*self.get_sketch_params())

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -198,17 +198,11 @@ def _to_rgba_no_colorcycle(c, alpha=None):
             # This may turn c into a non-string, so we check again below.
             c = _colors_full_map[c]
         except KeyError:
-            try:
-                c = _colors_full_map[c.lower()]
-            except KeyError:
-                pass
-            else:
-                if len(orig_c) == 1:
-                    cbook.warn_deprecated(
-                        "3.1", message="Support for uppercase "
-                        "single-letter colors is deprecated since Matplotlib "
-                        "%(since)s and will be removed %(removal)s; please "
-                        "use lowercase instead.")
+            if len(orig_c) != 1:
+                try:
+                    c = _colors_full_map[c.lower()]
+                except KeyError:
+                    pass
     if isinstance(c, str):
         # hex color in #rrggbb format.
         match = re.match(r"\A#[a-fA-F0-9]{6}\Z", c)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -444,28 +444,15 @@ class Legend(Artist):
                 loc = 'upper right'
         if isinstance(loc, str):
             if loc not in self.codes:
-                if self.isaxes:
-                    cbook.warn_deprecated(
-                        "3.1", message="Unrecognized location {!r}. Falling "
-                        "back on 'best'; valid locations are\n\t{}\n"
-                        "This will raise an exception %(removal)s."
-                        .format(loc, '\n\t'.join(self.codes)))
-                    loc = 0
-                else:
-                    cbook.warn_deprecated(
-                        "3.1", message="Unrecognized location {!r}. Falling "
-                        "back on 'upper right'; valid locations are\n\t{}\n'"
-                        "This will raise an exception %(removal)s."
-                        .format(loc, '\n\t'.join(self.codes)))
-                    loc = 1
+                raise ValueError(
+                    "Unrecognized location {!r}. Valid locations are\n\t{}\n"
+                    .format(loc, '\n\t'.join(self.codes)))
             else:
                 loc = self.codes[loc]
         if not self.isaxes and loc == 0:
-            cbook.warn_deprecated(
-                "3.1", message="Automatic legend placement (loc='best') not "
-                "implemented for figure legend. Falling back on 'upper "
-                "right'. This will raise an exception %(removal)s.")
-            loc = 1
+            raise ValueError(
+                "Automatic legend placement (loc='best') not implemented for "
+                "figure legend.")
 
         self._mode = mode
         self.set_bbox_to_anchor(bbox_to_anchor, bbox_transform)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -335,16 +335,6 @@ class Line2D(Artist):
         if solid_joinstyle is None:
             solid_joinstyle = rcParams['lines.solid_joinstyle']
 
-        if isinstance(linestyle, str):
-            ds, ls = self._split_drawstyle_linestyle(linestyle)
-            if ds is not None and drawstyle is not None and ds != drawstyle:
-                raise ValueError("Inconsistent drawstyle ({!r}) and linestyle "
-                                 "({!r})".format(drawstyle, linestyle))
-            linestyle = ls
-
-            if ds is not None:
-                drawstyle = ds
-
         if drawstyle is None:
             drawstyle = 'default'
 
@@ -1102,39 +1092,6 @@ class Line2D(Artist):
         self._dashOffset, self._dashSeq = _scale_dashes(
             self._us_dashOffset, self._us_dashSeq, self._linewidth)
 
-    def _split_drawstyle_linestyle(self, ls):
-        """
-        Split drawstyle from linestyle string.
-
-        If *ls* is only a drawstyle default to returning a linestyle
-        of '-'.
-
-        Parameters
-        ----------
-        ls : str
-            The linestyle to be processed
-
-        Returns
-        -------
-        ret_ds : str or None
-            If the linestyle string does not contain a drawstyle prefix
-            return None, otherwise return it.
-
-        ls : str
-            The linestyle with the drawstyle (if any) stripped.
-        """
-        for ds in self.drawStyleKeys:  # long names are first in the list
-            if ls.startswith(ds):
-                cbook.warn_deprecated(
-                    "3.1", message="Passing the drawstyle with the linestyle "
-                    "as a single string is deprecated since Matplotlib "
-                    "%(since)s and support will be removed %(removal)s; "
-                    "please pass the drawstyle separately using the drawstyle "
-                    "keyword argument to Line2D or set_drawstyle() method (or "
-                    "ds/set_ds()).")
-                return ds, ls[len(ds):] or '-'
-        return None, ls
-
     def set_linestyle(self, ls):
         """
         Set the linestyle of the line.
@@ -1167,10 +1124,6 @@ class Line2D(Artist):
             For examples see :doc:`/gallery/lines_bars_and_markers/linestyles`.
         """
         if isinstance(ls, str):
-            ds, ls = self._split_drawstyle_linestyle(ls)
-            if ds is not None:
-                self.set_drawstyle(ds)
-
             if ls in [' ', '', 'none']:
                 ls = 'None'
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1285,11 +1285,9 @@ class AnchoredText(AnchoredOffsetbox):
             prop = {}
         badkwargs = {'ha', 'horizontalalignment', 'va', 'verticalalignment'}
         if badkwargs & set(prop):
-            cbook.warn_deprecated(
-                "3.1", message="Mixing horizontalalignment or "
-                "verticalalignment with AnchoredText is not supported, "
-                "deprecated since %(since)s, and will raise an exception "
-                "%(removal)s.")
+            raise ValueError(
+                "Mixing horizontalalignment or verticalalignment with "
+                "AnchoredText is not supported.")
 
         self.txt = TextArea(s, textprops=prop, minimumdescent=False)
         fp = self.txt._text.get_fontproperties()

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3825,9 +3825,7 @@ class FancyArrowPatch(Patch):
     def __init__(self, posA=None, posB=None,
                  path=None,
                  arrowstyle="simple",
-                 arrow_transmuter=None,
                  connectionstyle="arc3",
-                 connector=None,
                  patchA=None,
                  patchB=None,
                  shrinkA=2,
@@ -3866,9 +3864,6 @@ class FancyArrowPatch(Patch):
 
             %(AvailableArrowstyles)s
 
-        arrow_transmuter
-            Ignored.
-
         connectionstyle : str or `.ConnectionStyle` or None, optional, \
 default: 'arc3'
             The `.ConnectionStyle` with which *posA* and *posB* are connected.
@@ -3877,9 +3872,6 @@ default: 'arc3'
             connection styles are available:
 
             %(AvailableConnectorstyles)s
-
-        connector
-            Ignored.
 
         patchA, patchB : `.Patch`, default: None
             Head and tail patches, respectively.
@@ -3910,20 +3902,6 @@ default: 'arc3'
             In contrast to other patches, the default ``capstyle`` and
             ``joinstyle`` for `FancyArrowPatch` are set to ``"round"``.
         """
-        if arrow_transmuter is not None:
-            cbook.warn_deprecated(
-                3.0,
-                message=('The "arrow_transmuter" keyword argument is not used,'
-                         ' and will be removed in Matplotlib 3.1'),
-                name='arrow_transmuter',
-                obj_type='keyword argument')
-        if connector is not None:
-            cbook.warn_deprecated(
-                3.0,
-                message=('The "connector" keyword argument is not used,'
-                         ' and will be removed in Matplotlib 3.1'),
-                name='connector',
-                obj_type='keyword argument')
         # Traditionally, the cap- and joinstyle for FancyArrowPatch are round
         kwargs.setdefault("joinstyle", "round")
         kwargs.setdefault("capstyle", "round")
@@ -4193,9 +4171,7 @@ class ConnectionPatch(FancyArrowPatch):
     def __init__(self, xyA, xyB, coordsA, coordsB=None,
                  axesA=None, axesB=None,
                  arrowstyle="-",
-                 arrow_transmuter=None,
                  connectionstyle="arc3",
-                 connector=None,
                  patchA=None,
                  patchB=None,
                  shrinkA=0.,
@@ -4278,9 +4254,7 @@ class ConnectionPatch(FancyArrowPatch):
         FancyArrowPatch.__init__(self,
                                  posA=(0, 0), posB=(1, 1),
                                  arrowstyle=arrowstyle,
-                                 arrow_transmuter=arrow_transmuter,
                                  connectionstyle=connectionstyle,
-                                 connector=connector,
                                  patchA=patchA,
                                  patchB=patchB,
                                  shrinkA=shrinkA,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -553,14 +553,7 @@ class Patch(artist.Artist):
 
         if self._hatch:
             gc.set_hatch(self._hatch)
-            try:
-                gc.set_hatch_color(self._hatch_color)
-            except AttributeError:
-                # if we end up with a GC that does not have this method
-                cbook.warn_deprecated(
-                    "3.1", message="Your backend does not support setting the "
-                    "hatch color; such backends will become unsupported in "
-                    "Matplotlib 3.3.")
+            gc.set_hatch_color(self._hatch_color)
 
         if self.get_sketch_params() is not None:
             gc.set_sketch_params(*self.get_sketch_params())

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -243,15 +243,6 @@ class Path:
     def simplify_threshold(self, threshold):
         self._simplify_threshold = threshold
 
-    @cbook.deprecated(
-        "3.1", alternative="not np.isfinite(self.vertices).all()")
-    @property
-    def has_nonfinite(self):
-        """
-        `True` if the vertices array has nonfinite values.
-        """
-        return not np.isfinite(self._vertices).all()
-
     @property
     def should_simplify(self):
         """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -48,7 +48,7 @@ from matplotlib.artist import Artist
 from matplotlib.axes import Axes, Subplot
 from matplotlib.projections import PolarAxes
 from matplotlib import mlab  # for detrend_none, window_hanning
-from matplotlib.scale import get_scale_docs, get_scale_names
+from matplotlib.scale import get_scale_names
 
 from matplotlib import cm
 from matplotlib.cm import get_cmap, register_cmap

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -667,16 +667,6 @@ def register_scale(scale_class):
     _scale_mapping[scale_class.name] = scale_class
 
 
-@cbook.deprecated(
-    '3.1', message='get_scale_docs() is considered private API since '
-                   '3.1 and will be removed from the public API in 3.3.')
-def get_scale_docs():
-    """
-    Helper function for generating docstrings related to scales.
-    """
-    return _get_scale_docs()
-
-
 def _get_scale_docs():
     """
     Helper function for generating docstrings related to scales.

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -293,12 +293,9 @@ class Table(Artist):
 
         if isinstance(loc, str):
             if loc not in self.codes:
-                cbook.warn_deprecated(
-                    "3.1", message="Unrecognized location {!r}. Falling back "
-                    "on 'bottom'; valid locations are\n\t{}\n"
-                    "This will raise an exception %(removal)s."
+                raise ValueError(
+                    "Unrecognized location {!r}. Valid locations are\n\t{}"
                     .format(loc, '\n\t'.join(self.codes)))
-                loc = 'bottom'
             loc = self.codes[loc]
         self.set_figure(ax.figure)
         self._axes = ax

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -459,23 +459,3 @@ def _image_directories(func):
     result_dir = Path().resolve() / "result_images" / module_path.stem
     result_dir.mkdir(parents=True, exist_ok=True)
     return baseline_dir, result_dir
-
-
-@cbook.deprecated("3.1", alternative="pytest.mark.backend")
-def switch_backend(backend):
-
-    def switch_backend_decorator(func):
-
-        @functools.wraps(func)
-        def backend_switcher(*args, **kwargs):
-            try:
-                prev_backend = mpl.get_backend()
-                matplotlib.testing.setup()
-                plt.switch_backend(backend)
-                return func(*args, **kwargs)
-            finally:
-                plt.switch_backend(prev_backend)
-
-        return backend_switcher
-
-    return switch_backend_decorator

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2855,9 +2855,7 @@ def test_errorbar():
     # Now switch to a more OO interface to exercise more features.
     fig, axs = plt.subplots(nrows=2, ncols=2, sharex=True)
     ax = axs[0, 0]
-    # Try a Nx1 shaped error just to check
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.errorbar(x, y, yerr=np.reshape(yerr, (len(y), 1)), fmt='o')
+    ax.errorbar(x, y, yerr=yerr, fmt='o')
     ax.set_title('Vert. symmetric')
 
     # With 4 subplots, reduce the number of axis ticks to avoid crowding.
@@ -4754,10 +4752,8 @@ def generate_errorbar_inputs():
                                 [1, 1, 1, 1, 1],
                                 [[1, 1, 1, 1, 1],
                                  [1, 1, 1, 1, 1]],
-                                [[1]] * 5,
                                 np.ones(5),
                                 np.ones((2, 5)),
-                                np.ones((5, 1)),
                                 None
                                 ])
     xerr_cy = cycler('xerr', err_cycler)
@@ -4774,11 +4770,9 @@ def generate_errorbar_inputs():
 
 @pytest.mark.parametrize('kwargs', generate_errorbar_inputs())
 def test_errorbar_inputs_shotgun(kwargs):
-    # (n, 1)-shaped error deprecation already tested by test_errorbar.
-    with mpl.cbook._suppress_matplotlib_deprecation_warning():
-        ax = plt.gca()
-        eb = ax.errorbar(**kwargs)
-        eb.remove()
+    ax = plt.gca()
+    eb = ax.errorbar(**kwargs)
+    eb.remove()
 
 
 @image_comparison(["dash_offset"], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5650,14 +5650,6 @@ def test_annotate_across_transforms():
                 arrowprops=dict(arrowstyle="->"))
 
 
-def test_deprecated_uppercase_colors():
-    # Remove after end of deprecation period.
-    fig, ax = plt.subplots()
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.plot([1, 2], color="B")
-        fig.canvas.draw()
-
-
 @image_comparison(['secondary_xy.png'], style='mpl20')
 def test_secondary_xy():
     fig, axs = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -349,8 +349,7 @@ class TextPath(Path):
     """
 
     def __init__(self, xy, s, size=None, prop=None,
-                 _interpolation_steps=1, usetex=False,
-                 *args, **kwargs):
+                 _interpolation_steps=1, usetex=False):
         r"""
         Create a path from the text. Note that it simply is a path,
         not an artist. You need to use the `~.PathPatch` (or other artists)
@@ -395,11 +394,6 @@ class TextPath(Path):
         """
         # Circular import.
         from matplotlib.text import Text
-
-        if args or kwargs:
-            cbook.warn_deprecated(
-                "3.1", message="Additional arguments to TextPath used to be "
-                "ignored, but will trigger a TypeError %(removal)s.")
 
         if prop is None:
             prop = FontProperties()

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -51,16 +51,6 @@ class TextToPath:
         char_id = urllib.parse.quote('%s-%d' % (ps_name, ccode))
         return char_id
 
-    @cbook.deprecated(
-        "3.1",
-        alternative="font.get_path() and manual translation of the vertices")
-    def glyph_to_path(self, font, currx=0.):
-        """Convert the *font*'s current glyph to a (vertices, codes) pair."""
-        verts, codes = font.get_path()
-        if currx != 0.0:
-            verts[:, 0] += currx
-        return verts, codes
-
     def get_text_width_height_descent(self, s, prop, ismath):
         if rcParams['text.usetex']:
             texmanager = self.get_texmanager()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2095,9 +2095,8 @@ class MaxNLocator(Locator):
             self._integer = kwargs.pop('integer')
         if kwargs:
             key, _ = kwargs.popitem()
-            cbook.warn_deprecated("3.1",
-                                  message="MaxNLocator.set_params got an "
-                                          f"unexpected parameter: {key}")
+            raise TypeError(
+                f"set_params() got an unexpected keyword argument '{key}'")
 
     def _raw_ticks(self, vmin, vmax):
         """

--- a/lib/mpl_toolkits/axisartist/axisline_style.py
+++ b/lib/mpl_toolkits/axisartist/axisline_style.py
@@ -21,7 +21,6 @@ class _FancyAxislineStyle:
             FancyArrowPatch.__init__(self,
                                      path=self._line_path,
                                      arrowstyle=self._ARROW_STYLE,
-                                     arrow_transmuter=None,
                                      patchA=None,
                                      patchB=None,
                                      shrinkA=0.,


### PR DESCRIPTION
## PR Summary

See title. There are still a few left, but they need different changes.

Also, sort the removal list (this looks a little bigger than it really is.)

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way