### PR TITLE
CI: Download wx wheels for the correct Ubuntu version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
       - libffi-dev
       - libgeos-dev
       - libgirepository1.0-dev
+      - libsdl2-2.0-0
       - lmodern
       - fonts-freefont-otf
       - texlive-pictures
@@ -149,7 +150,7 @@ install:
       echo 'PySide2 is available' ||
       echo 'PySide2 is not available'
     python -mpip install --upgrade \
-      -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04 \
+      -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 \
       wxPython &&
       python -c 'import wx' &&
       echo 'wxPython is available' ||


### PR DESCRIPTION
We are now on xenial, so should use the 16.04 URL.