### PR TITLE
Make deprecations versions explicit

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -516,7 +516,7 @@ def get_data_path(*, _from_rc=None):
             "3.2",
             message=("Setting the datapath via matplotlibrc is deprecated "
                      "%(since)s and will be removed %(removal)s."),
-            removal='3.3')
+            removal='3.4')
         path = Path(_from_rc)
         if path.is_dir():
             defaultParams['datapath'][0] = str(path)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -515,7 +515,7 @@ def get_data_path(*, _from_rc=None):
         cbook.warn_deprecated(
             "3.2",
             message=("Setting the datapath via matplotlibrc is deprecated "
-                     "%(since)s and will be removed in %(removal)s."),
+                     "%(since)s and will be removed %(removal)s."),
             removal='3.3')
         path = Path(_from_rc)
         if path.is_dir():

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5220,9 +5220,9 @@ default: :rc:`scatter.edgecolors`
             where = np.asarray(where, dtype=bool)
             if where.size != ind.size:
                 cbook.warn_deprecated(
-                    "3.2", message=f"The parameter where must have the same "
-                    f"size as {ind} in {func_name}(). This will become an "
-                    "error in future versions of Matplotlib.")
+                    "3.2", message=f"Since %(since)s, the parameter *where* "
+                    f"must have the same size as {ind} in {func_name}(). This "
+                    "will become an error %(removal)s.")
         where = where & ~functools.reduce(
             np.logical_or, map(np.ma.getmask, [ind, dep1, dep2]))
 
@@ -5606,7 +5606,8 @@ default: :rc:`scatter.edgecolors`
                     "dimensions as C is deprecated since %(since)s.  Either "
                     "specify the corners of the quadrilaterals with X and Y, "
                     "or pass shading='auto', 'nearest' or 'gouraud', or set "
-                    "rcParams['pcolor.shading']")
+                    "rcParams['pcolor.shading'].  This will become an error "
+                    "%(removal)s.")
             C = C[:Ny - 1, :Nx - 1]
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -188,7 +188,8 @@ def subplot_class_factory(axes_class=None):
     if axes_class is None:
         cbook.warn_deprecated(
             "3.3", message="Support for passing None to subplot_class_factory "
-            "is deprecated; explicitly pass the default Axes class instead.")
+            "is deprecated since %(since)s; explicitly pass the default Axes "
+            "class instead. This will become an error %(removal)s.")
         axes_class = Axes
     try:
         # Avoid creating two different instances of GeoAxesSubplot...

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1837,8 +1837,10 @@ class FigureCanvasBase:
             x = None
             y = None
             cbook.warn_deprecated(
-                '3.0', message='enter_notify_event expects a location but '
-                'your backend did not pass one.')
+                '3.0', removal='3.5', name='enter_notify_event',
+                message='Since %(since)s, %(name)s expects a location but '
+                'your backend did not pass one. This will become an error '
+                '%(removal)s.')
 
         event = LocationEvent('figure_enter_event', self, x, y, guiEvent)
         self.callbacks.process('figure_enter_event', event)

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -110,8 +110,8 @@ def register_cmap(name=None, cmap=None, data=None, lut=None):
         cbook.warn_deprecated(
             "3.3",
             message="Passing raw data via parameters data and lut to "
-                    "register_cmap() is deprecated. Instead use: "
-                    "register_cmap("
+                    "register_cmap() is deprecated since %(since)s and will "
+                    "become an error %(removal)s. Instead use: register_cmap("
                     "cmap=LinearSegmentedColormap(name, data, lut))")
     # For the remainder, let exceptions propagate.
     if lut is None:
@@ -195,7 +195,8 @@ class ScalarMappable:
                 cbook.warn_deprecated(
                     "3.3",
                     message="Passing parameters norm and vmin/vmax "
-                            "simultaneously is deprecated. Please pass "
+                            "simultaneously is deprecated since %(since)s and "
+                            "will become an error %(removal)s. Please pass "
                             "vmin/vmax directly to the norm when creating it.")
         else:
             self.autoscale_None()

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -321,9 +321,10 @@ def to_rgba_array(c, alpha=None):
                 "consisting of single character color specifiers such as "
                 "'rgb'. Note also that the latter is deprecated." % c) from err
         else:
-            cbook.warn_deprecated("3.2", message="Using a string of single "
-                                  "character colors as a color sequence is "
-                                  "deprecated. Use an explicit list instead.")
+            cbook.warn_deprecated(
+                "3.2", message="Using a string of single character colors as "
+                "a color sequence is deprecated since %(since)s and will be "
+                "removed %(removal)s. Use an explicit list instead.")
             return result
 
     if len(c) == 0:
@@ -1255,8 +1256,9 @@ class SymLogNorm(Normalize):
         if base is None:
             self._base = np.e
             cbook.warn_deprecated(
-                "3.3", message="default base will change from np.e to 10.  To "
-                "suppress this warning specify the base kwarg.")
+                "3.2", removal="3.3", message="default base will change from "
+                "np.e to 10 in %(removal)s.  To suppress this warning specify "
+                "the base keyword argument.")
         else:
             self._base = base
         self._log_base = np.log(self._base)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1256,8 +1256,8 @@ class SymLogNorm(Normalize):
         if base is None:
             self._base = np.e
             cbook.warn_deprecated(
-                "3.2", removal="3.3", message="default base will change from "
-                "np.e to 10 in %(removal)s.  To suppress this warning specify "
+                "3.2", removal="3.4", message="default base will change from "
+                "np.e to 10 %(removal)s.  To suppress this warning specify "
                 "the base keyword argument.")
         else:
             self._base = base

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1208,8 +1208,8 @@ default: 'top'
             cbook.warn_deprecated(
                 "3.3",
                 message="Calling add_axes() without argument is "
-                "deprecated. You may want to use add_subplot() "
-                "instead.")
+                "deprecated since %(since)s and will be removed %(removal)s. "
+                "You may want to use add_subplot() instead.")
             return
         elif 'rect' in kwargs:
             if len(args):
@@ -1382,7 +1382,8 @@ default: 'top'
                     cbook.warn_deprecated(
                         "3.3",
                         message="Passing non-integers as three-element "
-                                "position specification is deprecated.")
+                                "position specification is deprecated since "
+                                "%(since)s and will be removed %(removal)s.")
             args = tuple(map(int, args))
         else:
             raise TypeError(f'add_subplot() takes 1 or 3 positional arguments '

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -608,7 +608,8 @@ class Line2D(Artist):
             # After deprecation, the whole method can be deleted and inherited.
             cbook.warn_deprecated(
                 "3.3", message="Setting the line's pick radius via set_picker "
-                "is deprecated; use set_pickradius instead.")
+                "is deprecated since %(since)s and will be removed "
+                "%(removal)s; use set_pickradius instead.")
             self.pickradius = p
         self._picker = p
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -192,8 +192,7 @@ def validate_axisbelow(s):
                 cbook.warn_deprecated(
                     "3.3", message=f"Support for setting axes.axisbelow to "
                     f"{s!r} to mean 'line' is deprecated since %(since)s and "
-                    f"will be removed in %(removal)s; set it to 'line' "
-                    "instead.")
+                    f"will be removed %(removal)s; set it to 'line' instead.")
                 return 'line'
     raise ValueError('%s cannot be interpreted as'
                      ' True, False, or "line"' % s)

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -56,11 +56,11 @@ class ScaleBase:
         """
         if kwargs:
             warn_deprecated(
-                '3.2.0',
+                '3.2', removal='3.4',
                 message=(
-                    f"ScaleBase got an unexpected keyword "
-                    f"argument {next(iter(kwargs))!r}. "
-                    'In the future this will raise TypeError')
+                    f"ScaleBase got an unexpected keyword argument "
+                    f"{next(iter(kwargs))!r}. This will become an error "
+                    "%(removal)s.")
             )
 
     def get_transform(self):
@@ -483,11 +483,11 @@ class SymmetricalLogScale(ScaleBase):
         def __init__(*, base=10, linthresh=2, subs=None, linscale=1, **kwargs):
             if kwargs:
                 warn_deprecated(
-                    "3.2.0",
+                    '3.2', removal='3.4',
                     message=(
                         f"SymmetricalLogScale got an unexpected keyword "
-                        f"argument {next(iter(kwargs))!r}; in the future, "
-                        f"this will raise a TypeError")
+                        f"argument {next(iter(kwargs))!r}. This will become "
+                        "an error %(removal)s.")
                 )
             return base, linthresh, subs, linscale
 

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -237,7 +237,8 @@ class StreamplotSet:
             cbook.warn_deprecated(
                 "3.3",
                 message="Passing arbitrary keyword arguments to StreamplotSet "
-                        "is deprecated.")
+                        "is deprecated since %(since) and will become an "
+                        "error %(removal)s.")
         self.lines = lines
         self.arrows = arrows
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -54,8 +54,9 @@ def parasite_axes_class_factory(axes_class=None):
     if axes_class is None:
         cbook.warn_deprecated(
             "3.3", message="Support for passing None to "
-            "parasite_axes_class_factory is deprecated; explicitly pass the "
-            "default Axes class instead.")
+            "parasite_axes_class_factory is deprecated since %(since)s and "
+            "will be removed %(removal)s; explicitly pass the default Axes "
+            "class instead.")
         axes_class = Axes
 
     return type("%sParasite" % axes_class.__name__,
@@ -181,8 +182,9 @@ def parasite_axes_auxtrans_class_factory(axes_class=None):
     if axes_class is None:
         cbook.warn_deprecated(
             "3.3", message="Support for passing None to "
-            "parasite_axes_auxtrans_class_factory is deprecated; explicitly "
-            "pass the default ParasiteAxes class instead.")
+            "parasite_axes_auxtrans_class_factory is deprecated since "
+            "%(since)s and will be removed %(removal)s; explicitly pass the "
+            "default ParasiteAxes class instead.")
         parasite_axes_class = ParasiteAxes
     elif not issubclass(axes_class, ParasiteAxesBase):
         parasite_axes_class = parasite_axes_class_factory(axes_class)
@@ -363,7 +365,8 @@ def host_axes_class_factory(axes_class=None):
     if axes_class is None:
         cbook.warn_deprecated(
             "3.3", message="Support for passing None to host_axes_class is "
-            "deprecated; explicitly pass the default Axes class instead.")
+            "deprecated since %(since)s and will be removed %(removed)s; "
+            "explicitly pass the default Axes class instead.")
         axes_class = Axes
 
     def _get_base_axes(self):

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -10,8 +10,8 @@ def _deprecate_factor_none(factor):
     # removed.
     if factor is None:
         cbook.warn_deprecated(
-            "3.2",
-            message="factor=None is deprecated; use/return factor=1 instead")
+            "3.2", message="factor=None is deprecated since %(since)s and "
+            "support will be removed %(removal)s; use/return factor=1 instead")
         factor = 1
     return factor
 


### PR DESCRIPTION
## PR Summary

Messages without `%(since)s` and `%(removal)s` will be ambiguous as to when they were deprecated and when they will be removed.

Also clean up extra 'in's in the messages as `%(removal)s` will add the correct preposition.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way