### PR TITLE
Improve error handling in _parse_scatter_color_args

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4303,13 +4303,16 @@ class Axes(_AxesBase):
             try:  # Is 'c' acceptable as PathCollection facecolors?
                 colors = mcolors.to_rgba_array(c)
             except (TypeError, ValueError) as err:
-                if not valid_shape:
-                    raise invalid_shape_exception(c.size, xsize) from err
-                # Both the mapping *and* the RGBA conversion failed: pretty
-                # severe failure => one may appreciate a verbose feedback.
-                raise ValueError(
-                    f"'c' argument must be a color, a sequence of colors, or "
-                    f"a sequence of numbers, not {c}") from err
+                if "RGBA values should be within 0-1 range" in str(err):
+                    raise
+                else:
+                    if not valid_shape:
+                        raise invalid_shape_exception(c.size, xsize) from err
+                    # Both the mapping *and* the RGBA conversion failed: pretty
+                    # severe failure => one may appreciate a verbose feedback.
+                    raise ValueError(
+                        f"'c' argument must be a color, a sequence of colors, "
+                        f"or a sequence of numbers, not {c}") from err
             else:
                 if len(colors) not in (0, 1, xsize):
                     # NB: remember that a single color is also acceptable.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1977,6 +1977,17 @@ def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
     assert result_edgecolors == expected_edgecolors
 
 
+def test_parse_scatter_color_args_error():
+    def get_next_color():
+        return 'blue'  # currently unused
+
+    with pytest.raises(ValueError,
+                       match="RGBA values should be within 0-1 range"):
+        c = np.array([[0.1, 0.2, 0.7], [0.2, 0.4, 1.4]])  # value > 1
+        mpl.axes.Axes._parse_scatter_color_args(
+            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
+
+
 def test_as_mpl_axes_api():
     # tests the _as_mpl_axes api
     from matplotlib.projections.polar import PolarAxes


### PR DESCRIPTION
## PR Summary

Fixes #17243

The problem was that `mcolors.to_rgba_array(c)` can raise two categories of ValueErrors. One are generic array conversion-related errors, the other is our own `ValueError('RGBA values should be within 0-1 range')`. Only the former should be catched and rewritten. Our own `ValueError` should directly surface.

I chose the simple approach of just checking the error message. One could alternatively introduce an own Exception subtype. But we're not really doing that in other places and `ValueError` seems exactly right for out-of-bounds numbers. 