### PR TITLE
[agg24]: Fix bad pointer arithmetic

### DIFF
--- a/extern/agg24-svn/include/agg_pixfmt_rgba.h
+++ b/extern/agg24-svn/include/agg_pixfmt_rgba.h
@@ -1555,22 +1555,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return reinterpret_cast<pixel_type*>(c) + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return reinterpret_cast<const pixel_type*>(c) + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return reinterpret_cast<pixel_type*>(c) + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return reinterpret_cast<const pixel_type*>(c) + n;
             }
         };
 
@@ -2233,22 +2233,22 @@ namespace agg
 
             pixel_type* next()
             {
-                return (pixel_type*)(c + pix_step);
+                return reinterpret_cast<pixel_type*>(c) + 1;
             }
 
             const pixel_type* next() const
             {
-                return (const pixel_type*)(c + pix_step);
+                return reinterpret_cast<const pixel_type*>(c) + 1;
             }
 
             pixel_type* advance(int n)
             {
-                return (pixel_type*)(c + n * pix_step);
+                return reinterpret_cast<pixel_type*>(c) + n;
             }
 
             const pixel_type* advance(int n) const
             {
-                return (const pixel_type*)(c + n * pix_step);
+                return reinterpret_cast<const pixel_type*>(c) + n;
             }
         };
 


### PR DESCRIPTION
The array c is an array of value_type[4], and thus its initial pointer
cannot be arbitrarily advanced (without causing undefined
behaviour). What seems to be desired instead is to consider the
_containing_ object as a member of an array and perform arithmetic in
_that_ array. This can be done by _first_ computing the pointer to the
ambient object.