### PR TITLE
Fix bug where matplotlib.style('default') resets the backend

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -44,14 +44,14 @@ STYLE_BLACKLIST = {
 
 def _remove_blacklisted_style_params(d, warn=True):
     o = {}
-    for key, val in d.items():
+    for key in d:  # prevent triggering RcParams.__getitem__('backend')
         if key in STYLE_BLACKLIST:
             if warn:
                 cbook._warn_external(
                     "Style includes a parameter, '{0}', that is not related "
                     "to style.  Ignoring".format(key))
         else:
-            o[key] = val
+            o[key] = d[key]
     return o
 
 


### PR DESCRIPTION
## PR Summary

This is a two-line PR that fixes an issue where `matplotlib.style('default')` resets the backend.

While `matplotlib.style._remove_blacklisted_style_params` tries to prevent resetting the backend, it fails due to the implementation of `RcParams.__getitem__`. Basically these lines:

https://github.com/matplotlib/matplotlib/blob/002b27e352b90410c9840233b6ce42c54e291403/lib/matplotlib/style/core.py#L45-L47

end up triggering these lines when the `'backend'` key comes up:

https://github.com/matplotlib/matplotlib/blob/002b27e352b90410c9840233b6ce42c54e291403/lib/matplotlib/__init__.py#L697-L701

To repair this, I change the `_remove_blacklisted_style_params` iteration from `for key, val in d.items()` to `for key in d.keys():`, which prevents triggering the `__getitem__` override.


## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
