### PR TITLE
Improve ps handling of individual usetex strings.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -469,6 +469,14 @@ translate
 
     def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
         # docstring inherited
+        if not hasattr(self, "psfrag"):
+            _log.warning(
+                "The PS backend determines usetex status solely based on "
+                "rcParams['text.usetex'] and does not support having "
+                "usetex=True only for some elements; this element will thus "
+                "be rendered as if usetex=False.")
+            self.draw_text(gc, x, y, s, prop, angle, ismath, mtext)
+            return
 
         w, h, bl = self.get_text_width_height_descent(s, prop, ismath)
         fontsize = prop.get_size_in_points()

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -117,10 +117,19 @@ def test_transparency():
 
 
 @needs_usetex
-def test_failing_latex(tmpdir):
+def test_failing_latex():
     """Test failing latex subprocess call"""
     mpl.rcParams['text.usetex'] = True
     # This fails with "Double subscript"
     plt.xlabel("$22_2_2$")
     with pytest.raises(RuntimeError):
-        plt.savefig(Path(tmpdir, "tmpoutput.ps"))
+        plt.savefig(io.BytesIO(), format="ps")
+
+
+@needs_usetex
+def test_partial_usetex(caplog):
+    caplog.set_level("WARNING")
+    plt.figtext(.5, .5, "foo", usetex=True)
+    plt.savefig(io.BytesIO(), format="ps")
+    assert caplog.records and all("as if usetex=False" in record.getMessage()
+                                  for record in caplog.records)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -726,7 +726,7 @@ class Text(Artist):
                 if textobj.get_usetex():
                     textrenderer.draw_tex(gc, x, y, clean_line,
                                           textobj._fontproperties, angle,
-                                          mtext=mtext)
+                                          ismath=ismath, mtext=mtext)
                 else:
                     textrenderer.draw_text(gc, x, y, clean_line,
                                            textobj._fontproperties, angle,


### PR DESCRIPTION
The ps backend currently determines usetex status solely based on the
rcparam at renderer instantiation time; in particular, having single
Text objects with usetex=True in an otherwise usetex=False renderer
currently results in an AttributeError.  Instead, detect that and do a
best-effort fix which is to try rendering with mathtext instead of
usetex.

(Actually fixing the ps backend would be nicer, but a bit of work.)

Also fix another ps test to not use a temporary directory.

See #7741.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
