### PR TITLE
Improve info logged by tex subsystem.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2133,15 +2133,23 @@ def _check_and_log_subprocess(command, logger, **kwargs):
     proc = subprocess.run(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
     if proc.returncode:
+        stdout = proc.stdout
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode()
+        stderr = proc.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode()
         raise RuntimeError(
             f"The command\n"
             f"    {_pformat_subprocess(command)}\n"
             f"failed and generated the following output:\n"
-            f"{proc.stdout.decode('utf-8')}\n"
+            f"{stdout}\n"
             f"and the following error:\n"
-            f"{proc.stderr.decode('utf-8')}")
-    logger.debug("stdout:\n%s", proc.stdout)
-    logger.debug("stderr:\n%s", proc.stderr)
+            f"{stderr}")
+    if proc.stdout:
+        logger.debug("stdout:\n%s", proc.stdout)
+    if proc.stderr:
+        logger.debug("stderr:\n%s", proc.stderr)
     return proc.stdout
 
 

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -25,6 +25,7 @@ import os
 from pathlib import Path
 import re
 import struct
+import sys
 import textwrap
 
 import numpy as np
@@ -1067,9 +1068,11 @@ def find_tex_file(filename, format=None):
         # On Windows only, kpathsea can use utf-8 for cmd args and output.
         # The `command_line_encoding` environment variable is set to force it
         # to always use utf-8 encoding.  See Matplotlib issue #11848.
-        kwargs = dict(env=dict(os.environ, command_line_encoding='utf-8'))
-    else:
-        kwargs = {}
+        kwargs = {'env': {**os.environ, 'command_line_encoding': 'utf-8'},
+                  'encoding': 'utf-8'}
+    else:  # On POSIX, run through the equivalent of os.fsdecode().
+        kwargs = {'encoding': sys.getfilesystemencoding(),
+                  'errors': 'surrogatescape'}
 
     cmd = ['kpsewhich']
     if format is not None:
@@ -1079,10 +1082,7 @@ def find_tex_file(filename, format=None):
         result = cbook._check_and_log_subprocess(cmd, _log, **kwargs)
     except RuntimeError:
         return ''
-    if os.name == 'nt':
-        return result.decode('utf-8').rstrip('\r\n')
-    else:
-        return os.fsdecode(result).rstrip('\n')
+    return result.rstrip('\n')
 
 
 @lru_cache()

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -131,8 +131,7 @@ class TexManager:
                                font_family, font, self.font_info[font.lower()])
                     break
                 else:
-                    _log.debug('%s font is not compatible with usetex.',
-                               font_family)
+                    _log.debug('%s font is not compatible with usetex.', font)
             else:
                 _log.info('No LaTeX-compatible font found for the %s font '
                           'family in rcParams. Using default.', font_family)


### PR DESCRIPTION
- Call kpsewhich in text mode (with the correct encoding).
- Suppress empty stdout/stderr from logged outputs.

Together this changes the entries logged by dviread from
```
DEBUG:matplotlib.dviread:kpsewhich cmss10.tfm
DEBUG:matplotlib.dviread:stdout:
b'/usr/local/texlive/2019/texmf-dist/fonts/tfm/public/cm/cmss10.tfm\n'
DEBUG:matplotlib.dviread:stderr:
b''
```
to
```
DEBUG:matplotlib.dviread:kpsewhich cmss10.tfm
DEBUG:matplotlib.dviread:stdout:
/usr/local/texlive/2019/texmf-dist/fonts/tfm/public/cm/cmss10.tfm

```

- Fix logged info about loading of tex fonts (it's the font that
  matters, not the font family).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
