### PR TITLE
Mnt rearrange next api again

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 - [ ] New features are documented, with examples if plot related
 - [ ] Documentation is sphinx and numpydoc compliant
 - [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
-- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
+- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
 
 <!--
 Thank you so much for your PR!  To help us review your contribution, please

--- a/doc/api/api_changes.rst
+++ b/doc/api/api_changes.rst
@@ -33,6 +33,9 @@ added to Matplotlib, see :ref:`whats-new`.
       :glob:
       :maxdepth: 1
 
-      api_changes_3.4/*
+      next_api_changes/behavior/*
+      next_api_changes/deprecations/*
+      next_api_changes/development/*
+      next_api_changes/removals/*
 
 .. include:: prev_api_changes/api_changes_3.3.0.rst

--- a/doc/api/api_changes_3.4/behaviour.rst
+++ b/doc/api/api_changes_3.4/behaviour.rst
@@ -1,2 +1,0 @@
-Behaviour changes
------------------

--- a/doc/api/api_changes_3.4/development.rst
+++ b/doc/api/api_changes_3.4/development.rst
@@ -1,2 +1,0 @@
-Development changes
--------------------

--- a/doc/api/api_changes_3.4/removals.rst
+++ b/doc/api/api_changes_3.4/removals.rst
@@ -1,3 +1,0 @@
-Removals
---------
-The following deprecated APIs have been removed:

--- a/doc/api/next_api_changes/README.rst
+++ b/doc/api/next_api_changes/README.rst
@@ -3,8 +3,8 @@
 Adding API change notes
 =======================
 
-API change notes for future releases are collected in the most recent directory
-:file:`api_changes_X.Y`. They are divided into four categories:
+API change notes for future releases are collected in
+:file:`next_api_changes`. They are divided into four subdirectories:
 
 - **Deprecations**: Announcements of future changes. Typically, these will
   raise a deprecation warning and users of this API should change their code
@@ -16,14 +16,15 @@ API change notes for future releases are collected in the most recent directory
   result.
 - **Development changes**: Changes to the build process, dependencies, etc.
 
-Please place new entries in the respective files in this directory. Typically,
-each change will get its own section, but you may also amend existing sections
-when suitable. The overall goal is a comprehensible documentation of the
-changes.
+Please place new entries in these directories with a new file named
+``99999-ABC.rst``, where ``99999`` would be the PR number, and ``ABC`` the
+author's initials. Typically, each change will get its own file, but you may
+also amend existing files when suitable. The overall goal is a comprehensible
+documentation of the changes.
 
 A typical entry could look like this::
 
-    Locators
-    ~~~~~~~~
-    The unused `Locator.autoscale()` method is deprecated (pass the axis
-    limits to `Locator.view_limits()` instead).
+   Locators
+   ~~~~~~~~
+   The unused `Locator.autoscale()` method is deprecated (pass the axis
+   limits to `Locator.view_limits()` instead).

--- a/doc/api/next_api_changes/behavior/00001-ABC.rst
+++ b/doc/api/next_api_changes/behavior/00001-ABC.rst
@@ -1,0 +1,7 @@
+Behavior Change template
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enter description here....
+
+Please rename file with PR number and your initials i.e. "99999-ABC.rst"
+and ``git add`` the new file.  

--- a/doc/api/next_api_changes/deprecations/00001-ABC.rst
+++ b/doc/api/next_api_changes/deprecations/00001-ABC.rst
@@ -1,0 +1,7 @@
+Template for deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add description here...
+
+Please rename file with PR number and your initials i.e. "99999-ABC.rst"
+and ``git add`` the new file.

--- a/doc/api/next_api_changes/deprecations/00009-AL.rst
+++ b/doc/api/next_api_changes/deprecations/00009-AL.rst
@@ -1,10 +1,6 @@
-Deprecations
-------------
-
 ``dpi_cor`` property of `.FancyArrowPatch`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This parameter is considered internal and deprecated.
-
 
 Colorbar docstrings
 ~~~~~~~~~~~~~~~~~~~

--- a/doc/api/next_api_changes/development/00001-ABC.rst
+++ b/doc/api/next_api_changes/development/00001-ABC.rst
@@ -1,0 +1,7 @@
+Development Change template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enter description here....
+
+Please rename file with PR number and your initials i.e. "99999-ABC.rst"
+and ``git add`` the new file.  

--- a/doc/api/next_api_changes/removals/00001-ABC.rst
+++ b/doc/api/next_api_changes/removals/00001-ABC.rst
@@ -1,0 +1,7 @@
+Removal Change template
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Enter description of methods/classes removed here....
+
+Please rename file with PR number and your initials i.e. "99999-ABC.rst"
+and ``git add`` the new file.  

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -110,8 +110,9 @@ Documentation
   :file:`doc/users/whats_new.rst`.
 
 * If you change the API in a backward-incompatible way, please
-  document it in the relevant file in most recent
-  :file:`doc/api/api_changes_X.Y`.
+  document it by adding a file in the relevant subdirectory of
+  :file:`doc/api/next_api_changes/`, probably in the ``behavior/``
+  subdirectory.
 
 .. _pr-labels:
 
@@ -163,9 +164,9 @@ Merging
   approve the review and if you think no more review is needed, merge
   the PR.
 
-  Ensure that all API changes are documented in the relevant file in
-  the most recent :file:`doc/api/api_changes_X.Y` and significant new features
-  have an entry in :file:`doc/user/whats_new`.
+  Ensure that all API changes are documented in a file in one of the
+  subdirectories of :file:`doc/api/next_api_changes`, and significant new
+  features have an entry in :file:`doc/user/whats_new`.
 
   - If a PR already has a positive review, a core developer (e.g. the first
     reviewer, but not necessarily) may champion that PR for merging.  In order

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -227,8 +227,10 @@ rules before submitting a pull request:
   :file:`doc/users/next_whats_new/README.rst` for more information).
 
 * If you change the API in a backward-incompatible way, please document it in
-  :file:`doc/api/api_changes`, by adding to the relevant file
-  (see :file:`doc/api/api_changes.rst` for more information)
+  :file:`doc/api/next_api_changes/behavior`, by adding a new file with the
+  naming convention ``99999-ABC.rst`` where the pull request number is followed
+  by the contributor's initials. (see :file:`doc/api/api_changes.rst` for more
+  information)
 
 * See below for additional points about :ref:`keyword-argument-processing`, if
   applicable for your pull request.
@@ -317,8 +319,10 @@ API changes
 Changes to the public API must follow a standard deprecation procedure to
 prevent unexpected breaking of code that uses Matplotlib.
 
-- Deprecations must be announced via an entry in
-  the most recent :file:`doc/api/api_changes_X.Y`
+- Deprecations must be announced via a new file in
+  a new file in :file:`doc/api/next_api_changes/deprecations/` with
+  naming convention ``99999-ABC.rst`` where ``99999`` is the pull request
+  number and ``ABC`` are the contributor's initials.
 - Deprecations are targeted at the next point-release (i.e. 3.x.0).
 - The deprecated API should, to the maximum extent possible, remain fully
   functional during the deprecation period. In cases where this is not

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -112,7 +112,7 @@ For the "what's new",
 Similarly for the "API changes",
 
  1. copy the current api changes to a file is :file:`doc/api/prev_api_changes`
- 2. merge all of the files in the most recent :file:`doc/api/api_changes_X.Y`
+ 2. merge all of the files in the most recent :file:`doc/api/next_api_changes`
     into :file:`doc/api/api_changes.rst`
  3. comment out the most recent API changes at the top.
 


### PR DESCRIPTION
## PR Summary

The `next_api_changes` has some recent changes that I think should be reconsidered.  Less egregious, the `next_api_changes` were put into one of four files instead of individual files.  As explained in #15158 this was so that the API changes were not a huge mishmash of deprecations, behaviour changes etc, all of which are far easier to track at the outset rather than when the release is made.  

However, this leads to endless rebasing, and I don't think is particularly sustainable.  

This PR goes back to the one-file-per PR model, but introduces subdirectories:

```
next_api_changes/
   behaviour/
   deprecations/
   development/
   removal/
```
so the organization is by subdirectory.  The release manager will still have to concatenate the files, but that is pretty easy.  

The other change that happened was we renamed the directory `3.3_api_changes` which makes no sense if we have a PR that is slated for 3.4 or one that doesn't get into 3.4.  If 3.3 gets cut then my API change is a directory that has been removed.  

The one-file per PR gets around all these issues because the file will only appear in a tagged release in the right spot.  

ping @dstansby @QuLogic @anntzer 

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
