### PR TITLE
Keep explicit ticklabels in sync with ticks from FixedLocator

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -39,7 +39,7 @@ did nothing, when passed an unsupported value. It now raises a ``ValueError``.
 
 ``Axis.set_ticklabels()`` must match ``FixedLocator.locs``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If an axis is using a `.tickers.FixedLocator`, typically set by a call to
+If an axis is using a `.ticker.FixedLocator`, typically set by a call to
 `.Axis.set_ticks`, then the number of ticklabels supplied must match the
 number of locations available (``FixedFormattor.locs``).  If not, a
 ``ValueError`` is raised.

--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -37,6 +37,13 @@ did nothing, when passed an unsupported value. It now raises a ``ValueError``.
 `.pyplot.tick_params`) used to accept any value for ``which`` and silently
 did nothing, when passed an unsupported value. It now raises a ``ValueError``.
 
+``Axis.set_ticklabels()`` must match ``FixedLocator.locs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If an axis is using a `.tickers.FixedLocator`, typically set by a call to
+`.Axis.set_ticks`, then the number of ticklabels supplied must match the
+number of locations available (``FixedFormattor.locs``).  If not, a
+``ValueError`` is raised.
+
 ``backend_pgf.LatexManager.latex``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``backend_pgf.LatexManager.latex`` is now created with ``encoding="utf-8"``, so

--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -226,17 +226,20 @@ Other
 Discouraged
 -----------
 
-These methods implicitly use `~matplotlib.ticker.FixedLocator` and
-`~matplotlib.ticker.FixedFormatter`.  They can be convenient, but if
-not used together may de-couple your tick labels from your data.
+These methods should be used together with care, calling ``set_ticks``
+to specify the desired tick locations **before** calling ``set_ticklabels`` to
+specify a matching series of labels.  Calling ``set_ticks`` makes a
+`~matplotlib.ticker.FixedLocator`; it's list of locations is then used by
+``set_ticklabels`` to make an appropriate
+`~matplotlib.ticker.FuncFormatter`.
 
 .. autosummary::
    :toctree: _as_gen
    :template: autosummary.rst
    :nosignatures:
 
-   Axis.set_ticklabels
    Axis.set_ticks
+   Axis.set_ticklabels
 
 
 

--- a/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -289,7 +289,7 @@ annotate_heatmap(im, valfmt=fmt, size=9, fontweight="bold", threshold=-1,
 # `matplotlib.ticker.FuncFormatter`.
 
 corr_matrix = np.corrcoef(np.random.rand(6, 5))
-im, _ = heatmap(corr_matrix, vegetables, vegetables, ax=ax4,
+im, _ = heatmap(corr_matrix, vegetables, farmers, ax=ax4,
                 cmap="PuOr", vmin=-1, vmax=1,
                 cbarlabel="correlation coeff.")
 

--- a/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -288,8 +288,8 @@ annotate_heatmap(im, valfmt=fmt, size=9, fontweight="bold", threshold=-1,
 # the diagonal elements (which are all 1) by using a
 # `matplotlib.ticker.FuncFormatter`.
 
-corr_matrix = np.corrcoef(np.random.rand(6, 5))
-im, _ = heatmap(corr_matrix, vegetables, farmers, ax=ax4,
+corr_matrix = np.corrcoef(harvest)
+im, _ = heatmap(corr_matrix, vegetables, vegetables, ax=ax4,
                 cmap="PuOr", vmin=-1, vmax=1,
                 cbarlabel="correlation coeff.")
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3016,6 +3016,7 @@ class _AxesBase(martist.Artist):
             self.yaxis.get_major_locator().set_params(**kwargs)
         self._request_autoscale_view(tight=tight,
                                      scalex=update_x, scaley=update_y)
+        self.stale = True
 
     def tick_params(self, axis='both', **kwargs):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1626,11 +1626,18 @@ class Axis(martist.Artist):
         """
         ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
                       for t in ticklabels]
+        locator = (self.get_minor_locator() if minor
+                   else self.get_major_locator())
+        if isinstance(locator, mticker.FixedLocator):
+            formatter = mticker.FuncFormatter(
+                lambda x, pos: ticklabels[[*locator.locs].index(x)])
+        else:
+            formatter = mticker.FixedFormatter(ticklabels)
         if minor:
-            self.set_minor_formatter(mticker.FixedFormatter(ticklabels))
+            self.set_minor_formatter(formatter)
             ticks = self.get_minor_ticks()
         else:
-            self.set_major_formatter(mticker.FixedFormatter(ticklabels))
+            self.set_major_formatter(formatter)
             ticks = self.get_major_ticks()
         ret = []
         for tick_label, tick in zip(ticklabels, ticks):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1617,8 +1617,9 @@ class Axis(martist.Artist):
         Parameters
         ----------
         ticklabels : sequence of str or of `.Text`\s
-            List of texts for tick labels; must include values for non-visible
-            labels.
+            Texts for labeling each tick location in the sequence set by
+            `.Axis.set_ticks`; the number of labels must match the number of
+            locations.
         minor : bool
             If True, set minor ticks instead of major ticks.
         **kwargs

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1653,7 +1653,7 @@ class Axis(martist.Artist):
         ret = []
         for pos, (loc, tick) in enumerate(zip(locs, ticks)):
             tick.update_position(loc)
-            tick_label = formatter(tick._loc, pos)
+            tick_label = formatter(loc, pos)
             # deal with label1
             tick.label1.set_text(tick_label)
             tick.label1.update(kwargs)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1638,7 +1638,8 @@ class Axis(martist.Artist):
             if len(locator.locs) != len(ticklabels):
                 raise ValueError(
                     "The number of FixedLocator locations"
-                    f" ({len(locator.locs)}) does not match"
+                    f" ({len(locator.locs)}), usually from a call to"
+                    " set_ticks, does not match"
                     f" the number of ticklabels ({len(ticklabels)}).")
             tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}
             func = functools.partial(self._format_with_dict, tickd)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1599,6 +1599,11 @@ class Axis(martist.Artist):
         """
         self.pickradius = pickradius
 
+    # Helper for set_ticklabels. Defining it here makes it pickleable.
+    @staticmethod
+    def _format_with_dict(x, pos, tickd):
+        return tickd.get(x, "")
+
     def set_ticklabels(self, ticklabels, *, minor=False, **kwargs):
         r"""
         Set the text values of the tick labels.
@@ -1630,7 +1635,7 @@ class Axis(martist.Artist):
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
             tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}
-            formatter = mticker.FuncFormatter(lambda x, pos: tickd.get(x, ""))
+            formatter = mticker.FuncFormatter(self._format_with_dict, tickd)
         else:
             formatter = mticker.FixedFormatter(ticklabels)
         if minor:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1629,7 +1629,7 @@ class Axis(martist.Artist):
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
-            tickd = {loc:lab for loc, lab in zip(locator.locs, ticklabels)}
+            tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}
             formatter = mticker.FuncFormatter(lambda x, pos: tickd.get(x, ""))
         else:
             formatter = mticker.FixedFormatter(ticklabels)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1629,8 +1629,8 @@ class Axis(martist.Artist):
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
-            formatter = mticker.FuncFormatter(
-                lambda x, pos: ticklabels[[*locator.locs].index(x)])
+            tickd = {loc:lab for loc, lab in zip(locator.locs, ticklabels)}
+            formatter = mticker.FuncFormatter(lambda x, pos: tickd.get(x, ""))
         else:
             formatter = mticker.FixedFormatter(ticklabels)
         if minor:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1635,6 +1635,11 @@ class Axis(martist.Artist):
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
+            if len(locator.locs) != len(ticklabels):
+                raise ValueError(
+                    "The number of FixedLocator locations"
+                    f" ({len(locator.locs)}) does not match"
+                    f" the number of ticklabels ({len(ticklabels)}).")
             tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}
             func = functools.partial(self._format_with_dict, tickd)
             formatter = mticker.FuncFormatter(func)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1640,16 +1640,19 @@ class Axis(martist.Artist):
             formatter = mticker.FuncFormatter(func)
         else:
             formatter = mticker.FixedFormatter(ticklabels)
+
         if minor:
             self.set_minor_formatter(formatter)
-            ticks = self.get_minor_ticks()
+            locs = self.get_minorticklocs()
+            ticks = self.get_minor_ticks(len(locs))
         else:
             self.set_major_formatter(formatter)
-            ticks = self.get_major_ticks()
+            locs = self.get_majorticklocs()
+            ticks = self.get_major_ticks(len(locs))
 
-        self._update_ticks()
         ret = []
-        for pos, tick in enumerate(ticks):
+        for pos, (loc, tick) in enumerate(zip(locs, ticks)):
+            tick.update_position(loc)
             tick_label = formatter(tick._loc, pos)
             # deal with label1
             tick.label1.set_text(tick_label)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -3,6 +3,7 @@ Classes for the ticks and x and y axis.
 """
 
 import datetime
+import functools
 import logging
 
 import numpy as np
@@ -1601,7 +1602,7 @@ class Axis(martist.Artist):
 
     # Helper for set_ticklabels. Defining it here makes it pickleable.
     @staticmethod
-    def _format_with_dict(x, pos, tickd):
+    def _format_with_dict(tickd, x, pos):
         return tickd.get(x, "")
 
     def set_ticklabels(self, ticklabels, *, minor=False, **kwargs):
@@ -1635,7 +1636,8 @@ class Axis(martist.Artist):
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
             tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}
-            formatter = mticker.FuncFormatter(self._format_with_dict, tickd)
+            func = functools.partial(self._format_with_dict, tickd)
+            formatter = mticker.FuncFormatter(func)
         else:
             formatter = mticker.FixedFormatter(ticklabels)
         if minor:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1639,8 +1639,11 @@ class Axis(martist.Artist):
         else:
             self.set_major_formatter(formatter)
             ticks = self.get_major_ticks()
+
+        self._update_ticks()
         ret = []
-        for tick_label, tick in zip(ticklabels, ticks):
+        for pos, tick in enumerate(ticks):
+            tick_label = formatter(tick._loc, pos)
             # deal with label1
             tick.label1.set_text(tick_label)
             tick.label1.update(kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4452,6 +4452,18 @@ def test_set_get_ticklabels():
     ax[1].set_yticklabels(ax[0].get_yticklabels())
 
 
+def test_subsampled_ticklabels():
+    # test issue 11937
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    ax.xaxis.set_ticks(np.arange(10) + 0.1)
+    ax.locator_params(nbins=5)
+    ax.xaxis.set_ticklabels([c for c in "bcdefghijk"])
+    plt.draw()
+    labels = [t.get_text() for t in ax.xaxis.get_ticklabels()]
+    assert labels == ['b', 'd', 'f', 'h', 'j']
+
+
 @image_comparison(['retain_tick_visibility.png'])
 def test_retain_tick_visibility():
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4441,8 +4441,8 @@ def test_set_get_ticklabels():
     # set ticklabel to 1 plot in normal way
     ax[0].set_xticks(range(10))
     ax[0].set_yticks(range(10))
-    ax[0].set_xticklabels(['a', 'b', 'c', 'd'])
-    ax[0].set_yticklabels(['11', '12', '13', '14'])
+    ax[0].set_xticklabels(['a', 'b', 'c', 'd'] + 6 * [''])
+    ax[0].set_yticklabels(['11', '12', '13', '14'] + 6 * [''])
 
     # set ticklabel to the other plot, expect the 2 plots have same label
     # setting pass get_ticklabels return value as ticklabels argument
@@ -4462,6 +4462,14 @@ def test_subsampled_ticklabels():
     plt.draw()
     labels = [t.get_text() for t in ax.xaxis.get_ticklabels()]
     assert labels == ['b', 'd', 'f', 'h', 'j']
+
+
+def test_mismatched_ticklabels():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    ax.xaxis.set_ticks([1.5, 2.5])
+    with pytest.raises(ValueError):
+        ax.xaxis.set_ticklabels(['a', 'b', 'c'])
 
 
 @image_comparison(['retain_tick_visibility.png'])

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -379,11 +379,13 @@ class FuncFormatter(Formatter):
 
     The function should take in two inputs (a tick value ``x`` and a
     position ``pos``), and return a string containing the corresponding
-    tick label.
+    tick label.  The function may take additional arguments that are
+    supplied upon instantiation.
     """
 
-    def __init__(self, func):
+    def __init__(self, func, *args):
         self.func = func
+        self.args = args
         self.offset_string = ""
 
     def __call__(self, x, pos=None):
@@ -392,7 +394,7 @@ class FuncFormatter(Formatter):
 
         *x* and *pos* are passed through as-is.
         """
-        return self.func(x, pos)
+        return self.func(x, pos, *self.args)
 
     def get_offset(self):
         return self.offset_string

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -379,13 +379,11 @@ class FuncFormatter(Formatter):
 
     The function should take in two inputs (a tick value ``x`` and a
     position ``pos``), and return a string containing the corresponding
-    tick label.  The function may take additional arguments that are
-    supplied upon instantiation.
+    tick label.
     """
 
-    def __init__(self, func, *args):
+    def __init__(self, func):
         self.func = func
-        self.args = args
         self.offset_string = ""
 
     def __call__(self, x, pos=None):
@@ -394,7 +392,7 @@ class FuncFormatter(Formatter):
 
         *x* and *pos* are passed through as-is.
         """
-        return self.func(x, pos, *self.args)
+        return self.func(x, pos)
 
     def get_offset(self):
         return self.offset_string

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -381,8 +381,10 @@ class FuncFormatter(Formatter):
     position ``pos``), and return a string containing the corresponding
     tick label.
     """
+
     def __init__(self, func):
         self.func = func
+        self.offset_string = ""
 
     def __call__(self, x, pos=None):
         """
@@ -391,6 +393,12 @@ class FuncFormatter(Formatter):
         *x* and *pos* are passed through as-is.
         """
         return self.func(x, pos)
+
+    def get_offset(self):
+        return self.offset_string
+
+    def set_offset_string(self, ofs):
+        self.offset_string = ofs
 
 
 class FormatStrFormatter(Formatter):


### PR DESCRIPTION
## PR Summary
Using FixedFormatter with ticks from FixedLocator causes mislabeled ticks if the nbins kwarg of the locator triggers subsampling.  This PR addresses that in the common case where the `Axis.set_ticklabels` method is used, by setting a FuncFormatter instead of a FixedFormatter.

Closes #11937.
## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
