### PR TITLE
Improve image comparison decorator

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -398,13 +398,11 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
                              f"function has the signature {old_sig}")
 
         @pytest.mark.parametrize("ext", extensions)
-        def wrapper(*args, **kwargs):
-            ext = kwargs['ext']
-            if 'ext' not in old_sig.parameters:
-                kwargs.pop('ext')
-            request = kwargs['request']
-            if 'request' not in old_sig.parameters:
-                kwargs.pop('request')
+        def wrapper(*args, ext, request, **kwargs):
+            if 'ext' in old_sig.parameters:
+                kwargs['ext'] = ext
+            if 'request' in old_sig.parameters:
+                kwargs['request'] = request
 
             file_name = "".join(c for c in request.node.name
                                 if c in ALLOWED_CHARS)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3150,15 +3150,10 @@ def test_hist_stacked_weighted():
     ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
 
 
-@image_comparison(['stem.png', 'stem.png'], style='mpl20', remove_text=True)
-def test_stem():
-    # Note, we don't use @pytest.mark.parametrize, because in parallel this
-    # might cause one process result to overwrite another's.
-    for use_line_collection in [True, False]:
-        _test_stem(use_line_collection)
-
-
-def _test_stem(use_line_collection):
+@pytest.mark.parametrize("use_line_collection", [True, False],
+                         ids=['w/ line collection', 'w/o line collection'])
+@image_comparison(['stem.png'], style='mpl20', remove_text=True)
+def test_stem(use_line_collection):
     x = np.linspace(0.1, 2 * np.pi, 100)
     args = (x, np.cos(x))
     # Label is a single space to force a legend to be drawn, but to avoid any

--- a/lib/mpl_toolkits/tests/test_axes_grid.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid.py
@@ -12,16 +12,10 @@ from mpl_toolkits.axes_grid1 import ImageGrid
 # The original version of this test relied on mpl_toolkits's slightly different
 # colorbar implementation; moving to matplotlib's own colorbar implementation
 # caused the small image comparison error.
-@image_comparison(['imagegrid_cbar_mode.png', 'imagegrid_cbar_mode.png'],
+@pytest.mark.parametrize("legacy_colorbar", [False, True])
+@image_comparison(['imagegrid_cbar_mode.png'],
                   remove_text=True, style='mpl20', tol=0.3)
-def test_imagegrid_cbar_mode_edge():
-    # Note, we don't use @pytest.mark.parametrize, because in parallel this
-    # might cause one process result to overwrite another's.
-    for legacy_colorbar in [False, True]:
-        _test_imagegrid_cbar_mode_edge(legacy_colorbar)
-
-
-def _test_imagegrid_cbar_mode_edge(legacy_colorbar):
+def test_imagegrid_cbar_mode_edge(legacy_colorbar):
     mpl.rcParams["mpl_toolkits.legacy_colorbar"] = legacy_colorbar
 
     X, Y = np.meshgrid(np.linspace(0, 6, 30), np.linspace(0, 6, 30))


### PR DESCRIPTION
## PR Summary

Firstly, re-write the parameter indirection in `image_comparison` to use signature modifications, like `check_figures_equal`. Secondly add a lock file for any comparisons that are externally parametrized.

We've been seeing `test_loglog_nonpos` fail a lot on macOS, and this should help with that case. Since there's now a lock, revert some of my previous workarounds to avoid parallel writes.

`mpl_image_comparison_parameters` is no longer used, but I'm not sure if we consider `matplotlib.testing.conftest` public or whether I can just remove it. It's really only useful when applied via `image_comparison`.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way