### PR TITLE
Fix ConciseDateFormatter when plotting a range included in a second

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -775,6 +775,10 @@ class ConciseDateFormatter(ticker.Formatter):
         for level in range(5, -1, -1):
             if len(np.unique(tickdate[:, level])) > 1:
                 break
+            elif level == 0:
+                # all tickdate are the same, so only micros might be different
+                # set to the most precise available (level=6: microseconds doesn't exist...)
+                level = 5
 
         # level is the basic level we will label at.
         # now loop through and decide the actual ticklabels

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -777,7 +777,7 @@ class ConciseDateFormatter(ticker.Formatter):
                 break
             elif level == 0:
                 # all tickdate are the same, so only micros might be different
-                # set to the most precise available (level=6: microseconds doesn't exist...)
+                # set to the most precise (6: microseconds doesn't exist...)
                 level = 5
 
         # level is the basic level we will label at.

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -449,6 +449,14 @@ def test_auto_date_locator_intmult():
         assert list(map(str, mdates.num2date(locator()))) == expected
 
 
+def test_concise_formatter_subsecond():
+    locator = mdates.AutoDateLocator(interval_multiples=True)
+    formatter = mdates.ConciseDateFormatter(locator)
+    year_1996 = 9861.0
+    strings = formatter.format_ticks([year_1996, year_1996 + 500 / mdates.MUSECONDS_PER_DAY, year_1996 + 900 / mdates.MUSECONDS_PER_DAY])
+    assert strings == ['00:00', '00.0005', '00.0009']
+
+
 def test_concise_formatter():
     def _create_auto_date_locator(date1, date2):
         fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -453,7 +453,10 @@ def test_concise_formatter_subsecond():
     locator = mdates.AutoDateLocator(interval_multiples=True)
     formatter = mdates.ConciseDateFormatter(locator)
     year_1996 = 9861.0
-    strings = formatter.format_ticks([year_1996, year_1996 + 500 / mdates.MUSECONDS_PER_DAY, year_1996 + 900 / mdates.MUSECONDS_PER_DAY])
+    strings = formatter.format_ticks([
+        year_1996,
+        year_1996 + 500 / mdates.MUSECONDS_PER_DAY,
+        year_1996 + 900 / mdates.MUSECONDS_PER_DAY])
     assert strings == ['00:00', '00.0005', '00.0009']
 
 


### PR DESCRIPTION
When micros only are changing (the plot is showing a range inside a second),
the ConciseDateFormatter previously computed a level 0 : year,
which would make it display only years... when microseconds resolution is expected.