### PR TITLE
MNT: do not try to import xml.etree.cElementTree

### DIFF
--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -57,7 +57,7 @@ f = BytesIO()
 plt.savefig(f, format="svg")
 
 
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 # filter definition for a gaussian blur
 filter_def = """

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -46,7 +46,7 @@ from io import BytesIO
 f = BytesIO()
 plt.savefig(f, format="svg")
 
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 
 # filter definition for shadow using a gaussian blur


### PR DESCRIPTION
As of py33 the fastest available version is imported and in py39 the
alias of `xml.etree.cElementTree` for `xml.etree.ElementTree` will be
removed.

This will ensure that our examples keep running with future versions of Python.