### PR TITLE
Allow numpy arrays in markevery

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -537,7 +537,7 @@ class Line2D(Artist):
         Parameters
         ----------
         every : None or int or (int, int) or slice or List[int] or float or \
-(float, float)
+(float, float) or List[bool]
             Which markers to plot.
 
             - every=None, every point will be plotted.
@@ -549,6 +549,8 @@ class Line2D(Artist):
               point start, up to but not including point end, will be plotted.
             - every=[i, j, m, n], only markers at points i, j, m, and n
               will be plotted.
+            - every=[True, False, True], positions that are True will be
+              plotted.
             - every=0.1, (i.e. a float) then markers will be spaced at
               approximately equal distances along the line; the distance
               along the line between markers is determined by multiplying the
@@ -580,9 +582,8 @@ class Line2D(Artist):
         axes-bounding-box-diagonal regardless of the actual axes data limits.
 
         """
-        if self._markevery != every:
-            self.stale = True
         self._markevery = every
+        self.stale = True
 
     def get_markevery(self):
         """

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -199,6 +199,30 @@ def test_step_markers(fig_test, fig_ref):
     fig_ref.subplots().plot([0, 0, 1], [0, 1, 1], "-o", markevery=[0, 2])
 
 
+@check_figures_equal(extensions=('png',))
+def test_markevery(fig_test, fig_ref):
+    np.random.seed(42)
+    t = np.linspace(0, 3, 14)
+    y = np.random.rand(len(t))
+
+    casesA = [None, 4, (2, 5), [1, 5, 11],
+              [0, -1], slice(5, 10, 2), 0.3, (0.3, 0.4),
+              np.arange(len(t))[y > 0.5]]
+    casesB = ["11111111111111", "10001000100010", "00100001000010",
+              "01000100000100", "10000000000001", "00000101010000",
+              "11011011011110", "01010011011101", "01110001110110"]
+
+    axsA = fig_ref.subplots(3, 3)
+    axsB = fig_test.subplots(3, 3)
+
+    for ax, case in zip(axsA.flat, casesA):
+        ax.plot(t, y, "-gD", markevery=case)
+
+    for ax, case in zip(axsB.flat, casesB):
+        me = np.array(list(case)).astype(int).astype(bool)
+        ax.plot(t, y, "-gD", markevery=me)
+
+
 def test_marker_as_markerstyle():
     fig, ax = plt.subplots()
     line, = ax.plot([2, 4, 3], marker=MarkerStyle("D"))


### PR DESCRIPTION
## PR Summary

This line https://github.com/matplotlib/matplotlib/blob/9a9c8b8a7150de9a4d109cb7c0462b6e475e13b4/lib/matplotlib/lines.py#L583

prevents numpy arrays to be used as input to `markevery`, Because `The truth value of an array with more than one element is ambiguous.`
That's actually a regression that came in via #4091. 

I think we would like to support numpy arrays wherever possible. So this PR just removes the check and sets the artist stale on every call to `set_markevery`. 

Also creates tests for all possible cases that markevery can take.



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
