### PR TITLE
Make API of get_tightbbox more consistent between Axes and Axis.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -229,11 +229,9 @@ x direction, making the axes smaller in the x-direction doesn't help.  The
 behavior of both has been changed to ignore the width of the title and
 xlabel and the height of the ylabel in the layout logic.
 
-This also means there is a new keyword argument for `.axes.Axes.get_tightbbox`:
-``for_layout_only``, which defaults to *False*, but if *True* returns a
-bounding box using the rules above.  `.axis.Axis.get_tightbbox` gets an
-``ignore_label`` keyword argument, which is *None* by default, but which can
-also be 'x' or 'y'. 
+This also means there is a new keyword argument for `.axes.Axes.get_tightbbox`
+and `.axis.Axis.get_tightbbox`: ``for_layout_only``, which defaults to *False*,
+but if *True* returns a bounding box using the rules above.
 
 :rc:`savefig.facecolor` and :rc:`savefig.edgecolor` now default to "auto"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4143,22 +4143,24 @@ class _AxesBase(martist.Artist):
             self.apply_aspect()
 
         if self.axison:
-            try:
-                bb_xaxis = self.xaxis.get_tightbbox(
-                    renderer, for_layout_only=for_layout_only)
-            except TypeError:
-                # in case downstream library has redefined axis:
-                bb_xaxis = self.xaxis.get_tightbbox(renderer)
-            if bb_xaxis:
-                bb.append(bb_xaxis)
-            try:
-                bb_yaxis = self.yaxis.get_tightbbox(
-                    renderer, for_layout_only=for_layout_only)
-            except TypeError:
-                # in case downstream library has redefined axis:
-                bb_yaxis = self.yaxis.get_tightbbox(renderer)
-            if bb_yaxis:
-                bb.append(bb_yaxis)
+            if self.xaxis.get_visible():
+                try:
+                    bb_xaxis = self.xaxis.get_tightbbox(
+                        renderer, for_layout_only=for_layout_only)
+                except TypeError:
+                    # in case downstream library has redefined axis:
+                    bb_xaxis = self.xaxis.get_tightbbox(renderer)
+                if bb_xaxis:
+                    bb.append(bb_xaxis)
+            if self.yaxis.get_visible():
+                try:
+                    bb_yaxis = self.yaxis.get_tightbbox(
+                        renderer, for_layout_only=for_layout_only)
+                except TypeError:
+                    # in case downstream library has redefined axis:
+                    bb_yaxis = self.yaxis.get_tightbbox(renderer)
+                if bb_yaxis:
+                    bb.append(bb_yaxis)
         self._update_title_position(renderer)
         axbbox = self.get_window_extent(renderer)
         bb.append(axbbox)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4143,21 +4143,20 @@ class _AxesBase(martist.Artist):
             self.apply_aspect()
 
         if self.axison:
-            igl = 'x' if for_layout_only else None
             try:
-                bb_xaxis = self.xaxis.get_tightbbox(renderer, ignore_label=igl)
+                bb_xaxis = self.xaxis.get_tightbbox(
+                    renderer, for_layout_only=for_layout_only)
             except TypeError:
                 # in case downstream library has redefined axis:
                 bb_xaxis = self.xaxis.get_tightbbox(renderer)
             if bb_xaxis:
                 bb.append(bb_xaxis)
-
-            igl = 'y' if for_layout_only else None
             try:
-                bb_yaxis = self.yaxis.get_tightbbox(renderer, ignore_label=igl)
+                bb_yaxis = self.yaxis.get_tightbbox(
+                    renderer, for_layout_only=for_layout_only)
             except TypeError:
                 # in case downstream library has redefined axis:
-                bb_xaxis = self.yaxis.get_tightbbox(renderer)
+                bb_yaxis = self.yaxis.get_tightbbox(renderer)
             if bb_yaxis:
                 bb.append(bb_yaxis)
         self._update_title_position(renderer)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1079,15 +1079,15 @@ class Axis(martist.Artist):
                 [tick.label2.get_window_extent(renderer)
                  for tick in ticks if tick.label2.get_visible()])
 
-    def get_tightbbox(self, renderer, *, ignore_label=None):
+    def get_tightbbox(self, renderer, *, for_layout_only=False):
         """
         Return a bounding box that encloses the axis. It only accounts
         tick labels, axis label, and offsetText.
 
-        If ``ignore_label`` is 'x', then the width of the label is collapsed
-        to near zero.  If 'y', then the height is collapsed to near zero. This
-        is for tight/constrained_layout to be able to ignore too-long labels
-        when doing their layout.
+        If *for_layout_only* is True, then the width of the label (if this
+        is an x-axis) or the height of the label (if this is a y-axis) is
+        collapsed to near zero.  This allows tight/constrained_layout to ignore
+        too-long labels when doing their layout.
         """
         if not self.get_visible():
             return
@@ -1114,14 +1114,15 @@ class Axis(martist.Artist):
         if self.label.get_visible():
             bb = self.label.get_window_extent(renderer)
             # for constrained/tight_layout, we want to ignore the label's
-            # width because the adjustments they make can't be improved.
+            # width/height because the adjustments they make can't be improved.
             # this code collapses the relevant direction
-            if ignore_label == 'x' and bb.width > 0:
-                bb.x0 = (bb.x0 + bb.x1) / 2 - 0.5
-                bb.x1 = bb.x0 + 1.0
-            elif ignore_label == 'y' and bb.height > 0:
-                bb.y0 = (bb.y0 + bb.y1) / 2 - 0.5
-                bb.y1 = bb.y0 + 1.0
+            if for_layout_only:
+                if self.axis_name == "x" and bb.width > 0:
+                    bb.x0 = (bb.x0 + bb.x1) / 2 - 0.5
+                    bb.x1 = bb.x0 + 1.0
+                if self.axis_name == "y" and bb.height > 0:
+                    bb.y0 = (bb.y0 + bb.y1) / 2 - 0.5
+                    bb.y1 = bb.y0 + 1.0
             bboxes.append(bb)
         bboxes = [b for b in bboxes
                   if 0 < b.width < np.inf and 0 < b.height < np.inf]


### PR DESCRIPTION
Instead of having Axes trying to figure out what direction to ignore,
let the Axis handle that.  This keeps the signature of get_tightbbox
consistent between Axes and Axis.

Also fix a typo bb_xaxis -> bb_yaxis.

Followup to #17222; was discussed briefly in https://github.com/matplotlib/matplotlib/pull/17222#discussion_r414083433 though not acted upon.  Even if we decide not to go that route *at least* the bb_xaxis->bb_yaxis change should be split out and merged for 3.3.

Marked as release critical so that we don't change the API after the release, if we decide to go this route.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
