### PR TITLE
Normalize gridspec ratios to lists in the setter.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -314,10 +314,6 @@ def _align_spines(fig, gs):
     nrows, ncols = gs.get_geometry()
     width_ratios = gs.get_width_ratios()
     height_ratios = gs.get_height_ratios()
-    if width_ratios is None:
-        width_ratios = np.ones(ncols)
-    if height_ratios is None:
-        height_ratios = np.ones(nrows)
 
     # get axes in this gridspec....
     axs = [ax for ax in fig.axes

--- a/lib/matplotlib/_layoutbox.py
+++ b/lib/matplotlib/_layoutbox.py
@@ -499,36 +499,20 @@ def vpack(boxes, padding=0, strength='strong'):
         boxes[i].solver.addConstraint(c | strength)
 
 
-def match_heights(boxes, height_ratios=None, strength='medium'):
+def match_heights(boxes, height_ratios, strength='medium'):
     """Stack LayoutBox instances from top to bottom."""
-
-    if height_ratios is None:
-        height_ratios = np.ones(len(boxes))
     for i in range(1, len(boxes)):
         c = (boxes[i-1].height ==
              boxes[i].height*height_ratios[i-1]/height_ratios[i])
         boxes[i].solver.addConstraint(c | strength)
 
 
-def match_widths(boxes, width_ratios=None, strength='medium'):
+def match_widths(boxes, width_ratios, strength='medium'):
     """Stack LayoutBox instances from top to bottom."""
-
-    if width_ratios is None:
-        width_ratios = np.ones(len(boxes))
     for i in range(1, len(boxes)):
         c = (boxes[i-1].width ==
              boxes[i].width*width_ratios[i-1]/width_ratios[i])
         boxes[i].solver.addConstraint(c | strength)
-
-
-def vstackeq(boxes, padding=0, height_ratios=None):
-    vstack(boxes, padding=padding)
-    match_heights(boxes, height_ratios=height_ratios)
-
-
-def hstackeq(boxes, padding=0, width_ratios=None):
-    hstack(boxes, padding=padding)
-    match_widths(boxes, width_ratios=width_ratios)
 
 
 def align(boxes, attr, strength='strong'):

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -56,9 +56,9 @@ class GridSpecBase:
 
     def __repr__(self):
         height_arg = (', height_ratios=%r' % (self._row_height_ratios,)
-                      if self._row_height_ratios is not None else '')
+                      if len(set(self._row_height_ratios)) != 1 else '')
         width_arg = (', width_ratios=%r' % (self._col_width_ratios,)
-                     if self._col_width_ratios is not None else '')
+                     if len(set(self._col_width_ratios)) != 1 else '')
         return '{clsname}({nrows}, {ncols}{optionals})'.format(
             clsname=self.__class__.__name__,
             nrows=self._nrows,
@@ -104,7 +104,9 @@ class GridSpecBase:
         *width_ratios* must be of length *ncols*. Each column gets a relative
         width of ``width_ratios[i] / sum(width_ratios)``.
         """
-        if width_ratios is not None and len(width_ratios) != self._ncols:
+        if width_ratios is None:
+            width_ratios = [1] * self._ncols
+        elif len(width_ratios) != self._ncols:
             raise ValueError('Expected the given number of width ratios to '
                              'match the number of columns of the grid')
         self._col_width_ratios = width_ratios
@@ -124,7 +126,9 @@ class GridSpecBase:
         *height_ratios* must be of length *nrows*. Each row gets a relative
         height of ``height_ratios[i] / sum(height_ratios)``.
         """
-        if height_ratios is not None and len(height_ratios) != self._nrows:
+        if height_ratios is None:
+            height_ratios = [1] * self._nrows
+        elif len(height_ratios) != self._nrows:
             raise ValueError('Expected the given number of height ratios to '
                              'match the number of rows of the grid')
         self._row_height_ratios = height_ratios
@@ -181,22 +185,16 @@ class GridSpecBase:
         # calculate accumulated heights of columns
         cell_h = tot_height / (nrows + hspace*(nrows-1))
         sep_h = hspace * cell_h
-        if self._row_height_ratios is not None:
-            norm = cell_h * nrows / sum(self._row_height_ratios)
-            cell_heights = [r * norm for r in self._row_height_ratios]
-        else:
-            cell_heights = [cell_h] * nrows
+        norm = cell_h * nrows / sum(self._row_height_ratios)
+        cell_heights = [r * norm for r in self._row_height_ratios]
         sep_heights = [0] + ([sep_h] * (nrows-1))
         cell_hs = np.cumsum(np.column_stack([sep_heights, cell_heights]).flat)
 
         # calculate accumulated widths of rows
         cell_w = tot_width / (ncols + wspace*(ncols-1))
         sep_w = wspace * cell_w
-        if self._col_width_ratios is not None:
-            norm = cell_w * ncols / sum(self._col_width_ratios)
-            cell_widths = [r * norm for r in self._col_width_ratios]
-        else:
-            cell_widths = [cell_w] * ncols
+        norm = cell_w * ncols / sum(self._col_width_ratios)
+        cell_widths = [r * norm for r in self._col_width_ratios]
         sep_widths = [0] + ([sep_w] * (ncols-1))
         cell_ws = np.cumsum(np.column_stack([sep_widths, cell_widths]).flat)
 

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -40,8 +40,8 @@ def test_simple():
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
 
-@image_comparison(['multi_pickle.png'], remove_text=True, style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.082)
+@image_comparison(
+    ['multi_pickle.png'], remove_text=True, style='mpl20', tol=0.082)
 def test_complete():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -50,7 +50,8 @@ def test_tight_layout3():
     plt.tight_layout()
 
 
-@image_comparison(['tight_layout4'], freetype_version=('2.5.5', '2.6.1'))
+@image_comparison(['tight_layout4'], freetype_version=('2.5.5', '2.6.1'),
+                  tol=0.015)
 def test_tight_layout4():
     """Test tight_layout for subplot2grid."""
     ax1 = plt.subplot2grid((3, 3), (0, 0))


### PR DESCRIPTION
This avoids having to check for `ratios == None` every time someone
actually accesses the ratios.

I just deleted the never used and private `vstackeq` and `hstackeq`
instead of changing their signatures to make height_ratios/width_ratios
non-optional, given that they should be simple enough to bring back if
needed.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
