### PR TITLE
Simplify pickling support.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -256,16 +256,6 @@ class silent_list(list):
     def __repr__(self):
         return '<a list of %d %s objects>' % (len(self), self.type)
 
-    __str__ = __repr__
-
-    def __getstate__(self):
-        # store a dictionary of this SilentList's state
-        return {'type': self.type, 'seq': self[:]}
-
-    def __setstate__(self, state):
-        self.type = state['type']
-        self.extend(state['seq'])
-
 
 @deprecated("3.3")
 class IgnoredKeywordWarning(UserWarning):

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -312,17 +312,7 @@ class GridSpec(GridSpecBase):
     _AllowedKeys = ["left", "bottom", "right", "top", "wspace", "hspace"]
 
     def __getstate__(self):
-        state = self.__dict__
-        try:
-            state.pop('_layoutbox')
-        except KeyError:
-            pass
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-        # layoutboxes don't survive pickling...
-        self._layoutbox = None
+        return {**self.__dict__, "_layoutbox": None}
 
     def update(self, **kwargs):
         """
@@ -580,17 +570,7 @@ class SubplotSpec:
         self._num2 = value
 
     def __getstate__(self):
-        state = self.__dict__
-        try:
-            state.pop('_layoutbox')
-        except KeyError:
-            pass
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__ = state
-        # layoutboxes don't survive pickling...
-        self._layoutbox = None
+        return {**self.__dict__, "_layoutbox": None}
 
     def get_gridspec(self):
         return self._gridspec


### PR DESCRIPTION
- silent_list is directly picklable as is; no need to do anything about
  it.  While we're at it, also get rid of `__str__` -- `__str__` is
  documented to fall back on `__repr__`, so the latter is sufficient.
- When pickling GridSpec and SubplotSpec, set _layoutbox to None, so
  that no special loading is needed.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
