### PR TITLE
Avoid "dash motion" in qt zoom box.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -478,16 +478,23 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         # Draw the zoom rectangle to the QPainter.  _draw_rect_callback needs
         # to be called at the end of paintEvent.
         if rect is not None:
+            x0, y0, w, h = [pt / self._dpi_ratio for pt in rect]
+            x1 = x0 + w
+            y1 = y0 + h
             def _draw_rect_callback(painter):
-                scaled_rect = [pt / self._dpi_ratio for pt in rect]
                 pen = QtGui.QPen(QtCore.Qt.black, 1 / self._dpi_ratio)
                 pen.setDashPattern([3, 3])
-                painter.setPen(pen)
-                painter.drawRect(*scaled_rect)
-                pen.setDashOffset(3)
-                pen.setColor(QtCore.Qt.white)
-                painter.setPen(pen)
-                painter.drawRect(*scaled_rect)
+                for color, offset in [
+                        (QtCore.Qt.black, 0), (QtCore.Qt.white, 3)]:
+                    pen.setDashOffset(offset)
+                    pen.setColor(color)
+                    painter.setPen(pen)
+                    # Draw the lines from x0, y0 towards x1, y1 so that the
+                    # dashes don't "jump" when moving the zoom box.
+                    painter.drawLine(x0, y0, x0, y1)
+                    painter.drawLine(x0, y0, x1, y0)
+                    painter.drawLine(x0, y1, x1, y1)
+                    painter.drawLine(x1, y0, x1, y1)
         else:
             def _draw_rect_callback(painter):
                 return


### PR DESCRIPTION
Drawing the whole zoom box as a single rectangle causes the dashes on
the "last" edge of the rectangle to keep shifting (basically depending
on the total length of the other three edges).  Instead, draw the zoom
box as 4 separate lines always going from the "fixed" point (x0, y0)
towards to "mobile" point (x1, y1) so to avoid this effect.

before:
![before](https://user-images.githubusercontent.com/1322974/80841865-97081780-8c00-11ea-8426-b14071b11abb.gif)

after:
![after](https://user-images.githubusercontent.com/1322974/80841862-94a5bd80-8c00-11ea-93ef-465b78a8ad6d.gif)


## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
