### PR TITLE
Fix alignment of offset text on top axis.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2047,19 +2047,15 @@ class XAxis(Axis):
             else:
                 bbox = mtransforms.Bbox.union(bboxes)
                 bottom = bbox.y0
-            self.offsetText.set_position(
-                (x, bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72)
-            )
+            y = bottom - self.OFFSETTEXTPAD * self.figure.dpi / 72
         else:
             if not len(bboxes2):
                 top = self.axes.bbox.ymax
             else:
                 bbox = mtransforms.Bbox.union(bboxes2)
                 top = bbox.y1
-            self.offsetText.set_va('top')
-            self.offsetText.set_position(
-                (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
-            )
+            y = top + self.OFFSETTEXTPAD * self.figure.dpi / 72
+        self.offsetText.set_position((x, y))
 
     def get_text_heights(self, renderer):
         """
@@ -2102,10 +2098,12 @@ class XAxis(Axis):
             self.set_tick_params(which='both', top=True, labeltop=True,
                                  bottom=False, labelbottom=False)
             self._tick_position = 'top'
+            self.offsetText.set_verticalalignment('bottom')
         elif position == 'bottom':
             self.set_tick_params(which='both', top=False, labeltop=False,
                                  bottom=True, labelbottom=True)
             self._tick_position = 'bottom'
+            self.offsetText.set_verticalalignment('top')
         elif position == 'both':
             self.set_tick_params(which='both', top=True,
                                  bottom=True)
@@ -2116,6 +2114,7 @@ class XAxis(Axis):
             self.set_tick_params(which='both', top=True, labeltop=False,
                                  bottom=True, labelbottom=True)
             self._tick_position = 'bottom'
+            self.offsetText.set_verticalalignment('top')
         else:
             assert False, "unhandled parameter not caught by _check_in_list"
         self.stale = True

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4641,19 +4641,23 @@ def test_move_offsetlabel():
     ax.plot(data)
     fig.canvas.draw()
     before = ax.yaxis.offsetText.get_position()
+    assert ax.yaxis.offsetText.get_horizontalalignment() == 'left'
     ax.yaxis.tick_right()
     fig.canvas.draw()
     after = ax.yaxis.offsetText.get_position()
     assert after[0] > before[0] and after[1] == before[1]
+    assert ax.yaxis.offsetText.get_horizontalalignment() == 'right'
 
     fig, ax = plt.subplots()
     ax.plot(data)
     fig.canvas.draw()
     before = ax.xaxis.offsetText.get_position()
+    assert ax.xaxis.offsetText.get_verticalalignment() == 'top'
     ax.xaxis.tick_top()
     fig.canvas.draw()
     after = ax.xaxis.offsetText.get_position()
     assert after[0] == before[0] and after[1] > before[1]
+    assert ax.xaxis.offsetText.get_verticalalignment() == 'bottom'
 
 
 @image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})


### PR DESCRIPTION
## PR Summary

This was added in #15592, but with the wrong alignment. When set to show offset text on the top, the alignment is set to top, but that's the same alignment as if it were on the bottom. It should be set to bottom instead, or it will overlap with ticks.

On master, you get:
![Figure_1](https://user-images.githubusercontent.com/302469/80856322-ece7ba00-8c16-11ea-974c-e49d73d9fae6.png)

but it should be (in this PR):
![Figure_2](https://user-images.githubusercontent.com/302469/80856324-f4a75e80-8c16-11ea-8e34-4aeed323e62e.png)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way