### PR TITLE
FIX: CL more stable

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -399,15 +399,9 @@ def _align_spines(fig, gs):
                 if height0 > height1:
                     ax0._poslayoutbox.constrain_height_min(
                         ax1._poslayoutbox.height * height0 / height1)
-                    # these constraints stop the smaller axes from
-                    # being allowed to go to zero height...
-                    ax1._poslayoutbox.constrain_height_min(
-                        ax0._poslayoutbox.height * height1 / (height0*1.8))
                 elif height0 < height1:
                     ax1._poslayoutbox.constrain_height_min(
                         ax0._poslayoutbox.height * height1 / height0)
-                    ax0._poslayoutbox.constrain_height_min(
-                        ax0._poslayoutbox.height * height0 / (height1*1.8))
             # For widths, do it if the subplots share a row.
             if not alignwidth and len(colspan0) == len(colspan1):
                 ax0._poslayoutbox.constrain_width(
@@ -417,13 +411,9 @@ def _align_spines(fig, gs):
                 if width0 > width1:
                     ax0._poslayoutbox.constrain_width_min(
                         ax1._poslayoutbox.width * width0 / width1)
-                    ax1._poslayoutbox.constrain_width_min(
-                        ax0._poslayoutbox.width * width1 / (width0*1.8))
                 elif width0 < width1:
                     ax1._poslayoutbox.constrain_width_min(
                         ax0._poslayoutbox.width * width1 / width0)
-                    ax0._poslayoutbox.constrain_width_min(
-                        ax1._poslayoutbox.width * width0 / (width1*1.8))
 
 
 def _arrange_subplotspecs(gs, hspace=0, wspace=0):


### PR DESCRIPTION
## PR Summary

Closes #17304

An issue with CL is that zero-width axes are a solution to most of the constraints.  The removed code in this PR was meant to prevent this collapse, but other changes later also do the same work (by adding a weak constraint to make the axes try to fill the figure.  As #17304 shows, these lines are fragile for poorly constrained layouts. 

Removing these lines still passes all the tests, passes the issue in #17304, and doesn't change any of the tutorial examples, so I think its fine.  



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
