### PR TITLE
Cleanup parameter types in docstrings

### DIFF
--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -35,7 +35,7 @@ def filled_hist(ax, edges, values, bottoms=None, orientation='v',
     values : array
         A length n array of bin counts or values
 
-    bottoms : scalar or array, optional
+    bottoms : float or array, optional
         A length n array of the bottom of the bars.  If None, zero is used.
 
     orientation : {'v', 'h'}

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -708,7 +708,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x, y : scalars
+        x, y : float
             The position to place the text. By default, this is in data
             coordinates. The coordinate system can be changed using the
             *transform* parameter.
@@ -1123,14 +1123,14 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        y : scalar or sequence of scalar
+        y : float or array-like
             y-indexes where to plot the lines.
 
-        xmin, xmax : scalar or 1D array-like
+        xmin, xmax : float or array-like
             Respective beginning and end of each line. If scalars are
             provided, all lines will have same length.
 
-        colors : array-like of colors, default: 'k'
+        colors : list of colors, default: 'k'
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
@@ -1205,14 +1205,14 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x : scalar or 1D array-like
+        x : float or array-like
             x-indexes where to plot the lines.
 
-        ymin, ymax : scalar or 1D array-like
+        ymin, ymax : float or array-like
             Respective beginning and end of each line. If scalars are
             provided, all lines will have same length.
 
-        colors : array-like of colors, default: 'k'
+        colors : list of colors, default: 'k'
 
         linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
@@ -1312,28 +1312,28 @@ class Axes(_AxesBase):
             - 'vertical': the lines are arranged vertically in columns,
               and are horizontal.
 
-        lineoffsets : scalar or sequence of scalars, default: 1
+        lineoffsets : float or array-like, default: 1
             The offset of the center of the lines from the origin, in the
             direction orthogonal to *orientation*.
 
             A sequence must match the dimension of *positions*
             in the direction of *orientation*.
 
-        linelengths : scalar or sequence of scalars, default: 1
+        linelengths : float or array-like, default: 1
             The total height of the lines (i.e. the lines stretches from
             ``lineoffset - linelength/2`` to ``lineoffset + linelength/2``).
 
             If a sequence, then *positions* must be 2D and the length
             must match the first dimension of *positions*.
 
-        linewidths : scalar, scalar sequence or None, default: None
+        linewidths : float or array-like or None, default: None
             The line width(s) of the event lines, in points. If it is None,
             defaults to its rcParams setting.
 
             If a sequence, then *positions* must be 2D and the length
             must match the first dimension of *positions*.
 
-        colors : color, sequence of colors or None, default: None
+        colors : color or list of colors or None, default: None
             The color(s) of the event lines. If it is None, defaults to its
             rcParams setting.
 
@@ -3163,10 +3163,10 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x, y : scalar or array-like
+        x, y : float or array-like
             The data positions.
 
-        xerr, yerr : scalar or array-like, shape(N,) or shape(2, N), optional
+        xerr, yerr : float or array-like, shape(N,) or shape(2, N), optional
             The errorbar sizes:
 
             - scalar: Symmetric +/- values for all data points.
@@ -3192,14 +3192,14 @@ class Axes(_AxesBase):
             The color of the errorbar lines.  If None, use the color of the
             line connecting the markers.
 
-        elinewidth : scalar, default: None
+        elinewidth : float, default: None
             The linewidth of the errorbar lines. If None, the linewidth of
             the current style is used.
 
-        capsize : scalar, default: :rc:`errorbar.capsize`
+        capsize : float, default: :rc:`errorbar.capsize`
             The length of the error bar caps in points.
 
-        capthick : scalar, default: None
+        capthick : float, default: None
             An alias to the keyword argument *markeredgewidth* (a.k.a. *mew*).
             This setting is a more sensible name for the property that
             controls the thickness of the error bar cap in points. For
@@ -3625,7 +3625,7 @@ class Axes(_AxesBase):
             automatically set to match the positions. Defaults to
             ``range(1, N+1)`` where N is the number of boxes to be drawn.
 
-        widths : scalar or array-like
+        widths : float or array-like
             Sets the width of each box either with a scalar or a
             sequence. The default is 0.5, or ``0.15*(distance between
             extreme positions)``, if that is smaller.
@@ -3652,7 +3652,7 @@ class Axes(_AxesBase):
             *meanprops* (see below).  Not recommended if *shownotches* is also
             True.  Otherwise, means will be shown as points.
 
-        zorder : scalar, default: None
+        zorder : float, default: ``Line2D.zorder = 2``
             Sets the zorder of the boxplot.
 
         Returns
@@ -3928,7 +3928,7 @@ class Axes(_AxesBase):
           If True, the tick locations and labels will be adjusted to match the
           boxplot positions.
 
-        zorder : scalar, default: None
+        zorder : float, default: ``Line2D.zorder = 2``
           The zorder of the resulting boxplot.
 
         Returns
@@ -4346,14 +4346,14 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x, y : scalar or array-like, shape (n, )
+        x, y : float or array-like, shape (n, )
             The data positions.
 
-        s : scalar or array-like, shape (n, ), optional
+        s : float or array-like, shape (n, ), optional
             The marker size in points**2.
             Default is ``rcParams['lines.markersize'] ** 2``.
 
-        c : color, sequence, or sequence of colors, optional
+        c : color or list of colors or array-like, optional
             The marker color. Possible values:
 
             - A single color format string.
@@ -4391,16 +4391,16 @@ class Axes(_AxesBase):
             *cmap*.
             If *None*, use the default `.colors.Normalize`.
 
-        vmin, vmax : scalar, default: None
+        vmin, vmax : float, default: None
             *vmin* and *vmax* are used in conjunction with the default norm to
             map the color array *c* to the colormap *cmap*. If None, the
             respective min and max of the color array is used.
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
-        alpha : scalar, default: None
+        alpha : float, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
-        linewidths : scalar or array-like, default: :rc:`lines.linewidth`
+        linewidths : float or array-like, default: :rc:`lines.linewidth`
             The linewidth of the marker edges. Note: The default *edgecolors*
             is 'face'. You may want to change this as well.
 
@@ -5433,12 +5433,12 @@ default: :rc:`scatter.edgecolors`
             which can be set by *filterrad*. Additionally, the antigrain image
             resize filter is controlled by the parameter *filternorm*.
 
-        alpha : scalar or array-like, optional
+        alpha : float or array-like, optional
             The alpha blending value, between 0 (transparent) and 1 (opaque).
             If *alpha* is an array, the alpha blending values are applied pixel
             by pixel, and *alpha* must have the same shape as *X*.
 
-        vmin, vmax : scalar, optional
+        vmin, vmax : float, optional
             When using scalar data and no explicit *norm*, *vmin* and *vmax*
             define the data range that the colormap covers. By default,
             the colormap covers the complete value range of the supplied
@@ -5455,7 +5455,7 @@ default: :rc:`scatter.edgecolors`
             See the :doc:`/tutorials/intermediate/imshow_extent` tutorial for
             examples and a more detailed description.
 
-        extent : scalars (left, right, bottom, top), optional
+        extent : floats (left, right, bottom, top), optional
             The bounding box in data coordinates that the image will fill.
             The image is stretched individually along x and y to fill the box.
 
@@ -5736,7 +5736,7 @@ default: :rc:`scatter.edgecolors`
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
-        vmin, vmax : scalar, default: None
+        vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
@@ -5754,7 +5754,7 @@ default: :rc:`scatter.edgecolors`
 
             The singular form *edgecolor* works as an alias.
 
-        alpha : scalar, default: None
+        alpha : float, default: None
             The alpha blending value of the face color, between 0 (transparent)
             and 1 (opaque). Note: The edgecolor is currently not affected by
             this.
@@ -5967,7 +5967,7 @@ default: :rc:`scatter.edgecolors`
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
-        vmin, vmax : scalar, default: None
+        vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
@@ -5985,7 +5985,7 @@ default: :rc:`scatter.edgecolors`
 
             The singular form *edgecolor* works as an alias.
 
-        alpha : scalar, default: None
+        alpha : float, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
         shading : {'flat', 'nearest', 'gouraud', 'auto'}, optional
@@ -6215,14 +6215,14 @@ default: :rc:`scatter.edgecolors`
             colormap range [0, 1] for mapping to colors. By default, the data
             range is mapped to the colorbar range using linear scaling.
 
-        vmin, vmax : scalar, default: None
+        vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
             automatically chosen by the `~.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
 
-        alpha : scalar, default: None
+        alpha : float, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
         snap : bool, default: False
@@ -6486,7 +6486,7 @@ default: :rc:`scatter.edgecolors`
             If 'horizontal', `~.Axes.barh` will be used for bar-type histograms
             and the *bottom* kwarg will be the left edges.
 
-        rwidth : scalar or None, default: None
+        rwidth : float or None, default: None
             The relative width of the bars as a fraction of the bin width.  If
             ``None``, automatically compute the width.
 
@@ -6856,15 +6856,11 @@ default: :rc:`scatter.edgecolors`
         weights : array-like, shape (n, ), optional
             An array of values w_i weighing each sample (x_i, y_i).
 
-        cmin : scalar, default: None
-            All bins that has count less than cmin will not be displayed (set
-            to NaN before passing to imshow) and these count values in the
-            return value count histogram will also be set to nan upon return.
-
-        cmax : scalar, default: None
-            All bins that has count more than cmax will not be displayed (set
-            to NaN before passing to imshow) and these count values in the
-            return value count histogram will also be set to nan upon return.
+        cmin, cmax : float, default: None
+            All bins that has count less than *cmin* or more than *cmax* will
+            not be displayed (set to NaN before passing to imshow) and these
+            count values in the return value count histogram will also be set
+            to nan upon return.
 
         Returns
         -------
@@ -7798,7 +7794,7 @@ default: :rc:`scatter.edgecolors`
           which stands for the quantiles that will be rendered for that
           violin.
 
-        points : scalar, default: 100
+        points : int, default: 100
           Defines the number of points to evaluate each of the
           gaussian kernel density estimations at.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3509,7 +3509,7 @@ class _AxesBase(martist.Artist):
             Whether to turn on autoscaling of the y-axis. *True* turns on,
             *False* turns off, *None* leaves unchanged.
 
-        ymin, ymax : scalar, optional
+        ymin, ymax : float, optional
             They are equivalent to bottom and top respectively,
             and it is an error to pass both *ymin* and *bottom* or
             *ymax* and *top*.

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -311,7 +311,7 @@ class SecondaryAxis(_AxesBase):
         ylabel : str
             The label text.
 
-        labelpad : scalar, default: ``self.yaxis.labelpad``
+        labelpad : float, default: ``self.yaxis.labelpad``
             Spacing in points between the label and the y-axis.
 
         Other Parameters

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1567,7 +1567,7 @@ def index_of(y):
 
     Parameters
     ----------
-    y : scalar or array-like
+    y : float or array-like
 
     Returns
     -------

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1474,15 +1474,15 @@ class EventCollection(LineCollection):
             The orientation of the **collection** (the event bars are along
             the orthogonal direction).
 
-        lineoffset : scalar, default: 0
+        lineoffset : float, default: 0
             The offset of the center of the markers from the origin, in the
             direction orthogonal to *orientation*.
 
-        linelength : scalar, default: 1
+        linelength : float, default: 1
             The total height of the marker (i.e. the marker stretches from
             ``lineoffset - linelength/2`` to ``lineoffset + linelength/2``).
 
-        linewidth : scalar or None, default: None
+        linewidth : float or None, default: None
             If it is None, defaults to its rcParams setting, in sequence form.
 
         color : color, sequence of colors or None, default: None

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1827,11 +1827,11 @@ class LightSource:
             ``func(rgb, illum, **kwargs)``) Additional kwargs supplied
             to this function will be passed on to the *blend_mode*
             function.
-        vmin : scalar or None, optional
+        vmin : float or None, optional
             The minimum value used in colormapping *data*. If *None* the
             minimum value in *data* is used. If *norm* is specified, then this
             argument will be ignored.
-        vmax : scalar or None, optional
+        vmax : float or None, optional
             The maximum value used in colormapping *data*. If *None* the
             maximum value in *data* is used. If *norm* is specified, then this
             argument will be ignored.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -523,19 +523,19 @@ class Figure(Artist):
 
         Parameters
         ----------
-        w_pad : scalar
+        w_pad : float
             Width padding in inches.  This is the pad around axes
             and is meant to make sure there is enough room for fonts to
             look good.  Defaults to 3 pts = 0.04167 inches
 
-        h_pad : scalar
+        h_pad : float
             Height padding in inches. Defaults to 3 pts.
 
-        wspace : scalar
+        wspace : float
             Width padding between subplots, expressed as a fraction of the
             subplot width.  The total padding ends up being w_pad + wspace.
 
-        hspace : scalar
+        hspace : float
             Height padding between subplots, expressed as a fraction of the
             subplot width. The total padding ends up being h_pad + hspace.
 
@@ -588,11 +588,11 @@ class Figure(Artist):
 
         Parameters
         ----------
-        bottom : scalar
+        bottom : float, default: 0.2
             The bottom of the subplots for `subplots_adjust`.
-        rotation : angle in degrees
-            The rotation of the xtick labels.
-        ha : str
+        rotation : float, default: 30 degrees
+            The rotation angle of the xtick labels in degrees.
+        ha : {'left', 'center', 'right'}, default: 'right'
             The horizontal alignment of the xticklabels.
         which : {'major', 'minor', 'both'}, default: 'major'
             Selects which ticklabels to rotate.
@@ -787,7 +787,7 @@ default: 'top'
         cmap : str or `matplotlib.colors.Colormap`, default: :rc:`image.cmap`
             The colormap to use.
 
-        vmin, vmax : scalar
+        vmin, vmax : float
             If *norm* is not given, these values set the data limits for the
             colormap.
 
@@ -2128,9 +2128,8 @@ default: 'top'
             Bounding box in inches: only the given portion of the figure is
             saved.  If 'tight', try to figure out the tight bbox of the figure.
 
-        pad_inches : scalar, optional
-            Amount of padding around the figure when bbox_inches is
-            'tight'. If None, use savefig.pad_inches
+        pad_inches : float, default: :rc:`savefig.pad_inches`
+            Amount of padding around the figure when bbox_inches is 'tight'.
 
         bbox_extra_artists : list of `~matplotlib.artist.Artist`, optional
             A list of extra artists that will be considered when the
@@ -2290,7 +2289,7 @@ default: 'top'
         n : int, default: 1
             Number of mouse clicks to accumulate. If negative, accumulate
             clicks until the input is terminated manually.
-        timeout : scalar, default: 30 seconds
+        timeout : float, default: 30 seconds
             Number of seconds to wait before timing out. If zero or negative
             will never timeout.
         show_clicks : bool, default: True
@@ -2683,8 +2682,8 @@ def figaspect(arg):
 
     Parameters
     ----------
-    arg : scalar or 2d array
-        If a scalar, this defines the aspect ratio (i.e. the ratio height /
+    arg : float or 2d array
+        If a float, this defines the aspect ratio (i.e. the ratio height /
         width).
         In case of an array the aspect ratio is number of rows / number of
         columns, so that the array could be fitted in the figure undistorted.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1034,7 +1034,7 @@ class NonUniformImage(AxesImage):
 
         Parameters
         ----------
-        x, y : 1D array-likes
+        x, y : 1D array-like
             Monotonic arrays of shapes (N,) and (M,), respectively, specifying
             pixel centers.
         A : array-like
@@ -1463,7 +1463,7 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
     arr : array-like
         The image data. The shape can be one of
         MxN (luminance), MxNx3 (RGB) or MxNx4 (RGBA).
-    vmin, vmax : scalar, optional
+    vmin, vmax : float, optional
         *vmin* and *vmax* set the color scaling for the image by fixing the
         values that map to the colormap color limits. If either *vmin*
         or *vmax* is None, that limit is determined from the *arr*

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -3479,10 +3479,10 @@ def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
         Where to write the image data.
     prop : `.FontProperties`, optional
         The size and style of the text.
-    dpi : scalar, optional
+    dpi : float, optional
         The output dpi.  If not set, the dpi is determined as for
         `.Figure.savefig`.
-    format : str
+    format : str, optional
         The output format, e.g., 'svg', 'pdf', 'ps' or 'png'.  If not set, the
         format is determined as for `.Figure.savefig`.
     """

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -589,7 +589,7 @@ def _single_spectrum_helper(
 # Split out these keyword docs so that they can be used elsewhere
 docstring.interpd.update(
     Spectral="""\
-Fs : scalar, default: 2
+Fs : float, default: 2
     The sampling frequency (samples per time unit).  It is used to calculate
     the Fourier frequencies, *freqs*, in cycles per time unit.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1187,15 +1187,15 @@ class Arrow(Patch):
 
         Parameters
         ----------
-        x : scalar
-            x coordinate of the arrow tail
-        y : scalar
-            y coordinate of the arrow tail
-        dx : scalar
-            Arrow length in the x direction
-        dy : scalar
-            Arrow length in the y direction
-        width : scalar, default: 1
+        x : float
+            x coordinate of the arrow tail.
+        y : float
+            y coordinate of the arrow tail.
+        dx : float
+            Arrow length in the x direction.
+        dy : float
+            Arrow length in the y direction.
+        width : float, default: 1
             Scale factor for the width of the arrow. With a default value of 1,
             the tail width is 0.2 and head width is 0.6.
         **kwargs
@@ -3916,7 +3916,7 @@ default: 'arc3'
 
         Parameters
         ----------
-        dpi_cor : scalar
+        dpi_cor : float
         """
         self._dpi_cor = dpi_cor
         self.stale = True
@@ -4043,7 +4043,7 @@ default: 'arc3'
 
         Parameters
         ----------
-        scale : scalar
+        scale : float
         """
         self._mutation_scale = scale
         self.stale = True
@@ -4064,7 +4064,7 @@ default: 'arc3'
 
         Parameters
         ----------
-        aspect : scalar
+        aspect : float
         """
         self._mutation_aspect = aspect
         self.stale = True

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1223,14 +1223,14 @@ class PolarAxes(Axes):
 
         Parameters
         ----------
-        bottom : scalar, optional
+        bottom : float, optional
             The bottom limit (default: None, which leaves the bottom
             limit unchanged).
             The bottom and top ylims may be passed as the tuple
             (*bottom*, *top*) as the first positional argument (or as
             the *bottom* keyword argument).
 
-        top : scalar, optional
+        top : float, optional
             The top limit (default: None, which leaves the top limit
             unchanged).
 
@@ -1241,7 +1241,7 @@ class PolarAxes(Axes):
             Whether to turn on autoscaling of the y-axis. True turns on,
             False turns off, None leaves unchanged.
 
-        ymin, ymax : scalar, optional
+        ymin, ymax : float, optional
             These arguments are deprecated and will be removed in a future
             version.  They are equivalent to *bottom* and *top* respectively,
             and it is an error to pass both *ymin* and *bottom* or

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2825,9 +2825,9 @@ def interval_contains(interval, val):
 
     Parameters
     ----------
-    interval : sequence of scalar
-        A 2-length sequence, endpoints that define the interval.
-    val : scalar
+    interval : (float, float)
+        The endpoints of the interval.
+    val : float
         Value to check is within interval.
 
     Returns
@@ -2848,13 +2848,15 @@ def _interval_contains_close(interval, val, rtol=1e-10):
 
     Parameters
     ----------
-    interval : sequence of scalar
-        A 2-length sequence, endpoints that define the interval.
-    val : scalar
+    interval : (float, float)
+        The endpoints of the interval.
+    val : float
         Value to check is within interval.
-    rtol : scalar
-        Tolerance slippage allowed outside of this interval.  Default
-        1e-10 * (b - a).
+    rtol : float, default: 1e-10
+        Relative tolerance slippage allowed outside of the interval.
+        For an interval ``[a, b]``, values
+        ``a - rtol * (b - a) <= val <= b + rtol * (b - a)`` are considered
+        inside the interval.
 
     Returns
     -------
@@ -2874,9 +2876,9 @@ def interval_contains_open(interval, val):
 
     Parameters
     ----------
-    interval : sequence of scalar
-        A 2-length sequence, endpoints that define the interval.
-    val : scalar
+    interval : (float, float)
+        The endpoints of the interval.
+    val : float
         Value to check is within interval.
 
     Returns

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -173,8 +173,8 @@ class Line3D(lines.Line2D):
 
         Returns
         -------
-        verts3d : length-3 tuple or array-likes
-            The current data as a tuple or array-likes.
+        verts3d : length-3 tuple or array-like
+            The current data as a tuple or array-like.
         """
         return self._verts3d
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1304,7 +1304,7 @@ class Axes3D(Axes):
             x coordinates of vertices.
         ys : 1D array-like
             y coordinates of vertices.
-        zs : scalar or 1D array-like
+        zs : float or 1D array-like
             z coordinates of vertices; either one for all points or one for
             each point.
         zdir : {'x', 'y', 'z'}, default: 'z'
@@ -1764,7 +1764,7 @@ class Axes3D(Axes):
             A colormap for the surface patches.
         norm : Normalize
             An instance of Normalize to map values to colors.
-        vmin, vmax : scalar, default: None
+        vmin, vmax : float, default: None
             Minimum and maximum value to map.
         shade : bool, default: True
             Whether to shade the facecolors.  Shading is always disabled when
@@ -1908,7 +1908,7 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        X, Y, Z : array-likes
+        X, Y, Z : array-like
             Input data.
         extend3d : bool, default: False
             Whether to extend contour in 3D.
@@ -1916,9 +1916,9 @@ class Axes3D(Axes):
             Step size for extending contour.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
-        offset : scalar
+        offset : float, optional
             If specified, plot a projection of the contour lines at this
-            position in a plane normal to zdir
+            position in a plane normal to zdir.
         *args, **kwargs
             Other arguments are forwarded to `matplotlib.axes.Axes.contour`.
 
@@ -1951,7 +1951,7 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        X, Y, Z : array-likes
+        X, Y, Z : array-like
             Input data.
         extend3d : bool, default: False
             Whether to extend contour in 3D.
@@ -1959,9 +1959,9 @@ class Axes3D(Axes):
             Step size for extending contour.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
-        offset : scalar
+        offset : float, optional
             If specified, plot a projection of the contour lines at this
-            position in a plane normal to zdir
+            position in a plane normal to zdir.
         *args, **kwargs
             Other arguments are forwarded to `matplotlib.axes.Axes.tricontour`.
 
@@ -1996,13 +1996,13 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        X, Y, Z : array-likes
+        X, Y, Z : array-like
             Input data.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
-        offset : scalar
+        offset : float, optional
             If specified, plot a projection of the contour lines at this
-            position in a plane normal to zdir
+            position in a plane normal to zdir.
         *args, **kwargs
             Other arguments are forwarded to `matplotlib.axes.Axes.contourf`.
 
@@ -2036,13 +2036,13 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        X, Y, Z : array-likes
+        X, Y, Z : array-like
             Input data.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
-        offset : scalar
+        offset : float, optional
             If specified, plot a projection of the contour lines at this
-            position in a plane normal to zdir
+            position in a plane normal to zdir.
         *args, **kwargs
             Other arguments are forwarded to
             `matplotlib.axes.Axes.tricontourf`.
@@ -2129,7 +2129,7 @@ class Axes3D(Axes):
 
             See also :doc:`/gallery/mplot3d/2dcollections3d`.
 
-        s : scalar or array-like, default: 20
+        s : float or array-like, default: 20
             The marker size in points**2. Either an array of the same length
             as *xs* and *ys* or a single value to make all markers the same
             size.
@@ -2191,7 +2191,7 @@ class Axes3D(Axes):
             The x coordinates of the left sides of the bars.
         height : 1D array-like
             The height of the bars.
-        zs : scalar or 1D array-like
+        zs : float or 1D array-like
             Z coordinate of bars; if a single value is specified, it will be
             used for all bars.
         zdir : {'x', 'y', 'z'}, default: 'z'
@@ -2245,7 +2245,7 @@ class Axes3D(Axes):
         x, y, z : array-like
             The coordinates of the anchor point of the bars.
 
-        dx, dy, dz : scalar or array-like
+        dx, dy, dz : float or array-like
             The width, depth, and height of the bars, respectively.
 
         color : sequence of colors, optional


### PR DESCRIPTION
## PR Summary

According to https://matplotlib.org/devdocs/devel/documenting_mpl.html#parameter-type-descriptions; in particular

- `scalar` -> `float` or `int`
- `sequence of scalar` -> `array-like`

