### PR TITLE
Add 'binary' keyword argument to EngFormatter

### DIFF
--- a/doc/users/next_whats_new/2020-05-03-EngFormatter-binary.rst
+++ b/doc/users/next_whats_new/2020-05-03-EngFormatter-binary.rst
@@ -1,0 +1,5 @@
+``EngFormatter`` now accepts a ``binary`` keyword argument
+----------------------------------------------------------
+
+The ``binary`` keyword argument has been added to ``EngFormatter`` so that it
+can use 1024 instead of 1000 as a base for the unit prefix.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1178,6 +1178,13 @@ def test_engformatter_usetex_useMathText():
         assert x_tick_label_text == ['$0$', '$500$', '$1$ k']
 
 
+def test_engformatter_binary():
+    formatter = mticker.EngFormatter(binary=True)
+    assert formatter(1024) == "1 k"
+    assert formatter(1024 ** 2) == "1 M"
+    assert formatter(1024 ** 3) == "1 G"
+
+
 class TestPercentFormatter:
     percent_data = [
         # Check explicitly set decimals over different intervals and values


### PR DESCRIPTION
When plotting number of bits or bytes, the base for the unit prefix
should not be 1000, but 1024. If the 'binary' argument is set to True,
the EngFormatter will use 1024 as a base, otherwise it will use 1000.

Use case:
When plotting network throughput values I needed EngFormatter to use `1024` as a base.
I am sharing the code maybe it will be useful

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
