### PR TITLE
Deprecate parameter orientation of bar() and barh()

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -531,6 +531,11 @@ experimental and may change in the future.
 These are unused and can be easily reproduced by other date tools.
 `.get_epoch` will return Matplotlib's epoch.
 
+Passing ``orientation`` to ``bar()`` and ``barh()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This parameter is considered internal. Please use ``bar()`` for vertical bars
+and ``barh()`` for horizontal bars.
+
 ``axes_grid1.CbarAxes`` attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``cbid`` and ``locator`` attribute are deprecated.  Use

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2392,7 +2392,14 @@ class Axes(_AxesBase):
         error_kw.setdefault('ecolor', ecolor)
         error_kw.setdefault('capsize', capsize)
 
-        orientation = kwargs.pop('orientation', 'vertical')
+        if 'orientation' in kwargs:
+            orientation = kwargs['orientation']
+            cbook.warn_deprecated(
+                "3.3", message="passing 'orientation' to bar() is for "
+                               "internal use only. Please use barh() or bar() "
+                               "explicitly to define the orientation.")
+        else:
+            orientation = kwargs.pop('_orientation', 'vertical')
         cbook._check_in_list(['vertical', 'horizontal'],
                              orientation=orientation)
         log = kwargs.pop('log', False)
@@ -2630,9 +2637,17 @@ class Axes(_AxesBase):
         :doc:`/gallery/lines_bars_and_markers/horizontal_barchart_distribution`
         .
         """
-        kwargs.setdefault('orientation', 'horizontal')
+
+        if 'orientation' in kwargs:
+            orientation = kwargs['orientation']
+            cbook.warn_deprecated(
+                "3.3", message="passing 'orientation' to barh() is for "
+                               "internal use only. Please use bar() or barh() "
+                               "explicitly to define the orientation.")
+        else:
+            orientation = 'horizontal'
         patches = self.bar(x=left, height=height, width=width, bottom=y,
-                           align=align, **kwargs)
+                           align=align, _orientation=orientation, **kwargs)
         return patches
 
     @_preprocess_data()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5452,7 +5452,7 @@ def test_bar_broadcast_args():
     # Check that a bar chart with a single height for all bars works.
     ax.bar(range(4), 1)
     # Check that a horizontal chart with one width works.
-    ax.bar(0, 1, bottom=range(4), width=1, orientation='horizontal')
+    ax.barh(0, 1, left=range(4), height=1)
     # Check that edgecolor gets broadcast.
     rect1, rect2 = ax.bar([0, 1], [0, 1], edgecolor=(.1, .2, .3, .4))
     assert rect1.get_edgecolor() == rect2.get_edgecolor() == (.1, .2, .3, .4)


### PR DESCRIPTION
## PR Summary

While stated to be internal, there's a parameter 'orientation' to `bar()`, which is also documented. To make this very clear, this PR deprecates 'orientation' and uses a private '_orientation' parameter instead.

The aim is to finally remove 'orientation' also from the docs, because it's rather confusing than helpful to document a parameter and say it's not to be used.
