### PR TITLE
solarized dark custom style sheet

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/solarized_dark.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/solarized_dark.mplstyle
@@ -1,0 +1,30 @@
+## FIGURE
+figure.facecolor 	: 002b36 
+figure.frameon		: True
+figure.edgecolor	: 073642
+patch.antialiased	: True
+text.color			: 839496 
+
+## LINES
+lines.linewidth   	: 2.0
+lines.solid_capstyle: butt
+
+## AXES
+axes.titlesize 		: 16
+axes.labelsize 		: 12
+axes.labelcolor 	: 839496
+axes.facecolor		: 073642 
+axes.edgecolor		: 839496 
+axes.axisbelow		: True
+axes.prop_cycle     : cycler('color', ['268bd2', 'cb4b16', '6c71c4', '2aa198', '859900', 'd33682', 'fdf6e3', 'eee8d5', '93a1a1', '839496'])
+axes.grid 			: False
+
+## GRID
+grid.linestyle   	: -       	# line
+grid.linewidth   	: 1     	# in points
+
+## TICKS
+xtick.color 		: 839496
+xtick.direction 	: out
+ytick.color 		: 839496
+ytick.direction 	: out


### PR DESCRIPTION
I would like to propose a custom style sheet in line with the solarized dark colour palette. The style mirrors the ones already present and is the only addition to this pull request.