### PR TITLE
Fixes icon clipping issue with WxAgg NavigationToolbar2 for wxpython 4.1.0

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1105,6 +1105,8 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def __init__(self, canvas):
         wx.ToolBar.__init__(self, canvas.GetParent(), -1)
 
+        if 'wxMac' in wx.PlatformInfo:
+            self.SetToolBitmapSize((24, 24))
         self.wx_ids = {}
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:


### PR DESCRIPTION
## PR Summary

This fixes the problem of icons clipping in the NavigationToolbar2 using the WxAgg backend for wxpython 4.1.0 documented in issue #17326 . At the moment that issue seems to be only happening on MacOS, so this is mac specific. However, I have been unable to test 4.1.0 on linux, so it may also need to be applied there.

This fix has no effect on the ToolBar appearance in wxpython 4.0.4, so it should be backwards compatible in that way.

Toolbar in 4.1.0 without fix:
<img width="499" alt="mpl_toolbar_wx4p10" src="https://user-images.githubusercontent.com/23534688/81010796-761c0e00-8e1c-11ea-83a3-c483584fcd73.png">

Toolbar in 4.1.0 with fix
<img width="495" alt="mpl_toolbar_wx4p1_fix" src="https://user-images.githubusercontent.com/23534688/81010841-87fdb100-8e1c-11ea-917e-c60f86fa04f8.png">


Toolbar in 4.0.4 without fix:
<img width="497" alt="mac_mpl_toolbar_old" src="https://user-images.githubusercontent.com/23534688/81010927-ab286080-8e1c-11ea-8363-21cbe4654d07.png">

Toolbar in 4.0.4 with fix:
<img width="498" alt="mpl_toolbar_4p0p4_toolbar_icon_fix" src="https://user-images.githubusercontent.com/23534688/81010857-8f24bf00-8e1c-11ea-972e-a9da94eda5e3.png">


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
