### PR TITLE
Make sharex, etc. args of subplots() keyword-only.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -438,6 +438,11 @@ The qt4agg and qt4cairo backends are deprecated.
 *fontdict* and *minor* parameters of `.Axes.set_xticklabels` and `.Axes.set_yticklabels` will become keyword-only
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+All parameters of `.Figure.subplots` except *nrows* and *ncols* will become keyword-only
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This avoids typing e.g. ``subplots(1, 1, 1)`` when meaning ``subplot(1, 1, 1)``,
+but actually getting ``subplots(1, 1, sharex=1)``.
+
 ``RendererWx.get_gc``
 ~~~~~~~~~~~~~~~~~~~~~
 This method is deprecated.  Access the ``gc`` attribute directly instead.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1430,6 +1430,7 @@ default: 'top'
         ax.stale_callback = _stale_figure_callback
         return ax
 
+    @cbook._make_keyword_only("3.3", "sharex")
     def subplots(self, nrows=1, ncols=1, sharex=False, sharey=False,
                  squeeze=True, subplot_kw=None, gridspec_kw=None):
         """

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -235,7 +235,7 @@ class GridSpecBase:
 
         return SubplotSpec(self, num1, num2)
 
-    def subplots(self, sharex=False, sharey=False, squeeze=True,
+    def subplots(self, *, sharex=False, sharey=False, squeeze=True,
                  subplot_kw=None):
         """
         Add all subplots specified by this `GridSpec` to its parent figure.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1084,6 +1084,7 @@ def subplot(*args, **kwargs):
     return ax
 
 
+@cbook._make_keyword_only("3.3", "sharex")
 def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
              subplot_kw=None, gridspec_kw=None, **fig_kw):
     """


### PR DESCRIPTION
Currently subplots() has a specific codepath to check whether one typed
`subplots(1, 1, 1)` and warn in that case because the user likely meant
`subplot(1, 1, 1)` (no "s") but will instead get
`subplots(1, 1, sharex=1)`.  Making *sharex* keyword-only will remove
this trap; moreover `subplots(1, 1, sharex=True)` is anyways much more
legible than `subplots(1, 1, True)`.

If this makes it to 3.3 then GridSpec.subplots() won't need a
deprecation period as that API is new, so targeting as such.

Inspired from https://gitter.im/matplotlib/matplotlib?at=5eb1601cb6dd230697a8399d.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
