### PR TITLE
DOC: remove examples of subplot(123) from docs

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.54.rst
+++ b/doc/api/prev_api_changes/api_changes_0.54.rst
@@ -92,7 +92,7 @@ Axes creation
     use::
 
       f = Figure(figsize=(5,4), dpi=100)
-      a = f.add_subplot(111)
+      a = f.add_subplot(1, 1, 1)
 
     That is, add_axis no longer exists and is replaced by::
 

--- a/doc/api/prev_api_changes/api_changes_0.54.rst
+++ b/doc/api/prev_api_changes/api_changes_0.54.rst
@@ -92,7 +92,7 @@ Axes creation
     use::
 
       f = Figure(figsize=(5,4), dpi=100)
-      a = f.add_subplot(1, 1, 1)
+      a = f.add_subplot(111)
 
     That is, add_axis no longer exists and is replaced by::
 

--- a/doc/api/prev_api_changes/api_changes_2.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.0.0.rst
@@ -169,7 +169,7 @@ call the function with ::
 where "ax" is an ``Axes3d`` object created with something like ::
 
    import mpl_toolkits.mplot3d.axes3d
-   ax = plt.subplot(1, 1, 1, projection='3d')
+   ax = plt.subplot(111, projection='3d')
 
 
 Stale figure behavior

--- a/doc/api/prev_api_changes/api_changes_2.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.0.0.rst
@@ -169,7 +169,7 @@ call the function with ::
 where "ax" is an ``Axes3d`` object created with something like ::
 
    import mpl_toolkits.mplot3d.axes3d
-   ax = plt.subplot(111, projection='3d')
+   ax = plt.subplot(1, 1, 1, projection='3d')
 
 
 Stale figure behavior

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -55,7 +55,7 @@ back on the linear `.AutoLocator` to pick reasonable tick positions.
 `.Figure.add_subplot` with no arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Calling `.Figure.add_subplot()` with no positional arguments used to do
-nothing; this now is equivalent to calling ``add_subplot(1, 1, 1)`` instead.
+nothing; this now is equivalent to calling ``add_subplot()`` instead.
 
 `~.Axes.bxp` and rcparams
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -55,7 +55,7 @@ back on the linear `.AutoLocator` to pick reasonable tick positions.
 `.Figure.add_subplot` with no arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Calling `.Figure.add_subplot()` with no positional arguments used to do
-nothing; this now is equivalent to calling ``add_subplot(111)`` instead.
+nothing; this now is equivalent to calling ``add_subplot(1, 1, 1)`` instead.
 
 `~.Axes.bxp` and rcparams
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -55,7 +55,7 @@ back on the linear `.AutoLocator` to pick reasonable tick positions.
 `.Figure.add_subplot` with no arguments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Calling `.Figure.add_subplot()` with no positional arguments used to do
-nothing; this now is equivalent to calling ``add_subplot()`` instead.
+nothing; this now is equivalent to calling ``add_subplot(1, 1, 1)`` instead.
 
 `~.Axes.bxp` and rcparams
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -306,7 +306,7 @@ mplot3d auto-registration
 `mpl_toolkits.mplot3d` is always registered by default now. It is no
 longer necessary to import mplot3d to create 3d axes with ::
 
-  ax = fig.add_subplot(111, projection="3d")
+  ax = fig.add_subplot(1, 1, 1, projection="3d")
 
 `.SymLogNorm` now has a *base* parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -820,7 +820,7 @@ example is generated from
     s = 1 + np.sin(2 * np.pi * t)
 
     # Note that using plt.subplots below is equivalent to using
-    # fig = plt.figure and then ax = fig.add_subplot(1, 1, 1)
+    # fig = plt.figure and then ax = fig.add_subplot()
     fig, ax = plt.subplots()
     ax.plot(t, s)
 

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -820,7 +820,7 @@ example is generated from
     s = 1 + np.sin(2 * np.pi * t)
 
     # Note that using plt.subplots below is equivalent to using
-    # fig = plt.figure and then ax = fig.add_subplot(111)
+    # fig = plt.figure and then ax = fig.add_subplot(1, 1, 1)
     fig, ax = plt.subplots()
     ax.plot(t, s)
 

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -118,7 +118,7 @@ any property on them directly (*facecolor*, *edgecolor*, *linewidth*,
 
     fig = plt.figure()
     fig.patch.set_alpha(0.5)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.patch.set_alpha(0.5)
 
 If you need *all* the figure elements to be transparent, there is
@@ -177,7 +177,7 @@ labels::
 
     fig = plt.figure()
     fig.subplots_adjust(bottom=0.2)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
 You can control the defaults for these parameters in your
 :file:`matplotlibrc` file; see :doc:`/tutorials/introductory/customizing`.  For
@@ -400,7 +400,7 @@ locators as desired because the two axes are independent.
     import matplotlib.pyplot as plt
 
     fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
+    ax1 = fig.add_subplot()
     t = np.arange(0.01, 10.0, 0.01)
     s1 = np.exp(t)
     ax1.plot(t, s1, 'b-')

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -118,7 +118,7 @@ any property on them directly (*facecolor*, *edgecolor*, *linewidth*,
 
     fig = plt.figure()
     fig.patch.set_alpha(0.5)
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.patch.set_alpha(0.5)
 
 If you need *all* the figure elements to be transparent, there is
@@ -177,7 +177,7 @@ labels::
 
     fig = plt.figure()
     fig.subplots_adjust(bottom=0.2)
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
 
 You can control the defaults for these parameters in your
 :file:`matplotlibrc` file; see :doc:`/tutorials/introductory/customizing`.  For
@@ -400,7 +400,7 @@ locators as desired because the two axes are independent.
     import matplotlib.pyplot as plt
 
     fig = plt.figure()
-    ax1 = fig.add_subplot(111)
+    ax1 = fig.add_subplot(1, 1, 1)
     t = np.arange(0.01, 10.0, 0.01)
     s1 = np.exp(t)
     ax1.plot(t, s1, 'b-')

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -368,7 +368,7 @@ The Axes property :meth:`~matplotlib.axes.Axes.set_aspect` controls the
 aspect ratio of the axes.  You can set it to be 'auto', 'equal', or
 some ratio which controls the ratio::
 
-  ax = fig.add_subplot(111, aspect='equal')
+  ax = fig.add_subplot(1, 1, 1, aspect='equal')
 
 .. only:: html
 

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -139,7 +139,7 @@ is created every time a mouse is pressed::
             self.line.figure.canvas.draw()
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_title('click to build line segments')
     line, = ax.plot([0], [0])  # empty line
     linebuilder = LineBuilder(line)
@@ -230,7 +230,7 @@ Here is the solution::
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -334,7 +334,7 @@ Extra credit solution::
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -383,8 +383,8 @@ background that the mouse is over::
 
     fig1 = plt.figure()
     fig1.suptitle('mouse hover over figure or axes to trigger events')
-    ax1 = fig1.add_subplot(211)
-    ax2 = fig1.add_subplot(212)
+    ax1 = fig1.add_subplot(2, 1, 1)
+    ax2 = fig1.add_subplot(2, 1, 2)
 
     fig1.canvas.mpl_connect('figure_enter_event', enter_figure)
     fig1.canvas.mpl_connect('figure_leave_event', leave_figure)
@@ -393,8 +393,8 @@ background that the mouse is over::
 
     fig2 = plt.figure()
     fig2.suptitle('mouse hover over figure or axes to trigger events')
-    ax1 = fig2.add_subplot(211)
-    ax2 = fig2.add_subplot(212)
+    ax1 = fig2.add_subplot(2, 1, 1)
+    ax2 = fig2.add_subplot(2, 1, 2)
 
     fig2.canvas.mpl_connect('figure_enter_event', enter_figure)
     fig2.canvas.mpl_connect('figure_leave_event', leave_figure)
@@ -493,7 +493,7 @@ properties of the line.  Here is the code::
     import matplotlib.pyplot as plt
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_title('click on points')
 
     line, = ax.plot(np.random.rand(100), 'o', picker=5)  # 5 points tolerance
@@ -538,7 +538,7 @@ Exercise solution::
     ys = np.std(X, axis=1)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_title('click on point to plot time series')
     line, = ax.plot(xs, ys, 'o', picker=5)  # 5 points tolerance
 

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -139,7 +139,7 @@ is created every time a mouse is pressed::
             self.line.figure.canvas.draw()
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_title('click to build line segments')
     line, = ax.plot([0], [0])  # empty line
     linebuilder = LineBuilder(line)
@@ -230,7 +230,7 @@ Here is the solution::
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -334,7 +334,7 @@ Extra credit solution::
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -493,7 +493,7 @@ properties of the line.  Here is the code::
     import matplotlib.pyplot as plt
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_title('click on points')
 
     line, = ax.plot(np.random.rand(100), 'o', picker=5)  # 5 points tolerance
@@ -538,7 +538,7 @@ Exercise solution::
     ys = np.std(X, axis=1)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_title('click on point to plot time series')
     line, = ax.plot(xs, ys, 'o', picker=5)  # 5 points tolerance
 

--- a/doc/users/history.rst
+++ b/doc/users/history.rst
@@ -114,7 +114,7 @@ Matplotlib's original logo (2003 -- 2008).
    # 0.0005 is the sample interval
    t = 0.0005 * np.arange(len(x))
    plt.figure(1, figsize=(7, 1), dpi=100)
-   ax = plt.subplot(111, facecolor='y')
+   ax = plt.subplot(1, 1, 1, facecolor='y')
    plt.plot(t, x)
    plt.text(0.5, 0.5, 'matplotlib', color='r',
             fontsize=40, fontname=['Courier', 'DejaVu Sans Mono'],

--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -130,7 +130,7 @@ example code for GTK+ 3::
     win.add(vbox)
 
     fig = Figure(figsize=(5,4), dpi=100)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1,2,3])
 
     canvas = FigureCanvas(fig)  # a Gtk.DrawingArea

--- a/doc/users/navigation_toolbar.rst
+++ b/doc/users/navigation_toolbar.rst
@@ -130,7 +130,7 @@ example code for GTK+ 3::
     win.add(vbox)
 
     fig = Figure(figsize=(5,4), dpi=100)
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot([1,2,3])
 
     canvas = FigureCanvas(fig)  # a Gtk.DrawingArea

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -2289,7 +2289,7 @@ the `API changes <../../api/api_changes.html>`_.
                   fig1 = figure()
                   fig2 = figure()
 
-                   ax1 = fig1.add_subplot(1, 1, 1)
+                   ax1 = fig1.add_subplot()
                    ax2 = fig2.add_subplot(1, 1, 1, sharex=ax1, sharey=ax1)
 
            - linestyles now include steps-pre, steps-post and

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -2290,7 +2290,7 @@ the `API changes <../../api/api_changes.html>`_.
                   fig2 = figure()
 
                    ax1 = fig1.add_subplot(1, 1, 1)
-                   ax2 = fig2.add_subplot(111, sharex=ax1, sharey=ax1)
+                   ax2 = fig2.add_subplot(1, 1, 1, sharex=ax1, sharey=ax1)
 
            - linestyles now include steps-pre, steps-post and
              steps-mid.  The old step still works and is equivalent to

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -290,7 +290,7 @@ the `API changes <../../api/api_changes.html>`_.
            Uses a default range(n) when the first arg not provided.
            Damon McDougall
 
-2012-11-09 Make plt.subplot() without arguments act as subplot(111) - PI
+2012-11-09 Make plt.subplot() without arguments act as subplot(1, 1, 1) - PI
 
 2012-11-08 Replaced plt.figure and plt.subplot calls by the newer, more
            convenient single call to plt.subplots() in the documentation
@@ -2289,7 +2289,7 @@ the `API changes <../../api/api_changes.html>`_.
                   fig1 = figure()
                   fig2 = figure()
 
-                   ax1 = fig1.add_subplot(111)
+                   ax1 = fig1.add_subplot(1, 1, 1)
                    ax2 = fig2.add_subplot(111, sharex=ax1, sharey=ax1)
 
            - linestyles now include steps-pre, steps-post and

--- a/doc/users/prev_whats_new/whats_new_0.98.4.rst
+++ b/doc/users/prev_whats_new/whats_new_0.98.4.rst
@@ -97,10 +97,10 @@ boxes and connectors in annotations.  See
         ax.yaxis.set_visible(False)
 
 
-    ax1 = fig.add_subplot(121, frameon=False, xticks=[], yticks=[])
+    ax1 = fig.add_subplot(1, 2, 1, frameon=False, xticks=[], yticks=[])
     make_boxstyles(ax1)
 
-    ax2 = fig.add_subplot(122, frameon=False, xticks=[], yticks=[])
+    ax2 = fig.add_subplot(1, 2, 2, frameon=False, xticks=[], yticks=[])
     make_arrowstyles(ax2)
 
 

--- a/doc/users/prev_whats_new/whats_new_0.98.4.rst
+++ b/doc/users/prev_whats_new/whats_new_0.98.4.rst
@@ -97,10 +97,10 @@ boxes and connectors in annotations.  See
         ax.yaxis.set_visible(False)
 
 
-    ax1 = fig.add_subplot(1, 2, 1, frameon=False, xticks=[], yticks=[])
+    ax1 = fig.add_subplot(121, frameon=False, xticks=[], yticks=[])
     make_boxstyles(ax1)
 
-    ax2 = fig.add_subplot(1, 2, 2, frameon=False, xticks=[], yticks=[])
+    ax2 = fig.add_subplot(122, frameon=False, xticks=[], yticks=[])
     make_arrowstyles(ax2)
 
 

--- a/doc/users/prev_whats_new/whats_new_1.2.rst
+++ b/doc/users/prev_whats_new/whats_new_1.2.rst
@@ -88,12 +88,12 @@ minimum and maximum colorbar extensions.
     clevs = [-.75, -.5, -.25, 0., .25, .5, .75]
     cmap = plt.cm.get_cmap(name='jet', lut=8)
 
-    ax1 = plt.subplot(211)
+    ax1 = plt.subplot(2, 1, 1)
     cs1 = plt.contourf(x, y, Z, clevs, cmap=cmap, extend='both')
     cb1 = plt.colorbar(orientation='horizontal', extendfrac=None)
     cb1.set_label('Default length colorbar extensions')
 
-    ax2 = plt.subplot(212)
+    ax2 = plt.subplot(2, 1, 2)
     cs2 = plt.contourf(x, y, Z, clevs, cmap=cmap, extend='both')
     cb2 = plt.colorbar(orientation='horizontal', extendfrac='auto')
     cb2.set_label('Custom length colorbar extensions')

--- a/doc/users/prev_whats_new/whats_new_1.2.rst
+++ b/doc/users/prev_whats_new/whats_new_1.2.rst
@@ -88,12 +88,12 @@ minimum and maximum colorbar extensions.
     clevs = [-.75, -.5, -.25, 0., .25, .5, .75]
     cmap = plt.cm.get_cmap(name='jet', lut=8)
 
-    ax1 = plt.subplot(2, 1, 1)
+    ax1 = plt.subplot(211)
     cs1 = plt.contourf(x, y, Z, clevs, cmap=cmap, extend='both')
     cb1 = plt.colorbar(orientation='horizontal', extendfrac=None)
     cb1.set_label('Default length colorbar extensions')
 
-    ax2 = plt.subplot(2, 1, 2)
+    ax2 = plt.subplot(212)
     cs2 = plt.contourf(x, y, Z, clevs, cmap=cmap, extend='both')
     cb2 = plt.colorbar(orientation='horizontal', extendfrac='auto')
     cb2.set_label('Custom length colorbar extensions')

--- a/doc/users/prev_whats_new/whats_new_1.3.rst
+++ b/doc/users/prev_whats_new/whats_new_1.3.rst
@@ -176,7 +176,7 @@ oddly distributed data sets.
 Calling subplot() without arguments
 ```````````````````````````````````
 A call to :func:`~matplotlib.pyplot.subplot` without any arguments now
-acts the same as ``subplot(1, 1, 1)`` or ``subplot(1, 1, 1)`` -- it creates one
+acts the same as ``subplot(111)`` or ``subplot(1, 1, 1)`` -- it creates one
 axes for the whole figure. This was already the behavior for both
 :func:`~matplotlib.pyplot.axes` and
 :func:`~matplotlib.pyplot.subplots`, and now this consistency is

--- a/doc/users/prev_whats_new/whats_new_1.3.rst
+++ b/doc/users/prev_whats_new/whats_new_1.3.rst
@@ -176,7 +176,7 @@ oddly distributed data sets.
 Calling subplot() without arguments
 ```````````````````````````````````
 A call to :func:`~matplotlib.pyplot.subplot` without any arguments now
-acts the same as ``subplot(111)`` or ``subplot(1, 1, 1)`` -- it creates one
+acts the same as ``subplot(1, 1, 1)`` or ``subplot(1, 1, 1)`` -- it creates one
 axes for the whole figure. This was already the behavior for both
 :func:`~matplotlib.pyplot.axes` and
 :func:`~matplotlib.pyplot.subplots`, and now this consistency is

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -447,7 +447,7 @@ column line plots.
 
     from mpl_toolkits.mplot3d import Axes3D, axes3d
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1, projection='3d')
+    ax = fig.add_subplot(111, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rstride=10, cstride=0)
 

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -447,7 +447,7 @@ column line plots.
 
     from mpl_toolkits.mplot3d import Axes3D, axes3d
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rstride=10, cstride=0)
 

--- a/examples/animation/double_pendulum_sgskip.py
+++ b/examples/animation/double_pendulum_sgskip.py
@@ -70,7 +70,7 @@ x2 = L2*sin(y[:, 2]) + x1
 y2 = -L2*cos(y[:, 2]) + y1
 
 fig = plt.figure()
-ax = fig.add_subplot(111, autoscale_on=False, xlim=(-2, 2), ylim=(-2, 2))
+ax = fig.add_subplot(1, 1, 1, autoscale_on=False, xlim=(-2, 2), ylim=(-2, 2))
 ax.set_aspect('equal')
 ax.grid()
 

--- a/examples/animation/unchained.py
+++ b/examples/animation/unchained.py
@@ -21,7 +21,7 @@ np.random.seed(19680801)
 fig = plt.figure(figsize=(8, 8), facecolor='black')
 
 # Add a subplot with no frame
-ax = plt.subplot(111, frameon=False)
+ax = plt.subplot(1, 1, 1, frameon=False)
 
 # Generate random data
 data = np.random.uniform(0, 1, (64, 75))

--- a/examples/axes_grid1/demo_axes_grid.py
+++ b/examples/axes_grid1/demo_axes_grid.py
@@ -27,7 +27,7 @@ def demo_simple_grid(fig):
     A grid of 2x2 images with 0.05 inch pad between images and only
     the lower-left axes is labeled.
     """
-    grid = ImageGrid(fig, 141,  # similar to subplot(141)
+    grid = ImageGrid(fig, 141,  # similar to subplot(1, 4, 1)
                      nrows_ncols=(2, 2),
                      axes_pad=0.05,
                      label_mode="1",
@@ -44,7 +44,7 @@ def demo_grid_with_single_cbar(fig):
     """
     A grid of 2x2 images with a single colorbar
     """
-    grid = ImageGrid(fig, 142,  # similar to subplot(142)
+    grid = ImageGrid(fig, 142,  # similar to subplot(1, 4, 2)
                      nrows_ncols=(2, 2),
                      axes_pad=0.0,
                      share_all=True,
@@ -70,7 +70,7 @@ def demo_grid_with_each_cbar(fig):
     """
     A grid of 2x2 images. Each image has its own colorbar.
     """
-    grid = ImageGrid(fig, 143,  # similar to subplot(143)
+    grid = ImageGrid(fig, 143,  # similar to subplot(1, 4, 3)
                      nrows_ncols=(2, 2),
                      axes_pad=0.1,
                      label_mode="1",
@@ -95,7 +95,7 @@ def demo_grid_with_each_cbar_labelled(fig):
     """
     A grid of 2x2 images. Each image has its own colorbar.
     """
-    grid = ImageGrid(fig, 144,  # similar to subplot(144)
+    grid = ImageGrid(fig, 144,  # similar to subplot(1, 4, 4)
                      nrows_ncols=(2, 2),
                      axes_pad=(0.45, 0.15),
                      label_mode="1",

--- a/examples/axes_grid1/demo_axes_grid2.py
+++ b/examples/axes_grid1/demo_axes_grid2.py
@@ -44,7 +44,7 @@ ZS = [Z[i::3, :] for i in range(3)]
 extent = extent[0], extent[1]/3., extent[2], extent[3]
 
 # *** Demo 1: colorbar at each axes ***
-grid = ImageGrid(fig, 211,  # similar to subplot(211)
+grid = ImageGrid(fig, 211,  # similar to subplot(2, 1, 1)
                  nrows_ncols=(1, 3),
                  axes_pad=0.05,
                  label_mode="1",

--- a/examples/axes_grid1/demo_edge_colorbar.py
+++ b/examples/axes_grid1/demo_edge_colorbar.py
@@ -27,7 +27,7 @@ def demo_bottom_cbar(fig):
     """
     A grid of 2x2 images with a colorbar for each column.
     """
-    grid = AxesGrid(fig, 121,  # similar to subplot(121)
+    grid = AxesGrid(fig, 121,  # similar to subplot(1, 2, 1)
                     nrows_ncols=(2, 2),
                     axes_pad=0.10,
                     share_all=True,
@@ -59,7 +59,7 @@ def demo_right_cbar(fig):
     """
     A grid of 2x2 images. Each row has its own colorbar.
     """
-    grid = AxesGrid(fig, 122,  # similar to subplot(122)
+    grid = AxesGrid(fig, 122,  # similar to subplot(1, 2, 2)
                     nrows_ncols=(2, 2),
                     axes_pad=0.10,
                     label_mode="1",

--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -52,7 +52,7 @@ plt.show()
 #
 
 fig = plt.figure(figsize=[5.5, 2.8])
-ax = fig.add_subplot(121)
+ax = fig.add_subplot(1, 2, 1)
 
 # We use the axes transform as bbox_transform. Therefore the bounding box
 # needs to be specified in axes coordinates ((0, 0) is the lower left corner
@@ -80,10 +80,10 @@ ax.set(xlim=(0, 10), ylim=(0, 10))
 # Note how the two following insets are created at the same positions, one by
 # use of the default parent axes' bbox and the other via a bbox in axes
 # coordinates and the respective transform.
-ax2 = fig.add_subplot(222)
+ax2 = fig.add_subplot(2, 2, 2)
 axins2 = inset_axes(ax2, width="30%", height="50%")
 
-ax3 = fig.add_subplot(224)
+ax3 = fig.add_subplot(2, 2, 4)
 axins3 = inset_axes(ax3, width="100%", height="100%",
                     bbox_to_anchor=(.7, .5, .3, .5),
                     bbox_transform=ax3.transAxes)
@@ -108,7 +108,7 @@ plt.show()
 #
 
 fig = plt.figure(figsize=[5.5, 2.8])
-ax = fig.add_subplot(131)
+ax = fig.add_subplot(1, 3, 1)
 
 # Create an inset outside the axes
 axins = inset_axes(ax, width="100%", height="100%",
@@ -124,7 +124,7 @@ axins2 = inset_axes(ax, width=0.5, height=0.4,
                     bbox_transform=ax.transAxes, loc=3, borderpad=0)
 
 
-ax2 = fig.add_subplot(133)
+ax2 = fig.add_subplot(1, 3, 3)
 ax2.set_xscale("log")
 ax2.set(xlim=(1e-6, 1e6), ylim=(-2, 6))
 

--- a/examples/axes_grid1/parasite_simple.py
+++ b/examples/axes_grid1/parasite_simple.py
@@ -7,7 +7,7 @@ Parasite Simple
 from mpl_toolkits.axes_grid1 import host_subplot
 import matplotlib.pyplot as plt
 
-host = host_subplot(111)
+host = host_subplot(1, 1, 1)
 
 par = host.twinx()
 

--- a/examples/axes_grid1/simple_axesgrid.py
+++ b/examples/axes_grid1/simple_axesgrid.py
@@ -16,7 +16,7 @@ im3 = np.flipud(im1)
 im4 = np.fliplr(im2)
 
 fig = plt.figure(figsize=(4., 4.))
-grid = ImageGrid(fig, 111,  # similar to subplot(111)
+grid = ImageGrid(fig, 111,  # similar to subplot(1, 1, 1)
                  nrows_ncols=(2, 2),  # creates 2x2 grid of axes
                  axes_pad=0.1,  # pad between axes in inch.
                  )

--- a/examples/axes_grid1/simple_axesgrid2.py
+++ b/examples/axes_grid1/simple_axesgrid2.py
@@ -20,7 +20,7 @@ def get_demo_image():
 
 
 fig = plt.figure(figsize=(5.5, 3.5))
-grid = ImageGrid(fig, 111,  # similar to subplot(111)
+grid = ImageGrid(fig, 111,  # similar to subplot(1, 1, 1)
                  nrows_ncols=(1, 3),
                  axes_pad=0.1,
                  label_mode="L",

--- a/examples/axes_grid1/simple_axisline4.py
+++ b/examples/axes_grid1/simple_axisline4.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import host_subplot
 import numpy as np
 
-ax = host_subplot(111)
+ax = host_subplot(1, 1, 1)
 xx = np.arange(0, 2*np.pi, 0.01)
 ax.plot(xx, np.sin(xx))
 

--- a/examples/axes_grid1/simple_colorbar.py
+++ b/examples/axes_grid1/simple_colorbar.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 import numpy as np
 
-ax = plt.subplot(111)
+ax = plt.subplot(1, 1, 1)
 im = ax.imshow(np.arange(100).reshape((10, 10)))
 
 # create an axes on the right side of ax. The width of cax will be 5%

--- a/examples/axisartist/demo_parasite_axes2.py
+++ b/examples/axisartist/demo_parasite_axes2.py
@@ -26,7 +26,7 @@ from mpl_toolkits.axes_grid1 import host_subplot
 from mpl_toolkits import axisartist
 import matplotlib.pyplot as plt
 
-host = host_subplot(111, axes_class=axisartist.Axes)
+host = host_subplot(1, 1, 1, axes_class=axisartist.Axes)
 plt.subplots_adjust(right=0.75)
 
 par1 = host.twinx()

--- a/examples/event_handling/trifinder_event_demo.py
+++ b/examples/event_handling/trifinder_event_demo.py
@@ -52,7 +52,7 @@ triang.set_mask(np.hypot(x[triang.triangles].mean(axis=1),
 trifinder = triang.get_trifinder()
 
 # Setup plot and callbacks.
-plt.subplot(111, aspect='equal')
+plt.subplot(1, 1, 1, aspect='equal')
 plt.triplot(triang, 'bo-')
 polygon = Polygon([[0, 0], [0, 0]], facecolor='y')  # dummy data for (xs, ys)
 update_polygon(-1)

--- a/examples/lines_bars_and_markers/eventcollection_demo.py
+++ b/examples/lines_bars_and_markers/eventcollection_demo.py
@@ -31,7 +31,7 @@ ydata2 = 1 - xdata2 ** 3
 
 # plot the data
 fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 ax.plot(xdata1, ydata1, color='tab:blue')
 ax.plot(xdata2, ydata2, color='tab:orange')
 

--- a/examples/lines_bars_and_markers/psd_demo.py
+++ b/examples/lines_bars_and_markers/psd_demo.py
@@ -26,9 +26,9 @@ cnse = np.convolve(nse, r) * dt
 cnse = cnse[:len(t)]
 s = 0.1 * np.sin(2 * np.pi * t) + cnse
 
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot(t, s)
-plt.subplot(212)
+plt.subplot(2, 1, 2)
 plt.psd(s, 512, 1 / dt)
 
 plt.show()
@@ -44,9 +44,9 @@ plt.show()
 #     cnse = cnse(1:length(t));
 #     s = 0.1*sin(2*pi*t) + cnse;
 #
-#     subplot(211)
+#     subplot(2, 1, 1)
 #     plot(t, s)
-#     subplot(212)
+#     subplot(2, 1, 2)
 #     psd(s, 512, 1/dt)
 #
 # Below we'll show a slightly more complex example that demonstrates

--- a/examples/misc/agg_buffer_to_array.py
+++ b/examples/misc/agg_buffer_to_array.py
@@ -25,6 +25,6 @@ X = np.array(canvas.renderer.buffer_rgba())
 
 # now display the array X as an Axes in a new figure
 fig2 = plt.figure()
-ax2 = fig2.add_subplot(111, frameon=False)
+ax2 = fig2.add_subplot(1, 1, 1, frameon=False)
 ax2.imshow(X)
 plt.show()

--- a/examples/misc/custom_projection.py
+++ b/examples/misc/custom_projection.py
@@ -370,7 +370,7 @@ class HammerAxes(GeoAxes):
 
     # The projection must specify a name. This will be used by the
     # user to select the projection,
-    # i.e. ``subplot(111, projection='custom_hammer')``.
+    # i.e. ``subplot(1, 1, 1, projection='custom_hammer')``.
     name = 'custom_hammer'
 
     class HammerTransform(Transform):
@@ -441,7 +441,7 @@ register_projection(HammerAxes)
 if __name__ == '__main__':
     import matplotlib.pyplot as plt
     # Now make a simple example using the custom projection.
-    plt.subplot(111, projection="custom_hammer")
+    plt.subplot(1, 1, 1, projection="custom_hammer")
     p = plt.plot([-1, 1, 1], [-1, -1, 1], "o-")
     plt.grid(True)
 

--- a/examples/misc/customize_rc.py
+++ b/examples/misc/customize_rc.py
@@ -21,7 +21,7 @@ functions in a custom module that set the defaults, e.g.,::
 Then as you are working interactively, you just need to do::
 
     >>> set_pub()
-    >>> subplot(111)
+    >>> subplot(1, 1, 1)
     >>> plot([1, 2, 3])
     >>> savefig('myfig')
     >>> rcdefaults()  # restore the defaults
@@ -29,7 +29,7 @@ Then as you are working interactively, you just need to do::
 
 import matplotlib.pyplot as plt
 
-plt.subplot(311)
+plt.subplot(3, 1, 1)
 plt.plot([1, 2, 3])
 
 # the axes attributes need to be set before the call to subplot
@@ -40,13 +40,13 @@ plt.rc('xtick', labelsize=15)
 # using aliases for color, linestyle and linewidth; gray, solid, thick
 plt.rc('grid', c='0.5', ls='-', lw=5)
 plt.rc('lines', lw=2, color='g')
-plt.subplot(312)
+plt.subplot(3, 1, 2)
 
 plt.plot([1, 2, 3])
 plt.grid(True)
 
 plt.rcdefaults()
-plt.subplot(313)
+plt.subplot(3, 1, 3)
 plt.plot([1, 2, 3])
 plt.grid(True)
 plt.show()

--- a/examples/misc/patheffect_demo.py
+++ b/examples/misc/patheffect_demo.py
@@ -9,7 +9,7 @@ from matplotlib import patheffects
 import numpy as np
 
 plt.figure(figsize=(8, 3))
-ax1 = plt.subplot(131)
+ax1 = plt.subplot(1, 3, 1)
 ax1.imshow([[1, 2], [2, 3]])
 txt = ax1.annotate("test", (1., 1.), (0., 0),
                    arrowprops=dict(arrowstyle="->",
@@ -25,7 +25,7 @@ pe = [patheffects.withStroke(linewidth=3,
                              foreground="w")]
 ax1.grid(True, linestyle="-", path_effects=pe)
 
-ax2 = plt.subplot(132)
+ax2 = plt.subplot(1, 3, 2)
 arr = np.arange(25).reshape((5, 5))
 ax2.imshow(arr)
 cntr = ax2.contour(arr, colors="k")
@@ -38,7 +38,7 @@ plt.setp(clbls, path_effects=[
     patheffects.withStroke(linewidth=3, foreground="w")])
 
 # shadow as a path effect
-ax3 = plt.subplot(133)
+ax3 = plt.subplot(1, 3, 3)
 p1, = ax3.plot([0, 1], [0, 1])
 leg = ax3.legend([p1], ["Line 1"], fancybox=True, loc='upper left')
 leg.legendPatch.set_path_effects([patheffects.withSimplePatchShadow()])

--- a/examples/mplot3d/3d_bars.py
+++ b/examples/mplot3d/3d_bars.py
@@ -12,8 +12,8 @@ import matplotlib.pyplot as plt
 
 # setup the figure and axes
 fig = plt.figure(figsize=(8, 3))
-ax1 = fig.add_subplot(121, projection='3d')
-ax2 = fig.add_subplot(122, projection='3d')
+ax1 = fig.add_subplot(1, 2, 1, projection='3d')
+ax2 = fig.add_subplot(1, 2, 2, projection='3d')
 
 # fake data
 _x = np.arange(4)

--- a/examples/mplot3d/bars3d.py
+++ b/examples/mplot3d/bars3d.py
@@ -15,7 +15,7 @@ np.random.seed(19680801)
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 colors = ['r', 'g', 'b', 'y']
 yticks = [3, 2, 1, 0]

--- a/examples/mplot3d/hist3d.py
+++ b/examples/mplot3d/hist3d.py
@@ -14,7 +14,7 @@ np.random.seed(19680801)
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 x, y = np.random.rand(2, 100) * 4
 hist, xedges, yedges = np.histogram2d(x, y, bins=4, range=[[0, 4], [0, 4]])
 

--- a/examples/mplot3d/pathpatch3d.py
+++ b/examples/mplot3d/pathpatch3d.py
@@ -41,7 +41,7 @@ def text3d(ax, xyz, s, zdir="z", size=None, angle=0, usetex=False, **kwargs):
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # Draw a circle on the x=0 'wall'
 p = Circle((5, 5), 3)

--- a/examples/mplot3d/rotate_axes3d_sgskip.py
+++ b/examples/mplot3d/rotate_axes3d_sgskip.py
@@ -15,7 +15,7 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # load some test data for demonstration and plot a wireframe
 X, Y, Z = axes3d.get_test_data(0.1)

--- a/examples/mplot3d/scatter3d.py
+++ b/examples/mplot3d/scatter3d.py
@@ -21,7 +21,7 @@ def randrange(n, vmin, vmax):
     return (vmax - vmin)*np.random.rand(n) + vmin
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 n = 100
 

--- a/examples/mplot3d/surface3d_2.py
+++ b/examples/mplot3d/surface3d_2.py
@@ -11,7 +11,7 @@ import numpy as np
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # Make data
 u = np.linspace(0, 2 * np.pi, 100)

--- a/examples/mplot3d/surface3d_radial.py
+++ b/examples/mplot3d/surface3d_radial.py
@@ -15,7 +15,7 @@ import numpy as np
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # Create the mesh in polar coordinates and compute corresponding Z.
 r = np.linspace(0, 1.25, 50)

--- a/examples/mplot3d/wire3d.py
+++ b/examples/mplot3d/wire3d.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # Grab some test data.
 X, Y, Z = axes3d.get_test_data(0.05)

--- a/examples/mplot3d/wire3d_animation_sgskip.py
+++ b/examples/mplot3d/wire3d_animation_sgskip.py
@@ -23,7 +23,7 @@ def generate(X, Y, phi):
 
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='3d')
+ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 # Make the X, Y meshgrid.
 xs = np.linspace(-1, 1, 50)

--- a/examples/pie_and_polar_charts/bar_of_pie.py
+++ b/examples/pie_and_polar_charts/bar_of_pie.py
@@ -16,8 +16,8 @@ import numpy as np
 
 # make figure and assign axis objects
 fig = plt.figure(figsize=(9, 5))
-ax1 = fig.add_subplot(121)
-ax2 = fig.add_subplot(122)
+ax1 = fig.add_subplot(1, 2, 1)
+ax2 = fig.add_subplot(1, 2, 2)
 fig.subplots_adjust(wspace=0)
 
 # pie chart parameters

--- a/examples/pie_and_polar_charts/polar_bar.py
+++ b/examples/pie_and_polar_charts/polar_bar.py
@@ -19,7 +19,7 @@ radii = 10 * np.random.rand(N)
 width = np.pi / 4 * np.random.rand(N)
 colors = plt.cm.viridis(radii / 10.)
 
-ax = plt.subplot(111, projection='polar')
+ax = plt.subplot(1, 1, 1, projection='polar')
 ax.bar(theta, radii, width=width, bottom=0.0, color=colors, alpha=0.5)
 
 plt.show()

--- a/examples/pie_and_polar_charts/polar_demo.py
+++ b/examples/pie_and_polar_charts/polar_demo.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 r = np.arange(0, 2, 0.01)
 theta = 2 * np.pi * r
 
-ax = plt.subplot(111, projection='polar')
+ax = plt.subplot(1, 1, 1, projection='polar')
 ax.plot(theta, r)
 ax.set_rmax(2)
 ax.set_rticks([0.5, 1, 1.5, 2])  # Less radial ticks

--- a/examples/pie_and_polar_charts/polar_scatter.py
+++ b/examples/pie_and_polar_charts/polar_scatter.py
@@ -21,7 +21,7 @@ area = 200 * r**2
 colors = theta
 
 fig = plt.figure()
-ax = fig.add_subplot(111, projection='polar')
+ax = fig.add_subplot(1, 1, 1, projection='polar')
 c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 
 ###############################################################################
@@ -33,7 +33,7 @@ c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 # rotate the plot.
 
 fig = plt.figure()
-ax = fig.add_subplot(111, polar=True)
+ax = fig.add_subplot(1, 1, 1, polar=True)
 c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 
 ax.set_rorigin(-2.5)
@@ -47,7 +47,7 @@ ax.set_theta_zero_location('W', offset=10)
 # theta start and end limits, producing a sector instead of a full circle.
 
 fig = plt.figure()
-ax = fig.add_subplot(111, polar=True)
+ax = fig.add_subplot(1, 1, 1, polar=True)
 c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 
 ax.set_thetamin(45)

--- a/examples/pyplots/annotation_polar.py
+++ b/examples/pyplots/annotation_polar.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 fig = plt.figure()
-ax = fig.add_subplot(111, polar=True)
+ax = fig.add_subplot(1, 1, 1, polar=True)
 r = np.arange(0, 1, 0.001)
 theta = 2 * 2*np.pi * r
 line, = ax.plot(theta, r, color='#ee8d18', lw=3)

--- a/examples/pyplots/fig_axes_labels_simple.py
+++ b/examples/pyplots/fig_axes_labels_simple.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 
 fig = plt.figure()
 fig.subplots_adjust(top=0.8)
-ax1 = fig.add_subplot(211)
+ax1 = fig.add_subplot(2, 1, 1)
 ax1.set_ylabel('volts')
 ax1.set_title('a sine wave')
 

--- a/examples/pyplots/pyplot_two_subplots.py
+++ b/examples/pyplots/pyplot_two_subplots.py
@@ -17,11 +17,11 @@ t1 = np.arange(0.0, 5.0, 0.1)
 t2 = np.arange(0.0, 5.0, 0.02)
 
 plt.figure()
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot(t1, f(t1), color='tab:blue', marker='o')
 plt.plot(t2, f(t2), color='black')
 
-plt.subplot(212)
+plt.subplot(2, 1, 2)
 plt.plot(t2, np.cos(2*np.pi*t2), color='tab:orange', linestyle='--')
 plt.show()
 

--- a/examples/pyplots/text_commands.py
+++ b/examples/pyplots/text_commands.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 fig = plt.figure()
 fig.suptitle('bold figure suptitle', fontsize=14, fontweight='bold')
 
-ax = fig.add_subplot(111)
+ax = fig.add_subplot(1, 1, 1)
 fig.subplots_adjust(top=0.85)
 ax.set_title('axes title')
 

--- a/examples/pyplots/text_commands.py
+++ b/examples/pyplots/text_commands.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 fig = plt.figure()
 fig.suptitle('bold figure suptitle', fontsize=14, fontweight='bold')
 
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 fig.subplots_adjust(top=0.85)
 ax.set_title('axes title')
 

--- a/examples/pyplots/whats_new_98_4_legend.py
+++ b/examples/pyplots/whats_new_98_4_legend.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-ax = plt.subplot(111)
+ax = plt.subplot(1, 1, 1)
 t1 = np.arange(0.0, 1.0, 0.01)
 for n in [1, 2, 3, 4]:
     plt.plot(t1, t1**n, label=f"n={n}")

--- a/examples/recipes/create_subplots.py
+++ b/examples/recipes/create_subplots.py
@@ -20,9 +20,9 @@ x = np.random.randn(50)
 # old style
 fig = plt.figure()
 ax1 = fig.add_subplot(2, 2, 1)
-ax2 = fig.add_subplot(222, sharex=ax1, sharey=ax1)
-ax3 = fig.add_subplot(223, sharex=ax1, sharey=ax1)
-ax3 = fig.add_subplot(224, sharex=ax1, sharey=ax1)
+ax2 = fig.add_subplot(2, 2, 2, sharex=ax1, sharey=ax1)
+ax3 = fig.add_subplot(2, 2, 3, sharex=ax1, sharey=ax1)
+ax3 = fig.add_subplot(2, 2, 4, sharex=ax1, sharey=ax1)
 
 ###############################################################################
 # Fernando Perez has provided the nice top-level function

--- a/examples/recipes/create_subplots.py
+++ b/examples/recipes/create_subplots.py
@@ -19,7 +19,7 @@ x = np.random.randn(50)
 
 # old style
 fig = plt.figure()
-ax1 = fig.add_subplot(221)
+ax1 = fig.add_subplot(2, 2, 1)
 ax2 = fig.add_subplot(222, sharex=ax1, sharey=ax1)
 ax3 = fig.add_subplot(223, sharex=ax1, sharey=ax1)
 ax3 = fig.add_subplot(224, sharex=ax1, sharey=ax1)

--- a/examples/recipes/share_axis_lims_views.py
+++ b/examples/recipes/share_axis_lims_views.py
@@ -18,7 +18,7 @@ t = np.arange(0, 10, 0.01)
 ax1 = plt.subplot(2, 1, 1)
 ax1.plot(t, np.sin(2*np.pi*t))
 
-ax2 = plt.subplot(212, sharex=ax1)
+ax2 = plt.subplot(2, 1, 2, sharex=ax1)
 ax2.plot(t, np.sin(4*np.pi*t))
 
 plt.show()

--- a/examples/recipes/share_axis_lims_views.py
+++ b/examples/recipes/share_axis_lims_views.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 
 t = np.arange(0, 10, 0.01)
 
-ax1 = plt.subplot(211)
+ax1 = plt.subplot(2, 1, 1)
 ax1.plot(t, np.sin(2*np.pi*t))
 
 ax2 = plt.subplot(212, sharex=ax1)

--- a/examples/scales/symlog_demo.py
+++ b/examples/scales/symlog_demo.py
@@ -12,19 +12,19 @@ dt = 0.01
 x = np.arange(-50.0, 50.0, dt)
 y = np.arange(0, 100.0, dt)
 
-plt.subplot(311)
+plt.subplot(3, 1, 1)
 plt.plot(x, y)
 plt.xscale('symlog')
 plt.ylabel('symlogx')
 plt.grid(True)
 plt.gca().xaxis.grid(True, which='minor')  # minor grid on too
 
-plt.subplot(312)
+plt.subplot(3, 1, 2)
 plt.plot(y, x)
 plt.yscale('symlog')
 plt.ylabel('symlogy')
 
-plt.subplot(313)
+plt.subplot(3, 1, 3)
 plt.plot(x, np.sin(x / 3.0))
 plt.xscale('symlog')
 plt.yscale('symlog', linthresh=0.015)

--- a/examples/specialty_plots/skewt.py
+++ b/examples/specialty_plots/skewt.py
@@ -79,7 +79,7 @@ class SkewSpine(mspines.Spine):
 # spines and axes instances as appropriate.
 class SkewXAxes(Axes):
     # The projection must specify a name.  This will be used be the
-    # user to select the projection, i.e. ``subplot(111,
+    # user to select the projection, i.e. ``subplot(1, 1, 1,
     # projection='skewx')``.
     name = 'skewx'
 
@@ -236,7 +236,7 @@ if __name__ == '__main__':
 
     # Create a new figure. The dimensions here give a good aspect ratio
     fig = plt.figure(figsize=(6.5875, 6.2125))
-    ax = fig.add_subplot(111, projection='skewx')
+    ax = fig.add_subplot(1, 1, 1, projection='skewx')
 
     plt.grid(True)
 

--- a/examples/subplots_axes_and_figures/axes_margins.py
+++ b/examples/subplots_axes_and_figures/axes_margins.py
@@ -21,16 +21,16 @@ def f(t):
 
 t1 = np.arange(0.0, 3.0, 0.01)
 
-ax1 = plt.subplot(212)
+ax1 = plt.subplot(2, 1, 2)
 ax1.margins(0.05)           # Default margin is 0.05, value 0 means fit
 ax1.plot(t1, f(t1))
 
-ax2 = plt.subplot(221)
+ax2 = plt.subplot(2, 2, 1)
 ax2.margins(2, 2)           # Values >0.0 zoom out
 ax2.plot(t1, f(t1))
 ax2.set_title('Zoomed out')
 
-ax3 = plt.subplot(222)
+ax3 = plt.subplot(2, 2, 2)
 ax3.margins(x=0, y=-0.25)   # Values in (-0.5, 0.0) zooms in to center
 ax3.plot(t1, f(t1))
 ax3.set_title('Zoomed in')

--- a/examples/subplots_axes_and_figures/axes_zoom_effect.py
+++ b/examples/subplots_axes_and_figures/axes_zoom_effect.py
@@ -112,14 +112,14 @@ def zoom_effect02(ax1, ax2, **kwargs):
 import matplotlib.pyplot as plt
 
 plt.figure(figsize=(5, 5))
-ax1 = plt.subplot(221)
-ax2 = plt.subplot(212)
+ax1 = plt.subplot(2, 2, 1)
+ax2 = plt.subplot(2, 1, 2)
 ax2.set_xlim(0, 1)
 ax2.set_xlim(0, 5)
 zoom_effect01(ax1, ax2, 0.2, 0.8)
 
 
-ax1 = plt.subplot(222)
+ax1 = plt.subplot(2, 2, 2)
 ax1.set_xlim(2, 3)
 ax2.set_xlim(0, 5)
 zoom_effect02(ax1, ax2)

--- a/examples/subplots_axes_and_figures/demo_tight_layout.py
+++ b/examples/subplots_axes_and_figures/demo_tight_layout.py
@@ -67,9 +67,9 @@ plt.tight_layout()
 
 fig = plt.figure()
 
-ax1 = plt.subplot(221)
-ax2 = plt.subplot(223)
-ax3 = plt.subplot(122)
+ax1 = plt.subplot(2, 2, 1)
+ax2 = plt.subplot(2, 2, 3)
+ax3 = plt.subplot(1, 2, 2)
 
 example_plot(ax1)
 example_plot(ax2)

--- a/examples/subplots_axes_and_figures/geo_demo.py
+++ b/examples/subplots_axes_and_figures/geo_demo.py
@@ -14,28 +14,28 @@ import matplotlib.pyplot as plt
 ###############################################################################
 
 plt.figure()
-plt.subplot(111, projection="aitoff")
+plt.subplot(1, 1, 1, projection="aitoff")
 plt.title("Aitoff")
 plt.grid(True)
 
 ###############################################################################
 
 plt.figure()
-plt.subplot(111, projection="hammer")
+plt.subplot(1, 1, 1, projection="hammer")
 plt.title("Hammer")
 plt.grid(True)
 
 ###############################################################################
 
 plt.figure()
-plt.subplot(111, projection="lambert")
+plt.subplot(1, 1, 1, projection="lambert")
 plt.title("Lambert")
 plt.grid(True)
 
 ###############################################################################
 
 plt.figure()
-plt.subplot(111, projection="mollweide")
+plt.subplot(1, 1, 1, projection="mollweide")
 plt.title("Mollweide")
 plt.grid(True)
 

--- a/examples/subplots_axes_and_figures/multiple_figs_demo.py
+++ b/examples/subplots_axes_and_figures/multiple_figs_demo.py
@@ -16,9 +16,9 @@ s2 = np.sin(4*np.pi*t)
 # Create figure 1
 
 plt.figure(1)
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot(t, s1)
-plt.subplot(212)
+plt.subplot(2, 1, 2)
 plt.plot(t, 2*s1)
 
 ###############################################################################
@@ -31,7 +31,7 @@ plt.plot(t, s2)
 # Now switch back to figure 1 and make some changes
 
 plt.figure(1)
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot(t, s2, 's')
 ax = plt.gca()
 ax.set_xticklabels([])

--- a/examples/subplots_axes_and_figures/shared_axis_demo.py
+++ b/examples/subplots_axes_and_figures/shared_axis_demo.py
@@ -21,7 +21,7 @@ because you may want to make the tick labels smaller on the upper
 axes, e.g., in the example below.
 
 If you want to turn off the ticklabels for a given axes (e.g., on
-subplot(211) or subplot(212), you cannot do the standard trick::
+subplot(2, 1, 1) or subplot(2, 1, 2), you cannot do the standard trick::
 
    setp(ax2, xticklabels=[])
 
@@ -40,7 +40,7 @@ s1 = np.sin(2 * np.pi * t)
 s2 = np.exp(-t)
 s3 = np.sin(4 * np.pi * t)
 
-ax1 = plt.subplot(311)
+ax1 = plt.subplot(3, 1, 1)
 plt.plot(t, s1)
 plt.setp(ax1.get_xticklabels(), fontsize=6)
 

--- a/examples/subplots_axes_and_figures/shared_axis_demo.py
+++ b/examples/subplots_axes_and_figures/shared_axis_demo.py
@@ -45,13 +45,13 @@ plt.plot(t, s1)
 plt.setp(ax1.get_xticklabels(), fontsize=6)
 
 # share x only
-ax2 = plt.subplot(312, sharex=ax1)
+ax2 = plt.subplot(3, 1, 2, sharex=ax1)
 plt.plot(t, s2)
 # make these tick labels invisible
 plt.setp(ax2.get_xticklabels(), visible=False)
 
 # share x and y
-ax3 = plt.subplot(313, sharex=ax1, sharey=ax1)
+ax3 = plt.subplot(3, 1, 3, sharex=ax1, sharey=ax1)
 plt.plot(t, s3)
 plt.xlim(0.01, 5.0)
 plt.show()

--- a/examples/subplots_axes_and_figures/subplots_adjust.py
+++ b/examples/subplots_axes_and_figures/subplots_adjust.py
@@ -13,9 +13,9 @@ import numpy as np
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.imshow(np.random.random((100, 100)), cmap=plt.cm.BuPu_r)
-plt.subplot(212)
+plt.subplot(2, 1, 2)
 plt.imshow(np.random.random((100, 100)), cmap=plt.cm.BuPu_r)
 
 plt.subplots_adjust(bottom=0.1, right=0.8, top=0.9)

--- a/examples/text_labels_and_annotations/demo_text_path.py
+++ b/examples/text_labels_and_annotations/demo_text_path.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
 
     # EXAMPLE 1
 
-    ax = plt.subplot(211)
+    ax = plt.subplot(2, 1, 1)
 
     arr = plt.imread(get_sample_data("grace_hopper.png"))
 
@@ -103,7 +103,7 @@ if __name__ == "__main__":
 
     # EXAMPLE 2
 
-    ax = plt.subplot(212)
+    ax = plt.subplot(2, 1, 2)
 
     arr = np.arange(256).reshape(1, 256) / 256
 

--- a/examples/text_labels_and_annotations/multiline.py
+++ b/examples/text_labels_and_annotations/multiline.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 plt.figure(figsize=(7, 4))
-ax = plt.subplot(121)
+ax = plt.subplot(1, 2, 1)
 ax.set_aspect(1)
 plt.plot(np.arange(10))
 plt.xlabel('this is a xlabel\n(with newlines!)')
@@ -21,7 +21,7 @@ plt.text(2, 7, 'this is\nyet another test',
 
 plt.grid(True)
 
-plt.subplot(122)
+plt.subplot(1, 2, 2)
 
 plt.text(0.29, 0.4, "Mat\nTTp\n123", size=18,
          va="baseline", ha="right", multialignment="left",

--- a/examples/units/ellipse_with_units.py
+++ b/examples/units/ellipse_with_units.py
@@ -37,7 +37,7 @@ y += ycenter
 ###############################################################################
 
 fig = plt.figure()
-ax = fig.add_subplot(211, aspect='auto')
+ax = fig.add_subplot(2, 1, 1, aspect='auto')
 ax.fill(x, y, alpha=0.2, facecolor='yellow',
         edgecolor='yellow', linewidth=1, zorder=1)
 
@@ -46,7 +46,7 @@ e1 = patches.Ellipse((xcenter, ycenter), width, height,
 
 ax.add_patch(e1)
 
-ax = fig.add_subplot(212, aspect='equal')
+ax = fig.add_subplot(2, 1, 2, aspect='equal')
 ax.fill(x, y, alpha=0.2, facecolor='green', edgecolor='green', zorder=1)
 e2 = patches.Ellipse((xcenter, ycenter), width, height,
                      angle=angle, linewidth=2, fill=False, zorder=2)
@@ -58,7 +58,7 @@ fig.savefig('ellipse_compare')
 ###############################################################################
 
 fig = plt.figure()
-ax = fig.add_subplot(211, aspect='auto')
+ax = fig.add_subplot(2, 1, 1, aspect='auto')
 ax.fill(x, y, alpha=0.2, facecolor='yellow',
         edgecolor='yellow', linewidth=1, zorder=1)
 
@@ -67,7 +67,7 @@ e1 = patches.Arc((xcenter, ycenter), width, height,
 
 ax.add_patch(e1)
 
-ax = fig.add_subplot(212, aspect='equal')
+ax = fig.add_subplot(2, 1, 2, aspect='equal')
 ax.fill(x, y, alpha=0.2, facecolor='green', edgecolor='green', zorder=1)
 e2 = patches.Arc((xcenter, ycenter), width, height,
                  angle=angle, linewidth=2, fill=False, zorder=2)

--- a/examples/user_interfaces/canvasagg.py
+++ b/examples/user_interfaces/canvasagg.py
@@ -30,7 +30,7 @@ fig = Figure(figsize=(5, 4), dpi=100)
 canvas = FigureCanvasAgg(fig)
 
 # Do some plotting.
-ax = fig.add_subplot(111)
+ax = fig.add_subplot(1, 1, 1)
 ax.plot([1, 2, 3])
 
 # Option 1: Save the figure to a file; can also be a file-like object (BytesIO,

--- a/examples/user_interfaces/canvasagg.py
+++ b/examples/user_interfaces/canvasagg.py
@@ -30,7 +30,7 @@ fig = Figure(figsize=(5, 4), dpi=100)
 canvas = FigureCanvasAgg(fig)
 
 # Do some plotting.
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 ax.plot([1, 2, 3])
 
 # Option 1: Save the figure to a file; can also be a file-like object (BytesIO,

--- a/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
@@ -23,7 +23,7 @@ win.set_default_size(400, 300)
 win.set_title("Embedding in GTK")
 
 fig = Figure(figsize=(5, 4), dpi=100)
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 t = np.arange(0.0, 3.0, 0.01)
 s = np.sin(2*np.pi*t)
 ax.plot(t, s)

--- a/examples/user_interfaces/embedding_in_gtk3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_sgskip.py
@@ -22,7 +22,7 @@ win.set_default_size(400, 300)
 win.set_title("Embedding in GTK")
 
 fig = Figure(figsize=(5, 4), dpi=100)
-ax = fig.add_subplot(111)
+ax = fig.add_subplot(1, 1, 1)
 t = np.arange(0.0, 3.0, 0.01)
 s = np.sin(2*np.pi*t)
 ax.plot(t, s)

--- a/examples/user_interfaces/embedding_in_gtk3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_sgskip.py
@@ -22,7 +22,7 @@ win.set_default_size(400, 300)
 win.set_title("Embedding in GTK")
 
 fig = Figure(figsize=(5, 4), dpi=100)
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 t = np.arange(0.0, 3.0, 0.01)
 s = np.sin(2*np.pi*t)
 ax.plot(t, s)

--- a/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -21,7 +21,7 @@ root.wm_title("Embedding in Tk")
 
 fig = Figure(figsize=(5, 4), dpi=100)
 t = np.arange(0, 3, .01)
-fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
+fig.add_subplot(1, 1, 1).plot(t, 2 * np.sin(2 * np.pi * t))
 
 canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
 canvas.draw()

--- a/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -21,7 +21,7 @@ root.wm_title("Embedding in Tk")
 
 fig = Figure(figsize=(5, 4), dpi=100)
 t = np.arange(0, 3, .01)
-fig.add_subplot(1, 1, 1).plot(t, 2 * np.sin(2 * np.pi * t))
+fig.add_subplot().plot(t, 2 * np.sin(2 * np.pi * t))
 
 canvas = FigureCanvasTkAgg(fig, master=root)  # A tk.DrawingArea.
 canvas.draw()

--- a/examples/user_interfaces/embedding_in_wx2_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx2_sgskip.py
@@ -24,7 +24,7 @@ class CanvasFrame(wx.Frame):
                           'CanvasFrame', size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(111)
+        self.axes = self.figure.add_subplot(1, 1, 1)
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2 * np.pi * t)
 

--- a/examples/user_interfaces/embedding_in_wx2_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx2_sgskip.py
@@ -24,7 +24,7 @@ class CanvasFrame(wx.Frame):
                           'CanvasFrame', size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(1, 1, 1)
+        self.axes = self.figure.add_subplot()
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2 * np.pi * t)
 

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -54,7 +54,7 @@ class PlotPanel(wx.Panel):
         self.Fit()
 
     def init_plot_data(self):
-        ax = self.fig.add_subplot(111)
+        ax = self.fig.add_subplot(1, 1, 1)
 
         x = np.arange(120.0) * 2 * np.pi / 60.0
         y = np.arange(100.0) * 2 * np.pi / 50.0

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -54,7 +54,7 @@ class PlotPanel(wx.Panel):
         self.Fit()
 
     def init_plot_data(self):
-        ax = self.fig.add_subplot(1, 1, 1)
+        ax = self.fig.add_subplot()
 
         x = np.arange(120.0) * 2 * np.pi / 60.0
         y = np.arange(100.0) * 2 * np.pi / 50.0

--- a/examples/user_interfaces/embedding_in_wx4_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx4_sgskip.py
@@ -45,7 +45,7 @@ class CanvasFrame(wx.Frame):
                           'CanvasFrame', size=(550, 350))
 
         self.figure = Figure(figsize=(5, 4), dpi=100)
-        self.axes = self.figure.add_subplot(1, 1, 1)
+        self.axes = self.figure.add_subplot()
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2 * np.pi * t)
 

--- a/examples/user_interfaces/embedding_in_wx4_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx4_sgskip.py
@@ -45,7 +45,7 @@ class CanvasFrame(wx.Frame):
                           'CanvasFrame', size=(550, 350))
 
         self.figure = Figure(figsize=(5, 4), dpi=100)
-        self.axes = self.figure.add_subplot(111)
+        self.axes = self.figure.add_subplot(1, 1, 1)
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2 * np.pi * t)
 

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -39,7 +39,7 @@ def create_figure():
     Creates a simple example figure.
     """
     fig = Figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     t = np.arange(0.0, 3.0, 0.01)
     s = np.sin(2 * np.pi * t)
     ax.plot(t, s)

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -39,7 +39,7 @@ def create_figure():
     Creates a simple example figure.
     """
     fig = Figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     t = np.arange(0.0, 3.0, 0.01)
     s = np.sin(2 * np.pi * t)
     ax.plot(t, s)

--- a/examples/user_interfaces/gtk_spreadsheet_sgskip.py
+++ b/examples/user_interfaces/gtk_spreadsheet_sgskip.py
@@ -52,7 +52,7 @@ class DataManager(Gtk.Window):
 
         self.canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
         vbox.pack_start(self.canvas, True, True, 0)
-        ax = fig.add_subplot(111)
+        ax = fig.add_subplot(1, 1, 1)
         self.line, = ax.plot(self.data[0, :], 'go')  # plot the first row
 
         self.treeview.connect('row-activated', self.plot_row)

--- a/examples/user_interfaces/gtk_spreadsheet_sgskip.py
+++ b/examples/user_interfaces/gtk_spreadsheet_sgskip.py
@@ -52,7 +52,7 @@ class DataManager(Gtk.Window):
 
         self.canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
         vbox.pack_start(self.canvas, True, True, 0)
-        ax = fig.add_subplot(1, 1, 1)
+        ax = fig.add_subplot()
         self.line, = ax.plot(self.data[0, :], 'go')  # plot the first row
 
         self.treeview.connect('row-activated', self.plot_row)

--- a/examples/user_interfaces/mathtext_wx_sgskip.py
+++ b/examples/user_interfaces/mathtext_wx_sgskip.py
@@ -43,7 +43,7 @@ class CanvasFrame(wx.Frame):
         wx.Frame.__init__(self, parent, -1, title, size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(111)
+        self.axes = self.figure.add_subplot(1, 1, 1)
 
         self.canvas = FigureCanvas(self, -1, self.figure)
 

--- a/examples/user_interfaces/mathtext_wx_sgskip.py
+++ b/examples/user_interfaces/mathtext_wx_sgskip.py
@@ -43,7 +43,7 @@ class CanvasFrame(wx.Frame):
         wx.Frame.__init__(self, parent, -1, title, size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(1, 1, 1)
+        self.axes = self.figure.add_subplot()
 
         self.canvas = FigureCanvas(self, -1, self.figure)
 

--- a/examples/user_interfaces/mpl_with_glade3_sgskip.py
+++ b/examples/user_interfaces/mpl_with_glade3_sgskip.py
@@ -32,7 +32,7 @@ def main():
 
     # Start of Matplotlib specific code
     figure = Figure(figsize=(8, 6), dpi=71)
-    axis = figure.add_subplot(1, 1, 1)
+    axis = figure.add_subplot()
     t = np.arange(0.0, 3.0, 0.01)
     s = np.sin(2*np.pi*t)
     axis.plot(t, s)

--- a/examples/user_interfaces/mpl_with_glade3_sgskip.py
+++ b/examples/user_interfaces/mpl_with_glade3_sgskip.py
@@ -32,7 +32,7 @@ def main():
 
     # Start of Matplotlib specific code
     figure = Figure(figsize=(8, 6), dpi=71)
-    axis = figure.add_subplot(111)
+    axis = figure.add_subplot(1, 1, 1)
     t = np.arange(0.0, 3.0, 0.01)
     s = np.sin(2*np.pi*t)
     axis.plot(t, s)

--- a/examples/user_interfaces/wxcursor_demo_sgskip.py
+++ b/examples/user_interfaces/wxcursor_demo_sgskip.py
@@ -19,7 +19,7 @@ class CanvasFrame(wx.Frame):
         wx.Frame.__init__(self, None, -1, 'CanvasFrame', size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(111)
+        self.axes = self.figure.add_subplot(1, 1, 1)
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2*np.pi*t)
 

--- a/examples/user_interfaces/wxcursor_demo_sgskip.py
+++ b/examples/user_interfaces/wxcursor_demo_sgskip.py
@@ -19,7 +19,7 @@ class CanvasFrame(wx.Frame):
         wx.Frame.__init__(self, None, -1, 'CanvasFrame', size=(550, 350))
 
         self.figure = Figure()
-        self.axes = self.figure.add_subplot(1, 1, 1)
+        self.axes = self.figure.add_subplot()
         t = np.arange(0.0, 3.0, 0.01)
         s = np.sin(2*np.pi*t)
 

--- a/examples/userdemo/simple_legend01.py
+++ b/examples/userdemo/simple_legend01.py
@@ -7,7 +7,7 @@ Simple Legend01
 import matplotlib.pyplot as plt
 
 
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend above this subplot, expanding itself to
@@ -15,7 +15,7 @@ plt.plot([3, 2, 1], label="test2")
 plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
            ncol=2, mode="expand", borderaxespad=0.)
 
-plt.subplot(223)
+plt.subplot(2, 2, 3)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend to the right of this smaller subplot.

--- a/examples/widgets/cursor.py
+++ b/examples/widgets/cursor.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 np.random.seed(19680801)
 
 fig = plt.figure(figsize=(8, 6))
-ax = fig.add_subplot(111, facecolor='#FFFFCC')
+ax = fig.add_subplot(1, 1, 1, facecolor='#FFFFCC')
 
 x, y = 4*(np.random.rand(2, 100) - .5)
 ax.plot(x, y, 'o')

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1273,7 +1273,7 @@ default: 'top'
               and increases to the right.
             - A 3-digit integer. The digits are interpreted as if given
               separately as three single-digit integers, i.e.
-              ``fig.add_subplot(235)`` is the same as
+              ``fig.add_subplot($1, $2, $3)`` is the same as
               ``fig.add_subplot(2, 3, 5)``. Note that this can only be used
               if there are no more than 9 subplots.
             - A `.SubplotSpec`.
@@ -1345,7 +1345,7 @@ default: 'top'
 
             fig = plt.figure()
 
-            fig.add_subplot(231)
+            fig.add_subplot($1, $2, $3)
             ax1 = fig.add_subplot(2, 3, 1)  # equivalent but more general
 
             fig.add_subplot(232, frameon=False)  # subplot with no frame
@@ -1411,7 +1411,7 @@ default: 'top'
                     return ax
                 else:
                     # Undocumented convenience behavior:
-                    # subplot(111); subplot(111, projection='polar')
+                    # subplot($1, $2, $3); subplot(111, projection='polar')
                     # will replace the first with the second.
                     # Without this, add_subplot would be simpler and
                     # more similar to add_axes.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1271,9 +1271,10 @@ default: 'top'
               take the *index* position on a grid with *nrows* rows and
               *ncols* columns. *index* starts at 1 in the upper left corner
               and increases to the right.
-            - A 3-digit integer. The digits are interpreted as if given
-              separately as three single-digit integers, i.e.
-              ``fig.add_subplot($1, $2, $3)`` is the same as
+            - For backcompatibility, a 3-digit integer. The digits are
+              interpreted as if given separately as three
+              single-digit integers, i.e.
+              ``fig.add_subplot(235)`` is the same as
               ``fig.add_subplot(2, 3, 5)``. Note that this can only be used
               if there are no more than 9 subplots.
             - A `.SubplotSpec`.
@@ -1345,13 +1346,13 @@ default: 'top'
 
             fig = plt.figure()
 
-            fig.add_subplot($1, $2, $3)
+            fig.add_subplot(2, 3, 1)
             ax1 = fig.add_subplot(2, 3, 1)  # equivalent but more general
 
-            fig.add_subplot(232, frameon=False)  # subplot with no frame
-            fig.add_subplot(233, projection='polar')  # polar subplot
-            fig.add_subplot(234, sharex=ax1)  # subplot sharing x-axis with ax1
-            fig.add_subplot(235, facecolor="red")  # red subplot
+            fig.add_subplot($1, $2, $3, frameon=False)  # subplot with no frame
+            fig.add_subplot($1, $2, $3, projection='polar')  # polar subplot
+            fig.add_subplot($1, $2, $3, sharex=ax1)  # subplot sharing x-axis with ax1
+            fig.add_subplot($1, $2, $3, facecolor="red")  # red subplot
 
             ax1.remove()  # delete ax1 from the figure
             fig.add_subplot(ax1)  # add ax1 back to the figure
@@ -1411,7 +1412,7 @@ default: 'top'
                     return ax
                 else:
                     # Undocumented convenience behavior:
-                    # subplot($1, $2, $3); subplot(111, projection='polar')
+                    # subplot(1, 1, 1); subplot(1, 1, 1, projection='polar')
                     # will replace the first with the second.
                     # Without this, add_subplot would be simpler and
                     # more similar to add_axes.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1349,10 +1349,10 @@ default: 'top'
             fig.add_subplot(2, 3, 1)
             ax1 = fig.add_subplot(2, 3, 1)  # equivalent but more general
 
-            fig.add_subplot($1, $2, $3, frameon=False)  # subplot with no frame
-            fig.add_subplot($1, $2, $3, projection='polar')  # polar subplot
-            fig.add_subplot($1, $2, $3, sharex=ax1)  # subplot sharing x-axis with ax1
-            fig.add_subplot($1, $2, $3, facecolor="red")  # red subplot
+            fig.add_subplot(2, 3, 2, frameon=False)  # subplot with no frame
+            fig.add_subplot(2, 3, 3, projection='polar')  # polar subplot
+            fig.add_subplot(2, 3, 4, sharex=ax1)  # subplot sharing x-axis with ax1
+            fig.add_subplot(2, 3, 5, facecolor="red")  # red subplot
 
             ax1.remove()  # delete ax1 from the figure
             fig.add_subplot(ax1)  # add ax1 back to the figure

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1264,24 +1264,24 @@ default: 'top'
 
         Parameters
         ----------
-        *args, int or (int, int, int) or `SubplotSpec`, default: (1, 1, 1)
+        *args, (int, int, int) or `SubplotSpec`, default: (1, 1, 1)
             The position of the subplot described by one of
 
             - Three integers (*nrows*, *ncols*, *index*). The subplot will
               take the *index* position on a grid with *nrows* rows and
               *ncols* columns. *index* starts at 1 in the upper left corner
               and increases to the right.
+            - A `.SubplotSpec`.
             - For backcompatibility, a 3-digit integer. The digits are
               interpreted as if given separately as three
               single-digit integers, i.e.
               ``fig.add_subplot(235)`` is the same as
               ``fig.add_subplot(2, 3, 5)``. Note that this can only be used
               if there are no more than 9 subplots.
-            - A `.SubplotSpec`.
 
             In rare circumstances, `.add_subplot` may be called with a single
             argument, a subplot axes instance already created in the
-            present figure but not in the figure's list of axes.
+            present figure, but not in the figure's list of axes.
 
         projection : {None, 'aitoff', 'hammer', 'lambert', 'mollweide', \
 'polar', 'rectilinear', str}, optional
@@ -1351,7 +1351,7 @@ default: 'top'
 
             fig.add_subplot(2, 3, 2, frameon=False)  # subplot with no frame
             fig.add_subplot(2, 3, 3, projection='polar')  # polar subplot
-            fig.add_subplot(2, 3, 4, sharex=ax1)  # subplot sharing x-axis with ax1
+            fig.add_subplot(2, 3, 4, sharex=ax1)  # sharing x-axis with ax1
             fig.add_subplot(2, 3, 5, facecolor="red")  # red subplot
 
             ax1.remove()  # delete ax1 from the figure

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -57,7 +57,7 @@ def __prepare_fancyarrow_dpi_cor_test():
     NB: this function *is not* a test in itself!
     """
     fig2 = plt.figure("fancyarrow_dpi_cor_test", figsize=(4, 3), dpi=50)
-    ax = fig2.add_subplot(1, 1, 1)
+    ax = fig2.add_subplot()
     ax.set_xlim([0, 1])
     ax.set_ylim([0, 1])
     ax.add_patch(mpatches.FancyArrowPatch(posA=(0.3, 0.4), posB=(0.8, 0.6),

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -57,7 +57,7 @@ def __prepare_fancyarrow_dpi_cor_test():
     NB: this function *is not* a test in itself!
     """
     fig2 = plt.figure("fancyarrow_dpi_cor_test", figsize=(4, 3), dpi=50)
-    ax = fig2.add_subplot(111)
+    ax = fig2.add_subplot(1, 1, 1)
     ax.set_xlim([0, 1])
     ax.set_ylim([0, 1])
     ax.add_patch(mpatches.FancyArrowPatch(posA=(0.3, 0.4), posB=(0.8, 0.6),

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -105,7 +105,7 @@ def test_clipping():
     star = mpath.Path.unit_regular_star(6).deepcopy()
     star.vertices *= 2.6
 
-    ax1 = plt.subplot(121)
+    ax1 = plt.subplot(1, 2, 1)
     col = mcollections.PathCollection([star], lw=5, edgecolor='blue',
                                       facecolor='red', alpha=0.7, hatch='*')
     col.set_clip_path(clip_path, ax1.transData)

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -111,7 +111,7 @@ def test_clipping():
     col.set_clip_path(clip_path, ax1.transData)
     ax1.add_collection(col)
 
-    ax2 = plt.subplot(122, sharex=ax1, sharey=ax1)
+    ax2 = plt.subplot(1, 2, 2, sharex=ax1, sharey=ax1)
     patch = mpatches.PathPatch(star, lw=5, edgecolor='blue', facecolor='red',
                                alpha=0.7, hatch='*')
     patch.set_clip_path(clip_path, ax2.transData)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -320,7 +320,7 @@ def test_inverted_cla():
     # 5. two shared axes. Inverting the master axis should invert the shared
     # axes; clearing the master axis should bring axes in shared
     # axes back to normal.
-    ax0 = plt.subplot(211)
+    ax0 = plt.subplot(2, 1, 1)
     ax1 = plt.subplot(212, sharey=ax0)
     ax0.yaxis.set_inverted(True)
     assert ax1.yaxis_inverted()
@@ -411,11 +411,11 @@ def test_sticky_shared_axes(fig_test, fig_ref):
     # "master" in a share, or an axes that is a "follower".
     Z = np.arange(15).reshape(3, 5)
 
-    ax0 = fig_test.add_subplot(211)
+    ax0 = fig_test.add_subplot(2, 1, 1)
     ax1 = fig_test.add_subplot(212, sharex=ax0)
     ax1.pcolormesh(Z)
 
-    ax0 = fig_ref.add_subplot(212)
+    ax0 = fig_ref.add_subplot(2, 1, 2)
     ax1 = fig_ref.add_subplot(211, sharex=ax0)
     ax0.pcolormesh(Z)
 
@@ -508,23 +508,23 @@ def test_fill_units():
     fig = plt.figure()
 
     # Top-Left
-    ax1 = fig.add_subplot(221)
+    ax1 = fig.add_subplot(2, 2, 1)
     ax1.plot([t], [value], yunits='deg', color='red')
     ind = [0, 0, 1, 1]
     ax1.fill(dtn[ind], [0.0, 0.0, 90.0, 0.0], 'b')
     # Top-Right
-    ax2 = fig.add_subplot(222)
+    ax2 = fig.add_subplot(2, 2, 2)
     ax2.plot([t], [value], yunits='deg', color='red')
     ax2.fill([t, t, t + day, t + day],
              [0.0, 0.0, 90.0, 0.0], 'b')
     # Bottom-Left
-    ax3 = fig.add_subplot(223)
+    ax3 = fig.add_subplot(2, 2, 3)
     ax3.plot([t], [value], yunits='deg', color='red')
     ax3.fill(dtn[ind],
              [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
              'b')
     # Bottom-Right
-    ax4 = fig.add_subplot(224)
+    ax4 = fig.add_subplot(2, 2, 4)
     ax4.plot([t], [value], yunits='deg', color='red')
     ax4.fill([t, t, t + day, t + day],
              [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
@@ -539,20 +539,20 @@ def test_single_point():
     matplotlib.rcParams['axes.grid'] = True
 
     plt.figure()
-    plt.subplot(211)
+    plt.subplot(2, 1, 1)
     plt.plot([0], [0], 'o')
 
-    plt.subplot(212)
+    plt.subplot(2, 1, 2)
     plt.plot([1], [1], 'o')
 
     # Reuse testcase from above for a labeled data test
     data = {'a': [0], 'b': [1]}
 
     plt.figure()
-    plt.subplot(211)
+    plt.subplot(2, 1, 1)
     plt.plot('a', 'a', 'o', data=data)
 
-    plt.subplot(212)
+    plt.subplot(2, 1, 2)
     plt.plot('b', 'b', 'o', data=data)
 
 
@@ -745,7 +745,7 @@ def test_imshow():
     # Reuse testcase from above for a labeled data test
     data = {"r": r}
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.imshow("r", data=data)
 
 
@@ -984,15 +984,15 @@ def test_pcolormesh_datetime_axis():
     y = np.arange(21)
     z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
     z = z1 * z2
-    plt.subplot(221)
+    plt.subplot(2, 2, 1)
     plt.pcolormesh(x[:-1], y[:-1], z[:-1, :-1])
-    plt.subplot(222)
+    plt.subplot(2, 2, 2)
     plt.pcolormesh(x, y, z)
     x = np.repeat(x[np.newaxis], 21, axis=0)
     y = np.repeat(y[:, np.newaxis], 21, axis=1)
-    plt.subplot(223)
+    plt.subplot(2, 2, 3)
     plt.pcolormesh(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
-    plt.subplot(224)
+    plt.subplot(2, 2, 4)
     plt.pcolormesh(x, y, z)
     for ax in fig.get_axes():
         for label in ax.get_xticklabels():
@@ -1010,15 +1010,15 @@ def test_pcolor_datetime_axis():
     y = np.arange(21)
     z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
     z = z1 * z2
-    plt.subplot(221)
+    plt.subplot(2, 2, 1)
     plt.pcolor(x[:-1], y[:-1], z[:-1, :-1])
-    plt.subplot(222)
+    plt.subplot(2, 2, 2)
     plt.pcolor(x, y, z)
     x = np.repeat(x[np.newaxis], 21, axis=0)
     y = np.repeat(y[:, np.newaxis], 21, axis=1)
-    plt.subplot(223)
+    plt.subplot(2, 2, 3)
     plt.pcolor(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
-    plt.subplot(224)
+    plt.subplot(2, 2, 4)
     plt.pcolor(x, y, z)
     for ax in fig.get_axes():
         for label in ax.get_xticklabels():
@@ -1185,7 +1185,7 @@ def test_markevery():
 
     # check marker only plot
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(x, y, 'o', label='default')
     ax.plot(x, y, 'd', markevery=None, label='mark all')
     ax.plot(x, y, 's', markevery=10, label='mark every 10')
@@ -1200,7 +1200,7 @@ def test_markevery_line():
 
     # check line/marker combos
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(x, y, '-o', label='default')
     ax.plot(x, y, '-d', markevery=None, label='mark all')
     ax.plot(x, y, '-s', markevery=10, label='mark every 10')
@@ -1315,7 +1315,7 @@ def test_markevery_polar():
 def test_marker_edges():
     x = np.linspace(0, 1, 10)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(x, np.sin(x), 'y.', ms=30.0, mew=0, mec='r')
     ax.plot(x+0.1, np.sin(x), 'y.', ms=30.0, mew=1, mec='r')
     ax.plot(x+0.2, np.sin(x), 'y.', ms=30.0, mew=2, mec='b')
@@ -1330,7 +1330,7 @@ def test_bar_tick_label_single():
     # Reuse testcase from above for a labeled data test
     data = {"a": 0, "b": 1}
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax = plt.gca()
     ax.bar("a", "b", align='edge', tick_label='0', data=data)
 
@@ -1513,7 +1513,7 @@ def test_hist_log():
     data0 = np.linspace(0, 1, 200)**3
     data = np.concatenate([1 - data0, 1 + data0])
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist(data, fill=False, log=True)
 
 
@@ -1653,7 +1653,7 @@ def contour_dat():
 def test_contour_hatching():
     x, y, z = contour_dat()
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
                 cmap=plt.get_cmap('gray'),
                 extend='both', alpha=0.5)
@@ -1664,7 +1664,7 @@ def test_contour_colorbar():
     x, y, z = contour_dat()
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     cs = ax.contourf(x, y, z, levels=np.arange(-1.8, 1.801, 0.2),
                      cmap=plt.get_cmap('RdBu'),
                      vmin=-0.6,
@@ -1689,13 +1689,13 @@ def test_hist2d():
     x = np.random.randn(100)*2+5
     y = np.random.randn(100)-2
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist2d(x, y, bins=10, rasterized=True)
 
     # Reuse testcase from above for a labeled data test
     data = {"x": x, "y": y}
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist2d("x", "y", bins=10, data=data, rasterized=True)
 
 
@@ -1707,7 +1707,7 @@ def test_hist2d_transpose():
     x = np.array([5]*100)
     y = np.random.randn(100)-2
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist2d(x, y, bins=10, rasterized=True)
 
 
@@ -2507,7 +2507,7 @@ def test_boxplot_with_CIarray():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     CIs = np.array([[-1.5, 3.], [-1., 3.5]])
 
     # show a boxplot with Matplotlib medians and confidence intervals, and
@@ -3045,13 +3045,13 @@ def test_hist_stacked_stepfilled():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist((d1, d2), histtype="stepfilled", stacked=True)
 
     # Reuse testcase from above for a labeled data test
     data = {"x": (d1, d2)}
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist("x", histtype="stepfilled", stacked=True, data=data)
 
 
@@ -3061,7 +3061,7 @@ def test_hist_offset():
     d1 = np.linspace(0, 10, 50)
     d2 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist(d1, bottom=5)
     ax.hist(d2, bottom=15)
 
@@ -3071,7 +3071,7 @@ def test_hist_step():
     # make some data
     d1 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist(d1, histtype="step")
     ax.set_ylim(0, 10)
     ax.set_xlim(-1, 5)
@@ -3083,7 +3083,7 @@ def test_hist_step_horiz():
     d1 = np.linspace(0, 10, 50)
     d2 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist((d1, d2), histtype="step", orientation="horizontal")
 
 
@@ -3095,7 +3095,7 @@ def test_hist_stacked_weighted():
     w1 = np.linspace(0.01, 3.5, 50)
     w2 = np.linspace(0.05, 2., 20)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
 
 
@@ -3149,7 +3149,7 @@ def test_hist_stacked_stepfilled_alpha():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist((d1, d2), histtype="stepfilled", stacked=True, alpha=0.5)
 
 
@@ -3159,7 +3159,7 @@ def test_hist_stacked_step():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist((d1, d2), histtype="step", stacked=True)
 
 
@@ -3177,7 +3177,7 @@ def test_hist_step_bottom():
     # make some data
     d1 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist(d1, bottom=np.arange(10), histtype="stepfilled")
 
 
@@ -3324,7 +3324,7 @@ def test_hist_stacked_bar():
               (0.28302699607823545, 0.0, 1.0), (0.6849123462299822, 0.0, 1.0)]
     labels = ['green', 'orange', ' yellow', 'magenta', 'black']
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist(d, bins=10, histtype='barstacked', align='mid', color=colors,
             label=labels)
     ax.legend(loc='upper right', bbox_to_anchor=(1.0, 1.0), ncol=1)
@@ -3332,7 +3332,7 @@ def test_hist_stacked_bar():
 
 def test_hist_emptydata():
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.hist([[], range(10), range(10)], histtype="step")
 
 
@@ -3357,7 +3357,7 @@ def test_transparent_markers():
     data = np.random.random(50)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(data, 'D', mfc='none', markersize=100)
 
 
@@ -3436,7 +3436,7 @@ def test_alpha():
     data = np.random.random(50)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
 
     # alpha=.5 markers, solid line
     ax.plot(data, '-D', color=[1, 0, 0], mfc=[1, 0, 0, .5],
@@ -3488,7 +3488,7 @@ def test_eventplot():
     linelengths = linelengths1 + linelengths2
 
     fig = plt.figure()
-    axobj = fig.add_subplot(111)
+    axobj = fig.add_subplot(1, 1, 1)
     colls = axobj.eventplot(data, colors=colors, lineoffsets=lineoffsets,
                             linelengths=linelengths)
 
@@ -3498,7 +3498,7 @@ def test_eventplot():
     # Reuse testcase from above for a labeled data test
     data = {"pos": data, "c": colors, "lo": lineoffsets, "ll": linelengths}
     fig = plt.figure()
-    axobj = fig.add_subplot(111)
+    axobj = fig.add_subplot(1, 1, 1)
     colls = axobj.eventplot("pos", colors="c", lineoffsets="lo",
                             linelengths="ll", data=data)
     num_collections = len(colls)
@@ -3518,7 +3518,7 @@ def test_eventplot_defaults():
     data = data1 + data2
 
     fig = plt.figure()
-    axobj = fig.add_subplot(111)
+    axobj = fig.add_subplot(1, 1, 1)
     axobj.eventplot(data)
 
 
@@ -3562,7 +3562,7 @@ def test_eventplot_problem_kwargs(recwarn):
     data = [data1, data2]
 
     fig = plt.figure()
-    axobj = fig.add_subplot(111)
+    axobj = fig.add_subplot(1, 1, 1)
 
     axobj.eventplot(data,
                     colors=['r', 'b'],
@@ -3600,7 +3600,7 @@ def test_eventplot_orientation(data, orientation):
 @image_comparison(['marker_styles.png'], remove_text=True)
 def test_marker_styles():
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     for y, marker in enumerate(sorted(matplotlib.markers.MarkerStyle.markers,
                                       key=lambda x: str(type(x))+str(x))):
         ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
@@ -3623,7 +3623,7 @@ def test_vertex_markers():
     marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
     marker_as_list = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(data, linestyle='', marker=marker_as_tuple, mfc='k')
     ax.plot(data[::-1], linestyle='', marker=marker_as_list, mfc='b')
     ax.set_xlim([-1, 10])
@@ -4066,7 +4066,7 @@ def test_twin_spines():
     fig = plt.figure(figsize=(4, 3))
     fig.subplots_adjust(right=0.75)
 
-    host = fig.add_subplot(111)
+    host = fig.add_subplot(1, 1, 1)
     par1 = host.twinx()
     par2 = host.twinx()
 
@@ -4236,7 +4236,7 @@ def test_relim_visible_only():
     y2 = (-10., 30.)
 
     fig = matplotlib.figure.Figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(x1, y1)
     assert ax.get_xlim() == x1
     assert ax.get_ylim() == y1
@@ -4960,7 +4960,7 @@ def test_shared_axes_autoscale():
     l = np.arange(-80, 90, 40)
     t = np.random.random_sample((l.size, l.size))
 
-    ax1 = plt.subplot(211)
+    ax1 = plt.subplot(2, 1, 1)
     ax1.set_xlim(-1000, 1000)
     ax1.set_ylim(-1000, 1000)
     ax1.contour(l, l, t)
@@ -5423,7 +5423,7 @@ def test_invalid_axis_limits():
 @pytest.mark.parametrize('xscale', ['symlog', 'log'])
 @pytest.mark.parametrize('yscale', ['symlog', 'log'])
 def test_minorticks_on(xscale, yscale):
-    ax = plt.subplot(111)
+    ax = plt.subplot(1, 1, 1)
     ax.plot([1, 2, 3, 4])
     ax.set_xscale(xscale)
     ax.set_yscale(yscale)
@@ -5933,13 +5933,13 @@ def test_minor_accountedfor():
 @check_figures_equal(extensions=["png"])
 def test_axis_bool_arguments(fig_test, fig_ref):
     # Test if False and "off" give the same
-    fig_test.add_subplot(211).axis(False)
-    fig_ref.add_subplot(211).axis("off")
+    fig_test.add_subplot(2, 1, 1).axis(False)
+    fig_ref.add_subplot(2, 1, 1).axis("off")
     # Test if True after False gives the same as "on"
-    ax = fig_test.add_subplot(212)
+    ax = fig_test.add_subplot(2, 1, 2)
     ax.axis(False)
     ax.axis(True)
-    fig_ref.add_subplot(212).axis("on")
+    fig_ref.add_subplot(2, 1, 2).axis("on")
 
 
 def test_axis_extent_arg():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -214,7 +214,7 @@ def test_twin_axis_locators_formatters():
     minl = plt.FixedLocator([0.1, 0.2, 0.3])
 
     fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
+    ax1 = fig.add_subplot()
     ax1.plot([0.1, 100], [0, 1])
     ax1.yaxis.set_major_locator(majl)
     ax1.yaxis.set_minor_locator(minl)
@@ -745,7 +745,7 @@ def test_imshow():
     # Reuse testcase from above for a labeled data test
     data = {"r": r}
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.imshow("r", data=data)
 
 
@@ -1185,7 +1185,7 @@ def test_markevery():
 
     # check marker only plot
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(x, y, 'o', label='default')
     ax.plot(x, y, 'd', markevery=None, label='mark all')
     ax.plot(x, y, 's', markevery=10, label='mark every 10')
@@ -1200,7 +1200,7 @@ def test_markevery_line():
 
     # check line/marker combos
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(x, y, '-o', label='default')
     ax.plot(x, y, '-d', markevery=None, label='mark all')
     ax.plot(x, y, '-s', markevery=10, label='mark every 10')
@@ -1315,7 +1315,7 @@ def test_markevery_polar():
 def test_marker_edges():
     x = np.linspace(0, 1, 10)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(x, np.sin(x), 'y.', ms=30.0, mew=0, mec='r')
     ax.plot(x+0.1, np.sin(x), 'y.', ms=30.0, mew=1, mec='r')
     ax.plot(x+0.2, np.sin(x), 'y.', ms=30.0, mew=2, mec='b')
@@ -1330,7 +1330,7 @@ def test_bar_tick_label_single():
     # Reuse testcase from above for a labeled data test
     data = {"a": 0, "b": 1}
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax = plt.gca()
     ax.bar("a", "b", align='edge', tick_label='0', data=data)
 
@@ -1513,7 +1513,7 @@ def test_hist_log():
     data0 = np.linspace(0, 1, 200)**3
     data = np.concatenate([1 - data0, 1 + data0])
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist(data, fill=False, log=True)
 
 
@@ -1653,7 +1653,7 @@ def contour_dat():
 def test_contour_hatching():
     x, y, z = contour_dat()
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
                 cmap=plt.get_cmap('gray'),
                 extend='both', alpha=0.5)
@@ -1664,7 +1664,7 @@ def test_contour_colorbar():
     x, y, z = contour_dat()
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     cs = ax.contourf(x, y, z, levels=np.arange(-1.8, 1.801, 0.2),
                      cmap=plt.get_cmap('RdBu'),
                      vmin=-0.6,
@@ -1689,13 +1689,13 @@ def test_hist2d():
     x = np.random.randn(100)*2+5
     y = np.random.randn(100)-2
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist2d(x, y, bins=10, rasterized=True)
 
     # Reuse testcase from above for a labeled data test
     data = {"x": x, "y": y}
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist2d("x", "y", bins=10, data=data, rasterized=True)
 
 
@@ -1707,7 +1707,7 @@ def test_hist2d_transpose():
     x = np.array([5]*100)
     y = np.random.randn(100)-2
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist2d(x, y, bins=10, rasterized=True)
 
 
@@ -2052,7 +2052,7 @@ def test_pyplot_axes():
 @image_comparison(['log_scales'])
 def test_log_scales():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(np.log(np.linspace(0.1, 100)))
     ax.set_yscale('log', base=5.5)
     ax.invert_yaxis()
@@ -2068,7 +2068,7 @@ def test_log_scales_no_data():
 
 def test_log_scales_invalid():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_xscale('log')
     with pytest.warns(UserWarning, match='Attempted to set non-positive'):
         ax.set_xlim(-1, 10)
@@ -2084,7 +2084,7 @@ def test_stackplot():
     y1 = 1.0 * x
     y2 = 2.0 * x + 1
     y3 = 3.0 * x + 2
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.stackplot(x, y1, y2, y3)
     ax.set_xlim((0, 10))
     ax.set_ylim((0, 70))
@@ -2092,7 +2092,7 @@ def test_stackplot():
     # Reuse testcase from above for a labeled data test
     data = {"x": x, "y1": y1, "y2": y2, "y3": y3}
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.stackplot("x", "y1", "y2", "y3", data=data)
     ax.set_xlim((0, 10))
     ax.set_ylim((0, 70))
@@ -2507,7 +2507,7 @@ def test_boxplot_with_CIarray():
     x = np.linspace(-7, 7, 140)
     x = np.hstack([-25, x, 25])
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     CIs = np.array([[-1.5, 3.], [-1., 3.5]])
 
     # show a boxplot with Matplotlib medians and confidence intervals, and
@@ -2956,7 +2956,7 @@ def test_errorbar_limits():
     ls = 'dotted'
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
     # standard error bars
     plt.errorbar(x, y, xerr=xerr, yerr=yerr, ls=ls, color='blue')
@@ -3045,13 +3045,13 @@ def test_hist_stacked_stepfilled():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist((d1, d2), histtype="stepfilled", stacked=True)
 
     # Reuse testcase from above for a labeled data test
     data = {"x": (d1, d2)}
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist("x", histtype="stepfilled", stacked=True, data=data)
 
 
@@ -3061,7 +3061,7 @@ def test_hist_offset():
     d1 = np.linspace(0, 10, 50)
     d2 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist(d1, bottom=5)
     ax.hist(d2, bottom=15)
 
@@ -3071,7 +3071,7 @@ def test_hist_step():
     # make some data
     d1 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist(d1, histtype="step")
     ax.set_ylim(0, 10)
     ax.set_xlim(-1, 5)
@@ -3083,7 +3083,7 @@ def test_hist_step_horiz():
     d1 = np.linspace(0, 10, 50)
     d2 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist((d1, d2), histtype="step", orientation="horizontal")
 
 
@@ -3095,7 +3095,7 @@ def test_hist_stacked_weighted():
     w1 = np.linspace(0.01, 3.5, 50)
     w2 = np.linspace(0.05, 2., 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
 
 
@@ -3123,7 +3123,7 @@ def _test_stem(use_line_collection):
 
 def test_stem_args():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
     x = list(range(10))
     y = list(range(10))
@@ -3149,7 +3149,7 @@ def test_hist_stacked_stepfilled_alpha():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist((d1, d2), histtype="stepfilled", stacked=True, alpha=0.5)
 
 
@@ -3159,7 +3159,7 @@ def test_hist_stacked_step():
     d1 = np.linspace(1, 3, 20)
     d2 = np.linspace(0, 10, 50)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist((d1, d2), histtype="step", stacked=True)
 
 
@@ -3177,7 +3177,7 @@ def test_hist_step_bottom():
     # make some data
     d1 = np.linspace(1, 3, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist(d1, bottom=np.arange(10), histtype="stepfilled")
 
 
@@ -3324,7 +3324,7 @@ def test_hist_stacked_bar():
               (0.28302699607823545, 0.0, 1.0), (0.6849123462299822, 0.0, 1.0)]
     labels = ['green', 'orange', ' yellow', 'magenta', 'black']
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist(d, bins=10, histtype='barstacked', align='mid', color=colors,
             label=labels)
     ax.legend(loc='upper right', bbox_to_anchor=(1.0, 1.0), ncol=1)
@@ -3332,7 +3332,7 @@ def test_hist_stacked_bar():
 
 def test_hist_emptydata():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.hist([[], range(10), range(10)], histtype="step")
 
 
@@ -3357,7 +3357,7 @@ def test_transparent_markers():
     data = np.random.random(50)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(data, 'D', mfc='none', markersize=100)
 
 
@@ -3436,7 +3436,7 @@ def test_alpha():
     data = np.random.random(50)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
     # alpha=.5 markers, solid line
     ax.plot(data, '-D', color=[1, 0, 0], mfc=[1, 0, 0, .5],
@@ -3488,7 +3488,7 @@ def test_eventplot():
     linelengths = linelengths1 + linelengths2
 
     fig = plt.figure()
-    axobj = fig.add_subplot(1, 1, 1)
+    axobj = fig.add_subplot()
     colls = axobj.eventplot(data, colors=colors, lineoffsets=lineoffsets,
                             linelengths=linelengths)
 
@@ -3498,7 +3498,7 @@ def test_eventplot():
     # Reuse testcase from above for a labeled data test
     data = {"pos": data, "c": colors, "lo": lineoffsets, "ll": linelengths}
     fig = plt.figure()
-    axobj = fig.add_subplot(1, 1, 1)
+    axobj = fig.add_subplot()
     colls = axobj.eventplot("pos", colors="c", lineoffsets="lo",
                             linelengths="ll", data=data)
     num_collections = len(colls)
@@ -3518,7 +3518,7 @@ def test_eventplot_defaults():
     data = data1 + data2
 
     fig = plt.figure()
-    axobj = fig.add_subplot(1, 1, 1)
+    axobj = fig.add_subplot()
     axobj.eventplot(data)
 
 
@@ -3562,7 +3562,7 @@ def test_eventplot_problem_kwargs(recwarn):
     data = [data1, data2]
 
     fig = plt.figure()
-    axobj = fig.add_subplot(1, 1, 1)
+    axobj = fig.add_subplot()
 
     axobj.eventplot(data,
                     colors=['r', 'b'],
@@ -3600,7 +3600,7 @@ def test_eventplot_orientation(data, orientation):
 @image_comparison(['marker_styles.png'], remove_text=True)
 def test_marker_styles():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     for y, marker in enumerate(sorted(matplotlib.markers.MarkerStyle.markers,
                                       key=lambda x: str(type(x))+str(x))):
         ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
@@ -3623,7 +3623,7 @@ def test_vertex_markers():
     marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
     marker_as_list = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(data, linestyle='', marker=marker_as_tuple, mfc='k')
     ax.plot(data[::-1], linestyle='', marker=marker_as_list, mfc='b')
     ax.set_xlim([-1, 10])
@@ -3831,7 +3831,7 @@ def test_step_linestyle():
 def test_mixed_collection():
     # First illustrate basic pyplot interface, using defaults where possible.
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
     c = mpatches.Circle((8, 8), radius=4, facecolor='none', edgecolor='green')
 
@@ -4066,7 +4066,7 @@ def test_twin_spines():
     fig = plt.figure(figsize=(4, 3))
     fig.subplots_adjust(right=0.75)
 
-    host = fig.add_subplot(1, 1, 1)
+    host = fig.add_subplot()
     par1 = host.twinx()
     par2 = host.twinx()
 
@@ -4107,7 +4107,7 @@ def test_twin_spines_on_top():
     matplotlib.rcParams['lines.linewidth'] = 48.0
 
     fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
+    ax1 = fig.add_subplot()
 
     data = np.array([[1000, 1100, 1200, 1250],
                      [310, 301, 360, 400]])
@@ -4123,7 +4123,7 @@ def test_twin_spines_on_top():
     # Reuse testcase from above for a labeled data test
     data = {"i": data[0], "j": data[1]/1E3}
     fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
+    ax1 = fig.add_subplot()
     ax2 = ax1.twinx()
     ax1.plot("i", "j", color='#BEAED4', data=data)
     ax1.fill_between("i", "j", color='#BEAED4', alpha=.8, data=data)
@@ -4146,7 +4146,7 @@ def test_rcparam_grid_minor():
     for locator, result in values:
         matplotlib.rcParams['axes.grid.which'] = locator
         fig = plt.figure()
-        ax = fig.add_subplot(1, 1, 1)
+        ax = fig.add_subplot()
         assert (ax.xaxis._gridOnMajor, ax.xaxis._gridOnMinor) == result
 
     matplotlib.rcParams['axes.grid'] = orig_grid
@@ -4236,7 +4236,7 @@ def test_relim_visible_only():
     y2 = (-10., 30.)
 
     fig = matplotlib.figure.Figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(x1, y1)
     assert ax.get_xlim() == x1
     assert ax.get_ylim() == y1
@@ -4643,7 +4643,7 @@ def test_rc_tick():
          'ytick.left': True, 'ytick.right': False}
     with plt.rc_context(rc=d):
         fig = plt.figure()
-        ax1 = fig.add_subplot(1, 1, 1)
+        ax1 = fig.add_subplot()
         xax = ax1.xaxis
         yax = ax1.yaxis
         # tick1On bottom/left
@@ -4666,7 +4666,7 @@ def test_rc_major_minor_tick():
          'ytick.major.left': False, 'ytick.minor.left': False}
     with plt.rc_context(rc=d):
         fig = plt.figure()
-        ax1 = fig.add_subplot(1, 1, 1)
+        ax1 = fig.add_subplot()
         xax = ax1.xaxis
         yax = ax1.yaxis
         # tick1On bottom/left
@@ -5270,7 +5270,7 @@ def test_title_xticks_top_both():
 def test_offset_label_color():
     # Tests issue 6440
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1.01e9, 1.02e9, 1.03e9])
     ax.yaxis.set_tick_params(labelcolor='red')
     assert ax.yaxis.get_offset_text().get_color() == 'red'
@@ -5278,7 +5278,7 @@ def test_offset_label_color():
 
 def test_offset_text_visible():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1.01e9, 1.02e9, 1.03e9])
     ax.yaxis.set_tick_params(label1On=False, label2On=True)
     assert ax.yaxis.get_offset_text().get_visible()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -321,7 +321,7 @@ def test_inverted_cla():
     # axes; clearing the master axis should bring axes in shared
     # axes back to normal.
     ax0 = plt.subplot(2, 1, 1)
-    ax1 = plt.subplot(212, sharey=ax0)
+    ax1 = plt.subplot(2, 1, 2, sharey=ax0)
     ax0.yaxis.set_inverted(True)
     assert ax1.yaxis_inverted()
     ax1.plot(x, np.cos(x))
@@ -412,11 +412,11 @@ def test_sticky_shared_axes(fig_test, fig_ref):
     Z = np.arange(15).reshape(3, 5)
 
     ax0 = fig_test.add_subplot(2, 1, 1)
-    ax1 = fig_test.add_subplot(212, sharex=ax0)
+    ax1 = fig_test.add_subplot(2, 1, 2, sharex=ax0)
     ax1.pcolormesh(Z)
 
     ax0 = fig_ref.add_subplot(2, 1, 2)
-    ax1 = fig_ref.add_subplot(211, sharex=ax0)
+    ax1 = fig_ref.add_subplot(2, 1, 1, sharex=ax0)
     ax0.pcolormesh(Z)
 
 
@@ -429,7 +429,7 @@ def test_basic_annotate():
     # Offset Points
 
     fig = plt.figure()
-    ax = fig.add_subplot(111, autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
+    ax = fig.add_subplot(1, 1, 1, autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
     line, = ax.plot(t, s, lw=3, color='purple')
 
     ax.annotate('local max', xy=(3, 1), xycoords='data',
@@ -1161,7 +1161,7 @@ def test_arc_ellipse():
     y += ycenter
 
     fig = plt.figure()
-    ax = fig.add_subplot(211, aspect='auto')
+    ax = fig.add_subplot(2, 1, 1, aspect='auto')
     ax.fill(x, y, alpha=0.2, facecolor='yellow', edgecolor='yellow',
             linewidth=1, zorder=1)
 
@@ -1170,7 +1170,7 @@ def test_arc_ellipse():
 
     ax.add_patch(e1)
 
-    ax = fig.add_subplot(212, aspect='equal')
+    ax = fig.add_subplot(2, 1, 2, aspect='equal')
     ax.fill(x, y, alpha=0.2, facecolor='green', edgecolor='green', zorder=1)
     e2 = mpatches.Arc((xcenter, ycenter), width, height,
                       angle=angle, linewidth=2, fill=False, zorder=2)
@@ -2033,7 +2033,7 @@ def test_as_mpl_axes_api():
     plt.close()
 
     # testing axes creation with subplot
-    ax = plt.subplot(121, projection=prj)
+    ax = plt.subplot(1, 2, 1, projection=prj)
     assert type(ax) == mpl.axes._subplots.subplot_class_factory(PolarAxes)
     plt.close()
 
@@ -3383,7 +3383,7 @@ def test_mollweide_grid():
     # test that both horizontal and vertical gridlines appear on the Mollweide
     # projection
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='mollweide')
+    ax = fig.add_subplot(1, 1, 1, projection='mollweide')
     ax.grid()
 
 
@@ -3391,7 +3391,7 @@ def test_mollweide_forward_inverse_closure():
     # test that the round-trip Mollweide forward->inverse transformation is an
     # approximate identity
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='mollweide')
+    ax = fig.add_subplot(1, 1, 1, projection='mollweide')
 
     # set up 1-degree grid in longitude, latitude
     lon = np.linspace(-np.pi, np.pi, 360)
@@ -3413,7 +3413,7 @@ def test_mollweide_inverse_forward_closure():
     # test that the round-trip Mollweide inverse->forward transformation is an
     # approximate identity
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='mollweide')
+    ax = fig.add_subplot(1, 1, 1, projection='mollweide')
 
     # set up grid in x, y
     x = np.linspace(0, 1, 500)
@@ -4965,7 +4965,7 @@ def test_shared_axes_autoscale():
     ax1.set_ylim(-1000, 1000)
     ax1.contour(l, l, t)
 
-    ax2 = plt.subplot(212, sharex=ax1, sharey=ax1)
+    ax2 = plt.subplot(2, 1, 2, sharex=ax1, sharey=ax1)
     ax2.contour(l, l, t)
     assert not ax1.get_autoscalex_on() and not ax2.get_autoscalex_on()
     assert not ax1.get_autoscaley_on() and not ax2.get_autoscaley_on()

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -43,7 +43,7 @@ def test_type42():
     rcParams['pdf.fonttype'] = 42
 
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot([1, 2, 3])
     fig.savefig(io.BytesIO())
 
@@ -52,7 +52,7 @@ def test_multipage_pagecount():
     with PdfPages(io.BytesIO()) as pdf:
         assert pdf.get_pagecount() == 0
         fig = plt.figure()
-        ax = fig.add_subplot(111)
+        ax = fig.add_subplot(1, 1, 1)
         ax.plot([1, 2, 3])
         fig.savefig(pdf, format="pdf")
         assert pdf.get_pagecount() == 1
@@ -65,7 +65,7 @@ def test_multipage_properfinalize():
     with PdfPages(pdfio) as pdf:
         for i in range(10):
             fig = plt.figure()
-            ax = fig.add_subplot(111)
+            ax = fig.add_subplot(1, 1, 1)
             ax.set_title('This is a long title')
             fig.savefig(pdf, format="pdf")
     pdfio.seek(0)
@@ -87,7 +87,7 @@ def test_multipage_keep_empty():
     assert not os.path.exists(filename)
     # test pdf files with content, they should never be deleted
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot([1, 2, 3])
     # test that a non-empty pdf is left behind with keep_empty=True (default)
     with NamedTemporaryFile(delete=False) as tmp:

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -31,7 +31,7 @@ and containing some French characters and the euro symbol:
 "Merci pépé pour les 10 €"'''
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_title('Test PDF backend with option use14corefonts=True')
     ax.text(0.5, 0.5, text, horizontalalignment='center',
             verticalalignment='bottom',
@@ -43,7 +43,7 @@ def test_type42():
     rcParams['pdf.fonttype'] = 42
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1, 2, 3])
     fig.savefig(io.BytesIO())
 
@@ -52,7 +52,7 @@ def test_multipage_pagecount():
     with PdfPages(io.BytesIO()) as pdf:
         assert pdf.get_pagecount() == 0
         fig = plt.figure()
-        ax = fig.add_subplot(1, 1, 1)
+        ax = fig.add_subplot()
         ax.plot([1, 2, 3])
         fig.savefig(pdf, format="pdf")
         assert pdf.get_pagecount() == 1
@@ -65,7 +65,7 @@ def test_multipage_properfinalize():
     with PdfPages(pdfio) as pdf:
         for i in range(10):
             fig = plt.figure()
-            ax = fig.add_subplot(1, 1, 1)
+            ax = fig.add_subplot()
             ax.set_title('This is a long title')
             fig.savefig(pdf, format="pdf")
     pdfio.seek(0)
@@ -87,7 +87,7 @@ def test_multipage_keep_empty():
     assert not os.path.exists(filename)
     # test pdf files with content, they should never be deleted
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1, 2, 3])
     # test that a non-empty pdf is left behind with keep_empty=True (default)
     with NamedTemporaryFile(delete=False) as tmp:
@@ -111,7 +111,7 @@ def test_composite_image():
     X, Y = np.meshgrid(np.arange(-5, 5, 1), np.arange(-5, 5, 1))
     Z = np.sin(Y ** 2)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_xlim(0, 3)
     ax.imshow(Z, extent=[0, 1, 0, 1])
     ax.imshow(Z[::-1], extent=[2, 3, 0, 1])

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -202,9 +202,9 @@ def test_bbox_inches():
 
     Y, X = np.ogrid[-1:1:40j, -1:1:40j]
     fig = plt.figure()
-    ax1 = fig.add_subplot(121)
+    ax1 = fig.add_subplot(1, 2, 1)
     ax1.plot(range(5))
-    ax2 = fig.add_subplot(122)
+    ax2 = fig.add_subplot(1, 2, 2)
     ax2.plot(range(5))
     plt.tight_layout()
 

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -225,12 +225,12 @@ def test_pdf_pages():
     mpl.rcParams.update(rc_pdflatex)
 
     fig1 = plt.figure()
-    ax1 = fig1.add_subplot(1, 1, 1)
+    ax1 = fig1.add_subplot()
     ax1.plot(range(5))
     fig1.tight_layout()
 
     fig2 = plt.figure(figsize=(3, 2))
-    ax2 = fig2.add_subplot(1, 1, 1)
+    ax2 = fig2.add_subplot()
     ax2.plot(range(5))
     fig2.tight_layout()
 
@@ -251,7 +251,7 @@ def test_pdf_pages_metadata():
     mpl.rcParams.update(rc_pdflatex)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(range(5))
     fig.tight_layout()
 
@@ -278,7 +278,7 @@ def test_pdf_pages_lualatex():
     mpl.rcParams.update(rc_pdflatex)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(range(5))
     fig.tight_layout()
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -152,7 +152,7 @@ def test_gid():
 
     fig = plt.figure()
 
-    ax1 = fig.add_subplot(131)
+    ax1 = fig.add_subplot(1, 3, 1)
     ax1.imshow([[1., 2.], [2., 3.]], aspect="auto")
     ax1.scatter([1, 2, 3], [1, 2, 3], label="myscatter")
     ax1.plot([2, 3, 1], label="myplot")

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -160,10 +160,10 @@ def test_gid():
     ax1a = ax1.twinx()
     ax1a.bar([1, 2, 3], [1, 2, 3])
 
-    ax2 = fig.add_subplot(132, projection="polar")
+    ax2 = fig.add_subplot(1, 3, 2, projection="polar")
     ax2.plot([0, 1.5, 3], [1, 2, 3])
 
-    ax3 = fig.add_subplot(133, projection="3d")
+    ax3 = fig.add_subplot(1, 3, 3, projection="3d")
     ax3.plot([1, 2], [1, 2], [1, 2])
 
     fig.canvas.draw()

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -43,7 +43,7 @@ def test_visibility():
 @image_comparison(['fill_black_with_alpha.svg'], remove_text=True)
 def test_fill_black_with_alpha():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.scatter(x=[0, 0.1, 1], y=[0, 0, 0], c='k', alpha=0.1, s=10000)
 
 
@@ -53,7 +53,7 @@ def test_noscale():
     Z = np.sin(Y ** 2)
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.imshow(Z, cmap='gray', interpolation='none')
 
 
@@ -76,7 +76,7 @@ def test_text_urls():
 @image_comparison(['bold_font_output.svg'])
 def test_bold_font_output():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(np.arange(10), np.arange(10))
     ax.set_xlabel('nonbold-xlabel')
     ax.set_ylabel('bold-ylabel', fontweight='bold')
@@ -87,7 +87,7 @@ def test_bold_font_output():
 def test_bold_font_output_with_none_fonttype():
     plt.rcParams['svg.fonttype'] = 'none'
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(np.arange(10), np.arange(10))
     ax.set_xlabel('nonbold-xlabel')
     ax.set_ylabel('bold-ylabel', fontweight='bold')

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -86,7 +86,7 @@ def test_bbox_inches_tight_clipping():
 def test_bbox_inches_tight_raster():
     """Test rasterization with tight_layout"""
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1.0, 2.0], rasterized=True)
 
 

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -86,7 +86,7 @@ def test_bbox_inches_tight_clipping():
 def test_bbox_inches_tight_raster():
     """Test rasterization with tight_layout"""
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot([1.0, 2.0], rasterized=True)
 
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -38,7 +38,7 @@ def generate_EventCollection_plot():
                            )
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.add_collection(coll)
     ax.set_title('EventCollection: default')
     props = {'positions': positions,
@@ -522,7 +522,7 @@ def test_joinstyle():
 @image_comparison(['cap_and_joinstyle.png'])
 def test_cap_and_joinstyle_image():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_xlim([-0.5, 1.5])
     ax.set_ylim([-0.5, 2.5])
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -160,9 +160,9 @@ def test_colorbar_positioning():
     plt.figure()
     ax1 = plt.subplot(211, anchor='NE', aspect='equal')
     plt.contourf(data, levels=levels)
-    ax2 = plt.subplot(223)
+    ax2 = plt.subplot(2, 2, 3)
     plt.contourf(data, levels=levels)
-    ax3 = plt.subplot(224)
+    ax3 = plt.subplot(2, 2, 4)
     plt.contourf(data, levels=levels)
 
     plt.colorbar(ax=[ax2, ax3, ax1], location='right', pad=0.0, shrink=0.5,
@@ -180,11 +180,11 @@ def test_gridspec_make_colorbar():
     data = np.arange(1200).reshape(30, 40)
     levels = [0, 200, 400, 600, 800, 1000, 1200]
 
-    plt.subplot(121)
+    plt.subplot(1, 2, 1)
     plt.contourf(data, levels=levels)
     plt.colorbar(use_gridspec=True, orientation='vertical')
 
-    plt.subplot(122)
+    plt.subplot(1, 2, 2)
     plt.contourf(data, levels=levels)
     plt.colorbar(use_gridspec=True, orientation='horizontal')
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -158,7 +158,7 @@ def test_colorbar_positioning():
 
     # -------------------
     plt.figure()
-    ax1 = plt.subplot(211, anchor='NE', aspect='equal')
+    ax1 = plt.subplot(2, 1, 1, anchor='NE', aspect='equal')
     plt.contourf(data, levels=levels)
     ax2 = plt.subplot(2, 2, 3)
     plt.contourf(data, levels=levels)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -480,7 +480,7 @@ def test_SymLogNorm_colorbar():
     """
     norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1, base=np.e)
     fig = plt.figure()
-    mcolorbar.ColorbarBase(fig.add_subplot(1, 1, 1), norm=norm)
+    mcolorbar.ColorbarBase(fig.add_subplot(), norm=norm)
     plt.close(fig)
 
 
@@ -490,7 +490,7 @@ def test_SymLogNorm_single_zero():
     """
     fig = plt.figure()
     norm = mcolors.SymLogNorm(1e-5, vmin=-1, vmax=1, base=np.e)
-    cbar = mcolorbar.ColorbarBase(fig.add_subplot(1, 1, 1), norm=norm)
+    cbar = mcolorbar.ColorbarBase(fig.add_subplot(), norm=norm)
     ticks = cbar.get_ticks()
     assert sum(ticks == 0) == 1
     plt.close(fig)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -480,7 +480,7 @@ def test_SymLogNorm_colorbar():
     """
     norm = mcolors.SymLogNorm(0.1, vmin=-1, vmax=1, linscale=1, base=np.e)
     fig = plt.figure()
-    mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
+    mcolorbar.ColorbarBase(fig.add_subplot(1, 1, 1), norm=norm)
     plt.close(fig)
 
 
@@ -490,7 +490,7 @@ def test_SymLogNorm_single_zero():
     """
     fig = plt.figure()
     norm = mcolors.SymLogNorm(1e-5, vmin=-1, vmax=1, base=np.e)
-    cbar = mcolorbar.ColorbarBase(fig.add_subplot(111), norm=norm)
+    cbar = mcolorbar.ColorbarBase(fig.add_subplot(1, 1, 1), norm=norm)
     ticks = cbar.get_ticks()
     assert sum(ticks == 0) == 1
     plt.close(fig)

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -36,7 +36,7 @@ def example_pcolor(ax, fontsize=12):
 def test_constrained_layout1():
     """Test constrained_layout for a single subplot"""
     fig = plt.figure(constrained_layout=True)
-    ax = fig.add_subplot($1, $2, $3)
+    ax = fig.add_subplot(1, 1, 1)
     example_plot(ax, fontsize=24)
 
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -36,7 +36,7 @@ def example_pcolor(ax, fontsize=12):
 def test_constrained_layout1():
     """Test constrained_layout for a single subplot"""
     fig = plt.figure(constrained_layout=True)
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot($1, $2, $3)
     example_plot(ax, fontsize=24)
 
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -36,7 +36,7 @@ def example_pcolor(ax, fontsize=12):
 def test_constrained_layout1():
     """Test constrained_layout for a single subplot"""
     fig = plt.figure(constrained_layout=True)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     example_plot(ax, fontsize=24)
 
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -172,15 +172,15 @@ def test_contour_datetime_axis():
     y = np.arange(20)
     z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
     z = z1 * z2
-    plt.subplot(221)
+    plt.subplot(2, 2, 1)
     plt.contour(x, y, z)
-    plt.subplot(222)
+    plt.subplot(2, 2, 2)
     plt.contourf(x, y, z)
     x = np.repeat(x[np.newaxis], 20, axis=0)
     y = np.repeat(y[:, np.newaxis], 20, axis=1)
-    plt.subplot(223)
+    plt.subplot(2, 2, 3)
     plt.contour(x, y, z)
-    plt.subplot(224)
+    plt.subplot(2, 2, 4)
     plt.contourf(x, y, z)
     for ax in fig.get_axes():
         for label in ax.get_xticklabels():
@@ -317,9 +317,9 @@ def test_contourf_log_extension():
     # Test that contourf with lognorm is extended correctly
     fig = plt.figure(figsize=(10, 5))
     fig.subplots_adjust(left=0.05, right=0.95)
-    ax1 = fig.add_subplot(131)
-    ax2 = fig.add_subplot(132)
-    ax3 = fig.add_subplot(133)
+    ax1 = fig.add_subplot(1, 3, 1)
+    ax2 = fig.add_subplot(1, 3, 2)
+    ax3 = fig.add_subplot(1, 3, 3)
 
     # make data set with large range e.g. between 1e-8 and 1e10
     data_exp = np.linspace(-7.5, 9.5, 1200)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -20,12 +20,12 @@ def test_date_numpyx():
     timenp = np.array(time, dtype='datetime64[ns]')
     data = np.array([0., 2., 1.])
     fig = plt.figure(figsize=(10, 2))
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     h, = ax.plot(time, data)
     hnp, = ax.plot(timenp, data)
     np.testing.assert_equal(h.get_xdata(orig=False), hnp.get_xdata(orig=False))
     fig = plt.figure(figsize=(10, 2))
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     h, = ax.plot(data, time)
     hnp, = ax.plot(data, timenp)
     np.testing.assert_equal(h.get_ydata(orig=False), hnp.get_ydata(orig=False))
@@ -75,7 +75,7 @@ def test_date_empty():
     # if no date data has been presented, cf
     # http://sourceforge.net/tracker/?func=detail&aid=2850075&group_id=80706&atid=560720
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.xaxis_date()
 
 
@@ -85,7 +85,7 @@ def test_date_axhspan():
     t0 = datetime.datetime(2009, 1, 20)
     tf = datetime.datetime(2009, 1, 21)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
     ax.set_ylim(t0 - datetime.timedelta(days=5),
                 tf + datetime.timedelta(days=5))
@@ -98,7 +98,7 @@ def test_date_axvspan():
     t0 = datetime.datetime(2000, 1, 20)
     tf = datetime.datetime(2010, 1, 21)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.axvspan(t0, tf, facecolor="blue", alpha=0.25)
     ax.set_xlim(t0 - datetime.timedelta(days=720),
                 tf + datetime.timedelta(days=720))
@@ -111,7 +111,7 @@ def test_date_axhline():
     t0 = datetime.datetime(2009, 1, 20)
     tf = datetime.datetime(2009, 1, 31)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.axhline(t0, color="blue", lw=3)
     ax.set_ylim(t0 - datetime.timedelta(days=5),
                 tf + datetime.timedelta(days=5))
@@ -124,7 +124,7 @@ def test_date_axvline():
     t0 = datetime.datetime(2000, 1, 20)
     tf = datetime.datetime(2000, 1, 21)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.axvline(t0, color="red", lw=3)
     ax.set_xlim(t0 - datetime.timedelta(days=5),
                 tf + datetime.timedelta(days=5))
@@ -141,7 +141,7 @@ def test_too_many_date_ticks(caplog):
     t0 = datetime.datetime(2000, 1, 20)
     tf = datetime.datetime(2000, 1, 20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     with pytest.warns(UserWarning) as rec:
         ax.set_xlim((t0, tf), auto=True)
         assert len(rec) == 1
@@ -723,7 +723,7 @@ def test_date_inverted_limit():
     t0 = datetime.datetime(2009, 1, 20)
     tf = datetime.datetime(2009, 1, 31)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.axhline(t0, color="blue", lw=3)
     ax.set_ylim(t0 - datetime.timedelta(days=5),
                 tf + datetime.timedelta(days=5))

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -181,7 +181,7 @@ def test_RRuleLocator():
     tf = datetime.datetime(6000, 1, 1)
 
     fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.subplot(1, 1, 1)
     ax.set_autoscale_on(True)
     ax.plot([t0, tf], [0.0, 1.0], marker='o')
 
@@ -214,7 +214,7 @@ def test_DateFormatter():
     tf = datetime.datetime(2001, 1, 1, 0, 0, 1)
 
     fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.subplot(1, 1, 1)
     ax.set_autoscale_on(True)
     ax.plot([t0, tf], [0.0, 1.0], marker='o')
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -158,7 +158,7 @@ def test_gca():
     assert fig.gca(projection='rectilinear') is ax1
     assert fig.gca() is ax1
 
-    ax2 = fig.add_subplot(121, projection='polar')
+    ax2 = fig.add_subplot(1, 2, 1, projection='polar')
     assert fig.gca() is ax2
     assert fig.gca(polar=True) is ax2
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -162,7 +162,7 @@ def test_gca():
     assert fig.gca() is ax2
     assert fig.gca(polar=True) is ax2
 
-    ax3 = fig.add_subplot(122)
+    ax3 = fig.add_subplot(1, 2, 2)
     assert fig.gca() is ax3
 
     # the final request for a polar axes will end up creating one

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -31,16 +31,16 @@ def test_image_interps():
     X = X.reshape(5, 20)
 
     fig = plt.figure()
-    ax1 = fig.add_subplot(311)
+    ax1 = fig.add_subplot(3, 1, 1)
     ax1.imshow(X, interpolation='nearest')
     ax1.set_title('three interpolations')
     ax1.set_ylabel('nearest')
 
-    ax2 = fig.add_subplot(312)
+    ax2 = fig.add_subplot(3, 1, 2)
     ax2.imshow(X, interpolation='bilinear')
     ax2.set_ylabel('bilinear')
 
-    ax3 = fig.add_subplot(313)
+    ax3 = fig.add_subplot(3, 1, 3)
     ax3.imshow(X, interpolation='bicubic')
     ax3.set_ylabel('bicubic')
 
@@ -70,10 +70,10 @@ def test_interp_nearest_vs_none():
     X = np.array([[[218, 165, 32], [122, 103, 238]],
                   [[127, 255, 0], [255, 99, 71]]], dtype=np.uint8)
     fig = plt.figure()
-    ax1 = fig.add_subplot(121)
+    ax1 = fig.add_subplot(1, 2, 1)
     ax1.imshow(X, interpolation='none')
     ax1.set_title('interpolation none')
-    ax2 = fig.add_subplot(122)
+    ax2 = fig.add_subplot(1, 2, 2)
     ax2.imshow(X, interpolation='nearest')
     ax2.set_title('interpolation nearest')
 
@@ -276,13 +276,13 @@ def test_image_alpha():
     np.random.seed(0)
     Z = np.random.rand(6, 6)
 
-    plt.subplot(131)
+    plt.subplot(1, 3, 1)
     plt.imshow(Z, alpha=1.0, interpolation='none')
 
-    plt.subplot(132)
+    plt.subplot(1, 3, 2)
     plt.imshow(Z, alpha=0.5, interpolation='none')
 
-    plt.subplot(133)
+    plt.subplot(1, 3, 3)
     plt.imshow(Z, alpha=0.5, interpolation='nearest')
 
 
@@ -1074,10 +1074,10 @@ def test_image_array_alpha(fig_test, fig_ref):
     alpha = zz / zz.max()
 
     cmap = plt.get_cmap('viridis')
-    ax = fig_test.add_subplot(111)
+    ax = fig_test.add_subplot(1, 1, 1)
     ax.imshow(zz, alpha=alpha, cmap=cmap, interpolation='nearest')
 
-    ax = fig_ref.add_subplot(111)
+    ax = fig_ref.add_subplot(1, 1, 1)
     rgba = cmap(colors.Normalize()(zz))
     rgba[..., -1] = alpha
     ax.imshow(rgba, interpolation='nearest')

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1074,10 +1074,10 @@ def test_image_array_alpha(fig_test, fig_ref):
     alpha = zz / zz.max()
 
     cmap = plt.get_cmap('viridis')
-    ax = fig_test.add_subplot(1, 1, 1)
+    ax = fig_test.add_subplot()
     ax.imshow(zz, alpha=alpha, cmap=cmap, interpolation='nearest')
 
-    ax = fig_ref.add_subplot(1, 1, 1)
+    ax = fig_ref.add_subplot()
     rgba = cmap(colors.Normalize()(zz))
     rgba[..., -1] = alpha
     ax.imshow(rgba, interpolation='nearest')

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -37,7 +37,7 @@ def test_legend_ordereddict():
 def test_legend_auto1():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     x = np.arange(100)
     ax.plot(x, 50 - x, 'o', label='y=1')
     ax.plot(x, x - 50, 'o', label='y=-1')
@@ -48,7 +48,7 @@ def test_legend_auto1():
 def test_legend_auto2():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     x = np.arange(100)
     b1 = ax.bar(x, x, align='edge', color='m')
     b2 = ax.bar(x, x[::-1], align='edge', color='g')
@@ -59,7 +59,7 @@ def test_legend_auto2():
 def test_legend_auto3():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     x = [0.9, 0.1, 0.1, 0.9, 0.9, 0.5]
     y = [0.95, 0.95, 0.05, 0.05, 0.5, 0.5]
     ax.plot(x, y, 'o-', label='line')
@@ -83,7 +83,7 @@ def test_various_labels():
 def test_labels_first():
     # test labels to left of markers
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(np.arange(10), '-o', label=1)
     ax.plot(np.ones(10)*5, ':x', label="x")
     ax.plot(np.arange(20, 10, -1), 'd', label="diamond")
@@ -94,7 +94,7 @@ def test_labels_first():
 def test_multiple_keys():
     # test legend entries with multiple keys
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     p1, = ax.plot([1, 2, 3], '-o')
     p2, = ax.plot([2, 3, 4], '-x')
     p3, = ax.plot([3, 4, 5], '-d')
@@ -216,7 +216,7 @@ def test_hatching():
 
 def test_legend_remove():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     lines = ax.plot(range(10))
     leg = fig.legend(lines, "test")
     leg.remove()
@@ -366,7 +366,7 @@ def test_legend_stackplot():
     """Test legend for PolyCollection using stackplot."""
     # related to #1341, #1943, and PR #3303
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     x = np.linspace(0, 10, 10)
     y1 = 1.0 * x
     y2 = 2.0 * x + 1

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -37,7 +37,7 @@ def test_legend_ordereddict():
 def test_legend_auto1():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     x = np.arange(100)
     ax.plot(x, 50 - x, 'o', label='y=1')
     ax.plot(x, x - 50, 'o', label='y=-1')
@@ -48,7 +48,7 @@ def test_legend_auto1():
 def test_legend_auto2():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     x = np.arange(100)
     b1 = ax.bar(x, x, align='edge', color='m')
     b2 = ax.bar(x, x[::-1], align='edge', color='g')
@@ -59,7 +59,7 @@ def test_legend_auto2():
 def test_legend_auto3():
     """Test automatic legend placement"""
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     x = [0.9, 0.1, 0.1, 0.9, 0.9, 0.5]
     y = [0.95, 0.95, 0.05, 0.05, 0.5, 0.5]
     ax.plot(x, y, 'o-', label='line')
@@ -72,7 +72,7 @@ def test_legend_auto3():
 def test_various_labels():
     # tests all sorts of label types
     fig = plt.figure()
-    ax = fig.add_subplot(121)
+    ax = fig.add_subplot(1, 2, 1)
     ax.plot(np.arange(4), 'o', label=1)
     ax.plot(np.linspace(4, 4.1), 'o', label='Développés')
     ax.plot(np.arange(4, 1, -1), 'o', label='__nolegend__')
@@ -83,7 +83,7 @@ def test_various_labels():
 def test_labels_first():
     # test labels to left of markers
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.plot(np.arange(10), '-o', label=1)
     ax.plot(np.ones(10)*5, ':x', label="x")
     ax.plot(np.arange(20, 10, -1), 'd', label="diamond")
@@ -94,7 +94,7 @@ def test_labels_first():
 def test_multiple_keys():
     # test legend entries with multiple keys
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     p1, = ax.plot([1, 2, 3], '-o')
     p2, = ax.plot([2, 3, 4], '-x')
     p3, = ax.plot([3, 4, 5], '-d')
@@ -130,7 +130,7 @@ def test_alpha_rcparam():
 @image_comparison(['fancy'], remove_text=True)
 def test_fancy():
     # using subplot triggers some offsetbox functionality untested elsewhere
-    plt.subplot(121)
+    plt.subplot(1, 2, 1)
     plt.scatter(np.arange(10), np.arange(10, 0, -1), label='XX\nXX')
     plt.plot([5] * 10, 'o--', label='XX')
     plt.errorbar(np.arange(10), np.arange(10), xerr=0.5,
@@ -152,14 +152,14 @@ def test_framealpha():
 def test_rc():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.figure()
-    ax = plt.subplot(121)
+    ax = plt.subplot(1, 2, 1)
     ax.scatter(np.arange(10), np.arange(10, 0, -1), label='three')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
 
     mpl.rcParams['legend.scatterpoints'] = 1
     plt.figure()
-    ax = plt.subplot(121)
+    ax = plt.subplot(1, 2, 1)
     ax.scatter(np.arange(10), np.arange(10, 0, -1), label='one')
     ax.legend(loc="center left", bbox_to_anchor=[1.0, 0.5],
               title="My legend")
@@ -291,7 +291,7 @@ class TestLegendFunction:
     def test_parasite(self):
         from mpl_toolkits.axes_grid1 import host_subplot
 
-        host = host_subplot(111)
+        host = host_subplot(1, 1, 1)
         par = host.twinx()
 
         p1, = host.plot([0, 1, 2], [0, 1, 2], label="Density")
@@ -366,7 +366,7 @@ def test_legend_stackplot():
     """Test legend for PolyCollection using stackplot."""
     # related to #1341, #1943, and PR #3303
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     x = np.linspace(0, 10, 10)
     y1 = 1.0 * x
     y2 = 2.0 * x + 1

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -39,7 +39,7 @@ def test_invisible_Line_rendering():
 
     # Create a plot figure:
     fig = plt.figure()
-    ax = plt.subplot(111)
+    ax = plt.subplot(1, 1, 1)
 
     # Create a "big" Line instance:
     l = mlines.Line2D(x, y)

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -66,7 +66,7 @@ def test_invisible_Line_rendering():
 
 def test_set_line_coll_dash():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     np.random.seed(0)
     # Testing setting linestyles for line collections.
     # This should not produce an error.
@@ -76,14 +76,14 @@ def test_set_line_coll_dash():
 @image_comparison(['line_dashes'], remove_text=True)
 def test_line_dashes():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
 
     ax.plot(range(10), linestyle=(0, (3, 3)), lw=5)
 
 
 def test_line_colors():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot(range(10), color='none')
     ax.plot(range(10), color='r')
     ax.plot(range(10), color='.3')
@@ -94,7 +94,7 @@ def test_line_colors():
 
 def test_linestyle_variants():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     for ls in ["-", "solid", "--", "dashed",
                "-.", "dashdot", ":", "dotted"]:
         ax.plot(range(10), linestyle=ls)
@@ -142,7 +142,7 @@ def test_set_drawstyle():
 @image_comparison(['line_collection_dashes'], remove_text=True, style='mpl20')
 def test_set_line_coll_dash_image():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     np.random.seed(0)
     ax.contour(np.random.randn(20, 30), linestyles=[(0, (3, 3))])
 

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -87,7 +87,7 @@ def test_negative_rect():
 def test_clip_to_bbox():
     fig = plt.figure()
 
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_xlim([-18, 20])
     ax.set_ylim([-150, 100])
 
@@ -226,7 +226,7 @@ def test_patch_linestyle_accents():
                   "solid", "dashed", "dashdot", "dotted"]
 
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     for i, ls in enumerate(linestyles):
         star = mpath.Path(verts + i, codes)
         patch = mpatches.PathPatch(star,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -87,7 +87,7 @@ def test_negative_rect():
 def test_clip_to_bbox():
     fig = plt.figure()
 
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     ax.set_xlim([-18, 20])
     ax.set_ylim([-150, 100])
 

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -7,7 +7,7 @@ import matplotlib.patheffects as path_effects
 
 @image_comparison(['patheffect1'], remove_text=True)
 def test_patheffect1():
-    ax1 = plt.subplot(111)
+    ax1 = plt.subplot(1, 1, 1)
     ax1.imshow([[1, 2], [2, 3]])
     txt = ax1.annotate("test", (1., 1.), (0., 0),
                        arrowprops=dict(arrowstyle="->",
@@ -26,7 +26,7 @@ def test_patheffect1():
 @image_comparison(['patheffect2'], remove_text=True, style='mpl20')
 def test_patheffect2():
 
-    ax2 = plt.subplot(111)
+    ax2 = plt.subplot(1, 1, 1)
     arr = np.arange(25).reshape((5, 5))
     ax2.imshow(arr, interpolation='nearest')
     cntr = ax2.contour(arr, colors="k")

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -17,7 +17,7 @@ def test_simple():
     fig = plt.figure()
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
-    ax = plt.subplot(121)
+    ax = plt.subplot(1, 2, 1)
     pickle.dump(ax, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
     ax = plt.axes(projection='polar')

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -112,7 +112,7 @@ def test_no_pyplot():
     from matplotlib.backends.backend_pdf import FigureCanvasPdf
     fig = mfigure.Figure()
     _ = FigureCanvasPdf(fig)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.plot([1, 2, 3], [1, 2, 3])
     pickle.dump(fig, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
@@ -129,7 +129,7 @@ def test_image():
     from matplotlib.backends.backend_agg import new_figure_manager
     manager = new_figure_manager(1000)
     fig = manager.canvas.figure
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.imshow(np.arange(12).reshape(3, 4))
     manager.canvas.draw()
     pickle.dump(fig, BytesIO())

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -26,7 +26,7 @@ def test_simple():
 
     pickle.dump(ax, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
-#    ax = plt.subplot(121, projection='hammer')
+#    ax = plt.subplot(1, 2, 1, projection='hammer')
 #    pickle.dump(ax, BytesIO(), pickle.HIGHEST_PROTOCOL)
 
     plt.figure()
@@ -136,7 +136,7 @@ def test_image():
 
 
 def test_polar():
-    plt.subplot(111, polar=True)
+    plt.subplot(1, 1, 1, polar=True)
     fig = plt.gcf()
     pf = pickle.dumps(fig)
     pickle.loads(pf)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -22,7 +22,7 @@ def test_polar_annotations():
     theta = 2.0 * 2.0 * np.pi * r
 
     fig = plt.figure()
-    ax = fig.add_subplot(111, polar=True)
+    ax = fig.add_subplot(1, 1, 1, polar=True)
     line, = ax.plot(theta, r, color='#ee8d18', lw=3)
     line, = ax.plot((0, 0), (0, 1), color="#0000ff", lw=1)
 
@@ -49,7 +49,7 @@ def test_polar_coord_annotations():
     el = mpl.patches.Ellipse((0, 0), 10, 20, facecolor='r', alpha=0.5)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111, aspect='equal')
+    ax = fig.add_subplot(1, 1, 1, aspect='equal')
 
     ax.add_artist(el)
     el.set_clip_box(ax.bbox)
@@ -210,7 +210,7 @@ def test_polar_theta_position():
 @image_comparison(['polar_rlabel_position'], style='default')
 def test_polar_rlabel_position():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='polar')
+    ax = fig.add_subplot(1, 1, 1, projection='polar')
     ax.set_rlabel_position(315)
     ax.tick_params(rotation='auto')
 
@@ -292,7 +292,7 @@ def test_polar_not_datalim_adjustable():
 
 def test_polar_gridlines():
     fig = plt.figure()
-    ax = fig.add_subplot(111, polar=True)
+    ax = fig.add_subplot(1, 1, 1, polar=True)
     # make all major grid lines lighter, only x grid lines set in 2.1.0
     ax.grid(alpha=0.2)
     # hide y tick labels, no effect in 2.1.0
@@ -314,13 +314,13 @@ def test_get_tightbbox_polar():
 def test_polar_interpolation_steps_constant_r(fig_test, fig_ref):
     # Check that an extra half-turn doesn't make any difference -- modulo
     # antialiasing, which we disable here.
-    p1 = (fig_test.add_subplot(121, projection="polar")
+    p1 = (fig_test.add_subplot(1, 2, 1, projection="polar")
           .bar([0], [1], 3*np.pi, edgecolor="none"))
-    p2 = (fig_test.add_subplot(122, projection="polar")
+    p2 = (fig_test.add_subplot(1, 2, 2, projection="polar")
           .bar([0], [1], -3*np.pi, edgecolor="none"))
-    p3 = (fig_ref.add_subplot(121, projection="polar")
+    p3 = (fig_ref.add_subplot(1, 2, 1, projection="polar")
           .bar([0], [1], 2*np.pi, edgecolor="none"))
-    p4 = (fig_ref.add_subplot(122, projection="polar")
+    p4 = (fig_ref.add_subplot(1, 2, 2, projection="polar")
           .bar([0], [1], -2*np.pi, edgecolor="none"))
     for p in [p1, p2, p3, p4]:
         plt.setp(p, antialiased=False)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -13,12 +13,12 @@ import pytest
 
 @check_figures_equal()
 def test_log_scales(fig_test, fig_ref):
-    ax_test = fig_test.add_subplot(122, yscale='log', xscale='symlog')
+    ax_test = fig_test.add_subplot(1, 2, 2, yscale='log', xscale='symlog')
     ax_test.axvline(24.1)
     ax_test.axhline(24.1)
     xlim = ax_test.get_xlim()
     ylim = ax_test.get_ylim()
-    ax_ref = fig_ref.add_subplot(122, yscale='log', xscale='symlog')
+    ax_ref = fig_ref.add_subplot(1, 2, 2, yscale='log', xscale='symlog')
     ax_ref.set(xlim=xlim, ylim=ylim)
     ax_ref.plot([24.1, 24.1], ylim, 'b')
     ax_ref.plot(xlim, [24.1, 24.1], 'b')

--- a/lib/matplotlib/tests/test_skew.py
+++ b/lib/matplotlib/tests/test_skew.py
@@ -69,7 +69,7 @@ class SkewSpine(mspines.Spine):
 # spines and axes instances as appropriate.
 class SkewXAxes(Axes):
     # The projection must specify a name.  This will be used be the
-    # user to select the projection, i.e. ``subplot(111,
+    # user to select the projection, i.e. ``subplot(1, 1, 1,
     # projection='skewx')``.
     name = 'skewx'
 

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -10,7 +10,7 @@ def test_spines_axes_positions():
     fig = plt.figure()
     x = np.linspace(0, 2*np.pi, 100)
     y = 2*np.sin(x)
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_title('centered spines')
     ax.plot(x, y)
     ax.spines['right'].set_position(('axes', 0.1))
@@ -24,7 +24,7 @@ def test_spines_axes_positions():
 @image_comparison(['spines_data_positions'])
 def test_spines_data_positions():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.spines['left'].set_position(('data', -1.5))
     ax.spines['top'].set_position(('data', 0.5))
     ax.spines['right'].set_position(('data', -0.5))
@@ -59,14 +59,14 @@ def test_spines_capstyle():
     # issue 2542
     plt.rc('axes', linewidth=20)
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     ax.set_xticks([])
     ax.set_yticks([])
 
 
 def test_label_without_ticks():
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     plt.subplots_adjust(left=0.3, bottom=0.3)
     ax.plot(np.arange(10))
     ax.yaxis.set_ticks_position('left')

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -544,9 +544,9 @@ def test_usetex_is_copied():
     # properties) copies usetex state.
     fig = plt.figure()
     plt.rcParams["text.usetex"] = False
-    ax1 = fig.add_subplot(121)
+    ax1 = fig.add_subplot(1, 2, 1)
     plt.rcParams["text.usetex"] = True
-    ax2 = fig.add_subplot(122)
+    ax2 = fig.add_subplot(1, 2, 2)
     fig.canvas.draw()
     for ax, usetex in [(ax1, False), (ax2, True)]:
         for t in ax.xaxis.majorTicks:

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -134,7 +134,7 @@ def test_tight_layout8():
     """Test automatic use of tight_layout."""
     fig = plt.figure()
     fig.set_tight_layout({'pad': .1})
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     example_plot(ax, fontsize=24)
 
 

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -41,9 +41,9 @@ def test_tight_layout2():
 @image_comparison(['tight_layout3'])
 def test_tight_layout3():
     """Test tight_layout for multiple subplots."""
-    ax1 = plt.subplot(221)
-    ax2 = plt.subplot(223)
-    ax3 = plt.subplot(122)
+    ax1 = plt.subplot(2, 2, 1)
+    ax2 = plt.subplot(2, 2, 3)
+    ax3 = plt.subplot(1, 2, 2)
     example_plot(ax1)
     example_plot(ax2)
     example_plot(ax3)
@@ -67,7 +67,7 @@ def test_tight_layout4():
 @image_comparison(['tight_layout5'])
 def test_tight_layout5():
     """Test tight_layout for image."""
-    ax = plt.subplot(111)
+    ax = plt.subplot(1, 1, 1)
     arr = np.arange(100).reshape((10, 10))
     ax.imshow(arr, interpolation="none")
     plt.tight_layout()
@@ -134,7 +134,7 @@ def test_tight_layout8():
     """Test automatic use of tight_layout."""
     fig = plt.figure()
     fig.set_tight_layout({'pad': .1})
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     example_plot(ax, fontsize=24)
 
 
@@ -150,7 +150,7 @@ def test_tight_layout9():
 def test_outward_ticks():
     """Test automatic use of tight_layout."""
     fig = plt.figure()
-    ax = fig.add_subplot(221)
+    ax = fig.add_subplot(2, 2, 1)
     ax.xaxis.set_tick_params(tickdir='out', length=16, width=3)
     ax.yaxis.set_tick_params(tickdir='out', length=16, width=3)
     ax.xaxis.set_tick_params(
@@ -159,13 +159,13 @@ def test_outward_ticks():
         tickdir='out', length=32, width=3, tick1On=True, which='minor')
     ax.xaxis.set_ticks([0], minor=True)
     ax.yaxis.set_ticks([0], minor=True)
-    ax = fig.add_subplot(222)
+    ax = fig.add_subplot(2, 2, 2)
     ax.xaxis.set_tick_params(tickdir='in', length=32, width=3)
     ax.yaxis.set_tick_params(tickdir='in', length=32, width=3)
-    ax = fig.add_subplot(223)
+    ax = fig.add_subplot(2, 2, 3)
     ax.xaxis.set_tick_params(tickdir='inout', length=32, width=3)
     ax.yaxis.set_tick_params(tickdir='inout', length=32, width=3)
-    ax = fig.add_subplot(224)
+    ax = fig.add_subplot(2, 2, 4)
     ax.xaxis.set_tick_params(tickdir='out', length=32, width=3)
     ax.yaxis.set_tick_params(tickdir='out', length=32, width=3)
     plt.tight_layout()

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -168,11 +168,11 @@ def test_tripcolor():
     ymid = y[triang.triangles].mean(axis=1)
     Cfaces = 0.5*xmid + ymid
 
-    plt.subplot(121)
+    plt.subplot(1, 2, 1)
     plt.tripcolor(triang, Cpoints, edgecolors='k')
     plt.title('point colors')
 
-    plt.subplot(122)
+    plt.subplot(1, 2, 2)
     plt.tripcolor(triang, facecolors=Cfaces, edgecolors='k')
     plt.title('facecolors')
 

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -17,7 +17,7 @@ if not mpl.checkdep_usetex(True):
 def test_usetex():
     mpl.rcParams['text.usetex'] = True
     fig = plt.figure()
-    ax = fig.add_subplot(111)
+    ax = fig.add_subplot(1, 1, 1)
     kwargs = {"verticalalignment": "baseline", "size": 24,
               "bbox": dict(pad=0, edgecolor="k", facecolor="none")}
     ax.text(0.2, 0.7,

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -17,7 +17,7 @@ if not mpl.checkdep_usetex(True):
 def test_usetex():
     mpl.rcParams['text.usetex'] = True
     fig = plt.figure()
-    ax = fig.add_subplot(1, 1, 1)
+    ax = fig.add_subplot()
     kwargs = {"verticalalignment": "baseline", "size": 24,
               "bbox": dict(pad=0, edgecolor="k", facecolor="none")}
     ax.text(0.2, 0.7,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2395,7 +2395,7 @@ class LassoSelector(_SelectorWidget):
 
     Example usage::
 
-        ax = subplot(111)
+        ax = subplot(1, 1, 1)
         ax.plot(x, y)
 
         def onselect(verts):

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -436,7 +436,7 @@ def test_picking_callbacks_overlap(big_on_axes, small_on_axes, click_on):
     if "gca" in rectangles_on_axes:
         axes["gca"] = plt.gca()
     if "host" in rectangles_on_axes or "parasite" in rectangles_on_axes:
-        axes["host"] = host_subplot(111)
+        axes["host"] = host_subplot(1, 1, 1)
         axes["parasite"] = axes["host"].twin()
     # Add rectangles to axes
     axes[big_on_axes].add_patch(big)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -19,7 +19,7 @@ mpl3d_image_comparison = functools.partial(
 
 def test_aspect_equal_error():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     with pytest.raises(NotImplementedError):
         ax.set_aspect('equal')
 
@@ -27,7 +27,7 @@ def test_aspect_equal_error():
 @mpl3d_image_comparison(['bar3d.png'])
 def test_bar3d():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     for c, z in zip(['r', 'g', 'b', 'y'], [30, 20, 10, 0]):
         xs = np.arange(20)
         ys = np.arange(20)
@@ -59,7 +59,7 @@ def test_bar3d_shaded():
 @mpl3d_image_comparison(['bar3d_notshaded.png'])
 def test_bar3d_notshaded():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     x = np.arange(4)
     y = np.arange(5)
     x2d, y2d = np.meshgrid(x, y)
@@ -212,7 +212,7 @@ def test_tight_layout_text(fig_test, fig_ref):
 @mpl3d_image_comparison(['scatter3d.png'])
 def test_scatter3d():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     ax.scatter(np.arange(10), np.arange(10), np.arange(10),
                c='r', marker='o')
     x = y = z = np.arange(10, 20)
@@ -223,7 +223,7 @@ def test_scatter3d():
 @mpl3d_image_comparison(['scatter3d_color.png'])
 def test_scatter3d_color():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     ax.scatter(np.arange(10), np.arange(10), np.arange(10),
                color='r', marker='o')
     ax.scatter(np.arange(10, 20), np.arange(10, 20), np.arange(10, 20),
@@ -233,7 +233,7 @@ def test_scatter3d_color():
 @mpl3d_image_comparison(['plot_3d_from_2d.png'], tol=0.01)
 def test_plot_3d_from_2d():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     xs = np.arange(0, 5)
     ys = np.arange(5, 10)
     ax.plot(xs, ys, zs=0, zdir='x')
@@ -332,7 +332,7 @@ def test_trisurf3d_shaded():
 @mpl3d_image_comparison(['wireframe3d.png'])
 def test_wireframe3d():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rcount=13, ccount=13)
 
@@ -340,7 +340,7 @@ def test_wireframe3d():
 @mpl3d_image_comparison(['wireframe3dzerocstride.png'])
 def test_wireframe3dzerocstride():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rcount=13, ccount=0)
 
@@ -348,14 +348,14 @@ def test_wireframe3dzerocstride():
 @mpl3d_image_comparison(['wireframe3dzerorstride.png'])
 def test_wireframe3dzerorstride():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rstride=0, cstride=10)
 
 
 def test_wireframe3dzerostrideraises():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     with pytest.raises(ValueError):
         ax.plot_wireframe(X, Y, Z, rstride=0, cstride=0)
@@ -363,7 +363,7 @@ def test_wireframe3dzerostrideraises():
 
 def test_mixedsamplesraises():
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     with pytest.raises(ValueError):
         ax.plot_wireframe(X, Y, Z, rstride=10, ccount=50)
@@ -663,7 +663,7 @@ def test_axes3d_ortho():
 def test_invalid_axes_limits(setter, side, value):
     limit = {side: value}
     fig = plt.figure()
-    obj = fig.add_subplot(111, projection='3d')
+    obj = fig.add_subplot(1, 1, 1, projection='3d')
     with pytest.raises(ValueError):
         getattr(obj, setter)(**limit)
 
@@ -794,7 +794,7 @@ def test_line3d_set_get_data_3d():
     x, y, z = [0, 1], [2, 3], [4, 5]
     x2, y2, z2 = [6, 7], [8, 9], [10, 11]
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
+    ax = fig.add_subplot(1, 1, 1, projection='3d')
     lines = ax.plot(x, y, z)
     line = lines[0]
     np.testing.assert_array_equal((x, y, z), line.get_data_3d())

--- a/tools/memleak.py
+++ b/tools/memleak.py
@@ -92,18 +92,18 @@ class MemleakTest:
             y2 = np.random.rand(len(t1))
             X = np.random.rand(50, 50)
 
-            ax = fig.add_subplot(221)
+            ax = fig.add_subplot(2, 2, 1)
             ax.plot(t1, y1, '-')
             ax.plot(t1, y2, 's')
 
-            ax = fig.add_subplot(222)
+            ax = fig.add_subplot(2, 2, 2)
             ax.imshow(X)
 
-            ax = fig.add_subplot(223)
+            ax = fig.add_subplot(2, 2, 3)
             ax.scatter(np.random.rand(50), np.random.rand(50),
                        s=100 * np.random.rand(50), c=np.random.rand(50))
 
-            ax = fig.add_subplot(224)
+            ax = fig.add_subplot(2, 2, 4)
             ax.pcolor(10 * np.random.rand(50, 50))
 
         fig.savefig(BytesIO(), dpi=75)

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -489,7 +489,7 @@ plt.show()
 #
 # .. sourcecode:: ipython
 #
-#     In [80]: ax = subplot(111)
+#     In [80]: ax = subplot(1, 1, 1)
 #
 #     In [81]: ax.set_xlim(0, 10)
 #     Out[81]: (0, 10)

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -366,7 +366,7 @@ plt.show()
 # :class:`~matplotlib.patches.Circle` for polar coordinates; this patch
 # determines the shape, background and border of the plotting region::
 #
-#     ax = fig.add_subplot(1, 1, 1)
+#     ax = fig.add_subplot()
 #     rect = ax.patch  # a Rectangle instance
 #     rect.set_facecolor('green')
 #

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -125,7 +125,7 @@ import matplotlib.pyplot as plt
 
 fig = plt.figure()
 fig.subplots_adjust(top=0.8)
-ax1 = fig.add_subplot(211)
+ax1 = fig.add_subplot(2, 1, 1)
 ax1.set_ylabel('volts')
 ax1.set_title('a sine wave')
 
@@ -279,7 +279,7 @@ plt.show()
 #
 #     In [156]: fig = plt.figure()
 #
-#     In [157]: ax1 = fig.add_subplot(211)
+#     In [157]: ax1 = fig.add_subplot(2, 1, 1)
 #
 #     In [158]: ax2 = fig.add_axes([0.1, 0.1, 0.7, 0.3])
 #
@@ -366,7 +366,7 @@ plt.show()
 # :class:`~matplotlib.patches.Circle` for polar coordinates; this patch
 # determines the shape, background and border of the plotting region::
 #
-#     ax = fig.add_subplot(111)
+#     ax = fig.add_subplot(1, 1, 1)
 #     rect = ax.patch  # a Rectangle instance
 #     rect.set_facecolor('green')
 #

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -499,9 +499,9 @@ ax2 = fig.add_axes(bb_ax2)
 
 fig = plt.figure()
 
-ax1 = plt.subplot(221)
-ax2 = plt.subplot(223)
-ax3 = plt.subplot(122)
+ax1 = plt.subplot(2, 2, 1)
+ax2 = plt.subplot(2, 2, 3)
+ax3 = plt.subplot(1, 2, 2)
 
 example_plot(ax1)
 example_plot(ax2)

--- a/tutorials/intermediate/legend_guide.py
+++ b/tutorials/intermediate/legend_guide.py
@@ -115,7 +115,7 @@ plt.show()
 #
 # More examples of custom legend placement:
 
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 
@@ -124,7 +124,7 @@ plt.plot([3, 2, 1], label="test2")
 plt.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
            ncol=2, mode="expand", borderaxespad=0.)
 
-plt.subplot(223)
+plt.subplot(2, 2, 3)
 plt.plot([1, 2, 3], label="test1")
 plt.plot([3, 2, 1], label="test2")
 # Place a legend to the right of this smaller subplot.

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -104,9 +104,9 @@ plt.tight_layout(pad=0.4, w_pad=0.5, h_pad=1.0)
 plt.close('all')
 fig = plt.figure()
 
-ax1 = plt.subplot(221)
-ax2 = plt.subplot(223)
-ax3 = plt.subplot(122)
+ax1 = plt.subplot(2, 2, 1)
+ax2 = plt.subplot(2, 2, 3)
+ax3 = plt.subplot(1, 2, 2)
 
 example_plot(ax1)
 example_plot(ax2)
@@ -143,7 +143,7 @@ arr = np.arange(100).reshape((10, 10))
 plt.close('all')
 fig = plt.figure(figsize=(5, 4))
 
-ax = plt.subplot(111)
+ax = plt.subplot(1, 1, 1)
 im = ax.imshow(arr, interpolation="none")
 
 plt.tight_layout()

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -131,11 +131,11 @@ values = [1, 10, 100]
 
 plt.figure(figsize=(9, 3))
 
-plt.subplot(131)
+plt.subplot(1, 3, 1)
 plt.bar(names, values)
-plt.subplot(132)
+plt.subplot(1, 3, 2)
 plt.scatter(names, values)
-plt.subplot(133)
+plt.subplot(1, 3, 3)
 plt.plot(names, values)
 plt.suptitle('Categorical Plotting')
 plt.show()
@@ -250,21 +250,21 @@ t1 = np.arange(0.0, 5.0, 0.1)
 t2 = np.arange(0.0, 5.0, 0.02)
 
 plt.figure()
-plt.subplot(211)
+plt.subplot(2, 1, 1)
 plt.plot(t1, f(t1), 'bo', t2, f(t2), 'k')
 
-plt.subplot(212)
+plt.subplot(2, 1, 2)
 plt.plot(t2, np.cos(2*np.pi*t2), 'r--')
 plt.show()
 
 ###############################################################################
 # The `~.pyplot.figure` call here is optional because
-# ``figure(1)`` will be created by default, just as a ``subplot(111)``
+# ``figure(1)`` will be created by default, just as a ``subplot(1, 1, 1)``
 # will be created by default if you don't manually specify any axes.  The
 # `~.pyplot.subplot` call specifies ``numrows,
 # numcols, plot_number`` where ``plot_number`` ranges from 1 to
 # ``numrows*numcols``.  The commas in the ``subplot`` call are
-# optional if ``numrows*numcols<10``.  So ``subplot(211)`` is identical
+# optional if ``numrows*numcols<10``.  So ``subplot(2, 1, 1)`` is identical
 # to ``subplot(2, 1, 1)``.
 #
 # You can create an arbitrary number of subplots
@@ -284,17 +284,17 @@ plt.show()
 #
 #     import matplotlib.pyplot as plt
 #     plt.figure(1)                # the first figure
-#     plt.subplot(211)             # the first subplot in the first figure
+#     plt.subplot(2, 1, 1)             # the first subplot in the first figure
 #     plt.plot([1, 2, 3])
-#     plt.subplot(212)             # the second subplot in the first figure
+#     plt.subplot(2, 1, 2)             # the second subplot in the first figure
 #     plt.plot([4, 5, 6])
 #
 #
 #     plt.figure(2)                # a second figure
-#     plt.plot([4, 5, 6])          # creates a subplot(111) by default
+#     plt.plot([4, 5, 6])          # creates a subplot(1, 1, 1) by default
 #
-#     plt.figure(1)                # figure 1 current; subplot(212) still current
-#     plt.subplot(211)             # make subplot(211) in figure1 current
+#     plt.figure(1)                # figure 1 current; subplot(2, 1, 2) still current
+#     plt.subplot(2, 1, 1)             # make subplot(2, 1, 1) in figure1 current
 #     plt.title('Easy as 1, 2, 3') # subplot 211 title
 #
 # You can clear the current figure with `~.pyplot.clf`
@@ -380,7 +380,7 @@ plt.show()
 # the argument ``xy`` and the location of the text ``xytext``.  Both of
 # these arguments are ``(x, y)`` tuples.
 
-ax = plt.subplot(111)
+ax = plt.subplot(1, 1, 1)
 
 t = np.arange(0.0, 5.0, 0.01)
 s = np.cos(2*np.pi*t)
@@ -427,28 +427,28 @@ x = np.arange(len(y))
 plt.figure()
 
 # linear
-plt.subplot(221)
+plt.subplot(2, 2, 1)
 plt.plot(x, y)
 plt.yscale('linear')
 plt.title('linear')
 plt.grid(True)
 
 # log
-plt.subplot(222)
+plt.subplot(2, 2, 2)
 plt.plot(x, y)
 plt.yscale('log')
 plt.title('log')
 plt.grid(True)
 
 # symmetric log
-plt.subplot(223)
+plt.subplot(2, 2, 3)
 plt.plot(x, y - y.mean())
 plt.yscale('symlog', linthresh=0.01)
 plt.title('symlog')
 plt.grid(True)
 
 # logit
-plt.subplot(224)
+plt.subplot(2, 2, 4)
 plt.plot(x, y)
 plt.yscale('logit')
 plt.title('logit')

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -425,7 +425,7 @@ more control, it supports a few other options.
 
    This allows annotating a point in another axes::
 
-     ax1, ax2 = subplot(121), subplot(122)
+     ax1, ax2 = subplot(1, 2, 1), subplot(1, 2, 2)
      ax2.annotate("Test", xy=(0.5, 0.5), xycoords=ax1.transData,
                   xytext=(0.5, 0.5), textcoords=ax2.transData,
                   arrowprops=dict(arrowstyle="->"))

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -69,7 +69,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 fig = plt.figure()
-ax = fig.add_subplot(111)
+ax = fig.add_subplot(1, 1, 1)
 fig.subplots_adjust(top=0.85)
 
 # Set titles for the figure and the subplot respectively

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -69,7 +69,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 
 fig = plt.figure()
-ax = fig.add_subplot(1, 1, 1)
+ax = fig.add_subplot()
 fig.subplots_adjust(top=0.85)
 
 # Set titles for the figure and the subplot respectively

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -128,7 +128,7 @@ scatter_hist.py with AxesDivider
 The :doc:`/gallery/lines_bars_and_markers/scatter_hist` example can be
 rewritten using `~.axes_grid1.axes_divider.make_axes_locatable`::
 
-    axScatter = subplot(111)
+    axScatter = subplot(1, 1, 1)
     axScatter.scatter(x, y)
     axScatter.set_aspect(1.)
 

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -99,7 +99,7 @@ to create a host subplot with axisartist.Axes, ::
   import mpl_toolkits.axisartist as AA
   from mpl_toolkits.axes_grid1 import host_subplot
 
-  host = host_subplot(111, axes_class=AA.Axes)
+  host = host_subplot(1, 1, 1, axes_class=AA.Axes)
 
 Here is an example that uses ParasiteAxes.
 

--- a/tutorials/toolkits/mplot3d.py
+++ b/tutorials/toolkits/mplot3d.py
@@ -19,7 +19,7 @@ keyword argument to `.Figure.add_subplot`::
 
    import matplotlib.pyplot as plt
    fig = plt.figure()
-   ax = fig.add_subplot(111, projection='3d')
+   ax = fig.add_subplot(1, 1, 1, projection='3d')
 
 .. versionchanged:: 1.0.0
    Prior to Matplotlib 1.0.0, `.Axes3D` needed to be directly instantiated with


### PR DESCRIPTION
## PR Summary

Changes all `*subplot(123, ` to `subplot(1, 2, 3` in the docs and code base.  

Sorry, I dislike these thrashy PRs as well, but feel we should really soft-deprecate this usage...


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
