### PR TITLE
Support url on more Artists in svg

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -316,6 +316,19 @@ class Tick(martist.Artist):
         self.label2.set_text(s)
         self.stale = True
 
+    def set_url(self, url):
+        """
+        Set the url of label1 and label2.
+
+        Parameters
+        ----------
+        url : str
+        """
+        super().set_url(url)
+        self.label1.set_url(url)
+        self.label2.set_url(url)
+        self.stale = True
+
     def _set_artist_props(self, a):
         a.set_figure(self.figure)
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -761,6 +761,7 @@ class Line2D(Artist):
             if len(tpath.vertices):
                 gc = renderer.new_gc()
                 self._set_gc_clip(gc)
+                gc.set_url(self.get_url())
 
                 lc_rgba = mcolors.to_rgba(self._color, self._alpha)
                 gc.set_foreground(lc_rgba, isRGBA=True)
@@ -787,6 +788,7 @@ class Line2D(Artist):
         if self._marker and self._markersize > 0:
             gc = renderer.new_gc()
             self._set_gc_clip(gc)
+            gc.set_url(self.get_url())
             gc.set_linewidth(self._markeredgewidth)
             gc.set_antialiased(self._antialiased)
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -220,14 +220,20 @@ def test_url():
     # Test that object url appears in output svg.
 
     fig, ax = plt.subplots()
+
+    # collections
     s = ax.scatter([1, 2, 3], [4, 5, 6])
     s.set_urls(['http://example.com/foo', 'http://example.com/bar', None])
+
+    # Line2D
+    p, = plt.plot([1, 3], [6, 5])
+    p.set_url('http://example.com/baz')
 
     b = BytesIO()
     fig.savefig(b, format='svg')
     b = b.getvalue()
-    assert b'http://example.com/foo' in b
-    assert b'http://example.com/bar' in b
+    for v in [b'foo', b'bar', b'baz']:
+        assert b'http://example.com/' + v in b
 
 
 def test_url_tick():

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -214,3 +214,42 @@ def test_savefig_tight():
     # Check that the draw-disabled renderer correctly disables open/close_group
     # as well.
     plt.savefig(BytesIO(), format="svgz", bbox_inches="tight")
+
+
+def test_url():
+    # Test that object url appears in output svg.
+
+    fig, ax = plt.subplots()
+    s = ax.scatter([1, 2, 3], [4, 5, 6])
+    s.set_urls(['http://example.com/foo', 'http://example.com/bar', None])
+
+    b = BytesIO()
+    fig.savefig(b, format='svg')
+    b = b.getvalue()
+    assert b'http://example.com/foo' in b
+    assert b'http://example.com/bar' in b
+
+
+def test_url_tick():
+    fig1, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    for i, tick in enumerate(ax.yaxis.get_major_ticks()):
+        tick.set_url(f'http://example.com/{i}')
+
+    fig2, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    for i, tick in enumerate(ax.yaxis.get_major_ticks()):
+        tick.label1.set_url(f'http://example.com/{i}')
+        tick.label2.set_url(f'http://example.com/{i}')
+
+    b1 = BytesIO()
+    fig1.savefig(b1, format='svg')
+    b1 = b1.getvalue()
+
+    b2 = BytesIO()
+    fig2.savefig(b2, format='svg')
+    b2 = b2.getvalue()
+
+    for i in range(len(ax.yaxis.get_major_ticks())):
+        assert f'http://example.com/{i}'.encode('ascii') in b1
+    assert b1 == b2


### PR DESCRIPTION
## PR Summary

Add `Line2D`, ~~`QuadMesh`,~~ and `Ticks` (from #9696.)

Fixes #9695.
Fixes #17336.

Don't know if this should be documented.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [?] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [?] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way