### PR TITLE
FIX: allow start-stop subplot

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1271,7 +1271,7 @@ default: 'top'
               take the *index* position on a grid with *nrows* rows and
               *ncols* columns. *index* starts at 1 in the upper left corner
               and increases to the right. *index* can also be  a two-tuple
-              specifying the (*start*, *stop*) indices of the subplot, i.e.,
+              specifying the (*start*, *stop*) indices of the subplot, e.g.,
               ``fig.add_subplot(3, 1, (1, 2))`` makes a subplot that spans the
               upper 2/3 of the figure.
             - A 3-digit integer. The digits are interpreted as if given
@@ -1365,44 +1365,7 @@ default: 'top'
             raise TypeError(
                 "add_subplot() got an unexpected keyword argument 'figure'")
 
-        nargs = len(args)
-        if nargs == 0:
-            args = (1, 1, 1)
-        elif nargs == 1:
-            if isinstance(args[0], Integral):
-                if not 100 <= args[0] <= 999:
-                    raise ValueError(f"Integer subplot specification must be "
-                                     f"a three-digit number, not {args[0]}")
-                args = tuple(map(int, str(args[0])))
-            elif isinstance(args[0], (SubplotBase, SubplotSpec)):
-                pass  # no further validation or normalization needed
-            else:
-                raise TypeError('Positional arguments are not a valid '
-                                'position specification.')
-        elif nargs == 3:
-            newarg = [None] * 3
-            message = ("Passing non-integers as three-element "
-                       "position specification is deprecated since "
-                       "%(since)s and will be removed %(removal)s.")
-            for nn, arg in enumerate(args[:2]):
-                if not isinstance(arg, Integral):
-                    cbook.warn_deprecated("3.3", message=message)
-                newarg[nn] = int(arg)
-            args2 = args[2]
-            if isinstance(args2, tuple) and len(args2) == 2:
-                # start/stop two-tuple is allowed...
-                for arg in args2:
-                    if not isinstance(arg, Integral):
-                        cbook.warn_deprecated("3.3", message=message)
-                newarg[2] = (int(args2[0]), int(args2[1]))
-            else:
-                if not isinstance(args2, Integral):
-                    cbook.warn_deprecated("3.3", message=message)
-                newarg[2] = int(args2)
-            args = tuple(newarg)
-        else:
-            raise TypeError(f'add_subplot() takes 1 or 3 positional arguments '
-                            f'but {nargs} were given')
+        args = SubplotSpec._check_subplots_args(args)
 
         if isinstance(args[0], SubplotBase):
             ax = args[0]

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1264,13 +1264,16 @@ default: 'top'
 
         Parameters
         ----------
-        *args, int or (int, int, int) or `SubplotSpec`, default: (1, 1, 1)
+        *args, int, (int, int, *index*), or `SubplotSpec`, default: (1, 1, 1)
             The position of the subplot described by one of
 
             - Three integers (*nrows*, *ncols*, *index*). The subplot will
               take the *index* position on a grid with *nrows* rows and
               *ncols* columns. *index* starts at 1 in the upper left corner
-              and increases to the right.
+              and increases to the right. *index* can also be  a two-tuple
+              specifying the (*start*, *stop*) indices of the subplot, i.e.,
+              ``fig.add_subplot(3, 1, (1, 2))`` makes a subplot that spans the
+              upper 2/3 of the figure.
             - A 3-digit integer. The digits are interpreted as if given
               separately as three single-digit integers, i.e.
               ``fig.add_subplot(235)`` is the same as
@@ -1377,14 +1380,26 @@ default: 'top'
                 raise TypeError('Positional arguments are not a valid '
                                 'position specification.')
         elif nargs == 3:
-            for arg in args:
+            newarg = [None] * 3
+            message = ("Passing non-integers as three-element "
+                       "position specification is deprecated since "
+                       "%(since)s and will be removed %(removal)s.")
+            for nn, arg in enumerate(args[:2]):
                 if not isinstance(arg, Integral):
-                    cbook.warn_deprecated(
-                        "3.3",
-                        message="Passing non-integers as three-element "
-                                "position specification is deprecated since "
-                                "%(since)s and will be removed %(removal)s.")
-            args = tuple(map(int, args))
+                    cbook.warn_deprecated("3.3", message=message)
+                newarg[nn] = int(arg)
+            args2 = args[2]
+            if isinstance(args2, tuple) and len(args2) == 2:
+                # start/stop two-tuple is allowed...
+                for arg in args2:
+                    if not isinstance(arg, Integral):
+                        cbook.warn_deprecated("3.3", message=message)
+                newarg[2] = (int(args2[0]), int(args2[1]))
+            else:
+                if not isinstance(args2, Integral):
+                    cbook.warn_deprecated("3.3", message=message)
+                newarg[2] = int(args2)
+            args = tuple(newarg)
         else:
             raise TypeError(f'add_subplot() takes 1 or 3 positional arguments '
                             f'but {nargs} were given')

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -533,3 +533,16 @@ def test_removed_axis():
     fig, axs = plt.subplots(2, sharex=True)
     axs[0].remove()
     fig.canvas.draw()
+
+
+def test_add_subplot_twotuple():
+    fig = plt.figure()
+    ax2 = fig.add_subplot(3, 2, (3, 5))
+    assert ax2.get_subplotspec().rowspan == range(1, 3)
+    assert ax2.get_subplotspec().colspan == range(0, 1)
+    ax3 = fig.add_subplot(3, 2, (4, 6))
+    assert ax3.get_subplotspec().rowspan == range(1, 3)
+    assert ax3.get_subplotspec().colspan == range(1, 2)
+    ax4 = fig.add_subplot(3, 2, (3, 6))
+    assert ax4.get_subplotspec().rowspan == range(1, 3)
+    assert ax4.get_subplotspec().colspan == range(0, 2)


### PR DESCRIPTION
## PR Summary


Closes #17343

`add_subplot` is meant to accept spans for the third parameter, but this was broken by #16527 which was doing more careful argument checking.   Happy to take criticism on how I did this, but I think it works...

```python 
import matplotlib.pyplot as plt

fig = plt.figure()

ax = fig.add_subplot(3, 4, 1)
ax2 = fig.add_subplot(3, 2, (3, 5))
plt.show()
```


![Figure_1](https://user-images.githubusercontent.com/1562854/81231838-b3150b80-8fa8-11ea-9ae0-8fc235c7aa9a.png)

TODO:

- [x] Add tests so this doesn't break again
- [ ] Add examples?
- [x] Fix the docstring to make this clear



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
