### PR TITLE
Make zooming work in qt-embedding example.

### DIFF
--- a/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -45,19 +45,18 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self._static_ax.plot(t, np.tan(t), ".")
 
         self._dynamic_ax = dynamic_canvas.figure.subplots()
+        t = np.linspace(0, 10, 101)
+        # Set up a Line2D.
+        self._line, = self._dynamic_ax.plot(t, np.sin(t + time.time()))
         self._timer = dynamic_canvas.new_timer(50)
         self._timer.add_callback(self._update_canvas)
         self._timer.start()
 
     def _update_canvas(self):
-        self._dynamic_ax.clear()
         t = np.linspace(0, 10, 101)
-        # Use fixed vertical limits to prevent autoscaling changing the scale
-        # of the axis.
-        self._dynamic_ax.set_ylim(-1.1, 1.1)
         # Shift the sinusoid as a function of time.
-        self._dynamic_ax.plot(t, np.sin(t + time.time()))
-        self._dynamic_ax.figure.canvas.draw()
+        self._line.set_data(t, np.sin(t + time.time()))
+        self._line.figure.canvas.draw()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Calling set_ylim everytime in _update_canvas breaks interactive zoom.

Closes https://github.com/matplotlib/matplotlib/issues/17352 (see description there).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
