### PR TITLE
Change subprocess for inkscape version detection

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -330,7 +330,8 @@ def _get_executable_info(name):
         message = "Failed to find a Ghostscript installation"
         raise ExecutableNotFoundError(message)
     elif name == "inkscape":
-        info = impl(["inkscape", "-V"], "^Inkscape ([^ ]*)")
+        # use "no-gui" option for inkscape version detection:
+        info = impl(["inkscape", "-z", "-V"], "^Inkscape ([^ ]*)")
         if info and info.version >= "1.0":
             raise ExecutableNotFoundError(
                 f"You have Inkscape version {info.version} but Matplotlib "

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -334,7 +334,7 @@ def _get_executable_info(name):
             # use headless option first (works with inkscape version < 1.0):
             info = impl(["inkscape", "--without-gui", "-V"],
                         "Inkscape ([^ ]*)")
-        except ExecutableNotFoundError as _e:
+        except ExecutableNotFoundError:
             # if --without-gui is not accepted, we're using Inkscape v > 1.0
             # so try without the headless option:
             info = impl(["inkscape", "-V"], "Inkscape ([^ ]*)")

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -332,7 +332,7 @@ def _get_executable_info(name):
     elif name == "inkscape":
         try:
             # use headless option first (works with inkscape version < 1.0):
-            info = impl(["inkscape", "--without-gui", "-V"], 
+            info = impl(["inkscape", "--without-gui", "-V"],
                         "Inkscape ([^ ]*)")
         except ExecutableNotFoundError as _e:
             # if --without-gui is not accepted, we're using Inkscape v > 1.0

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -331,10 +331,12 @@ def _get_executable_info(name):
         raise ExecutableNotFoundError(message)
     elif name == "inkscape":
         try:
-            # use "without-gui" option (only works with inkscape version < 1.0):
-            info = impl(["inkscape", "--without-gui", "-V"], "Inkscape ([^ ]*)")
-        except subprocess.CalledProcessError as _cpe:
-            # for inkscape v > 1.0, --without-gui is not needed:
+            # use headless option first (works with inkscape version < 1.0):
+            info = impl(["inkscape", "--without-gui", "-V"], 
+                        "Inkscape ([^ ]*)")
+        except ExecutableNotFoundError as _e:
+            # if --without-gui is not accepted, we're using Inkscape v > 1.0
+            # so try without the headless option:
             info = impl(["inkscape", "-V"], "Inkscape ([^ ]*)")
         if info and info.version >= "1.0":
             raise ExecutableNotFoundError(

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -330,8 +330,12 @@ def _get_executable_info(name):
         message = "Failed to find a Ghostscript installation"
         raise ExecutableNotFoundError(message)
     elif name == "inkscape":
-        # use "no-gui" option for inkscape version detection:
-        info = impl(["inkscape", "-z", "-V"], "^Inkscape ([^ ]*)")
+        try:
+            # use "without-gui" option (only works with inkscape version < 1.0):
+            info = impl(["inkscape", "--without-gui", "-V"], "Inkscape ([^ ]*)")
+        except subprocess.CalledProcessError as _cpe:
+            # for inkscape v > 1.0, --without-gui is not needed:
+            info = impl(["inkscape", "-V"], "Inkscape ([^ ]*)")
         if info and info.version >= "1.0":
             raise ExecutableNotFoundError(
                 f"You have Inkscape version {info.version} but Matplotlib "


### PR DESCRIPTION
Use the `--without-gui` (`-z`) for inkscape to prevent depending on an X server for version detection

## PR Summary

A very small change to how inkscape version detection is implemented in order to prevent depending on access to the interactive X session (on Linux, at least)

Resolves #17354 

(Apologies if this is not the best solution to this issue since I don't really know the internals of `matplotlib` very well)