### PR TITLE
Fix masked CubicTriInterpolator

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -935,6 +935,24 @@ def test_trirefine():
     assert_array_almost_equal(xyz_data[0], xyz_data[1])
 
 
+@pytest.mark.parametrize('interpolator',
+                         [mtri.LinearTriInterpolator,
+                          mtri.CubicTriInterpolator],
+                         ids=['linear', 'cubic'])
+def test_trirefine_masked(interpolator):
+    # Repeated points means we will have fewer triangles than points, and thus
+    # get masking.
+    x, y = np.mgrid[:2, :2]
+    x = np.repeat(x.flatten(), 2)
+    y = np.repeat(y.flatten(), 2)
+
+    z = np.zeros_like(x)
+    tri = mtri.Triangulation(x, y)
+    refiner = mtri.UniformTriRefiner(tri)
+    interp = interpolator(tri, z)
+    refiner.refine_field(z, triinterpolator=interp, subdiv=2)
+
+
 def meshgrid_triangles(n):
     """
     Return (2*(N-1)**2, 3) array of triangles to mesh (N, N)-point np.meshgrid.

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -400,9 +400,8 @@ class CubicTriInterpolator(TriInterpolator):
         self._triangles = compressed_triangles
         self._tri_renum = tri_renum
         # Taking into account the node renumbering in self._z:
-        node_mask = (node_renum == -1)
-        self._z = self._z[~node_mask]
-        self._z[node_renum[~node_mask]] = self._z
+        valid_node = (node_renum != -1)
+        self._z[node_renum[valid_node]] = self._z[valid_node]
 
         # Computing scale factors
         self._unit_x = np.ptp(compressed_x)

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -401,8 +401,8 @@ class CubicTriInterpolator(TriInterpolator):
         self._tri_renum = tri_renum
         # Taking into account the node renumbering in self._z:
         node_mask = (node_renum == -1)
-        self._z[node_renum[~node_mask]] = self._z
         self._z = self._z[~node_mask]
+        self._z[node_renum[~node_mask]] = self._z
 
         # Computing scale factors
         self._unit_x = np.ptp(compressed_x)


### PR DESCRIPTION
## PR Summary

This is a rebase of #12807, with a simplification of the test, and the suggested simplification to masking, plus a few other cases of the same.

Fixes #11820 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way