### PR TITLE
Fix running test_internal_cpp_api directly.

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1031,6 +1031,7 @@ def test_tricontourf_decreasing_levels():
 
 def test_internal_cpp_api():
     # Following github issue 8197.
+    from matplotlib import _tri  # noqa: ensure lazy-loaded module *is* loaded.
 
     # C++ Triangulation.
     with pytest.raises(


### PR DESCRIPTION
## PR Summary

The `matplotlib._tri` module is lazily loaded, so using it directly (as done in this test) may fail if something else doesn't load it. This test would fail if it was the first tri-related test run in a process (if
testing in parallel), or if just called as the only test, i.e., this commit fixes:
```
$ pytest -k test_internal_cpp_api lib/matplotlib/tests/test_triangulation.py
__________ test_internal_cpp_api __________

    def test_internal_cpp_api():
        # Following github issue 8197.

        # C++ Triangulation.
        with pytest.raises(
                TypeError,
                match=r'function takes exactly 7 arguments \(0 given\)'):
>           mpl._tri.Triangulation()
E           AttributeError: module 'matplotlib' has no attribute '_tri'

lib/matplotlib/tests/test_triangulation.py:1039: AttributeError
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way