### PR TITLE
Remove randomness from test_colorbar_get_ticks_2.

### DIFF
--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -534,13 +534,11 @@ def test_colorbar_scale_reset():
 
 
 def test_colorbar_get_ticks_2():
-    with rc_context({'_internal.classic_mode': False}):
-
-        fig, ax = plt.subplots()
-        np.random.seed(19680801)
-        pc = ax.pcolormesh(np.random.rand(30, 30))
-        cb = fig.colorbar(pc)
-        np.testing.assert_allclose(cb.get_ticks(), [0.2, 0.4, 0.6, 0.8])
+    plt.rcParams['_internal.classic_mode'] = False
+    fig, ax = plt.subplots()
+    pc = ax.pcolormesh([[.05, .95]])
+    cb = fig.colorbar(pc)
+    np.testing.assert_allclose(cb.get_ticks(), [0.2, 0.4, 0.6, 0.8])
 
 
 def test_colorbar_inverted_ticks():


### PR DESCRIPTION
The point of the test is to check that colorbar ticks have certain
values when the scalarmappable's lower and upper lims are a bit more
than 0 and a bit less than 1, respectively.  Certainly sampling 30x30
random values will nearly always accomplish this, but we may as well
just enforce the values.

Extracted from https://github.com/matplotlib/matplotlib/pull/16438.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
