### PR TITLE
BUGFIX: scatter should draw ',' as a single pixel

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4471,6 +4471,8 @@ default: :rc:`scatter.edgecolors`
             linewidths = rcParams['lines.linewidth']
 
         offsets = np.ma.column_stack([x, y])
+        # "pixel" markers should be drawn at their "true" size
+        ignore_scale = marker_obj.get_marker() == ','
 
         collection = mcoll.PathCollection(
                 (path,), scales,
@@ -4479,7 +4481,8 @@ default: :rc:`scatter.edgecolors`
                 linewidths=linewidths,
                 offsets=offsets,
                 transOffset=kwargs.pop('transform', self.transData),
-                alpha=alpha
+                alpha=alpha,
+                ignore_scale=ignore_scale
                 )
         collection.set_transform(mtransforms.IdentityTransform())
         collection.update(kwargs)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -845,6 +845,10 @@ class _CollectionWithSizes(Collection):
     """
     _factor = 1.0
 
+    def __init__(self, ignore_scale=False, **kwargs):
+        super().__init__(**kwargs)
+        self._ignore_scale = ignore_scale
+
     def get_sizes(self):
         """
         Return the sizes ('areas') of the elements in the collection.
@@ -874,7 +878,10 @@ class _CollectionWithSizes(Collection):
         else:
             self._sizes = np.asarray(sizes)
             self._transforms = np.zeros((len(self._sizes), 3, 3))
-            scale = np.sqrt(self._sizes) * dpi / 72.0 * self._factor
+            if self._ignore_scale:
+                scale = 1
+            else:
+                scale = np.sqrt(self._sizes) * dpi / 72.0 * self._factor
             self._transforms[:, 0, 0] = scale
             self._transforms[:, 1, 1] = scale
             self._transforms[:, 2, 2] = 1.0
@@ -899,7 +906,7 @@ class PathCollection(_CollectionWithSizes):
         %(Collection)s
         """
 
-        Collection.__init__(self, **kwargs)
+        super().__init__(**kwargs)
         self.set_paths(paths)
         self.set_sizes(sizes)
         self.stale = True


### PR DESCRIPTION
## PR Summary

Attempt to fix #11460. 

Instead of adding a special case to `PathCollection`, which (IMO, and I am happy to be told I'm wrong about this) has no business knowing that the path its drawing came from a MarkerStyle at all, let alone that it came from the weird, special-case marker `','`, I added a kwarg to `_CollectionWithSizes` that allows one to specify that the self-same sizes should actually just be ignored. With this in place, `Axes.scatter` (which *does* know that we are using `MarkerStyle`) can pass the appropriate `Path` to `PathCollection` (of width one) and ask the PathCollection to ignore the scaling information, which is what that particular marker is *supposed* to do, I think. 

WIP because I can't seem to figure out one last little issue, where what appear to be identical inputs are being sent to Agg's `draw_marker` and producing two different results (off-by-one pixel).

**Test Cases**

```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.plot(0, 0, marker=',')
plt.savefig('plot_single_pixel.png')
fig, ax = plt.subplots()
ax.scatter(0, 0, marker=',', linewidths=0, edgecolors='none')
plt.savefig('scatter_single_pixel.png')
```

**Output**

(Screenshots from GIMP to make it more clear exactly what the error is)

`plot` case (correctly one pixel):
![pixel-zoom](https://user-images.githubusercontent.com/1475390/81441117-08c2f280-9126-11ea-9b7b-aade688b64d8.png)

`scatter` case currently in master (many pixels...):
![unfix-scatter-zoom](https://user-images.githubusercontent.com/1475390/81441148-19736880-9126-11ea-8ff6-1551edb7f100.png)

`scatter` case in current PR (almost correct):
![fix-scatter-zoom](https://user-images.githubusercontent.com/1475390/81441696-162cac80-9127-11ea-9fe4-b9be2e15a530.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
