### PR TITLE
CI: Add eslint for JS linting

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,11 +18,15 @@ jobs:
 
       - name: Set up reviewdog
         run: |
-          mkdir -p $HOME/bin && curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh| sh -s -- -b $HOME/bin
+          mkdir -p $HOME/bin
+          curl -sfL \
+            https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
+              sh -s -- -b $HOME/bin
           echo ::add-path::$HOME/bin
 
       - name: Run flake8
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          flake8 --docstring-convention=all | reviewdog -f=pep8 -name=flake8 -reporter=github-check
+          flake8 --docstring-convention=all | \
+            reviewdog -f=pep8 -name=flake8 -reporter=github-check

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,3 +30,16 @@ jobs:
         run: |
           flake8 --docstring-convention=all | \
             reviewdog -f=pep8 -name=flake8 -reporter=github-check
+
+  eslint:
+    name: eslint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: eslint
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-check
+          workdir: 'lib/matplotlib/backends/web_backend/'

--- a/lib/matplotlib/backends/web_backend/.eslintrc.js
+++ b/lib/matplotlib/backends/web_backend/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     MozWebSocket: "readonly",
   },
   rules: {
+    indent: ["error", 2, { SwitchCase: 1 }],
     "no-unused-vars": [
       "error",
       {
@@ -18,4 +19,12 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: "js/**/*.js",
+      rules: {
+        indent: ["error", 4, { SwitchCase: 1 }],
+      },
+    },
+  ],
 };

--- a/lib/matplotlib/backends/web_backend/.eslintrc.js
+++ b/lib/matplotlib/backends/web_backend/.eslintrc.js
@@ -18,12 +18,14 @@ module.exports = {
         argsIgnorePattern: "^_",
       },
     ],
+    quotes: ["error", "double", { avoidEscape: true }],
   },
   overrides: [
     {
       files: "js/**/*.js",
       rules: {
         indent: ["error", 4, { SwitchCase: 1 }],
+        quotes: ["error", "single", { avoidEscape: true }],
       },
     },
   ],


### PR DESCRIPTION
The latest release of reviewdog now supports running checks in a subdirectory, so we can now check eslint, which is run in the web backend subdirectory.

Also add a couple rules to eslint so it matches prettier, without having to run prettier (since there's no reviewdog action for it), and lint the YAML a bit (mostly word-wrap at 80).