### PR TITLE
add context manager functionality to ion and ioff

### DIFF
--- a/doc/api/next_api_changes/behavior/17371-IHI.rst
+++ b/doc/api/next_api_changes/behavior/17371-IHI.rst
@@ -1,7 +1,7 @@
 ioff and ion can be used as context managers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``plt.ion()`` and ``plt.ioff()`` may now be used as context managers to create
+`plt.ion()` and `plt.ioff()` may now be used as context managers to create
 a context with interactive mode on, or off respectively. The old behavior of
-calling these functions was maintained. To use the new functionality
+calling these functions is maintained. To use the new functionality
 call as ``with plt.ioff():``

--- a/doc/api/next_api_changes/behavior/17371-IHI.rst
+++ b/doc/api/next_api_changes/behavior/17371-IHI.rst
@@ -2,6 +2,6 @@ ioff and ion can be used as context managers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``plt.ion()`` and ``plt.ioff()`` may now be used as context managers to create
-a context with interactive mode off, or on respectively. The old behavior of
+a context with interactive mode on, or off respectively. The old behavior of
 calling these functions was maintained. To use the new functionality
 call as ``with plt.ioff():``

--- a/doc/api/next_api_changes/behavior/17371-IHI.rst
+++ b/doc/api/next_api_changes/behavior/17371-IHI.rst
@@ -1,7 +1,7 @@
 ioff and ion can be used as context managers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`plt.ion()` and `plt.ioff()` may now be used as context managers to create
+`.pyplot.ion` and `.pyplot.ioff` may now be used as context managers to create
 a context with interactive mode on, or off respectively. The old behavior of
 calling these functions is maintained. To use the new functionality
 call as ``with plt.ioff():``

--- a/doc/api/next_api_changes/behavior/17371-IHI.rst
+++ b/doc/api/next_api_changes/behavior/17371-IHI.rst
@@ -1,0 +1,7 @@
+ioff and ion can be used as context managers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``plt.ion()`` and ``plt.ioff()`` may now be used as context managers to create
+a context with interactive mode off, or on respectively. The old behavior of
+calling these functions was maintained. To use the new functionality
+call as ``with plt.ioff():``

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -365,6 +365,14 @@ def isinteractive():
 
 
 class _ioff:
+    """
+    Context manager for `.ioff`.
+
+    The state is changed in ``__init__()`` instead of ``__enter__()``. The
+    latter is a no-op. This allows using `.ioff` both as a function and
+    as a context.
+    """
+
     def __init__(self):
         self.wasinteractive = isinteractive()
         matplotlib.interactive(False)
@@ -380,6 +388,14 @@ class _ioff:
 
 
 class _ion:
+    """
+    Context manager for `.ion`.
+
+    The state is changed in ``__init__()`` instead of ``__enter__()``. The
+    latter is a no-op. This allows using `.ion` both as a function and
+    as a context.
+    """
+
     def __init__(self):
         self.wasinteractive = isinteractive()
         matplotlib.interactive(True)
@@ -392,7 +408,6 @@ class _ion:
         if not self.wasinteractive:
             matplotlib.interactive(False)
             uninstall_repl_displayhook()
-        self._used
 
 
 def ioff():
@@ -409,8 +424,7 @@ def ioff():
 
     Notes
     -----
-    If you want the effects of this function to be temporary, it can
-    be used as a context manager, for example::
+    For a temporary change, this can be used as a context manager::
 
         with plt.ioff():
             # interactive mode will be off
@@ -420,6 +434,10 @@ def ioff():
 
         # This figure will be shown immediately
         fig2 = plt.figure()
+
+    The return value of `plt.ioff` is necessary to make the function work
+    as a context manager. It is not intended to be stored or accessed
+    by the user.
     """
     return _ioff()
 
@@ -438,8 +456,7 @@ def ion():
 
     Notes
     -----
-    If you want the effects of this function to be temporary, it can
-    be used as a context manager, for example::
+    For a temporary change, this can be used as a context manager::
 
         # if interactive mode is off
         # then figures will not be shown on creation
@@ -452,6 +469,10 @@ def ion():
             # figures will automatically be shown
             fig1 = plt.figure()
             # ...
+
+    The return value of `plt.ion` is necessary to make the function work
+    as a context manager. It is not intended to be stored or accessed
+    by the user.
     """
     return _ion()
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -385,6 +385,9 @@ class _IoffContext:
         if self.wasinteractive:
             matplotlib.interactive(True)
             install_repl_displayhook()
+        else:
+            matplotlib.interactive(False)
+            uninstall_repl_displayhook()
 
 
 class _IonContext:
@@ -408,6 +411,9 @@ class _IonContext:
         if not self.wasinteractive:
             matplotlib.interactive(False)
             uninstall_repl_displayhook()
+        else:
+            matplotlib.interactive(True)
+            install_repl_displayhook()
 
 
 def ioff():

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -364,36 +364,35 @@ def isinteractive():
     return matplotlib.is_interactive()
 
 
-class _ioff():
-    def __call__(self):
+class _ioff:
+    def __init__(self):
+        self.wasinteractive = isinteractive()
         matplotlib.interactive(False)
         uninstall_repl_displayhook()
 
     def __enter__(self):
-        self.wasinteractive = isinteractive()
-        self.__call__()
+        pass
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.wasinteractive:
             matplotlib.interactive(True)
             install_repl_displayhook()
-        del self.wasinteractive
 
 
-class _ion():
-    def __call__(self):
+class _ion:
+    def __init__(self):
+        self.wasinteractive = isinteractive()
         matplotlib.interactive(True)
         install_repl_displayhook()
 
     def __enter__(self):
-        self.wasinteractive = isinteractive()
-        self.__call__()
+        pass
 
     def __exit__(self, exc_type, exc_value, traceback):
         if not self.wasinteractive:
             matplotlib.interactive(False)
             uninstall_repl_displayhook()
-        del self.wasinteractive
+        self._used
 
 
 def ioff():

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -364,9 +364,41 @@ def isinteractive():
     return matplotlib.is_interactive()
 
 
+class _ioff():
+    def __call__(self):
+        matplotlib.interactive(False)
+        uninstall_repl_displayhook()
+
+    def __enter__(self):
+        self.wasinteractive = isinteractive()
+        self.__call__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.wasinteractive:
+            matplotlib.interactive(True)
+            install_repl_displayhook()
+        del self.wasinteractive
+
+
+class _ion():
+    def __call__(self):
+        matplotlib.interactive(True)
+        install_repl_displayhook()
+
+    def __enter__(self):
+        self.wasinteractive = isinteractive()
+        self.__call__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.wasinteractive:
+            matplotlib.interactive(False)
+            uninstall_repl_displayhook()
+        del self.wasinteractive
+
+
 def ioff():
     """
-    Turn the interactive mode off.
+    Turn interactive mode off.
 
     See Also
     --------
@@ -375,25 +407,54 @@ def ioff():
 
     show : show windows (and maybe block)
     pause : show windows, run GUI event loop, and block for a time
+
+    Notes
+    -----
+    If you want the effects of this function to be temporary, it can
+    be used as a context manager, for example::
+
+        with plt.ioff():
+            # interactive mode will be off
+            # figures will not automatically be shown
+            fig1 = plt.figure()
+            # ...
+
+        # This figure will be shown immediately
+        fig2 = plt.figure()
     """
-    matplotlib.interactive(False)
-    uninstall_repl_displayhook()
+    return _ioff()
 
 
 def ion():
     """
-    Turn the interactive mode on.
+    Turn interactive mode on.
 
     See Also
     --------
-    ioff : disable interactive mode
+    ion : enable interactive mode
     isinteractive : query current state
 
     show : show windows (and maybe block)
     pause : show windows, run GUI event loop, and block for a time
+
+    Notes
+    -----
+    If you want the effects of this function to be temporary, it can
+    be used as a context manager, for example::
+
+        # if interactive mode is off
+        # then figures will not be shown on creation
+        plt.ioff()
+        # This figure will not be shown immediately
+        fig2 = plt.figure()
+
+        with plt.ion():
+            # interactive mode will be on
+            # figures will automatically be shown
+            fig1 = plt.figure()
+            # ...
     """
-    matplotlib.interactive(True)
-    install_repl_displayhook()
+    return _ion()
 
 
 def pause(interval):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -364,7 +364,7 @@ def isinteractive():
     return matplotlib.is_interactive()
 
 
-class _ioff:
+class _IoffContext:
     """
     Context manager for `.ioff`.
 
@@ -387,7 +387,7 @@ class _ioff:
             install_repl_displayhook()
 
 
-class _ion:
+class _IonContext:
     """
     Context manager for `.ion`.
 
@@ -426,20 +426,23 @@ def ioff():
     -----
     For a temporary change, this can be used as a context manager::
 
+        # if interactive mode is on
+        # then figures will be shown on creation
+        plt.ion()
+        # This figure will be shown immediately
+        fig = plt.figure()
+
         with plt.ioff():
             # interactive mode will be off
             # figures will not automatically be shown
-            fig1 = plt.figure()
+            fig2 = plt.figure()
             # ...
 
-        # This figure will be shown immediately
-        fig2 = plt.figure()
-
-    The return value of `plt.ioff` is necessary to make the function work
-    as a context manager. It is not intended to be stored or accessed
-    by the user.
+    To enable usage as a context manager, this function returns an
+    ``_IoffContext`` object. The return value is not intended to be stored
+    or accessed by the user.
     """
-    return _ioff()
+    return _IoffContext()
 
 
 def ion():
@@ -448,7 +451,7 @@ def ion():
 
     See Also
     --------
-    ion : enable interactive mode
+    ioff : disable interactive mode
     isinteractive : query current state
 
     show : show windows (and maybe block)
@@ -462,19 +465,19 @@ def ion():
         # then figures will not be shown on creation
         plt.ioff()
         # This figure will not be shown immediately
-        fig2 = plt.figure()
+        fig = plt.figure()
 
         with plt.ion():
             # interactive mode will be on
             # figures will automatically be shown
-            fig1 = plt.figure()
+            fig2 = plt.figure()
             # ...
 
-    The return value of `plt.ion` is necessary to make the function work
-    as a context manager. It is not intended to be stored or accessed
-    by the user.
+    To enable usage as a context manager, this function returns an
+    ``_IonContext`` object. The return value is not intended to be stored
+    or accessed by the user.
     """
-    return _ion()
+    return _IonContext()
 
 
 def pause(interval):

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -83,25 +83,29 @@ def test_nrows_error():
         plt.subplot(ncols=1)
 
 
-def test_ioff_context():
-    mpl.interactive(True)
+def test_ioff():
+    plt.ion()
+    assert mpl.is_interactive()
     with plt.ioff():
         assert not mpl.is_interactive()
     assert mpl.is_interactive()
 
-    mpl.interactive(False)
+    plt.ioff()
+    assert not mpl.is_interactive()
     with plt.ioff():
         assert not mpl.is_interactive()
     assert not mpl.is_interactive()
 
 
-def test_ion_context():
-    mpl.interactive(False)
+def test_ion():
+    plt.ioff()
+    assert not mpl.is_interactive()
     with plt.ion():
         assert mpl.is_interactive()
     assert not mpl.is_interactive()
 
-    mpl.interactive(True)
+    plt.ion()
+    assert mpl.is_interactive()
     with plt.ion():
         assert mpl.is_interactive()
     assert mpl.is_interactive()

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -109,3 +109,23 @@ def test_ion():
     with plt.ion():
         assert mpl.is_interactive()
     assert mpl.is_interactive()
+
+def test_nested_ion_ioff():
+    plt.ion()
+    with plt.ioff():
+        assert not mpl.is_interactive()
+        with plt.ion():
+            assert mpl.is_interactive()
+        assert not mpl.is_interactive()
+    assert mpl.is_interactive()
+
+    with plt.ioff():
+        with plt.ioff():
+            assert not mpl.is_interactive()
+    assert mpl.is_interactive()
+
+    plt.ioff()
+    with plt.ion():
+        with plt.ion():
+            assert mpl.is_interactive()
+    assert not mpl.is_interactive()

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -86,22 +86,22 @@ def test_nrows_error():
 def test_ioff_context():
     mpl.interactive(True)
     with plt.ioff():
-        assert not mpl.is_interactive
-    assert mpl.is_interactive
+        assert not mpl.is_interactive()
+    assert mpl.is_interactive()
 
     mpl.interactive(False)
     with plt.ioff():
-        assert not mpl.is_interactive
-    assert not mpl.is_interactive
+        assert not mpl.is_interactive()
+    assert not mpl.is_interactive()
 
 
 def test_ion_context():
     mpl.interactive(False)
-    with plt.ioff():
-        assert mpl.is_interactive
-    assert not mpl.is_interactive
+    with plt.ion():
+        assert mpl.is_interactive()
+    assert not mpl.is_interactive()
 
     mpl.interactive(True)
     with plt.ion():
-        assert not mpl.is_interactive
-    assert mpl.is_interactive
+        assert mpl.is_interactive()
+    assert mpl.is_interactive()

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -81,3 +81,27 @@ def test_nrows_error():
         plt.subplot(nrows=1)
     with pytest.raises(TypeError):
         plt.subplot(ncols=1)
+
+
+def test_ioff_context():
+    mpl.interactive(True)
+    with plt.ioff():
+        assert not mpl.is_interactive
+    assert mpl.is_interactive
+
+    mpl.interactive(False)
+    with plt.ioff():
+        assert not mpl.is_interactive
+    assert not mpl.is_interactive
+
+
+def test_ion_context():
+    mpl.interactive(False)
+    with plt.ioff():
+        assert mpl.is_interactive
+    assert not mpl.is_interactive
+
+    mpl.interactive(True)
+    with plt.ion():
+        assert not mpl.is_interactive
+    assert mpl.is_interactive

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -110,8 +110,12 @@ def test_ion():
         assert mpl.is_interactive()
     assert mpl.is_interactive()
 
+
 def test_nested_ion_ioff():
+    # initial state is interactive
     plt.ion()
+
+    # mixed ioff/ion
     with plt.ioff():
         assert not mpl.is_interactive()
         with plt.ion():
@@ -119,13 +123,33 @@ def test_nested_ion_ioff():
         assert not mpl.is_interactive()
     assert mpl.is_interactive()
 
+    # redundant contexts
     with plt.ioff():
         with plt.ioff():
             assert not mpl.is_interactive()
     assert mpl.is_interactive()
 
+    with plt.ion():
+        plt.ioff()
+    assert mpl.is_interactive()
+
+    # initial state is not interactive
     plt.ioff()
+
+    # mixed ioff/ion
+    with plt.ion():
+        assert mpl.is_interactive()
+        with plt.ioff():
+            assert not mpl.is_interactive()
+        assert mpl.is_interactive()
+    assert not mpl.is_interactive()
+
+    # redunant contexts
     with plt.ion():
         with plt.ion():
             assert mpl.is_interactive()
+    assert not mpl.is_interactive()
+
+    with plt.ioff():
+        plt.ion()
     assert not mpl.is_interactive()


### PR DESCRIPTION
## PR Summary
Closes: https://github.com/matplotlib/matplotlib/issues/17013
Also closes: https://github.com/matplotlib/ipympl/issues/220

This allows the usage of `plt.ioff` and `plt.ion` as context managers:
```python
plt.ion()
with plt.ioff():
    # now interactive mode is off
    fig = plt.figure()
    ax = fig.gca()
```
```python
plt.ioff()
with plt.ion():
    # now interactive mode is on
    fig = plt.figure()
    ax = fig.gca()
```
It also caches the state and returns to the original state on exit:
```python
plt.ion()
with plt.ioff():
    # now interactive mode is off
    fig = plt.figure()
    ax = fig.gca()
assert plt.isinteractive
```
## Documentation - WIP -  advice welcome
I think that this additional behavior ought to be documented but I was a bit unsure how to go about it. In general things in the documentation seem divided into being functions or objects, and this PR puts `ion` and `ioff` somewhere between. So I think it makes sense to keep these on this page: https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.html?highlight=pyplot#module-matplotlib.pyplot. But, then they would be mislabelled as Functions, and I'm not sure that they will end up there anyway as that page is autogenerated. I also wasn't sure which docstring to put information about the context manager usage in, I think the most sensible place is in the `__call__` method, but this isn't strictly what is used as the context manager.

The documentation needs be updated at these links:  
https://matplotlib.org/3.2.1/users/shell.html#controlling-interactive-updating  
https://matplotlib.org/3.2.1/tutorials/introductory/usage.html?highlight=usage#what-is-interactive-mode

I'll give this a go but wanted to get input on where to put extended docstrings and how to manage the autogenerating docs. Also, if anyone has any wording suggestions I'd be happy to hear them.


## Tests
There don't seem to be any tests that make use of `ion` or `ioff`
```bash
cd lib/matplotlib/tests
grep -rni 'ioff()'
```
returns no results. Does this PR warrant adding new tests?

## PR Checklist

- [x] Has Pytest style unit tests 
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
    - See above discussion of documentation
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] NA? Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
