### PR TITLE
Remove code for sphinx < 1.8

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -101,10 +101,7 @@ os.environ.pop("DISPLAY", None)
 autosummary_generate = True
 
 autodoc_docstring_signature = True
-if sphinx.version_info < (1, 8):
-    autodoc_default_flags = ['members', 'undoc-members']
-else:
-    autodoc_default_options = {'members': None, 'undoc-members': None}
+autodoc_default_options = {'members': None, 'undoc-members': None}
 
 # missing-references names matches sphinx>=3 behavior, so we can't be nitpicky
 # for older sphinxes.
@@ -345,10 +342,7 @@ latex_appendices = []
 # If false, no module index is generated.
 latex_use_modindex = True
 
-if hasattr(sphinx, 'version_info') and sphinx.version_info[:2] >= (1, 4):
-    latex_toplevel_sectioning = 'part'
-else:
-    latex_use_parts = True
+latex_toplevel_sectioning = 'part'
 
 # Show both class-level docstring and __init__ docstring in class
 # documentation


### PR DESCRIPTION
## PR Summary

We require sphinx >= 1.8.1 (https://github.com/matplotlib/matplotlib/blob/b5d4a6c6b484afaa97ce999b36c03a28ec750ea3/requirements/doc/doc-requirements.txt#L10)

So we can remove code to support older sphinx versions.