### PR TITLE
Support standard names for freetype hinting flags.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -278,3 +278,11 @@ Qt and wx backends no longer create a status bar by default
 The coordinates information is now displayed in the toolbar, consistently with
 the other backends.  This is intended to simplify embedding of Matplotlib in
 larger GUIs, where Matplotlib may control the toolbar but not the status bar.
+
+:rc:`text.hinting` now supports names mapping to FreeType flags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:rc:`text.hinting` now supports the values "default", "no_autohint",
+"force_autohint", and "no_hinting", which directly map to the FreeType flags
+FT_LOAD_DEFAULT, etc.  The old synonyms (respectively "either", "native",
+"auto", and "none") are still supported.  To get normalized values, use
+`.backend_agg.get_hinting_flag`, which returns integer flag values.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -54,13 +54,17 @@ backend_version = 'v2.2'
 
 def get_hinting_flag():
     mapping = {
+        'default': LOAD_DEFAULT,
+        'no_autohint': LOAD_NO_AUTOHINT,
+        'force_autohint': LOAD_FORCE_AUTOHINT,
+        'no_hinting': LOAD_NO_HINTING,
         True: LOAD_FORCE_AUTOHINT,
         False: LOAD_NO_HINTING,
         'either': LOAD_DEFAULT,
         'native': LOAD_NO_AUTOHINT,
         'auto': LOAD_FORCE_AUTOHINT,
-        'none': LOAD_NO_HINTING
-        }
+        'none': LOAD_NO_HINTING,
+    }
     return mapping[mpl.rcParams['text.hinting']]
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -691,9 +691,11 @@ def _validate_hinting(s):
             "True or False is deprecated since %(since)s and will be removed "
             "%(removal)s; set it to its synonyms 'auto' or 'none' instead.")
         return s
-    if s.lower() in ('auto', 'native', 'either', 'none'):
-        return s.lower()
-    raise ValueError("hinting should be 'auto', 'native', 'either' or 'none'")
+    return ValidateInStrings(
+        'text.hinting',
+        ['default', 'no_autohint', 'force_autohint', 'no_hinting',
+         'auto', 'native', 'either', 'none'],
+        ignorecase=True)(s)
 
 
 validate_pgf_texsystem = ValidateInStrings(

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -292,14 +292,15 @@
                         # Adobe Postscript (PSSNFS) font packages may also be
                         # loaded, depending on your font settings.
 
-#text.hinting: auto  # May be one of the following:
-                     #     - none: Perform no hinting
-                     #     - auto: Use FreeType's autohinter
-                     #     - native: Use the hinting information in the
-                     #               font file, if available, and if your
-                     #               FreeType library supports it
-                     #     - either: Use the native hinting information,
-                     #               or the autohinter if none is available.
+## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the following:
+## - default: Use the font's native hinter if possible, else FreeType's auto-hinter.
+##            ("either" is a synonym).
+## - no_autohint: Use the font's native hinter if possible, else don't hint.
+##                ("native" is a synonym.)
+## - force_autohint: Use FreeType's auto-hinter.  ("auto" is a synonym.)
+## - no_hinting: Disable hinting.  ("none" is a synonym.)
+#text.hinting: force_autohint
+
 #text.hinting_factor: 8  # Specifies the amount of softness for hinting in the
                          # horizontal direction.  A value of 1 will hint to full
                          # pixels.  A value of 2 will hint to half pixels etc.


### PR DESCRIPTION
We have a custom mapping of FreeType hinting flags (FT_LOAD_DEFAULT,
FT_LOAD_NO_AUTOHINT, FT_LOAD_FORCE_AUTOHINT, FT_LOAD_NO_HINTING) to our
own string names ("either", "native", "auto", "default") which is
basically not documented anywhere and makes searching the docs tricky,
*even* when one knows where to look for FreeType flags.  Add support for
synonyms which map directly to the standard flag names ("default",
"no_autohint", "force_autohint", "no_hinting") which should at least
make the correspondence more transparent.

There's not much benefit in killing the old synonyms, so I left them in
place.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
