### PR TITLE
FIX: Better constrain CL for uneven grids

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -403,9 +403,25 @@ def _align_spines(fig, gs):
                 if height0 > height1:
                     ax0._poslayoutbox.constrain_height_min(
                         ax1._poslayoutbox.height * height0 / height1)
+                    # the precise constraint must be weak because
+                    # we may have one col with two axes, and the other
+                    # column with just one, and we want the top and
+                    # bottom of the short axes to align with the large one,
+                    # so the height of the long one is greater than
+                    # twice the height of the small ones. OTOH, if the
+                    # axes are not so constrained, we would like the pos
+                    # boxes to be the proper relative widths.
+                    # See test_constrained_layout17 fo
+                    ax0._poslayoutbox.constrain_height(
+                        ax1._poslayoutbox.height * height0 / height1,
+                        strength='weak')
                 elif height0 < height1:
                     ax1._poslayoutbox.constrain_height_min(
                         ax0._poslayoutbox.height * height1 / height0)
+                    # see above
+                    ax1._poslayoutbox.constrain_height(
+                        ax0._poslayoutbox.height * height1 / height0,
+                        strength='weak')
             # For widths, do it if the subplots share a row.
             if not alignwidth and len(colspan0) == len(colspan1):
                 ax0._poslayoutbox.constrain_width(
@@ -415,9 +431,17 @@ def _align_spines(fig, gs):
                 if width0 > width1:
                     ax0._poslayoutbox.constrain_width_min(
                         ax1._poslayoutbox.width * width0 / width1)
+                    # see comment above
+                    ax0._poslayoutbox.constrain_width(
+                        ax1._poslayoutbox.width * width0 / width1,
+                        strength='weak')
                 elif width0 < width1:
                     ax1._poslayoutbox.constrain_width_min(
                         ax0._poslayoutbox.width * width1 / width0)
+                    # see comment above
+                    ax1._poslayoutbox.constrain_width_min(
+                        ax0._poslayoutbox.width * width1 / width0,
+                        strength='weak')
 
 
 def _arrange_subplotspecs(gs, hspace=0, wspace=0):

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -399,3 +399,20 @@ def test_hidden_axes():
 
     np.testing.assert_allclose(
         extents1, [0.045552, 0.548288, 0.47319, 0.982638], rtol=1e-5)
+
+
+def test_two_under_one():
+    fig = plt.figure(constrained_layout=True)
+    gs = fig.add_gridspec(2, 2)
+    ax0 = fig.add_subplot(gs[0, :])
+    ax10 = fig.add_subplot(gs[1, 0])
+    ax11 = fig.add_subplot(gs[1, 1])
+    fig.canvas.draw()
+    extents0 = np.copy(ax0.get_position().extents)
+    extents10 = np.copy(ax10.get_position().extents)
+    extents11 = np.copy(ax11.get_position().extents)
+
+    np.testing.assert_allclose(extents0[0], extents10[0])
+    np.testing.assert_allclose(extents0[2], extents11[2])
+    np.testing.assert_allclose(extents11[0] - extents10[2],
+                               0.077362, atol=1e-6)


### PR DESCRIPTION
## PR Summary

test_constrainedlayout.py::test_constrained_layout17 is a bit flakey because the constraints are poor.  In general, constrained layout needs to be able to handle the situation below where the bottom axes is twice as large as the upper two, but the outer spines must be aligned.  

![CLIss0](https://user-images.githubusercontent.com/1562854/81716274-0b775d80-942e-11ea-938c-32a3e1bde79d.png)

However, it also has to work in the case where there are no inner spines to align:

![CLIss1](https://user-images.githubusercontent.com/1562854/81716548-598c6100-942e-11ea-90e8-4c49b7941e51.png)

This case was flakey before because I can only strong constrain the widths of the larger axes to be at least twice as large as the smaller.  If there are also spines to line up, then this works fine, but in the second example above, it doesn't constrain the smaller axes from being any size smaller than twice the width of the bigger axes.

The change here is to introduce a 'weak' constraint that is ignored in the first case, and executed in the second case.

This is a follow up to #17306

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
