### PR TITLE
Clarify deprecation message re: tex/pgf preambles as list-of-strings.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -170,19 +170,21 @@ def validate_bool_maybe_none(b):
 
 
 def _validate_tex_preamble(s):
-    message = (
-        f"Support for setting the 'text.latex.preamble' and 'pgf.preamble' "
-        f"rcParams to {s!r} is deprecated since %(since)s and will be "
-        f"removed %(removal)s; please set them to plain (possibly empty) "
-        f"strings instead.")
     if s is None or s == 'None':
-        cbook.warn_deprecated("3.3", message=message)
+        cbook.warn_deprecated(
+            "3.3", message="Support for setting the 'text.latex.preamble' or "
+            "'pgf.preamble' rcParam to None is deprecated since %(since)s and "
+            "will be removed %(removal)s; set it to an empty string instead.")
         return ""
     try:
         if isinstance(s, str):
             return s
         elif np.iterable(s):
-            cbook.warn_deprecated("3.3", message=message)
+            cbook.warn_deprecated(
+                "3.3", message="Support for setting the 'text.latex.preamble' "
+                "or 'pgf.preamble' rcParam to a list of strings is deprecated "
+                "since %(since)s and will be removed %(removal)s; set it to a "
+                "single string instead.")
             return '\n'.join(s)
         else:
             raise TypeError


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/pull/16164#issuecomment-627853036.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
