### PR TITLE
Deprecate passing keys to update_keymap as single comma-separated string

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -554,3 +554,7 @@ in which they are given.  This only affects the interaction between the
 properties: the *color* property now needs to be passed first in order not to
 override the other properties.  This is consistent with e.g. `.Artist.update`,
 which did not reorder the properties passed to it.
+
+Passing multiple keys as a single comma-separated string or multiple arguments to `.ToolManager.update_keymap`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is deprecated; pass keys as a list of strings instead.

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -183,7 +183,8 @@ class ToolManager:
         for k in self.get_tool_keymap(name):
             del self._keys[k]
 
-    def update_keymap(self, name, *keys):
+    @cbook._delete_parameter("3.3", "args")
+    def update_keymap(self, name, key, *args):
         """
         Set the keymap to associate with the specified tool.
 
@@ -191,17 +192,23 @@ class ToolManager:
         ----------
         name : str
             Name of the Tool.
-        keys : list of str
+        keys : str or list of str
             Keys to associate with the tool.
         """
-
         if name not in self._tools:
             raise KeyError('%s not in Tools' % name)
-
         self._remove_keys(name)
-
-        for key in keys:
-            for k in validate_stringlist(key):
+        for key in [key, *args]:
+            if isinstance(key, str) and validate_stringlist(key) != [key]:
+                cbook.warn_deprecated(
+                    "3.3", message="Passing a list of keys as a single "
+                    "comma-separated string is deprecated since %(since)s and "
+                    "support will be removed %(removal)s; pass keys as a list "
+                    "of strings instead.")
+                key = validate_stringlist(key)
+            if isinstance(key, str):
+                key = [key]
+            for k in key:
                 if k in self._keys:
                     cbook._warn_external('Key %s changed from %s to %s' %
                                          (k, self._keys[k], name))


### PR DESCRIPTION
... to ToolManager.update_keymap.

This allows one to correctly set a keymap to "," (a single comma).  This
also will help further cleanup of rc validators (by not "leaking"
validate_stringlist out of rcsetup).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
