### PR TITLE
TexManager fixes.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -137,9 +137,10 @@ This method is deprecated.  Use
 ``SymmetricalScale.InvertedSymmetricalTransform`` are deprecated.  Directly
 access the transform classes from the :mod:`.scale` module.
 
-``TexManager.cachedir``
-~~~~~~~~~~~~~~~~~~~~~~~
-Use `matplotlib.get_cachedir()` instead.
+``TexManager.cachedir``, ``TexManager.rgba_arrayd``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use `matplotlib.get_cachedir()` instead for the former; there is no replacement
+for the latter.
 
 Setting `.Line2D`\'s pickradius via `.Line2D.set_picker`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Fix calling get_grey with fontsize=None or dpi=None (this would
  previously just pass the string "None" down the stack and crash).
- Fix get_rgba stacking colors and get rid of its cache (the slow part
  is accessing the filesystem in get_grey, just stacking some colors
  should be cheap and not caching the result is also nicer memory-wise).

Closes #17393.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
