### PR TITLE
Remove qt4 backends from backend fallback candidates.

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -234,8 +234,7 @@ def switch_backend(newbackend):
         # Don't try to fallback on the cairo-based backends as they each have
         # an additional dependency (pycairo) over the agg-based backend, and
         # are of worse quality.
-        for candidate in [
-                "macosx", "qt5agg", "qt4agg", "gtk3agg", "tkagg", "wxagg"]:
+        for candidate in ["macosx", "qt5agg", "gtk3agg", "tkagg", "wxagg"]:
             try:
                 switch_backend(candidate)
             except ImportError:

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -65,9 +65,10 @@
 ## ***************************************************************************
 ## The default backend.  If you omit this parameter, the first working
 ## backend from the following list is used:
-##     MacOSX Qt5Agg Qt4Agg Gtk3Agg TkAgg WxAgg Agg
+##     MacOSX Qt5Agg Gtk3Agg TkAgg WxAgg Agg
 ## Other choices include:
-##     Qt5Cairo Qt4Cairo GTK3Cairo TkCairo WxCairo Cairo Wx
+##     Qt5Cairo GTK3Cairo TkCairo WxCairo Cairo
+##     Qt4Agg Qt4Cairo Wx  # deprecated.
 ##     PS PDF SVG Template
 ## You can also deploy your own backend outside of matplotlib by referring to
 ## the module name (which must be in the PYTHONPATH) as 'module://my_backend'.


### PR DESCRIPTION
This avoids triggering a deprecation warning whenever backend fallback
occurs, even if the fallback mechanism was not going to select qt4foo.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
