### PR TITLE
FIX: Fix for FFmpeg + GIF

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -570,7 +570,9 @@ class FFMpegBase:
 
     @property
     def output_args(self):
-        args = ['-vcodec', self.codec]
+        args = []
+        if not self.outfile.endswith('.gif'):
+            args.extend(['-vcodec', self.codec])
         extra_args = (self.extra_args if self.extra_args is not None
                       else mpl.rcParams[self._args_key])
         # For h264, the default format is yuv444p, which is not compatible

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -571,7 +571,7 @@ class FFMpegBase:
     @property
     def output_args(self):
         args = []
-        if not self.outfile.endswith('.gif'):
+        if not Path(self.outfile).suffix == '.gif':
             args.extend(['-vcodec', self.codec])
         extra_args = (self.extra_args if self.extra_args is not None
                       else mpl.rcParams[self._args_key])


### PR DESCRIPTION
Working on making a GIF thumbnail for https://github.com/sphinx-gallery/sphinx-gallery/issues/150 I stumbled across this bug writing GIF with FFmpeg:

<details>
<summary>Minimal example</summary>

```
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.animation as animation


def _update_line(num):
    line.set_data(data[..., :num])
    return line,


fig, ax = plt.subplots()
data = np.random.RandomState(0).rand(2, 25)
line, = ax.plot([], [], 'r-')
ax.set(xlim=(0, 1), ylim=(0, 1))
ani = animation.FuncAnimation(fig, _update_line, 25, interval=100, blit=True)
ani.save('test.gif', 'ffmpeg')
```

</details>

Produces:

```
$ python -ui anim.py 
MovieWriter stderr:
[gif @ 0x555affbb0580] GIF muxer supports only a single video GIF stream.
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Error initializing output stream 0:0 -- 

Traceback (most recent call last):
...
  File "/home/larsoner/python/matplotlib/lib/matplotlib/backends/backend_agg.py", line 429, in print_raw
    fh.write(renderer.buffer_rgba())
BrokenPipeError: [Errno 32] Broken pipe

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
...
  File "/home/larsoner/python/matplotlib/lib/matplotlib/animation.py", line 397, in cleanup
    raise subprocess.CalledProcessError(
subprocess.CalledProcessError: Command '['ffmpeg', '-f', 'rawvideo', '-vcodec', 'rawvideo', '-s', '640x480', '-pix_fmt', 'rgba', '-r', '10.0', '-loglevel', 'error', '-i', 'pipe:', '-vcodec', 'h264', '-pix_fmt', 'yuv420p', '-y', 'test.gif']' returned non-zero exit status 1.
>>> exit()
```

Basically the problem [seems to be](https://stackoverflow.com/questions/47493355/gif-muxer-supports-only-a-single-video-gif-stream) that you shouldn't pass `-vcodec` when using GIF. This PR works around the problem by not adding those arguments when the `outputfile` ends with `.gif`. Not the most elegant solution, but it seems to work.

I can try to add some simple variant of this as a test if this does seem like the right fix.