### PR TITLE
FIX: don't try to use non-standard functions on standard status bars

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1501,7 +1501,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def set_message(self, s):
         status_bar = self.GetTopLevelParent().GetStatusBar()
-        if status_bar is not None:
+        if status_bar is not None and hasattr(status_bar, 'set_function'):
             status_bar.set_function(s)
 
     def set_history_buttons(self):


### PR DESCRIPTION
closes #17085

## PR Summary

This is the minimal fix to stop printing out warnings is user's code and leave the deprecation in place.