### PR TITLE
Revert "DOC: drop the experimental tag constrained_layout and tight_layout"

### DIFF
--- a/doc/users/next_whats_new/2020-04-11-constrainedlayout-not-exp.rst
+++ b/doc/users/next_whats_new/2020-04-11-constrainedlayout-not-exp.rst
@@ -1,7 +1,0 @@
-Constrained layout is no longer marked as experimental
-------------------------------------------------------
-
-The *constrained_layout* option for figures and gridspecs was introduced
-in Matplotlib 2.2, and is no longer considered experimental.  For an
-overview of the feature, please see
-:doc:`/tutorials/intermediate/constrainedlayout_guide`.

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -30,11 +30,12 @@ Those are described in detail throughout the following sections.
 
 .. warning::
 
-    Constrained layout can lead to irreproducible plots
-    as the solver sometimes returns slightly different results.
-    If you *require* your plots to be absolutely reproducible, get the
-    Axes positions after running Constrained Layout and use
-    ``ax.set_position()`` in your code with ``constrained_layout=False``.
+    Currently Constrained Layout is **experimental**.  The
+    behaviour and API are subject to change, or the whole functionality
+    may be removed without a deprecation period.  If you *require* your
+    plots to be absolutely reproducible, get the Axes positions after
+    running Constrained Layout and use ``ax.set_position()`` in your code
+    with ``constrained_layout=False``.
 
 Simple Example
 ==============

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -6,9 +6,9 @@ Tight Layout guide
 How to use tight-layout to fit plots within your figure cleanly.
 
 *tight_layout* automatically adjusts subplot params so that the
-subplot(s) fits in to the figure area. This feature may not work
-for some cases. It only checks the extents of ticklabels, axis labels,
-and titles.
+subplot(s) fits in to the figure area. This is an experimental
+feature and may not work for some cases. It only checks the extents
+of ticklabels, axis labels, and titles.
 
 An alternative to *tight_layout* is :doc:`constrained_layout
 </tutorials/intermediate/constrainedlayout_guide>`.


### PR DESCRIPTION
OK, I've been working on constrained layout a lot lately, and have *greatly* simplified it, to the point where I'd like to keep the experimental tag for 3.3, in anticipation of some minor changes for 3.4.  I don't anticipate that any of the API will change, and the features will be the same, however, a few of the layout details may change.

Sorry for the churn, but the new implementation is far less confusing (I think).   

Reverts matplotlib/matplotlib#17094