### PR TITLE
Cygwin fixes

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -396,8 +396,8 @@ class Matplotlib(SetupPackage):
             include_dirs=["src"],
             # psapi library needed for finding Tcl/Tk at run time.
             # user32 library needed for window manipulation functions.
-            libraries=({"linux": ["dl"], "win32": ["psapi", "user32"]}
-                       .get(sys.platform, [])),
+            libraries=({"linux": ["dl"], "win32": ["psapi", "user32"],
+                        "cygwin": ["psapi"]}.get(sys.platform, [])),
             extra_link_args={"win32": ["-mwindows"]}.get(sys.platform, []))
         add_numpy_flags(ext)
         add_libagg_flags(ext)

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -11,6 +11,20 @@
 #include <Python.h>
 
 #ifdef _WIN32
+#define WIN32_DLL
+#endif
+#ifdef __CYGWIN__
+/*
+ * Unfortunately cygwin's libdl inherits restrictions from the underlying
+ * Windows OS, at least currently. Therefore, a symbol may be loaded from a
+ * module by dlsym() only if it is really located in the given modile,
+ * dependencies are not included. So we have to use native WinAPI on Cygwin
+ * also.
+ */
+#define WIN32_DLL
+#endif
+
+#ifdef WIN32_DLL
 #include <windows.h>
 #define PSAPI_VERSION 1
 #include <psapi.h>  // Must be linked with 'psapi' library
@@ -122,7 +136,7 @@ int load_tk(T lib)
             (Tk_PhotoPutBlock_NoComposite_t)dlsym(lib, "Tk_PhotoPutBlock_NoComposite"));
 }
 
-#ifdef _WIN32
+#ifdef WIN32_DLL
 
 /*
  * On Windows, we can't load the tkinter module to get the Tk symbols, because


### PR DESCRIPTION
Use native windows API for loading symbols from dlls instead of libdl. dlsym()
inherits underlying Windows restrictions and does not find symbols located in
dependencies of the library being explored.

This fixes issue #5962
