### PR TITLE
Tk: Fix idle-callbacks triggering exceptions after canvas been destroyed

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -215,8 +215,11 @@ class FigureCanvasTk(FigureCanvasBase):
         # to the window and filter.
         def filter_destroy(event):
             if event.widget is self._tkcanvas:
+                self._destroying = True
                 self._master.update_idletasks()
                 self.close_event()
+
+        self._destroying = False
         root.bind("<Destroy>", filter_destroy, "+")
 
         self._master = master
@@ -250,7 +253,8 @@ class FigureCanvasTk(FigureCanvasBase):
 
         def idle_draw(*args):
             try:
-                self.draw()
+                if not self._destroying:
+                    self.draw()
             finally:
                 self._idle = True
 

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -32,7 +32,7 @@ def test_blit():
                       bad_boxes)
 
 
-@pytest.mark.backend('TkAgg')
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
 def test_draw_after_destroy():
     """
     Idle callbacks should not trigger exceptions after canvas been destroyed.

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -58,4 +58,4 @@ def test_draw_after_destroy():
     th.daemon = True  # in order to pass through input() blocking
     th.start()
     time.sleep(3)
-    assert sys.last_type == None
+    assert sys.last_type is None


### PR DESCRIPTION
## PR Summary
After closing an **animation** object, **Tkinter** will throw an exception as soon as the builtin `input()` method been called, as described in #17104.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->