### PR TITLE
Add machinery to generate test-only wheels.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include INSTALL.rst README.rst
-include pytest.ini
 include MANIFEST.in
 include matplotlibrc.template setup.cfg.template
 include setupext.py setup.py
@@ -20,4 +19,3 @@ recursive-include tools *
 recursive-include tutorials *
 include versioneer.py
 include lib/matplotlib/_version.py
-include tests.py

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -277,6 +277,10 @@ day), generate the tarball ::
   git checkout v2.0.0
   git clean -xfd
   python setup.py sdist
+  # Generate test-only wheels.
+  for dir in sub-wheels/*; do
+    (cd "$dir" && python setup.py bdist_wheel)
+  done
 
 and copy all of the wheels into :file:`dist` directory.  First, check
 that the dist files are OK ::

--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -9,13 +9,6 @@
 #system_freetype = False
 #system_qhull = False
 
-[packages]
-# There are a number of data subpackages from Matplotlib that are
-# considered optional. All except 'tests' data (meaning the baseline
-# image files) are installed by default, but that can be changed here.
-#tests = False
-#sample_data = True
-
 [gui_support]
 # Matplotlib supports multiple GUI toolkits, known as backends.
 # The MacOSX backend requires the Cocoa headers included with XCode.

--- a/sub-wheels/matplotlib.tests/MANIFEST.in
+++ b/sub-wheels/matplotlib.tests/MANIFEST.in
@@ -1,0 +1,4 @@
+include sub-wheels/matplotlib.tests/README.rst
+include sub-wheels/matplotlib.tests/MANIFEST.in
+include pytest.ini
+include tests.py

--- a/sub-wheels/matplotlib.tests/MANIFEST.in
+++ b/sub-wheels/matplotlib.tests/MANIFEST.in
@@ -1,4 +1,5 @@
 include sub-wheels/matplotlib.tests/README.rst
 include sub-wheels/matplotlib.tests/MANIFEST.in
+include matplotlibrc.template sub-wheels/matplotlib.test/setup.cfg.template
 include pytest.ini
 include tests.py

--- a/sub-wheels/matplotlib.tests/README.rst
+++ b/sub-wheels/matplotlib.tests/README.rst
@@ -1,0 +1,12 @@
+Running ``python setup.py bdist_wheel`` (*not* ``pip wheel .``) generates a
+wheel for a ``matplotlib.tests`` distribution (in the distutils sense, i.e.
+a PyPI package) that can be installed alongside a main, test-less Matplotlib
+distribution.
+
+Note that
+
+- ``pip wheel`` doesn't work as that starts by copying the *current* directory
+  to a temporary one (for isolation purposes), before we get to ``chdir`` back
+  to the root directory.
+- ``python setup.py sdist`` doesn't work as that would pick up the
+  ``MANIFEST.in`` file in the root directory.

--- a/sub-wheels/matplotlib.tests/setup.cfg.template
+++ b/sub-wheels/matplotlib.tests/setup.cfg.template
@@ -1,0 +1,8 @@
+# Rename this file to setup.cfg to modify Matplotlib-tests's build options.
+
+[packages]
+# There are a number of data subpackages from Matplotlib that are
+# considered optional. All except 'tests' data (meaning the baseline
+# image files) are installed by default, but that can be changed here.
+#tests = False
+#sample_data = True

--- a/sub-wheels/matplotlib.tests/setup.py
+++ b/sub-wheels/matplotlib.tests/setup.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+import sys
+
+
+rootdir = str(Path(__file__).resolve().parents[2])
+sys.path.insert(0, rootdir)
+os.chdir(rootdir)
+
+
+from setuptools import setup, find_packages
+import versioneer
+
+
+__version__ = versioneer.get_version()
+
+
+if "sdist" in sys.argv:
+    sys.exit("Only wheels can be generated.")
+setup(
+    name="matplotlib.tests",
+    version=__version__,
+    package_dir={"": "lib"},
+    packages=find_packages("lib", include=["*.tests"]),
+    include_package_data=True,
+    install_requires=["matplotlib=={}".format(__version__)]
+)


### PR DESCRIPTION
## PR Summary

Generate a matplotlib.tests wheel that can be uploaded to PyPI as a separate PyPI package ("distribution", in distutils parlance), to make it possible to install tests and test data from PyPI.

This is useful e.g. for mplcairo, whose test suite relies on matplotlib's one. 
Also, useful for [Baseline image problem](https://github.com/matplotlib/matplotlib/issues/16447) optimisation. 

Co-authored-by: @anntzer
Closes #11732
Thanks
