### PR TITLE
Backport PR #17422: Unstale viewlims before draw()ing polar axes.

### DIFF
--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -217,7 +217,7 @@ confidence_ellipse(x, y, ax_kwargs,
 
 ax_kwargs.scatter(x, y, s=0.5)
 ax_kwargs.scatter(mu[0], mu[1], c='red', s=3)
-ax_kwargs.set_title(f'Using kwargs')
+ax_kwargs.set_title('Using kwargs')
 
 fig.subplots_adjust(hspace=0.25)
 plt.show()

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -953,6 +953,7 @@ class PolarAxes(Axes):
         return self._yaxis_text_transform + pad_shift, 'center', halign
 
     def draw(self, *args, **kwargs):
+        self._unstale_viewLim()
         thetamin, thetamax = np.rad2deg(self._realViewLim.intervalx)
         if thetamin > thetamax:
             thetamin, thetamax = thetamax, thetamin

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -750,7 +750,11 @@ def test_polar_invertedylim():
 def test_polar_invertedylim_rorigin():
     fig = plt.figure()
     ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], polar=True)
-    ax.set_ylim(2, 0)
+    ax.yaxis.set_inverted(True)
+    # Set the rlims to inverted (2, 0) without calling set_rlim, to check that
+    # viewlims are correctly unstaled before draw()ing.
+    ax.plot([0, 0], [0, 2], c="none")
+    ax.margins(0)
     ax.set_rorigin(3)
 
 


### PR DESCRIPTION
Merge pull request #17422 from anntzer/polarunstale

Unstale viewlims before draw()ing polar axes.

Conflicts:
	lib/matplotlib/projections/polar.py
          - conflicts from nearyby changes to signature of draw
	lib/matplotlib/tests/test_polar.py
          - tests are still in test_axes.py on v3.2.x

