### PR TITLE
Discourage use of proprietary Matplotlib names for freetype hinting

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -291,5 +291,6 @@ larger GUIs, where Matplotlib may control the toolbar but not the status bar.
 :rc:`text.hinting` now supports the values "default", "no_autohint",
 "force_autohint", and "no_hinting", which directly map to the FreeType flags
 FT_LOAD_DEFAULT, etc.  The old synonyms (respectively "either", "native",
-"auto", and "none") are still supported.  To get normalized values, use
-`.backend_agg.get_hinting_flag`, which returns integer flag values.
+"auto", and "none") are still supported, but their use is discouraged.  To get
+normalized values, use `.backend_agg.get_hinting_flag`, which returns integer
+flag values.

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -293,7 +293,9 @@
                         # Adobe Postscript (PSSNFS) font packages may also be
                         # loaded, depending on your font settings.
 
-## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the following:
+## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the
+## following (Proprietary Matplotlib-specific synonyms are given in parentheses,
+## but their use is discouraged):
 ## - default: Use the font's native hinter if possible, else FreeType's auto-hinter.
 ##            ("either" is a synonym).
 ## - no_autohint: Use the font's native hinter if possible, else don't hint.


### PR DESCRIPTION
Follow up to #17380, which introduced freetype-conform names.

While it's not worth deprecating our old names, we should indicate clear preference for the freetype-conform names.
