### PR TITLE
Fix rcParams validator for dashes.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -793,7 +793,7 @@ def validate_hatch(s):
 
 
 validate_hatchlist = _listify_validator(validate_hatch)
-validate_dashlist = _listify_validator(validate_nseq_float(allow_none=True))
+validate_dashlist = _listify_validator(validate_floatlist)
 
 
 _prop_validators = {
@@ -1069,9 +1069,9 @@ _validators = {
     "lines.solid_joinstyle": validate_joinstyle,
     "lines.dash_capstyle":   validate_capstyle,
     "lines.solid_capstyle":  validate_capstyle,
-    "lines.dashed_pattern":  validate_nseq_float(allow_none=True),
-    "lines.dashdot_pattern": validate_nseq_float(allow_none=True),
-    "lines.dotted_pattern":  validate_nseq_float(allow_none=True),
+    "lines.dashed_pattern":  validate_floatlist,
+    "lines.dashdot_pattern": validate_floatlist,
+    "lines.dotted_pattern":  validate_floatlist,
     "lines.scale_dashes":    validate_bool,
 
     # marker props

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -111,7 +111,7 @@ def test_valid_input_forms():
     ax.set_prop_cycle('color', np.array([[1, 0, 0],
                                          [0, 1, 0],
                                          [0, 0, 1]]))
-    ax.set_prop_cycle('dashes', [[], [13, 2], [8, 3, 1, 3], [None, None]])
+    ax.set_prop_cycle('dashes', [[], [13, 2], [8, 3, 1, 3]])
     ax.set_prop_cycle(lw=[1, 2], color=['k', 'w'], ls=['-', '--'])
     ax.set_prop_cycle(lw=np.array([1, 2]),
                       color=np.array(['k', 'w']),


### PR DESCRIPTION
Valid dash-patterns are actually just lists of floats:
```
rcParams["lines.dashed_pattern"] = (1, None)
plt.plot([1, 2], ls="--")
```
throws
```
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
