### PR TITLE
Support odd-length dash patterns in Agg.

### DIFF
--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -217,3 +217,9 @@ def test_marker_as_markerstyle():
 
     assert_array_equal(line2.get_marker().vertices, triangle1.vertices)
     assert_array_equal(line3.get_marker().vertices, triangle1.vertices)
+
+
+@check_figures_equal()
+def test_odd_dashes(fig_test, fig_ref):
+    fig_test.add_subplot().plot([1, 2], dashes=[1, 2, 3])
+    fig_ref.add_subplot().plot([1, 2], dashes=[1, 2, 3, 1, 2, 3])

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -226,7 +226,6 @@ int convert_dashes(PyObject *dashobj, void *dashesp)
     PyObject *dash_offset_obj = NULL;
     double dash_offset = 0.0;
     PyObject *dashes_seq = NULL;
-    Py_ssize_t nentries;
 
     if (!PyArg_ParseTuple(dashobj, "OO:dashes", &dash_offset_obj, &dashes_seq)) {
         return 0;
@@ -256,18 +255,17 @@ int convert_dashes(PyObject *dashobj, void *dashesp)
         return 0;
     }
 
-    nentries = PySequence_Size(dashes_seq);
-    if (nentries % 2 != 0) {
-        PyErr_Format(PyExc_ValueError, "dashes sequence must have an even number of elements");
-        return 0;
-    }
+    Py_ssize_t nentries = PySequence_Size(dashes_seq);
+    // If the dashpattern has odd length, iterate through it twice (in
+    // accordance with the pdf/ps/svg specs).
+    Py_ssize_t dash_pattern_length = (nentries % 2) ? 2 * nentries : nentries;
 
-    for (Py_ssize_t i = 0; i < nentries; ++i) {
+    for (Py_ssize_t i = 0; i < dash_pattern_length; ++i) {
         PyObject *item;
         double length;
         double skip;
 
-        item = PySequence_GetItem(dashes_seq, i);
+        item = PySequence_GetItem(dashes_seq, i % nentries);
         if (item == NULL) {
             return 0;
         }
@@ -280,7 +278,7 @@ int convert_dashes(PyObject *dashobj, void *dashesp)
 
         ++i;
 
-        item = PySequence_GetItem(dashes_seq, i);
+        item = PySequence_GetItem(dashes_seq, i % nentries);
         if (item == NULL) {
             return 0;
         }


### PR DESCRIPTION
## PR Summary

All vector backends already support passing an odd-length dash pattern,
duplicating the on/off array (so that on the second repetition "on"
becomes "off" and vice-versa).  This is also explicitly supported by
the svg spec for `stroke-dasharray` ("If an odd number of values is
provided, then the list of values is repeated to yield an even number of
values. Thus, 5,3,2 is equivalent to 5,3,2,5,3,2.") and less explicitly
by the pdf and ps specs, and by cairo.  So the backend needing support
is Agg; iterating twice over the sequence is likely simplest.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
