### PR TITLE
Cleanup C++ code

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -67,8 +67,7 @@ _get_transform_mesh(PyObject *py_affine, npy_intp *dims)
     out_dims[0] = dims[0] * dims[1];
     out_dims[1] = 2;
 
-    py_inverse = PyObject_CallMethod(
-        py_affine, (char *)"inverted", (char *)"", NULL);
+    py_inverse = PyObject_CallMethod(py_affine, "inverted", NULL);
     if (py_inverse == NULL) {
         return NULL;
     }
@@ -83,10 +82,8 @@ _get_transform_mesh(PyObject *py_affine, npy_intp *dims)
         }
     }
 
-    PyObject *output_mesh =
-        PyObject_CallMethod(
-            py_inverse, (char *)"transform", (char *)"O",
-            (char *)input_mesh.pyobj_steal(), NULL);
+    PyObject *output_mesh = PyObject_CallMethod(
+        py_inverse, "transform", "O", input_mesh.pyobj_steal());
 
     Py_DECREF(py_inverse);
 

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -86,7 +86,7 @@ _get_transform_mesh(PyObject *py_affine, npy_intp *dims)
     PyObject *output_mesh =
         PyObject_CallMethod(
             py_inverse, (char *)"transform", (char *)"O",
-            (char *)input_mesh.pyobj(), NULL);
+            (char *)input_mesh.pyobj_steal(), NULL);
 
     Py_DECREF(py_inverse);
 

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -120,7 +120,12 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     PyArrayObject *output_array = NULL;
     PyArrayObject *transform_mesh_array = NULL;
 
+    params.interpolation = NEAREST;
     params.transform_mesh = NULL;
+    params.resample = false;
+    params.norm = false;
+    params.radius = 1.0;
+    params.alpha = 1.0;
 
     const char *kwlist[] = {
         "input_array", "output_array", "transform", "interpolation",

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -151,9 +151,18 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         goto error;
     }
 
-    output_array = (PyArrayObject *)PyArray_FromAny(
-        py_output_array, NULL, 2, 3, NPY_ARRAY_C_CONTIGUOUS, NULL);
-    if (output_array == NULL) {
+    if (!PyArray_Check(py_output_array)) {
+        PyErr_SetString(PyExc_ValueError, "output array must be a NumPy array");
+        goto error;
+    }
+    output_array = (PyArrayObject *)py_output_array;
+    if (!PyArray_IS_C_CONTIGUOUS(output_array)) {
+        PyErr_SetString(PyExc_ValueError, "output array must be C-contiguous");
+        goto error;
+    }
+    if (PyArray_NDIM(output_array) < 2 || PyArray_NDIM(output_array) > 3) {
+        PyErr_SetString(PyExc_ValueError,
+                        "output array must be 2- or 3-dimensional");
         goto error;
     }
 
@@ -335,11 +344,10 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
 
     Py_DECREF(input_array);
     Py_XDECREF(transform_mesh_array);
-    return (PyObject *)output_array;
+    Py_RETURN_NONE;
 
  error:
     Py_XDECREF(input_array);
-    Py_XDECREF(output_array);
     Py_XDECREF(transform_mesh_array);
     return NULL;
 }

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -49,7 +49,7 @@ class PythonFileWriter : public TTStreamWriter
             if (decoded == NULL) {
                 throw py::exception();
             }
-            result = PyObject_CallFunction(_write_method, (char *)"O", decoded);
+            result = PyObject_CallFunctionObjArgs(_write_method, decoded, NULL);
             Py_DECREF(decoded);
             if (!result) {
                 throw py::exception();

--- a/src/mplutils.cpp
+++ b/src/mplutils.cpp
@@ -10,7 +10,7 @@ int add_dict_int(PyObject *dict, const char *key, long val)
         return 1;
     }
 
-    if (PyDict_SetItemString(dict, (char *)key, valobj)) {
+    if (PyDict_SetItemString(dict, key, valobj)) {
         Py_DECREF(valobj);
         return 1;
     }

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -441,7 +441,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         return *this;
     }
 
-    int set(PyObject *arr, bool contiguous = false)
+    bool set(PyObject *arr, bool contiguous = false)
     {
         PyArrayObject *tmp;
 
@@ -458,7 +458,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
                 tmp = (PyArrayObject *)PyArray_FromObject(arr, type_num_of<T>::value, 0, ND);
             }
             if (tmp == NULL) {
-                return 0;
+                return false;
             }
 
             if (PyArray_NDIM(tmp) == 0 || PyArray_DIM(tmp, 0) == 0) {
@@ -469,7 +469,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
                 m_strides = zeros;
                 if (PyArray_NDIM(tmp) == 0 && ND == 0) {
                     m_arr = tmp;
-                    return 1;
+                    return true;
                 }
             }
             if (PyArray_NDIM(tmp) != ND) {
@@ -478,7 +478,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
                              ND,
                              PyArray_NDIM(tmp));
                 Py_DECREF(tmp);
-                return 0;
+                return false;
             }
 
             /* Copy some of the data to the view object for faster access */
@@ -489,7 +489,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
             m_data = (char *)PyArray_BYTES(tmp);
         }
 
-        return 1;
+        return true;
     }
 
     npy_intp dim(size_t i) const

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -406,7 +406,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         Py_XINCREF(arr);
         m_shape = PyArray_DIMS(m_arr);
         m_strides = PyArray_STRIDES(m_arr);
-        m_data = (char *)PyArray_BYTES(m_arr);
+        m_data = PyArray_BYTES(m_arr);
     }
 
     array_view(npy_intp shape[ND]) : m_arr(NULL), m_shape(NULL), m_strides(NULL), m_data(NULL)
@@ -486,7 +486,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
             m_arr = tmp;
             m_shape = PyArray_DIMS(m_arr);
             m_strides = PyArray_STRIDES(m_arr);
-            m_data = (char *)PyArray_BYTES(tmp);
+            m_data = PyArray_BYTES(tmp);
         }
 
         return true;

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -54,9 +54,9 @@ int convert_from_method(PyObject *obj, const char *name, converter func, void *p
 {
     PyObject *value;
 
-    value = PyObject_CallMethod(obj, (char *)name, NULL);
+    value = PyObject_CallMethod(obj, name, NULL);
     if (value == NULL) {
-        if (!PyObject_HasAttrString(obj, (char *)name)) {
+        if (!PyObject_HasAttrString(obj, name)) {
             PyErr_Clear();
             return 1;
         }
@@ -76,9 +76,9 @@ int convert_from_attr(PyObject *obj, const char *name, converter func, void *p)
 {
     PyObject *value;
 
-    value = PyObject_GetAttrString(obj, (char *)name);
+    value = PyObject_GetAttrString(obj, name);
     if (value == NULL) {
-        if (!PyObject_HasAttrString(obj, (char *)name)) {
+        if (!PyObject_HasAttrString(obj, name)) {
             PyErr_Clear();
             return 1;
         }


### PR DESCRIPTION
## PR Summary

Fixes parsing of input arguments, as optional ones should be given a default value (though the Python side may always provide them), and cleanup the ref counts of `output_array` using @anntzer's patch from #15474.

Fixes the memory leak due to an extra reference.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way