### PR TITLE
Use light icons on dark themes for wx and gtk, too.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -703,6 +703,10 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         return str(cbook._get_data_path('images'))
 
     def _icon(self, name):
+        """
+        Construct a `.QIcon` from an image file *name*, including the extension
+        and relative to Matplotlib's "images" data directory.
+        """
         if QtCore.qVersion() >= '5.':
             name = name.replace('.png', '_large.png')
         pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))


### PR DESCRIPTION
These can be tried e.g. by setting `GTK_THEME` to `Adwaita:dark`.
I couldn't find how to get the foreground color in GTK3 so the check for
dark themes is just looking at the luminance of the background, and the
icon color is set to white.  (Better approaches welcome...)
I made the `_icon` API "consistent" across qt, wx, and gtk.

(Qt already supports this, and I don't think Tk supports this kind of theming out of the box anyways.)

before:
![old](https://user-images.githubusercontent.com/1322974/82445943-05c0ee00-9aa6-11ea-8a6e-d8b6f9693945.png)
after:
![new](https://user-images.githubusercontent.com/1322974/82445948-08234800-9aa6-11ea-96d2-b81de61434ae.png)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
