### PR TITLE
Deprecate the private FigureCanvasGTK3._renderer_init.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -406,6 +406,16 @@ what the docs stated).  They are deprecated; if you write a backend
 which needs to customize such events, please directly override
 ``press_pan``/``press_zoom``/``release_pan``/``release_zoom`` instead.
 
+FigureCanvasGTK3._renderer_init
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Overriding this method to initialize renderers for GTK3 canvases is deprecated.
+Instead, the renderer should be initialized in the ``__init__`` method of the
+subclass (which should call the base-class' ``__init__`` as appropriate).  To
+keep back-compatibility with earlier versions of Matplotlib (which *required*
+``_renderer_init`` to be overridden), a fully empty implementation (``def
+_renderer_init(self): pass``) may be kept and will not trigger the deprecation
+warning.
+
 Path helpers in :mod:`.bezier`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -176,7 +176,19 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
 
         self.set_double_buffered(True)
         self.set_can_focus(True)
-        self._renderer_init()
+
+        renderer_init = cbook._deprecate_method_override(
+            __class__._renderer_init, self, allow_empty=True, since="3.3",
+            addendum="Please initialize the renderer, if needed, in the "
+            "subclass' __init__; a fully empty _renderer_init implementation "
+            "may be kept for compatibility with earlier versions of "
+            "Matplotlib.")
+        if renderer_init:
+            renderer_init()
+
+    @cbook.deprecated("3.3", alternative="__init__")
+    def _renderer_init(self):
+        pass
 
     def destroy(self):
         #Gtk.DrawingArea.destroy(self)

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -17,9 +17,6 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         backend_gtk3.FigureCanvasGTK3.__init__(self, figure)
         self._bbox_queue = []
 
-    def _renderer_init(self):
-        pass
-
     def _render_figure(self, width, height):
         backend_agg.FigureCanvasAgg.draw(self)
 

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -16,8 +16,8 @@ class RendererGTK3Cairo(backend_cairo.RendererCairo):
 class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
                             backend_cairo.FigureCanvasCairo):
 
-    def _renderer_init(self):
-        """Use cairo renderer."""
+    def __init__(self, figure):
+        super().__init__(figure)
         self._renderer = RendererGTK3Cairo(self.figure.dpi)
 
     def _render_figure(self, width, height):


### PR DESCRIPTION
Previously, subclasses of FigureCanvasGTK3 needed to override the
undocumented `_renderer_init` method.  Instead, just move the relevant
initialization code to the subclass' `__init__`.  (Conceptually this is
similar to the deprecation of `_init_toolbar` method on toolbars.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
