### PR TITLE
Inline FigureCanvasGtkFoo._render_figure.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -17,9 +17,6 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         backend_gtk3.FigureCanvasGTK3.__init__(self, figure)
         self._bbox_queue = []
 
-    def _render_figure(self, width, height):
-        backend_agg.FigureCanvasAgg.draw(self)
-
     def on_draw_event(self, widget, ctx):
         """GtkDrawable draw event, like expose_event in GTK 2.X."""
         allocation = self.get_allocation()
@@ -71,8 +68,7 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
 
     def draw(self):
         if self.get_visible() and self.get_mapped():
-            allocation = self.get_allocation()
-            self._render_figure(allocation.width, allocation.height)
+            backend_agg.FigureCanvasAgg.draw(self)
         super().draw()
 
     def print_png(self, filename, *args, **kwargs):

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -20,10 +20,6 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
         super().__init__(figure)
         self._renderer = RendererGTK3Cairo(self.figure.dpi)
 
-    def _render_figure(self, width, height):
-        self._renderer.set_width_height(width, height)
-        self.figure.draw(self._renderer)
-
     def on_draw_event(self, widget, ctx):
         """GtkDrawable draw event."""
         with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
@@ -34,7 +30,9 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
-            self._render_figure(allocation.width, allocation.height)
+            self._renderer.set_width_height(
+                allocation.width, allocation.height)
+            self.figure.draw(self._renderer)
 
 
 @_BackendGTK3.export


### PR DESCRIPTION
Having it as a separate function obscures the flow for little benefit,
and caused an unnecessary call to get_allocation() in gtk3agg.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
