### PR TITLE
FIX: add guardrails for too big tk figures

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -431,6 +431,17 @@ class FigureManagerTk(FigureManagerBase):
         return toolbar
 
     def resize(self, width, height):
+        max_size = 1_400_000  # the measured max on xorg 1.20.8 was 1_409_023
+
+        if (width > max_size or height > max_size) and sys.platform == 'linux':
+            raise ValueError(
+                'You have requested to resize the '
+                f'Tk window to ({width}, {height}), one of which '
+                f'is bigger than {max_size}.  At larger sizes xorg will '
+                'either exit with an error on never versions (~1.20) or '
+                'cause corruption on older version (~1.19).  We '
+                'do not expect a window over a million pixel wide or tall '
+                'to be intended behavior.')
         self.canvas._tkcanvas.configure(width=width, height=height)
 
     def show(self):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -438,7 +438,7 @@ class FigureManagerTk(FigureManagerBase):
                 'You have requested to resize the '
                 f'Tk window to ({width}, {height}), one of which '
                 f'is bigger than {max_size}.  At larger sizes xorg will '
-                'either exit with an error on never versions (~1.20) or '
+                'either exit with an error on newer versions (~1.20) or '
                 'cause corruption on older version (~1.19).  We '
                 'do not expect a window over a million pixel wide or tall '
                 'to be intended behavior.')


### PR DESCRIPTION
## PR Summary

Depending on the version of xserver creating a too big tk window
either corrupts xorg (!) or causes the process to exit.  This adds a
guard rail that will convert this into a python exception instead.

closes #17460


## PR Checklist

- [ ] Has Pytest style unit tests
- [k] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant

Not sure if it is worth adding a test for this as it is such an out-there condition.