### PR TITLE
Numpydocify RectangleSelector docstring.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1930,61 +1930,81 @@ class RectangleSelector(_SelectorWidget):
     _shape_klass = Rectangle
 
     def __init__(self, ax, onselect, drawtype='box',
-                 minspanx=None, minspany=None, useblit=False,
+                 minspanx=0, minspany=0, useblit=False,
                  lineprops=None, rectprops=None, spancoords='data',
                  button=None, maxdist=10, marker_props=None,
                  interactive=False, state_modifier_keys=None):
-        r"""
-        Create a selector in *ax*.  When a selection is made, clear
-        the span and call onselect with::
+        """
+        Parameters
+        ----------
+        ax : `~matplotlib.axes.Axes`
+            The parent axes for the widget.
 
-          onselect(pos_1, pos_2)
+        onselect : function
+            A callback function that is called after a selection is completed.
+            It must have the signature::
 
-        and clear the drawn box/line. The ``pos_1`` and ``pos_2`` are
-        arrays of length 2 containing the x- and y-coordinate.
+                def onselect(eclick: MouseEvent, erelease: MouseEvent)
 
-        If *minspanx* is not *None* then events smaller than *minspanx*
-        in x direction are ignored (it's the same for y).
+            where *eclick* and *erelease* are the mouse click and release
+            `.MouseEvent`\s that start and complete the selection.
 
-        The rectangle is drawn with *rectprops*; default::
+        drawtype : {"box", "line", "none"}, default: "box"
+            Whether to draw the full rectangle box, the diagonal line of the
+            rectangle, or nothing at all.
 
-          rectprops = dict(facecolor='red', edgecolor = 'black',
-                           alpha=0.2, fill=True)
+        minspanx : float, default: 0
+            Selections with an x-span less than *minspanx* are ignored.
 
-        The line is drawn with *lineprops*; default::
+        minspany : float, default: 0
+            Selections with an y-span less than *minspany* are ignored.
 
-          lineprops = dict(color='black', linestyle='-',
-                           linewidth = 2, alpha=0.5)
+        useblit : bool, default: False
+            Whether to use blitting for faster drawing (if supported by the
+            backend).
 
-        Use *drawtype* if you want the mouse to draw a line,
-        a box or nothing between click and actual position by setting
+        lineprops : dict, optional
+            Properties with which the line is drawn, if ``drawtype == "line"``.
+            Default::
 
-        ``drawtype = 'line'``, ``drawtype='box'`` or ``drawtype = 'none'``.
-        Drawing a line would result in a line from vertex A to vertex C in
-        a rectangle ABCD.
+                dict(color="black", linestyle="-", linewidth=2, alpha=0.5)
 
-        *spancoords* is one of 'data' or 'pixels'.  If 'data', *minspanx*
-        and *minspanx* will be interpreted in the same coordinates as
-        the x and y axis. If 'pixels', they are in pixels.
+        rectprops : dict, optional
+            Properties with which the rectangle is drawn, if ``drawtype ==
+            "box"``.  Default::
 
-        *button* is the `.MouseButton` or list of `.MouseButton`\s used for
-        rectangle selection.  Default is *None*, which means any button.
+                dict(facecolor="red", edgecolor="black", alpha=0.2, fill=True)
 
-        *interactive* will draw a set of handles and allow you interact
-        with the widget after it is drawn.
+        spancoords : {"data", "pixels"}, default: "data"
+            Whether to interpret *minspanx* and *minspany* in data or in pixel
+            coordinates.
 
-        *state_modifier_keys* are keyboard modifiers that affect the behavior
-        of the widget.
+        button : `.MouseButton`, list of `.MouseButton`, default: all buttons
+            Button(s) that trigger rectangle selection.
 
-        The defaults are:
-        dict(move=' ', clear='escape', square='shift', center='ctrl')
+        maxdist : float, default: 10
+            Distance in pixels within which the interactive tool handles can be
+            activated.
 
-        Keyboard modifiers, which:
-        'move': Move the existing shape.
-        'clear': Clear the current shape.
-        'square': Makes the shape square.
-        'center': Make the initial point the center of the shape.
-        'square' and 'center' can be combined.
+        marker_props : dict
+            Properties with which the interactive handles are drawn.  Currently
+            not implemented and ignored.
+
+        interactive : bool, default: False
+            Whether to draw a set of handles that allow interaction with the
+            widget after it is drawn.
+
+        state_modifier_keys : dict, optional
+            Keyboard modifiers which affect the widget's behavior.  Values
+            amend the defaults.
+
+            - "move": Move the existing shape, default: no modifier.
+            - "clear": Clear the current shape, default: "escape".
+            - "square": Makes the shape square, default: "shift".
+            - "center": Make the initial point the center of the shape,
+              default: "ctrl".
+
+            "square" and "center" can be combined.
         """
         _SelectorWidget.__init__(self, ax, onselect, useblit=useblit,
                                  button=button,


### PR DESCRIPTION
- The given signature for `onselect` was wrong -- it is called with the
  start and end events as arguments.
- Changed the default of `minspanx`, `minspany` to 0 -- it is easier to
  document.  None is kept as undocumented backcompat; deprecating None
  would also beed to cover assignment to the `minspanx/y` attributes
  (probably using a property, yada yada).
- `marker_props` is currently ignored, but let's not deprecate it as it
  would actually make sense to support it (consistently with
  PolygonSelector -- which names it `markerprops` but heh...).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
