### PR TITLE
Cleanup RectangleSelector example.

### DIFF
--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -30,23 +30,23 @@ def line_select_callback(eclick, erelease):
 
 def toggle_selector(event):
     print(' Key pressed.')
-    if event.key in ['Q', 'q'] and toggle_selector.RS.active:
-        print(' RectangleSelector deactivated.')
-        toggle_selector.RS.set_active(False)
-    if event.key in ['A', 'a'] and not toggle_selector.RS.active:
-        print(' RectangleSelector activated.')
-        toggle_selector.RS.set_active(True)
+    if event.key == 't':
+        if toggle_selector.RS.active:
+            print(' RectangleSelector deactivated.')
+            toggle_selector.RS.set_active(False)
+        else:
+            print(' RectangleSelector activated.')
+            toggle_selector.RS.set_active(True)
 
 
 fig, ax = plt.subplots()
 N = 100000  # If N is large one can see improvement by using blitting.
-x = np.linspace(0.0, 10.0, N)
+x = np.linspace(0, 10, N)
 
-ax.plot(x, +np.sin(.2*np.pi*x), lw=3.5, c='b', alpha=.7)  # plot something
-ax.plot(x, +np.cos(.2*np.pi*x), lw=3.5, c='r', alpha=.5)
-ax.plot(x, -np.sin(.2*np.pi*x), lw=3.5, c='g', alpha=.3)
-
-print("\n      click  -->  release")
+ax.plot(x, np.sin(2*np.pi*x))  # plot something
+ax.set_title(
+    "Click and drag to draw a rectangle.\n"
+    "Press 't' to toggle the selector on and off.")
 
 # drawtype is 'box' or 'line' or 'none'
 toggle_selector.RS = RectangleSelector(ax, line_select_callback,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1896,35 +1896,9 @@ class RectangleSelector(_SelectorWidget):
 
     For the cursor to remain responsive you must keep a reference to it.
 
-    Example usage::
-
-        import numpy as np
-        import matplotlib.pyplot as plt
-        from matplotlib.widgets import RectangleSelector
-
-        def onselect(eclick, erelease):
-            "eclick and erelease are matplotlib events at press and release."
-            print('startposition: (%f, %f)' % (eclick.xdata, eclick.ydata))
-            print('endposition  : (%f, %f)' % (erelease.xdata, erelease.ydata))
-            print('used button  : ', eclick.button)
-
-        def toggle_selector(event):
-            print('Key pressed.')
-            if event.key in ['Q', 'q'] and toggle_selector.RS.active:
-                print('RectangleSelector deactivated.')
-                toggle_selector.RS.set_active(False)
-            if event.key in ['A', 'a'] and not toggle_selector.RS.active:
-                print('RectangleSelector activated.')
-                toggle_selector.RS.set_active(True)
-
-        x = np.arange(100.) / 99
-        y = np.sin(x)
-        fig, ax = plt.subplots()
-        ax.plot(x, y)
-
-        toggle_selector.RS = RectangleSelector(ax, onselect, drawtype='line')
-        fig.canvas.mpl_connect('key_press_event', toggle_selector)
-        plt.show()
+    Examples
+    --------
+    :doc:`/gallery/widgets/rectangle_selector`
     """
 
     _shape_klass = Rectangle


### PR DESCRIPTION
- Don't use "q" or "a" as keys given that they are already mapped to
  "quit" and "all_axes" (even though the latter is deprecated).
- Document the interactivity directly as the axes title.
- No need to plot too many things in the axes; they're irrelevant.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
