### PR TITLE
DOC: Use Sphinx-gallery animation capture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ apt-run:  &apt-install
       graphviz \
       fonts-crosextra-carlito \
       fonts-freefont-otf \
-      fonts-humor-sans
+      fonts-humor-sans \
+      optipng
 
 fonts-run:  &fonts-install
   name: Install custom fonts

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -25,7 +25,7 @@ clean:
 	rm -rf "$(SOURCEDIR)/sphinxext/__pycache__"
 
 show:
-	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(shell pwd)/build/html/index.html')"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -24,6 +24,9 @@ clean:
 	rm -rf "$(SOURCEDIR)/savefig"
 	rm -rf "$(SOURCEDIR)/sphinxext/__pycache__"
 
+show:
+	@python -c "import webbrowser; webbrowser.open_new_tab('file://$(PWD)/build/html/index.html')"
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -189,10 +189,6 @@ div.documentwrapper {
 }
 */
 
-div.clearer {
-    clear: both;
-}
-
 div.related h3 {
     display: none;
 }

--- a/doc/_templates/autosummary.rst
+++ b/doc/_templates/autosummary.rst
@@ -21,11 +21,8 @@
    creates no example file for those (sphinx-gallery/sphinx-gallery#365)
 
 {% else %}
-.. include:: {{module}}.{{objname}}.examples
-
-.. raw:: html
-
-    <div class="clearer"></div>
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading:
 
 {% endif %}
 {% endif %}

--- a/doc/_templates/function.rst
+++ b/doc/_templates/function.rst
@@ -5,8 +5,5 @@
 
 .. autofunction:: {{ objname }}
 
-.. include:: {{module}}.{{objname}}.examples
-
-.. raw:: html
-
-    <div class="clearer"></div>
+.. minigallery:: {{module}}.{{objname}}
+   :add-heading:

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -135,7 +135,7 @@ Examples
 
    ../gallery/animation/animate_decay
    ../gallery/animation/bayes_update
-   ../gallery/animation/double_pendulum_sgskip
+   ../gallery/animation/double_pendulum
    ../gallery/animation/animated_histogram
    ../gallery/animation/rain
    ../gallery/animation/random_walk

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -139,6 +139,8 @@ sphinx_gallery_conf = {
     'within_subsection_order': gallery_order.subsectionorder,
     'remove_config_comments': True,
     'min_reported_time': 1,
+    'compress_images': ('thumbnails', 'images'),
+    'matplotlib_animations': True,
 }
 
 plot_gallery = 'True'

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -890,7 +890,9 @@ Miscellaneous
 Adding animations
 -----------------
 
-There is a Matplotlib Google/Gmail account with username ``mplgithub``
+Animations are scraped automatically by Sphinx-gallery. If this is not
+desired,
+there is also a Matplotlib Google/Gmail account with username ``mplgithub``
 which was used to setup the github account but can be used for other
 purposes, like hosting Google docs or Youtube videos.  You can embed a
 Matplotlib animation in the docs by first saving the animation as a

--- a/doc/matplotlibrc
+++ b/doc/matplotlibrc
@@ -2,3 +2,4 @@ backend            : Agg
 figure.figsize     : 5.5, 4.5 # figure size in inches
 savefig.dpi        : 80       # figure dots per inch
 docstring.hardcopy : True     # set this when you want to generate hardcopy docstring
+animation.embed_limit : 30    # allow embedded animations to be big

--- a/examples/animation/animated_histogram.py
+++ b/examples/animation/animated_histogram.py
@@ -87,5 +87,5 @@ ax.add_patch(patch)
 ax.set_xlim(left[0], right[-1])
 ax.set_ylim(bottom.min(), top.max())
 
-ani = animation.FuncAnimation(fig, animate, 100, repeat=False, blit=True)
+ani = animation.FuncAnimation(fig, animate, 50, repeat=False, blit=True)
 plt.show()

--- a/examples/animation/bayes_update.py
+++ b/examples/animation/bayes_update.py
@@ -31,7 +31,7 @@ class UpdateDist:
 
         # Set up plot parameters
         self.ax.set_xlim(0, 1)
-        self.ax.set_ylim(0, 15)
+        self.ax.set_ylim(0, 10)
         self.ax.grid(True)
 
         # This vertical line represents the theoretical value, to

--- a/examples/animation/double_pendulum.py
+++ b/examples/animation/double_pendulum.py
@@ -20,6 +20,7 @@ L1 = 1.0  # length of pendulum 1 in m
 L2 = 1.0  # length of pendulum 2 in m
 M1 = 1.0  # mass of pendulum 1 in kg
 M2 = 1.0  # mass of pendulum 2 in kg
+t_stop = 5  # how many seconds to simulate
 
 
 def derivs(state, t):
@@ -48,7 +49,7 @@ def derivs(state, t):
 
 # create a time array from 0..100 sampled at 0.05 second steps
 dt = 0.05
-t = np.arange(0, 20, dt)
+t = np.arange(0, t_stop, dt)
 
 # th1 and th2 are the initial angles (degrees)
 # w10 and w20 are the initial angular velocities (degrees per second)
@@ -69,8 +70,8 @@ y1 = -L1*cos(y[:, 0])
 x2 = L2*sin(y[:, 2]) + x1
 y2 = -L2*cos(y[:, 2]) + y1
 
-fig = plt.figure()
-ax = fig.add_subplot(111, autoscale_on=False, xlim=(-2, 2), ylim=(-2, 2))
+fig = plt.figure(figsize=(5, 4))
+ax = fig.add_subplot(111, autoscale_on=False, xlim=(-2, 2), ylim=(-2, 1))
 ax.set_aspect('equal')
 ax.grid()
 

--- a/examples/animation/dynamic_image.py
+++ b/examples/animation/dynamic_image.py
@@ -9,7 +9,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
-fig = plt.figure()
+fig, ax = plt.subplots()
 
 
 def f(x, y):
@@ -17,6 +17,7 @@ def f(x, y):
 
 x = np.linspace(0, 2 * np.pi, 120)
 y = np.linspace(0, 2 * np.pi, 100).reshape(-1, 1)
+
 # ims is a list of lists, each row is a list of artists to draw in the
 # current frame; here we are just animating one artist, the image, in
 # each frame
@@ -24,7 +25,9 @@ ims = []
 for i in range(60):
     x += np.pi / 15.
     y += np.pi / 20.
-    im = plt.imshow(f(x, y), animated=True)
+    im = ax.imshow(f(x, y), animated=True)
+    if i == 0:
+        ax.imshow(f(x, y))  # show an initial one first
     ims.append([im])
 
 ani = animation.ArtistAnimation(fig, ims, interval=50, blit=True,

--- a/examples/animation/random_walk.py
+++ b/examples/animation/random_walk.py
@@ -69,6 +69,6 @@ ax.set_title('3D Test')
 
 # Creating the Animation object
 line_ani = animation.FuncAnimation(
-    fig, update_lines, 25, fargs=(data, lines), interval=50)
+    fig, update_lines, 50, fargs=(data, lines), interval=50)
 
 plt.show()

--- a/examples/animation/simple_anim.py
+++ b/examples/animation/simple_anim.py
@@ -16,12 +16,12 @@ line, = ax.plot(x, np.sin(x))
 
 
 def animate(i):
-    line.set_ydata(np.sin(x + i / 100))  # update the data.
+    line.set_ydata(np.sin(x + i / 50))  # update the data.
     return line,
 
 
 ani = animation.FuncAnimation(
-    fig, animate, interval=2, blit=True, save_count=50)
+    fig, animate, interval=20, blit=True, save_count=50)
 
 # To save the animation, use e.g.
 #

--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -39,7 +39,7 @@ class Scope:
         return self.line,
 
 
-def emitter(p=0.03):
+def emitter(p=0.1):
     """Return a random value in [0, 1) with probability p, else 0."""
     while True:
         v = np.random.rand(1)
@@ -49,14 +49,14 @@ def emitter(p=0.03):
             yield np.random.rand(1)
 
 # Fixing random state for reproducibility
-np.random.seed(19680801)
+np.random.seed(1968080)
 
 
 fig, ax = plt.subplots()
 scope = Scope(ax)
 
 # pass a generator in "emitter" to produce data for the update func
-ani = animation.FuncAnimation(fig, scope.update, emitter, interval=10,
+ani = animation.FuncAnimation(fig, scope.update, emitter, interval=50,
                               blit=True)
 
 plt.show()

--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -48,6 +48,7 @@ def emitter(p=0.1):
         else:
             yield np.random.rand(1)
 
+
 # Fixing random state for reproducibility
 np.random.seed(19680801 // 10)
 

--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -49,7 +49,7 @@ def emitter(p=0.1):
             yield np.random.rand(1)
 
 # Fixing random state for reproducibility
-np.random.seed(1968080)
+np.random.seed(19680801 // 10)
 
 
 fig, ax = plt.subplots()

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -12,5 +12,5 @@ colorspacious
 ipython
 ipywidgets
 numpydoc>=0.8
-sphinx-gallery>=0.5
+sphinx-gallery>=0.7
 sphinx-copybutton

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -14,3 +14,4 @@ ipywidgets
 numpydoc>=0.8
 sphinx-gallery>=0.7
 sphinx-copybutton
+scipy


### PR DESCRIPTION
## PR Summary

1. Use the Matplotlib animation capture built into Sphinx-gallery 0.7.0 to capture animations.
2. Update to latest syntax for mini-gallery inclusion
3. Add image compression (optipng)
4. EDIT: Add a make show target in doc/Makefile to make it easier to pop open the built docs
5. EDIT: Add SciPy to the doc build requirements
6. EDIT: Rename a `double_pendulum_sgskip` to actually build

It does move some animations into the slowest category (local build times with this PR):

```
    - ../examples/style_sheets/style_sheets_reference.py:                          15.52 sec   0.0 MB
    - ../examples/animation/animate_decay.py:                                      12.85 sec   0.0 MB
    - ../tutorials/intermediate/constrainedlayout_guide.py:                        12.30 sec   0.0 MB
    - ../examples/animation/animated_histogram.py:                                 11.79 sec   0.0 MB
    - ../examples/animation/strip_chart.py:                                        11.09 sec   0.0 MB
    - ../tutorials/colors/colormaps.py:                                            10.36 sec   0.0 MB
    - ../examples/animation/animation_demo.py:                                      8.99 sec   0.0 MB
    - ../examples/animation/unchained.py:                                           7.68 sec   0.0 MB
    - ../examples/animation/bayes_update.py:                                        7.60 sec   0.0 MB
    - ../examples/lines_bars_and_markers/markevery_demo.py:                         7.00 sec   0.0 MB
    - ../examples/animation/simple_anim.py:                                         6.33 sec   0.0 MB
    - ../tutorials/intermediate/gridspec.py:                                        6.09 sec   0.0 MB
    - ../examples/subplots_axes_and_figures/subplots_demo.py:                       5.40 sec   0.0 MB
    - ../tutorials/introductory/images.py:                                          5.39 sec   0.0 MB
    - ../tutorials/intermediate/tight_layout_guide.py:                              4.95 sec   0.0 MB
    - ../examples/animation/rain.py:                                                4.58 sec   0.0 MB
    - ../examples/animation/random_walk.py:                                         4.57 sec   0.0 MB
```

It might be possible to optimize these examples to be faster (I haven't looked/tried). Or maybe it's acceptable already...

## PR Checklist

- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant

## Looks like this on my machine

![Peek 2020-05-21 13-47](https://user-images.githubusercontent.com/2365790/82589158-b6dc8c80-9b69-11ea-8f5f-cb83d55c4745.gif)

![Peek 2020-05-21 13-48](https://user-images.githubusercontent.com/2365790/82589248-da073c00-9b69-11ea-8264-3b817d322273.gif)

Let's see if CircleCI agrees!

Happy to iterate here if people agree it's worth having, let someone else take over if they want, or scrap it if it's not worth adding.