### PR TITLE
Fix LightSource.shade on fully unmasked array.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1936,7 +1936,7 @@ class LightSource:
                                  .format(lookup.keys)) from err
 
         # Only apply result where hillshade intensity isn't masked
-        if hasattr(intensity, 'mask'):
+        if np.ma.is_masked(intensity):
             mask = intensity.mask[..., 0]
             for i in range(3):
                 blend[..., i][mask] = rgb[..., i][mask]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -692,6 +692,19 @@ def test_light_source_shading_default():
     assert_array_almost_equal(rgb, expect, decimal=2)
 
 
+def test_light_source_shading_empty_mask():
+    y, x = np.mgrid[-1.2:1.2:8j, -1.2:1.2:8j]
+    z0 = 10 * np.cos(x**2 + y**2)
+    z1 = np.ma.array(z0)
+
+    cmap = plt.cm.copper
+    ls = mcolors.LightSource(315, 45)
+    rgb0 = ls.shade(z0, cmap)
+    rgb1 = ls.shade(z1, cmap)
+
+    assert_array_almost_equal(rgb0, rgb1)
+
+
 # Numpy 1.9.1 fixed a bug in masked arrays which resulted in
 # additional elements being masked when calculating the gradient thus
 # the output is different with earlier numpy versions.


### PR DESCRIPTION
## PR Summary

In previous versions of NumPy, `np.clip` would expand the mask, but it no longer does so. Use `np.ma.is_masked` to check for a mask instead of `hasattr`, as the former also checks whether any *values* are actually masked.

Fixes #17455.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way