### PR TITLE
Support marking a single artist as not-usetex.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -301,3 +301,9 @@ When `.cbook.get_sample_data` is used to load a npy or npz file and the
 keyword-only parameter ``np_load`` is True, the file is automatically loaded
 using `numpy.load`.  ``np_load`` defaults to False for backwards compatibility,
 but will become True in a later release.
+
+``get_text_width_height_descent`` now checks ``ismath`` rather than :rc:`text.usetex`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... to determine whether a string should be passed to the usetex machinery or
+not.  This allows single strings to be marked as not-usetex even when the
+rcParam is True.

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -80,7 +80,7 @@ class RendererPDFPSBase(RendererBase):
 
     def get_text_width_height_descent(self, s, prop, ismath):
         # docstring inherited
-        if mpl.rcParams["text.usetex"]:
+        if ismath == "TeX":
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()
             w, h, d = texmanager.get_text_width_height_descent(

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -558,9 +558,21 @@ def test_single_artist_usetex():
     # Check that a single artist marked with usetex does not get passed through
     # the mathtext parser at all (for the Agg backend) (the mathtext parser
     # currently fails to parse \frac12, requiring \frac{1}{2} instead).
-    fig, ax = plt.subplots()
-    ax.text(.5, .5, r"$\frac12$", usetex=True)
+    fig = plt.figure()
+    fig.text(.5, .5, r"$\frac12$", usetex=True)
     fig.canvas.draw()
+
+
+@pytest.mark.parametrize("fmt", ["png", "pdf", "svg"])
+def test_single_artist_usenotex(fmt):
+    # Check that a single artist can be marked as not-usetex even though the
+    # rcParam is on ("2_2_2" fails if passed to TeX).  This currently skips
+    # postscript output as the ps renderer doesn't support mixing usetex and
+    # non-usetex.
+    plt.rcParams["text.usetex"] = True
+    fig = plt.figure()
+    fig.text(.5, .5, "2_2_2", usetex=False)
+    fig.savefig(io.BytesIO(), format=fmt)
 
 
 @image_comparison(['text_as_path_opacity.svg'])

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -52,7 +52,7 @@ class TextToPath:
         return char_id
 
     def get_text_width_height_descent(self, s, prop, ismath):
-        if rcParams['text.usetex']:
+        if ismath == "TeX":
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()
             w, h, d = texmanager.get_text_width_height_descent(s, fontsize,


### PR DESCRIPTION
... even when `rcParams["text.usetex"] = True`.  See
test_single_artist_no_usetex for an example.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
