### PR TITLE
Simplify handling of fontproperties=None.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -638,8 +638,20 @@ class FontProperties:
 
     @classmethod
     def _from_any(cls, arg):
+        """
+        Generic constructor which can build a `.FontProperties` from any of the
+        following:
+
+        - a `.FontProperties`: it is passed through as is;
+        - `None`: a `.FontProperties` using rc values is used;
+        - an `os.PathLike`: it is used as path to the font file;
+        - a `str`: it is parsed as a fontconfig pattern;
+        - a `dict`: it is passed as ``**kwargs`` to `.FontProperties`.
+        """
         if isinstance(arg, cls):
             return arg
+        elif arg is None:
+            return cls()
         elif isinstance(arg, os.PathLike):
             return cls(fname=arg)
         elif isinstance(arg, str):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -147,15 +147,9 @@ class Text(Artist):
         """
         Artist.__init__(self)
         self._x, self._y = x, y
-
-        if color is None:
-            color = rcParams['text.color']
-        if fontproperties is None:
-            fontproperties = FontProperties()
-
         self._text = ''
         self.set_text(text)
-        self.set_color(color)
+        self.set_color(color if color is not None else rcParams["text.color"])
         self.set_fontproperties(fontproperties)
         self.set_usetex(usetex)
         self.set_wrap(wrap)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -385,10 +385,7 @@ class TextPath(Path):
         # Circular import.
         from matplotlib.text import Text
 
-        if prop is None:
-            prop = FontProperties()
-        else:
-            prop = FontProperties._from_any(prop)
+        prop = FontProperties._from_any(prop)
         if size is None:
             size = prop.get_size_in_points()
 


### PR DESCRIPTION
... by moving support for it (building a default FontProperties()) to
the generic constructor `FontProperties._from_any`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
