### PR TITLE
Make error message explicit in legend.py

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -404,8 +404,9 @@ class Legend(Artist):
         _lab, _hand = [], []
         for label, handle in zip(labels, handles):
             if isinstance(label, str) and label.startswith('_'):
-                cbook._warn_external('The label {!r} of handle {!r} cannot be a '
-                                     'string starting with "_"'.format(handle, label))
+                cbook._warn_external('The label {!r} of handle {!r} cannot be '
+                                     'a string starting with '
+                                     '"_"'.format(handle, label))
             else:
                 _lab.append(label)
                 _hand.append(handle)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -406,7 +406,7 @@ class Legend(Artist):
             if isinstance(label, str) and label.startswith('_'):
                 cbook._warn_external('The label {!r} of handle {!r} cannot be '
                                      'a string starting with '
-                                     '"_"'.format(handle, label))
+                                     '"_"'.format(label, handle))
             else:
                 _lab.append(label)
                 _hand.append(handle)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -404,8 +404,8 @@ class Legend(Artist):
         _lab, _hand = [], []
         for label, handle in zip(labels, handles):
             if isinstance(label, str) and label.startswith('_'):
-                cbook._warn_external('The label {!r} of handle {!r} cannot be a string
-                                     'starting with "_"'.format(handle, label))
+                cbook._warn_external('The label {!r} of handle {!r} cannot be a '
+                                     'string starting with "_"'.format(handle, label))
             else:
                 _lab.append(label)
                 _hand.append(handle)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -404,9 +404,8 @@ class Legend(Artist):
         _lab, _hand = [], []
         for label, handle in zip(labels, handles):
             if isinstance(label, str) and label.startswith('_'):
-                cbook._warn_external('The handle {!r} has a label of {!r} '
-                                     'which cannot be automatically added to'
-                                     ' the legend.'.format(handle, label))
+                cbook._warn_external('The label {!r} of handle {!r} cannot be a string
+                                     'starting with "_"'.format(handle, label))
             else:
                 _lab.append(label)
                 _hand.append(handle)


### PR DESCRIPTION
## PR Summary

Update the error message when label is a string and starts with `_` so as to make it clearer to the user.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
