### PR TITLE
BUG: Picking vertical line broken

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -80,7 +80,7 @@ def segment_hits(cx, cy, x, y, radius):
     """
     # Process single points specially
     if len(x) <= 1:
-        res, = np.nonzero(np.hypot(cx - x, cy - y) <= radius)
+        res, = np.nonzero((cx - x) ** 2 + (cy - y) ** 2 <= radius ** 2)
         return res
 
     # We need to lop the last element off a lot.
@@ -89,24 +89,24 @@ def segment_hits(cx, cy, x, y, radius):
     # Only look at line segments whose nearest point to C on the line
     # lies within the segment.
     dx, dy = x[1:] - xr, y[1:] - yr
-    u = (cx - xr) * dx + (cy - yr) * dy
-    candidates = (0 <= u) & (u <= dx ** 2 + dy ** 2)
+    Lnorm_sq = dx ** 2 + dy ** 2  # Possibly want to eliminate Lnorm==0
+    u = ((cx - xr) * dx + (cy - yr) * dy) / Lnorm_sq
+    candidates = (u >= 0) & (u <= 1)
 
     # Note that there is a little area near one side of each point
     # which will be near neither segment, and another which will
     # be near both, depending on the angle of the lines.  The
     # following radius test eliminates these ambiguities.
-    point_hits = np.hypot(cx - x, cy - y) <= radius
+    point_hits = (cx - x) ** 2 + (cy - y) ** 2 <= radius ** 2
     candidates = candidates & ~(point_hits[:-1] | point_hits[1:])
 
     # For those candidates which remain, determine how far they lie away
     # from the line.
     px, py = xr + u * dx, yr + u * dy
-    line_hits = np.hypot(cx - px, cy - py) <= radius
+    line_hits = (cx - px) ** 2 + (cy - py) ** 2 <= radius ** 2
     line_hits = line_hits & candidates
-
-    points, = point_hits.nonzero()
-    lines, = line_hits.nonzero()
+    points, = point_hits.ravel().nonzero()
+    lines, = line_hits.ravel().nonzero()
     return np.concatenate((points, lines))
 
 
@@ -454,16 +454,21 @@ class Line2D(Artist):
         else:
             pixels = self.figure.dpi / 72. * self.pickradius
 
-        # Check for collision
-        if self._linestyle in ['None', None]:
-            # If no line, return the nearby point(s)
-            ind, = np.nonzero(
-                np.hypot(xt - mouseevent.x, yt - mouseevent.y) <= pixels)
-        else:
-            # If line, return the nearby segment(s)
-            ind = segment_hits(mouseevent.x, mouseevent.y, xt, yt, pixels)
-            if self._drawstyle.startswith("steps"):
-                ind //= 2
+        # The math involved in checking for containment (here and inside of
+        # segment_hits) assumes that it is OK to overflow, so temporarily set
+        # the error flags accordingly.
+        with np.errstate(all='ignore'):
+            # Check for collision
+            if self._linestyle in ['None', None]:
+                # If no line, return the nearby point(s)
+                ind, = np.nonzero(
+                    (xt - mouseevent.x) ** 2 + (yt - mouseevent.y) ** 2
+                    <= pixels ** 2)
+            else:
+                # If line, return the nearby segment(s)
+                ind = segment_hits(mouseevent.x, mouseevent.y, xt, yt, pixels)
+                if self._drawstyle.startswith("steps"):
+                    ind //= 2
 
         ind += self.ind_offset
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -18,6 +18,14 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
+def test_segment_hits():
+    """Test a problematic case."""
+    cx, cy = 553, 902
+    x, y = np.array([553., 553.]), np.array([95., 947.])
+    radius = 6.94
+    assert_array_equal(mlines.segment_hits(cx, cy, x, y, radius), [0])
+
+
 # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
 # won't help, hopefully.
 @pytest.mark.flaky(reruns=3)


### PR DESCRIPTION
#17282 introduced a bug where a vertical line could no longer be picked properly. This test is a minimal example showing it, it passes on 25187774153eee580cca5aabbc3e685326128c80 but fails on fdf07f585563f5813621f5e43313df215deff125 .

@anntzer #17282 was yours, any interest in fixing this? If not, I can try to understand why it fails but the old code works. It wasn't immediately obvious to me from looking at the code.