### PR TITLE
Fix Pillow import in testing.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -13,7 +13,7 @@ import sys
 from tempfile import TemporaryDirectory, TemporaryFile
 
 import numpy as np
-import PIL
+from PIL import Image
 
 import matplotlib as mpl
 from matplotlib import cbook
@@ -391,8 +391,8 @@ def compare_images(expected, actual, tol, in_decorator=False):
         expected = convert(expected, cache=True)
 
     # open the image files and remove the alpha channel (if it exists)
-    expected_image = np.asarray(PIL.Image.open(expected).convert("RGB"))
-    actual_image = np.asarray(PIL.Image.open(actual).convert("RGB"))
+    expected_image = np.asarray(Image.open(expected).convert("RGB"))
+    actual_image = np.asarray(Image.open(actual).convert("RGB"))
 
     actual_image, expected_image = crop_to_same(
         actual, actual_image, expected, expected_image)
@@ -442,8 +442,8 @@ def save_diff_image(expected, actual, output):
         File path to save difference image to.
     """
     # Drop alpha channels, similarly to compare_images.
-    expected_image = np.asarray(PIL.Image.open(expected).convert("RGB"))
-    actual_image = np.asarray(PIL.Image.open(actual).convert("RGB"))
+    expected_image = np.asarray(Image.open(expected).convert("RGB"))
+    actual_image = np.asarray(Image.open(actual).convert("RGB"))
     actual_image, expected_image = crop_to_same(
         actual, actual_image, expected, expected_image)
     expected_image = np.array(expected_image).astype(float)
@@ -469,4 +469,4 @@ def save_diff_image(expected, actual, output):
     # Hard-code the alpha channel to fully solid
     save_image_np[:, :, 3] = 255
 
-    PIL.Image.fromarray(save_image_np).save(output, format="png")
+    Image.fromarray(save_image_np).save(output, format="png")


### PR DESCRIPTION
## PR Summary

The expected import is `from PIL import Image`, and if you import the compare function directly, it will fail:
```python
>>> from matplotlib.testing.compare import compare_images
>>> compare_images('a.png', 'b.png', 0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../matplotlib/testing/compare.py", line 394, in compare_images
    expected_image = np.asarray(PIL.Image.open(expected).convert("RGB"))
AttributeError: module 'PIL' has no attribute 'Image'
```

It only works in our test suite because some other file does it correctly.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way