### PR TITLE
Dedupe some C++ templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,14 @@ class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
         env = self.add_optimization_flags()
         for package in good_packages:
             package.do_custom_build(env)
+        # Make sure we don't accidentally use too modern C++ constructs, even
+        # though modern compilers default to enabling them.  Enabling this for
+        # a single platform is enough; also only do this for C++-only
+        # extensions as clang refuses to compile C/ObjC with -std=c++11.
+        if sys.platform != "win32":
+            for ext in self.distribution.ext_modules[:]:
+                if not any(src.endswith((".c", ".m")) for src in ext.sources):
+                    ext.extra_compile_args.append("-std=c++11")
         return super().build_extensions()
 
     def build_extension(self, ext):

--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -500,240 +500,58 @@ typedef enum {
 } interpolation_e;
 
 
-template <typename T>
-class type_mapping;
+// T is rgba if and only if it has an T::r field.
+template<typename T, typename = void> struct is_grayscale : std::true_type {};
+template<typename T> struct is_grayscale<T, decltype(T::r, void())> : std::false_type {};
 
 
-template <> class type_mapping<agg::rgba8>
+template<typename color_type>
+struct type_mapping
 {
- public:
-    typedef agg::rgba8 color_type;
-    typedef fixed_blender_rgba_plain<color_type, agg::order_rgba> blender_type;
-    typedef fixed_blender_rgba_pre<color_type, agg::order_rgba> pre_blender_type;
-    typedef agg::pixfmt_alpha_blend_rgba<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef agg::pixfmt_alpha_blend_rgba<pre_blender_type, agg::rendering_buffer> pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_rgba_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_rgba<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_rgba_nn<A, B> type;
-    };
+    using blender_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        agg::blender_gray<color_type>,
+        typename std::conditional<
+            std::is_same<color_type, agg::rgba8>::value,
+            fixed_blender_rgba_plain<color_type, agg::order_rgba>,
+            agg::blender_rgba_plain<color_type, agg::order_rgba>
+        >::type
+    >::type;
+    using pixfmt_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        agg::pixfmt_alpha_blend_gray<blender_type, agg::rendering_buffer>,
+        agg::pixfmt_alpha_blend_rgba<blender_type, agg::rendering_buffer>
+    >::type;
+    using pixfmt_pre_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        pixfmt_type,
+        agg::pixfmt_alpha_blend_rgba<
+            typename std::conditional<
+                std::is_same<color_type, agg::rgba8>::value,
+                fixed_blender_rgba_pre<color_type, agg::order_rgba>,
+                agg::blender_rgba_pre<color_type, agg::order_rgba>
+            >::type,
+            agg::rendering_buffer>
+    >::type;
+    template<typename A> using span_gen_affine_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        agg::span_image_resample_gray_affine<A>,
+        agg::span_image_resample_rgba_affine<A>
+    >::type;
+    template<typename A, typename B> using span_gen_filter_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        agg::span_image_filter_gray<A, B>,
+        agg::span_image_filter_rgba<A, B>
+    >::type;
+    template<typename A, typename B> using span_gen_nn_type = typename std::conditional<
+        is_grayscale<color_type>::value,
+        agg::span_image_filter_gray_nn<A, B>,
+        agg::span_image_filter_rgba_nn<A, B>
+    >::type;
 };
 
 
-template <> class type_mapping<agg::rgba16>
-{
- public:
-    typedef agg::rgba16 color_type;
-    typedef fixed_blender_rgba_plain<color_type, agg::order_rgba> blender_type;
-    typedef fixed_blender_rgba_pre<color_type, agg::order_rgba> pre_blender_type;
-    typedef agg::pixfmt_alpha_blend_rgba<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef agg::pixfmt_alpha_blend_rgba<pre_blender_type, agg::rendering_buffer> pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_rgba_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_rgba<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_rgba_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<agg::rgba32>
-{
- public:
-    typedef agg::rgba32 color_type;
-    typedef agg::blender_rgba_plain<color_type, agg::order_rgba> blender_type;
-    typedef agg::blender_rgba_pre<color_type, agg::order_rgba> pre_blender_type;
-    typedef agg::pixfmt_alpha_blend_rgba<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef agg::pixfmt_alpha_blend_rgba<pre_blender_type, agg::rendering_buffer> pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_rgba_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_rgba<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_rgba_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<agg::rgba64>
-{
- public:
-    typedef agg::rgba64 color_type;
-    typedef agg::blender_rgba_plain<color_type, agg::order_rgba> blender_type;
-    typedef agg::blender_rgba_pre<color_type, agg::order_rgba> pre_blender_type;
-    typedef agg::pixfmt_alpha_blend_rgba<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef agg::pixfmt_alpha_blend_rgba<pre_blender_type, agg::rendering_buffer> pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_rgba_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_rgba<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_rgba_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<double>
-{
- public:
-    typedef agg::gray64 color_type;
-    typedef agg::blender_gray<color_type> blender_type;
-    typedef agg::pixfmt_alpha_blend_gray<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef pixfmt_type pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_gray_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_gray<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_gray_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<float>
-{
- public:
-    typedef agg::gray32 color_type;
-    typedef agg::blender_gray<color_type> blender_type;
-    typedef agg::pixfmt_alpha_blend_gray<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef pixfmt_type pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_gray_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_gray<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_gray_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<unsigned short>
-{
- public:
-    typedef agg::gray16 color_type;
-    typedef agg::blender_gray<color_type> blender_type;
-    typedef agg::pixfmt_alpha_blend_gray<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef pixfmt_type pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_gray_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_gray<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_gray_nn<A, B> type;
-    };
-};
-
-
-template <> class type_mapping<unsigned char>
-{
- public:
-    typedef agg::gray8 color_type;
-    typedef agg::blender_gray<color_type> blender_type;
-    typedef agg::pixfmt_alpha_blend_gray<blender_type, agg::rendering_buffer> pixfmt_type;
-    typedef pixfmt_type pixfmt_pre_type;
-
-    template <typename A>
-    struct span_gen_affine_type
-    {
-        typedef agg::span_image_resample_gray_affine<A> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_filter_type
-    {
-        typedef agg::span_image_filter_gray<A, B> type;
-    };
-
-    template <typename A, typename B>
-    struct span_gen_nn_type
-    {
-        typedef agg::span_image_filter_gray_nn<A, B> type;
-    };
-};
-
-
-
-template<class color_type>
+template<typename color_type>
 class span_conv_alpha
 {
 public:
@@ -882,29 +700,34 @@ static void get_filter(const resample_params_t &params,
 }
 
 
-template<class T>
+template<typename color_type>
 void resample(
-    const T *input, int in_width, int in_height,
-    T *output, int out_width, int out_height,
+    const void *input, int in_width, int in_height,
+    void *output, int out_width, int out_height,
     resample_params_t &params)
 {
-    typedef type_mapping<T> type_mapping_t;
+    using type_mapping_t = type_mapping<color_type>;
 
-    typedef typename type_mapping_t::pixfmt_type input_pixfmt_t;
-    typedef typename type_mapping_t::pixfmt_type output_pixfmt_t;
+    using input_pixfmt_t = typename type_mapping_t::pixfmt_type;
+    using output_pixfmt_t = typename type_mapping_t::pixfmt_type;
 
-    typedef agg::renderer_base<output_pixfmt_t> renderer_t;
-    typedef agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip_dbl> rasterizer_t;
+    using renderer_t = agg::renderer_base<output_pixfmt_t>;
+    using rasterizer_t = agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip_dbl>;
 
-    typedef agg::wrap_mode_reflect reflect_t;
-    typedef agg::image_accessor_wrap<input_pixfmt_t, reflect_t, reflect_t> image_accessor_t;
+    using reflect_t = agg::wrap_mode_reflect;
+    using image_accessor_t = agg::image_accessor_wrap<input_pixfmt_t, reflect_t, reflect_t>;
 
-    typedef agg::span_allocator<typename type_mapping_t::color_type> span_alloc_t;
-    typedef span_conv_alpha<typename type_mapping_t::color_type> span_conv_alpha_t;
+    using span_alloc_t = agg::span_allocator<color_type>;
+    using span_conv_alpha_t = span_conv_alpha<color_type>;
 
-    typedef agg::span_interpolator_linear<> affine_interpolator_t;
-    typedef agg::span_interpolator_adaptor<agg::span_interpolator_linear<>, lookup_distortion>
-        arbitrary_interpolator_t;
+    using affine_interpolator_t = agg::span_interpolator_linear<>;
+    using arbitrary_interpolator_t =
+        agg::span_interpolator_adaptor<agg::span_interpolator_linear<>, lookup_distortion>;
+
+    size_t itemsize = sizeof(color_type);
+    if (is_grayscale<color_type>::value) {
+        itemsize /= 2;  // agg::grayXX includes an alpha channel which we don't have.
+    }
 
     if (params.interpolation != NEAREST &&
         params.is_affine &&
@@ -922,14 +745,14 @@ void resample(
     span_conv_alpha_t conv_alpha(params.alpha);
 
     agg::rendering_buffer input_buffer;
-    input_buffer.attach((unsigned char *)input, in_width, in_height,
-                        in_width * sizeof(T));
+    input_buffer.attach(
+        (unsigned char *)input, in_width, in_height, in_width * itemsize);
     input_pixfmt_t input_pixfmt(input_buffer);
     image_accessor_t input_accessor(input_pixfmt);
 
     agg::rendering_buffer output_buffer;
-    output_buffer.attach((unsigned char *)output, out_width, out_height,
-                         out_width * sizeof(T));
+    output_buffer.attach(
+        (unsigned char *)output, out_width, out_height, out_width * itemsize);
     output_pixfmt_t output_pixfmt(output_buffer);
     renderer_t renderer(output_pixfmt);
 
@@ -958,20 +781,18 @@ void resample(
 
     if (params.interpolation == NEAREST) {
         if (params.is_affine) {
-            typedef typename type_mapping_t::template span_gen_nn_type<image_accessor_t, affine_interpolator_t>::type span_gen_t;
-            typedef agg::span_converter<span_gen_t, span_conv_alpha_t> span_conv_t;
-            typedef agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t> nn_renderer_t;
-
+            using span_gen_t = typename type_mapping_t::template span_gen_nn_type<image_accessor_t, affine_interpolator_t>;
+            using span_conv_t = agg::span_converter<span_gen_t, span_conv_alpha_t>;
+            using nn_renderer_t = agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t>;
             affine_interpolator_t interpolator(inverted);
             span_gen_t span_gen(input_accessor, interpolator);
             span_conv_t span_conv(span_gen, conv_alpha);
             nn_renderer_t nn_renderer(renderer, span_alloc, span_conv);
             agg::render_scanlines(rasterizer, scanline, nn_renderer);
         } else {
-            typedef typename type_mapping_t::template span_gen_nn_type<image_accessor_t, arbitrary_interpolator_t>::type span_gen_t;
-            typedef agg::span_converter<span_gen_t, span_conv_alpha_t> span_conv_t;
-            typedef agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t> nn_renderer_t;
-
+            using span_gen_t = typename type_mapping_t::template span_gen_nn_type<image_accessor_t, arbitrary_interpolator_t>;
+            using span_conv_t = agg::span_converter<span_gen_t, span_conv_alpha_t>;
+            using nn_renderer_t = agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t>;
             lookup_distortion dist(
                 params.transform_mesh, in_width, in_height, out_width, out_height);
             arbitrary_interpolator_t interpolator(inverted, dist);
@@ -985,20 +806,18 @@ void resample(
         get_filter(params, filter);
 
         if (params.is_affine && params.resample) {
-            typedef typename type_mapping_t::template span_gen_affine_type<image_accessor_t>::type span_gen_t;
-            typedef agg::span_converter<span_gen_t, span_conv_alpha_t> span_conv_t;
-            typedef agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t> int_renderer_t;
-
+            using span_gen_t = typename type_mapping_t::template span_gen_affine_type<image_accessor_t>;
+            using span_conv_t = agg::span_converter<span_gen_t, span_conv_alpha_t>;
+            using int_renderer_t = agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t>;
             affine_interpolator_t interpolator(inverted);
             span_gen_t span_gen(input_accessor, interpolator, filter);
             span_conv_t span_conv(span_gen, conv_alpha);
             int_renderer_t int_renderer(renderer, span_alloc, span_conv);
             agg::render_scanlines(rasterizer, scanline, int_renderer);
         } else {
-            typedef typename type_mapping_t::template span_gen_filter_type<image_accessor_t, arbitrary_interpolator_t>::type span_gen_t;
-            typedef agg::span_converter<span_gen_t, span_conv_alpha_t> span_conv_t;
-            typedef agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t> int_renderer_t;
-
+            using span_gen_t = typename type_mapping_t::template span_gen_filter_type<image_accessor_t, arbitrary_interpolator_t>;
+            using span_conv_t = agg::span_converter<span_gen_t, span_conv_alpha_t>;
+            using int_renderer_t = agg::renderer_scanline_aa<renderer_t, span_alloc_t, span_conv_t>;
             lookup_distortion dist(
                 params.transform_mesh, in_width, in_height, out_width, out_height);
             arbitrary_interpolator_t interpolator(inverted, dist);

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -102,19 +102,6 @@ _get_transform_mesh(PyObject *py_affine, npy_intp *dims)
 }
 
 
-template<class T>
-static void
-resample(PyArrayObject* input, PyArrayObject* output, resample_params_t params)
-{
-    Py_BEGIN_ALLOW_THREADS
-    resample(
-        (T*)PyArray_DATA(input), PyArray_DIM(input, 1), PyArray_DIM(input, 0),
-        (T*)PyArray_DATA(output), PyArray_DIM(output, 1), PyArray_DIM(output, 0),
-        params);
-    Py_END_ALLOW_THREADS
-}
-
-
 static PyObject *
 image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
 {
@@ -127,6 +114,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     PyArrayObject *output = NULL;
     PyArrayObject *transform_mesh = NULL;
     int ndim;
+    int type;
 
     params.interpolation = NEAREST;
     params.transform_mesh = NULL;
@@ -159,6 +147,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         goto error;
     }
     ndim = PyArray_NDIM(input);
+    type = PyArray_TYPE(input);
 
     if (!PyArray_Check(py_output)) {
         PyErr_SetString(PyExc_ValueError, "Output array must be a NumPy array");
@@ -181,7 +170,7 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
             " respectively", PyArray_DIM(input, 2), PyArray_DIM(output, 2));
         goto error;
     }
-    if (PyArray_TYPE(input) != PyArray_TYPE(output)) {
+    if (PyArray_TYPE(output) != type) {
         PyErr_SetString(PyExc_ValueError, "Mismatched types");
         goto error;
     }
@@ -221,50 +210,34 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         }
     }
 
-    if (ndim == 3) {
-        switch (PyArray_TYPE(input)) {
-        case NPY_UINT8:
-        case NPY_INT8:
-            resample<agg::rgba8>(input, output, params);
-            break;
-        case NPY_UINT16:
-        case NPY_INT16:
-            resample<agg::rgba16>(input, output, params);
-            break;
-        case NPY_FLOAT32:
-            resample<agg::rgba32>(input, output, params);
-            break;
-        case NPY_FLOAT64:
-            resample<agg::rgba64>(input, output, params);
-            break;
-        default:
-            PyErr_SetString(
-                PyExc_ValueError,
-                "arrays must be of dtype byte, short, float32 or float64");
-            goto error;
-        }
-    } else { // ndim == 2
-        switch (PyArray_TYPE(input)) {
-        case NPY_UINT8:
-        case NPY_INT8:
-            resample<unsigned char>(input, output, params);
-            break;
-        case NPY_UINT16:
-        case NPY_INT16:
-            resample<unsigned short>(input, output, params);
-            break;
-        case NPY_FLOAT32:
-            resample<float>(input, output, params);
-            break;
-        case NPY_FLOAT64:
-            resample<double>(input, output, params);
-            break;
-        default:
-            PyErr_SetString(
-                PyExc_ValueError,
-                "arrays must be of dtype byte, short, float32 or float64");
-            goto error;
-        }
+    if (auto resampler =
+            (ndim == 2) ? (
+                (type == NPY_UINT8) ? resample<agg::gray8> :
+                (type == NPY_INT8) ? resample<agg::gray8> :
+                (type == NPY_UINT16) ? resample<agg::gray16> :
+                (type == NPY_INT16) ? resample<agg::gray16> :
+                (type == NPY_FLOAT32) ? resample<agg::gray32> :
+                (type == NPY_FLOAT64) ? resample<agg::gray64> :
+                nullptr) : (
+            // ndim == 3
+                (type == NPY_UINT8) ? resample<agg::rgba8> :
+                (type == NPY_INT8) ? resample<agg::rgba8> :
+                (type == NPY_UINT16) ? resample<agg::rgba16> :
+                (type == NPY_INT16) ? resample<agg::rgba16> :
+                (type == NPY_FLOAT32) ? resample<agg::rgba32> :
+                (type == NPY_FLOAT64) ? resample<agg::rgba64> :
+                nullptr)) {
+        Py_BEGIN_ALLOW_THREADS
+        resampler(
+            PyArray_DATA(input), PyArray_DIM(input, 1), PyArray_DIM(input, 0),
+            PyArray_DATA(output), PyArray_DIM(output, 1), PyArray_DIM(output, 0),
+            params);
+        Py_END_ALLOW_THREADS
+    } else {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "arrays must be of dtype byte, short, float32 or float64");
+        goto error;
     }
 
     Py_DECREF(input);


### PR DESCRIPTION
## PR Summary

Now that we're messing up with C++ image resampling... ;)

1st commit: Dedupe some C++ templates.
2nd commit: Make sure we don't use C++14 accidentally.  (Was originally: don't use C++11 accidentally.)

Edit: apparently running into a MSVC bug (per https://devblogs.microsoft.com/cppblog/expression-sfinae-improvements-in-vs-2015-update-3/); will look into it...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
