### PR TITLE
Fix `swap_if_landscape` call in backend_ps

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -840,7 +840,7 @@ class FigureCanvasPS(FigureCanvasBase):
             # distillers improperly clip eps files if pagesize is too small
             if width > paper_width or height > paper_height:
                 papertype = _get_papertype(
-                    *orientation.swap_if_landscape(width, height))
+                    *orientation.swap_if_landscape((width, height)))
                 paper_width, paper_height = orientation.swap_if_landscape(
                     papersize[papertype])
 


### PR DESCRIPTION
`orientation.swap_if_landscape` takes one tuple/list, but here the parenthesis is dropped. Another similar call right above demonstrates the correct usage:

https://github.com/matplotlib/matplotlib/blob/51a19409e71bc96403ce26399e93eccaf3d83885/lib/matplotlib/backends/backend_ps.py#L834-L837