### PR TITLE
Fix exception handling in FT2Font init.

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+from io import BytesIO, StringIO
 import multiprocessing
 import os
 from pathlib import Path
@@ -126,6 +126,24 @@ def test_find_ttc():
         fig.savefig(BytesIO(), format="pdf")
     with pytest.raises(RuntimeError):
         fig.savefig(BytesIO(), format="ps")
+
+
+def test_find_invalid(tmpdir):
+    tmp_path = Path(tmpdir)
+
+    with pytest.raises(FileNotFoundError):
+        get_font(tmp_path / 'non-existent-font-name.ttf')
+
+    with pytest.raises(FileNotFoundError):
+        get_font(str(tmp_path / 'non-existent-font-name.ttf'))
+
+    with pytest.raises(FileNotFoundError):
+        get_font(bytes(tmp_path / 'non-existent-font-name.ttf'))
+
+    # Not really public, but get_font doesn't expose non-filename constructor.
+    from matplotlib.ft2font import FT2Font
+    with pytest.raises(TypeError, match='path or binary-mode file'):
+        FT2Font(StringIO())
 
 
 @pytest.mark.skipif(sys.platform != 'linux', reason='Linux only')

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -488,12 +488,14 @@ static int PyFT2Font_init(PyFT2Font *self, PyObject *args, PyObject *kwds)
                || !PyBytes_Check(data)) {
         PyErr_SetString(PyExc_TypeError,
                         "First argument must be a path or binary-mode file object");
+        Py_CLEAR(data);
         goto exit;
     } else {
         self->py_file = filename;
         self->stream.close = NULL;
         Py_INCREF(filename);
     }
+    Py_CLEAR(data);
 
     CALL_CPP_FULL(
         "FT2Font", (self->x = new FT2Font(open_args, hinting_factor)),
@@ -505,9 +507,7 @@ static int PyFT2Font_init(PyFT2Font *self, PyObject *args, PyObject *kwds)
     self->fname = filename;
 
 exit:
-    Py_XDECREF(data);
-
-    return 0;
+    return PyErr_Occurred() ? -1 : 0;
 }
 
 static void PyFT2Font_dealloc(PyFT2Font *self)


### PR DESCRIPTION
## PR Summary

It needs to return -1 when an exception is set, or Python raises a `SystemError` instead.

Missed this in #15104.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way