### PR TITLE
Support url on QuadMesh in svg

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -316,6 +316,17 @@ class Tick(martist.Artist):
         self.label2.set_text(s)
         self.stale = True
 
+    def set_url(self, s):
+        """
+        Set the url of label1 and label2
+
+        ACCEPTS: str
+        """
+        super().set_url(s)
+        self.label1.set_url(s)
+        self.label2.set_url(s)
+        self.stale = True
+
     def _set_artist_props(self, a):
         a.set_figure(self.figure)
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -239,7 +239,7 @@ class RendererBase:
 
     def draw_quad_mesh(self, gc, master_transform, meshWidth, meshHeight,
                        coordinates, offsets, offsetTrans, facecolors,
-                       antialiased, edgecolors):
+                       antialiased, edgecolors, urls=None):
         """
         Fallback implementation of :meth:`draw_quad_mesh` that generates paths
         and then calls :meth:`draw_path_collection`.
@@ -252,10 +252,14 @@ class RendererBase:
         if edgecolors is None:
             edgecolors = facecolors
         linewidths = np.array([gc.get_linewidth()], float)
+        if urls is None:
+            urls = [None]
+        else:
+            urls = list(cbook.flatten(urls))
 
         return self.draw_path_collection(
             gc, master_transform, paths, [], offsets, offsetTrans, facecolors,
-            edgecolors, linewidths, [], [antialiased], [None], 'screen')
+            edgecolors, linewidths, [], [antialiased], urls, 'screen')
 
     def draw_gouraud_triangle(self, gc, points, colors, transform):
         """

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2048,7 +2048,8 @@ class QuadMesh(Collection):
                 coordinates, offsets, transOffset,
                 # Backends expect flattened rgba arrays (n*m, 4) for fc and ec
                 self.get_facecolor().reshape((-1, 4)),
-                self._antialiased, self.get_edgecolors().reshape((-1, 4)))
+                self._antialiased, self.get_edgecolors().reshape((-1, 4)),
+                urls=self.get_urls())
         gc.restore()
         renderer.close_group(self.__class__.__name__)
         self.stale = False

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -761,6 +761,7 @@ class Line2D(Artist):
             if len(tpath.vertices):
                 gc = renderer.new_gc()
                 self._set_gc_clip(gc)
+                gc.set_url(self.get_url())
 
                 lc_rgba = mcolors.to_rgba(self._color, self._alpha)
                 gc.set_foreground(lc_rgba, isRGBA=True)
@@ -787,6 +788,7 @@ class Line2D(Artist):
         if self._marker and self._markersize > 0:
             gc = renderer.new_gc()
             self._set_gc_clip(gc)
+            gc.set_url(self.get_url())
             gc.set_linewidth(self._markeredgewidth)
             gc.set_antialiased(self._antialiased)
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -229,10 +229,25 @@ def test_url():
     p, = plt.plot([1, 3], [6, 5])
     p.set_url('http://example.com/baz')
 
+    # QuadMesh
+    data = np.array([
+        [np.nan, 4, np.nan],
+        [2, 7, 5],
+        [np.nan, 8, np.nan]
+    ])
+    links = np.array([
+        [np.nan, 'http://example.com/qux', np.nan],
+        ['http://example.com/quux', 'http://example.com/quuz',
+            'http://example.com/corge'],
+        [np.nan, 'http://example.com/grault', np.nan]
+    ])
+    ax.pcolormesh(data, urls=links)
+
     b = BytesIO()
     fig.savefig(b, format='svg')
     b = b.getvalue()
-    for v in [b'foo', b'bar', b'baz']:
+    for v in [b'foo', b'bar', b'baz', b'qux', b'quux', b'quuz', b'corge',
+              b'grault']:
         assert b'http://example.com/' + v in b
 
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -220,14 +220,20 @@ def test_url():
     # Test that object url appears in output svg.
 
     fig, ax = plt.subplots()
+
+    # collections
     s = ax.scatter([1, 2, 3], [4, 5, 6])
     s.set_urls(['http://example.com/foo', 'http://example.com/bar', None])
+
+    # Line2D
+    p, = plt.plot([1, 3], [6, 5])
+    p.set_url('http://example.com/baz')
 
     b = BytesIO()
     fig.savefig(b, format='svg')
     b = b.getvalue()
-    assert b'http://example.com/foo' in b
-    assert b'http://example.com/bar' in b
+    for v in [b'foo', b'bar', b'baz']:
+        assert b'http://example.com/' + v in b
 
 
 def test_url_tick():

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -214,3 +214,42 @@ def test_savefig_tight():
     # Check that the draw-disabled renderer correctly disables open/close_group
     # as well.
     plt.savefig(BytesIO(), format="svgz", bbox_inches="tight")
+
+
+def test_url():
+    # Test that object url appears in output svg.
+
+    fig, ax = plt.subplots()
+    s = ax.scatter([1, 2, 3], [4, 5, 6])
+    s.set_urls(['http://example.com/foo', 'http://example.com/bar', None])
+
+    b = BytesIO()
+    fig.savefig(b, format='svg')
+    b = b.getvalue()
+    assert b'http://example.com/foo' in b
+    assert b'http://example.com/bar' in b
+
+
+def test_url_tick():
+    fig1, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    for i, tick in enumerate(ax.yaxis.get_major_ticks()):
+        tick.set_url(f'http://example.com/{i}')
+
+    fig2, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    for i, tick in enumerate(ax.yaxis.get_major_ticks()):
+        tick.label1.set_url(f'http://example.com/{i}')
+        tick.label2.set_url(f'http://example.com/{i}')
+
+    b1 = BytesIO()
+    fig1.savefig(b1, format='svg')
+    b1 = b1.getvalue()
+
+    b2 = BytesIO()
+    fig2.savefig(b2, format='svg')
+    b2 = b2.getvalue()
+
+    for i in range(len(ax.yaxis.get_major_ticks())):
+        assert f'http://example.com/{i}'.encode('ascii') in b1
+    assert b1 == b2


### PR DESCRIPTION
## PR Summary

This is just a quick rebase of the two commits from #17338. I have not addressed the comments yet, so this is just a PR so I don't forget about it.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way