### PR TITLE
Make sure _parent is in sync with Qt parent in NavigationToolbar2QT

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -656,7 +656,6 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         self.setAllowedAreas(
             QtCore.Qt.TopToolBarArea | QtCore.Qt.BottomToolBarArea)
 
-        self._parent = parent
         self.coordinates = coordinates
         self._actions = {}  # mapping of toolitem method names to QActions.
 
@@ -687,8 +686,15 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
         NavigationToolbar2.__init__(self, canvas)
 
-    parent = cbook._deprecate_privatize_attribute(
-        "3.3", alternative="self.canvas.parent()")
+    @cbook.deprecated("3.3", alternative="self.canvas.parent()")
+    @property
+    def parent(self):
+        return self.canvas.parent()
+
+    @cbook.deprecated("3.3", alternative="self.canvas.setParent()")
+    @parent.setter
+    def parent(self, value):
+        pass
 
     @cbook.deprecated(
         "3.3", alternative="os.path.join(mpl.get_data_path(), 'images')")


### PR DESCRIPTION
## PR Summary

Since 52a204b4f9c3176c98a55ce290a0ff655b34fea5, ``_parent`` may retain a reference to the widget parent even if the user/caller has called ``setParent(None)``. This is leading to issues in a package I maintain (glue) due to circular references to objects. This PR ensures that the ``_parent`` attribute is always in sync with the actual widget parent.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

