### PR TITLE
Privatize ttconv module.

### DIFF
--- a/doc/api/api_changes_3.3/deprecations.rst
+++ b/doc/api/api_changes_3.3/deprecations.rst
@@ -589,3 +589,7 @@ implementers).
 Passing ``ismath="TeX!"`` to `.RendererAgg.get_text_width_height_descent` is
 deprecated.  Pass ``ismath="TeX"`` instead, consistently with other low-level
 APIs which support the values True, False, and "TeX" for ``ismath``.
+
+``matplotlib.ttconv``
+~~~~~~~~~~~~~~~~~~~~~
+This module is deprecated.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -41,7 +41,7 @@ from matplotlib.transforms import Affine2D, BboxBase
 from matplotlib.path import Path
 from matplotlib.dates import UTC
 from matplotlib import _path
-from matplotlib import ttconv
+from matplotlib import _ttconv
 from . import _backend_pdf_ps
 
 _log = logging.getLogger(__name__)
@@ -996,7 +996,7 @@ end"""
             # Make the charprocs array (using ttconv to generate the
             # actual outlines)
             try:
-                rawcharprocs = ttconv.get_pdf_charprocs(
+                rawcharprocs = _ttconv.get_pdf_charprocs(
                     os.fsencode(filename), glyph_ids)
             except RuntimeError:
                 _log.warning("The PDF backend does not currently support the "

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -26,7 +26,7 @@ from matplotlib.backend_bases import (
 from matplotlib.cbook import is_writable_file_like, file_requires_unicode
 from matplotlib.font_manager import is_opentype_cff_font, get_font
 from matplotlib.ft2font import LOAD_NO_HINTING
-from matplotlib.ttconv import convert_ttf_to_ps
+from matplotlib._ttconv import convert_ttf_to_ps
 from matplotlib.mathtext import MathTextParser
 from matplotlib._mathtext_data import uni2type1
 from matplotlib.path import Path

--- a/lib/matplotlib/ttconv.py
+++ b/lib/matplotlib/ttconv.py
@@ -1,0 +1,9 @@
+"""
+Converting and subsetting TrueType fonts to PS types 3 and 42, and PDF type 3.
+"""
+
+from . import cbook
+from ._ttconv import convert_ttf_to_ps, get_pdf_charprocs  # noqa
+
+
+cbook.warn_deprecated('3.3', name=__name__, obj_type='module')

--- a/setupext.py
+++ b/setupext.py
@@ -413,7 +413,7 @@ class Matplotlib(SetupPackage):
         yield ext
         # ttconv
         ext = Extension(
-            "matplotlib.ttconv", [
+            "matplotlib._ttconv", [
                 "src/_ttconv.cpp",
                 "extern/ttconv/pprdrv_tt.cpp",
                 "extern/ttconv/pprdrv_tt2.cpp",

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -279,7 +279,7 @@ static PyModuleDef ttconv_module = {
 #pragma GCC visibility push(default)
 
 PyMODINIT_FUNC
-PyInit_ttconv(void)
+PyInit__ttconv(void)
 {
     PyObject* m;
 


### PR DESCRIPTION
## PR Summary

It's an internal detail, much like `_qhull`, and not exposed externally.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way