### PR TITLE
DOC/API: set __qualname__ when using class factory

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -174,6 +174,7 @@ def _subclass_with_normal(effect_class):
             renderer.draw_path(gc, tpath, affine, rgbFace)
 
     withEffect.__name__ = f"with{effect_class.__name__}"
+    withEffect.__qualname__ = f"with{effect_class.__name__}"
     withEffect.__doc__ = f"""
     A shortcut PathEffect for applying `.{effect_class.__name__}` and then
     drawing the original Artist.


### PR DESCRIPTION
## PR Summary


In patheffects.py we have a helper function to reduce the
boiler plate in defining the path effect sub-classes.  We are setting
the `__name__` and `__doc__` to (templated) values, but were not
setting the `__qualname__` which was leaving the string '<locals>' in
the `__qualname__`.  This string is then used by sphinx-gallery to
generate an index of examples that use a given class with files named
like `f'{obj.__qualname__}.examples'` which works correctly (but not
in the way we want) on liunx but fails on windows as `<>` are
forbidden in file names.-

This sets the `__qualname__` to match the `__name__` and fully
simulate defining these classes in the module.

The changes that broke this came in via https://github.com/matplotlib/matplotlib/pull/15515

