### PR TITLE
Update documenting_mpl.rst

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -121,8 +121,12 @@ You can use the ``O`` variable to set additional options:
 Multiple options can be combined using e.g. ``make O='-j4 -Dplot_gallery=0'
 html``.
 
-On Windows, options needs to be set as environment variables, e.g. ``set O=-W
---keep-going -j4 & make html``.
+On Windows, options needs to be set as environment variables, e.g.:
+
+.. code-block:: bat
+
+   set O=-W --keep-going -j4 
+   make html 
 
 .. _writing-rest-pages:
 


### PR DESCRIPTION
 Breaking this:
> set O=-W --keep-going -j4 & make html.

out into:

```bash
set O=-W --keep-going -j4 
make html
```
'cause first way didn't work and then I went down rabbit hole of trying to sort out if I need ticks (the answer is no) so figure this might be clearer. 

## PR Checklist
- [x] Documentation is sphinx and numpydoc compliant