### PR TITLE
Use symbolic icons for buttons in GTK toolbar.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -27,7 +27,7 @@ except ValueError as e:
     # auto-backend selection logic correctly skips.
     raise ImportError from e
 
-from gi.repository import GLib, GObject, Gtk, Gdk
+from gi.repository import Gio, GLib, GObject, Gtk, Gdk
 
 
 _log = logging.getLogger(__name__)
@@ -464,9 +464,11 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
             if text is None:
                 self.insert(Gtk.SeparatorToolItem(), -1)
                 continue
-            image = Gtk.Image()
-            image.set_from_file(
-                str(cbook._get_data_path('images', image_file + '.png')))
+            image = Gtk.Image.new_from_gicon(
+                Gio.Icon.new_for_string(
+                    str(cbook._get_data_path('images',
+                                             f'{image_file}-symbolic.svg'))),
+                Gtk.IconSize.LARGE_TOOLBAR)
             self._gtk_ids[text] = tbutton = (
                 Gtk.ToggleToolButton() if callback in ['zoom', 'pan'] else
                 Gtk.ToolButton())
@@ -623,7 +625,7 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
 
 
 class ToolbarGTK3(ToolContainerBase, Gtk.Box):
-    _icon_extension = '.png'
+    _icon_extension = '-symbolic.svg'
 
     def __init__(self, toolmanager):
         ToolContainerBase.__init__(self, toolmanager)
@@ -644,8 +646,9 @@ class ToolbarGTK3(ToolContainerBase, Gtk.Box):
         tbutton.set_label(name)
 
         if image_file is not None:
-            image = Gtk.Image()
-            image.set_from_file(image_file)
+            image = Gtk.Image.new_from_gicon(
+                Gio.Icon.new_for_string(image_file),
+                Gtk.IconSize.LARGE_TOOLBAR)
             tbutton.set_icon_widget(image)
 
         if position is None:

--- a/lib/matplotlib/mpl-data/images/back-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/back-symbolic.svg
@@ -1,0 +1,1 @@
+back.svg

--- a/lib/matplotlib/mpl-data/images/filesave-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/filesave-symbolic.svg
@@ -1,0 +1,1 @@
+filesave.svg

--- a/lib/matplotlib/mpl-data/images/forward-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/forward-symbolic.svg
@@ -1,0 +1,1 @@
+forward.svg

--- a/lib/matplotlib/mpl-data/images/help-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/help-symbolic.svg
@@ -1,0 +1,1 @@
+help.svg

--- a/lib/matplotlib/mpl-data/images/home-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/home-symbolic.svg
@@ -1,0 +1,1 @@
+home.svg

--- a/lib/matplotlib/mpl-data/images/move-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/move-symbolic.svg
@@ -1,0 +1,1 @@
+move.svg

--- a/lib/matplotlib/mpl-data/images/subplots-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/subplots-symbolic.svg
@@ -1,0 +1,1 @@
+subplots.svg

--- a/lib/matplotlib/mpl-data/images/zoom_to_rect-symbolic.svg
+++ b/lib/matplotlib/mpl-data/images/zoom_to_rect-symbolic.svg
@@ -1,0 +1,1 @@
+zoom_to_rect.svg


### PR DESCRIPTION
## PR Summary

Unfortunately, the only way to trigger this is to rename the files, so add some symlinks to the existing SVG. Switching from PNG to SVG should be scalable as well.

This is an alternative to #17459 _for GTK only_. The main advantage is that leaving it to GTK allows it to work for any theme, e.g., if you use [Caribbean-Blue](https://www.gnome-look.org/p/1388334/), the buttons will be blue instead of black or white.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [?] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way