### PR TITLE
Fix help window on GTK.

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -430,7 +430,7 @@ class _ToolEnableNavigation(ToolBase):
     """Tool to enable a specific axes for toolmanager interaction."""
 
     description = 'Enable one axes toolmanager'
-    default_keymap = (1, 2, 3, 4, 5, 6, 7, 8, 9)
+    default_keymap = ('1', '2', '3', '4', '5', '6', '7', '8', '9')
 
     def trigger(self, sender, event, data=None):
         mpl.backend_bases.key_press_handler(event, self.figure.canvas, None)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -824,6 +824,15 @@ class HelpGTK3(backend_tools.ToolHelpBase):
 
         return ''.join(mods) + key
 
+    def _is_valid_shortcut(self, key):
+        """
+        Check for a valid shortcut to be displayed.
+
+        - GTK will never send 'cmd+' (see `FigureCanvasGTK3._get_key`).
+        - The shortcut window only shows keyboard shortcuts, not mouse buttons.
+        """
+        return 'cmd+' not in key and not key.startswith('MouseButton.')
+
     def _show_shortcuts_window(self):
         section = Gtk.ShortcutsSection()
 
@@ -844,8 +853,7 @@ class HelpGTK3(backend_tools.ToolHelpBase):
                 accelerator=' '.join(
                     self._normalize_shortcut(key)
                     for key in self.toolmanager.get_tool_keymap(name)
-                    # Will never be sent:
-                    if 'cmd+' not in key),
+                    if self._is_valid_shortcut(key)),
                 title=tool.name,
                 subtitle=tool.description)
             group.add(shortcut)


### PR DESCRIPTION
## PR Summary

The shortcuts for Axes numbers are now `int`s, but should be `str`s.

And `MouseButton`s are apparently now included, which need to be skipped.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way