### PR TITLE
Don't load textcomp by default.

### DIFF
--- a/doc/api/api_changes_3.3/behaviour.rst
+++ b/doc/api/api_changes_3.3/behaviour.rst
@@ -307,3 +307,11 @@ but will become True in a later release.
 ... to determine whether a string should be passed to the usetex machinery or
 not.  This allows single strings to be marked as not-usetex even when the
 rcParam is True.
+
+LaTeX ``textcomp`` package no longer loaded by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The LaTeX ``textcomp`` package provides various commands such as
+``\textdagger``.  It used to be loaded by default in usetex mode, but this
+occasionally conflicted with other packages.  Hence, it is no longer loaded by
+default; add ``\usepackage{textcomp}`` to :rc:`text.latex.preamble` if you need
+it.

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -154,8 +154,7 @@ class TexManager:
                self._fonts['monospace'][1]]
         if self.font_family == 'cursive':
             cmd.append(self._fonts['cursive'][1])
-        self._font_preamble = '\n'.join(
-            [r'\usepackage{type1cm}', *cmd, r'\usepackage{textcomp}'])
+        self._font_preamble = '\n'.join([r'\usepackage{type1cm}', *cmd])
 
         return ''.join(fontconfig)
 


### PR DESCRIPTION
I *think* this will only affect people using commands such as
\textdagger, which don't work by default anyways on LaTeX (i.e. it is
reasonable to require that they explicitly load `textcomp` themselves).

Closes #9118, I think.

Edit: Ah, I see why textcomp is needed now...

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
