### PR TITLE
markerfacecolor should not override fillstyle='none' in plot()

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -936,12 +936,11 @@ class Line2D(Artist):
         return self._markeredgewidth
 
     def _get_markerfacecolor(self, alt=False):
+        if self.get_fillstyle() == 'none':
+            return 'none'
         fc = self._markerfacecoloralt if alt else self._markerfacecolor
         if cbook._str_lower_equal(fc, 'auto'):
-            if self.get_fillstyle() == 'none':
-                return 'none'
-            else:
-                return self._color
+            return self._color
         else:
             return fc
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -183,6 +183,14 @@ def test_marker_fill_styles():
     ax.set_xlim([-5, 155])
 
 
+def test_markerfacecolor_fillstyle():
+    """Test that markerfacecolor does not override fillstyle='none'."""
+    l, = plt.plot([1, 3, 2], marker=MarkerStyle('o', fillstyle='none'),
+                  markerfacecolor='red')
+    assert l.get_fillstyle() == 'none'
+    assert l.get_markerfacecolor() == 'none'
+
+
 @image_comparison(['scaled_lines'], style='default')
 def test_lw_scaling():
     th = np.linspace(0, 32)


### PR DESCRIPTION
## PR Summary

Previously using `plt.plot([1, 3, 2], marker=MarkerStyle('o', fillstyle='none'), markerfacecolor='red')` resulted in the markers to be filled red. This does not make sense as it silently discards fillstyle='none'.

Instead, the markers should still be unfilled. Markerfacecolor is already ignored for unfillable markers like 'x'. The same should hold for unfilled marker that could potentially be filled but are explicitly set to be unfilled.

The effect of this can be seen in the 'none' markers being filled at
https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/marker_reference.html#marker-fill-styles. (Here  it's triggered with keyword argument fillstyle='none', but the code path is the same).