### PR TITLE
`func` argument in `legend_elements` with non-monotonically increasing functions

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1076,8 +1076,10 @@ class PathCollection(_CollectionWithSizes):
             cond = ((label_values >= func(arr).min()) &
                     (label_values <= func(arr).max()))
             label_values = label_values[cond]
-            xarr = np.linspace(arr.min(), arr.max(), 256)
-            values = np.interp(label_values, func(xarr), xarr)
+            yarr = np.linspace(arr.min(), arr.max(), 256)
+            xarr = func(yarr)
+            ix = np.argsort(xarr)
+            values = np.interp(label_values, xarr[ix], yarr[ix])
 
         kw = dict(markeredgewidth=self.get_linewidths()[0],
                   alpha=self.get_alpha())

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -682,4 +682,4 @@ def test_legend_size_with_inverse_relationship():
     handle_sizes = [x.get_markersize() for x in handles]
     handle_sizes = [5 / x**2 for x in handle_sizes]
 
-    assert_almost_equal(handle_sizes, leg_sizes, decimal=2)
+    assert_array_almost_equal(handle_sizes, leg_sizes, decimal=1)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -661,7 +661,8 @@ def test_quadmesh_set_array():
     fig.canvas.draw()
     assert np.array_equal(coll.get_array(), np.ones(9))
 
-def test_legend_size_with_inverse_relationship():
+
+def test_legend_inverse_size_label_relationship():
     '''
     Ensure legend markers scale appropriately when label and size are inversely related.
     Here label = 5 / size
@@ -673,13 +674,13 @@ def test_legend_size_with_inverse_relationship():
     C = 1 - np.random.random(50)
     S = 5 / C
 
-    leg_sizes = [0.2, 0.4, 0.6, 0.8]
+    legend_sizes = [0.2, 0.4, 0.6, 0.8]
     fig, ax = plt.subplots()
     sc = ax.scatter(X, Y, s=S)
-    handles, labels = sc.legend_elements(prop='sizes', num=leg_sizes, func=lambda x: 5 / x)
+    handles, labels = sc.legend_elements(prop='sizes', num=legend_sizes, func=lambda s: 5 / s)
 
     # Convert markersize scale to 's' scale
     handle_sizes = [x.get_markersize() for x in handles]
     handle_sizes = [5 / x**2 for x in handle_sizes]
 
-    assert_array_almost_equal(handle_sizes, leg_sizes, decimal=1)
+    assert_array_almost_equal(handle_sizes, legend_sizes, decimal=1)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -660,3 +660,26 @@ def test_quadmesh_set_array():
     coll.set_array(np.ones(9))
     fig.canvas.draw()
     assert np.array_equal(coll.get_array(), np.ones(9))
+
+def test_legend_size_with_inverse_relationship():
+    '''
+    Ensure legend markers scale appropriately when label and size are inversely related.
+    Here label = 5 / size
+    '''
+
+    np.random.seed(19680801)
+    X = np.random.random(50)
+    Y = np.random.random(50)
+    C = 1 - np.random.random(50)
+    S = 5 / C
+
+    leg_sizes = [0.2, 0.4, 0.6, 0.8]
+    fig, ax = plt.subplots()
+    sc = ax.scatter(X, Y, s=S)
+    handles, labels = sc.legend_elements(prop='sizes', num=leg_sizes, func=lambda x: 5 / x)
+
+    # Convert markersize scale to 's' scale
+    handle_sizes = [x.get_markersize() for x in handles]
+    handle_sizes = [5 / x**2 for x in handle_sizes]
+
+    assert_almost_equal(handle_sizes, leg_sizes, decimal=2)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -663,10 +663,11 @@ def test_quadmesh_set_array():
 
 
 def test_legend_inverse_size_label_relationship():
-    '''
-    Ensure legend markers scale appropriately when label and size are inversely related.
+    """
+    Ensure legend markers scale appropriately when label and size are
+    inversely related.
     Here label = 5 / size
-    '''
+    """
 
     np.random.seed(19680801)
     X = np.random.random(50)
@@ -677,7 +678,9 @@ def test_legend_inverse_size_label_relationship():
     legend_sizes = [0.2, 0.4, 0.6, 0.8]
     fig, ax = plt.subplots()
     sc = ax.scatter(X, Y, s=S)
-    handles, labels = sc.legend_elements(prop='sizes', num=legend_sizes, func=lambda s: 5 / s)
+    handles, labels = sc.legend_elements(
+      prop='sizes', num=legend_sizes, func=lambda s: 5 / s
+    )
 
     # Convert markersize scale to 's' scale
     handle_sizes = [x.get_markersize() for x in handles]


### PR DESCRIPTION
Account for inverse (or other) relationships where `np.interp` will not work correctly.

## PR Summary
`legend_elements` does not account for inverse or non-monotonically increasing functions. See [this post](https://stackoverflow.com/questions/62124674/doing-a-custom-legend-of-marker-sizes-in-matplotlib-using-a-lambda-function/62124742#62124742) for an example. The problem is in using `np.interp`, which requires a monotonically increasing input `xp`. This PR sorts `xp` first before calling `np.interp`.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
