### PR TITLE
ci: Add xcb libraries that were removed from PyQt5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,13 @@ addons:
       - libgeos-dev
       - libgirepository1.0-dev
       - libsdl2-2.0-0
+      - libxkbcommon-x11-0
+      - libxcb-icccm4
+      - libxcb-image0
+      - libxcb-keysyms1
+      - libxcb-randr0
+      - libxcb-render-util0
+      - libxcb-xinerama0
       - lmodern
       - fonts-freefont-otf
       - texlive-pictures


### PR DESCRIPTION
## PR Summary

See https://www.riverbankcomputing.com/pipermail/pyqt/2020-June/042949.html