### PR TITLE
FIX: do not let no-op monkey patches to renderer leak out

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2392,6 +2392,8 @@ default: 'top'
 
         from .tight_layout import (
             get_renderer, get_subplotspec_list, get_tight_layout_figure)
+        from .cbook import _setattr_cm
+        from .backend_bases import RendererBase
 
         subplotspec_list = get_subplotspec_list(self.axes)
         if None in subplotspec_list:
@@ -2402,9 +2404,17 @@ default: 'top'
         if renderer is None:
             renderer = get_renderer(self)
 
-        kwargs = get_tight_layout_figure(
-            self, self.axes, subplotspec_list, renderer,
-            pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
+        no_ops = {
+            meth_name: lambda *args, **kwargs: None
+            for meth_name in dir(RendererBase)
+            if (meth_name.startswith("draw_")
+                or meth_name in ["open_group", "close_group"])
+        }
+
+        with _setattr_cm(renderer, **no_ops):
+            kwargs = get_tight_layout_figure(
+                self, self.axes, subplotspec_list, renderer,
+                pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
         if kwargs:
             self.subplots_adjust(**kwargs)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2392,9 +2392,7 @@ default: 'top'
 
         from .tight_layout import (
             get_renderer, get_subplotspec_list, get_tight_layout_figure)
-        from .cbook import _setattr_cm
-        from .backend_bases import RendererBase
-
+        from contextlib import suppress
         subplotspec_list = get_subplotspec_list(self.axes)
         if None in subplotspec_list:
             cbook._warn_external("This figure includes Axes that are not "
@@ -2403,15 +2401,10 @@ default: 'top'
 
         if renderer is None:
             renderer = get_renderer(self)
-
-        no_ops = {
-            meth_name: lambda *args, **kwargs: None
-            for meth_name in dir(RendererBase)
-            if (meth_name.startswith("draw_")
-                or meth_name in ["open_group", "close_group"])
-        }
-
-        with _setattr_cm(renderer, **no_ops):
+        ctx = (renderer._draw_disabled()
+               if hasattr(renderer, '_draw_disabled')
+               else suppress())
+        with ctx:
             kwargs = get_tight_layout_figure(
                 self, self.axes, subplotspec_list, renderer,
                 pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -110,3 +110,26 @@ def test_tight_pcolorfast():
     # Previously, the bbox would include the area of the image clipped out by
     # the axes, resulting in a very tall image given the y limits of (0, 0.1).
     assert width > height
+
+
+def test_noop_tight_bbox():
+    from PIL import Image
+    x_size, y_size = (10, 7)
+    dpi = 100
+    # make the figure just the right size up front
+    fig = plt.figure(frameon=False, dpi=dpi, figsize=(x_size/dpi, y_size/dpi))
+    ax = plt.Axes(fig, [0., 0., 1., 1.])
+    fig.add_axes(ax)
+    ax.set_axis_off()
+    ax.get_xaxis().set_visible(False)
+    ax.get_yaxis().set_visible(False)
+
+    data = np.arange(x_size * y_size).reshape(y_size, x_size)
+    ax.imshow(data)
+    out = BytesIO()
+    fig.savefig(out, bbox_inches='tight', pad_inches=0)
+    out.seek(0)
+    im = np.asarray(Image.open(out))
+    assert (im[:, :, 3] == 255).all()
+    assert not (im[:, :, :3] == 255).all()
+    assert im.shape == (7, 10, 4)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -173,7 +173,7 @@ def get_renderer(fig):
             return canvas.get_renderer()
         else:
             from . import backend_bases
-            return backend_bases._get_renderer(fig, draw_disabled=True)
+            return backend_bases._get_renderer(fig)
 
 
 def get_subplotspec_list(axes_list, grid_spec=None):


### PR DESCRIPTION
## PR Summary

closes #17542

This issue is that in some cases the no-op monkey patched renderer was getting cached deep in the backend code and the no-op functions were getting used for the actual save which resulted in empty figures.  This moves the monkey patching to the call sites so we can use the `_setattr_cm` to manage this.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [NA] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way (internal api only)

