### PR TITLE
Rc parameter to set [full] option on latex textcomp package

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1168,6 +1168,7 @@ _validators = {
     "text.usetex":         validate_bool,
     "text.latex.preamble": _validate_tex_preamble,
     "text.latex.preview":  validate_bool,
+    "text.latex.textcomp_full": validate_bool,
     "text.hinting":        _validate_hinting,
     "text.hinting_factor": validate_int,
     "text.kerning_factor": validate_int,

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager
 
+import pytest
+
 
 def test_fontconfig_preamble():
     """
@@ -16,3 +18,30 @@ def test_fontconfig_preamble():
     font_config2 = tm2.get_font_config()
 
     assert font_config1 != font_config2
+
+
+@pytest.mark.parametrize('textcomp_full, expected_result',
+                         [(True, 'usepackage[full]{textcomp}'),
+                          (False, 'usepackage{textcomp}')])
+def test_textcomp_full(textcomp_full, expected_result):
+    """
+    Addresses issue #9118.
+    See https://github.com/matplotlib/matplotlib/issues/9118.
+
+    Test that the [full] option is set for the textcomp package
+    in _font_preamble if the rcParam text.latex.textcomp_full
+    is set to True, and that the option is not set otherwise.
+    """
+    plt.rcParams['text.usetex'] = True
+    plt.rcParams['text.latex.textcomp_full'] = textcomp_full
+
+    tm = TexManager()
+    tm.get_font_config()  # This also sets tm1._font_preamble
+
+    font_preamble = tm.get_font_preamble()
+    if 'textcomp' not in font_preamble:
+        # Do not test for anything if the textcomp package
+        # is not in the font preamble.
+        return
+
+    assert expected_result in font_preamble

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -154,8 +154,10 @@ class TexManager:
                self._fonts['monospace'][1]]
         if self.font_family == 'cursive':
             cmd.append(self._fonts['cursive'][1])
+        textcomp_full = rcParams['text.latex.textcomp_full']
         self._font_preamble = '\n'.join(
-            [r'\usepackage{type1cm}', *cmd, r'\usepackage{textcomp}'])
+            [r'\usepackage{type1cm}', *cmd,
+             r'\usepackage%s{textcomp}' % ('[full]' if textcomp_full else '')])
 
         return ''.join(fontconfig)
 

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -298,6 +298,10 @@
                         # type1cm, textcomp.
                         # Adobe Postscript (PSSNFS) font packages may also be
                         # loaded, depending on your font settings.
+#text.latex.textcomp_full: False  # Set this to True to use the form
+                                  # \usepackage[full]{textcomp} in the preamble
+                                  # instead of \usepackage{textcomp}. This
+                                  # prevents package collision with newtxtext.
 
 ## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the
 ## following (Proprietary Matplotlib-specific synonyms are given in parentheses,


### PR DESCRIPTION
## PR Summary

This PR is intended to close address issue #9118 by adding a boolean `rc` parameter `text.latex.textcomp_full`. The parameter toggles the `[full]` option of the `textcomp` package in `_font_preamble`. 

Setting the `[full]` option prevents `textcomp` from conflicting with the `newtxtext` package as described in issue #9118.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
