### PR TITLE
_AnnotationBase keeps copy of mutable parameter (issue  #17566)

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -689,3 +689,20 @@ def test_fontproperties_kwarg_precedence():
     text2 = plt.ylabel("counts", size=40.0, fontproperties='Times New Roman')
     assert text1.get_size() == 40.0
     assert text2.get_size() == 40.0
+
+
+@check_figures_equal()
+def test_mutable_xy_copied(fig_test, fig_ref)
+    ax = fig_test.add_subplot()
+    ax.set_xlim(-5, 5)
+    ax.set_ylim(-3, 3)
+    xy_0 =np.array((-4, 1))
+    xy_f =np.array((-1, 1))
+    ax.annotate(s='', xy=xy_0, xytext=xy_f, arrowprops=dict(arrowstyle='<->'))
+    xy_0[1] = 3
+    ax = fig_ref.add_subplot()
+    ax.set_xlim(-5, 5)
+    ax.set_ylim(-3, 3)
+    xy_0 =np.array((-4, 1))
+    xy_f =np.array((-1, 1))
+    ax.annotate(s='', xy=xy_0, xytext=xy_f, arrowprops=dict(arrowstyle='<->'))

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -692,17 +692,18 @@ def test_fontproperties_kwarg_precedence():
 
 
 @check_figures_equal()
-def test_mutable_xy_copied(fig_test, fig_ref)
+def test_mutable_xy_copied_annotate(fig_test, fig_ref):
     ax = fig_test.add_subplot()
     ax.set_xlim(-5, 5)
     ax.set_ylim(-3, 3)
-    xy_0 =np.array((-4, 1))
-    xy_f =np.array((-1, 1))
-    ax.annotate(s='', xy=xy_0, xytext=xy_f, arrowprops=dict(arrowstyle='<->'))
+    xy_0 = np.array((-4, 1))
+    xy_f = np.array((-1, 1))
+    aprops = dict(arrowstyle='<->')
+    ax.annotate(text='', xy=xy_0, xytext=xy_f, arrowprops=aprops)
     xy_0[1] = 3
     ax = fig_ref.add_subplot()
     ax.set_xlim(-5, 5)
     ax.set_ylim(-3, 3)
-    xy_0 =np.array((-4, 1))
-    xy_f =np.array((-1, 1))
-    ax.annotate(s='', xy=xy_0, xytext=xy_f, arrowprops=dict(arrowstyle='<->'))
+    xy_0 = np.array((-4, 1))
+    xy_f = np.array((-1, 1))
+    ax.annotate(text='', xy=xy_0, xytext=xy_f, arrowprops=aprops)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1330,7 +1330,7 @@ class _AnnotationBase:
                  xycoords='data',
                  annotation_clip=None):
 
-        self.xy = copy.copy(xy)
+        self.xy = tuple(xy)
         self.xycoords = xycoords
         self.set_annotation_clip(annotation_clip)
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1329,7 +1329,7 @@ class _AnnotationBase:
                  xycoords='data',
                  annotation_clip=None):
 
-        self.xy = xy
+        self.xy = np.array(xy)
         self.xycoords = xycoords
         self.set_annotation_clip(annotation_clip)
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 import math
 import weakref
+import copy
 
 import numpy as np
 
@@ -1262,7 +1263,7 @@ class OffsetFrom:
             The screen units to use (pixels or points) for the offset input.
         """
         self._artist = artist
-        self._ref_coord = ref_coord
+        self._ref_coord = copy.copy(ref_coord)
         self.set_unit(unit)
 
     def set_unit(self, unit):
@@ -1329,7 +1330,7 @@ class _AnnotationBase:
                  xycoords='data',
                  annotation_clip=None):
 
-        self.xy = np.array(xy)
+        self.xy = copy.copy(xy)
         self.xycoords = xycoords
         self.set_annotation_clip(annotation_clip)
 


### PR DESCRIPTION
Fixes  #17566

## PR Summary
_AnnotationBase now keeps a copy of the data passed as the xy parameter, instead of the same object. Otherwise, passing an ndarray as xy and changing its elements later unexpectedly changes the annotation.
It is a one-line change, so I have performed no extensive tests beside basic functionality  yet

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
