### PR TITLE
Delay \usepackage{textcomp} until after the custom tex preamble.

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -77,3 +77,10 @@ def test_minus_no_descent():
         heights[vals] = ((np.array(fig.canvas.buffer_rgba())[..., 0] != 255)
                          .any(axis=1).sum())
     assert len({*heights.values()}) == 1
+
+
+def test_textcomp_full():
+    plt.rcParams["text.latex.preamble"] = r"\usepackage[full]{textcomp}"
+    fig = plt.figure()
+    fig.text(.5, .5, "hello, world", usetex=True)
+    fig.canvas.draw()

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -154,8 +154,7 @@ class TexManager:
                self._fonts['monospace'][1]]
         if self.font_family == 'cursive':
             cmd.append(self._fonts['cursive'][1])
-        self._font_preamble = '\n'.join(
-            [r'\usepackage{type1cm}', *cmd, r'\usepackage{textcomp}'])
+        self._font_preamble = '\n'.join([r'\usepackage{type1cm}', *cmd])
 
         return ''.join(fontconfig)
 
@@ -188,10 +187,16 @@ class TexManager:
             self._font_preamble,
             r"\usepackage[utf8]{inputenc}",
             r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
-            # Needs to come early so that the custom preamble can change the
-            # geometry, e.g. in convert_psfrags.
+            # geometry is loaded before the custom preamble as convert_psfrags
+            # relies on a custom preamble to change the geometry.
             r"\usepackage[papersize=72in,body=70in,margin=1in]{geometry}",
             self.get_custom_preamble(),
+            # textcomp is loaded last (if not already loaded by the custom
+            # preamble) in order not to clash with custom packages (e.g.
+            # newtxtext) which load it with different options.
+            r"\makeatletter"
+            r"\@ifpackageloaded{textcomp}{}{\usepackage{textcomp}}"
+            r"\makeatother",
         ])
 
     def make_tex(self, tex, fontsize):


### PR DESCRIPTION
... and only load textcomp if it hasn't already been loaded.  This
avoids option clashes in case the custom preamble loads textcomp with
other options.

Closes #9118.  Simpler than to #17563, I guess.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
