### PR TITLE
Examples: fix formatting issue in 'Errorbar limit selection'

### DIFF
--- a/examples/lines_bars_and_markers/errorbar_limits_simple.py
+++ b/examples/lines_bars_and_markers/errorbar_limits_simple.py
@@ -34,7 +34,7 @@ plt.legend(loc='lower right')
 
 
 ##############################################################################
-# Similarly ``xuplims``and ``xlolims`` can be used on the horizontal ``xerr``
+# Similarly ``xuplims`` and ``xlolims`` can be used on the horizontal ``xerr``
 # errorbars.
 
 fig = plt.figure()


### PR DESCRIPTION
## PR Summary

I noticed a minor formatting issue (backticks being displayed due to missing space after a literal item) in the text in the ['Errorbar limit selection'](https://matplotlib.org/gallery/lines_bars_and_markers/errorbar_limits_simple.html#sphx-glr-gallery-lines-bars-and-markers-errorbar-limits-simple-py) example page that has not been picked up on or fixed in master (as far as I can tell by searching the PRs/ issues from some keywords), & since I had forked the repo already to submit another PR thought I would raise it here. Thanks.

## PR Checklist

**[Only one checklist item applicable:]**

~~- [ ] Has Pytest style unit tests~~
~~- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant~~
~~- [ ] New features are documented, with examples if plot related~~
- [x] Documentation is sphinx and numpydoc compliant

~~- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)~~
~~- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
