### PR TITLE
Search for minus of any font size to get height of tex result

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -595,11 +595,13 @@ class DviFont:
                 result.append(0)
             else:
                 result.append(_mul2012(value, self._scale))
-        # cmsy10 glyph 0 ("minus") has a nonzero descent so that TeX aligns
-        # equations properly (https://tex.stackexchange.com/questions/526103/),
-        # but we actually care about the rasterization depth to align the
-        # dvipng-generated images.
-        if self.texname == b"cmsy10" and char == 0:
+        # cmsyXX (symbols font) glyph 0 ("minus") has a nonzero descent
+        # so that TeX aligns equations properly
+        # (https://tex.stackexchange.com/questions/526103/),
+        # but we actually care about the rasterization depth to align
+        # the dvipng-generated images.
+        minus_re = re.compile(br'^cmsy\d+$')
+        if minus_re.match(self.texname) and char == 0:
             result[-1] = 0
         return result
 

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -600,8 +600,7 @@ class DviFont:
         # (https://tex.stackexchange.com/questions/526103/),
         # but we actually care about the rasterization depth to align
         # the dvipng-generated images.
-        minus_re = re.compile(br'^cmsy\d+$')
-        if minus_re.match(self.texname) and char == 0:
+        if re.match(br'^cmsy\d+$', self.texname) and char == 0:
             result[-1] = 0
         return result
 

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -61,11 +61,13 @@ def test_mathdefault():
     fig.canvas.draw()
 
 
-def test_minus_no_descent():
+@pytest.mark.parametrize("fontsize", [8, 10, 12])
+def test_minus_no_descent(fontsize):
     # Test special-casing of minus descent in DviFont._height_depth_of, by
     # checking that overdrawing a 1 and a -1 results in an overall height
     # equivalent to drawing either of them separately.
     mpl.style.use("mpl20")
+    mpl.rcParams['font.size'] = fontsize
     heights = {}
     fig = plt.figure()
     for vals in [(1,), (-1,), (-1, 1)]:


### PR DESCRIPTION
## PR Summary

When searching for minus symbols in tex output, to treat them as a special case, do so for any font size not just font size 10. Minus is glyph zero of the font cmsyXX (XX being the font size).

This ensures that negative numbers have correct alignment when using tex, whatever the font size being used. This closes #17574.

The same example in the issue now gives the correct output:

```python
from matplotlib import pyplot as plt
fig = plt.figure(dpi=300)
plt.rc('text', usetex=True)
ax = fig.add_subplot(1,2,1)
plt.plot((-7.,0.,7.), (-1.,0.,1.), 'r-')
plt.rc('text', usetex=True)
ax = fig.add_subplot(1,2,2)
plt.plot((-7.,0.,7.), (-1.,0.,1.), 'r-')
plt.xticks(fontsize=8)
plt.yticks(fontsize=8)
plt.show()
```

![working_example_17574](https://user-images.githubusercontent.com/22192046/83878003-be8c5b80-a73b-11ea-9db4-b2d042ae6c4c.png)

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way