### PR TITLE
Fix same_color() for 'none' color

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -138,8 +138,22 @@ def is_color_like(c):
 
 
 def same_color(c1, c2):
-    """Return whether the colors *c1* and *c2* are the same."""
-    return (to_rgba_array(c1) == to_rgba_array(c2)).all()
+    """
+    Return whether the colors *c1* and *c2* are the same.
+
+    *c1*, *c2* can be single colors or lists/arrays of colors.
+    """
+    c1 = to_rgba_array(c1)
+    c2 = to_rgba_array(c2)
+    n1 = max(c1.shape[0], 1)  # 'none' results in shape (0, 4), but is 1-elem
+    n2 = max(c2.shape[0], 1)  # 'none' results in shape (0, 4), but is 1-elem
+
+    if n1 != n2:
+        raise ValueError('Different number of elements passed.')
+    # The following shape test is needed to correctly handle comparisons with
+    # 'none', which results in a shape (0, 4) array and thus cannot be tested
+    # via value comparison.
+    return c1.shape == c2.shape and (c1 == c2).all()
 
 
 def to_rgba(c, alpha=None):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1118,6 +1118,13 @@ def test_ndarray_subclass_norm():
 def test_same_color():
     assert mcolors.same_color('k', (0, 0, 0))
     assert not mcolors.same_color('w', (1, 1, 0))
+    assert mcolors.same_color(['red', 'blue'], ['r', 'b'])
+    assert mcolors.same_color('none', 'none')
+    assert not mcolors.same_color('none', 'red')
+    with pytest.raises(ValueError):
+        mcolors.same_color(['r', 'g', 'b'], ['r'])
+    with pytest.raises(ValueError):
+        mcolors.same_color(['red', 'green'], 'none')
 
 
 def test_hex_shorthand_notation():


### PR DESCRIPTION
## PR Summary

`same_color('none', 'red')` was True. See the comment in the code fix for an explanation.

*Edit:* Additional changes: I realized that we would do funny things when passing multiple colors, e.g.
- `same_color(['r', 'g', 'b'], ['r', 'g'])` would raise `AttributeError: 'bool' object has no attribute 'all'`.
- `same_color(['r', 'r'], 'r')` was true due to broadcasting.

Therefore, I've added an explicit length check and error out with a `ValueError` if different numbers of colors are supplied. Technically, this is an API change, but only concerns cases which had raised exceptions anyway or yielded false-positives. Therefore, I consider it rather a bug fix and don't think we need an API-change not for this.