### PR TITLE
Add a docstring to toolkit's BezierPath.__init__.

### DIFF
--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -180,7 +180,7 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
                     obj.__doc__ = new_doc
                 except AttributeError:  # Can't set on some extension objects.
                     pass
-                obj.__init__ = wrapper
+                obj.__init__ = functools.wraps(obj.__init__)(wrapper)
                 return obj
 
         elif isinstance(obj, property):

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -108,6 +108,14 @@ from .axisline_style import AxislineStyle
 class BezierPath(Line2D):
 
     def __init__(self, path, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        path : `~.path.Path`
+            The path to draw.
+        **kwargs
+            All remaining keyword arguments are passed to `.Line2D`.
+        """
         Line2D.__init__(self, [], [], *args, **kwargs)
         self._path = path
         self._invalid = False


### PR DESCRIPTION
## PR Summary

This breaks on new Sphinx due to missing the docstring for the inherited methods that the superclass docstring references, but this method doesn't need it.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way