### PR TITLE
MNT: cleanup minor style issues

### DIFF
--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -209,7 +209,7 @@ confidence_ellipse(x, y, ax_kwargs,
 
 ax_kwargs.scatter(x, y, s=0.5)
 ax_kwargs.scatter(mu[0], mu[1], c='red', s=3)
-ax_kwargs.set_title(f'Using kwargs')
+ax_kwargs.set_title('Using kwargs')
 
 fig.subplots_adjust(hspace=0.25)
 plt.show()

--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -73,6 +73,7 @@ axs1[0].xaxis.set_major_formatter(ticker.NullFormatter())
 setup(axs1[1], title="StrMethodFormatter('{x:.3f}')")
 axs1[1].xaxis.set_major_formatter(ticker.StrMethodFormatter("{x:.3f}"))
 
+
 # FuncFormatter can be used as a decorator
 @ticker.FuncFormatter
 def major_formatter(x, pos):

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -100,6 +100,7 @@ def create_figure():
 def test_common_texification(plain_text, escaped_text):
     assert common_texification(plain_text) == escaped_text
 
+
 # test compiling a figure to pdf with xelatex
 @needs_xelatex
 @pytest.mark.backend('pgf')

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1908,7 +1908,7 @@ class RectangleSelector(_SelectorWidget):
                  lineprops=None, rectprops=None, spancoords='data',
                  button=None, maxdist=10, marker_props=None,
                  interactive=False, state_modifier_keys=None):
-        """
+        r"""
         Parameters
         ----------
         ax : `~matplotlib.axes.Axes`


### PR DESCRIPTION
## PR Summary

 - remove un-needed f-string in examples
 - escape an escape sequence aimed at sphinx (not python)
 - whitespace in examples and tests



## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
