### PR TITLE
FIX: propagate _is_saving state when changing canvases

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2073,8 +2073,9 @@ class FigureCanvasBase:
         # Some code (e.g. Figure.show) differentiates between having *no*
         # manager and a *None* manager, which should be fixed at some point,
         # but this should be fine.
-        with cbook._setattr_cm(self, _is_saving=True, manager=None), \
-                cbook._setattr_cm(self.figure, dpi=dpi):
+        with cbook._setattr_cm(self, manager=None), \
+                cbook._setattr_cm(self.figure, dpi=dpi), \
+                cbook._setattr_cm(canvas, _is_saving=True):
             origfacecolor = self.figure.get_facecolor()
             origedgecolor = self.figure.get_edgecolor()
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -579,3 +579,12 @@ def test_tightbbox_box_aspect():
     ax2 = fig.add_subplot(gs[0, 1], projection='3d')
     ax1.set_box_aspect(.5)
     ax2.set_box_aspect((2, 1, 1))
+
+
+@check_figures_equal(extensions=["svg", "pdf", "eps", "png"])
+def test_animated_with_canvas_change(fig_test, fig_ref):
+    ax_ref = fig_ref.subplots()
+    ax_ref.plot(range(5))
+
+    ax_test = fig_test.subplots()
+    ax_test.plot(range(5), animated=True)


### PR DESCRIPTION
## PR Summary

We have logic to draw animated artists if we are rendering due to
savefig (as opposed to rendering to put into a GUI).  Not every canvas
class can write every format so we can switch the canvas as save time
based on the requested extension / format.  Make sure we set the sate
on the canvas we are actually using to save the figure rather than the
canvas that is attached to the figure when we start saving.

closes #17599


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
