### PR TITLE
Backport PR #17602: FIX: propagate _is_saving state when changing can…

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2068,8 +2068,9 @@ default: :rc:`savefig.bbox`
         # Some code (e.g. Figure.show) differentiates between having *no*
         # manager and a *None* manager, which should be fixed at some point,
         # but this should be fine.
-        with cbook._setattr_cm(self, _is_saving=True, manager=None), \
-                cbook._setattr_cm(self.figure, dpi=dpi):
+        with cbook._setattr_cm(self, manager=None), \
+                cbook._setattr_cm(self.figure, dpi=dpi), \
+                cbook._setattr_cm(canvas, _is_saving=True):
 
             if facecolor is None:
                 facecolor = rcParams['savefig.facecolor']

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -487,3 +487,12 @@ def test_removed_axis():
     fig, axs = plt.subplots(2, sharex=True)
     axs[0].remove()
     fig.canvas.draw()
+
+
+@check_figures_equal(extensions=["svg", "pdf", "eps", "png"])
+def test_animated_with_canvas_change(fig_test, fig_ref):
+    ax_ref = fig_ref.subplots()
+    ax_ref.plot(range(5))
+
+    ax_test = fig_test.subplots()
+    ax_test.plot(range(5), animated=True)


### PR DESCRIPTION
…vases

Merge pull request #17602 from tacaswell/fix_mixed_canvas_animation_save

FIX: propagate _is_saving state when changing canvases
Conflicts:
	lib/matplotlib/backend_bases.py
         - other nearby changes, only backport the context manager
           related changes
	lib/matplotlib/tests/test_figure.py
         - did not backport the other tests that are currently only on
           master branch.

