### PR TITLE
MNT: allow 0 sized figures

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -317,7 +317,7 @@ class Figure(Artist):
         if frameon is None:
             frameon = mpl.rcParams['figure.frameon']
 
-        if not np.isfinite(figsize).all() or (np.array(figsize) <= 0).any():
+        if not np.isfinite(figsize).all() or (np.array(figsize) < 0).any():
             raise ValueError('figure size must be positive finite not '
                              f'{figsize}')
         self.bbox_inches = Bbox.from_bounds(0, 0, *figsize)
@@ -876,7 +876,7 @@ default: 'top'
         if h is None:  # Got called with a single pair as argument.
             w, h = w
         size = np.array([w, h])
-        if not np.isfinite(size).all() or (size <= 0).any():
+        if not np.isfinite(size).all() or (size < 0).any():
             raise ValueError(f'figure size must be positive finite not {size}')
         self.bbox_inches.p1 = size
         if forward:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -374,7 +374,6 @@ def test_change_dpi():
 
 @pytest.mark.parametrize('width, height', [
     (1, np.nan),
-    (0, 1),
     (-1, 1),
     (np.inf, 1)
 ])


### PR DESCRIPTION
## PR Summary

This can happen if the figure is embedded in a larger GUI application.

Closes #17093

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
