### PR TITLE
fix resizeEvent in FigureCanvasQTAgg

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -364,8 +364,12 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         # the rendered buffer is useless before anyways.
         if self._dpi_ratio_prev is None:
             return
-        w = event.size().width() * self._dpi_ratio
-        h = event.size().height() * self._dpi_ratio
+        width = event.size().width()
+        height = event.size().height()
+        if width <= 0 or height <= 0:
+            return
+        w = width * self._dpi_ratio
+        h = height * self._dpi_ratio
         dpival = self.figure.dpi
         winch = w / dpival
         hinch = h / dpival


### PR DESCRIPTION
When FigureCanvasQTAgg is used with a QSplitter the resizeEvent() method receives an event where the width or height can be 0 generating the winch or hinch to be 0 and this throws an exception:

```
Traceback (most recent call last):
  File "C:\Python36\lib\site-packages\matplotlib\backends\backend_qt5.py", line 397, in resizeEvent
    self.figure.set_size_inches(winch, hinch, forward=False)
  File "C:\Python36\lib\site-packages\matplotlib\figure.py", line 902, in set_size_inches
    raise ValueError(f'figure size must be positive finite not {size}')
ValueError: figure size must be positive finite not [0.   6.12]
```

A possible solution to the problem is to verify that the dimensions are positive, and that is what I have implemented in this PR.

Relative  #17608 