### PR TITLE
Rewrite pdf test to use check_figures_equal.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -11,8 +11,7 @@ import pytest
 import matplotlib as mpl
 from matplotlib import dviread, pyplot as plt, checkdep_usetex, rcParams
 from matplotlib.backends.backend_pdf import PdfPages
-from matplotlib.testing.compare import compare_images
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 
 needs_usetex = pytest.mark.skipif(
@@ -245,16 +244,13 @@ def test_missing_psfont(monkeypatch):
 
 
 @pytest.mark.style('default')
-def test_pdf_savefig_when_color_is_none(tmpdir):
-    fig, ax = plt.subplots()
-    plt.axis('off')
-    ax.plot(np.sin(np.linspace(-5, 5, 100)), 'v', c='none')
-    actual_image = tmpdir.join('figure.pdf')
-    expected_image = tmpdir.join('figure.eps')
-    fig.savefig(str(actual_image), format='pdf')
-    fig.savefig(str(expected_image), format='eps')
-    result = compare_images(str(actual_image), str(expected_image), 0)
-    assert result is None
+@check_figures_equal(extensions=["pdf", "eps"])
+def test_pdf_eps_savefig_when_color_is_none(fig_test, fig_ref):
+    ax_test = fig_test.add_subplot()
+    ax_test.set_axis_off()
+    ax_test.plot(np.sin(np.linspace(-5, 5, 100)), "v", c="none")
+    ax_ref = fig_ref.add_subplot()
+    ax_ref.set_axis_off()
 
 
 @needs_usetex


### PR DESCRIPTION
... instead of manually calling compare_images().
(This now tests that both the pdf and the eps results are blank (and
thus equal), rather than checking that the two of them are equal.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
