### PR TITLE
Skip test_tmpconfigdir_warning when running as root.

### DIFF
--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -9,6 +9,8 @@ import matplotlib
 
 @pytest.mark.skipif(
     os.name == "nt", reason="chmod() doesn't work as is on Windows")
+@pytest.mark.skipif(os.name != "nt" and os.geteuid() == 0,
+                    reason="chmod() doesn't work as root")
 def test_tmpconfigdir_warning(tmpdir):
     """Test that a warning is emitted if a temporary configdir must be used."""
     mode = os.stat(tmpdir).st_mode


### PR DESCRIPTION
## PR Summary

This is something that happens when building wheels in the manylinux1 container.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way