### PR TITLE
FIX: restore ability to pass a tuple to axes_class in axes_grid

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -1,4 +1,5 @@
 from numbers import Number
+import functools
 
 import numpy as np
 
@@ -173,6 +174,9 @@ class Grid:
 
         if axes_class is None:
             axes_class = self._defaultAxesClass
+        elif isinstance(axes_class, (list, tuple)):
+            cls, kwargs = axes_class
+            axes_class = functools.partial(cls, **kwargs)
 
         kw = dict(horizontal=[], vertical=[], aspect=aspect)
         if isinstance(rect, (str, Number, SubplotSpec)):

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -18,6 +18,7 @@ from mpl_toolkits.axes_grid1.anchored_artists import (
 from mpl_toolkits.axes_grid1.axes_divider import HBoxDivider
 from mpl_toolkits.axes_grid1.inset_locator import (
     zoomed_inset_axes, mark_inset, inset_axes, BboxConnectorPatch)
+import mpl_toolkits.axes_grid1.mpl_axes
 
 import pytest
 
@@ -471,3 +472,9 @@ def test_hbox_divider():
     p2 = ax2.get_position()
     assert p1.height == p2.height
     assert p2.width / p1.width == pytest.approx((4 / 5) ** 2)
+
+
+def test_axes_class_tuple():
+    fig = plt.figure()
+    axes_class = (mpl_toolkits.axes_grid1.mpl_axes.Axes, {})
+    gr = AxesGrid(fig, 111, nrows_ncols=(1, 1), axes_class=axes_class)


### PR DESCRIPTION
## PR Summary

This was not documented by use, but is used in a cartopy example so
presumably has adaption in the wild.

Partially reverts #15461 

Probably better to leave this un-documented, but now has a test.



## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
