### PR TITLE
Add a flag for disabling LTO.

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -3,6 +3,9 @@
 [egg_info]
 
 [libs]
+# By default, Matplotlib builds with LTO, which may be slow if you re-compile
+# often, and don't need the space saving/speedup.
+#enable_lto = True
 # By default, Matplotlib downloads and builds its own copy of FreeType, and
 # builds its own copy of Qhull.  You may set the following to True to instead
 # link against a system FreeType/Qhull.

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,8 @@ class BuildExtraLibraries(BuildExtCommand):
         """
 
         env = os.environ.copy()
+        if not setupext.config.getboolean('libs', 'enable_lto', fallback=True):
+            return env
         if sys.platform == 'win32':
             return env
 


### PR DESCRIPTION
## PR Summary

For developers, it may be useful to disable it to improve build time when repeatedly re-building.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way