### PR TITLE
Fix autoscaling with tiny sticky values.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2545,15 +2545,17 @@ class _AxesBase(martist.Artist):
             locator = axis.get_major_locator()
             x0, x1 = locator.nonsingular(x0, x1)
 
-            # Prevent margin addition from crossing a sticky value.  Small
-            # tolerances (whose values come from isclose()) must be used due to
-            # floating point issues with streamplot.
-            def tol(x): return 1e-5 * abs(x) + 1e-8
+            # Prevent margin addition from crossing a sticky value.  A small
+            # tolerance must be added due to floating point issues with
+            # streamplot; it is defined relative to x0, x1, x1-x0 but has
+            # no absolute term (e.g. "+1e-8") to avoid issues when working with
+            # datasets where all values are tiny (less than 1e-8).
+            tol = 1e-5 * max(abs(x0), abs(x1), abs(x1 - x0))
             # Index of largest element < x0 + tol, if any.
-            i0 = stickies.searchsorted(x0 + tol(x0)) - 1
+            i0 = stickies.searchsorted(x0 + tol) - 1
             x0bound = stickies[i0] if i0 != -1 else None
             # Index of smallest element > x1 - tol, if any.
-            i1 = stickies.searchsorted(x1 - tol(x1))
+            i1 = stickies.searchsorted(x1 - tol)
             x1bound = stickies[i1] if i1 != len(stickies) else None
 
             # Add the margin in figure space and then transform back, to handle

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6314,3 +6314,11 @@ def test_polar_interpolation_steps_variable_r(fig_test, fig_ref):
     l.get_path()._interpolation_steps = 100
     fig_ref.add_subplot(projection="polar").plot(
         np.linspace(0, np.pi/2, 101), np.linspace(1, 2, 101))
+
+
+@pytest.mark.style('default')
+def test_autoscale_tiny_sticky():
+    fig, ax = plt.subplots()
+    ax.bar(0, 1e-9)
+    fig.canvas.draw()
+    assert ax.get_ylim() == (0, 1.05e-9)


### PR DESCRIPTION
## PR Summary

Closes #17633.  I guess may be nice to have in 3.3, but heh.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
