### PR TITLE
DOC: Update colormap deprecation warning to use Python's copy function.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -500,7 +500,7 @@ def _warn_if_global_cmap_modified(cmap):
                     "colormap. In future versions, you will not be able to "
                     "modify a registered colormap in-place. To remove this "
                     "warning, you can make a copy of the colormap first. "
-                    f"cmap = mpl.cm.get_cmap({cmap.name}).copy()"
+                    f'cmap = copy.copy(mpl.cm.get_cmap("{cmap.name}"))'
         )
 
 


### PR DESCRIPTION
## PR Summary

Fixes #17634

This updates the deprecation warning to suggest using the `copy.copy()` function.

An alternative would be to add the `.copy()` function to Colormaps, but there was some discussion previously over whether to make them immutable or return copies, so this is the simple fix for now rather than adding additional functions.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
