### PR TITLE
Fix default colouring of Shadows

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3076,8 +3076,7 @@ class Axes(_AxesBase):
             if shadow:
                 # Make sure to add a shadow after the call to add_patch so the
                 # figure and transform props will be set.
-                shad = mpatches.Shadow(w, -0.02, -0.02)
-                shad.set(zorder=0.9 * w.get_zorder(), label='_nolegend_')
+                shad = mpatches.Shadow(w, -0.02, -0.02, label='_nolegend_')
                 self.add_patch(shad)
 
             if labeldistance is not None:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -645,7 +645,14 @@ class Shadow(Patch):
         self.patch = patch
         # Note: when removing props, we can directly pass kwargs to _update()
         # and remove self._props
-        self._props = {**(props if props is not None else {}), **kwargs}
+        if props is None:
+            color = .3 * np.asarray(colors.to_rgb(self.patch.get_facecolor()))
+            props = {
+                'facecolor': color,
+                'edgecolor': color,
+                'alpha': 0.5,
+            }
+        self._props = {**props, **kwargs}
         self._ox, self._oy = ox, oy
         self._shadow_transform = transforms.Affine2D()
         self._update()
@@ -658,13 +665,7 @@ class Shadow(Patch):
         # Place the shadow patch directly behind the inherited patch.
         self.set_zorder(np.nextafter(self.patch.zorder, -np.inf))
 
-        if self._props:
-            self.update(self._props)
-        else:
-            color = .3 * np.asarray(colors.to_rgb(self.patch.get_facecolor()))
-            self.set_facecolor(color)
-            self.set_edgecolor(color)
-            self.set_alpha(0.5)
+        self.update(self._props)
 
     def _update_transform(self, renderer):
         ox = renderer.points_to_pixels(self._ox)


### PR DESCRIPTION
## PR Summary
Starting with #16098, extra keyword arguments are now processed, but that means that default colours and alpha are not set. Instead, those properties should only be overridden if specified.

As a proof that this works as one might expect, change the `Shadow` call in `pie` to use keyword arguments instead of `.set`.

This is not a perfect match to previous behaviour, but at least makes the constructor work in an expected manner.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way