### PR TITLE
Don't pass "wrong" `indent=False` in SVG generation.

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -334,7 +334,7 @@ class RendererSVG(RendererBase):
         writer = self.writer
 
         if 'Title' in metadata:
-            writer.element('title', text=metadata['Title'], indent=False)
+            writer.element('title', text=metadata['Title'])
 
         # Special handling.
         date = metadata.get('Date', None)
@@ -387,7 +387,7 @@ class RendererSVG(RendererBase):
                     'identifier', 'language', 'relation', 'source']:
             info = metadata.pop(key.title(), None)
             if info is not None:
-                writer.element(f'dc:{key}', text=info, indent=False)
+                writer.element(f'dc:{key}', text=info)
 
         # Multiple Agent values.
         for key in ['creator', 'contributor', 'publisher', 'rights']:
@@ -401,7 +401,7 @@ class RendererSVG(RendererBase):
             writer.start(f'dc:{key}')
             for agent in agents:
                 writer.start('cc:Agent')
-                writer.element('dc:title', text=agent, indent=False)
+                writer.element('dc:title', text=agent)
                 writer.end('cc:Agent')
             writer.end(f'dc:{key}')
 
@@ -414,7 +414,7 @@ class RendererSVG(RendererBase):
             writer.start('dc:subject')
             writer.start('rdf:Bag')
             for keyword in keywords:
-                writer.element('rdf:li', text=keyword, indent=False)
+                writer.element('rdf:li', text=keyword)
             writer.end('rdf:Bag')
             writer.end('dc:subject')
 


### PR DESCRIPTION
All kwargs to `XMLWriter.element()` are interpreted as XML attributes --
except the Falsy ones.  So passing `indent=False` doesn't have any
effect, but it's wrong to pass `indent` to `element()` anyways (e.g.
passing `indent=True` would crash it instead of doing any indenting).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
