### PR TITLE
Small changes to svg font embedding details

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1018,9 +1018,12 @@ class RendererSVG(RendererBase):
             writer.start('defs')
             for char_id, (vertices, codes) in glyph_map_new.items():
                 char_id = self._adjust_char_id(char_id)
+                # x64 to go back to FreeType's internal (integral) units.
                 path_data = self._convert_path(
-                    Path(vertices, codes), simplify=False)
-                writer.element('path', id=char_id, d=path_data)
+                    Path(vertices * 64, codes), simplify=False)
+                writer.element(
+                    'path', id=char_id, d=path_data,
+                    transform=generate_transform([('scale', (1 / 64,))]))
             writer.end('defs')
             self._glyph_map.update(glyph_map_new)
 

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -1,6 +1,5 @@
 import datetime
 from io import BytesIO
-import re
 import tempfile
 import xml.etree.ElementTree
 import xml.parsers.expat
@@ -211,11 +210,13 @@ def test_unicode_won():
 
     with BytesIO() as fd:
         fig.savefig(fd, format='svg')
-        buf = fd.getvalue().decode('ascii')
+        buf = fd.getvalue()
 
-    won_id = 'Computer_Modern_Sans_Serif-142'
-    assert re.search(r'<path d=(.|\s)*?id="{0}"/>'.format(won_id), buf)
-    assert re.search(r'<use[^/>]*? xlink:href="#{0}"/>'.format(won_id), buf)
+    tree = xml.etree.ElementTree.fromstring(buf)
+    ns = 'http://www.w3.org/2000/svg'
+    won_id = 'SFSS3583-8e'
+    assert len(tree.findall(f'.//{{{ns}}}path[@d][@id="{won_id}"]')) == 1
+    assert f'#{won_id}' in tree.find(f'.//{{{ns}}}use').attrib.values()
 
 
 def test_svgnone_with_data_coordinates():

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -41,15 +41,7 @@ class TextToPath:
         """
         Return a unique id for the given font and character-code set.
         """
-        return urllib.parse.quote('{}-{}'.format(font.postscript_name, ccode))
-
-    def _get_char_id_ps(self, font, ccode):
-        """
-        Return a unique id for the given font and character-code set (for tex).
-        """
-        ps_name = font.get_ps_font_info()[2]
-        char_id = urllib.parse.quote('%s-%d' % (ps_name, ccode))
-        return char_id
+        return urllib.parse.quote(f"{font.postscript_name}-{ccode:x}")
 
     def get_text_width_height_descent(self, s, prop, ismath):
         if ismath == "TeX":
@@ -254,7 +246,7 @@ class TextToPath:
         # characters into strings.
         for x1, y1, dvifont, glyph, width in page.text:
             font, enc = self._get_ps_font_and_encoding(dvifont.texname)
-            char_id = self._get_char_id_ps(font, glyph)
+            char_id = self._get_char_id(font, glyph)
 
             if char_id not in glyph_map:
                 font.clear()


### PR DESCRIPTION
## PR Summary

1st commit: Switch svg glyph references back to hex; merge tex & non-tex names.

When embedding glyphs as paths in SVG files, each glyph has a name just
so that we can link to them when actually placing the glyphs.
Previously there were two different paths for non-usetex glyphs and
usetex glyphs.

- In a2287b1 I accidentally changed the number component of non-usetex
  names from hex to decimal (usetex was always using decimal); switch it
  back to hex as that's typically how glyph tables are listed anyways.
  Also switch the usetex case to hex for consistency.
- Make non-usetex and usetex names use the same way to generate the
  name.  The 2nd entry of ps_font_info typically matches postscript_name
  (but is only available for Type1 fonts, whereas postscript_name is
  defined for all fonts), but even if they donn't (see test_unicode_won),
  this doesn't matter as long as we are internally consistent...
  Also changed unicode_won test to actually parse the xml -- the regexp
  search seems quite slow locally, and anyways regex'ing xml is not
  necessarily a great idea :)

2nd commit: Record svg glyphs in 1/64 pixel units.

1/64-pixel is the "natural" unit for TrueType and FreeType ("F26Dot6").
Using it makes glyphs recorded in SVG files shorter, e.g.
```
M 88.796875 4.296875
Q 88.796875 2.09375 87.140625 0.5
Q 85.5 -1.09375 83.203125 -1.09375
```
becomes
```
M 1113 -72
Q 709 -72 476 233
Q 244 538 244 953
```
(the concatenated svg output of test_mathtext.py is ~10% shorter)
and easier to compare with FreeType values when troubleshooting font
embedding.  An additional `transform="scale(0.015625)"` (i.e. 1/64) is
added at the end to scale the glyph, but given that a further scaling
and translation is done to actually render the glyph at the right size
and position in the svg, I doubt that this really affects svg renderer
performance (likely they can compose the two scalings first).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
