### PR TITLE
FIX: correctly process the tick label size

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1340,7 +1340,7 @@ class Axis(martist.Artist):
         tick_kw = self._major_tick_kw
         size = tick_kw.get('labelsize',
                            mpl.rcParams[f'{axis_name}tick.labelsize'])
-        return mtext.FontProperties(size).get_size_in_points()
+        return mtext.FontProperties(size=size).get_size_in_points()
 
     def _copy_tick_props(self, src, dest):
         """Copy the properties from *src* tick to *dest* tick."""

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -21,11 +21,12 @@ import matplotlib
 import matplotlib as mpl
 from matplotlib.testing.decorators import (
     image_comparison, check_figures_equal, remove_ticks_and_titles)
-import matplotlib.pyplot as plt
-import matplotlib.markers as mmarkers
-import matplotlib.patches as mpatches
 import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
+import matplotlib.font_manager as mfont_manager
+import matplotlib.markers as mmarkers
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 from numpy.testing import (
@@ -6322,3 +6323,17 @@ def test_autoscale_tiny_sticky():
     ax.bar(0, 1e-9)
     fig.canvas.draw()
     assert ax.get_ylim() == (0, 1.05e-9)
+
+
+@pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings
+                                  if size is not None] + [8, 10, 12])
+@pytest.mark.style('default')
+def test_relative_ticklabel_sizes(size):
+    mpl.rcParams['xtick.labelsize'] = size
+    mpl.rcParams['ytick.labelsize'] = size
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+
+    for name, axis in zip(['x', 'y'], [ax.xaxis, ax.yaxis]):
+        for tick in axis.get_major_ticks():
+            assert tick.label1.get_size() == axis._get_tick_label_size(name)


### PR DESCRIPTION

## PR Summary

Passing the size positional caused it to be treated as a fontconfig
pattern.  For the relative sizes without '-' in them this formally
works and stashes the relative size in the family.  We don't actually
resolve that we can _find_ the font so this, while wrong, is not
noticed and when we ask for the size it gives us back the default
size so our size estimate was silently wrong.

In the cases where we have a '-' in the relative size the fontconfig
pattern parsing fails when we try to estimate the size.

closes  #17670


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
