### PR TITLE
Deprecate passing bytes to FT2Font.set_text.

### DIFF
--- a/doc/api/api_changes_3.4/deprecations.rst
+++ b/doc/api/api_changes_3.4/deprecations.rst
@@ -1,2 +1,6 @@
 Deprecations
 ------------
+
+Passing `bytes` to ``FT2Font.set_text``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated, pass `str` instead.

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -642,6 +642,13 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
             codepoints[i] = unistr[i];
         }
     } else if (PyBytes_Check(textobj)) {
+        if (PyErr_WarnEx(
+            PyExc_FutureWarning,
+            "Passing bytes to FTFont.set_text is deprecated since Matplotlib "
+            "3.4 and support will be removed in Matplotlib 3.6; pass str instead",
+            1)) {
+            return NULL;
+        }
         size = PyBytes_Size(textobj);
         codepoints.resize(size);
         char *bytestr = PyBytes_AsString(textobj);


### PR DESCRIPTION
The bytes object was previously implicitly interpreted as a latin-1
str, but we're not on Py2 anymore :-)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
