### PR TITLE
DOC: Add svg2pdf converter for generating PDF docs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,7 @@ extensions = [
     'sphinx_gallery.gen_gallery',
     'matplotlib.sphinxext.mathmpl',
     'matplotlib.sphinxext.plot_directive',
+    'sphinxcontrib.inkscapeconverter',
     'sphinxext.custom_roles',
     'sphinxext.github',
     'sphinxext.math_symbol_table',
@@ -69,6 +70,7 @@ def _check_dependencies():
         "PIL.Image": 'pillow',
         "sphinx_copybutton": 'sphinx_copybutton',
         "sphinx_gallery": 'sphinx_gallery',
+        "sphinxcontrib.inkscapeconverter": 'sphinxcontrib-svg2pdfconverter',
     }
     missing = []
     for name in names:

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -12,6 +12,7 @@ colorspacious
 ipython
 ipywidgets
 numpydoc>=0.8
+sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.7
 sphinx-copybutton
 scipy


### PR DESCRIPTION
## PR Summary

This is needed in order to build a PDF, as the Zenodo citation images are SVGs. The specified minimum version supports Inkscape 1.

Fixes #17681.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [a] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way