### PR TITLE
CI: Only skip devdocs deploy if PR is to this repo.

### DIFF
--- a/.circleci/deploy-docs.sh
+++ b/.circleci/deploy-docs.sh
@@ -4,7 +4,7 @@ set -e
 
 if [ "$CIRCLE_PROJECT_USERNAME" != "matplotlib" ] || \
         [ "$CIRCLE_BRANCH" != "master" ] || \
-        [ "$CIRCLE_PULL_REQUEST" != "" ]; then
+        [[ "$CIRCLE_PULL_REQUEST" == https://github.com/matplotlib/matplotlib/pull/* ]]; then
     echo "Not uploading docs for ${CIRCLE_SHA1}"\
          "from non-master branch (${CIRCLE_BRANCH})"\
          "or pull request (${CIRCLE_PULL_REQUEST})"\


### PR DESCRIPTION
## PR Summary

There's currently a PR open to some random fork to keep their master branch updated, and Circle (or GitHub, really) tag this in the build information.  However, we don't want to skip devdocs deployment if there's a PR on some other repo, only this one.

Followup from looking at the build results of #17691.