### PR TITLE
Keep cachedRenderer as None when pickling Figure.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2108,8 +2108,10 @@ default: 'top'
         # The canvas cannot currently be pickled, but this has the benefit
         # of meaning that a figure can be detached from one canvas, and
         # re-attached to another.
-        for attr_to_pop in ('canvas', '_cachedRenderer'):
-            state.pop(attr_to_pop, None)
+        state.pop("canvas")
+
+        # Set cached renderer to None -- it can't be pickled.
+        state["_cachedRenderer"] = None
 
         # add version information to the state
         state['__mpl_version__'] = _mpl_version


### PR DESCRIPTION
`Figure.__init__` sets cachedRenderer to None, so it's awkward that
pickling and unpickling a figure completely removes the attribute,
causing obscure AttributeErrors.

Closes https://github.com/matplotlib/matplotlib/issues/17627.  (Well, I can't actually repro the issue as reported -- I suspect it has something to do with interagg, i.e. pycharm -- but this should certainly get rid of the AttributeError.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
