### PR TITLE
Enh: SymNorm for normalizing symmetrical data around a center

### DIFF
--- a/doc/api/colors_api.rst
+++ b/doc/api/colors_api.rst
@@ -20,6 +20,7 @@ Classes
 
    BoundaryNorm
    Colormap
+   CenteredNorm
    LightSource
    LinearSegmentedColormap
    ListedColormap

--- a/doc/users/next_whats_new/centerednorm.rst
+++ b/doc/users/next_whats_new/centerednorm.rst
@@ -1,0 +1,35 @@
+New CenteredNorm for symmetrical data around a center
+-----------------------------------------------------
+In cases where data is symmetrical around a center, for example, positive and
+negative anomalies around a center zero, `~.matplotlib.colors.CenteredNorm`
+is a new norm that automatically creates a symmetrical mapping around the
+center. This norm is well suited to be combined with a divergent colormap which
+uses an unsaturated color in its center.
+
+  .. plot::
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from matplotlib.colors import CenteredNorm
+
+    np.random.seed(20201004)
+    data = np.random.normal(size=(3, 4), loc=1)
+
+    fig, ax = plt.subplots()
+    pc = ax.pcolormesh(data, cmap=plt.get_cmap('RdGy'), norm=CenteredNorm())
+    fig.colorbar(pc)
+    ax.set_title('data centered around zero')
+
+    # add text annotation
+    for irow, data_row in enumerate(data):
+        for icol, val in enumerate(data_row):
+            ax.text(icol + 0.5, irow + 0.5, f'{val:.2f}', color='C0',
+                    size=16, va='center', ha='center')
+    plt.show()
+
+If the center of symmetry is different from 0, it can be set with the *vcenter*
+argument. To manually set the range of `~.matplotlib.colors.CenteredNorm`, use
+the *halfrange* argument.
+
+See :doc:`/tutorials/colors/colormapnorms` for an example and more details
+about data normalization.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1290,6 +1290,7 @@ class CenteredNorm(Normalize):
             array([0.25, 0.5 , 1.  ])
         """
         self._vcenter = vcenter
+        # calling the halfrange setter to set vmin and vmax
         self.halfrange = halfrange
         self.clip = clip
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1342,7 +1342,7 @@ class CenteredNorm(Normalize):
             self.vmax = None
         else:
             self._halfrange = abs(halfrange)
-            self._set_vmin_vmax()
+            #self._set_vmin_vmax()
 
     def __call__(self, value, clip=None):
         if self._halfrange is not None:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1303,8 +1303,7 @@ class CenteredNorm(Normalize):
 
     def autoscale(self, A):
         """
-        Set *halfrange* to max(abs(*A*-*vcenter*)),
-        then set *vmin* and *vmax*.
+        Set *halfrange* to ``max(abs(A-vcenter))``, then set *vmin* and *vmax*.
         """
         A = np.asanyarray(A)
         self._halfrange = max(self._vcenter-A.min(),

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1342,7 +1342,6 @@ class CenteredNorm(Normalize):
             self.vmax = None
         else:
             self._halfrange = abs(halfrange)
-            #self._set_vmin_vmax()
 
     def __call__(self, value, clip=None):
         if self._halfrange is not None:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1256,7 +1256,7 @@ class TwoSlopeNorm(Normalize):
 
 
 class SymNorm(Normalize):
-    def __init__(self, vcenter=0.0, vmax=None, clip=False):
+    def __init__(self, vcenter=0, vmax=None, clip=False):
         """
         Normalize symmetrical data around a center (0 by default).
 
@@ -1269,9 +1269,8 @@ class SymNorm(Normalize):
 
         Parameters
         ----------
-        vcenter : float, optional
+        vcenter : float, default: 0
             The data value that defines ``0.5`` in the normalization.
-            Defaults to ``0.0``.
         vmax : float, optional
             The data value that defines ``1.0`` in the normalization.
             Defaults to the sum of *vcenter* plus the largest absolute
@@ -1303,7 +1302,7 @@ class SymNorm(Normalize):
     def autoscale(self, A):
         """
         Set *vmax* to *vcenter* + max(abs(*A*-*vcenter*)),
-        then mirror *vmax* around *vcenter* to set *vmin*.
+        then set *vmin* by mirroring *vmax* at *vcenter*.
         """
         A = np.asanyarray(A)
         self.vmax = self._vcenter + max(self._vcenter-A.min(),

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1287,7 +1287,7 @@ class SymNorm(Normalize):
             >>> norm = mcolors.SymNorm(vmax=4.0)
             >>> data = [-2., 0., 4.]
             >>> norm(data)
-            array([[0.25, 0.5 , 1.  ])
+            array([0.25, 0.5 , 1.  ])
         """
 
         self._vcenter = vcenter
@@ -1328,6 +1328,12 @@ class SymNorm(Normalize):
             self.vmax = self._vcenter + max(self._vcenter-self.vmin,
                                             self.vmax-self._vcenter)
             self.vmin = 2*self._vcenter - self.vmax
+
+    def __call__(self, value, clip=None):
+        if self.vmax is not None:
+            # enforce symmetry, undo changes to vmin
+            self.vmin = 2*self._vcenter - self.vmax
+        return super().__call__(value, clip=clip)
 
 
 def _make_norm_from_scale(scale_cls, base_norm_cls=None, *, init=None):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1298,8 +1298,8 @@ class CenteredNorm(Normalize):
         """
         Set *vmin* and *vmax* based on *vcenter* and *halfrange*.
         """
-        self.vmax = self._vcenter + self.halfrange
-        self.vmin = self._vcenter - self.halfrange
+        self.vmax = self._vcenter + self._halfrange
+        self.vmin = self._vcenter - self._halfrange
 
     def autoscale(self, A):
         """
@@ -1338,10 +1338,11 @@ class CenteredNorm(Normalize):
     @halfrange.setter
     def halfrange(self, halfrange):
         if halfrange is None:
+            self._halfrange = None
             self.vmin = None
             self.vmax = None
         else:
-            self.halfrange = abs(halfrange)
+            self._halfrange = abs(halfrange)
             self._set_vmin_vmax()
 
     def __call__(self, value, clip=None):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -360,24 +360,40 @@ def test_BoundaryNorm():
 
 
 def test_CenteredNorm():
+    np.random.seed(0)
+
     # Assert equivalence to symmetrical Normalize.
     x = np.random.normal(size=100)
     x_maxabs = np.max(np.abs(x))
     norm_ref = mcolors.Normalize(vmin=-x_maxabs, vmax=x_maxabs)
     norm = mcolors.CenteredNorm()
     assert_array_almost_equal(norm_ref(x), norm(x))
+
     # Check that vcenter is in the center of vmin and vmax
     # when vcenter is set.
     vcenter = int(np.random.normal(scale=50))
     norm = mcolors.CenteredNorm(vcenter=vcenter)
     norm.autoscale_None([1, 2])
     assert norm.vmax + norm.vmin == 2 * vcenter
+
     # Check that halfrange input works correctly.
     x = np.random.normal(size=10)
     norm = mcolors.CenteredNorm(vcenter=0.5, halfrange=0.5)
     assert_array_almost_equal(x, norm(x))
     norm = mcolors.CenteredNorm(vcenter=1, halfrange=1)
     assert_array_almost_equal(x, 2 * norm(x))
+
+    # Check that halfrange input works correctly and use setters.
+    norm = mcolors.CenteredNorm()
+    norm.vcenter = 2
+    norm.halfrange = 2
+    assert_array_almost_equal(x, 4 * norm(x))
+
+    # Check that prior to adding data, setting halfrange first has same effect.
+    norm = mcolors.CenteredNorm()
+    norm.halfrange = 2
+    norm.vcenter = 2
+    assert_array_almost_equal(x, 4 * norm(x))
 
 
 @pytest.mark.parametrize("vmin,vmax", [[-1, 2], [3, 1]])

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -395,6 +395,19 @@ def test_CenteredNorm():
     norm.vcenter = 2
     assert_array_almost_equal(x, 4 * norm(x))
 
+    # Check that manual change of vcenter adjusts halfrange accordingly.
+    norm = mcolors.CenteredNorm()
+    assert norm.vcenter == 0
+    # add data
+    norm(np.linspace(-1.0, 0.0, 10))
+    assert norm.vmax == 1.0
+    assert norm.halfrange == 1.0
+    # set vcenter to 1, which should double halfrange
+    norm.vcenter = 1
+    assert norm.vmin == -1.0
+    assert norm.vmax == 3.0
+    assert norm.halfrange == 2.0
+
 
 @pytest.mark.parametrize("vmin,vmax", [[-1, 2], [3, 1]])
 def test_lognorm_invalid(vmin, vmax):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -359,6 +359,27 @@ def test_BoundaryNorm():
     assert_array_equal(cmshould(mynorm(x)), cmref(refnorm(x)))
 
 
+def test_CenteredNorm():
+    # Assert equivalence to symmetrical Normalize.
+    x = np.random.normal(size=100)
+    x_maxabs = np.max(np.abs(x))
+    norm_ref = mcolors.Normalize(vmin=-x_maxabs, vmax=x_maxabs)
+    norm = mcolors.CenteredNorm()
+    assert_array_almost_equal(norm_ref(x), norm(x))
+    # Check that vcenter is in the center of vmin and vmax
+    # when vcenter is set.
+    vcenter = int(np.random.normal(scale=50))
+    norm = mcolors.CenteredNorm(vcenter=vcenter)
+    norm.autoscale_None([1, 2])
+    assert norm.vmax + norm.vmin == 2 * vcenter
+    # Check that halfrange input works correctly.
+    x = np.random.normal(size=10)
+    norm = mcolors.CenteredNorm(vcenter=0.5, halfrange=0.5)
+    assert_array_almost_equal(x, norm(x))
+    norm = mcolors.CenteredNorm(vcenter=1, halfrange=1)
+    assert_array_almost_equal(x, 2 * norm(x))
+
+
 @pytest.mark.parametrize("vmin,vmax", [[-1, 2], [3, 1]])
 def test_lognorm_invalid(vmin, vmax):
     # Check that invalid limits in LogNorm error

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -47,6 +47,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
 import matplotlib.cbook as cbook
+from matplotlib import cm
 
 N = 100
 X, Y = np.mgrid[-3:3:complex(0, N), -2:2:complex(0, N)]
@@ -67,6 +68,46 @@ fig.colorbar(pcm, ax=ax[0], extend='max')
 
 pcm = ax[1].pcolor(X, Y, Z, cmap='PuBu_r', shading='auto')
 fig.colorbar(pcm, ax=ax[1], extend='max')
+plt.show()
+
+###############################################################################
+# Centered
+# --------
+#
+# In many cases, data is symmetrical around a center, for example, positive and
+# negative anomalies around a center 0. In this case, we would like the center
+# to be mapped to 0.5 and the datapoint with the largest deviation from the
+# center to be mapped to 1.0, if its value is greater than the center, or -1.0
+# otherwise. The norm `.colors.CenteredNorm` creates such a mapping
+# automatically. It is well suited to be combined with a divergent colormap
+# which uses different colors edges that meet in the center at an unsaturated
+# color.
+#
+# If the center of symmetry is different from 0, it can be set with the
+# *vcenter* argument. For logarithmic scaling on both sides of the center, see
+# `.colors.SymLogNorm` below; to apply a different mapping above and below the
+# center, use `.colors.TwoSlopeNorm` below.
+
+delta = 0.1
+x = np.arange(-3.0, 4.001, delta)
+y = np.arange(-4.0, 3.001, delta)
+X, Y = np.meshgrid(x, y)
+Z1 = np.exp(-X**2 - Y**2)
+Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
+Z = (0.9*Z1 - 0.5*Z2) * 2
+
+# select a divergent colormap
+cmap = cm.coolwarm
+
+fig, (ax1, ax2) = plt.subplots(ncols=2)
+pc = ax1.pcolormesh(Z, cmap=cmap)
+fig.colorbar(pc, ax=ax1)
+ax1.set_title('Normalize()')
+
+pc = ax2.pcolormesh(Z, norm=colors.CenteredNorm(), cmap=cmap)
+fig.colorbar(pc, ax=ax2)
+ax2.set_title('CenteredNorm()')
+
 plt.show()
 
 ###############################################################################

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -77,7 +77,7 @@ plt.show()
 # In many cases, data is symmetrical around a center, for example, positive and
 # negative anomalies around a center 0. In this case, we would like the center
 # to be mapped to 0.5 and the datapoint with the largest deviation from the
-# center to be mapped to 1.0, if its value is greater than the center, or -1.0
+# center to be mapped to 1.0, if its value is greater than the center, or 0.0
 # otherwise. The norm `.colors.CenteredNorm` creates such a mapping
 # automatically. It is well suited to be combined with a divergent colormap
 # which uses different colors edges that meet in the center at an unsaturated


### PR DESCRIPTION
## PR Summary

Adds `SymNorm`, a new norm that automatically creates linear colormaps that are symmetrical around a center. Useful for symmetrical data and in combination with diverging colormaps.

![symnorm](https://user-images.githubusercontent.com/11616994/85242073-d4b04200-b3f2-11ea-999f-4cfa4e558a17.png)

I often create plots where I want the color norm to be symmetric around a center, typically for visualizing anomalies. I tend to use one of the diverging colormaps and I often end up with code like this, where the norm is adjusted after creating the plot to make it symmetric:
```
pc = ax.pcolormesh(...)
vmax = max(-pc.norm.vmin, pc.norm.vmax)
pc.norm.vmin = -vmax
pc.norm.vmax = vmax
```
While the above is not a long piece of code, its more elegant to achieve the same goal automatically using a new norm. This approach also has the advantage of easily being able to set a center different from 0 (using, e.g.: `SymNorm(vcenter=1.0)`).

When I was scrolling through the pull requests here, I noticed that a somewhat similar approach has been discussed [here](/matplotlib/matplotlib/pull/15333). The proposed `SymNorm` goes a slightly different direction, in that the norm may extend beyond the data on one side of `vcenter`. I personally like this, as it, for example, gives the colorbar a symmetrical look (see figure above).

A quick note regarding the new code: The implementation of SymNorm makes use of `@property` syntax to implement a setter for `vcenter`. This syntax does not appear in other parts of `colors.py` and I would be happy to change the implementation, for example by overriding the `__call__` method which is currently not overridden.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
