### PR TITLE
Clarify gridspec error message for non-integer inputs.

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -45,9 +45,11 @@ class GridSpecBase:
             If not given, all rows will have the same height.
         """
         if not isinstance(nrows, Integral) or nrows <= 0:
-            raise ValueError(f"Number of rows must be > 0, not {nrows}")
+            raise ValueError(
+                f"Number of rows must be a positive integer, not {nrows}")
         if not isinstance(ncols, Integral) or ncols <= 0:
-            raise ValueError(f"Number of columns must be > 0, not {ncols}")
+            raise ValueError(
+                f"Number of columns must be a positive integer, not {ncols}")
         self._nrows, self._ncols = nrows, ncols
         self.set_height_ratios(height_ratios)
         self.set_width_ratios(width_ratios)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -182,9 +182,11 @@ def test_gca():
 
 def test_add_subplot_invalid():
     fig = plt.figure()
-    with pytest.raises(ValueError, match='Number of columns must be > 0'):
+    with pytest.raises(ValueError,
+                       match='Number of columns must be a positive integer'):
         fig.add_subplot(2, 0, 1)
-    with pytest.raises(ValueError, match='Number of rows must be > 0'):
+    with pytest.raises(ValueError,
+                       match='Number of rows must be a positive integer'):
         fig.add_subplot(0, 2, 1)
     with pytest.raises(ValueError, match='num must be 1 <= num <= 4'):
         fig.add_subplot(2, 2, 0)


### PR DESCRIPTION
This patch avoids nonsensical error messages such as
"Number of rows must be > 0, not 4.0".

Milestoning as 3.3 as relatively benign but nice to have, but not critical either.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
