### PR TITLE
Fix check for manager = None.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2233,7 +2233,7 @@ class FigureCanvasBase:
         Return the title text of the window containing the figure, or None
         if there is no window (e.g., a PS backend).
         """
-        if self.manager:
+        if self.manager is not None:
             return self.manager.get_window_title()
 
     def set_window_title(self, title):
@@ -2241,7 +2241,7 @@ class FigureCanvasBase:
         Set the title text of the window containing the figure.  Note that
         this has no effect if there is no window (e.g., a PS backend).
         """
-        if hasattr(self, "manager"):
+        if self.manager is not None:
             self.manager.set_window_title(title)
 
     def get_default_filename(self):


### PR DESCRIPTION
The previous check was for `hasattr(canvas, "manager")` but canvases now
always have the attribute present.  Missed this in 3ccc17b.

Closes #17716.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
