### PR TITLE
Move Win32_{Get,Set}ForegroundWindow to c_internal_utils.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -11,7 +11,7 @@ import tkinter.messagebox
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import backend_tools, cbook
+from matplotlib import backend_tools, cbook, _c_internal_utils
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     StatusbarBase, TimerBase, ToolContainerBase, cursors)
@@ -19,22 +19,6 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
 from . import _tkagg
-
-try:
-    from ._tkagg import Win32_GetForegroundWindow, Win32_SetForegroundWindow
-except ImportError:
-    @contextmanager
-    def _restore_foreground_window_at_end():
-        yield
-else:
-    @contextmanager
-    def _restore_foreground_window_at_end():
-        foreground = Win32_GetForegroundWindow()
-        try:
-            yield
-        finally:
-            if mpl.rcParams['tk.window_focus']:
-                Win32_SetForegroundWindow(foreground)
 
 
 _log = logging.getLogger(__name__)
@@ -48,6 +32,16 @@ cursord = {
     cursors.SELECT_REGION: "tcross",
     cursors.WAIT: "watch",
     }
+
+
+@contextmanager
+def _restore_foreground_window_at_end():
+    foreground = _c_internal_utils.Win32_GetForegroundWindow()
+    try:
+        yield
+    finally:
+        if mpl.rcParams['tk.window_focus']:
+            _c_internal_utils.Win32_SetForegroundWindow(foreground)
 
 
 def blit(photoimage, aggimage, offsets, bbox=None):

--- a/setupext.py
+++ b/setupext.py
@@ -341,7 +341,8 @@ class Matplotlib(SetupPackage):
         # c_internal_utils
         ext = Extension(
             "matplotlib._c_internal_utils", ["src/_c_internal_utils.c"],
-            libraries={"win32": ["ole32", "shell32"]}.get(sys.platform, []))
+            libraries=({"win32": ["ole32", "shell32", "user32"]}
+                       .get(sys.platform, [])))
         yield ext
         # contour
         ext = Extension(
@@ -400,8 +401,7 @@ class Matplotlib(SetupPackage):
             ],
             include_dirs=["src"],
             # psapi library needed for finding Tcl/Tk at run time.
-            # user32 library needed for window manipulation functions.
-            libraries=({"linux": ["dl"], "win32": ["psapi", "user32"],
+            libraries=({"linux": ["dl"], "win32": ["psapi"],
                         "cygwin": ["psapi"]}.get(sys.platform, [])),
             extra_link_args={"win32": ["-mwindows"]}.get(sys.platform, []))
         add_numpy_flags(ext)

--- a/src/_c_internal_utils.c
+++ b/src/_c_internal_utils.c
@@ -3,6 +3,7 @@
 #ifdef _WIN32
 #include <Objbase.h>
 #include <Shobjidl.h>
+#include <Windows.h>
 #endif
 
 static PyObject* mpl_GetCurrentProcessExplicitAppUserModelID(PyObject* module)
@@ -39,6 +40,31 @@ static PyObject* mpl_SetCurrentProcessExplicitAppUserModelID(PyObject* module, P
 #endif
 }
 
+static PyObject* mpl_GetForegroundWindow(PyObject* module)
+{
+#ifdef _WIN32
+  return PyLong_FromVoidPtr(GetForegroundWindow());
+#else
+  Py_RETURN_NONE;
+#endif
+}
+
+static PyObject* mpl_SetForegroundWindow(PyObject* module, PyObject *arg)
+{
+#ifdef _WIN32
+  HWND handle = PyLong_AsVoidPtr(arg);
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
+  if (!SetForegroundWindow(handle)) {
+    return PyErr_Format(PyExc_RuntimeError, "Error setting window");
+  }
+  Py_RETURN_NONE;
+#else
+  Py_RETURN_NONE;
+#endif
+}
+
 static PyMethodDef functions[] = {
     {"Win32_GetCurrentProcessExplicitAppUserModelID",
      (PyCFunction)mpl_GetCurrentProcessExplicitAppUserModelID, METH_NOARGS,
@@ -50,6 +76,16 @@ static PyMethodDef functions[] = {
      "Win32_SetCurrentProcessExplicitAppUserModelID(appid, /)\n--\n\n"
      "Wrapper for Windows's SetCurrentProcessExplicitAppUserModelID.  On \n"
      "non-Windows platforms, a no-op."},
+    {"Win32_GetForegroundWindow",
+     (PyCFunction)mpl_GetForegroundWindow, METH_NOARGS,
+     "Win32_GetForegroundWindow()\n--\n\n"
+     "Wrapper for Windows' GetForegroundWindow.  On non-Windows platforms, \n"
+     "always returns None."},
+    {"Win32_SetForegroundWindow",
+     (PyCFunction)mpl_SetForegroundWindow, METH_O,
+     "Win32_SetForegroundWindow(hwnd)\n--\n\n"
+     "Wrapper for Windows' SetForegroundWindow.  On non-Windows platforms, \n"
+     "a no-op."},
     {NULL, NULL}};  // sentinel.
 static PyModuleDef util_module = {
     PyModuleDef_HEAD_INIT, "_c_internal_utils", "", 0, functions, NULL, NULL, NULL, NULL};

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -89,38 +89,8 @@ exit:
     }
 }
 
-#ifdef _WIN32
-static PyObject *
-Win32_GetForegroundWindow(PyObject *module, PyObject *args)
-{
-    HWND handle = GetForegroundWindow();
-    if (!PyArg_ParseTuple(args, ":GetForegroundWindow")) {
-        return NULL;
-    }
-    return PyLong_FromSize_t((size_t)handle);
-}
-
-static PyObject *
-Win32_SetForegroundWindow(PyObject *module, PyObject *args)
-{
-    HWND handle;
-    if (!PyArg_ParseTuple(args, "n:SetForegroundWindow", &handle)) {
-        return NULL;
-    }
-    if (!SetForegroundWindow(handle)) {
-        return PyErr_Format(PyExc_RuntimeError, "Error setting window");
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-#endif
-
 static PyMethodDef functions[] = {
     { "blit", (PyCFunction)mpl_tk_blit, METH_VARARGS },
-#ifdef _WIN32
-    { "Win32_GetForegroundWindow", (PyCFunction)Win32_GetForegroundWindow, METH_VARARGS },
-    { "Win32_SetForegroundWindow", (PyCFunction)Win32_SetForegroundWindow, METH_VARARGS },
-#endif
     { NULL, NULL } /* sentinel */
 };
 


### PR DESCRIPTION
... and also make them noops on non-Windows, simplifying the definition
of _restore_foreground_window_at_end, and simplify their implementation
using METH_NOARGS/METH_O.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
