### PR TITLE
Adds multiple arrows to streamplot

### DIFF
--- a/examples/images_contours_and_fields/plot_streamplot.py
+++ b/examples/images_contours_and_fields/plot_streamplot.py
@@ -61,12 +61,18 @@ mask[40:60, 40:60] = True
 U[:20, :20] = np.nan
 U = np.ma.array(U, mask=mask)
 
-ax4 = fig.add_subplot(gs[2:, :])
+ax4 = fig.add_subplot(gs[2:, 0])
 ax4.streamplot(X, Y, U, V, color='r')
 ax4.set_title('Streamplot with Masking')
 
 ax4.imshow(~mask, extent=(-w, w, -w, w), alpha=0.5, cmap='gray', aspect='auto')
 ax4.set_aspect('equal')
+
+# Multiple arrows on streamline
+ax5 = fig.add_subplot(gs[2, 1])
+strm = ax5.streamplot(X, Y, U, V, color=U, linewidth=2, numarrows=3)
+ax5.set_title('Multiple Arrows on Streamplots')
+ax5.set_aspect('equal')
 
 plt.tight_layout()
 plt.show()

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -206,24 +206,27 @@ over all axes)
             raise ValueError("The value of numarrows must be"
                              "greater than -1")
 
-        # Add arrows along each trajectory.
-        for x in range(1, numarrows+1):
+        s = np.cumsum(np.hypot(np.diff(tx), np.diff(ty)))
+        n = np.searchsorted(s, s[-1])
 
-            s = np.cumsum(np.hypot(np.diff(tx), np.diff(ty)))
-            n = np.searchsorted(s, s[-1] * (x/(numarrows+1)))
+        if isinstance(linewidth, np.ndarray):
+
+            line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
+            line_kw['linewidth'].extend(line_widths)
+            arrow_kw['linewidth'] = line_widths[n]   
+
+        # Add arrows along each trajectory.
+        for x in range(numarrows):
+
+            n = np.searchsorted(s, s[-1] * ((x+1)/(numarrows+1)))
             arrow_tail = (tx[n], ty[n])
             arrow_head = (np.mean(tx[n:n + 2]), np.mean(ty[n:n + 2]))
-
-            if isinstance(linewidth, np.ndarray):
-                line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
-                line_kw['linewidth'].extend(line_widths)
-                arrow_kw['linewidth'] = line_widths[n]
 
             if use_multicolor_lines:
                 arrow_kw['color'] = cmap(norm(color_values[n]))
 
             p = patches.FancyArrowPatch(
-                arrow_tail, arrow_head, transform=transform, **arrow_kw)
+            arrow_tail, arrow_head, transform=transform, **arrow_kw)
 
             axes.add_patch(p)
             arrows.append(p)

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -717,32 +717,3 @@ def _gen_starting_points(shape):
             if y <= yfirst:
                 yfirst += 1
                 direction = 'right'
-
-
-def test_num_arrows(arrows=4):
-    """
-    Example test to determine whether the numarrows parameter is actually
-    plotting the correct number of arrows per streamline
-    """
-    import matplotlib.pyplot as plt
-
-    # Create dummy data of a streamplot with 15 vertical lines
-    x = np.arange(0, 2)
-    y = np.arange(0, 2)
-    X, Y = np.meshgrid(x, y)
-    u = np.ones((2, 2))
-    v = np.zeros((2, 2))
-
-    fig = plt.figure(figsize=(8, 8))
-    ax = fig.add_subplot()
-    strmplot = streamplot(ax, X, Y, u, v, density=0.5, numarrows=arrows)
-
-    # Get data for all arrow locations
-    arrowpaths = strmplot.arrows.get_paths()
-    numarrows = len(arrowpaths)
-
-    # Num arrows should be number of lines * the number of arrows on each line
-    assert numarrows == 15*arrows
-
-for x in range(10):
-    test_num_arrows(arrows=x)

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -18,9 +18,10 @@ __all__ = ['streamplot']
 
 
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
-               cmap=None, norm=None, arrowsize=1, arrowstyle='-|>', numarrows=1, 
-               minlength=0.1, transform=None, zorder=None, start_points=None,
-               maxlength=4.0, integration_direction='both'):
+               cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
+               numarrows=1, minlength=0.1, transform=None, zorder=None,
+               start_points=None, maxlength=4.0, 
+               integration_direction='both'):
     """
     Draw streamlines of a vector flow.
 
@@ -59,7 +60,6 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     numarrows : int
         Number of arrows per streamline.
         The default is 1, which plots one arrow in the middle of the streamline.
-over all axes)
     minlength : float
         Minimum length of streamline in axes coordinates.
     start_points : Nx2 array

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -20,7 +20,7 @@ __all__ = ['streamplot']
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
                numarrows=1, minlength=0.1, transform=None, zorder=None,
-               start_points=None, maxlength=4.0, 
+               start_points=None, maxlength=4.0,
                integration_direction='both'):
     """
     Draw streamlines of a vector flow.
@@ -59,7 +59,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         See `~matplotlib.patches.FancyArrowPatch`.
     numarrows : int
         Number of arrows per streamline.
-        The default is 1, which plots one arrow in the middle of the streamline.
+        The default is 1, which plots one arrow in the middle of the
+        streamline.
     minlength : float
         Minimum length of streamline in axes coordinates.
     start_points : Nx2 array
@@ -199,8 +200,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         streamlines.extend(np.hstack([points[:-1], points[1:]]))
 
         if use_multicolor_lines:
-                color_values = interpgrid(color, tgx, tgy)[:-1]
-                line_colors.append(color_values)
+            color_values = interpgrid(color, tgx, tgy)[:-1]
+            line_colors.append(color_values)
 
         if numarrows <= -1:
             raise ValueError("The value of numarrows must be"
@@ -210,10 +211,9 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         n = np.searchsorted(s, s[-1])
 
         if isinstance(linewidth, np.ndarray):
-
             line_widths = interpgrid(linewidth, tgx, tgy)[:-1]
             line_kw['linewidth'].extend(line_widths)
-            arrow_kw['linewidth'] = line_widths[n]   
+            arrow_kw['linewidth'] = line_widths[n]
 
         # Add arrows along each trajectory.
         for x in range(numarrows):

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -16,6 +16,7 @@ import matplotlib.patches as patches
 
 __all__ = ['streamplot']
 
+
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
                numarrows=1, minlength=0.1, transform=None, zorder=None,
@@ -243,6 +244,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     ac = matplotlib.collections.PatchCollection(arrows)
     stream_container = StreamplotSet(lc, ac)
     return stream_container
+
 
 class StreamplotSet:
 
@@ -716,26 +718,24 @@ def _gen_starting_points(shape):
                 yfirst += 1
                 direction = 'right'
 
-# Test streamplot function
 
-# First test function
 def test_num_arrows(arrows=4):
     """
-    Example test to determine whether the numarrows parameter is actually 
+    Example test to determine whether the numarrows parameter is actually
     plotting the correct number of arrows per streamline
     """
     import matplotlib.pyplot as plt
 
     # Create dummy data of a streamplot with 15 vertical lines
-    x = np.arange(0, 2) 
-    y = np.arange(0, 2) 
-    X, Y = np.meshgrid(x, y) 
+    x = np.arange(0, 2)
+    y = np.arange(0, 2)
+    X, Y = np.meshgrid(x, y)
     u = np.ones((2, 2))
     v = np.zeros((2, 2))
-  
-    fig = plt.figure(figsize = (8, 8)) 
+
+    fig = plt.figure(figsize=(8, 8))
     ax = fig.add_subplot()
-    strmplot = streamplot(ax, X, Y, u, v, density = 0.5, numarrows=arrows)
+    strmplot = streamplot(ax, X, Y, u, v, density=0.5, numarrows=arrows)
 
     # Get data for all arrow locations
     arrowpaths = strmplot.arrows.get_paths()

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -16,7 +16,6 @@ import matplotlib.patches as patches
 
 __all__ = ['streamplot']
 
-
 def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
                cmap=None, norm=None, arrowsize=1, arrowstyle='-|>',
                numarrows=1, minlength=0.1, transform=None, zorder=None,
@@ -58,9 +57,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         Arrow style specification.
         See `~matplotlib.patches.FancyArrowPatch`.
     numarrows : int
-        Number of arrows per streamline.
-        The default is 1, which plots one arrow in the middle of the
-        streamline.
+        Number of arrows per streamline. The arrows are
+        distributed equidistantly on each line.
     minlength : float
         Minimum length of streamline in axes coordinates.
     start_points : Nx2 array
@@ -203,9 +201,9 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
             color_values = interpgrid(color, tgx, tgy)[:-1]
             line_colors.append(color_values)
 
-        if numarrows <= -1:
+        if numarrows < 0:
             raise ValueError("The value of numarrows must be"
-                             "greater than -1")
+                             "not be negative")
 
         s = np.cumsum(np.hypot(np.diff(tx), np.diff(ty)))
         n = np.searchsorted(s, s[-1])
@@ -245,7 +243,6 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     ac = matplotlib.collections.PatchCollection(arrows)
     stream_container = StreamplotSet(lc, ac)
     return stream_container
-
 
 class StreamplotSet:
 
@@ -718,3 +715,34 @@ def _gen_starting_points(shape):
             if y <= yfirst:
                 yfirst += 1
                 direction = 'right'
+
+# Test streamplot function
+
+# First test function
+def test_num_arrows(arrows=4):
+    """
+    Example test to determine whether the numarrows parameter is actually 
+    plotting the correct number of arrows per streamline
+    """
+    import matplotlib.pyplot as plt
+
+    # Create dummy data of a streamplot with 15 vertical lines
+    x = np.arange(0, 2) 
+    y = np.arange(0, 2) 
+    X, Y = np.meshgrid(x, y) 
+    u = np.ones((2, 2))
+    v = np.zeros((2, 2))
+  
+    fig = plt.figure(figsize = (8, 8)) 
+    ax = fig.add_subplot()
+    strmplot = streamplot(ax, X, Y, u, v, density = 0.5, numarrows=arrows)
+
+    # Get data for all arrow locations
+    arrowpaths = strmplot.arrows.get_paths()
+    numarrows = len(arrowpaths)
+
+    # Num arrows should be number of lines * the number of arrows on each line
+    assert numarrows == 15*arrows
+
+for x in range(10):
+    test_num_arrows(arrows=x)

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -114,6 +114,7 @@ def test_streamplot_limits():
     assert_array_almost_equal(ax.dataLim.bounds, (20, 30, 15, 6),
                               decimal=1)
 
+
 def test_num_arrows():
     # Test numarrows values 0 through 9
     for arrows in range(10):
@@ -133,5 +134,5 @@ def test_num_arrows():
         arrowpaths = strmplot.arrows.get_paths()
         numarrows = len(arrowpaths)
 
-        # Num arrows should be number of lines * the number of arrows on each line
+        # Num arrows should be (num of lines)*(num of arrows on each line)
         assert numarrows == 15*arrows

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -113,3 +113,25 @@ def test_streamplot_limits():
     # datalim.
     assert_array_almost_equal(ax.dataLim.bounds, (20, 30, 15, 6),
                               decimal=1)
+
+def test_num_arrows():
+    # Test numarrows values 0 through 9
+    for arrows in range(10):
+
+        # Create dummy data of a streamplot with 15 vertical lines
+        x = np.arange(0, 2)
+        y = np.arange(0, 2)
+        X, Y = np.meshgrid(x, y)
+        u = np.ones((2, 2))
+        v = np.zeros((2, 2))
+
+        fig = plt.figure(figsize=(8, 8))
+        ax = fig.add_subplot()
+        strmplot = ax.streamplot(X, Y, u, v, density=0.5, numarrows=arrows)
+
+        # Get data for all arrow locations
+        arrowpaths = strmplot.arrows.get_paths()
+        numarrows = len(arrowpaths)
+
+        # Num arrows should be number of lines * the number of arrows on each line
+        assert numarrows == 15*arrows


### PR DESCRIPTION
Closes #17740

## PR Summary
This pull request adds a parameter "numarrows" to the streamplot function to allow the user to choose how many arrows to plot on each streamline, rather that plotting just one in the middle. This would be very helpful when plotting geoscience data. Languages such as NCL (NCAR Commandline language) have this functionality:

https://www.ncl.ucar.edu/Applications/Images/stream_9_1_lg.png

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way
