### PR TITLE
Deprecate `FancyBboxPatch(..., boxstyle="custom", bbox_transmuter=...)`

### DIFF
--- a/doc/api/api_changes_3.4/deprecations.rst
+++ b/doc/api/api_changes_3.4/deprecations.rst
@@ -13,6 +13,6 @@ The following globals in :mod:`matplotlib.colorbar` are deprecated:
 
 ``FancyBboxPatch(..., boxstyle="custom", bbox_transmuter=...)``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-In order to use a custom boxsyle, directly pass it as the *boxstyle* argument
+In order to use a custom boxstyle, directly pass it as the *boxstyle* argument
 to `.FancyBboxPatch`.  This was previously already possible, and is consistent
 with custom arrow styles and connection styles.

--- a/doc/api/api_changes_3.4/deprecations.rst
+++ b/doc/api/api_changes_3.4/deprecations.rst
@@ -5,7 +5,14 @@ Deprecations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This parameter is considered internal and deprecated.
 
+
 Colorbar docstrings
 ~~~~~~~~~~~~~~~~~~~
 The following globals in :mod:`matplotlib.colorbar` are deprecated:
 ``colorbar_doc``, ``colormap_kw_doc``, ``make_axes_kw_doc``.
+
+``FancyBboxPatch(..., boxstyle="custom", bbox_transmuter=...)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In order to use a custom boxsyle, directly pass it as the *boxstyle* argument
+to `.FancyBboxPatch`.  This was previously already possible, and is consistent
+with custom arrow styles and connection styles.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3564,6 +3564,7 @@ class FancyBboxPatch(Patch):
         return s % (self._x, self._y, self._width, self._height)
 
     @docstring.dedent_interpd
+    @cbook._delete_parameter("3.4", "bbox_transmuter", alternative="boxstyle")
     def __init__(self, xy, width, height,
                  boxstyle="round", bbox_transmuter=None,
                  mutation_scale=1, mutation_aspect=1,
@@ -3616,6 +3617,10 @@ class FancyBboxPatch(Patch):
         self._height = height
 
         if boxstyle == "custom":
+            cbook._warn_deprecated(
+                "3.4", message="Support for boxstyle='custom' is deprecated "
+                "since %(since)s and will be removed %(removal)s; directly "
+                "pass a boxstyle instance as the boxstyle parameter instead.")
             if bbox_transmuter is None:
                 raise ValueError("bbox_transmuter argument is needed with "
                                  "custom boxstyle")
@@ -3641,10 +3646,12 @@ class FancyBboxPatch(Patch):
 
         Parameters
         ----------
-        boxstyle : str
-            The name of the box style. Optionally, followed by a comma and a
-            comma-separated list of attributes. The attributes may
-            alternatively be passed separately as keyword arguments.
+        boxstyle : str or `matplotlib.patches.BoxStyle`
+            The style of the fancy box. This can either be a `.BoxStyle`
+            instance or a string of the style name and optionally comma
+            seprarated attributes (e.g. "Round, pad=0.2"). This string is
+            passed to `.BoxStyle` to construct a `.BoxStyle` object. See
+            there for a full documentation.
 
             The following box styles are available:
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -449,20 +449,12 @@ class Text(Artist):
             else:
                 if pad is None:
                     pad = 0.3
-
             # boxstyle could be a callable or a string
             if isinstance(boxstyle, str) and "pad" not in boxstyle:
                 boxstyle += ",pad=%0.2f" % pad
-
-            bbox_transmuter = props.pop("bbox_transmuter", None)
-
             self._bbox_patch = FancyBboxPatch(
-                                    (0., 0.),
-                                    1., 1.,
-                                    boxstyle=boxstyle,
-                                    bbox_transmuter=bbox_transmuter,
-                                    transform=IdentityTransform(),
-                                    **props)
+                (0, 0), 1, 1,
+                boxstyle=boxstyle, transform=IdentityTransform(), **props)
         else:
             self._bbox_patch = None
 


### PR DESCRIPTION
One can directly pass the custom bbox as the `boxstyle` argument,
instead of setting `boxstyle` to "custom" and passing it as the
(otherwise unused) `bbox_transmuter` argument.  This is consistent with
arrowstyles and connectionstyles.

The old API appears to date back to very early boxstyle API designs
(pre-73f34bf), where arbitrary callables were not directly supported.

In text.py one can just not pop `bbox_transmuter` from rectprops but
just pass the dict as is to FancyBboxPatch, triggering the deprecation
if and only if the key is present.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
