### PR TITLE
Support location="left"/"top" for gridspec-based colorbars.

### DIFF
--- a/doc/users/next_whats_new/colorbar_position.rst
+++ b/doc/users/next_whats_new/colorbar_position.rst
@@ -1,0 +1,5 @@
+Gridspec-based colorbars can now be positioned above or to the right of the main axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... by passing ``location="top"`` or ``location="left"`` to the ``colorbar()``
+call.

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -115,6 +115,7 @@ def test_colorbar_extension_length():
     _colorbar_extension_length('proportional')
 
 
+@pytest.mark.parametrize('use_gridspec', [True, False])
 @image_comparison(['cbar_with_orientation',
                    'cbar_locationing',
                    'double_cbar',
@@ -122,21 +123,21 @@ def test_colorbar_extension_length():
                    ],
                   extensions=['png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
-def test_colorbar_positioning():
+def test_colorbar_positioning(use_gridspec):
     data = np.arange(1200).reshape(30, 40)
     levels = [0, 200, 400, 600, 800, 1000, 1200]
 
     # -------------------
     plt.figure()
     plt.contourf(data, levels=levels)
-    plt.colorbar(orientation='horizontal', use_gridspec=False)
+    plt.colorbar(orientation='horizontal', use_gridspec=use_gridspec)
 
     locations = ['left', 'right', 'top', 'bottom']
     plt.figure()
     for i, location in enumerate(locations):
         plt.subplot(2, 2, i + 1)
         plt.contourf(data, levels=levels)
-        plt.colorbar(location=location, use_gridspec=False)
+        plt.colorbar(location=location, use_gridspec=use_gridspec)
 
     # -------------------
     plt.figure()
@@ -152,9 +153,9 @@ def test_colorbar_positioning():
     plt.contour(hatch_mappable, colors='black')
 
     plt.colorbar(color_mappable, location='left', label='variable 1',
-                 use_gridspec=False)
+                 use_gridspec=use_gridspec)
     plt.colorbar(hatch_mappable, location='right', label='variable 2',
-                 use_gridspec=False)
+                 use_gridspec=use_gridspec)
 
     # -------------------
     plt.figure()
@@ -166,11 +167,11 @@ def test_colorbar_positioning():
     plt.contourf(data, levels=levels)
 
     plt.colorbar(ax=[ax2, ax3, ax1], location='right', pad=0.0, shrink=0.5,
-                 panchor=False, use_gridspec=False)
+                 panchor=False, use_gridspec=use_gridspec)
     plt.colorbar(ax=[ax2, ax3, ax1], location='left', shrink=0.5,
-                 panchor=False, use_gridspec=False)
+                 panchor=False, use_gridspec=use_gridspec)
     plt.colorbar(ax=[ax1], location='bottom', panchor=False,
-                 anchor=(0.8, 0.5), shrink=0.6, use_gridspec=False)
+                 anchor=(0.8, 0.5), shrink=0.6, use_gridspec=use_gridspec)
 
 
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,


### PR DESCRIPTION
They were already supported for non-gridspec-based colorbars, but adding
support to make_axes_gridspec was not too hard.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
