### PR TITLE
BUG: Convert from str to writer on 3.2.x

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1106,6 +1106,8 @@ class Animation:
                                      "save animations.")
                 _log.warning("MovieWriter %s unavailable; trying to use %s "
                              "instead.", writer, alt_writer)
+                if isinstance(alt_writer, str):
+                    alt_writer = writers[alt_writer]
                 writer = alt_writer(
                     fps, codec, bitrate,
                     extra_args=extra_args, metadata=metadata)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1106,8 +1106,7 @@ class Animation:
                                      "save animations.")
                 _log.warning("MovieWriter %s unavailable; trying to use %s "
                              "instead.", writer, alt_writer)
-                if isinstance(alt_writer, str):
-                    alt_writer = writers[alt_writer]
+                alt_writer = writers[alt_writer]
                 writer = alt_writer(
                     fps, codec, bitrate,
                     extra_args=extra_args, metadata=metadata)


### PR DESCRIPTION
Just taking a simple [animation example](https://matplotlib.org/gallery/animation/animate_decay.html) and trying to use `anim.save(..., writer='imagemagick')` when it's not available on the platform produces on v3.2.x (it's fine on `master` but is [breaking some CIs currently](https://ci.appveyor.com/project/sphinx-gallery/sphinx-gallery/builds/33742826/job/5849j56nuga46609) that use 3.2):
```
Traceback (most recent call last):
  File "ani.py", line 45, in <module>
    ani.save('temp.gif', writer='imagemagick')
  File "/home/larsoner/python/matplotlib/lib/matplotlib/animation.py", line 1109, in save
    writer = alt_writer(
TypeError: 'str' object is not callable
```
On this PR:
```
MovieWriter imagemagick unavailable; trying to use pillow instead.
```
Code I used to test:

<details>

```
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.animation as animation
from matplotlib.animation import ImageMagickWriter


def data_gen():
    for cnt in range(10):
        t = cnt / 10
        yield t, np.sin(2*np.pi*t) * np.exp(-t/10.)


def init():
    ax.set_ylim(-1.1, 1.1)
    ax.set_xlim(0, 10)
    del xdata[:]
    del ydata[:]
    line.set_data(xdata, ydata)
    return line,

fig, ax = plt.subplots()
line, = ax.plot([], [], lw=2)
ax.grid()
xdata, ydata = [], []


def run(data):
    # update the data
    t, y = data
    xdata.append(t)
    ydata.append(y)
    xmin, xmax = ax.get_xlim()

    if t >= xmax:
        ax.set_xlim(xmin, 2*xmax)
        ax.figure.canvas.draw()
    line.set_data(xdata, ydata)

    return line,


ImageMagickWriter.isAvailable = lambda: False  # emulate not available on the platform
ani = animation.FuncAnimation(fig, run, data_gen, blit=False, interval=10,
                              repeat=False, init_func=init)
ani.save('temp.gif', writer='imagemagick')
```

</details>