### PR TITLE
FIX: be more careful about not importing pyplot early

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -473,7 +473,10 @@ def test_backend_fallback_headless(tmpdir):
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             [sys.executable, "-c",
-             "import matplotlib; matplotlib.use('tkagg')"],
+             ("import matplotlib;" +
+              "matplotlib.use('tkagg');" +
+              "import matplotlib.pyplot")
+             ],
             env=env, check=True)
 
 


### PR DESCRIPTION

## PR Summary


In matplotlib.use we import pyplot to use `switch_backend`, however
if the user calls  `mpl.use(...)` before importing pyplot then
during the initial import of pyplot, before we set the selected
backend we try to set the backend set via rcParams.

This change only imports pyplot if it is already imported, otherwise
it is safe to just set the rcParams and not go through the full
`plt.switch_backend` path.

closes #17763

This seems difficult to test given that it is dependent on import order.


## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
