### PR TITLE
Fix limit setting after plotting empty data

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5291,9 +5291,7 @@ default: :rc:`scatter.edgecolors`
                             np.column_stack([ind[where], dep2[where]])])
         if ind_dir == "y":
             pts = pts[:, ::-1]
-        self.dataLim.update_from_data_xy(pts, self.ignore_existing_data_limits,
-                                         updatex=True, updatey=True)
-        self.ignore_existing_data_limits = False
+        self.update_datalim(pts, updatex=True, updatey=True)
         self.add_collection(collection, autolim=False)
         self._request_autoscale_view()
         return collection

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2148,7 +2148,7 @@ class _AxesBase(martist.Artist):
             Whether to update the x/y limits.
         """
         xys = np.asarray(xys)
-        if not len(xys):
+        if not np.any(np.isfinite(xys)):
             return
         self.dataLim.update_from_data_xy(xys, self.ignore_existing_data_limits,
                                          updatex=updatex, updatey=updatey)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -779,21 +779,21 @@ def test_nonfinite_limits():
     ax.plot(x, y)
 
 
-@pytest.mark.parametrize('plot_fun, lims',
-                         [[plt.plot, (14610.0, 14974.0)],
-                          [plt.scatter, (14591.8, 14992.2)]])
-def test_limits_empty_data(plot_fun, lims):
+@pytest.mark.style('default')
+@pytest.mark.parametrize('plot_fun',
+                         ['scatter', 'plot', 'fill_between'])
+@check_figures_equal(extensions=["png"])
+def test_limits_empty_data(plot_fun, fig_test, fig_ref):
     # Check that plotting empty data doesn't change autoscaling of dates
     x = np.arange("2010-01-01", "2011-01-01", dtype="datetime64[D]")
 
-    fig, ax = plt.subplots()
-    plot_fun(x, np.arange(len(x)))
-    assert ax.get_xlim() == lims
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
 
-    fig, ax = plt.subplots()
-    plot_fun([], [])
-    plot_fun(x, np.arange(len(x)))
-    assert ax.get_xlim() == lims
+    getattr(ax_test, plot_fun)([], [])
+
+    for ax in [ax_test, ax_ref]:
+        getattr(ax, plot_fun)(x, range(len(x)), color='C0')
 
 
 @image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -779,18 +779,20 @@ def test_nonfinite_limits():
     ax.plot(x, y)
 
 
-def test_limits_empty_data():
+@pytest.mark.parametrize('plot_fun, lims',
+                         [[plt.plot, (14610.0, 14974.0)],
+                          [plt.scatter, (14591.8, 14992.2)]])
+def test_limits_empty_data(plot_fun, lims):
     # Check that plotting empty data doesn't change autoscaling of dates
     x = np.arange("2010-01-01", "2011-01-01", dtype="datetime64[D]")
-    lims = (14591.8, 14992.2)
 
     fig, ax = plt.subplots()
-    ax.scatter(x, np.arange(len(x)))
+    plot_fun(x, np.arange(len(x)))
     assert ax.get_xlim() == lims
 
     fig, ax = plt.subplots()
-    ax.scatter([], [])
-    ax.scatter(x, np.arange(len(x)))
+    plot_fun([], [])
+    plot_fun(x, np.arange(len(x)))
     assert ax.get_xlim() == lims
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -779,6 +779,21 @@ def test_nonfinite_limits():
     ax.plot(x, y)
 
 
+def test_limits_empty_data():
+    # Check that plotting empty data doesn't change autoscaling of dates
+    x = np.arange("2010-01-01", "2011-01-01", dtype="datetime64[D]")
+    lims = (14591.8, 14992.2)
+
+    fig, ax = plt.subplots()
+    ax.scatter(x, np.arange(len(x)))
+    assert ax.get_xlim() == lims
+
+    fig, ax = plt.subplots()
+    ax.scatter([], [])
+    ax.scatter(x, np.arange(len(x)))
+    assert ax.get_xlim() == lims
+
+
 @image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')
 def test_imshow():
     # use former defaults to match existing baseline image


### PR DESCRIPTION
Fixes #17586

This was a fun one to track down... It boiled down to plotting `[], []` updating the datalims with `[-inf, inf]`, which then set `ignore_existing_data_limits` to `False`. Having non-finite limits means that `ignore_existing_data_limits` shouldn't be set to `False` though, so now check that the limits are finite.