### PR TITLE
DOC: point to bbox static "constructor" functions in set_position

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -906,6 +906,10 @@ class _AxesBase(martist.Artist):
         which : {'both', 'active', 'original'}, default: 'both'
             Determines which position variables to change.
 
+        See Also
+        --------
+        matplotlib.transforms.Bbox.from_bounds
+        matplotlib.transforms.Bbox.from_extents
         """
         self._set_position(pos, which=which)
         # because this is being called externally to the library we


### PR DESCRIPTION
## PR Summary

Seems like a good idea to provide pointers to how to make a Bbox instance.

xref #17777

