### PR TITLE
Allow passing emtpy list of ticks to FixedLocator

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1712,7 +1712,9 @@ class Axis(martist.Artist):
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):
-            if len(locator.locs) != len(ticklabels):
+            # Passing [] as a list of ticklabels is often used as a way to
+            # remove all tick labels, so only error for > 0 ticklabels
+            if len(locator.locs) != len(ticklabels) and len(ticklabels) != 0:
                 raise ValueError(
                     "The number of FixedLocator locations"
                     f" ({len(locator.locs)}), usually from a call to"

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4593,6 +4593,14 @@ def test_mismatched_ticklabels():
         ax.xaxis.set_ticklabels(['a', 'b', 'c'])
 
 
+def test_empty_ticks_fixed_loc():
+    # Smoke test that [] can be used to unset all tick labels
+    fig, ax = plt.subplots()
+    ax.bar([1, 2], [1, 2])
+    ax.set_xticks([1, 2])
+    ax.set_xticklabels([])
+
+
 @image_comparison(['retain_tick_visibility.png'])
 def test_retain_tick_visibility():
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary
Fixes #17736. See https://github.com/matplotlib/matplotlib/issues/17736#issuecomment-648496870 for reasons why I haven't added a deprecation; we can always add that later anyway if desired. The test errors without the fix, but maybe I should make it a figure comparison to make sure the ticks are being removed?

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
