### PR TITLE
Tighten a bit the RendererAgg API.

### DIFF
--- a/doc/api/next_api_changes/deprecations/17788-AL.rst
+++ b/doc/api/next_api_changes/deprecations/17788-AL.rst
@@ -1,0 +1,3 @@
+``RendererAgg.get_content_extents``, ``RendererAgg.tostring_rgba_minimized``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -117,9 +117,12 @@ class RendererAgg(RendererBase):
         self.draw_quad_mesh = self._renderer.draw_quad_mesh
         self.copy_from_bbox = self._renderer.copy_from_bbox
 
-    @cbook.deprecated("3.4")  # Also needs to be removed at C-level.
+    @cbook.deprecated("3.4")
     def get_content_extents(self):
-        return self._renderer.get_content_extents()
+        orig_img = np.asarray(self.buffer_rgba())
+        slice_y, slice_x = cbook._get_nonzero_slices(orig_img[..., 3])
+        return (slice_x.start, slice_y.start,
+                slice_x.stop - slice_x.start, slice_y.stop - slice_y.start)
 
     @cbook.deprecated("3.4")
     def tostring_rgba_minimized(self):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2162,6 +2162,24 @@ def _unmultiplied_rgba8888_to_premultiplied_argb32(rgba8888):
     return argb32
 
 
+def _get_nonzero_slices(buf):
+    """
+    Return the bounds of the nonzero region of a 2D array as a pair of slices.
+
+    ``buf[_get_nonzero_slices(buf)]`` is the smallest sub-rectangle in *buf*
+    that encloses all non-zero entries in *buf*.  If *buf* is fully zero, then
+    ``(slice(0, 0), slice(0, 0))`` is returned.
+    """
+    x_nz, = buf.any(axis=0).nonzero()
+    y_nz, = buf.any(axis=1).nonzero()
+    if len(x_nz) and len(y_nz):
+        l, r = x_nz[[0, -1]]
+        b, t = y_nz[[0, -1]]
+        return slice(b, t + 1), slice(l, r + 1)
+    else:
+        return slice(0, 0), slice(0, 0)
+
+
 def _pformat_subprocess(command):
     """Pretty-format a subprocess command for printing/logging purposes."""
     return (command if isinstance(command, str)

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -167,41 +167,6 @@ bool RendererAgg::render_clippath(py::PathIterator &clippath,
     return has_clippath;
 }
 
-agg::rect_i RendererAgg::get_content_extents()
-{
-    agg::rect_i r(width, height, 0, 0);
-
-    // Looks at the alpha channel to find the minimum extents of the image
-    unsigned char *pixel = pixBuffer + 3;
-    for (int y = 0; y < (int)height; ++y) {
-        for (int x = 0; x < (int)width; ++x) {
-            if (*pixel) {
-                if (x < r.x1)
-                    r.x1 = x;
-                if (y < r.y1)
-                    r.y1 = y;
-                if (x > r.x2)
-                    r.x2 = x;
-                if (y > r.y2)
-                    r.y2 = y;
-            }
-            pixel += 4;
-        }
-    }
-
-    if (r.x1 == (int)width && r.x2 == 0) {
-      // The buffer is completely empty.
-      r.x1 = r.y1 = r.x2 = r.y2 = 0;
-    } else {
-      r.x1 = std::max(0, r.x1);
-      r.y1 = std::max(0, r.y1);
-      r.x2 = std::min(r.x2 + 1, (int)width);
-      r.y2 = std::min(r.y2 + 1, (int)height);
-    }
-
-    return r;
-}
-
 void RendererAgg::clear()
 {
     //"clear the rendered buffer";

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -526,17 +526,6 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args, PyObje
     Py_RETURN_NONE;
 }
 
-static PyObject *
-PyRendererAgg_get_content_extents(PyRendererAgg *self, PyObject *args, PyObject *kwds)
-{
-    agg::rect_i extents;
-
-    CALL_CPP("get_content_extents", (extents = self->x->get_content_extents()));
-
-    return Py_BuildValue(
-        "iiii", extents.x1, extents.y1, extents.x2 - extents.x1, extents.y2 - extents.y1);
-}
-
 int PyRendererAgg_get_buffer(PyRendererAgg *self, Py_buffer *buf, int flags)
 {
     Py_INCREF(self);
@@ -627,7 +616,6 @@ static PyTypeObject *PyRendererAgg_init_type(PyObject *m, PyTypeObject *type)
         {"draw_gouraud_triangle", (PyCFunction)PyRendererAgg_draw_gouraud_triangle, METH_VARARGS, NULL},
         {"draw_gouraud_triangles", (PyCFunction)PyRendererAgg_draw_gouraud_triangles, METH_VARARGS, NULL},
 
-        {"get_content_extents", (PyCFunction)PyRendererAgg_get_content_extents, METH_NOARGS, NULL},
         {"clear", (PyCFunction)PyRendererAgg_clear, METH_NOARGS, NULL},
 
         {"copy_from_bbox", (PyCFunction)PyRendererAgg_copy_from_bbox, METH_VARARGS, NULL},


### PR DESCRIPTION
The get_content_extents and tostring_rgba_minimized methods of
RendererAgg are used to implement 1) agg_filter and 2) rasterization in
MixedModeRenderer (i.e. for vector backends).  They can easily instead
be implemented at the Python level (i.e., via _get_nonzero_slices),
which makes it easier to plug in an alternative renderer (e.g.,
mplcairo) for rasterization in MixedModeRenderer.  I'm not convinced
_get_nonzero_slices needs to be exposed as public API (it's quite simple
anyways), but it could be if we absolutely want to present an
alternative for the deprecated methods.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
