### PR TITLE
Tk backend improvements

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -381,6 +381,16 @@ class FigureCanvasTk(FigureCanvasBase):
         # docstring inherited
         self._master.update()
 
+    def start_event_loop(self, timeout=0):
+        # docstring inherited
+        if timeout > 0:
+            self._master.after(timeout, self.stop_event_loop)
+        self._master.mainloop()
+
+    def stop_event_loop(self):
+        # docstring inherited
+        self._master.quit()
+
 
 class FigureManagerTk(FigureManagerBase):
     """

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -525,10 +525,6 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         if pack_toolbar:
             self.pack(side=tk.BOTTOM, fill=tk.X)
 
-    def destroy(self, *args):
-        del self.message
-        tk.Frame.destroy(self, *args)
-
     def set_message(self, s):
         self.message.set(s)
 

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -209,7 +209,6 @@ class FigureCanvasTk(FigureCanvasBase):
         # to the window and filter.
         def filter_destroy(event):
             if event.widget is self._tkcanvas:
-                self._master.update_idletasks()
                 self.close_event()
         root.bind("<Destroy>", filter_destroy, "+")
 
@@ -554,8 +553,6 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             window.configure(cursor=cursord[cursor])
         except tkinter.TclError:
             pass
-        else:
-            window.update_idletasks()
 
     def _Button(self, text, image_file, toggle, command):
         image = (tk.PhotoImage(master=self, file=image_file)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -232,7 +232,6 @@ class FigureCanvasTk(FigureCanvasBase):
         self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
         self.resize_event()
-        self.draw()
 
     def draw_idle(self):
         # docstring inherited

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -384,7 +384,7 @@ class FigureCanvasTk(FigureCanvasBase):
     def start_event_loop(self, timeout=0):
         # docstring inherited
         if timeout > 0:
-            self._master.after(timeout, self.stop_event_loop)
+            self._master.after(int(1000*timeout), self.stop_event_loop)
         self._master.mainloop()
 
     def stop_event_loop(self):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -8,12 +8,10 @@ class FigureCanvasTkAgg(FigureCanvasAgg, FigureCanvasTk):
     def draw(self):
         super().draw()
         _backend_tk.blit(self._tkphoto, self.renderer._renderer, (0, 1, 2, 3))
-        self._master.update_idletasks()
 
     def blit(self, bbox=None):
         _backend_tk.blit(
             self._tkphoto, self.renderer._renderer, (0, 1, 2, 3), bbox=bbox)
-        self._master.update_idletasks()
 
 
 @_BackendTk.export

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -23,7 +23,6 @@ class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
         _backend_tk.blit(
             self._tkphoto, buf,
             (2, 1, 0, 3) if sys.byteorder == "little" else (1, 2, 3, 0))
-        self._master.update_idletasks()
 
 
 @_BackendTk.export

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -207,5 +207,4 @@ def test_never_update(monkeypatch):
     plt.show(block=False)
     fig = plt.gcf()
     fig.canvas.toolbar.configure_subplots()
-    # skirt monkeypatch
-    tkinter._default_root.tk.call('update')
+    plt.pause(1e-9)

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -194,3 +194,18 @@ def test_webagg():
     conn.close()
     proc.send_signal(signal.SIGINT)
     assert proc.wait(timeout=_test_timeout) == 0
+
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+def test_never_update(monkeypatch):
+    import tkinter
+    monkeypatch.delattr(tkinter.Misc, 'update')
+    monkeypatch.delattr(tkinter.Misc, 'update_idletasks')
+
+    import matplotlib.pyplot as plt
+    plt.plot([1, 2, 3], [1, 3, 5])
+    plt.show(block=False)
+    fig = plt.gcf()
+    fig.canvas.toolbar.configure_subplots()
+    # skirt monkeypatch
+    tkinter._default_root.tk.call('update')

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -223,4 +223,3 @@ def test_never_update(monkeypatch, capsys):
     # test framework doesn't see tkinter callback exceptions normally
     # see tkinter.Misc.report_callback_exception
     assert "Exception in Tkinter callback" not in capsys.readouterr().err
-

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -197,14 +197,30 @@ def test_webagg():
 
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
-def test_never_update(monkeypatch):
+def test_never_update(monkeypatch, capsys):
     import tkinter
     monkeypatch.delattr(tkinter.Misc, 'update')
     monkeypatch.delattr(tkinter.Misc, 'update_idletasks')
 
     import matplotlib.pyplot as plt
-    plt.plot([1, 2, 3], [1, 3, 5])
+    fig = plt.figure()
     plt.show(block=False)
-    fig = plt.gcf()
+
+    # regression test on FigureCanvasTkAgg
+    plt.draw()
+    # regression test on NavigationToolbar2Tk
     fig.canvas.toolbar.configure_subplots()
-    plt.pause(1e-9)
+
+    # check for update() or update_idletasks() in the event queue
+    # functionally equivalent to tkinter.Misc.update
+    # must pause >= 1 ms to process tcl idle events plus
+    # extra time to avoid flaky tests on slow systems
+    plt.pause(0.1)
+
+    # regression test on FigureCanvasTk filter_destroy callback
+    plt.close(fig)
+
+    # test framework doesn't see tkinter callback exceptions normally
+    # see tkinter.Misc.report_callback_exception
+    assert "Exception in Tkinter callback" not in capsys.readouterr().err
+


### PR DESCRIPTION
## PR Summary

This PR makes changes to the Tk backend to prevent unnecessary recursion into the Tcl event loop, REPL hangs on figure close, and unnecessary draws on resize plus some extras. 

### Background
I have a project to explore [structured concurrency](https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/) as applied to GUI design. Specifically, I have written a tkinter "app" that hosts [trio](https://trio.readthedocs.io/en/stable/) in [guest mode](https://trio.readthedocs.io/en/stable/reference-lowlevel.html?#using-guest-mode-to-run-trio-on-top-of-other-event-loops), and then uses callbacks exclusively to launch async functions, which themselves are eventually scheduled to run using `Tk.after_idle`.

### Changes
Without going in to detail, it is easy to wind up in a situation where `FigureCanvasTkAgg.draw` is called from an async function in such a way that it deadlocks the event loop. Fortunately, there are absolutely no legitimate reasons to invoke `Tk.update` or `tk.update_idletasks` while an event loop is running, so this PR removes them entirely.

Other changes are less directly related to my primary motivation but became apparent as I was diagnosing the deadlock issue.

Resize events call `FigureCanvasTkAgg.draw` in `FigureCanvasTkAgg.resize` unnecessarily, as `FigureCanvasBase.resize_event` calls `FigureCanvasTk.draw_idle`. This PR removes that line, so resizes will be drawn eventually, without hogging the event loop.

`NavigationToolbar2Tk` has a special destroy method to delete it's `tkinter.StringVar` attribute named `message`. It will be destroyed via Tk object tree (master=self) and GCd by Python (only referred to by other self attributes) without this, so this PR removes it outright.

`FigureManagerTk` has a destroy method that is completely ineffective and also fails to stop the Tk mainloop. This PR rewrites the method entirely using `protocol("WM_DELETE_WINDOW",...)` rather than `bind("<Destroy>",...)`. (Cherry picked and merged to master in #17802)

`FigureCanvasTk` is missing methods `start_event_loop` and `stop_event_loop` and so relies on `FigureCanvasBase` pure Python event loop implementations. This PR reimplements them following the example of the Qt and wx backends. However, I can't find any test code or Matplotlib API functions that actually exercise these methods.

### Summary
These changes have minor or no user facing effect unless somewhere `Tk.after_idle` schedules a callback that contains `Tk.update_idletasks`. Writing this summary, it seems the fix to `FigureManagerTk` may actually the most user-noticeable (except most users are probably using Qt.) Not knowing why `Tk.update_idletasks` was sprinkled about in the first place, it is hard to say if this is backward-incompatable; it should be fine. A test to assert that `update` or `update_idletasks` is never called when using the Tk backend would be appropriate, as well as a test of the `FigureCanvasTk` event loop methods, but I can't fathom how the backend tests are constructed, so some help would be appreciated. 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
