### PR TITLE
Increase tolerance for alternate architectures

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -336,6 +336,9 @@ def image_comparison(baseline_images, extensions=None, tol=0,
     tol : float, default: 0
         The RMS threshold above which the test is considered failed.
 
+        Due to expected small differences in floating-point calculations, on
+        32-bit systems an additional 0.06 is added to this threshold.
+
     freetype_version : str or tuple
         The expected freetype version or range of versions for this test to
         pass.
@@ -378,6 +381,8 @@ def image_comparison(baseline_images, extensions=None, tol=0,
         extensions = ['png', 'pdf', 'svg']
     if savefig_kwarg is None:
         savefig_kwarg = dict()  # default no kwargs to savefig
+    if sys.maxsize <= 2**32:
+        tol += 0.06
     return _pytest_image_comparison(
         baseline_images=baseline_images, extensions=extensions, tol=tol,
         freetype_version=freetype_version, remove_text=remove_text,

--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -67,7 +67,7 @@ def __prepare_fancyarrow_dpi_cor_test():
 
 
 @image_comparison(['fancyarrow_dpi_cor_100dpi.png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
+                  tol=0 if platform.machine() == 'x86_64' else 0.02,
                   savefig_kwarg=dict(dpi=100))
 def test_fancyarrow_dpi_cor_100dpi():
     """
@@ -82,7 +82,7 @@ def test_fancyarrow_dpi_cor_100dpi():
 
 
 @image_comparison(['fancyarrow_dpi_cor_200dpi.png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
+                  tol=0 if platform.machine() == 'x86_64' else 0.02,
                   savefig_kwarg=dict(dpi=200))
 def test_fancyarrow_dpi_cor_200dpi():
     """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3738,7 +3738,7 @@ def test_vertex_markers():
 
 
 @image_comparison(['vline_hline_zorder', 'errorbar_zorder'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.02)
 def test_eb_line_zorder():
     x = list(range(10))
 

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -8,7 +8,6 @@ from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
-import platform
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -179,10 +178,7 @@ def test_pathclip():
 # test mixed mode rendering
 @needs_xelatex
 @pytest.mark.backend('pgf')
-@image_comparison(['pgf_mixedmode.pdf'], style='default',
-                  tol={'aarch64': 1.086, 'x86_64': 1.086}.get(
-                      platform.machine(), 0.0
-                      ))
+@image_comparison(['pgf_mixedmode.pdf'], style='default')
 def test_mixedmode():
     rc_xelatex = {'font.family': 'serif',
                   'pgf.rcfonts': False}

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1,5 +1,4 @@
 import io
-import platform
 from types import SimpleNamespace
 
 import numpy as np
@@ -334,8 +333,7 @@ def test_barb_limits():
                               decimal=1)
 
 
-@image_comparison(['EllipseCollection_test_image.png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+@image_comparison(['EllipseCollection_test_image.png'], remove_text=True)
 def test_EllipseCollection():
     # Test basic functionality
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -191,7 +191,7 @@ def test_contour_datetime_axis():
 
 @image_comparison(['contour_test_label_transforms.png'],
                   remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.08}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.08)
 def test_labels():
     # Adapted from pylab_examples example code: contour_demo.py
     # see issues #2475, #2843, and #2818 for explanation

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -1,4 +1,5 @@
 import datetime
+import platform
 import re
 
 import numpy as np
@@ -189,7 +190,8 @@ def test_contour_datetime_axis():
 
 
 @image_comparison(['contour_test_label_transforms.png'],
-                  remove_text=True, style='mpl20')
+                  remove_text=True, style='mpl20',
+                  tol={'aarch64': 0.08}.get(platform.machine(), 0))
 def test_labels():
     # Adapted from pylab_examples example code: contour_demo.py
     # see issues #2475, #2843, and #2818 for explanation

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -22,7 +22,7 @@ import pytest
 
 
 @image_comparison(['figure_align_labels'],
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_align_labels():
     fig = plt.figure(tight_layout=True)
     gs = gridspec.GridSpec(3, 3)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -22,7 +22,7 @@ import pytest
 
 
 @image_comparison(['figure_align_labels'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_align_labels():
     fig = plt.figure(tight_layout=True)
     gs = gridspec.GridSpec(3, 3)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -861,7 +861,7 @@ def test_imshow_endianess():
 
 
 @image_comparison(['imshow_masked_interpolation'],
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0),
+                  tol=0 if platform.machine() == 'x86_64' else 0.01,
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -861,7 +861,7 @@ def test_imshow_endianess():
 
 
 @image_comparison(['imshow_masked_interpolation'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0),
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0),
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -105,7 +105,7 @@ def test_multiple_keys():
 
 
 @image_comparison(['rgba_alpha.png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_alpha_rgba():
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)
@@ -114,7 +114,7 @@ def test_alpha_rgba():
 
 
 @image_comparison(['rcparam_alpha.png'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_alpha_rcparam():
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -105,7 +105,7 @@ def test_multiple_keys():
 
 
 @image_comparison(['rgba_alpha.png'], remove_text=True,
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_alpha_rgba():
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)
@@ -114,7 +114,7 @@ def test_alpha_rgba():
 
 
 @image_comparison(['rcparam_alpha.png'], remove_text=True,
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_alpha_rcparam():
     fig, ax = plt.subplots(1, 1)
     ax.plot(range(10), lw=5)
@@ -140,7 +140,7 @@ def test_fancy():
 
 
 @image_comparison(['framealpha'], remove_text=True,
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.02)
 def test_framealpha():
     x = np.linspace(1, 100, 100)
     y = x

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -115,7 +115,7 @@ def test_SimplePatchShadow_offset():
     assert pe._offset == (4, 5)
 
 
-@image_comparison(['collection'], tol=0.02, style='mpl20')
+@image_comparison(['collection'], tol=0.03, style='mpl20')
 def test_collection():
     x, y = np.meshgrid(np.linspace(0, 10, 150), np.linspace(-5, 5, 100))
     data = np.sin(x) + np.cos(y)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -41,7 +41,7 @@ def test_simple():
 
 
 @image_comparison(['multi_pickle.png'], remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.082}.get(platform.machine(), 0.0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.082)
 def test_complete():
     fig = plt.figure('Figure with a label?', figsize=(10, 6))
 

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -7,7 +9,8 @@ from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
-@image_comparison(['polar_axes'], style='default')
+@image_comparison(['polar_axes'], style='default',
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_polar_annotations():
     # You can specify the xypoint and the xytext in different positions and
     # coordinate systems, and optionally turn on a connecting line and mark the

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -10,7 +10,7 @@ from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
 @image_comparison(['polar_axes'], style='default',
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_polar_annotations():
     # You can specify the xypoint and the xytext in different positions and
     # coordinate systems, and optionally turn on a connecting line and mark the

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -1,5 +1,4 @@
 import sys
-import platform
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
@@ -48,8 +47,7 @@ def test_colormap():
     plt.colorbar()
 
 
-@image_comparison(['streamplot_linewidth'], remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+@image_comparison(['streamplot_linewidth'], remove_text=True, style='mpl20')
 def test_linewidth():
     X, Y, U, V = velocity_field()
     speed = np.hypot(U, V)

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -74,7 +74,7 @@ def quantity_converter():
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
 @image_comparison(['plot_pint.png'], remove_text=False, style='mpl20',
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_numpy_facade(quantity_converter):
     # use former defaults to match existing baseline image
     plt.rcParams['axes.formatter.limits'] = -7, 7
@@ -101,7 +101,7 @@ def test_numpy_facade(quantity_converter):
 
 # Tests gh-8908
 @image_comparison(['plot_masked_units.png'], remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_plot_masked_units():
     data = np.linspace(-5, 5)
     data_masked = np.ma.array(data, mask=(data > -2) & (data < 2))

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -74,7 +74,7 @@ def quantity_converter():
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
 @image_comparison(['plot_pint.png'], remove_text=False, style='mpl20',
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_numpy_facade(quantity_converter):
     # use former defaults to match existing baseline image
     plt.rcParams['axes.formatter.limits'] = -7, 7
@@ -101,7 +101,7 @@ def test_numpy_facade(quantity_converter):
 
 # Tests gh-8908
 @image_comparison(['plot_masked_units.png'], remove_text=True, style='mpl20',
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_plot_masked_units():
     data = np.linspace(-5, 5)
     data_masked = np.ma.array(data, mask=(data > -2) & (data < 2))

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -331,7 +331,7 @@ def test_zooming_with_inverted_axes():
 
 
 @image_comparison(['anchored_direction_arrows.png'],
-                  tol={'aarch64': 0.02}.get(platform.machine(), 0.0))
+                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((10, 10)), interpolation='nearest')

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -331,7 +331,7 @@ def test_zooming_with_inverted_axes():
 
 
 @image_comparison(['anchored_direction_arrows.png'],
-                  tol={'aarch64': 0.01}.get(platform.machine(), 0))
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((10, 10)), interpolation='nearest')

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -17,7 +17,7 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
 
 
 @image_comparison(['custom_transform.png'], style='default',
-                  tol={'aarch64': 0.034}.get(platform.machine(), 0.03))
+                  tol=0.03 if platform.machine() == 'x86_64' else 0.034)
 def test_custom_transform():
     class MyTransform(Transform):
         input_dims = output_dims = 2


### PR DESCRIPTION
## PR Summary

Most of the differences are just adding the other architectures alongside `aarch64`.

The other change is a blanket increase of tolerance on 32-bit systems. There are too many failures, and the RMS is so small, that I don't think there's any need to investigate much further.

This should pass tests on all Fedora-supported architectures (x86_64, i686, armv7hl, aarch64, ppc64le, and s390x), though we do not currently test SVG output.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way