### PR TITLE
BUG: Fix implementation of _is_closed_polygon

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -629,7 +629,7 @@ def _is_closed_polygon(X):
     presumably coordinates on a polygonal curve, in which case this function
     tests if that curve is closed.
     """
-    return np.all(X[0] == X[-1])
+    return np.allclose(X[0], X[-1], rtol=1e-10, atol=1e-13)
 
 
 def _find_closest_point_on_path(lc, point):


### PR DESCRIPTION
## PR Summary
It's a bad idea to use floating point equality to check if two points are equal. While not a huge difference, especially in the case of contour analysis, this was causing testing issues downstream for MetPy. Specifically, I had one test that yielded different results on macOS vs. Linux/Windows, and this was the root cause. This change then slightly adjusted where a seemingly closed contour was labelled.

## PR Checklist
- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way