### PR TITLE
fix FigureManagerTk close behavior if embedded in Tk App

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -460,7 +460,7 @@ class FigureManagerTk(FigureManagerBase):
 
         self.window.destroy()
 
-        if not Gcf.get_num_fig_managers() and self._owns_mainloop:
+        if self._owns_mainloop and not Gcf.get_num_fig_managers():
             self.window.quit()
 
     def get_window_title(self):
@@ -884,6 +884,10 @@ class _BackendTk(_Backend):
         if managers:
             first_manager = managers[0]
             manager_class = type(first_manager)
+            if manager_class._owns_mainloop:
+                return
             manager_class._owns_mainloop = True
-            first_manager.window.mainloop()
-            manager_class._owns_mainloop = False
+            try:
+                first_manager.window.mainloop()
+            finally:
+                manager_class._owns_mainloop = False

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -444,9 +444,8 @@ class FigureManagerTk(FigureManagerBase):
         with _restore_foreground_window_at_end():
             if not self._shown:
                 def destroy(*args):
-                    self.window = None
                     Gcf.destroy(self)
-                self.canvas._tkcanvas.bind("<Destroy>", destroy)
+                self.window.protocol("WM_DELETE_WINDOW", destroy)
                 self.window.deiconify()
             else:
                 self.canvas.draw_idle()
@@ -456,15 +455,13 @@ class FigureManagerTk(FigureManagerBase):
             self._shown = True
 
     def destroy(self, *args):
-        if self.window is not None:
-            #self.toolbar.destroy()
-            if self.canvas._idle_callback:
-                self.canvas._tkcanvas.after_cancel(self.canvas._idle_callback)
-            self.window.destroy()
-        if Gcf.get_num_fig_managers() == 0:
-            if self.window is not None and self._owns_mainloop:
-                self.window.quit()
-        self.window = None
+        if self.canvas._idle_callback:
+            self.canvas._tkcanvas.after_cancel(self.canvas._idle_callback)
+
+        self.window.destroy()
+
+        if not Gcf.get_num_fig_managers() and self._owns_mainloop:
+            self.window.quit()
 
     def get_window_title(self):
         return self.window.wm_title()

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -398,6 +398,8 @@ class FigureManagerTk(FigureManagerBase):
         The tk.Window
     """
 
+    #_owns_mainloop = False
+
     def __init__(self, canvas, num, window):
         FigureManagerBase.__init__(self, canvas, num)
         self.window = window
@@ -414,7 +416,6 @@ class FigureManagerTk(FigureManagerBase):
                 backend_tools.add_tools_to_container(self.toolbar)
 
         self._shown = False
-        self._tk_mainloop_already_started_before_creation = 'tk' == cbook._get_running_interactive_framework()
 
     def _get_toolbar(self):
         if mpl.rcParams['toolbar'] == 'toolbar2':
@@ -461,7 +462,7 @@ class FigureManagerTk(FigureManagerBase):
                 self.canvas._tkcanvas.after_cancel(self.canvas._idle_callback)
             self.window.destroy()
         if Gcf.get_num_fig_managers() == 0:
-            if self.window is not None and not self._tk_mainloop_already_started_before_creation:
+            if self.window is not None:# and self._owns_mainloop:
                 self.window.quit()
         self.window = None
 
@@ -880,11 +881,10 @@ class _BackendTk(_Backend):
     def trigger_manager_draw(manager):
         manager.show()
 
-    @staticmethod
-    def mainloop():
+    @classmethod
+    def mainloop(cls):
         managers = Gcf.get_all_fig_managers()
-        if not managers:
-            return
-        if not 'tk' == cbook._get_running_interactive_framework():
+        if managers:
+            #cls._owns_mainloop = True
             managers[0].window.mainloop()
-
+            #cls._owns_mainloop = False

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -398,7 +398,7 @@ class FigureManagerTk(FigureManagerBase):
         The tk.Window
     """
 
-    #_owns_mainloop = False
+    _owns_mainloop = False
 
     def __init__(self, canvas, num, window):
         FigureManagerBase.__init__(self, canvas, num)
@@ -462,7 +462,7 @@ class FigureManagerTk(FigureManagerBase):
                 self.canvas._tkcanvas.after_cancel(self.canvas._idle_callback)
             self.window.destroy()
         if Gcf.get_num_fig_managers() == 0:
-            if self.window is not None:# and self._owns_mainloop:
+            if self.window is not None and self._owns_mainloop:
                 self.window.quit()
         self.window = None
 
@@ -885,6 +885,6 @@ class _BackendTk(_Backend):
     def mainloop(cls):
         managers = Gcf.get_all_fig_managers()
         if managers:
-            #cls._owns_mainloop = True
+            cls._owns_mainloop = True
             managers[0].window.mainloop()
-            #cls._owns_mainloop = False
+            cls._owns_mainloop = False

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -881,10 +881,12 @@ class _BackendTk(_Backend):
     def trigger_manager_draw(manager):
         manager.show()
 
-    @classmethod
-    def mainloop(cls):
+    @staticmethod
+    def mainloop():
         managers = Gcf.get_all_fig_managers()
         if managers:
-            cls._owns_mainloop = True
-            managers[0].window.mainloop()
-            cls._owns_mainloop = False
+            first_manager = managers[0]
+            manager_class = type(first_manager)
+            manager_class._owns_mainloop = True
+            first_manager.window.mainloop()
+            manager_class._owns_mainloop = False

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -64,9 +64,10 @@ def _get_running_interactive_framework():
         return "wx"
     tkinter = sys.modules.get("tkinter")
     if tkinter:
+        codes = {tkinter.mainloop.__code__, tkinter.Misc.mainloop.__code__}
         for frame in sys._current_frames().values():
             while frame:
-                if frame.f_code == tkinter.mainloop.__code__:
+                if frame.f_code in codes:
                     return "tk"
                 frame = frame.f_back
     if 'matplotlib.backends._macosx' in sys.modules:

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -1,3 +1,5 @@
+import tkinter
+
 import pytest
 import numpy as np
 from matplotlib import pyplot as plt
@@ -26,3 +28,24 @@ def test_blit():
                       np.ones((4, 4, 4)),
                       (0, 1, 2, 3),
                       bad_boxes)
+
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+def test_figuremanager_preserves_host_mainloop():
+    success = False
+    def do_plot():
+        plt.figure()
+        plt.plot([1,2],[3,5])
+        plt.close()
+        root.after(0, legitmate_quit)
+
+    def legitmate_quit():
+        root.quit()
+        nonlocal success
+        success = True
+
+    root = tkinter.Tk()
+    root.after(0, do_plot)
+    root.mainloop()
+
+    assert success

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -75,7 +75,7 @@ def target():
     plt.close()
     if show_finished_event.wait():
         print('success')
-        
+
 show_finished_event = threading.Event()
 thread = threading.Thread(target=target, daemon=True)
 thread.start()
@@ -87,7 +87,9 @@ thread.join()
     try:
         proc = subprocess.run(
             [sys.executable, "-c", script],
-            env={**os.environ, "MPLBACKEND": "TkAgg", "SOURCE_DATE_EPOCH": "0"},
+            env={**os.environ,
+                 "MPLBACKEND": "TkAgg",
+                 "SOURCE_DATE_EPOCH": "0"},
             timeout=10,
             stdout=subprocess.PIPE,
             universal_newlines=True,

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -42,9 +42,9 @@ def test_figuremanager_preserves_host_mainloop():
         plt.figure()
         plt.plot([1, 2], [3, 5])
         plt.close()
-        root.after(0, legitmate_quit)
+        root.after(0, legitimate_quit)
 
-    def legitmate_quit():
+    def legitimate_quit():
         root.quit()
         nonlocal success
         success = True


### PR DESCRIPTION
## PR Summary
Fixes #13470. I test to see if the Tk mainloop was running before FigureManagerTk was created and if that was the case, then I don't call the `window.quit` method. 

The solution relies on implementation details of the tkinter c module and a disgusting hack using threads, so I have made this PR a draft. Really, the functionality of my `is_tk_mainloop_running` function should be provided as a method on `_tkinter.tkapp` AKA `TkappObject` to access the [dispatching](https://github.com/python/cpython/blob/2515a28230b1a011205f30263da6b01c6bd167a3/Modules/_tkinter.c#L293) struct member from Python, but that's a job for cPython upstream. 

I suppose there could be an alternative method involving traversing the children of the `_default_root`, or parents of the figure window but that feels just as much like leaning on implementation details and more error prone.

If there is any interest in maintaining the "fix" within matplotlib, I'll work on this PR further, otherwise this and #13470 should be closed pending upstream changes.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
