### PR TITLE
Set colorbar label only in set_label.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -548,7 +548,7 @@ class ColorbarBase:
                       ticks_position=self.ticklocation)
         short_axis.set_ticks([])
         short_axis.set_ticks([], minor=True)
-        self._set_label()
+        self.stale = True
 
     def _get_ticker_locator_formatter(self):
         """
@@ -726,15 +726,7 @@ class ColorbarBase:
         """Turn the minor ticks of the colorbar off."""
         ax = self.ax
         long_axis = ax.yaxis if self.orientation == 'vertical' else ax.xaxis
-
         long_axis.set_minor_locator(ticker.NullLocator())
-
-    def _set_label(self):
-        if self.orientation == 'vertical':
-            self.ax.set_ylabel(self._label, **self._labelkw)
-        else:
-            self.ax.set_xlabel(self._label, **self._labelkw)
-        self.stale = True
 
     def set_label(self, label, *, loc=None, **kwargs):
         """Add a label to the long axis of the colorbar."""
@@ -759,9 +751,11 @@ class ColorbarBase:
         elif loc in ['left', 'bottom']:
             kwargs[_pos_xy] = 0.
             kwargs['horizontalalignment'] = 'left'
-        self._label = label
-        self._labelkw = kwargs
-        self._set_label()
+        if self.orientation == 'vertical':
+            self.ax.set_ylabel(label, **kwargs)
+        else:
+            self.ax.set_xlabel(label, **kwargs)
+        self.stale = True
 
     def _outline(self, X, Y):
         """


### PR DESCRIPTION
... instead of doing so also in _config_axis.

_config_axis is also called when e.g. the norm is changed, but we don't
want to reset the label in that case.

Note that the previous `self._labelkw` was only usable for one colorbar
orientation anyways (because the choice of `_pos_kw` depends on the
orientation) so everything was already tied to a single orientation.

Closes https://github.com/matplotlib/matplotlib/issues/17804.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
