### PR TITLE
FIX: don't fail on first show if animation already exhausted

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1666,8 +1666,21 @@ class FuncAnimation(TimedAnimation):
         # For blitting, the init_func should return a sequence of modified
         # artists.
         if self._init_func is None:
-            self._draw_frame(next(self.new_frame_seq()))
-
+            try:
+                frame_data = next(self.new_frame_seq())
+            except StopIteration:
+                # we can't start the iteration, it may have already been
+                # exhausted by a previous save or just be 0 length.
+                # warn and bail.
+                warnings.warn(
+                    "Can not start iterating the frames for the initial draw. "
+                    "This can be caused by passing in a 0 length sequence "
+                    "for *frames*.\n\n"
+                    "If you passed *frames* as a generator "
+                    "it may be exhausted due to a previous display or save."
+                )
+                return
+            self._draw_frame(frame_data)
         else:
             self._drawn_artists = self._init_func()
             if self._blit:

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -359,3 +359,36 @@ def test_draw_frame(return_value):
 
     with pytest.raises(RuntimeError):
         animation.FuncAnimation(fig, animate, blit=True)
+
+
+def test_exhausted_animation(tmpdir):
+    fig, ax = plt.subplots()
+
+    def update(frame):
+        return []
+
+    anim = animation.FuncAnimation(
+        fig, update, frames=iter(range(10)), repeat=False,
+        cache_frame_data=False
+    )
+
+    with tmpdir.as_cwd():
+        anim.save("test.gif", writer='pillow')
+
+    with pytest.warns(UserWarning, match="exhausted"):
+        anim._start()
+
+
+def test_no_frame_warning(tmpdir):
+    fig, ax = plt.subplots()
+
+    def update(frame):
+        return []
+
+    anim = animation.FuncAnimation(
+        fig, update, frames=[], repeat=False,
+        cache_frame_data=False
+    )
+
+    with pytest.warns(UserWarning, match="exhausted"):
+        anim._start()


### PR DESCRIPTION
## PR Summary

If `_init_draw()` fails, assume the animation is dead, but do not fail.

closes #17770

I am not sure this is actually the best fix.  On one hand, this is elides the problem, but does so by ignoring the problem.  There is some poor interaction going on here between the ways access the data sources and how we try to "peek" at the first frame if we are not passed an init function.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
