### PR TITLE
Check for float values for min/max values to ax{v,h}line

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -833,7 +833,7 @@ class Axes(_AxesBase):
         """
         self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
         if "transform" in kwargs:
-            raise ValueError("'transform' is not allowed as a kwarg; "
+            raise ValueError("'transform' is not allowed as a keyword argument; "
                              "axhline generates its own transform.")
         ymin, ymax = self.get_ybound()
 
@@ -902,7 +902,7 @@ class Axes(_AxesBase):
         """
         self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
         if "transform" in kwargs:
-            raise ValueError("'transform' is not allowed as a kwarg; "
+            raise ValueError("'transform' is not allowed as a keyword argument; "
                              "axvline generates its own transform.")
         xmin, xmax = self.get_xbound()
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -29,6 +29,7 @@ import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
+import matplotlib.units as munits
 from matplotlib import _preprocess_data, rcParams
 from matplotlib.axes._base import _AxesBase, _process_plot_format
 from matplotlib.axes._secondary_axes import SecondaryAxis
@@ -830,10 +831,10 @@ class Axes(_AxesBase):
 
             >>> axhline(y=.5, xmin=0.25, xmax=0.75)
         """
+        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
         if "transform" in kwargs:
-            raise ValueError(
-                "'transform' is not allowed as a kwarg;"
-                + "axhline generates its own transform.")
+            raise ValueError("'transform' is not allowed as a kwarg; "
+                             "axhline generates its own transform.")
         ymin, ymax = self.get_ybound()
 
         # We need to strip away the units for comparison with
@@ -899,11 +900,10 @@ class Axes(_AxesBase):
 
             >>> axvline(x=.5, ymin=0.25, ymax=0.75)
         """
-
+        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
         if "transform" in kwargs:
-            raise ValueError(
-                "'transform' is not allowed as a kwarg;"
-                + "axvline generates its own transform.")
+            raise ValueError("'transform' is not allowed as a kwarg; "
+                             "axvline generates its own transform.")
         xmin, xmax = self.get_xbound()
 
         # We need to strip away the units for comparison with
@@ -917,6 +917,14 @@ class Axes(_AxesBase):
         self.add_line(l)
         self._request_autoscale_view(scalex=scalex, scaley=False)
         return l
+
+    @staticmethod
+    def _check_no_units(vals, names):
+        # Helper method to check that vals are not unitized
+        for val, name in zip(vals, names):
+            if not munits._is_natively_supported(val):
+                raise ValueError(f"{name} must be a single scalar value, "
+                                 f"but got {val}")
 
     @docstring.dedent_interpd
     def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
@@ -1038,6 +1046,7 @@ class Axes(_AxesBase):
         --------
         axvspan : Add a vertical span across the axes.
         """
+        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
         trans = self.get_yaxis_transform(which='grid')
 
         # process the unit information
@@ -1098,6 +1107,7 @@ class Axes(_AxesBase):
         >>> axvspan(1.25, 1.55, facecolor='g', alpha=0.5)
 
         """
+        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
         trans = self.get_xaxis_transform(which='grid')
 
         # process the unit information

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4251,6 +4251,22 @@ def test_vline_limit():
     assert_allclose(ax.get_ylim(), (-.1, .2))
 
 
+@pytest.mark.parametrize('fv, fh, args', [[plt.axvline, plt.axhline, (1,)],
+                                          [plt.axvspan, plt.axhspan, (1, 1)]])
+def test_axline_minmax(fv, fh, args):
+    bad_lim = matplotlib.dates.num2date(1)
+    # Check vertical functions
+    with pytest.raises(ValueError, match='ymin must be a single scalar value'):
+        fv(*args, ymin=bad_lim, ymax=1)
+    with pytest.raises(ValueError, match='ymax must be a single scalar value'):
+        fv(*args, ymin=1, ymax=bad_lim)
+    # Check horizontal functions
+    with pytest.raises(ValueError, match='xmin must be a single scalar value'):
+        fh(*args, xmin=bad_lim, xmax=1)
+    with pytest.raises(ValueError, match='xmax must be a single scalar value'):
+        fh(*args, xmin=1, xmax=bad_lim)
+
+
 def test_empty_shared_subplots():
     # empty plots with shared axes inherit limits from populated plots
     fig, axs = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)


### PR DESCRIPTION
Fixes #12198. This now errors if a non-float value is provided for xmin/xmax or ymin/ymax to ax{v,h}{line,span}. This should get an API change or a what's new, but I'm not sure which, could someone advise? 