### PR TITLE
Improve categorical converter error message

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -50,6 +50,7 @@ class StrCategoryConverter(units.ConversionInterface):
                 'Missing category information for StrCategoryConverter; '
                 'this might be caused by unintendedly mixing categorical and '
                 'numeric data')
+        StrCategoryConverter._validate_unit(unit)
         # dtype = object preserves numerical pass throughs
         values = np.atleast_1d(np.array(value, dtype=object))
         # pass through sequence of non binary numbers
@@ -80,6 +81,7 @@ class StrCategoryConverter(units.ConversionInterface):
 
         .. note: axis is not used
         """
+        StrCategoryConverter._validate_unit(unit)
         # locator and formatter take mapping dict because
         # args need to be pass by reference for updates
         majloc = StrCategoryLocator(unit._mapping)
@@ -108,6 +110,13 @@ class StrCategoryConverter(units.ConversionInterface):
         else:
             axis.units.update(data)
         return axis.units
+
+    @staticmethod
+    def _validate_unit(unit):
+        if not hasattr(unit, '_mapping'):
+            raise ValueError(
+                f'Provided unit "{unit}" is not a valid for a categorical '
+                'converter, as it does not have a _mapping attribute.')
 
 
 class StrCategoryLocator(ticker.Locator):

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -115,7 +115,7 @@ class StrCategoryConverter(units.ConversionInterface):
     def _validate_unit(unit):
         if not hasattr(unit, '_mapping'):
             raise ValueError(
-                f'Provided unit "{unit}" is not a valid for a categorical '
+                f'Provided unit "{unit}" is not valid for a categorical '
                 'converter, as it does not have a _mapping attribute.')
 
 


### PR DESCRIPTION
## PR Summary
xref #11095. Provide a nicer error message if the user tries to set a `unit` without `_mapping` to a categorical converter.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
