### PR TITLE
Add quick-link buttons for contributing

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1001,26 +1001,36 @@ figcaption {
   }
 }
 
+.mpl-button {
+    background: #11557C;
+    font-weight: normal;
+    display: inline-block;
+    padding: 0 1em;
+    line-height: 2.8;
+    font-size: 16px;
+    text-align: center;
+    cursor: pointer;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 6px;
+    z-index: 1;
+    transition: background .25s ease;
+}
+
+.mpl-button:hover, .mpl-button:active, .mpl-button:focus {
+    background: #003c63;
+    outline-color: #003c63;
+}
+
 #sidebar-donations {
     margin-top: 40px;
 }
 
 .donate_button {
-    background:#11557C;
-    font-weight:normal;
     clear: both;
     display: block;
-    width:200px;
-    line-height:2.8;
-    font-size: 16px;
-    text-align: center;
-    cursor:pointer;
-    color:#fff;
-    text-decoration: none;
+    width: 200px;
     margin: 30px auto 0;
-    border-radius: 6px;
-    z-index:1;
-    transition: background .25s ease;
 }
 
 .donate_button:last-of-type {
@@ -1028,12 +1038,6 @@ figcaption {
 
 
 }
-
-.donate_button:hover, .donate_button:active, .donate_button:focus {
-    background: #003c63;
-    outline-color: #003c63;
-}
-
 
 div.responsive_screenshots {
     /* Horizontally centered */

--- a/doc/_templates/donate_sidebar.html
+++ b/doc/_templates/donate_sidebar.html
@@ -2,5 +2,5 @@
 
 
 <div id="sidebar-donations">
-  <a href="https://numfocus.org/donate-to-matplotlib" target="_blank"> <div class="donate_button" >Support Matplotlib</div></a>
+  <a href="https://numfocus.org/donate-to-matplotlib" target="_blank"> <span class="mpl-button donate_button" >Support Matplotlib</span></a>
 </div>

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -4,10 +4,13 @@
 The Matplotlib Developers' Guide
 ################################
 
-.. only:: html
+.. raw:: html
 
-   :Release: |version|
-   :Date: |today|
+   <div style="margin: 2em 0;">
+     <a href="contributing.html#submitting-a-bug-report"><span class="mpl-button">Report a bug</span></a>
+     <a href="contributing.html#contributing-code"><span class="mpl-button">Contribute code</span></a>
+     <a href="contributing.html#contributing-documentation"><span class="mpl-button">Write documentation</span></a>
+   </div>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## PR Summary

This PR adds button to the top of the Developers Guide:

  ![image](https://user-images.githubusercontent.com/2836374/86417375-14b5d580-bccd-11ea-8ac5-b8da95f4afbf.png)

### Motivation
The Developers Guide is linked from "Contributing" in the main menu. The buttons provide quick links to the most common operations users want to do when contributing.

### Technical notes
- CSS: The buttons reuse the style of the donate button on the front page. For layout reasons, all buttons are now `<span>`s instead of `<div>`s. The button styling code is extracted to `.mpl-button` class and separated from the layout (display/margin) of the donate button.
- I've removed the info on release and date from the Developers Guide because it is already written to the documentation overview page (https://matplotlib.org/devdocs/contents.html).
