### PR TITLE
API: treat xunits=None and yunits=None as "default"

### DIFF
--- a/doc/api/next_api_changes/behavior/17828-TAC.rst
+++ b/doc/api/next_api_changes/behavior/17828-TAC.rst
@@ -1,0 +1,20 @@
+xunits=None and yunits=None passed as kwargs are treated as "no action"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many (but not all) of the methods on `~.axes.Axes` take the (undocumented)
+kwargs *xunits* and *yunits* that will update the units on the given
+Axis by calling `.Axis.set_units` and `.Axis.update_units`.
+
+Previously if `None` was passed it would clear the value stored in
+``.Axis.units`` which will in turn break converters (notably
+`.StrCategoryConverter`) which rely on the value in
+``.Axis.units`` to work properly.
+
+This changes the semantics of ``ax.meth(..., xunits=None,
+yunits=None)`` from "please clear the units" to "do the default thing
+as if they had not been passed" which is consistent with the standard
+behavior of Matplotlib keyword arguments.
+
+If you were relying on passing ``xuints=None`` to plotting methods to
+clear the ``.Axes.units`` attribute, directly call `.Axis.set_units` (and
+`.Axis.update_units` if you also require the converter to be updated).

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2172,7 +2172,15 @@ class _AxesBase(martist.Artist):
         self.dataLim.set(mtransforms.Bbox.union([self.dataLim, bounds]))
 
     def _process_unit_info(self, xdata=None, ydata=None, kwargs=None):
-        """Look for unit *kwargs* and update the axis instances as necessary"""
+        """
+        Look for unit *kwargs* and update the axis instances as necessary
+
+
+        .. warning ::
+
+           This method may mutate the dictionary passed in an kwargs and
+           the Axis instances attached to this Axes.
+        """
 
         def _process_single_axis(data, axis, unit_name, kwargs):
             # Return if there's no axis set
@@ -2188,10 +2196,12 @@ class _AxesBase(martist.Artist):
             if kwargs is not None:
                 units = kwargs.pop(unit_name, axis.units)
                 if self.name == 'polar':
+                    # handle special casing to allow the kwargs
+                    # thetaunits and runits to be used with polar
                     polar_units = {'xunits': 'thetaunits', 'yunits': 'runits'}
                     units = kwargs.pop(polar_units[unit_name], units)
 
-                if units != axis.units:
+                if units != axis.units and units is not None:
                     axis.set_units(units)
                     # If the units being set imply a different converter,
                     # we need to update.
@@ -3780,7 +3790,7 @@ class _AxesBase(martist.Artist):
         """
         Set the navigation toolbar button status;
 
-        .. warning::
+        .. warning ::
             this is not a user-API function.
 
         """

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -5,6 +5,7 @@ import numpy as np
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import matplotlib.category as cat
+from matplotlib.testing.decorators import check_figures_equal
 
 
 class TestUnitData:
@@ -269,3 +270,28 @@ class TestPlotTypes:
         with pytest.raises(TypeError):
             plotter(ax, [0, 3], [1, 3])
             plotter(ax, xdata, [1, 2])
+
+
+@pytest.mark.style('default')
+@check_figures_equal(extensions=["png"])
+def test_overriding_units_in_plot(fig_test, fig_ref):
+    from datetime import datetime
+
+    t0 = datetime(2018, 3, 1)
+    t1 = datetime(2018, 3, 2)
+    t2 = datetime(2018, 3, 3)
+    t3 = datetime(2018, 3, 4)
+
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+    for ax, kwargs in zip([ax_test, ax_ref],
+                          ({}, dict(xunits=None, yunits=None))):
+        # First call works
+        ax.plot([t0, t1], ["V1", "V2"], **kwargs)
+        x_units = ax.xaxis.units
+        y_units = ax.yaxis.units
+        # this should not raise
+        ax.plot([t2, t3], ["V1", "V2"], **kwargs)
+        # assert that we have not re-set the units attribute at all
+        assert x_units is ax.xaxis.units
+        assert y_units is ax.yaxis.units


### PR DESCRIPTION
## PR Summary

If the user passes None, treat as if they had passed nothing and do
not try to change the units on the respective axis.

closes #11095


I still need to write an API changes note (even though this is fixing a regression, it is a very old regression).

I don't think this conflicts with #17824 as the improved error message is a good idea independent of if this goes in.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way


