### PR TITLE
Fix BoundaryNorm for multiple colors and one region 

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1502,18 +1502,16 @@ class BoundaryNorm(Normalize):
         # this gives us the bins in the lookup table in the range
         # [0, _n_regions - 1]  (the offset is baked in in the init)
         iret = np.digitize(xx, self.boundaries) - 1 + self._offset
-        # if we have more colors than regions, stretch the region index
-        # computed above to full range of the color bins.  This will
-        # make use skip some of the colors in the middle of the
-        # colormap but will use the full range
+        # if we have more colors than regions, stretch the region
+        # index computed above to full range of the color bins.  This
+        # will make use of the full range (but skip some of the colors
+        # in the middle) such that the first region is mapped to the
+        # first color and the last region is mapped to the last color.
         if self.Ncmap > self._n_regions:
             # the maximum possible value in iret
             divsor = self._n_regions - 1
             if divsor == 0:
-                # special case the 1 region case.  What we should do here
-                # is a bit undefined (as _any_ color in the colormap is
-                # justifiable) we go with not adjusting the value (which will
-                # either be 0 or 1 depending on if we are extending down)
+                # special case the 1 region case, don't scale anything
                 scalefac = 1
             else:
                 # otherwise linearly remap the values from the region index

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1473,18 +1473,18 @@ class BoundaryNorm(Normalize):
         self.Ncmap = ncolors
         self.extend = extend
 
-        self._N = self.N - 1  # number of colors needed
+        self._n_regions = self.N - 1  # number of colors needed
         self._offset = 0
         if extend in ('min', 'both'):
-            self._N += 1
+            self._n_regions += 1
             self._offset = 1
         if extend in ('max', 'both'):
-            self._N += 1
-        if self._N > self.Ncmap:
-            raise ValueError(f"There are {self._N} color bins including "
-                             f"extensions, but ncolors = {ncolors}; "
-                             "ncolors must equal or exceed the number of "
-                             "bins")
+            self._n_regions += 1
+        if self._n_regions > self.Ncmap:
+            raise ValueError(f"There are {self._n_regions} color bins "
+                             "including extensions, but ncolors = "
+                             f"{ncolors}; ncolors must equal or exceed the "
+                             "number of bins")
 
     def __call__(self, value, clip=None):
         if clip is None:
@@ -1499,8 +1499,8 @@ class BoundaryNorm(Normalize):
         else:
             max_col = self.Ncmap
         iret = np.digitize(xx, self.boundaries) - 1 + self._offset
-        if self.Ncmap > self._N:
-            scalefac = (self.Ncmap - 1) / (self._N - 1)
+        if self.Ncmap > self._n_regions:
+            scalefac = (self.Ncmap - 1) / (self._n_regions - 1)
             iret = (iret * scalefac).astype(np.int16)
         iret[xx < self.vmin] = -1
         iret[xx >= self.vmax] = max_col

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1429,7 +1429,7 @@ class BoundaryNorm(Normalize):
         Parameters
         ----------
         boundaries : array-like
-            Monotonically increasing sequence of boundaries.
+            Monotonically increasing sequence of at least 2 boundaries.
         ncolors : int
             Number of colors in the colormap to be used.
         clip : bool, optional

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1470,6 +1470,9 @@ class BoundaryNorm(Normalize):
         self.vmax = boundaries[-1]
         self.boundaries = np.asarray(boundaries)
         self.N = len(self.boundaries)
+        if self.N < 2:
+            raise ValueError("You must provide at least 2 boundaries "
+                             f"(1 region) but you passed in {boundaries!r}")
         self.Ncmap = ncolors
         self.extend = extend
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1429,9 +1429,9 @@ class BoundaryNorm(Normalize):
         Parameters
         ----------
         boundaries : array-like
-            Monotonically increasing sequence of boundaries
+            Monotonically increasing sequence of boundaries.
         ncolors : int
-            Number of colors in the colormap to be used
+            Number of colors in the colormap to be used.
         clip : bool, optional
             If clip is ``True``, out of range values are mapped to 0 if they
             are below ``boundaries[0]`` or mapped to ``ncolors - 1`` if they
@@ -1492,6 +1492,7 @@ class BoundaryNorm(Normalize):
 
         xx, is_scalar = self.process_value(value)
         mask = np.ma.getmaskarray(xx)
+        # Fill masked values a value above the upper boundary
         xx = np.atleast_1d(xx.filled(self.vmax + 1))
         if clip:
             np.clip(xx, self.vmin, self.vmax, out=xx)
@@ -1500,7 +1501,10 @@ class BoundaryNorm(Normalize):
             max_col = self.Ncmap
         iret = np.digitize(xx, self.boundaries) - 1 + self._offset
         if self.Ncmap > self._n_regions:
-            scalefac = (self.Ncmap - 1) / (self._n_regions - 1)
+            if self._n_regions == 1:
+                scalefac = 1
+            else:
+                scalefac = (self.Ncmap - 1) / (self._n_regions - 1)
             iret = (iret * scalefac).astype(np.int16)
         iret[xx < self.vmin] = -1
         iret[xx >= self.vmax] = max_col

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1511,17 +1511,15 @@ class BoundaryNorm(Normalize):
         # in the middle) such that the first region is mapped to the
         # first color and the last region is mapped to the last color.
         if self.Ncmap > self._n_regions:
-            # the maximum possible value in iret
-            divsor = self._n_regions - 1
-            if divsor == 0:
-                # special case the 1 region case, don't scale anything
-                scalefac = 1
+            if self._n_regions == 1:
+                # special case the 1 region case, pick the middle color
+                iret[iret == 0] = (self.Ncmap - 1) // 2
             else:
                 # otherwise linearly remap the values from the region index
                 # to the color index spaces
-                scalefac = (self.Ncmap - 1) / divsor
-            # do the scaling and re-cast to integers
-            iret = (iret * scalefac).astype(np.int16)
+                iret = (self.Ncmap - 1) / (self._n_regions - 1) * iret
+        # cast to 16bit integers in all cases
+        iret = iret.astype(np.int16)
         iret[xx < self.vmin] = -1
         iret[xx >= self.vmax] = max_col
         ret = np.ma.array(iret, mask=mask)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -207,6 +207,11 @@ def test_BoundaryNorm():
     bn = mcolors.BoundaryNorm(boundaries, ncolors)
     assert_array_equal(bn(vals), expected)
 
+    # with a single region and interpolation
+    expected = [-1, 0, 0, 0, 3, 3]
+    bn = mcolors.BoundaryNorm([0, 2.2], ncolors)
+    assert_array_equal(bn(vals), expected)
+
     # more boundaries for a third color
     boundaries = [0, 1, 2, 3]
     vals = [-1, 0.1, 1.1, 2.2, 4]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -208,7 +208,7 @@ def test_BoundaryNorm():
     assert_array_equal(bn(vals), expected)
 
     # with a single region and interpolation
-    expected = [-1, 0, 0, 0, 3, 3]
+    expected = [-1, 1, 1, 1, 3, 3]
     bn = mcolors.BoundaryNorm([0, 2.2], ncolors)
     assert_array_equal(bn(vals), expected)
 


### PR DESCRIPTION
Fixes #17579. I don't understand why the scaling is `scalefac = (self.Ncmap - 1) / (self._n_regions - 1)`, and the logic when the number of colours is > the number of regions is not well defined in the dosctring so I don't know what it should be. This prevents the case with 1 region and > 1 colours from crashing though, and gives a sensible result.

I also changed a variable name from `_N` to make the code more readable.