### PR TITLE
BLD: default to system freetype on AIX

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -198,12 +198,13 @@ etc., you can install the following:
 FreeType and Qhull
 ------------------
 
-Matplotlib depends on `FreeType <https://www.freetype.org/>`_ (>= 2.3), a
-font rendering library, and on `Qhull <http://www.qhull.org/>`_ (>= 2015.2),
-a library for computing triangulations.  By default, Matplotlib downloads and
-builds its own copy of FreeType (this is necessary to run the test suite,
-because different versions of FreeType rasterize characters differently), and
-uses its own copy of Qhull.
+Matplotlib depends on `FreeType <https://www.freetype.org/>`_ (>=
+2.3), a font rendering library, and on `Qhull
+<http://www.qhull.org/>`_ (>= 2015.2), a library for computing
+triangulations.  By default (except on AIX) Matplotlib downloads and
+builds its own copy of FreeType (this is necessary to run the test
+suite, because different versions of FreeType rasterize characters
+differently), and uses its own copy of Qhull.
 
 To force Matplotlib to use a copy of FreeType or Qhull already installed in
 your system, create a :file:`setup.cfg` file with the following contents:

--- a/setupext.py
+++ b/setupext.py
@@ -137,8 +137,8 @@ if os.path.exists(setup_cfg):
     config.read(setup_cfg)
 options = {
     'backend': config.get('rc_options', 'backend', fallback=None),
-    'system_freetype': config.getboolean('libs', 'system_freetype',
-                                         fallback=False),
+    'system_freetype': config.getboolean(
+        'libs', 'system_freetype', fallback=sys.platform.startswith('aix')),
     'system_qhull': config.getboolean('libs', 'system_qhull',
                                       fallback=False),
 }


### PR DESCRIPTION
Our internal freetype build fails due to incorrect compiler flags.
The easy path to make sure AIX users will be able to pip install is to
default to system freetype when on AIX.

closes #17829

