### PR TITLE
pdf: Support setting URLs on Text objects

### DIFF
--- a/doc/users/next_whats_new/pdf_urls.rst
+++ b/doc/users/next_whats_new/pdf_urls.rst
@@ -1,0 +1,5 @@
+PDF supports URLs on ``Text`` artists
+-------------------------------------
+
+URLs on `.text.Text` artists (i.e., from `.Artist.set_url`) will now be saved
+in PDF files.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2106,6 +2106,19 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         width, height, descent, glyphs, rects = \
             self._text2path.mathtext_parser.parse(s, 72, prop)
 
+        if gc.get_url() is not None:
+            link_annotation = {
+                'Type': Name('Annot'),
+                'Subtype': Name('Link'),
+                'Rect': (x, y, x + width, y + height),
+                'Border': [0, 0, 0],
+                'A': {
+                    'S': Name('URI'),
+                    'URI': gc.get_url(),
+                },
+            }
+            self.file._annotations[-1][1].append(link_annotation)
+
         global_fonttype = mpl.rcParams['pdf.fonttype']
 
         # Set up a global transformation matrix for the whole math expression
@@ -2161,6 +2174,19 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         dvifile = texmanager.make_dvi(s, fontsize)
         with dviread.Dvi(dvifile, 72) as dvi:
             page, = dvi
+
+        if gc.get_url() is not None:
+            link_annotation = {
+                'Type': Name('Annot'),
+                'Subtype': Name('Link'),
+                'Rect': (x, y, x + page.width, y + page.height),
+                'Border': [0, 0, 0],
+                'A': {
+                    'S': Name('URI'),
+                    'URI': gc.get_url(),
+                },
+            }
+            self.file._annotations[-1][1].append(link_annotation)
 
         # Gather font information and do some setup for combining
         # characters into strings. The variable seq will contain a
@@ -2260,6 +2286,21 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             # in that case.
             if is_opentype_cff_font(font.fname):
                 fonttype = 42
+
+        if gc.get_url() is not None:
+            font.set_text(s)
+            width, height = font.get_width_height()
+            link_annotation = {
+                'Type': Name('Annot'),
+                'Subtype': Name('Link'),
+                'Rect': (x, y, x + width / 64, y + height / 64),
+                'Border': [0, 0, 0],
+                'A': {
+                    'S': Name('URI'),
+                    'URI': gc.get_url(),
+                },
+            }
+            self.file._annotations[-1][1].append(link_annotation)
 
         # If fonttype != 3 or there are no multibyte characters, emit the whole
         # string at once.


### PR DESCRIPTION
## PR Summary

This is the minimum needed to get what I wanted ~~, but it still needs some work to be fully implemented. It currently only works for plain text, and not text that goes through `draw_tex`, as I don't yet know how to get the text bounding box in that path.~~

~~Also needs tests and documentation.~~

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way