### PR TITLE
Keep using a single dividers LineCollection instance in colorbar.

### DIFF
--- a/doc/api/next_api_changes/behavior/17834-AL.rst
+++ b/doc/api/next_api_changes/behavior/17834-AL.rst
@@ -1,0 +1,5 @@
+``Colorbar.dividers`` changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This attribute is now always a `.LineCollection` -- an empty one if
+``drawedges`` is False.  Its default colors and linewidth (:rc:`axes.edgecolor`,
+:rc:`axes.linewidth`) are now resolved at instantiation time, not at draw time.


### PR DESCRIPTION
... updating its data as needed, instead of repeatedly deleting it and
instantiating new ones.

Similar to #15981, just for another attribute.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
