### PR TITLE
Colorbar cleanups.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1007,18 +1007,6 @@ class ColorbarBase:
             nb -= 1
         return nb
 
-    def _extended_N(self):
-        """
-        Based on the colormap and extend variable, return the
-        number of boundaries.
-        """
-        N = self.cmap.N + 1
-        if self.extend == 'both':
-            N += 2
-        elif self.extend in ('min', 'max'):
-            N += 1
-        return N
-
     def _get_extension_lengths(self, frac, automin, automax, default=0.05):
         """
         Return the lengths of colorbar extensions.
@@ -1267,13 +1255,7 @@ class Colorbar(ColorbarBase):
             raise ValueError('add_lines is only for a ContourSet of lines')
         tcolors = [c[0] for c in CS.tcolors]
         tlinewidths = [t[0] for t in CS.tlinewidths]
-        # The following was an attempt to get the colorbar lines
-        # to follow subsequent changes in the contour lines,
-        # but more work is needed: specifically, a careful
-        # look at event sequences, and at how
-        # to make one object track another automatically.
-        #tcolors = [col.get_colors()[0] for col in CS.collections]
-        #tlinewidths = [col.get_linewidth()[0] for lw in CS.collections]
+        # Wishlist: Make colorbar lines auto-follow changes in contour lines.
         ColorbarBase.add_lines(self, CS.levels, tcolors, tlinewidths,
                                erase=erase)
 


### PR DESCRIPTION
- Remove unused colorbar private method _extended_N: This method appears
  to never ever have been used ever since it was added to the codebase.
- Shorten a comment about a wishlist item, and delete commented code
  which is clearly similar to the uncommented one just above.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
