### PR TITLE
More precise axes section names in docs

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -165,7 +165,7 @@ Contours
    Axes.pcolormesh
    Axes.spy
 
-Unstructured Triangles
+Unstructured triangles
 ----------------------
 
 .. autosummary::
@@ -179,7 +179,7 @@ Unstructured Triangles
    Axes.tricontourf
 
 
-Text and Annotations
+Text and annotations
 --------------------
 
 .. autosummary::
@@ -274,7 +274,7 @@ Axis / limits
    Axes.get_xaxis
    Axes.get_yaxis
 
-Axis Limits and direction
+Axis limits and direction
 -------------------------
 
 .. autosummary::
@@ -300,7 +300,7 @@ Axis Limits and direction
    Axes.set_ybound
    Axes.get_ybound
 
-Axis Labels, title, and legend
+Axis labels, title, and legend
 ------------------------------
 
 .. autosummary::
@@ -434,7 +434,7 @@ Units
    Axes.have_units
 
 
-Adding Artists
+Adding artists
 ==============
 
 .. autosummary::
@@ -470,7 +470,7 @@ Twinning and sharing
    Axes.get_shared_y_axes
 
 
-Axes Position
+Axes position
 =============
 .. autosummary::
    :toctree: _as_gen
@@ -489,7 +489,7 @@ Axes Position
    Axes.set_position
 
 
-Async/Event based
+Async/event based
 =================
 
 .. autosummary::

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -150,8 +150,8 @@ Contours
    Axes.contour
    Axes.contourf
 
-Array
------
+2D arrays
+---------
 
 .. autosummary::
    :toctree: _as_gen
@@ -198,8 +198,8 @@ Text and Annotations
    Axes.secondary_yaxis
 
 
-Fields
-------
+Vector fields
+-------------
 
 .. autosummary::
    :toctree: _as_gen


### PR DESCRIPTION
## PR Summary

- `Array` -> `2D arrays`, `Fields` -> `Vector fields`. Closes  #17733.
-  Conform section capitalization with our doc guidelines