### PR TITLE
Avoid need to lock in dvi generation, to avoid deadlocks.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -35,6 +35,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+from tempfile import TemporaryDirectory
 
 import numpy as np
 
@@ -269,12 +270,12 @@ class TexManager:
 
         return texfile
 
-    def _run_checked_subprocess(self, command, tex):
+    def _run_checked_subprocess(self, command, tex, *, cwd=None):
         _log.debug(cbook._pformat_subprocess(command))
         try:
-            report = subprocess.check_output(command,
-                                             cwd=self.texcache,
-                                             stderr=subprocess.STDOUT)
+            report = subprocess.check_output(
+                command, cwd=cwd if cwd is not None else self.texcache,
+                stderr=subprocess.STDOUT)
         except FileNotFoundError as exc:
             raise RuntimeError(
                 'Failed to process string with tex because {} could not be '
@@ -305,17 +306,16 @@ class TexManager:
         dvifile = '%s.dvi' % basefile
         if not os.path.exists(dvifile):
             texfile = self.make_tex(tex, fontsize)
-            with cbook._lock_path(texfile):
+            # Generate the dvi in a temporary directory to avoid race
+            # conditions e.g. if multiple processes try to process the same tex
+            # string at the same time.  Having tmpdir be a subdirectory of the
+            # final output dir ensures that they are on the same filesystem,
+            # and thus replace() works atomically.
+            with TemporaryDirectory(dir=Path(dvifile).parent) as tmpdir:
                 self._run_checked_subprocess(
                     ["latex", "-interaction=nonstopmode", "--halt-on-error",
-                     texfile], tex)
-            for fname in glob.glob(basefile + '*'):
-                if not fname.endswith(('dvi', 'tex')):
-                    try:
-                        os.remove(fname)
-                    except OSError:
-                        pass
-
+                     texfile], tex, cwd=tmpdir)
+                (Path(tmpdir) / Path(dvifile).name).replace(dvifile)
         return dvifile
 
     @cbook.deprecated("3.3")


### PR DESCRIPTION
Instead, generate the dvi in a temporary directory and move it to its
final path.

This should likely help with https://github.com/matplotlib/matplotlib/issues/7776#issuecomment-653889789 (although I don't have a repro for that issue).

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
