### PR TITLE
Deprecate ColorbarBase.add_lines, simplify Colorbar.add_lines.

### DIFF
--- a/doc/api/next_api_changes/deprecations/17840-AL.rst
+++ b/doc/api/next_api_changes/deprecations/17840-AL.rst
@@ -1,0 +1,6 @@
+ColorbarBase.add_lines
+~~~~~~~~~~~~~~~~~~~~~~
+This method is deprecated.  Use standard axes methods (e.g.
+``colorbar.ax.axhline``, ``colorbar.ax.axvline``) to draw lines on the colorbar.
+
+Note that ``Colorbar.add_lines(contourset)`` is not deprecated.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -832,6 +832,7 @@ class ColorbarBase:
         elif len(self._y) >= self.n_rasterize:
             self.solids.set_rasterized(True)
 
+    @cbook.deprecated("3.4", alternative="axhline()/axvline()")
     def add_lines(self, levels, colors, linewidths, erase=True):
         """
         Draw lines on the colorbar.
@@ -1256,8 +1257,19 @@ class Colorbar(ColorbarBase):
         tcolors = [c[0] for c in CS.tcolors]
         tlinewidths = [t[0] for t in CS.tlinewidths]
         # Wishlist: Make colorbar lines auto-follow changes in contour lines.
-        ColorbarBase.add_lines(self, CS.levels, tcolors, tlinewidths,
-                               erase=erase)
+        if erase:
+            for lc in self.lines:
+                lc.remove()
+        if self.orientation == "vertical":
+            self.lines.append(self.ax.hlines(
+                self._locate(CS.levels), 0, 1,
+                colors=tcolors, linewidths=tlinewidths,
+                transform=self.ax.get_yaxis_transform()))
+        else:
+            self.lines.append(self.ax.vlines(
+                self._locate(CS.levels), 0, 1,
+                colors=tcolors, linewidths=tlinewidths,
+                transform=self.ax.get_xaxis_transform()))
 
     def update_normal(self, mappable):
         """


### PR DESCRIPTION
Now that colorbar axes are in norm units, `ColorbarBase.add_lines`
can be replaced by simple calls to `axvline()`/`axhline()`,
or ``hlines()`/`vlines()` if one wants to keep having
`LineCollections` (but then one needs to know about
`get_xaxis_transform()`/`get_yaxis_transform()`).

Deprecate it, and also rewrite `Colorbar.add_lines` to use
`hlines`/`vlines`.  This also gets rid of the awkward difference in API
between `ColorbarBase.add_lines` and `Colorbar.add_lines` (which have
completely different signatures).  Also note that it was unlikely that
`ColorbarBase.add_lines` was used much, because one nearly always works
with `Colorbar` rather than with `ColorbarBase`.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
