### PR TITLE
Move "Request a new feature" from How-to to Contributing

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -17,8 +17,8 @@ Submitting a bug report
 
 If you find a bug in the code or documentation, do not hesitate to submit a
 ticket to the
-`Bug Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are also
-welcome to post feature requests or pull requests.
+`Issue Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are
+also welcome to post feature requests or pull requests.
 
 If you are reporting a bug, please do your best to include the following:
 
@@ -47,6 +47,17 @@ We have preloaded the issue creation page with a Markdown template that you can
 use to organize this information.
 
 Thank you for your help in keeping bug reports complete, targeted and descriptive.
+
+Requesting a new feature
+========================
+
+Please post feature requests to the
+`Issue Tracker <https://github.com/matplotlib/matplotlib/issues>`_.
+
+The Matplotlib developers will give feedback on the feature proposal. Since
+Matplotlib is an open source project with limited resources, we encourage
+users to then also
+:ref:`participate in the implementation <contributing-code>`.
 
 .. _installing_for_devs:
 
@@ -123,6 +134,7 @@ You can then run the tests to check your work environment is set up properly::
 
   * :ref:`testing`
 
+.. _contributing-code:
 
 Contributing code
 =================

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -8,6 +8,7 @@ The Matplotlib Developers' Guide
 
    <div style="margin: 2em 0;">
      <a href="contributing.html#submitting-a-bug-report"><span class="mpl-button">Report a bug</span></a>
+     <a href="contributing.html#request-a-new-feature"><span class="mpl-button">Request a feature</span></a>
      <a href="contributing.html#contributing-code"><span class="mpl-button">Contribute code</span></a>
      <a href="contributing.html#contributing-documentation"><span class="mpl-button">Write documentation</span></a>
    </div>

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -532,19 +532,6 @@ most GUI backends *require* being run from the main thread as well.
 How-to: Contributing
 ====================
 
-.. _how-to-request-feature:
-
-Request a new feature
----------------------
-
-Is there a feature you wish Matplotlib had?  Then ask!  The best
-way to get started is to email the developer `mailing
-list <matplotlib-devel@python.org>`_ for discussion.
-This is an open source project developed primarily in the
-contributors free time, so there is no guarantee that your
-feature will be added.  The *best* way to get the feature
-you need added is to contribute it your self.
-
 .. _how-to-contribute-docs:
 
 Contribute to Matplotlib documentation


### PR DESCRIPTION
## PR Summary

Part of moving all contribution related info from How-to to the developers guide. (Related/follow up to #17837 and #17825.)

I've removed mentioning the mailing list:

> The best way to get started is to email the developer `mailing list <matplotlib-devel@python.org>`_ for discussion.

<s>I suppose this is just outdated. One could add it as an alternative to the issue tracker, but OTOH the issue tracker makes management of feature requests much simpler, and personally, I would not want to have feature requests coming via the malinglist.</s>

Not mentioning the mailinglist here was discussed and approved in the last dev call.