### PR TITLE
Add fullscreen toggle support to WxAgg backend

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1063,6 +1063,10 @@ class FigureManagerWx(FigureManagerBase):
         if wxapp:
             wxapp.Yield()
 
+    def full_screen_toggle(self):
+        # docstring inherited
+        self.frame.ShowFullScreen(not self.frame.IsFullScreen())
+
     def get_window_title(self):
         # docstring inherited
         return self.window.GetTitle()


### PR DESCRIPTION
## PR Summary

This implements the by default empty [FigureManagerBase.full_screen_toggle](https://matplotlib.org/devdocs/_modules/matplotlib/backend_bases.html#FigureManagerBase.full_screen_toggle) for the WxAgg backend. Qt, Tk and GTK3 already have working implementations for this.

can be tested with either:

~~~
import matplotlib
matplotlib.use('wxagg')
import matplotlib.pyplot as plt
plt.plot([1,3,2])
plt.get_current_fig_manager().full_screen_toggle()
~~~

or

~~~
import matplotlib
matplotlib.use('wxagg')
import matplotlib.pyplot as plt
plt.plot([1,3,2])
plt.show()
~~~

and toggle with shortcut `f`.

