### PR TITLE
Remove overspecified latex geometry.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -190,7 +190,7 @@ class TexManager:
             r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
             # geometry is loaded before the custom preamble as convert_psfrags
             # relies on a custom preamble to change the geometry.
-            r"\usepackage[papersize=72in,body=70in,margin=1in]{geometry}",
+            r"\usepackage[papersize=72in, margin=1in]{geometry}",
             self.get_custom_preamble(),
             # textcomp is loaded last (if not already loaded by the custom
             # preamble) in order not to clash with custom packages (e.g.


### PR DESCRIPTION
The geometry package derives `body` from `papersize` and `margin`.  Even
though the value given for `body` is consistent (`papersize -
2*margin`), giving all three of them yields a warning in the tex log
(which can be seen e.g. when processing an invalid tex string in usetex
mode (e.g. `figtext(.5, .5, r"\foo")`):
```
Package geometry Warning: Over-specification in `h'-direction.
    `width' (5058.9pt) is ignored.

Package geometry Warning: Over-specification in `v'-direction.
    `height' (5058.9pt) is ignored.
```
Just get rid of the overspecification.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
