### PR TITLE
API: resolve unset vmin / vmax in all ScalarMapple based methods

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.3.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/behaviour.rst
@@ -96,9 +96,10 @@ internal quotes) now cause a ValueError to be raised.
 `.SymLogNorm` now has a *base* parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, `.SymLogNorm` had no *base* kwarg, and defaulted to ``base=np.e``
-whereas the documentation said it was ``base=10``.  In preparation to make
-the default 10, calling `.SymLogNorm` without the new *base* kwarg emits a
+Previously, `.SymLogNorm` had no *base* keyword argument, and
+defaulted to ``base=np.e`` whereas the documentation said it was
+``base=10``.  In preparation to make the default 10, calling
+`.SymLogNorm` without the new *base* keyword argument emits a
 deprecation warning.
 
 
@@ -312,3 +313,29 @@ rcParam is True.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The *colors* parameter will now default to :rc:`lines.color`, while previously it defaulted to 'k'.
+
+Aggressively autoscale clim in ``ScalerMappable`` classes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Previously some plotting methods would defer autoscaling until the
+first draw if only one of the *vmin* or *vmax* keyword arguments were
+passed (`.Axes.scatter`, `.Axes.hexbin`, `.Axes.imshow`,
+`.Axes.pcolorfast`) but would scale based on the passed data if
+neither was passed (independent of the *norm* keyword arguments).
+Other methods (`.Axes.pcolor`, `.Axes.pcolormesh`) always autoscaled
+base on the initial data.
+
+All of the plotting methods now resolve the unset *vmin* or *vmax*
+at the initial call time using the data passed in.
+
+If you were relying on exactly one of the *vmin* or *vmax* remaining
+unset between the time when the method is called and the first time
+the figure is rendered you get back the old behavior by manually setting
+the relevant limit back to `None` ::
+
+  cm_obj.norm.vmin = None
+  # or
+  cm_obj.norm.vmax = None
+
+which will be resolved during the draw process.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -258,8 +258,10 @@ class ScalarMappable:
                             "simultaneously is deprecated since %(since)s and "
                             "will become an error %(removal)s. Please pass "
                             "vmin/vmax directly to the norm when creating it.")
-        else:
-            self.autoscale_None()
+
+        # always resolve the autoscaling so we have concrete limits
+        # rather than deferring to draw time.
+        self.autoscale_None()
 
     def to_rgba(self, x, alpha=None, bytes=False, norm=True):
         """


### PR DESCRIPTION
## PR Summary

See analysis in #17703 


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

- Resolves #17703 