### PR TITLE
Revert "Fix linewidths and colors for scatter() with unfilled markers"

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4392,9 +4392,8 @@ default: :rc:`scatter.edgecolors`
             - 'none': No patch boundary will be drawn.
             - A color or sequence of colors.
 
-            For non-filled markers, *edgecolors* is ignored. Instead, the color
-            is determined like with 'face', i.e. from *c*, *colors*, or
-            *facecolors*.
+            For non-filled markers, the *edgecolors* kwarg is ignored and
+            forced to 'face' internally.
 
         plotnonfinite : bool, default: False
             Set to plot points with nonfinite *c*, in conjunction with
@@ -4476,6 +4475,7 @@ default: :rc:`scatter.edgecolors`
         path = marker_obj.get_path().transformed(
             marker_obj.get_transform())
         if not marker_obj.is_filled():
+            edgecolors = 'face'
             if linewidths is None:
                 linewidths = rcParams['lines.linewidth']
             elif np.iterable(linewidths):
@@ -4487,8 +4487,8 @@ default: :rc:`scatter.edgecolors`
 
         collection = mcoll.PathCollection(
                 (path,), scales,
-                facecolors=colors if marker_obj.is_filled() else 'none',
-                edgecolors=edgecolors if marker_obj.is_filled() else colors,
+                facecolors=colors,
+                edgecolors=edgecolors,
                 linewidths=linewidths,
                 offsets=offsets,
                 transOffset=kwargs.pop('transform', self.transData),

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -237,10 +237,7 @@ class MarkerStyle:
         self._snap_threshold = None
         self._joinstyle = 'round'
         self._capstyle = 'butt'
-        # Initial guess: Assume the marker is filled unless the fillstyle is
-        # set to 'none'. The marker function will override this for unfilled
-        # markers.
-        self._filled = self._fillstyle != 'none'
+        self._filled = True
         self._marker_function()
 
     def __bool__(self):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1855,16 +1855,6 @@ class TestScatter:
         with pytest.raises(ValueError):
             plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
 
-    def test_scatter_unfilled(self):
-        coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
-                           marker=mmarkers.MarkerStyle('o', fillstyle='none'),
-                           linewidths=[1.1, 1.2, 1.3])
-        assert coll.get_facecolors().shape == (0, 4)  # no facecolors
-        assert_array_equal(coll.get_edgecolors(), [[0.1, 0.1, 0.1, 1],
-                                                   [0.3, 0.3, 0.3, 1],
-                                                   [0.5, 0.5, 0.5, 1]])
-        assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
-
     def test_scatter_size_arg_size(self):
         x = np.arange(4)
         with pytest.raises(ValueError):

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -7,12 +7,6 @@ from matplotlib.testing.decorators import check_figures_equal
 import pytest
 
 
-def test_marker_fillstyle():
-    marker_style = markers.MarkerStyle(marker='o', fillstyle='none')
-    assert marker_style.get_fillstyle() == 'none'
-    assert not marker_style.is_filled()
-
-
 def test_markers_valid():
     marker_style = markers.MarkerStyle()
     mrk_array = np.array([[-0.5, 0],


### PR DESCRIPTION
Reverts #17543.

This reverts commit 16ae71f90b2465d2b78121504c05830bb822f4f7, reversing changes made to 7a6c5d3373e160f1440ba273f1d7152f36cb2af8.

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way