### PR TITLE
CI: Install, or upgrade, Python 3 on homebrew.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ before_install: |
     ci/silence brew update
     brew uninstall numpy gdal postgis
     brew unlink python@2
-    brew upgrade python
+    brew install python || brew upgrade python
     brew install ffmpeg imagemagick mplayer ccache
     hash -r
     which python


### PR DESCRIPTION
It seems it may not be available by default now, so try installing it first.
