### PR TITLE
FIX: new date rcParams weren't being evaluated

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1926,6 +1926,8 @@ class _rcParam_helper:
     @classmethod
     def set_converter(cls, s):
         """Called by validator for rcParams date.converter"""
+        if s not in ['concise', 'auto']:
+            raise ValueError('Converter must be one of "concise" or "auto"')
         cls.conv_st = s
         cls.register_converters()
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -176,20 +176,24 @@ def validate_bool_maybe_none(b):
 
 
 def _validate_date_converter(s):
+    if s is None:
+        return
     s = validate_string(s)
-    mdates = sys.modules.get("matplotlib.dates")
-    if mdates:
-        mdates._rcParam_helper.set_converter(s)
+    if s not in ['auto', 'concise']:
+        cbook._warn_external(f'date.converter string must be "auto" '
+                             f'or "concise", not "{s}".  Check your '
+                             'matplotlibrc')
+        return
+    import matplotlib.dates as mdates
+    mdates._rcParam_helper.set_converter(s)
 
 
 def _validate_date_int_mult(s):
     if s is None:
         return
     s = validate_bool(s)
-    # only do this if dates is already imported...
-    mdates = sys.modules.get("matplotlib.dates")
-    if mdates:
-        mdates._rcParam_helper.set_int_mult(s)
+    import matplotlib.dates as mdates
+    mdates._rcParam_helper.set_int_mult(s)
 
 
 def _validate_tex_preamble(s):

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -977,6 +977,8 @@ def test_change_converter():
     fig.canvas.draw()
     assert ax.get_xticklabels()[0].get_text() == 'Jan 01 2020'
     assert ax.get_xticklabels()[1].get_text() == 'Jan 15 2020'
+    with pytest.warns(UserWarning) as rec:
+        plt.rcParams['date.converter'] = 'boo'
 
 
 def test_change_interval_multiples():


### PR DESCRIPTION
## PR Summary
Closes #17867

#17022 introduced new rcparams for dates.  However, this changed the registration mechanism for dates and broke date plotting if the entry was not in the users matplotlibrc.  

This new version fixes that logic (and adds a bit more argument checking)



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
