### PR TITLE
Mention single char colors shading in more places

### DIFF
--- a/examples/color/color_demo.py
+++ b/examples/color/color_demo.py
@@ -8,19 +8,22 @@ Matplotlib recognizes the following formats to specify a color:
 1) an RGB or RGBA tuple of float values in ``[0, 1]`` (e.g. ``(0.1, 0.2, 0.5)``
    or ``(0.1, 0.2, 0.5, 0.3)``).  RGBA is short for Red, Green, Blue, Alpha;
 2) a hex RGB or RGBA string (e.g., ``'#0F0F0F'`` or ``'#0F0F0F0F'``);
-3) a string representation of a float value in ``[0, 1]`` inclusive for gray
+3) a shorthand hex RGB or RGBA string, equivalent to the hex RGB or RGBA
+   string obtained by duplicating each character, (e.g., ``'#abc'``, equivalent
+   to ``'#aabbcc'``, or ``'#abcd'``, equivalent to ``'#aabbccdd'``);
+4) a string representation of a float value in ``[0, 1]`` inclusive for gray
    level (e.g., ``'0.5'``);
-4) a single letter string, i.e. one of
+5) a single letter string, i.e. one of
    ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, which are short-hand notations
    for shades of blue, green, red, cyan, magenta, yellow, black, and white;
-5) a X11/CSS4 ("html") color name, e.g. ``"blue"``;
-6) a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__,
+6) a X11/CSS4 ("html") color name, e.g. ``"blue"``;
+7) a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__,
    prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``);
-7) a "Cn" color spec, i.e. ``'C'`` followed by a number, which is an index into
+8) a "Cn" color spec, i.e. ``'C'`` followed by a number, which is an index into
    the default property cycle (:rc:`axes.prop_cycle`); the indexing is intended
    to occur at rendering time, and defaults to black if the cycle does not
    include color.
-8) one of ``{'tab:blue', 'tab:orange', 'tab:green', 'tab:red', 'tab:purple',
+9) one of ``{'tab:blue', 'tab:orange', 'tab:green', 'tab:red', 'tab:purple',
    'tab:brown', 'tab:pink', 'tab:gray', 'tab:olive', 'tab:cyan'}`` which are
    the Tableau Colors from the 'tab10' categorical palette (which is the
    default color cycle);

--- a/examples/color/color_demo.py
+++ b/examples/color/color_demo.py
@@ -6,12 +6,13 @@ Color Demo
 Matplotlib recognizes the following formats to specify a color:
 
 1) an RGB or RGBA tuple of float values in ``[0, 1]`` (e.g. ``(0.1, 0.2, 0.5)``
-   or  ``(0.1, 0.2, 0.5, 0.3)``).  RGBA is short for Red, Green, Blue, Alpha;
+   or ``(0.1, 0.2, 0.5, 0.3)``).  RGBA is short for Red, Green, Blue, Alpha;
 2) a hex RGB or RGBA string (e.g., ``'#0F0F0F'`` or ``'#0F0F0F0F'``);
 3) a string representation of a float value in ``[0, 1]`` inclusive for gray
    level (e.g., ``'0.5'``);
 4) a single letter string, i.e. one of
-   ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``;
+   ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, which are short-hand notations
+   for shades of blue, green, red, cyan, magenta, yellow, black, and white;
 5) a X11/CSS4 ("html") color name, e.g. ``"blue"``;
 6) a name from the `xkcd color survey <https://xkcd.com/color/rgb/>`__,
    prefixed with ``'xkcd:'`` (e.g., ``'xkcd:sky blue'``);
@@ -19,10 +20,10 @@ Matplotlib recognizes the following formats to specify a color:
    the default property cycle (:rc:`axes.prop_cycle`); the indexing is intended
    to occur at rendering time, and defaults to black if the cycle does not
    include color.
-8) one of ``{'tab:blue', 'tab:orange', 'tab:green',
-   'tab:red', 'tab:purple', 'tab:brown', 'tab:pink',
-   'tab:gray', 'tab:olive', 'tab:cyan'}`` which are the Tableau Colors from the
-   'tab10' categorical palette (which is the default color cycle);
+8) one of ``{'tab:blue', 'tab:orange', 'tab:green', 'tab:red', 'tab:purple',
+   'tab:brown', 'tab:pink', 'tab:gray', 'tab:olive', 'tab:cyan'}`` which are
+   the Tableau Colors from the 'tab10' categorical palette (which is the
+   default color cycle);
 
 For more information on colors in matplotlib see
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -44,9 +44,11 @@ Matplotlib recognizes the following formats to specify a color:
   case-insensitive);
 * a string representation of a float value in ``[0, 1]`` inclusive for gray
   level (e.g., ``'0.5'``);
-* one of ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, they are the single
-  character short-hand notations for blue, green, red, cyan, magenta, yellow,
-  black, and white.
+* one of the characters ``{'b', 'g', 'r', 'c', 'm', 'y', 'k', 'w'}``, which
+  are short-hand notations for shades of blue, green, red, cyan, magenta,
+  yellow, black, and white. Note that the colors ``'g', 'c', 'm', 'y'`` do not
+  coincide with the X11/CSS4 colors. Their particular shades were chosen for
+  better visibility of colored lines against typical backgrounds.
 * a X11/CSS4 color name (case-insensitive);
 * a name from the `xkcd color survey`_, prefixed with ``'xkcd:'`` (e.g.,
   ``'xkcd:sky blue'``; case insensitive);


### PR DESCRIPTION
## PR Summary

That is, copy #17665 to more places.

Also mention shorthand RGB(A) hex codes in one more place.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way