### PR TITLE
Fix drawing zoom rubberband on GTK backends.

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -612,8 +612,8 @@ Previously, the x/y position displayed by the cursor text would usually include
 far more significant digits than the mouse pointing precision (typically one
 pixel). This is now fixed for linear scales.
 
-Qt zoom rectangle now black and white
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GTK / Qt zoom rectangle now black and white
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This makes it visible even over a dark background.
 


### PR DESCRIPTION
## PR Summary

Just like Qt, the drawing should only be done in the draw (paint) event, so move the rubberband draw there. Also, make it black-and-white like the Qt one.

Fixes #17773.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way