### PR TITLE
Link to style-file example page in style tutorial

### DIFF
--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -12,7 +12,8 @@ The :mod:`.style` package adds support for easy-to-switch plotting
 <customizing-with-matplotlibrc-files>` file (which is read at startup to
 configure Matplotlib).
 
-There are a number of pre-defined styles `provided by Matplotlib`_. For
+There are a number of pre-defined styles :doc:`provided by Matplotlib
+</gallery/style_sheets/style_sheets_reference>`. For
 example, there's a pre-defined style called "ggplot", which emulates the
 aesthetics of ggplot_ (a popular plotting package for R_). To use this style,
 just add:
@@ -202,4 +203,3 @@ plt.plot(data)
 #
 # .. _ggplot: https://ggplot2.tidyverse.org/
 # .. _R: https://www.r-project.org/
-# .. _provided by Matplotlib: https://github.com/matplotlib/matplotlib/tree/master/lib/matplotlib/mpl-data/stylelib


### PR DESCRIPTION
The current link is to https://github.com/matplotlib/matplotlib/tree/master/lib/matplotlib/mpl-data/stylelib, which is a listing of the actual style files. I think it's more helpful to link to https://matplotlib.org/devdocs/gallery/style_sheets/style_sheets_reference.html, which shows an overview of the different styles.

Even if it's desirable to keep the direct github link, I think the introductory style tutorial should link to the style sheet reference page somewhere.