### PR TITLE
Fix FFMpegBase.isAvailable with detached terminals.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -597,7 +597,8 @@ class FFMpegBase:
             # NOTE: when removed, remove the same method in AVConvBase.
             and b'LibAv' not in subprocess.run(
                 [cls.bin_path()], creationflags=subprocess_creation_flags,
-                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE).stderr)
+                stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE).stderr)
 
 
 # Combine FFMpeg options with pipe-based writing


### PR DESCRIPTION
## PR Summary

When checking for ffmpeg/libav, set stdin to /dev/null, otherwise the process will sleep if Python is running with a detached terminal. And we definitely don't want ffmpeg/libav to grab user input here.

I don't think there's any way to test this automatically, really, but if anyone has any ideas...

Fixes #17875.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way