### PR TITLE
Remove Python 3.6 compatibility shims

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -25,10 +25,7 @@ try:
     import threading
 except ImportError:
     import dummy_threading as threading
-try:
-    from contextlib import nullcontext
-except ImportError:
-    from contextlib import ExitStack as nullcontext  # Py 3.6.
+from contextlib import nullcontext
 from math import radians, cos, sin
 
 import numpy as np

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,7 +1,4 @@
-try:
-    from contextlib import nullcontext
-except ImportError:
-    from contextlib import ExitStack as nullcontext  # Py 3.6.
+from contextlib import nullcontext
 
 from . import backend_cairo, backend_gtk3
 from .backend_gtk3 import Gtk, _BackendGTK3

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -9,10 +9,6 @@ import string
 import sys
 import unittest
 import warnings
-try:
-    from contextlib import nullcontext
-except ImportError:
-    from contextlib import ExitStack as nullcontext  # Py3.6.
 
 import matplotlib as mpl
 import matplotlib.style
@@ -219,7 +215,8 @@ class _ImageComparisonBase:
                               {'Creator': None, 'Producer': None,
                                'CreationDate': None})
 
-        lock = cbook._lock_path(actual_path) if _lock else nullcontext()
+        lock = (cbook._lock_path(actual_path)
+                if _lock else contextlib.nullcontext())
         with lock:
             fig.savefig(actual_path, **kwargs)
             expected_path = self.copy_baseline(baseline, extension)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,13 +1,10 @@
+from contextlib import nullcontext
 from datetime import datetime
 import io
 from pathlib import Path
 import platform
 from types import SimpleNamespace
 import warnings
-try:
-    from contextlib import nullcontext
-except ImportError:
-    from contextlib import ExitStack as nullcontext  # Py3.6
 
 import matplotlib as mpl
 from matplotlib import cbook, rcParams

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1,7 +1,4 @@
-try:
-    from contextlib import nullcontext
-except ImportError:
-    from contextlib import ExitStack as nullcontext  # Py 3.6.
+from contextlib import nullcontext
 import re
 import itertools
 

--- a/setup.py
+++ b/setup.py
@@ -258,9 +258,9 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         'License :: OSI Approved :: Python Software Foundation License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Visualization',
     ],
 


### PR DESCRIPTION
## PR Summary

A followup to #17662.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way