### PR TITLE
Created Hatch marker styles Demo for Example Gallery

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -226,7 +226,7 @@ per-file-ignores =
     examples/shapes_and_collections/ellipse_demo.py: E402
     examples/shapes_and_collections/fancybox_demo.py: E402
     examples/shapes_and_collections/hatch_demo.py: E402
-    examples/shapes_and_collections/hatches_styles.py: E402
+    examples/shapes_and_collections/hatch_style_reference: E402
     examples/shapes_and_collections/line_collection.py: E402
     examples/shapes_and_collections/marker_path.py: E402
     examples/shapes_and_collections/patch_collection.py: E402

--- a/.flake8
+++ b/.flake8
@@ -226,6 +226,7 @@ per-file-ignores =
     examples/shapes_and_collections/ellipse_demo.py: E402
     examples/shapes_and_collections/fancybox_demo.py: E402
     examples/shapes_and_collections/hatch_demo.py: E402
+    examples/shapes_and_collections/hatches_styles.py: E402
     examples/shapes_and_collections/line_collection.py: E402
     examples/shapes_and_collections/marker_path.py: E402
     examples/shapes_and_collections/patch_collection.py: E402

--- a/.flake8
+++ b/.flake8
@@ -226,7 +226,7 @@ per-file-ignores =
     examples/shapes_and_collections/ellipse_demo.py: E402
     examples/shapes_and_collections/fancybox_demo.py: E402
     examples/shapes_and_collections/hatch_demo.py: E402
-    examples/shapes_and_collections/hatch_style_reference: E402
+    examples/shapes_and_collections/hatch_style_reference.py: E402
     examples/shapes_and_collections/line_collection.py: E402
     examples/shapes_and_collections/marker_path.py: E402
     examples/shapes_and_collections/patch_collection.py: E402

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -7,7 +7,6 @@ Hatching (pattern filled polygons) is supported currently in the PS,
 PDF, SVG and Agg backends only.
 """
 import matplotlib.pyplot as plt
-import numpy as np
 from matplotlib.patches import Rectangle
 
 fig, axs = plt.subplots(2, 5, constrained_layout=True, figsize=(10, 5))

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -1,7 +1,7 @@
 """
-===================
-Hatches Styles Demo
-===================
+=====================
+Hatch style reference
+=====================
 
 Hatching (pattern filled polygons) is supported currently in the PS,
 PDF, SVG and Agg backends only.
@@ -10,25 +10,19 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.patches import Rectangle
 
-fig, ax = plt.subplots()
+fig, axs = plt.subplots(2, 5, constrained_layout=True, figsize=(10, 5))
 
-x = np.repeat([1, 4, 7, 10, 13], 2)
-y = np.tile([2, 5], 5)
+hatches = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
-pos = np.column_stack((x, y))
-text_pos = pos + [0.9, -0.5]
 
-hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
+def hatches_plot(ax, h):
+    ax.add_patch(Rectangle((0, 0), 2, 2, fill=False, hatch=h))
+    ax.set_title(f"' {h} '")
+    ax.axis('equal')
+    ax.axis('off')
 
-for h, p, t in zip(hashes, pos, text_pos):
-    ax.add_patch(Rectangle(p, 2, 2, fill=False, hatch=h))
-    ax.text(t[0], t[1], h, fontsize=15)
-
-ax.axis('equal')
-ax.axis('off')
-fig.tight_layout()
-
-plt.show()
+for ax, h in zip(axs.flat, hatches):
+    hatches_plot(ax, h)
 
 #############################################################################
 #

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -16,7 +16,7 @@ hatches = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
 def hatches_plot(ax, h):
     ax.add_patch(Rectangle((0, 0), 2, 2, fill=False, hatch=h))
-    ax.set_title(f"' {h} '")
+    ax.text(1, -0.5, f"' {h} '", size=15, ha="center")
     ax.axis('equal')
     ax.axis('off')
 

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -4,7 +4,7 @@ Hatch style reference
 =====================
 
 Hatching (pattern filled polygons) is currently supported in the backends
-PS, PDF, SVG and *Agg. The backends OSX, WX and *Cairo ignore hatching.
+PS, PDF, SVG and Agg. The backends OSX, WX and Cairo ignore hatching.
 """
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -3,8 +3,8 @@
 Hatch style reference
 =====================
 
-Hatching (pattern filled polygons) is supported currently in the PS,
-PDF, SVG and Agg backends only.
+Hatching (pattern filled polygons) is currently supported in the backends
+PS, PDF, SVG and *Agg. The backends OSX, WX and *Cairo ignore hatching.
 """
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -4,7 +4,7 @@ Hatches Styles Demo
 ==========
 
 Hatching (pattern filled polygons) is supported currently in the PS,
-PDF, SVG and Agg backends only. 
+PDF, SVG and Agg backends only.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -21,8 +21,8 @@ text_pos = pos + [0.9, -0.5]
 hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
 for h in range(len(hashes)):
-  ax.add_patch(Rectangle(pos[h], 2, 2, fill=False, hatch=hashes[h]))
-  ax.text(text_pos[h][0], text_pos[h][1], hashes[h], fontsize=15)
+    ax.add_patch(Rectangle(pos[h], 2, 2, fill=False, hatch=hashes[h]))
+    ax.text(text_pos[h][0], text_pos[h][1], hashes[h], fontsize=15)
 
 plt.axis('equal')
 plt.axis('off')

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -1,7 +1,7 @@
 """
-==========
+===================
 Hatches Styles Demo
-==========
+===================
 
 Hatching (pattern filled polygons) is supported currently in the PS,
 PDF, SVG and Agg backends only.

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -20,9 +20,9 @@ text_pos = pos + [0.9, -0.5]
 
 hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
-for h in range(len(hashes)):
-    ax.add_patch(Rectangle(pos[h], 2, 2, fill=False, hatch=hashes[h]))
-    ax.text(text_pos[h][0], text_pos[h][1], hashes[h], fontsize=15)
+for h, p, t in zip(hashes, pos, text_pos):
+    ax.add_patch(Rectangle(p, 2, 2, fill=False, hatch=h))
+    ax.text(t[0], t[1], h, fontsize=15)
 
 plt.axis('equal')
 plt.axis('off')

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -1,0 +1,47 @@
+"""
+==========
+Hatches Styles Demo
+==========
+
+Hatching (pattern filled polygons) is supported currently in the PS,
+PDF, SVG and Agg backends only. 
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.patches import Rectangle
+
+fig, ax = plt.subplots()
+
+x = np.repeat([1, 4, 7, 10, 13], 2)
+y = np.tile([2, 5], 5)
+
+pos = np.array(list(zip(x, y)))
+text_pos = pos + [0.9, -0.5]
+
+hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
+
+for h in range(len(hashes)):
+  ax.add_patch(Rectangle(pos[h], 2, 2, fill=False, hatch=hashes[h]))
+  ax.text(text_pos[h][0],text_pos[h][1], hashes[h], fontsize=15)
+
+plt.axis('equal')
+plt.axis('off')
+plt.tight_layout()
+
+plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.patches
+matplotlib.patches.Rectangle
+matplotlib.axes.Axes.add_patch
+matplotlib.axes.Axes.text

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -15,7 +15,7 @@ fig, ax = plt.subplots()
 x = np.repeat([1, 4, 7, 10, 13], 2)
 y = np.tile([2, 5], 5)
 
-pos = np.array(list(zip(x, y)))
+pos = np.column_stack((x, y))
 text_pos = pos + [0.9, -0.5]
 
 hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -22,7 +22,7 @@ hashes = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
 for h in range(len(hashes)):
   ax.add_patch(Rectangle(pos[h], 2, 2, fill=False, hatch=hashes[h]))
-  ax.text(text_pos[h][0],text_pos[h][1], hashes[h], fontsize=15)
+  ax.text(text_pos[h][0], text_pos[h][1], hashes[h], fontsize=15)
 
 plt.axis('equal')
 plt.axis('off')

--- a/examples/shapes_and_collections/hatches_styles.py
+++ b/examples/shapes_and_collections/hatches_styles.py
@@ -24,9 +24,9 @@ for h, p, t in zip(hashes, pos, text_pos):
     ax.add_patch(Rectangle(p, 2, 2, fill=False, hatch=h))
     ax.text(t[0], t[1], h, fontsize=15)
 
-plt.axis('equal')
-plt.axis('off')
-plt.tight_layout()
+ax.axis('equal')
+ax.axis('off')
+fig.tight_layout()
 
 plt.show()
 


### PR DESCRIPTION
## PR Summary
![Screen Shot 2020-07-10 at 6 07 33 PM](https://user-images.githubusercontent.com/11200528/87211034-594cfc80-c2dd-11ea-9633-2300ce8e87ac.png)

This is a hatch marker styles demo. The script will plot 10 squares filled with 10 hatching markers. There was no example that demonstrated the 10 different hatching markers. Thanks.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
