### PR TITLE
BF: ignore CLOSEPOLY after NaN in PathNanRemover

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1404,6 +1404,11 @@ def test_bar_tick_label_single():
     ax.bar("a", "b", align='edge', tick_label='0', data=data)
 
 
+def test_nan_bar_values():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1], [np.nan, 4])
+
+
 def test_bar_ticklabel_fail():
     fig, ax = plt.subplots()
     ax.bar([], [])

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -452,3 +452,15 @@ def test_intersect_zero_length_segment():
 
     assert outline_path.intersects_path(this_path)
     assert this_path.intersects_path(outline_path)
+
+
+def test_cleanup_closepoly():
+    # if the first connected component of a Path ends in a CLOSEPOLY, but that
+    # component contains a NaN, then Path.cleaned should ignore not just the
+    # control points but also the CLOSEPOLY, since it has nowhere valid to
+    # point.
+    p = Path([[np.nan, np.nan], [np.nan, np.nan]],
+             [Path.MOVETO, Path.CLOSEPOLY])
+    cleaned = p.cleaned(remove_nans=True)
+    assert len(cleaned) == 1
+    assert cleaned.codes[0] == Path.STOP

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -459,8 +459,19 @@ def test_cleanup_closepoly():
     # component contains a NaN, then Path.cleaned should ignore not just the
     # control points but also the CLOSEPOLY, since it has nowhere valid to
     # point.
-    p = Path([[np.nan, np.nan], [np.nan, np.nan]],
-             [Path.MOVETO, Path.CLOSEPOLY])
-    cleaned = p.cleaned(remove_nans=True)
-    assert len(cleaned) == 1
-    assert cleaned.codes[0] == Path.STOP
+    paths = [
+        Path([[np.nan, np.nan], [np.nan, np.nan]],
+             [Path.MOVETO, Path.CLOSEPOLY]),
+        # we trigger a different path in the C++ code if we don't pass any
+        # codes explicitly, so we must also make sure that this works
+        Path([[np.nan, np.nan], [np.nan, np.nan]]),
+        # we should also make sure that this cleanup works if there's some
+        # multi-vertex curves
+        Path([[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan],
+              [np.nan, np.nan]],
+             [Path.MOVETO, Path.CURVE3, Path.CURVE3, Path.CLOSEPOLY])
+    ]
+    for p in paths:
+        cleaned = p.cleaned(remove_nans=True)
+        assert len(cleaned) == 1
+        assert cleaned.codes[0] == Path.STOP


### PR DESCRIPTION
## PR Summary

Fixes #17868.

In short, the current `PathNanRemover` always keeps `CLOSEPOLY` "vertices" around, even if they contain NaN.  This is arguably okay (since it is documented in comments that the values of `CLOSEPOLY` vertices are ignored). However, because of this, if a CLOSEPOLY occurs before any non-NaN segments of a Path are encountered, then `PathNanRemover` (and, by proxy, `Path.cleaned(remove_nans=True)` will return a malformed `Path` that starts with a `CLOSEPOLY`.

### Current behavior:

```python
>>> p = Path(
    [[np.nan, np.nan], [np.nan, np.nan]],
    [1, 79])
>>> p.cleaned(remove_nans=True)
Path(array([[np.nan, np.nan], [0., 0.]]), array([79, 0]))
```

### New behavior
```python
>>> p.cleaned(remove_nans=True)
Path(array([[0., 0.]]), array([0], dtype=uint8))
```

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
