### PR TITLE
Minor doc fixes

### DIFF
--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -44,7 +44,7 @@ plt.show()
 
 
 ###############################################################################
-# The parameters *bbox_to_anchor* and *bbox_transfrom* can be used for a more
+# The parameters *bbox_to_anchor* and *bbox_transform* can be used for a more
 # fine grained control over the inset position and size or even to position
 # the inset at completely arbitrary positions.
 # The *bbox_to_anchor* sets the bounding box in coordinates according to the

--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -44,7 +44,7 @@ plt.show()
 
 
 ###############################################################################
-# The arguments *bbox_to_anchor* and *bbox_transfrom* can be used for a more
+# The parameters *bbox_to_anchor* and *bbox_transfrom* can be used for a more
 # fine grained control over the inset position and size or even to position
 # the inset at completely arbitrary positions.
 # The *bbox_to_anchor* sets the bounding box in coordinates according to the

--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -21,7 +21,7 @@ def koch_snowflake(order, scale=10):
     Return two lists x, y of point coordinates of the Koch snowflake.
 
     Parameters
-    ---------
+    ----------
     order : int
         The recursion depth.
     scale : float

--- a/examples/lines_bars_and_markers/fill.py
+++ b/examples/lines_bars_and_markers/fill.py
@@ -20,7 +20,7 @@ def koch_snowflake(order, scale=10):
     """
     Return two lists x, y of point coordinates of the Koch snowflake.
 
-    Arguments
+    Parameters
     ---------
     order : int
         The recursion depth.

--- a/examples/mplot3d/voxels_torus.py
+++ b/examples/mplot3d/voxels_torus.py
@@ -3,7 +3,7 @@
 3D voxel / volumetric plot with cylindrical coordinates
 =======================================================
 
-Demonstrates using the *x*, *y*, *z* arguments of `.Axes3D.voxels`.
+Demonstrates using the *x*, *y*, *z* parameters of `.Axes3D.voxels`.
 """
 
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -77,17 +77,16 @@ def do_constrained_layout(fig, renderer, h_pad, w_pad,
     Parameters
     ----------
     fig : Figure
-      is the ``figure`` instance to do the layout in.
+        ``Figure`` instance to do the layout in.
 
     renderer : Renderer
-      the renderer to use.
+        Renderer to use.
 
-     h_pad, w_pad : float
-       are in figure-normalized units, and are a padding around the axes
-       elements.
+    h_pad, w_pad : float
+        Padding around the axes elements in figure-normalized units.
 
-     hspace, wspace : float
-        are in fractions of the subplot sizes.
+    hspace, wspace : float
+        Spacing in fractions of the subplot sizes.
 
     """
 


### PR DESCRIPTION
## PR Summary

Some minor changes on the use of the word `arguments` instead of `parameters`. These are the ones I spotted and feel the change would be suitable. 

I also changed the indenting and wording of the `do_constrained_layout` docstring.

Both issues were flagged by Matthias Bussonier in the Scipy2020 Sprint slack channel as easy to get started. Thanks!


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
