### PR TITLE
Add earlier color validation

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2255,7 +2255,7 @@ def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
         Whether to print *_values* when raising ValueError
     **kwargs : dict-like
         *key, values* pairs as keyword arguments to find in *_values*
-    
+
     Raises
     ------
     ValueError

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2242,7 +2242,7 @@ def _check_isinstance(_types, **kwargs):
                     type_name(type(v))))
 
 
-def _check_in_list(_values, **kwargs):
+def _check_in_list(_values, _print_supported_values=True, **kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* is in *_values*;
     if not, raise an appropriate ValueError.
@@ -2254,9 +2254,13 @@ def _check_in_list(_values, **kwargs):
     values = _values
     for k, v in kwargs.items():
         if v not in values:
-            raise ValueError(
-                "{!r} is not a valid value for {}; supported values are {}"
-                .format(v, k, ', '.join(map(repr, values))))
+            if _print_supported_values:
+                raise ValueError(
+                    "{!r} is not a valid value for {}; supported values are {}"
+                    .format(v, k, ', '.join(map(repr, values))))
+            else:
+                raise ValueError(
+                    "{!r} is not a valid value for {}".format(v, k))
 
 
 def _check_shape(_shape, **kwargs):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2242,7 +2242,7 @@ def _check_isinstance(_types, **kwargs):
                     type_name(type(v))))
 
 
-def _check_in_list(_values, _print_supported_values=True, **kwargs):
+def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* is in *_values*;
     if not, raise an appropriate ValueError.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2244,8 +2244,7 @@ def _check_isinstance(_types, **kwargs):
 
 def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
     """
-    For each *key, value* pair in *kwargs*, check that *value* is in *_values*;
-    if not, raise an appropriate ValueError.
+    For each *key, value* pair in *kwargs*, check that *value* is in *_values*.
 
     Parameters
     ----------
@@ -2254,7 +2253,7 @@ def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
     _print_supported_values : bool, default: True
         Whether to print *_values* when raising ValueError
     **kwargs : dict-like
-        *key, values* pairs as keyword arguments to find in *_values*
+        *key, value* pairs as keyword arguments to find in *_values*
 
     Raises
     ------

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2249,31 +2249,31 @@ def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
     Parameters
     ----------
     _values : iterable
-        Sequence of values to check on
+        Sequence of values to check on.
     _print_supported_values : bool, default: True
-        Whether to print *_values* when raising ValueError
-    **kwargs : dict-like
-        *key, value* pairs as keyword arguments to find in *_values*
+        Whether to print *_values* when raising ValueError.
+    **kwargs : dict
+        *key, value* pairs as keyword arguments to find in *_values*.
 
     Raises
     ------
     ValueError
-        If any *value* in *kwargs* is not found in *_values*
+        If any *value* in *kwargs* is not found in *_values*.
 
     Examples
     --------
     >>> cbook._check_in_list(["foo", "bar"], arg=arg, other_arg=other_arg)
     """
     values = _values
-    for k, v in kwargs.items():
-        if v not in values:
+    for key, val in kwargs.items():
+        if val not in values:
             if _print_supported_values:
                 raise ValueError(
-                    "{!r} is not a valid value for {}; supported values are {}"
-                    .format(v, k, ', '.join(map(repr, values))))
+                    f"{val!r} is not a valid value for {key}; "
+                    f"supported values are {', '.join(map(repr, values))}")
             else:
                 raise ValueError(
-                    "{!r} is not a valid value for {}".format(v, k))
+                    f"{val!r} is not a valid value for {key}")
 
 
 def _check_shape(_shape, **kwargs):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2247,6 +2247,20 @@ def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
     For each *key, value* pair in *kwargs*, check that *value* is in *_values*;
     if not, raise an appropriate ValueError.
 
+    Parameters
+    ----------
+    _values : iterable
+        Sequence of values to check on
+    _print_supported_values : bool, default: True
+        Whether to print *_values* when raising ValueError
+    **kwargs : dict-like
+        *key, values* pairs as keyword arguments to find in *_values*
+    
+    Raises
+    ------
+    ValueError
+        If any *value* in *kwargs* is not found in *_values*
+
     Examples
     --------
     >>> cbook._check_in_list(["foo", "bar"], arg=arg, other_arg=other_arg)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -14,6 +14,7 @@ from . import artist, cbook, colors as mcolors, docstring, rcParams
 from .artist import Artist, allow_rasterization
 from .cbook import (
     _to_unmasked_float_array, ls_mapper, ls_mapper_r, STEP_LOOKUP_MAP)
+from .colors import is_color_like, get_named_colors_mapping
 from .markers import MarkerStyle
 from .path import Path
 from .transforms import (
@@ -1039,6 +1040,9 @@ class Line2D(Artist):
         ----------
         color : color
         """
+        if not is_color_like(color):
+            cbook._check_in_list(get_named_colors_mapping(),
+                                 _print_supported_values=False, color=color)
         self._color = color
         self.stale = True
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1040,7 +1040,7 @@ class Line2D(Artist):
         ----------
         color : color
         """
-        if not is_color_like(color):
+        if not is_color_like(color) and color != 'auto':
             cbook._check_in_list(get_named_colors_mapping(),
                                  _print_supported_values=False, color=color)
         self._color = color

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -100,6 +100,12 @@ def test_line_colors():
     fig.canvas.draw()
 
 
+def test_valid_colors():
+    line = mlines.Line2D([], [])
+    with pytest.raises(ValueError):
+        line.set_color("foobar")
+
+
 def test_linestyle_variants():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)


### PR DESCRIPTION
## PR Summary

This PR fixes #17865 by raising an error when an invalid `color` argument is passed.

```
>>> plt.plot([1, 2], c="foobar")
ValueError: 'foobar' is not a valid value for color
```


I used the `_check_in_list` method of `cbook` but had to add an additional parameter to avoid printing all the color values and flood the terminal.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant



<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
