### PR TITLE
DOC: Numpydoc format.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -273,9 +273,8 @@ def _get_executable_info(name):
 
     Returns
     -------
-
-    tuple or None
-        If the executable is found, a namedtuple with fields ``executable``
+    tuple
+        A namedtuple with fields ``executable``
         (`str`) and ``version`` (`distutils.version.LooseVersion`, or ``None``
         if the version cannot be determined).
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -273,9 +273,11 @@ def _get_executable_info(name):
 
     Returns
     -------
-    If the executable is found, a namedtuple with fields ``executable`` (`str`)
-    and ``version`` (`distutils.version.LooseVersion`, or ``None`` if the
-    version cannot be determined).
+
+    tuple or None:
+        If the executable is found, a namedtuple with fields ``executable``
+        (`str`) and ``version`` (`distutils.version.LooseVersion`, or ``None``
+        if the version cannot be determined).
 
     Raises
     ------

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -274,9 +274,9 @@ def _get_executable_info(name):
     Returns
     -------
     tuple
-        A namedtuple with fields ``executable``
-        (`str`) and ``version`` (`distutils.version.LooseVersion`, or ``None``
-        if the version cannot be determined).
+        A namedtuple with fields ``executable`` (`str`) and ``version``
+        (`distutils.version.LooseVersion`, or ``None`` if the version cannot be
+        determined).
 
     Raises
     ------

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -274,7 +274,7 @@ def _get_executable_info(name):
     Returns
     -------
 
-    tuple or None:
+    tuple or None
         If the executable is found, a namedtuple with fields ``executable``
         (`str`) and ``version`` (`distutils.version.LooseVersion`, or ``None``
         if the version cannot be determined).

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -934,11 +934,10 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     Returns
     -------
-
-    tuple (*Cxy*, *f*)
-        where *f* are the frequencies of the coherence vector. For cohere,
-        scaling the individual densities by the sampling frequency has no
-        effect, since the factors cancel out.
+    Cxy : 1-D array
+        The coherence vector.
+    freqs : 1-D array
+            The frequencies for the elements in *Cxy*.
 
     See Also
     --------

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -934,10 +934,11 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     Returns
     -------
-    The return value is the tuple (*Cxy*, *f*), where *f* are the
-    frequencies of the coherence vector. For cohere, scaling the
-    individual densities by the sampling frequency has no effect,
-    since the factors cancel out.
+
+    tuple (*Cxy*, *f*)
+        where *f* are the frequencies of the coherence vector. For cohere,
+        scaling the individual densities by the sampling frequency has no
+        effect, since the factors cancel out.
 
     See Also
     --------


### PR DESCRIPTION
Returns is supposed to be a description list to be properly parsed by
numpydoc, otherwise each line is parsed as an individual item.

- [x] Documentation is sphinx and numpydoc compliant