### PR TITLE
Use indexed color for PNG images in PDF files when possible

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1521,28 +1521,33 @@ end"""
                 alpha = None
             return rgb, alpha
 
-    def _writePng(self, data):
+    def _writePng(self, img):
         """
-        Write the image *data* into the pdf file using png
+        Write the image *img* into the pdf file using png
         predictors with Flate compression.
         """
         buffer = BytesIO()
-        if data.shape[-1] == 1:
-            data = data.squeeze(axis=-1)
-        Image.fromarray(data).save(buffer, format="png")
+        img.save(buffer, format="png")
         buffer.seek(8)
+        png_data = bit_depth = palette = None
         while True:
             length, type = struct.unpack(b'!L4s', buffer.read(8))
-            if type == b'IDAT':
+            if type in [b'IHDR', b'PLTE', b'IDAT']:
                 data = buffer.read(length)
                 if len(data) != length:
                     raise RuntimeError("truncated data")
-                self.currentstream.write(data)
+                if type == b'IHDR':
+                    bit_depth = int(data[8])
+                elif type == b'PLTE':
+                    palette = data
+                elif type == b'IDAT':
+                    png_data = data
             elif type == b'IEND':
                 break
             else:
                 buffer.seek(length, 1)
             buffer.seek(4, 1)   # skip CRC
+        return png_data, bit_depth, palette
 
     def _writeImg(self, data, id, smask=None):
         """
@@ -1561,6 +1566,34 @@ end"""
         if smask:
             obj['SMask'] = smask
         if mpl.rcParams['pdf.compression']:
+            if data.shape[-1] == 1:
+                data = data.squeeze(axis=-1)
+            img = Image.fromarray(data)
+            img_colors = img.getcolors(maxcolors=256)
+            if img_colors is not None:
+                # Convert to indexed color if there are 256 colors or fewer
+                # This can significantly reduce the file size
+                num_colors = len(img_colors)
+                img = img.convert(mode='P', dither=Image.NONE,
+                                  palette=Image.ADAPTIVE, colors=num_colors)
+                data, bit_depth, palette = self._writePng(img)
+                if bit_depth is None or palette is None:
+                    raise RuntimeError("invalid PNG header")
+                palette = palette[:num_colors * 3]  # Trim padding
+                if colors == 1:
+                    # The PNG format uses an RGB palette for all indexed color
+                    # images, but the PDF format allows for grayscale palettes.
+                    # Thus, we convert the palette.
+                    palette = palette[::3]
+                palette = pdfRepr(palette)
+                colorspace = obj['ColorSpace'].pdfRepr()
+                obj['ColorSpace'] = Verbatim(b'[/Indexed ' + colorspace + b' '
+                                             + str(num_colors - 1).encode()
+                                             + b' ' + palette + b']')
+                obj['BitsPerComponent'] = bit_depth
+                colors = 1
+            else:
+                data, _, _ = self._writePng(img)
             png = {'Predictor': 10, 'Colors': colors, 'Columns': width}
         else:
             png = None
@@ -1571,7 +1604,7 @@ end"""
             png=png
             )
         if png:
-            self._writePng(data)
+            self.currentstream.write(data)
         else:
             self.currentstream.write(data.tobytes())
         self.endStream()

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1570,7 +1570,7 @@ end"""
                 data = data.squeeze(axis=-1)
             img = Image.fromarray(data)
             img_colors = img.getcolors(maxcolors=256)
-            if img_colors is not None:
+            if colors == 3 and img_colors is not None:
                 # Convert to indexed color if there are 256 colors or fewer
                 # This can significantly reduce the file size
                 num_colors = len(img_colors)
@@ -1580,14 +1580,8 @@ end"""
                 if bit_depth is None or palette is None:
                     raise RuntimeError("invalid PNG header")
                 palette = palette[:num_colors * 3]  # Trim padding
-                if colors == 1:
-                    # The PNG format uses an RGB palette for all indexed color
-                    # images, but the PDF format allows for grayscale palettes.
-                    # Thus, we convert the palette.
-                    palette = palette[::3]
                 palette = pdfRepr(palette)
-                colorspace = obj['ColorSpace'].pdfRepr()
-                obj['ColorSpace'] = Verbatim(b'[/Indexed ' + colorspace + b' '
+                obj['ColorSpace'] = Verbatim(b'[/Indexed /DeviceRGB '
                                              + str(num_colors - 1).encode()
                                              + b' ' + palette + b']')
                 obj['BitsPerComponent'] = bit_depth

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1529,7 +1529,8 @@ end"""
         buffer = BytesIO()
         img.save(buffer, format="png")
         buffer.seek(8)
-        png_data = bit_depth = palette = None
+        png_data = b''
+        bit_depth = palette = None
         while True:
             length, type = struct.unpack(b'!L4s', buffer.read(8))
             if type in [b'IHDR', b'PLTE', b'IDAT']:
@@ -1541,7 +1542,7 @@ end"""
                 elif type == b'PLTE':
                     palette = data
                 elif type == b'IDAT':
-                    png_data = data
+                    png_data += data
             elif type == b'IEND':
                 break
             else:

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -732,7 +732,11 @@ def test_log_scale_image():
     ax.set(yscale='log')
 
 
-@image_comparison(['rotate_image'], remove_text=True)
+# Increased tolerance is needed for PDF test to avoid failure. After the PDF
+# backend was modified to use indexed color, there are ten pixels that differ
+# due to how the subpixel calculation is done when converting the PDF files to
+# PNG images.
+@image_comparison(['rotate_image'], remove_text=True, tol=0.35)
 def test_rotate_image():
     delta = 0.25
     x = y = np.arange(-3.0, 3.0, delta)


### PR DESCRIPTION
## PR Summary

This pull requests modifies the PDF backend to use indexed color for PNG images in PDF files when possible.

When PNG images have 256 colors or fewer, it converts them to indexed color before saving them in a PDF. This can result in a significant reduction in file size in some cases. The is particularly true for raster data that uses a colormap but no interpolation, such as [Healpy](https://github.com/healpy/healpy) `mollview` plots (for some of the maps I tested, the new PDFs are less than half the size).

Currently, this is only done for RGB images. For grayscale images with 128 colors or fewer, there should also be an improvement, since this allows for 4-bit indexed color (or lower) instead of 8-bit grayscale. However, Pillow seems to always use 8-bit indexed color, so there's no improvement in practice. Edit: The PDF specification requires that soft-mask images must use the `DeviceGray` color space, so they can't be indexed color; this would further complicate extending indexed color to grayscale images, since the PDF backend uses soft-masks.

## PR Checklist

- [ ] [Existing PDF tests should cover this] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] [Not applicable] New features are documented, with examples if plot related
- [ ] [Not applicable] Documentation is sphinx and numpydoc compliant
- [ ] [Not applicable] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] [Not applicable] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
