### PR TITLE
Force origin='upper' in pyplot.specgram

### DIFF
--- a/doc/api/next_api_changes/behavior/17897-KLP.rst
+++ b/doc/api/next_api_changes/behavior/17897-KLP.rst
@@ -1,11 +1,9 @@
-pyplot.specgram uses origin='upper' even if an different kwarg or rcParam value is set  
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+pyplot.specgram always uses origin='upper'
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously if ``image.origin`` was set to something other than upper or if 
-the ``origin`` kwarg was passed with a value other than upper, the spectrogram
-itself would flip, but the axes would remain oriented for an origin value 
+Previously if ``image.origin`` was set to something other than 'upper' or if 
+the ``origin`` keyword argument was passed with a value other than 'upper', the spectrogram itself would flip, but the axes would remain oriented for an origin value 
 of 'upper', so that the resulting plot was incorrectly labelled.
 
-Now, the ``origin`` kwarg is not supported and the ``image.origin`` rcParam is ignored.
-The function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that
-the axes are correct for the plotted spectrogram.
+Now, the ``origin`` keyword argument is not supported and the ``image.origin`` rcParam 
+is ignored. The function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that the axes are correct for the plotted spectrogram.

--- a/doc/api/next_api_changes/behavior/17897-KLP.rst
+++ b/doc/api/next_api_changes/behavior/17897-KLP.rst
@@ -2,8 +2,10 @@ pyplot.specgram always uses origin='upper'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously if ``image.origin`` was set to something other than 'upper' or if 
-the ``origin`` keyword argument was passed with a value other than 'upper', the spectrogram itself would flip, but the axes would remain oriented for an origin value 
+the ``origin`` keyword argument was passed with a value other than 'upper', the 
+spectrogram itself would flip, but the axes would remain oriented for an origin value 
 of 'upper', so that the resulting plot was incorrectly labelled.
 
 Now, the ``origin`` keyword argument is not supported and the ``image.origin`` rcParam 
-is ignored. The function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that the axes are correct for the plotted spectrogram.
+is ignored. The function matplotlib.pyplot.specgram is forced to use ``origin='upper'``,
+so that the axes are correct for the plotted spectrogram.

--- a/doc/api/next_api_changes/behavior/17897-KLP.rst
+++ b/doc/api/next_api_changes/behavior/17897-KLP.rst
@@ -6,6 +6,6 @@ the ``origin`` kwarg was passed with a value other than upper, the spectrogram
 itself would flip, but the axes would remain oriented for an origin value 
 of 'upper', so that the resulting plot was incorrectly labelled.
 
-Now, the ``origin`` kwarg and ``image.origin`` rcParam are ignored and the 
-function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that
+Now, the ``origin`` kwarg is not supported and the ``image.origin`` rcParam is ignored.
+The function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that
 the axes are correct for the plotted spectrogram.

--- a/doc/api/next_api_changes/behavior/17897-KLP.rst
+++ b/doc/api/next_api_changes/behavior/17897-KLP.rst
@@ -1,0 +1,11 @@
+pyplot.specgram uses origin='upper' even if an different kwarg or rcParam value is set  
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously if ``image.origin`` was set to something other than upper or if 
+the ``origin`` kwarg was passed with a value other than upper, the spectrogram
+itself would flip, but the axes would remain oriented for an origin value 
+of 'upper', so that the resulting plot was incorrectly labelled.
+
+Now, the ``origin`` kwarg and ``image.origin`` rcParam are ignored and the 
+function matplotlib.pyplot.specgram is forced to use ``origin='upper'``, so that
+the axes are correct for the plotted spectrogram.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7466,6 +7466,7 @@ such objects
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
             which makes the specgram image. The origin keyword argument
             is not supported.
+            
         Returns
         -------
         spectrum : 2-D array

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7464,8 +7464,8 @@ such objects
 
         **kwargs
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
-            which makes the specgram image. The origin kwarg is ignored.
-
+            which makes the specgram image. The origin keyword argument
+            is not supported.
         Returns
         -------
         spectrum : 2-D array
@@ -7503,7 +7503,7 @@ such objects
         is set to 'psd'.
 
         The origin of the plot is forced to 'upper'. The image.origin rcParam
-        and the value of the origin kwarg, if passed, are ignored.
+        is ignored and passing origin as a keyword argument raises a `TypeError.`
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()
@@ -7552,7 +7552,10 @@ such objects
         freqs += Fc
         extent = xmin, xmax, freqs[0], freqs[-1]
 
-        kwargs.pop('origin', None)
+        if 'origin' in kwargs:
+            raise TypeError("specgram() got an unexpected keyword argument "
+                            "'origin'")
+
         im = self.imshow(Z, cmap, extent=extent, vmin=vmin, vmax=vmax,
                          origin='upper', **kwargs)
         self.axis('auto')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7548,8 +7548,10 @@ such objects
         xmin, xmax = xextent
         freqs += Fc
         extent = xmin, xmax, freqs[0], freqs[-1]
+
+        kwargs.pop('origin', None)
         im = self.imshow(Z, cmap, extent=extent, vmin=vmin, vmax=vmax,
-                         **kwargs)
+                         origin='upper', **kwargs)
         self.axis('auto')
 
         return spec, freqs, t, im

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7503,7 +7503,7 @@ such objects
         is set to 'psd'.
 
         The origin of the plot is forced to 'upper'. The image.origin rcParam
-        is ignored. Passing origin as a keyword argument raises a `TypeError.`
+        is ignored. Passing origin as a keyword argument raises a `TypeError`.
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7501,9 +7501,6 @@ such objects
         -----
         The parameters *detrend* and *scale_by_freq* do only apply when *mode*
         is set to 'psd'.
-
-        The origin of the plot is forced to 'upper'. The image.origin rcParam
-        is ignored. Passing origin as a keyword argument raises a `TypeError`.
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7502,8 +7502,8 @@ such objects
         The parameters *detrend* and *scale_by_freq* do only apply when *mode*
         is set to 'psd'.
 
-        The origin of the plot is forced to 'upper'. The origin rcParam and
-        the value of the origin kwarg, if passed, are ignored.
+        The origin of the plot is forced to 'upper'. The image.origin rcParam
+        and the value of the origin kwarg, if passed, are ignored.
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7464,7 +7464,7 @@ such objects
 
         **kwargs
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
-            which makes the specgram image.
+            which makes the specgram image. The origin kwarg is ignored.
 
         Returns
         -------
@@ -7501,6 +7501,9 @@ such objects
         -----
         The parameters *detrend* and *scale_by_freq* do only apply when *mode*
         is set to 'psd'.
+
+        The origin of the plot is forced to 'upper'. The origin rcParam and
+        the value of the origin kwarg, if passed, are ignored.
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7503,7 +7503,7 @@ such objects
         is set to 'psd'.
 
         The origin of the plot is forced to 'upper'. The image.origin rcParam
-        is ignored and passing origin as a keyword argument raises a `TypeError.`
+        is ignored. Passing origin as a keyword argument raises a `TypeError.`
         """
         if NFFT is None:
             NFFT = 256  # same default as in mlab.specgram()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7466,7 +7466,7 @@ such objects
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
             which makes the specgram image. The origin keyword argument
             is not supported.
-            
+
         Returns
         -------
         spectrum : 2-D array

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4099,6 +4099,22 @@ def test_specgram_fs_none():
     assert xmin == 32 and xmax == 96
 
 
+@check_figures_equal(extensions=["png"])
+def test_specgram_origin(fig_test, fig_ref):
+    """Test that specgram ignores origin='lower' and always uses origin='upper'."""
+    t = np.arange(0.0, 500)
+    signal = np.sin(2 * np.pi * 100 * t)
+
+    # Reference: First graph using default origin in imshow (upper),
+    fig_ref.subplots().specgram(signal)
+
+    # Try to overwrite the setting trying to flip the specgram
+    plt.rcParams["image.origin"] = 'lower'
+
+    # Test: origin='lower' should be ignored
+    fig_test.subplots().specgram(signal)
+
+
 @image_comparison(
     ["psd_freqs.png", "csd_freqs.png", "psd_noise.png", "csd_noise.png"],
     remove_text=True, tol=0.002)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4102,8 +4102,10 @@ def test_specgram_fs_none():
 @check_figures_equal(extensions=["png"])
 def test_specgram_origin(fig_test, fig_ref):
     """Test that specgram ignores origin='lower' and always uses origin='upper'."""
-    t = np.arange(0.0, 500)
-    signal = np.sin(2 * np.pi * 100 * t)
+    t = np.arange(500)
+    signal = np.sin(t)
+
+    plt.rcParams["image.origin"] = 'upper'
 
     # Reference: First graph using default origin in imshow (upper),
     fig_ref.subplots().specgram(signal)
@@ -4112,7 +4114,7 @@ def test_specgram_origin(fig_test, fig_ref):
     plt.rcParams["image.origin"] = 'lower'
 
     # Test: origin='lower' should be ignored
-    fig_test.subplots().specgram(signal)
+    fig_test.subplots().specgram(signal,  origin='lower')
 
 
 @image_comparison(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4117,13 +4117,13 @@ def test_specgram_origin_rcparam(fig_test, fig_ref):
     fig_test.subplots().specgram(signal)
 
 
-@pytest.mark.xfail(strict=True)
 def test_specgram_origin_kwarg():
-    """Ensure passing origin as a kwarg raises an exception."""
+    """Ensure passing origin as a kwarg raises a TypeError."""
     t = np.arange(500)
     signal = np.sin(t)
 
-    plt.specgram(signal, origin='lower')
+    with pytest.raises(TypeError):
+        plt.specgram(signal, origin='lower')
 
 
 @image_comparison(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4100,8 +4100,8 @@ def test_specgram_fs_none():
 
 
 @check_figures_equal(extensions=["png"])
-def test_specgram_origin(fig_test, fig_ref):
-    """Test that specgram ignores origin='lower' and always uses origin='upper'."""
+def test_specgram_origin_rcparam(fig_test, fig_ref):
+    """Test that specgram ignores the image.origin rcParam"""
     t = np.arange(500)
     signal = np.sin(t)
 
@@ -4114,7 +4114,16 @@ def test_specgram_origin(fig_test, fig_ref):
     plt.rcParams["image.origin"] = 'lower'
 
     # Test: origin='lower' should be ignored
-    fig_test.subplots().specgram(signal,  origin='lower')
+    fig_test.subplots().specgram(signal)
+
+
+@pytest.mark.xfail(strict=True)
+def test_specgram_origin_kwarg():
+    """Ensure passing origin as a kwarg raises an exception."""
+    t = np.arange(500)
+    signal = np.sin(t)
+
+    plt.specgram(signal, origin='lower')
 
 
 @image_comparison(

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -12,7 +12,8 @@ The :mod:`.style` package adds support for easy-to-switch plotting
 <customizing-with-matplotlibrc-files>` file (which is read at startup to
 configure Matplotlib).
 
-There are a number of pre-defined styles `provided by Matplotlib`_. For
+There are a number of pre-defined styles :doc:`provided by Matplotlib
+</gallery/style_sheets/style_sheets_reference>`. For
 example, there's a pre-defined style called "ggplot", which emulates the
 aesthetics of ggplot_ (a popular plotting package for R_). To use this style,
 just add:
@@ -202,4 +203,3 @@ plt.plot(data)
 #
 # .. _ggplot: https://ggplot2.tidyverse.org/
 # .. _R: https://www.r-project.org/
-# .. _provided by Matplotlib: https://github.com/matplotlib/matplotlib/tree/master/lib/matplotlib/mpl-data/stylelib


### PR DESCRIPTION
## PR Summary
Fix #17878

In ``pyplot.specgram``, the ``origin`` kwarg is popped. The ``origin`` is explicitly set to 'upper' 
in the call to ``imshow`` inside ``pyplot.specgram``. Test added to check that changing the 
``image.origin`` rcParam and the ``origin`` kwarg to 'lower' does not change the spectrogram. 
Documentation updated with note that ``image.origin`` rcParam and ``origin`` kwarg are ignored.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
