### PR TITLE
Add getters and _repr_html_ for over/under/bad values of Colormap objects.

### DIFF
--- a/doc/users/next_whats_new/colormap_get_under_over_bad.rst
+++ b/doc/users/next_whats_new/colormap_get_under_over_bad.rst
@@ -1,4 +1,4 @@
-Get over/under/bad colors of Colormap objects
+Get under/over/bad colors of Colormap objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `matplotlib.colors.Colormap` object now has methods

--- a/doc/users/next_whats_new/colormap_get_under_over_bad.rst
+++ b/doc/users/next_whats_new/colormap_get_under_over_bad.rst
@@ -1,0 +1,7 @@
+Get over/under/bad colors of Colormap objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `matplotlib.colors.Colormap` object now has methods
+`~colors.Colormap.get_under`, `~colors.Colormap.get_over`,
+`~colors.Colormap.get_bad` for the colors used for out-of-range and masked
+values.

--- a/doc/users/next_whats_new/colormap_get_under_over_bad.rst
+++ b/doc/users/next_whats_new/colormap_get_under_over_bad.rst
@@ -1,7 +1,7 @@
 Get under/over/bad colors of Colormap objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `matplotlib.colors.Colormap` object now has methods
+`matplotlib.colors.Colormap` now has methods
 `~colors.Colormap.get_under`, `~colors.Colormap.get_over`,
 `~colors.Colormap.get_bad` for the colors used for out-of-range and masked
 values.

--- a/doc/users/next_whats_new/colormap_get_under_over_bad.rst
+++ b/doc/users/next_whats_new/colormap_get_under_over_bad.rst
@@ -2,6 +2,6 @@ Get under/over/bad colors of Colormap objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `matplotlib.colors.Colormap` now has methods
-`~colors.Colormap.get_under`, `~colors.Colormap.get_over`,
-`~colors.Colormap.get_bad` for the colors used for out-of-range and masked
+`~.colors.Colormap.get_under`, `~.colors.Colormap.get_over`,
+`~.colors.Colormap.get_bad` for the colors used for out-of-range and masked
 values.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -614,12 +614,26 @@ class Colormap:
         cmapobject._global = False
         return cmapobject
 
+    def get_bad(self):
+        """Get the color for masked values."""
+        if not self._isinit:
+            self._init()
+        return self._lut[self._i_bad]
+
     def set_bad(self, color='k', alpha=None):
         """Set the color for masked values."""
         _warn_if_global_cmap_modified(self)
         self._rgba_bad = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+
+    def get_under(self):
+        """
+        Get the color for low out-of-range values when ``norm.clip = False``.
+        """
+        if not self._isinit:
+            self._init()
+        return self._lut[self._i_under]
 
     def set_under(self, color='k', alpha=None):
         """
@@ -629,6 +643,14 @@ class Colormap:
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
+
+    def get_over(self):
+        """
+        Get the color for high out-of-range values when ``norm.clip = False``.
+        """
+        if not self._isinit:
+            self._init()
+        return self._lut[self._i_over]
 
     def set_over(self, color='k', alpha=None):
         """

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -628,34 +628,26 @@ class Colormap:
             self._set_extremes()
 
     def get_under(self):
-        """
-        Get the color for low out-of-range values.
-        """
+        """Get the color for low out-of-range values."""
         if not self._isinit:
             self._init()
         return self._lut[self._i_under]
 
     def set_under(self, color='k', alpha=None):
-        """
-        Set the color for low out-of-range values.
-        """
+        """Set the color for low out-of-range values."""
         _warn_if_global_cmap_modified(self)
         self._rgba_under = to_rgba(color, alpha)
         if self._isinit:
             self._set_extremes()
 
     def get_over(self):
-        """
-        Get the color for high out-of-range values.
-        """
+        """Get the color for high out-of-range values."""
         if not self._isinit:
             self._init()
         return self._lut[self._i_over]
 
     def set_over(self, color='k', alpha=None):
-        """
-        Set the color for high out-of-range values.
-        """
+        """Set the color for high out-of-range values."""
         _warn_if_global_cmap_modified(self)
         self._rgba_over = to_rgba(color, alpha)
         if self._isinit:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -110,6 +110,8 @@ _colors_full_map.update({k.replace('gray', 'grey'): v
 _colors_full_map.update(BASE_COLORS)
 _colors_full_map = _ColorMapping(_colors_full_map)
 
+_REPR_PNG_SIZE = (512, 64)
+
 
 def get_named_colors_mapping():
     """Return the global mapping of names to named colors."""
@@ -700,8 +702,7 @@ class Colormap:
 
     def _repr_png_(self):
         """Generate a PNG representation of the Colormap."""
-        IMAGE_SIZE = (400, 50)
-        X = np.tile(np.linspace(0, 1, IMAGE_SIZE[0]), (IMAGE_SIZE[1], 1))
+        X = np.tile(np.linspace(0, 1, _REPR_PNG_SIZE[0]), (_REPR_PNG_SIZE[1], 1))
         pixels = self(X, bytes=True)
         png_bytes = io.BytesIO()
         title = self.name + ' color map'
@@ -736,7 +737,8 @@ class Colormap:
                 f'title="{self.name}" '
                 'style="border: 1px solid #555;" '
                 f'src="data:image/png;base64,{png_base64}"></div>'
-                '<div style="vertical-align: middle; max-width: 402px; '
+                '<div style="vertical-align: middle; '
+                f'max-width: {_REPR_PNG_SIZE[0]+2}px; '
                 'display: flex; justify-content: space-between;">'
                 '<div style="float: left;">'
                 f'{color_block(self.get_under())} under'

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -677,7 +677,7 @@ class Colormap:
         raise NotImplementedError("Abstract class only")
 
     def is_gray(self):
-        """Determine if the color map is grayscale."""
+        """Return whether the color map is grayscale."""
         if not self._isinit:
             self._init()
         return (np.all(self._lut[:, 0] == self._lut[:, 1]) and

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -726,12 +726,30 @@ class Colormap:
         """Generate an HTML representation of the Colormap."""
         png_bytes = self._repr_png_()
         png_base64 = base64.b64encode(png_bytes).decode('ascii')
-        return ('<strong>' + self.name + '</strong>' +
-                '<img ' +
+        def color_block(name, color):
+            hex_color = to_hex(color, keep_alpha=True)
+            return ('<span style="margin: 0 0.4em 0 0.4em;">' +
+                    '<span>' + name + ':</span> ' +
+                    '<div title="' + hex_color + '" ' +
+                    'style="display: inline-block; ' +
+                    'width: 1em; height: 1em; ' +
+                    'margin: 0; ' +
+                    'vertical-align: middle; ' +
+                    'border: 1px solid #555; ' +
+                    'background-color: ' + hex_color + ';"></div>' +
+                    '</span>')
+
+        return ('<div style="vertical-align: middle;">' +
+                '<strong>' + self.name + '</strong> ' +
+                color_block('under', self.get_under()) +
+                color_block('over', self.get_over()) +
+                color_block('bad', self.get_bad()) +
+                '</div>' +
+                '<div><img ' +
                 'alt="' + self.name + ' color map" ' +
                 'title="' + self.name + '"' +
                 'style="border: 1px solid #555;" ' +
-                'src="data:image/png;base64,' + png_base64 + '">')
+                'src="data:image/png;base64,' + png_base64 + '"></div>')
 
 
 class LinearSegmentedColormap(Colormap):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -728,7 +728,7 @@ class Colormap:
         png_base64 = base64.b64encode(png_bytes).decode('ascii')
         def color_block(name, color):
             hex_color = to_hex(color, keep_alpha=True)
-            return ('<span style="margin: 0 0.4em 0 0.4em;">' +
+            return ('<span style="margin-right: 0.8em;">' +
                     '<span>' + name + ':</span> ' +
                     '<div title="' + hex_color + '" ' +
                     'style="display: inline-block; ' +
@@ -741,15 +741,17 @@ class Colormap:
 
         return ('<div style="vertical-align: middle;">' +
                 '<strong>' + self.name + '</strong> ' +
-                color_block('under', self.get_under()) +
-                color_block('over', self.get_over()) +
-                color_block('bad', self.get_bad()) +
                 '</div>' +
                 '<div><img ' +
                 'alt="' + self.name + ' color map" ' +
                 'title="' + self.name + '"' +
                 'style="border: 1px solid #555;" ' +
-                'src="data:image/png;base64,' + png_base64 + '"></div>')
+                'src="data:image/png;base64,' + png_base64 + '"></div>' +
+                '<div style="vertical-align: middle;">' +
+                color_block('under', self.get_under()) +
+                color_block('bad', self.get_bad()) +
+                color_block('over', self.get_over()) +
+                '</div>')
 
 
 class LinearSegmentedColormap(Colormap):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -629,7 +629,7 @@ class Colormap:
 
     def get_under(self):
         """
-        Get the color for low out-of-range values when ``norm.clip = False``.
+        Get the color for low out-of-range values.
         """
         if not self._isinit:
             self._init()
@@ -637,7 +637,7 @@ class Colormap:
 
     def set_under(self, color='k', alpha=None):
         """
-        Set the color for low out-of-range values when ``norm.clip = False``.
+        Set the color for low out-of-range values.
         """
         _warn_if_global_cmap_modified(self)
         self._rgba_under = to_rgba(color, alpha)
@@ -646,7 +646,7 @@ class Colormap:
 
     def get_over(self):
         """
-        Get the color for high out-of-range values when ``norm.clip = False``.
+        Get the color for high out-of-range values.
         """
         if not self._isinit:
             self._init()
@@ -654,7 +654,7 @@ class Colormap:
 
     def set_over(self, color='k', alpha=None):
         """
-        Set the color for high out-of-range values when ``norm.clip = False``.
+        Set the color for high out-of-range values.
         """
         _warn_if_global_cmap_modified(self)
         self._rgba_over = to_rgba(color, alpha)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -726,31 +726,35 @@ class Colormap:
         """Generate an HTML representation of the Colormap."""
         png_bytes = self._repr_png_()
         png_base64 = base64.b64encode(png_bytes).decode('ascii')
-        def color_block(name, color):
+        def color_block(color):
             hex_color = to_hex(color, keep_alpha=True)
-            return ('<span style="margin-right: 0.8em;">' +
-                    '<span>' + name + ':</span> ' +
-                    '<div title="' + hex_color + '" ' +
+            return ('<div title="' + hex_color + '" ' +
                     'style="display: inline-block; ' +
                     'width: 1em; height: 1em; ' +
                     'margin: 0; ' +
                     'vertical-align: middle; ' +
                     'border: 1px solid #555; ' +
-                    'background-color: ' + hex_color + ';"></div>' +
-                    '</span>')
+                    'background-color: ' + hex_color + ';">' +
+                    '</div>')
 
         return ('<div style="vertical-align: middle;">' +
                 '<strong>' + self.name + '</strong> ' +
                 '</div>' +
-                '<div><img ' +
+                '<div class="cmap"><img ' +
                 'alt="' + self.name + ' color map" ' +
-                'title="' + self.name + '"' +
+                'title="' + self.name + '" ' +
                 'style="border: 1px solid #555;" ' +
                 'src="data:image/png;base64,' + png_base64 + '"></div>' +
-                '<div style="vertical-align: middle;">' +
-                color_block('under', self.get_under()) +
-                color_block('bad', self.get_bad()) +
-                color_block('over', self.get_over()) +
+                '<div style="vertical-align: middle; width: 402px; ' +
+                'display: flex; justify-content: space-between;">' +
+                '<div style="float: left;">' +
+                color_block(self.get_under()) + ' under' +
+                '</div>' +
+                '<div style="margin: 0 auto; display: inline-block;">' +
+                'bad ' + color_block(self.get_bad()) +
+                '</div>' +
+                '<div style="float: right;">' +
+                'over ' + color_block(self.get_over()) +
                 '</div>')
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -677,6 +677,7 @@ class Colormap:
         raise NotImplementedError("Abstract class only")
 
     def is_gray(self):
+        """Determine if the color map is grayscale."""
         if not self._isinit:
             self._init()
         return (np.all(self._lut[:, 0] == self._lut[:, 1]) and

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -720,33 +720,32 @@ class Colormap:
         png_base64 = base64.b64encode(png_bytes).decode('ascii')
         def color_block(color):
             hex_color = to_hex(color, keep_alpha=True)
-            return ('<div title="' + hex_color + '" ' +
-                    'style="display: inline-block; ' +
-                    'width: 1em; height: 1em; ' +
-                    'margin: 0; ' +
-                    'vertical-align: middle; ' +
-                    'border: 1px solid #555; ' +
-                    'background-color: ' + hex_color + ';">' +
-                    '</div>')
+            return (f'<div title="{hex_color}" '
+                    'style="display: inline-block; '
+                    'width: 1em; height: 1em; '
+                    'margin: 0; '
+                    'vertical-align: middle; '
+                    'border: 1px solid #555; '
+                    f'background-color: {hex_color};"></div>')
 
-        return ('<div style="vertical-align: middle;">' +
-                '<strong>' + self.name + '</strong> ' +
-                '</div>' +
-                '<div class="cmap"><img ' +
-                'alt="' + self.name + ' color map" ' +
-                'title="' + self.name + '" ' +
-                'style="border: 1px solid #555;" ' +
-                'src="data:image/png;base64,' + png_base64 + '"></div>' +
-                '<div style="vertical-align: middle; max-width: 402px; ' +
-                'display: flex; justify-content: space-between;">' +
-                '<div style="float: left;">' +
-                color_block(self.get_under()) + ' under' +
-                '</div>' +
-                '<div style="margin: 0 auto; display: inline-block;">' +
-                'bad ' + color_block(self.get_bad()) +
-                '</div>' +
-                '<div style="float: right;">' +
-                'over ' + color_block(self.get_over()) +
+        return ('<div style="vertical-align: middle;">'
+                f'<strong>{self.name}</strong> '
+                '</div>'
+                '<div class="cmap"><img '
+                f'alt="{self.name} color map" '
+                f'title="{self.name}" '
+                'style="border: 1px solid #555;" '
+                f'src="data:image/png;base64,{png_base64}"></div>'
+                '<div style="vertical-align: middle; max-width: 402px; '
+                'display: flex; justify-content: space-between;">'
+                '<div style="float: left;">'
+                f'{color_block(self.get_under())} under'
+                '</div>'
+                '<div style="margin: 0 auto; display: inline-block;">'
+                f'bad {color_block(self.get_bad())}'
+                '</div>'
+                '<div style="float: right;">'
+                f'over {color_block(self.get_over())}'
                 '</div>')
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -745,7 +745,7 @@ class Colormap:
                 'title="' + self.name + '" ' +
                 'style="border: 1px solid #555;" ' +
                 'src="data:image/png;base64,' + png_base64 + '"></div>' +
-                '<div style="vertical-align: middle; width: 402px; ' +
+                '<div style="vertical-align: middle; max-width: 402px; ' +
                 'display: flex; justify-content: space-between;">' +
                 '<div style="float: left;">' +
                 color_block(self.get_under()) + ' under' +

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -702,7 +702,8 @@ class Colormap:
 
     def _repr_png_(self):
         """Generate a PNG representation of the Colormap."""
-        X = np.tile(np.linspace(0, 1, _REPR_PNG_SIZE[0]), (_REPR_PNG_SIZE[1], 1))
+        X = np.tile(np.linspace(0, 1, _REPR_PNG_SIZE[0]),
+                    (_REPR_PNG_SIZE[1], 1))
         pixels = self(X, bytes=True)
         png_bytes = io.BytesIO()
         title = self.name + ' color map'

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1172,6 +1172,6 @@ def test_repr_html():
 
 def test_get_under_over_bad():
     cmap = plt.get_cmap('viridis')
-    assert_array_equal(cmap.get_under(), cmap(0.0))
-    assert_array_equal(cmap.get_over(), cmap(1.0))
+    assert_array_equal(cmap.get_under(), cmap(-np.inf))
+    assert_array_equal(cmap.get_over(), cmap(np.inf))
     assert_array_equal(cmap.get_bad(), cmap(np.nan))

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -5,6 +5,7 @@ from io import BytesIO
 import numpy as np
 from PIL import Image
 import pytest
+import base64
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
@@ -1168,7 +1169,7 @@ def test_repr_html():
     html = cmap._repr_html_()
     assert len(html) > 0
     png = cmap._repr_png_()
-    assert len(html) > len(png)
+    assert base64.b64encode(png).decode('ascii') in html
     assert cmap.name in html
     assert html.startswith('<div')
     assert html.endswith('</div>')

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1169,6 +1169,7 @@ def test_repr_html():
     assert len(html) > 0
     assert cmap.name in html
 
+
 def test_get_under_over_bad():
     cmap = plt.get_cmap('viridis')
     assert_array_equal(cmap.get_under(), cmap(0.0))

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -303,6 +303,9 @@ def test_BoundaryNorm():
     cmref.set_under('white')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red', 'black'])
 
+    assert_array_equal(cmref.get_over(), mcolors.to_rgba('black'))
+    assert_array_equal(cmref.get_under(), mcolors.to_rgba('white'))
+
     refnorm = mcolors.BoundaryNorm(bounds, cmref.N)
     mynorm = mcolors.BoundaryNorm(bounds, cmshould.N, extend='both')
     assert mynorm.vmin == refnorm.vmin
@@ -323,6 +326,8 @@ def test_BoundaryNorm():
     cmref.set_under('white')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red'])
 
+    assert_array_equal(cmref.get_under(), mcolors.to_rgba('white'))
+
     assert cmref.N == 2
     assert cmshould.N == 3
     refnorm = mcolors.BoundaryNorm(bounds, cmref.N)
@@ -338,6 +343,8 @@ def test_BoundaryNorm():
     cmref = mcolors.ListedColormap(['blue', 'red'])
     cmref.set_over('black')
     cmshould = mcolors.ListedColormap(['blue', 'red', 'black'])
+
+    assert_array_equal(cmref.get_over(), mcolors.to_rgba('black'))
 
     assert cmref.N == 2
     assert cmshould.N == 3
@@ -1161,3 +1168,9 @@ def test_repr_html():
     html = cmap._repr_html_()
     assert len(html) > 0
     assert cmap.name in html
+
+def test_get_under_over_bad():
+    cmap = plt.get_cmap('viridis')
+    assert_array_equal(cmap.get_under(), cmap(0.0))
+    assert_array_equal(cmap.get_over(), cmap(1.0))
+    assert_array_equal(cmap.get_bad(), cmap(np.nan))

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1167,7 +1167,11 @@ def test_repr_html():
     cmap = plt.get_cmap('viridis')
     html = cmap._repr_html_()
     assert len(html) > 0
+    png = cmap._repr_png_()
+    assert len(html) > len(png)
     assert cmap.name in html
+    assert html.startswith('<div')
+    assert html.endswith('</div>')
 
 
 def test_get_under_over_bad():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -303,8 +303,8 @@ def test_BoundaryNorm():
     cmref.set_under('white')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red', 'black'])
 
-    assert_array_equal(cmref.get_over(), mcolors.to_rgba('black'))
-    assert_array_equal(cmref.get_under(), mcolors.to_rgba('white'))
+    assert mcolors.same_color(cmref.get_over(), 'black')
+    assert mcolors.same_color(cmref.get_under(), 'white')
 
     refnorm = mcolors.BoundaryNorm(bounds, cmref.N)
     mynorm = mcolors.BoundaryNorm(bounds, cmshould.N, extend='both')
@@ -326,7 +326,7 @@ def test_BoundaryNorm():
     cmref.set_under('white')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red'])
 
-    assert_array_equal(cmref.get_under(), mcolors.to_rgba('white'))
+    assert mcolors.same_color(cmref.get_under(), 'white')
 
     assert cmref.N == 2
     assert cmshould.N == 3
@@ -344,7 +344,7 @@ def test_BoundaryNorm():
     cmref.set_over('black')
     cmshould = mcolors.ListedColormap(['blue', 'red', 'black'])
 
-    assert_array_equal(cmref.get_over(), mcolors.to_rgba('black'))
+    assert mcolors.same_color(cmref.get_over(), 'black')
 
     assert cmref.N == 2
     assert cmshould.N == 3


### PR DESCRIPTION
## PR Summary

This PR extends from #17888 to add over/under/bad values in the `_repr_html_` of `matplotlib.colors.Colormap` objects. This also adds public getters for those values, which previously had only setters.

## Demo

![image](https://user-images.githubusercontent.com/3943761/89747011-68f96580-da82-11ea-8353-8d7a7ab5b0cf.png)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [x] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way