### PR TITLE
DOC: Autoreformating of backend/*.py

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -545,16 +545,13 @@ class FigureCanvasAgg(FigureCanvasBase):
             the JPEG compression algorithm, and results in large files
             with hardly any gain in image quality.  This parameter is
             deprecated.
-
         optimize : bool, default: False
             Whether the encoder should make an extra pass over the image
             in order to select optimal encoder settings.  This parameter is
             deprecated.
-
         progressive : bool, default: False
             Whether the image should be stored as a progressive JPEG file.
             This parameter is deprecated.
-
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to
             `PIL.Image.Image.save` when saving the figure.  These take

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -20,21 +20,16 @@ class MixedModeRenderer:
         ----------
         figure : `matplotlib.figure.Figure`
             The figure instance.
-
         width : scalar
             The width of the canvas in logical units
-
         height : scalar
             The height of the canvas in logical units
-
         dpi : float
             The dpi of the canvas
-
         vector_renderer : `matplotlib.backend_bases.RendererBase`
             An instance of a subclass of
             `~matplotlib.backend_bases.RendererBase` that will be used for the
             vector drawing.
-
         raster_renderer_class : `matplotlib.backend_bases.RendererBase`
             The renderer class to use for the raster drawing.  If not provided,
             this will use the Agg backend (which is currently the only viable

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -150,6 +150,7 @@ def _create_pdf_info_dict(backend, metadata):
     ----------
     backend : str
         The name of the backend to use in the Producer value.
+
     metadata : Dict[str, Union[str, datetime, Name]]
         A dictionary of metadata supplied by the user with information
         following the PDF specification, also defined in
@@ -451,7 +452,6 @@ class Stream:
         """
         Parameters
         ----------
-
         id : int
             Object id of the stream.
         len : Reference or None
@@ -539,9 +539,9 @@ class PdfFile:
         """
         Parameters
         ----------
-
         filename : str or path-like or file-like
             Output target; if a string, a file will be opened for writing.
+
         metadata : dict from strings to strings and dates
             Information dictionary object (see PDF reference section 10.2.1
             'Document Information Dictionary'), e.g.:
@@ -2470,9 +2470,11 @@ class PdfPages:
             Plots using `PdfPages.savefig` will be written to a file at this
             location. The file is opened at once and any older file with the
             same name is overwritten.
+
         keep_empty : bool, optional
             If set to False, then empty pdf files will be deleted automatically
             when closed.
+
         metadata : dict, optional
             Information dictionary object (see PDF reference section 10.2.1
             'Document Information Dictionary'), e.g.:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -1024,9 +1024,11 @@ class PdfPages:
         filename : str or path-like
             Plots using `PdfPages.savefig` will be written to a file at this
             location. Any older file with the same name is overwritten.
+
         keep_empty : bool, default: True
             If set to False, then empty pdf files will be deleted automatically
             when closed.
+
         metadata : dict, optional
             Information dictionary object (see PDF reference section 10.2.1
             'Document Information Dictionary'), e.g.:

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -198,7 +198,7 @@ class XMLWriter:
         tag
             Element tag.  If given, the tag must match the start tag.  If
             omitted, the current element is closed.
-       """
+        """
         if tag:
             assert self.__tags, "unbalanced end(%s)" % tag
             assert escape_cdata(tag) == self.__tags[-1], \
@@ -1023,11 +1023,11 @@ class RendererSVG(RendererBase):
         Parameters
         ----------
         s : str
-          text to be converted
+            text to be converted
         prop : `matplotlib.font_manager.FontProperties`
-          font property
+            font property
         ismath : bool
-          If True, use mathtext parser. If "TeX", use *usetex* mode.
+            If True, use mathtext parser. If "TeX", use *usetex* mode.
         """
         writer = self.writer
 
@@ -1278,6 +1278,7 @@ class FigureCanvasSVG(FigureCanvasBase):
         ----------
         filename : str or path-like or file-like
             Output target; if a string, a file will be opened for writing.
+
         metadata : Dict[str, Any], optional
             Metadata in the SVG file defined as key-value pairs of strings,
             datetimes, or lists of strings, e.g., ``{'Creator': 'My software',

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -217,7 +217,6 @@ class FormWidget(QtWidgets.QWidget):
         data : list of (label, value) pairs
             The data to be edited in the form.
         comment : str, optional
-
         with_margin : bool, default: False
             If False, the form elements reach to the border of the widget.
             This is the desired behavior if the FormWidget is used as a widget


### PR DESCRIPTION
Most of the changes are whitespaces, mostly in Parameters/definitions
lines. You'll see two types, compact:

```
name : type
    description
name : type
    description
```

and spaced:

```
name : type
    description
<blankline>
name : type
    description
```

The heuristic is the following:
 - if any of the "description" is multiline and contain a blank line ->
 spaced.
 - otherwise -> compact.

