### PR TITLE
Fix figure size in path effects guide

### DIFF
--- a/tutorials/advanced/patheffects_guide.py
+++ b/tutorials/advanced/patheffects_guide.py
@@ -98,7 +98,7 @@ plt.show()
 # class with the original path.  The keywords to this effect are identical to
 # those of `.patches.PathPatch`:
 
-fig = plt.figure(figsize=(8, 1))
+fig = plt.figure(figsize=(8.5, 1))
 t = fig.text(0.02, 0.5, 'Hatch shadow', fontsize=75, weight=1000, va='center')
 t.set_path_effects([
     path_effects.PathPatchEffect(


### PR DESCRIPTION
## PR Summary

The figure was too small so that the text was clipped.

https://matplotlib.org/3.2.2/tutorials/advanced/patheffects_guide.html#greater-control-of-the-path-effect-artist

This PR increases the figure size so that the text is fully visible.