### PR TITLE
Fix release() method name in macosx backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -125,7 +125,8 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
     def draw_rubberband(self, event, x0, y0, x1, y1):
         self.canvas.set_rubberband(int(x0), int(y0), int(x1), int(y1))
 
-    def release(self, event):
+    def release_zoom(self, event):
+        super().release_zoom(event)
         self.canvas.remove_rubberband()
 
     def set_cursor(self, cursor):


### PR DESCRIPTION
Fixes #17905, I think this change was forgotten in https://github.com/matplotlib/matplotlib/commit/fb199bafc74fb488f646b86ac324eea1a9f3eb79. I have copied the changes to the wx backend in that commit, and verified locally that zooming works as intended without raising a deprecation warning.