### PR TITLE
frame_format to support all listed by animation writers

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -747,7 +747,8 @@ def validate_movie_writer(s):
 
 
 validate_movie_frame_fmt = ValidateInStrings(
-    'animation.frame_format', ['png', 'jpeg', 'tiff', 'raw', 'rgba'],
+    'animation.frame_format', ['png', 'jpeg', 'tiff', 'raw', 'rgba', 'ppm',
+                               'sgi', 'bmp', 'pbm', 'svg'],
     _deprecated_since="3.3")
 validate_axis_locator = ValidateInStrings(
     'major', ['minor', 'both', 'major'], _deprecated_since="3.3")
@@ -1491,7 +1492,8 @@ _validators = {
     "animation.codec":        validate_string,
     "animation.bitrate":      validate_int,
     # Controls image format when frames are written to disk
-    "animation.frame_format": ["png", "jpeg", "tiff", "raw", "rgba"],
+    "animation.frame_format": ["png", "jpeg", "tiff", "raw", "rgba", "ppm",
+                               "sgi", "bmp", "pbm", "svg"],
     # Additional arguments for HTML writer
     "animation.html_args":    validate_stringlist,
     # Path to ffmpeg binary. If just binary name, subprocess uses $PATH.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -204,9 +204,10 @@ def test_Issue_1713(tmpdir):
     assert rc.get('timezone') == 'UTC'
 
 
-def test_Issue_17908():
+def test_animation_frame_formats():
     # Animation frame_format should allow any of the following
     # if any of these are not allowed, an exception will be raised
+    # test for gh issue #17908
     for fmt in ['png', 'jpeg', 'tiff', 'raw', 'rgba', 'ppm',
                 'sgi', 'bmp', 'pbm', 'svg']:
         mpl.rcParams['animation.frame_format'] = fmt

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -204,6 +204,14 @@ def test_Issue_1713(tmpdir):
     assert rc.get('timezone') == 'UTC'
 
 
+def test_Issue_17908():
+    # Animation frame_format should allow any of the following
+    # if any of these are not allowed, an exception will be raised
+    for fmt in ['png', 'jpeg', 'tiff', 'raw', 'rgba', 'ppm',
+                'sgi', 'bmp', 'pbm', 'svg']:
+        mpl.rcParams['animation.frame_format'] = fmt
+
+
 def generate_validator_testcases(valid):
     validation_tests = (
         {'validator': validate_bool,


### PR DESCRIPTION
## PR Summary

Fixes #17908 .  As documented in the issue, various animation writers support different formats, and there is no way to set the format directly from the API.  This forces users to go through rcParams, but rcParams only listed a subset of frame formats.

This PR extends the supported frame formats in `rcsetup.py` to support any format supported by at least one writer.  If the user selects a format that is not supported by their chosen writer, an exception will be raised at runtime (rather than at configuration time).  This will allow a user to, for example, use `svg` format for `jshtml` output, which is not currently possible.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
