### PR TITLE
Deprecate hatch patterns with invalid values

### DIFF
--- a/doc/api/next_api_changes/deprecations/17926-ES.rst
+++ b/doc/api/next_api_changes/deprecations/17926-ES.rst
@@ -1,0 +1,5 @@
+Invalid hatch pattern characters are no longer ignored
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When specifying hatching patterns, characters that are not recognized will
+raise a DeprecationWarning. In the future, this will become a hard error.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -141,8 +141,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         hatch : str, optional
             Hatching pattern to use in filled paths, if any. Valid strings are
             ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']. See
-            :doc:`/gallery/shapes_and_collections/hatch_demo` for the meaning
-            of each hatch type.
+            :doc:`/gallery/shapes_and_collections/hatch_style_reference` for
+            the meaning of each hatch type.
         pickradius : float, default: 5.0
             If ``pickradius <= 0``, then `.Collection.contains` will return
             ``True`` whenever the test point is inside of one of the polygons

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -15,7 +15,7 @@ import numpy as np
 
 import matplotlib as mpl
 from . import (_path, artist, cbook, cm, colors as mcolors, docstring,
-               lines as mlines, path as mpath, transforms)
+               hatch as mhatch, lines as mlines, path as mpath, transforms)
 import warnings
 
 
@@ -522,6 +522,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         ----------
         hatch : {'/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*'}
         """
+        # Use validate_hatch(list) after deprecation.
+        mhatch._validate_hatch_pattern(hatch)
         self._hatch = hatch
         self.stale = True
 

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -1,6 +1,8 @@
 """Contains classes for generating hatch patterns."""
 
 import numpy as np
+
+from matplotlib import cbook
 from matplotlib.path import Path
 
 
@@ -179,6 +181,22 @@ _hatch_types = [
     SmallFilledCircles,
     Stars
     ]
+
+
+def _validate_hatch_pattern(hatch):
+    valid_hatch_patterns = set(r'-+|/\xXoO.*')
+    if hatch is not None:
+        invalids = set(hatch).difference(valid_hatch_patterns)
+        if invalids:
+            valid = ''.join(sorted(valid_hatch_patterns))
+            invalids = ''.join(sorted(invalids))
+            cbook.warn_deprecated(
+                '3.4',
+                message=f'hatch must consist of a string of "{valid}" or '
+                        'None, but found the following invalid values '
+                        f'"{invalids}". Passing invalid values is deprecated '
+                        'since %(since)s and will become an error %(removal)s.'
+            )
 
 
 def get_path(hatchpattern, density=6):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -8,7 +8,8 @@ import textwrap
 import numpy as np
 
 import matplotlib as mpl
-from . import artist, cbook, colors, docstring, lines as mlines, transforms
+from . import (artist, cbook, colors, docstring, hatch as mhatch,
+               lines as mlines, transforms)
 from .bezier import (
     NonIntersectingPathException, get_cos_sin, get_intersection,
     get_parallels, inside_circle, make_wedged_bezier2,
@@ -513,6 +514,8 @@ class Patch(artist.Artist):
         ----------
         hatch : {'/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*'}
         """
+        # Use validate_hatch(list) after deprecation.
+        mhatch._validate_hatch_pattern(hatch)
         self._hatch = hatch
         self.stale = True
 


### PR DESCRIPTION
## PR Summary

I noticed while going over the hatch doc PRs that we don't really validate this. This magically works because we just check for the count of the various hatch characters. Since it used to 'work', this adds a deprecation period over which people can fix their calls.

Also, use the new hatch style reference in the `Collection` docstring since that's more in line with what the docstring is asking for.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [x] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way