### PR TITLE
Improve hatch demo

### DIFF
--- a/examples/shapes_and_collections/hatch_demo.py
+++ b/examples/shapes_and_collections/hatch_demo.py
@@ -1,11 +1,20 @@
 """
 ==========
-Hatch Demo
+Hatch demo
 ==========
 
-Hatching (pattern filled polygons) is supported currently in the PS,
-PDF, SVG and Agg backends only.
+Hatches can be added to most polygons in Matplotlib, including `~.Axes.bar`,
+`~.Axes.fill_between`, `~.Axes.contourf`, and childern of `~.patches.Polygon`.
+They are currently supported in the PS, PDF, SVG, OSX, and Agg backends. The WX
+and Cairo backends do not currently support hatching.
+
+See also :doc:`/gallery/images_contours_and_fields/contourf_hatching` for
+an example using `~.Axes.contourf`, and
+:doc:`/gallery/shapes_and_collections/hatch_style_reference` for swatches
+of the existing hatches.
+
 """
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse, Polygon
@@ -14,23 +23,26 @@ x = np.arange(1, 5)
 y1 = np.arange(1, 5)
 y2 = np.ones(y1.shape) * 4
 
-fig, (ax1, ax2, ax3) = plt.subplots(3)
+fig = plt.figure()
+axs = fig.subplot_mosaic([['bar1', 'patches'], ['bar2', 'patches']])
 
-ax1.bar(x, y1, edgecolor='black', hatch="/")
-ax1.bar(x, y2, bottom=y1, edgecolor='black', hatch='//')
-ax1.set_xticks([1.5, 2.5, 3.5, 4.5])
+axs['bar1'].bar(x, y1, edgecolor='black', hatch="/")
+axs['bar1'].bar(x, y2, bottom=y1, edgecolor='black', hatch='//')
 
-ax2.bar(x, y1, edgecolor='black', hatch=['-', '+', 'x', '\\'])
-ax2.bar(x, y2, bottom=y1, edgecolor='black', hatch=['*', 'o', 'O', '.'])
-ax2.set_xticks([1.5, 2.5, 3.5, 4.5])
+axs['bar2'].bar(x, y1, edgecolor='black', hatch=['--', '+', 'x', '\\'])
+axs['bar2'].bar(x, y2, bottom=y1, edgecolor='black',
+                hatch=['*', 'o', 'O', '.'])
 
-ax3.fill([1, 3, 3, 1], [1, 1, 2, 2], fill=False, hatch='\\')
-ax3.add_patch(Ellipse((4, 1.5), 4, 0.5, fill=False, hatch='*'))
-ax3.add_patch(Polygon([[0, 0], [4, 1.1], [6, 2.5], [2, 1.4]], closed=True,
-                      fill=False, hatch='/'))
-ax3.set_xlim((0, 6))
-ax3.set_ylim((0, 2.5))
-
+x = np.arange(0, 40, 0.2)
+axs['patches'].fill_between(x, np.sin(x) * 4 + 30, y2=0,
+                            hatch='///', zorder=2, fc='c')
+axs['patches'].add_patch(Ellipse((4, 50), 10, 10, fill=True,
+                                 hatch='*', facecolor='y'))
+axs['patches'].add_patch(Polygon([(10, 20), (30, 50), (50, 10)],
+                                 hatch='\\/...', facecolor='g'))
+axs['patches'].set_xlim([0, 40])
+axs['patches'].set_ylim([10, 60])
+axs['patches'].set_aspect(1)
 plt.show()
 
 #############################################################################

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -3,8 +3,15 @@
 Hatch style reference
 =====================
 
-Hatching (pattern filled polygons) is currently supported in the backends
-PS, PDF, SVG and Agg. The backends OSX, WX and Cairo ignore hatching.
+Hatches can be added to most polygons in Matplotlib, including `~.Axes.bar`,
+`~.Axes.fill_between`, `~.Axes.contourf`, and childern of `~.patches.Polygon`.
+They are currently supported in the PS, PDF, SVG, OSX, and Agg backends. The WX
+and Cairo backends do not currently support hatching.
+
+See also :doc:`/gallery/images_contours_and_fields/contourf_hatching` for
+an example using `~.Axes.contourf`, and
+:doc:`/gallery/shapes_and_collections/hatch_demo` for more usage examples.
+
 """
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle


### PR DESCRIPTION
## PR Summary

Minor improvement to the hatch demo:

- more cross ref.
- OSX actually has hatches.  Not sure about WX or Cairo.  Updated that in `hatch_style_reference` and added a couple of crosslinks.

New demo is at:

https://41352-1385122-gh.circle-artifacts.com/0/doc/build/html/gallery/shapes_and_collections/hatch_demo.html#sphx-glr-gallery-shapes-and-collections-hatch-demo-py

Lightly modified hatch_reference_style.py: 

https://41352-1385122-gh.circle-artifacts.com/0/doc/build/html/gallery/shapes_and_collections/hatch_style_reference.html#sphx-glr-gallery-shapes-and-collections-hatch-style-reference-py

![Figure_1](https://user-images.githubusercontent.com/1562854/87504054-92a5a500-c61a-11ea-81ce-f551fa4b4fde.png)


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
