### PR TITLE
MNT: improve error messages on bad pdf metadata input

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -183,19 +183,19 @@ def _create_pdf_info_dict(backend, metadata):
     info = {k: v for (k, v) in info.items() if v is not None}
 
     def is_string_like(x):
-        """an instance of str"""
         return isinstance(x, str)
+    is_string_like.text_for_warning = "an instance of str"
 
     def is_date(x):
-        """an instance of datetime.datetime"""
         return isinstance(x, datetime)
+    is_date.text_for_warning = "an instance of datetime.datetime"
 
     def check_trapped(x):
-        """one of {"True", "False", "Unknown"}"""
         if isinstance(x, Name):
             return x.name in (b'True', b'False', b'Unknown')
         else:
             return x in ('True', 'False', 'Unknown')
+    check_trapped.text_for_warning = 'one of {"True", "False", "Unknown"}'
 
     keywords = {
         'Title': is_string_like,
@@ -215,7 +215,7 @@ def _create_pdf_info_dict(backend, metadata):
         elif not keywords[k](info[k]):
             cbook._warn_external(f'Bad value for infodict keyword {k}. '
                                  f'Got {info[k]!r} which is not '
-                                 f'{keywords[k].__doc__}.')
+                                 f'{keywords[k].text_for_warning}.')
     if 'Trapped' in info:
         info['Trapped'] = Name(info['Trapped'])
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -183,36 +183,39 @@ def _create_pdf_info_dict(backend, metadata):
     info = {k: v for (k, v) in info.items() if v is not None}
 
     def is_string_like(x):
+        """an instance of str"""
         return isinstance(x, str)
 
     def is_date(x):
+        """an instance of datetime.datetime"""
         return isinstance(x, datetime)
 
     def check_trapped(x):
+        """one of {"True", "False", "Unknown"}"""
         if isinstance(x, Name):
             return x.name in (b'True', b'False', b'Unknown')
         else:
             return x in ('True', 'False', 'Unknown')
 
     keywords = {
-        'Title': (is_string_like, 'an instance of str'),
-        'Author': (is_string_like, 'an instance of str'),
-        'Subject': (is_string_like, 'an instance of str'),
-        'Keywords': (is_string_like, 'an instance of str'),
-        'Creator': (is_string_like, 'an instance of  str'),
-        'Producer': (is_string_like, 'an instance of str'),
-        'CreationDate': (is_date, 'an instance of datetime.datetime'),
-        'ModDate': (is_date, 'an instance of datetime.datetime'),
-        'Trapped': (check_trapped, 'one of {"True", "False", "Unknown"}'),
+        'Title': is_string_like,
+        'Author': is_string_like,
+        'Subject': is_string_like,
+        'Keywords': is_string_like,
+        'Creator': is_string_like,
+        'Producer': is_string_like,
+        'CreationDate': is_date,
+        'ModDate': is_date,
+        'Trapped': check_trapped,
     }
     for k in info:
         if k not in keywords:
             cbook._warn_external(f'Unknown infodict keyword: {k!r}. '
                                  f'Must be one of {set(keywords)!r}.')
-        elif not keywords[k][0](info[k]):
+        elif not keywords[k](info[k]):
             cbook._warn_external(f'Bad value for infodict keyword {k}. '
                                  f'Got {info[k]!r} which is not '
-                                 f'{keywords[k][1]}.')
+                                 f'{keywords[k].__doc__}.')
     if 'Trapped' in info:
         info['Trapped'] = Name(info['Trapped'])
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -195,21 +195,24 @@ def _create_pdf_info_dict(backend, metadata):
             return x in ('True', 'False', 'Unknown')
 
     keywords = {
-        'Title': is_string_like,
-        'Author': is_string_like,
-        'Subject': is_string_like,
-        'Keywords': is_string_like,
-        'Creator': is_string_like,
-        'Producer': is_string_like,
-        'CreationDate': is_date,
-        'ModDate': is_date,
-        'Trapped': check_trapped,
+        'Title': (is_string_like, 'an instance of str'),
+        'Author': (is_string_like, 'an instance of str'),
+        'Subject': (is_string_like, 'an instance of str'),
+        'Keywords': (is_string_like, 'an instance of str'),
+        'Creator': (is_string_like, 'an instance of  str'),
+        'Producer': (is_string_like, 'an instance of str'),
+        'CreationDate': (is_date, 'an instance of datetime.datetime'),
+        'ModDate': (is_date, 'an instance of datetime.datetime'),
+        'Trapped': (check_trapped, 'one of {"True", "False", "Unknown"}'),
     }
     for k in info:
         if k not in keywords:
-            cbook._warn_external(f'Unknown infodict keyword: {k}')
-        elif not keywords[k](info[k]):
-            cbook._warn_external(f'Bad value for infodict keyword {k}')
+            cbook._warn_external(f'Unknown infodict keyword: {k!r}. '
+                                 f'Must be one of {set(keywords)!r}.')
+        elif not keywords[k][0](info[k]):
+            cbook._warn_external(f'Bad value for infodict keyword {k}. '
+                                 f'Got {info[k]!r} which is not '
+                                 f'{keywords[k][1]}.')
     if 'Trapped' in info:
         info['Trapped'] = Name(info['Trapped'])
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -161,6 +161,26 @@ def test_savefig_metadata(monkeypatch):
     }
 
 
+def test_invalid_metadata():
+    fig, ax = plt.subplots()
+
+    with pytest.warns(UserWarning,
+                      match="Unknown infodict keyword: 'foobar'."):
+        fig.savefig(io.BytesIO(), format='pdf', metadata={'foobar': 'invalid'})
+
+    with pytest.warns(UserWarning,
+                      match='not an instance of datetime.datetime.'):
+        fig.savefig(io.BytesIO(), format='pdf',
+                    metadata={'ModDate': '1968-08-01'})
+
+    with pytest.warns(UserWarning,
+                      match='not one of {"True", "False", "Unknown"}'):
+        fig.savefig(io.BytesIO(), format='pdf', metadata={'Trapped': 'foo'})
+
+    with pytest.warns(UserWarning, match='not an instance of str.'):
+        fig.savefig(io.BytesIO(), format='pdf', metadata={'Title': 1234})
+
+
 def test_multipage_metadata(monkeypatch):
     pikepdf = pytest.importorskip('pikepdf')
     monkeypatch.setenv('SOURCE_DATE_EPOCH', '0')


### PR DESCRIPTION

## PR Summary

Tell the user what keys and types are expected.

This still needs tests.  Happy if anyone wants to adopt the PR and finish it.


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
