### PR TITLE
Don't allow 1D lists as subplot_moasic layout.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1615,6 +1615,8 @@ default: 'top'
             """
             r0, *rest = inp
             for j, r in enumerate(rest, start=1):
+                if isinstance(r, str):
+                    raise ValueError('List layout specification must be 2D')
                 if len(r0) != len(r):
                     raise ValueError(
                         "All of the rows must be the same length, however "

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -725,6 +725,10 @@ class TestSubplotMosaic:
         axB = fig_ref.add_subplot(gs[1, 1])
         axB.set_title(labels[1])
 
+    def test_fail_list_of_str(self):
+        with pytest.raises(ValueError, match='must be 2D'):
+            plt.subplot_mosaic(['foo', 'bar'])
+
     @check_figures_equal(extensions=["png"])
     @pytest.mark.parametrize("subplot_kw", [{}, {"projection": "polar"}, None])
     def test_subplot_kw(self, fig_test, fig_ref, subplot_kw):


### PR DESCRIPTION
## PR Summary

`plt.subplot_mosaic(['foo', 'bar'])` created a layout
![image](https://user-images.githubusercontent.com/2836374/87597220-b556bd00-c6f1-11ea-9437-3e368d2e95ba.png)

which is probably surprising, the characters of the inner strings being interpreted as separate specifiers.

This PR chooses the strict solution and prohibits 1D lists of strings and raise a `ValueError` in this case.


### Alterantive solution
An alternative solution would be to allow it and create 
![image](https://user-images.githubusercontent.com/2836374/87597510-3615b900-c6f2-11ea-91a1-a9c4ac077b95.png)

E.g. we allow the string version to be 1D: `plt.subplot_mosaic('fb')` generates plots f and b side-by-side.

OTOH we can start with failing and add that feature later if wanted.

ping @tacaswell 


