### PR TITLE
Interpret subplot_moasic(['foo', 'bar']) as 1 row 2 cols

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1613,6 +1613,9 @@ default: 'top'
             2D object array
 
             """
+            if all(isinstance(e, str) for e in inp):
+                # ['foo', 'bar'] is interpreted as [['foo', 'bar']]
+                inp = [inp]
             r0, *rest = inp
             for j, r in enumerate(rest, start=1):
                 if len(r0) != len(r):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -726,6 +726,11 @@ class TestSubplotMosaic:
         axB.set_title(labels[1])
 
     @check_figures_equal(extensions=["png"])
+    def test_list_of_str(self, fig_test, fig_ref):
+        fig_test.subplot_mosaic(['foo', 'bar'])
+        fig_ref.subplot_mosaic([['foo', 'bar']])
+
+    @check_figures_equal(extensions=["png"])
     @pytest.mark.parametrize("subplot_kw", [{}, {"projection": "polar"}, None])
     def test_subplot_kw(self, fig_test, fig_ref, subplot_kw):
         x = [[1, 2]]


### PR DESCRIPTION
## PR Summary

Alternative to #17938. Personally, I'd slightly prefer it over raising. It's "obvious" and convenient and I expect many people will forget the second pair of brackets for simple side-by-side plots anyway.

`subplot_moasic(['foo', 'bar'])`

![image](https://user-images.githubusercontent.com/2836374/87597510-3615b900-c6f2-11ea-91a1-a9c4ac077b95.png)

This is similar to the string version: `plt.subplot_mosaic('fb')` generates plots f and b side-by-side.
