### PR TITLE
Sync Cairo's usetex measurement with base class.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -286,10 +286,12 @@ class RendererCairo(RendererBase):
     def get_text_width_height_descent(self, s, prop, ismath):
         # docstring inherited
 
+        if ismath == 'TeX':
+            return super().get_text_width_height_descent(s, prop, ismath)
+
         if ismath:
-            width, height, descent, fonts, used_characters = \
-                self.mathtext_parser.parse(s, self.dpi, prop)
-            return width, height, descent
+            dims = self.mathtext_parser.parse(s, self.dpi, prop)
+            return dims[0:3]  # return width, height, descent
 
         ctx = self.text_ctx
         # problem - scale remembers last setting and font can become


### PR DESCRIPTION
## PR Summary

I don't really know how to test this since we do so little Cairo testing (it's very broken if you just use it instead of Agg.)

I'm also a bit concerned that it's so 'simple' when @anntzer said it was wholly unsupported in #17594.

But this fixes #17932.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way