### PR TITLE
examples: fix a few deprecated subplot specifiers.

### DIFF
--- a/examples/axisartist/axis_direction_demo_step01.py
+++ b/examples/axisartist/axis_direction_demo_step01.py
@@ -25,7 +25,7 @@ def setup_axes(fig, rect):
 
 fig = plt.figure(figsize=(3, 2.5))
 fig.subplots_adjust(top=0.8)
-ax1 = setup_axes(fig, "111")
+ax1 = setup_axes(fig, 111)
 
 ax1.axis["x"].set_axis_direction("left")
 

--- a/examples/axisartist/axis_direction_demo_step02.py
+++ b/examples/axisartist/axis_direction_demo_step02.py
@@ -28,13 +28,13 @@ def setup_axes(fig, rect):
 fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
-ax1 = setup_axes(fig, "121")
+ax1 = setup_axes(fig, 121)
 ax1.axis["x"].set_ticklabel_direction("+")
 ax1.annotate("ticklabel direction=$+$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
 
-ax2 = setup_axes(fig, "122")
+ax2 = setup_axes(fig, 122)
 ax2.axis["x"].set_ticklabel_direction("-")
 ax2.annotate("ticklabel direction=$-$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",

--- a/examples/axisartist/axis_direction_demo_step03.py
+++ b/examples/axisartist/axis_direction_demo_step03.py
@@ -28,7 +28,7 @@ def setup_axes(fig, rect):
 fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
-ax1 = setup_axes(fig, "121")
+ax1 = setup_axes(fig, 121)
 ax1.axis["x"].label.set_text("Label")
 ax1.axis["x"].toggle(ticklabels=False)
 ax1.axis["x"].set_axislabel_direction("+")
@@ -36,7 +36,7 @@ ax1.annotate("label direction=$+$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
 
-ax2 = setup_axes(fig, "122")
+ax2 = setup_axes(fig, 122)
 ax2.axis["x"].label.set_text("Label")
 ax2.axis["x"].toggle(ticklabels=False)
 ax2.axis["x"].set_axislabel_direction("-")

--- a/examples/axisartist/axis_direction_demo_step04.py
+++ b/examples/axisartist/axis_direction_demo_step04.py
@@ -29,7 +29,7 @@ def setup_axes(fig, rect):
 fig = plt.figure(figsize=(6, 2.5))
 fig.subplots_adjust(bottom=0.2, top=0.8)
 
-ax1 = setup_axes(fig, "121")
+ax1 = setup_axes(fig, 121)
 ax1.axis["x1"].label.set_text("rotation=0")
 ax1.axis["x1"].toggle(ticklabels=False)
 
@@ -41,7 +41,7 @@ ax1.annotate("label direction=$+$", (0.5, 0), xycoords="axes fraction",
              xytext=(0, -10), textcoords="offset points",
              va="top", ha="center")
 
-ax2 = setup_axes(fig, "122")
+ax2 = setup_axes(fig, 122)
 
 ax2.axis["x1"].set_axislabel_direction("-")
 ax2.axis["x2"].set_axislabel_direction("-")

--- a/examples/axisartist/simple_axis_direction01.py
+++ b/examples/axisartist/simple_axis_direction01.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import mpl_toolkits.axisartist as axisartist
 
 fig = plt.figure(figsize=(4, 2.5))
-ax1 = fig.add_subplot(axisartist.Subplot(fig, "111"))
+ax1 = fig.add_subplot(axisartist.Subplot(fig, 111))
 fig.subplots_adjust(right=0.8)
 
 ax1.axis["left"].major_ticklabels.set_axis_direction("top")

--- a/examples/axisartist/simple_axis_direction03.py
+++ b/examples/axisartist/simple_axis_direction03.py
@@ -22,13 +22,13 @@ def setup_axes(fig, rect):
 fig = plt.figure(figsize=(5, 2))
 fig.subplots_adjust(wspace=0.4, bottom=0.3)
 
-ax1 = setup_axes(fig, "121")
+ax1 = setup_axes(fig, 121)
 ax1.set_xlabel("X-label")
 ax1.set_ylabel("Y-label")
 
 ax1.axis[:].invert_ticklabel_direction()
 
-ax2 = setup_axes(fig, "122")
+ax2 = setup_axes(fig, 122)
 ax2.set_xlabel("X-label")
 ax2.set_ylabel("Y-label")
 


### PR DESCRIPTION
## PR Summary

These examples produce a deprecation warning with mpl>3.3.0
Following PR #16527, use int instead of strings.

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
