### PR TITLE
Remove another overspecified latex geometry.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1107,8 +1107,7 @@ def convert_psfrags(tmpfile, psfrags, font_preamble, custom_preamble,
             mpl.rcParams["text.latex.preamble"] +
             r"\usepackage{psfrag,color}""\n"
             r"\usepackage[dvips]{graphicx}""\n"
-            r"\geometry{papersize={%(width)sin,%(height)sin},"
-            r"body={%(width)sin,%(height)sin},margin=0in}"
+            r"\geometry{papersize={%(width)sin,%(height)sin},margin=0in}"
             % {"width": paper_width, "height": paper_height}
     }):
         dvifile = TexManager().make_dvi(


### PR DESCRIPTION
## PR Summary

This is a corollary to #17847; specifying paper size, body and margin causes a warning from the geometry package.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way