### PR TITLE
ENH: Add version check for mac sdk version

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -657,7 +657,7 @@ class BackendMacOSX(OptionalPackage):
             'src/_macosx.m'
             ]
         ext = Extension('matplotlib.backends._macosx', sources)
-        ext.extra_compile_args.extend(['-Wunguarded-availability', '-Werror'])
+        ext.extra_compile_args.extend(['-Werror=unguarded-availability'])
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
         if platform.python_implementation().lower() == 'pypy':
             ext.extra_compile_args.append('-DPYPY=1')

--- a/setupext.py
+++ b/setupext.py
@@ -657,6 +657,8 @@ class BackendMacOSX(OptionalPackage):
             'src/_macosx.m'
             ]
         ext = Extension('matplotlib.backends._macosx', sources)
+        ext.extra_compile_args.extend(['-mmacosx-version-min=10.9',
+                                       '-Wunguarded-availability', '-Werror'])
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
         if platform.python_implementation().lower() == 'pypy':
             ext.extra_compile_args.append('-DPYPY=1')

--- a/setupext.py
+++ b/setupext.py
@@ -657,8 +657,7 @@ class BackendMacOSX(OptionalPackage):
             'src/_macosx.m'
             ]
         ext = Extension('matplotlib.backends._macosx', sources)
-        ext.extra_compile_args.extend(['-mmacosx-version-min=10.9',
-                                       '-Wunguarded-availability', '-Werror'])
+        ext.extra_compile_args.extend(['-Wunguarded-availability', '-Werror'])
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
         if platform.python_implementation().lower() == 'pypy':
             ext.extra_compile_args.append('-DPYPY=1')

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1184,8 +1184,10 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     rect.size.height = 0;
     rect.origin.x += height;
     NSTextView* messagebox = [[NSTextView alloc] initWithFrame: rect];
-    messagebox.textContainer.maximumNumberOfLines = 2;
-    messagebox.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
+    if (@available(macOS 10.11, *)) {
+        messagebox.textContainer.maximumNumberOfLines = 2;
+        messagebox.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
+    }
     [messagebox setFont: font];
     [messagebox setDrawsBackground: NO];
     [messagebox setSelectable: NO];


### PR DESCRIPTION
## PR Summary

This specifically lists the macOS SDK version (currently 10.11) needed to build the osx backend. It also turns on compiler warnings for when code uses features newer than the minimum version (and makes warnings errors for this file).

This should hopefully help CI catch when we start using API's past our minimum desired version. It's currently set to 10.9 specifically to see it now fail.

Questions: 
* Where in the docs should we document that we only support macOS >= 10.11?
* By having the compiler flag set the version, we override anywhere else right now using e.g. `MACOS_DEPLOYMENT_TARGET`. The problem right now is that most places (default Python builds, etc.) are using 10.9, so this has to be set somewhere for things to build properly out of the box.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
