### PR TITLE
DOCS: Remove How-to: Contributing

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -299,8 +299,8 @@ Contributing documentation
 ==========================
 
 You as an end-user of Matplotlib can a make valuable contribution because you
-more clearly see the potentials for improvement as compared to a core
-developer, e.g.
+more clearly see the potential for improvement than a core developer. 
+For example:
 
 - Fix a typo
 - Clarify a docstring

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -12,6 +12,8 @@ The project is hosted on https://github.com/matplotlib/matplotlib
 
 .. _coc: http://www.python.org/psf/codeofconduct/
 
+.. _submitting-a-bug-report:
+
 Submitting a bug report
 =======================
 
@@ -296,24 +298,31 @@ besides which, we frequently underestimate how easy an issue is to solve!
 Contributing documentation
 ==========================
 
-Code is not the only way to contribute to Matplotlib. For instance,
-documentation is also a very important part of the project and often doesn't
-get as much attention as it deserves. If you find a typo in the documentation,
-or have made improvements, do not hesitate to send an email to the mailing
-list or submit a GitHub pull request.  To make a pull request, refer to the
-guidelines outlined in :ref:`how-to-contribute`.
+You as an end-user of Matplotlib can a make valuable contribution because you
+more clearly see the potentials for improvement as compared to a core
+developer, e.g.
 
-Full documentation can be found under the :file:`doc/`, :file:`tutorials/`,
-and :file:`examples/` directories.
+- Fix a typo
+- Clarify a docstring
+- Write or update an :ref:`example plot <gallery>`
+- Write or update a comprehensive :ref:`tutorial <tutorials>`
+
+The documentation source files live in the same GitHub repository as the code.
+Contributions are proposed and accepted through the pull request process.
+For details see :ref:`how-to-contribute`.
+
+If you have trouble getting started, you may instead open an `issue`_
+describing the intended improvement.
+
+.. _issue: https://github.com/matplotlib/matplotlib/issues
 
 .. seealso::
   * :ref:`documenting-matplotlib`
 
-
 .. _other_ways_to_contribute:
 
 Other ways to contribute
-=========================
+========================
 
 It also helps us if you spread the word: reference the project from your blog
 and articles or link to it from your website!  If Matplotlib contributes to a

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -298,9 +298,8 @@ besides which, we frequently underestimate how easy an issue is to solve!
 Contributing documentation
 ==========================
 
-You as an end-user of Matplotlib can a make valuable contribution because you
-more clearly see the potential for improvement than a core developer. 
-For example:
+You as an end-user of Matplotlib can make a valuable contribution because you
+more clearly see the potential for improvement than a core developer. For example, you can:
 
 - Fix a typo
 - Clarify a docstring

--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -527,58 +527,6 @@ You may be able to work on separate figures from separate threads.  However,
 you must in that case use a *non-interactive backend* (typically Agg), because
 most GUI backends *require* being run from the main thread as well.
 
-.. _howto-contribute:
-
-How-to: Contributing
-====================
-
-.. _how-to-contribute-docs:
-
-Contribute to Matplotlib documentation
---------------------------------------
-
-Matplotlib is a big library, which is used in many ways, and the
-documentation has only scratched the surface of everything it can
-do.  So far, the place most people have learned all these features are
-through studying the :ref:`examples-index`, which is a
-recommended and great way to learn, but it would be nice to have more
-official narrative documentation guiding people through all the dark
-corners.  This is where you come in.
-
-There is a good chance you know more about Matplotlib usage in some
-areas, the stuff you do every day, than many of the core developers
-who wrote most of the documentation.  Just pulled your hair out
-compiling Matplotlib for Windows?  Write a FAQ or a section for the
-:ref:`installing-faq` page.  Are you a digital signal processing wizard?
-Write a tutorial on the signal analysis plotting functions like
-:func:`~matplotlib.pyplot.xcorr`, :func:`~matplotlib.pyplot.psd` and
-:func:`~matplotlib.pyplot.specgram`.  Do you use Matplotlib with
-`django <https://www.djangoproject.com/>`_ or other popular web
-application servers?  Write a FAQ or tutorial and we'll find a place
-for it in the :ref:`users-guide-index`.  And so on...  I think you get the
-idea.
-
-Matplotlib is documented using the `sphinx
-<http://www.sphinx-doc.org/en/stable/>`_ extensions to restructured text
-`(ReST) <http://docutils.sourceforge.net/rst.html>`_.  sphinx is an
-extensible python framework for documentation projects which generates
-HTML and PDF, and is pretty easy to write; you can see the source for this
-document or any page on this site by clicking on the *Show Source* link
-at the end of the page in the sidebar.
-
-The sphinx website is a good resource for learning sphinx, but we have
-put together a cheat-sheet at :ref:`documenting-matplotlib` which
-shows you how to get started, and outlines the Matplotlib conventions
-and extensions, e.g., for including plots directly from external code in
-your documents.
-
-Once your documentation contributions are working (and hopefully
-tested by actually *building* the docs) you can submit them as a patch
-against git.  See :ref:`install-git` and :ref:`pr-guidelines`.
-Looking for something to do?  Search for `TODO <../search.html?q=todo>`_
-or look at the open issues on github.
-
-
 .. _howto-webapp:
 
 How to use Matplotlib in a web application server


### PR DESCRIPTION
## PR Summary

Contributing is handled in the developer guide.

This PR removes the last "How-to: Contributing" section on documentation
and updates the section "Contributing documentation" in the developer
guide.

Follow-up to #17837 and #17842. Partly addresses #17920.