### PR TITLE
TST: Ignore deprecations when switching backends.

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -78,21 +78,21 @@ def mpl_test_settings(request):
             style, = style_marker.args
 
         matplotlib.testing.setup()
-        if backend is not None:
-            # This import must come after setup() so it doesn't load the
-            # default backend prematurely.
-            import matplotlib.pyplot as plt
-            try:
-                plt.switch_backend(backend)
-            except ImportError as exc:
-                # Should only occur for the cairo backend tests, if neither
-                # pycairo nor cairocffi are installed.
-                if 'cairo' in backend.lower() or skip_on_importerror:
-                    pytest.skip("Failed to switch to backend {} ({})."
-                                .format(backend, exc))
-                else:
-                    raise
         with cbook._suppress_matplotlib_deprecation_warning():
+            if backend is not None:
+                # This import must come after setup() so it doesn't load the
+                # default backend prematurely.
+                import matplotlib.pyplot as plt
+                try:
+                    plt.switch_backend(backend)
+                except ImportError as exc:
+                    # Should only occur for the cairo backend tests, if neither
+                    # pycairo nor cairocffi are installed.
+                    if 'cairo' in backend.lower() or skip_on_importerror:
+                        pytest.skip("Failed to switch to backend {} ({})."
+                                    .format(backend, exc))
+                    else:
+                        raise
             matplotlib.style.use(style)
         try:
             yield


### PR DESCRIPTION
## PR Summary

Otherwise, stuff like Qt4 backend cannot be tested because the deprecation warning will cause a failure.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way