### PR TITLE
Honor `'Date': None` in metadata

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -360,7 +360,8 @@ class RendererSVG(RendererBase):
                                  'Expected str, date, datetime, or iterable '
                                  'of the same, not {!r}.'.format(type(date)))
             metadata['Date'] = '/'.join(dates)
-        else:
+        elif 'Date' not in metadata:
+            # Do not add `Date` if the user explicitly set `Date` to `None`
             # Get source date from SOURCE_DATE_EPOCH, if set.
             # See https://reproducible-builds.org/specs/source-date-epoch/
             date = os.getenv("SOURCE_DATE_EPOCH")

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -371,6 +371,70 @@ def test_svg_default_metadata(monkeypatch):
     # Type
     assert 'StillImage' in buf
 
+    # Now make sure all the default metadata can be cleared.
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg', metadata={'Date': None, 'Creator': None,
+                                                'Format': None, 'Type': None})
+        buf = fd.getvalue().decode()
+
+    # Creator
+    assert mpl.__version__ not in buf
+    # Date
+    assert '1970-08-16' not in buf
+    # Format
+    assert 'image/svg+xml' not in buf
+    # Type
+    assert 'StillImage' not in buf
+
+
+def test_svg_clear_default_metadata(monkeypatch):
+    # Makes sure that setting a default metadata to `None`
+    # removes the corresponding tag from the metadata.
+    monkeypatch.setenv('SOURCE_DATE_EPOCH', '19680801')
+
+    metadata_contains = {'creator': mpl.__version__, 'date': '1970-08-16',
+                         'format': 'image/svg+xml', 'type': 'StillImage'}
+
+    SVGNS = '{http://www.w3.org/2000/svg}'
+    RDFNS = '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}'
+    CCNS = '{http://creativecommons.org/ns#}'
+    DCNS = '{http://purl.org/dc/elements/1.1/}'
+
+    fig, ax = plt.subplots()
+    for name in metadata_contains:
+        with BytesIO() as fd:
+            fig.savefig(fd, format='svg', metadata={name.title(): None})
+            buf = fd.getvalue().decode()
+
+        root = xml.etree.ElementTree.fromstring(buf)
+        work, = root.findall(f'./{SVGNS}metadata/{RDFNS}RDF/{CCNS}Work')
+        for key in metadata_contains:
+            data = work.findall(f'./{DCNS}{key}')
+            if key == name:
+                # The one we cleared is not there
+                assert not data
+                continue
+            # Everything else should be there
+            data, = data
+            xmlstr = xml.etree.ElementTree.tostring(data, encoding="unicode")
+            assert metadata_contains[key] in xmlstr
+
+
+def test_svg_clear_all_metadata():
+    # Makes sure that setting all default metadata to `None`
+    # removes the metadata tag from the output.
+
+    fig, ax = plt.subplots()
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg', metadata={'Date': None, 'Creator': None,
+                                                'Format': None, 'Type': None})
+        buf = fd.getvalue().decode()
+
+    SVGNS = '{http://www.w3.org/2000/svg}'
+
+    root = xml.etree.ElementTree.fromstring(buf)
+    assert not root.findall(f'./{SVGNS}metadata')
+
 
 def test_svg_metadata():
     single_value = ['Coverage', 'Identifier', 'Language', 'Relation', 'Source',


### PR DESCRIPTION
Allow removing the 'Date' metadata from output.

Fix #17968

## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
