### PR TITLE
Fixed #17970 - Docstrings should not accessed with -OO

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5307,8 +5307,10 @@ default: :rc:`scatter.edgecolors`
             "x", x, y1, y2,
             where=where, interpolate=interpolate, step=step, **kwargs)
 
-    fill_between.__doc__ = _fill_between_x_or_y.__doc__.format(
-        dir="horizontal", ind="x", dep="y")
+    if _fill_between_x_or_y.__doc__:
+        fill_between.__doc__ = _fill_between_x_or_y.__doc__.format(
+            dir="horizontal", ind="x", dep="y"
+        )
     fill_between = _preprocess_data(
         docstring.dedent_interpd(fill_between),
         replace_names=["x", "y1", "y2", "where"])
@@ -5319,8 +5321,10 @@ default: :rc:`scatter.edgecolors`
             "y", y, x1, x2,
             where=where, interpolate=interpolate, step=step, **kwargs)
 
-    fill_betweenx.__doc__ = _fill_between_x_or_y.__doc__.format(
-        dir="vertical", ind="y", dep="x")
+    if _fill_between_x_or_y.__doc__:
+        fill_betweenx.__doc__ = _fill_between_x_or_y.__doc__.format(
+            dir="vertical", ind="y", dep="x"
+        )
     fill_betweenx = _preprocess_data(
         docstring.dedent_interpd(fill_betweenx),
         replace_names=["y", "x1", "x2", "where"])


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
