### PR TITLE
gtk: Fix `draw` on unmapped windows.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -539,8 +539,10 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         self.message.set_label(s)
 
     def set_cursor(self, cursor):
-        self.canvas.get_property("window").set_cursor(cursord[cursor])
-        Gtk.main_iteration()
+        window = self.canvas.get_property("window")
+        if window is not None:
+            window.set_cursor(cursord[cursor])
+            Gtk.main_iteration()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -67,8 +67,7 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         self.queue_draw_area(x, y, width, height)
 
     def draw(self):
-        if self.get_visible() and self.get_mapped():
-            backend_agg.FigureCanvasAgg.draw(self)
+        backend_agg.FigureCanvasAgg.draw(self)
         super().draw()
 
     def print_png(self, filename, *args, **kwargs):


### PR DESCRIPTION
## PR Summary

Most other backends do not skip drawing on unmapped windows; this skip causes explicit draws to do nothing and breaks things that expect it to work.

For example, the `TextBox` example broke since the widget was changed to set text before showing the window (#17117). This required drawing to work in order to measure text size and place the caret.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
Maybe?