### PR TITLE
FIX: undeprecate and update num2epoch/epoch2num

### DIFF
--- a/doc/api/next_api_changes/deprecations/17983-JMK.rst
+++ b/doc/api/next_api_changes/deprecations/17983-JMK.rst
@@ -1,0 +1,8 @@
+Reverted deprecation of `~.dates.num2epoch` and `~.dates.epoch2num`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These two functions were deprecated in 3.3.0, and did not return
+an accurate Matplotlib datenum relative to the new Matplotlib epoch
+handling (`~.dates.get_epoch` and :rc:`date.epoch`).  This version
+reverts the deprecation and fixes those functions to work with
+`~.dates.get_epoch`. 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1750,21 +1750,45 @@ class MicrosecondLocator(DateLocator):
         return self._interval
 
 
-@cbook.deprecated("3.3")
 def epoch2num(e):
     """
-    Convert an epoch or sequence of epochs to the new date format,
-    that is days since 0001.
+    Convert UNIX time to days since Matplotlib epoch.
+
+    Parameters
+    ----------
+    e : list of floats
+        Time in seconds since 1970-01-01.
+
+    Returns
+    -------
+    `numpy.array`
+        Time in days since Matplotlib epoch (see `~.dates.get_epoch()`).
     """
-    return EPOCH_OFFSET + np.asarray(e) / SEC_PER_DAY
+
+    dt = (np.datetime64('1970-01-01T00:00:00', 's') -
+          np.datetime64(get_epoch(), 's')).astype(float)
+
+    return (dt + np.asarray(e)) / SEC_PER_DAY
 
 
-@cbook.deprecated("3.3")
 def num2epoch(d):
     """
-    Convert days since 0001 to epoch.  *d* can be a number or sequence.
+    Convert days since Matplotlib epoch to UNIX time.
+
+    Parameters
+    ----------
+    d : list of floats
+        Time in days since Matplotlib epoch (see `~.dates.get_epoch()`).
+
+    Returns
+    -------
+    `numpy.array`
+        Time in seconds since 1970-01-01.
     """
-    return (np.asarray(d) - EPOCH_OFFSET) * SEC_PER_DAY
+    dt = (np.datetime64('1970-01-01T00:00:00', 's') -
+          np.datetime64(get_epoch(), 's')).astype(float)
+
+    return np.asarray(d) * SEC_PER_DAY - dt
 
 
 @cbook.deprecated("3.2")

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -998,3 +998,15 @@ def test_change_interval_multiples():
     fig.canvas.draw()
     assert ax.get_xticklabels()[0].get_text() == 'Jan 15 2020'
     assert ax.get_xticklabels()[1].get_text() == 'Feb 01 2020'
+
+
+def test_epoch2num():
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('0000-12-31')
+    assert mdates.epoch2num(86400) == 719164.0
+    assert mdates.num2epoch(719165.0) == 86400 * 2
+    # set back to the default
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('1970-01-01T00:00:00')
+    assert mdates.epoch2num(86400) == 1.0
+    assert mdates.num2epoch(2.0) == 86400 * 2


### PR DESCRIPTION
## PR Summary

https://github.com/matplotlib/matplotlib/pull/15008 added a new variable epoch.

At the time I did not update the unfortunately named `epoch2num` and `num2epoch` because Matplotlib does not use these.  They are also ill-named because in this case `epoch` refers to a UNIX-like time of seconds since 1970-01-01, and thats not at all what an epoch is.  We also deprecated these functions at the time.

Unfortunately pandas uses them, and they need to be made compatible with the new epoch handling.  https://github.com/pandas-dev/pandas/issues/35350 and https://github.com/pandas-dev/pandas/issues/34850

Here I've updated those functions to work with the variable epoch, and removed the deprecation, and added a test for the basic functionality with both the old and new epoch.

On the pandas side, 

```python 
import datetime
import matplotlib
import matplotlib.pyplot as plt
from matplotlib.dates import DateFormatter

from pandas.plotting import register_matplotlib_converters
register_matplotlib_converters()

t = [
    datetime.datetime(2022, 12, 31, 0, 0),
    datetime.datetime(2022, 11, 30, 0, 0),
    datetime.datetime(2022, 10, 31, 0, 0),
]
s = [0.0, 0.1, 0.2]

fig, ax = plt.subplots()
ax.plot_date(x=t, y=s)
ax.xaxis.set_major_formatter(DateFormatter("%b '%y"))

plt.xticks(rotation=90)
plt.show()
```

is fixed, with no further work on their side needed. 



## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
