### PR TITLE
gtk/tk: Ensure no flicker when hovering over images.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -512,6 +512,14 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
                 if tooltip_text is not None:
                     ToolTip.createToolTip(button, tooltip_text)
 
+        # This filler item ensures the toolbar is always at least two text
+        # lines high. Otherwise the canvas gets redrawn as the mouse hovers
+        # over images because those use two-line messages which resize the
+        # toolbar.
+        label = tk.Label(master=self,
+                         text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+        label.pack(side=tk.RIGHT)
+
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, textvariable=self.message)
         self._message_label.pack(side=tk.RIGHT)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -521,6 +521,17 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         toolitem.set_draw(False)
         toolitem.set_expand(True)
 
+        # This filler item ensures the toolbar is always at least two text
+        # lines high. Otherwise the canvas gets redrawn as the mouse hovers
+        # over images because those use two-line messages which resize the
+        # toolbar.
+        toolitem = Gtk.ToolItem()
+        self.insert(toolitem, -1)
+        label = Gtk.Label()
+        label.set_markup(
+            '<small>\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}</small>')
+        toolitem.add(label)
+
         toolitem = Gtk.ToolItem()
         self.insert(toolitem, -1)
         self.message = Gtk.Label()
@@ -536,7 +547,8 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         return self.canvas.get_property("window").cairo_create()
 
     def set_message(self, s):
-        self.message.set_label(s)
+        escaped = GLib.markup_escape_text(s)
+        self.message.set_markup(f'<small>{escaped}</small>')
 
     def set_cursor(self, cursor):
         self.canvas.get_property("window").set_cursor(cursord[cursor])


### PR DESCRIPTION
## PR Summary

When the mouse is over an image, the status message is two lines long. This causes the toolbar to increase size slightly. On Qt, this is ignored by a sizing policy, but there is no such thing in other toolkits. On GTK this steals space from the canvas, so it re-draws a little bit smaller, until the mouse moves off the image. On Tk, the space is added to the window, _unless_ the window is maximized, and then it's stolen from the canvas as well.

As a simple workaround, we add an additional label with invisible text (spaces) on two lines. This forces the toolbar to always be two lines high and thus not flicker. If the message were 3 or more lines long, then the same thing would happen, but we don't have any of those by default. The advantage of using a label is that it saves us having to measure text in some toolkit-specific way, and thus works regardless of theme.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way