### PR TITLE
Special case degree-1 Bezier curves.

### DIFF
--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -287,10 +287,10 @@ class BezierSegment:
             0`
         """
         n = self.degree
+        if n <= 1:
+            return np.array([]), np.array([])
         Cj = self.polynomial_coefficients
         dCj = np.arange(1, n+1)[:, None] * Cj[1:]
-        if len(dCj) == 0:
-            return np.array([]), np.array([])
         dims = []
         roots = []
         for i, pi in enumerate(dCj.T):


### PR DESCRIPTION
This greatly speeds up extent computation for the common case of
polylines.  (We were previously only special-casing the degree-0 case.)

Partially fixes #17974 (4x speedup locally).  My guess is that the real fix will involve restoring a special-case in Path.get_extents for paths that do not contain curves, but this fix is still useful by itself with no additional complexity cost.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
