### PR TITLE
Deprecate various vector-backend-specific mathtext helpers.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18002-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18002-AL.rst
@@ -1,0 +1,11 @@
+Deprecation of various mathtext helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``MathtextBackendPdf``, ``MathtextBackendPs``, ``MathtextBackendSvg``,
+and ``MathtextBackendCairo`` classes from the :mod:`.mathtext` module, as
+well as the corresponding ``.mathtext_parser`` attributes on ``RendererPdf``,
+``RendererPS``, ``RendererSVG``, and ``RendererCairo``, are deprecated.  The
+``MathtextBackendPath`` class can be used to obtain a list of glyphs and
+rectangles in a mathtext expression, and renderer-specific logic should be
+directly implemented in the renderer.
+
+``StandardPsFonts.pswriter`` is unused and deprecated.

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -469,6 +469,10 @@ class AFM:
         """Return the font name, e.g., 'Times-Roman'."""
         return self._header[b'FontName']
 
+    @property
+    def postscript_name(self):  # For consistency with FT2Font.
+        return self.get_fontname()
+
     def get_fullname(self):
         """Return the font full name, e.g., 'Times-Roman'."""
         name = self._header.get(b'FullName')

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -45,6 +45,7 @@ class CharacterTracker:
             fname = font.fname
         self.used.setdefault(fname, set()).update(map(ord, s))
 
+    # Not public, can be removed when pdf/ps merge_used_characters is removed.
     def merge(self, other):
         """Update self with a font path to character codepoints."""
         for fname, charset in other.items():
@@ -87,7 +88,12 @@ class RendererPDFPSBase(RendererBase):
                 s, fontsize, renderer=self)
             return w, h, d
         elif ismath:
-            parse = self.mathtext_parser.parse(s, 72, prop)
+            # Circular import.
+            from matplotlib.backends.backend_ps import RendererPS
+            parse = self._text2path.mathtext_parser.parse(
+                s, 72, prop,
+                _force_standard_ps_fonts=(isinstance(self, RendererPS)
+                                          and mpl.rcParams["ps.useafm"]))
             return parse.width, parse.height, parse.depth
         elif mpl.rcParams[self._use_afm_rc_name]:
             font = self._get_font_afm(prop)

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1772,8 +1772,12 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         super().__init__(width, height)
         self.file = file
         self.gc = self.new_gc()
-        self.mathtext_parser = MathTextParser("Pdf")
         self.image_dpi = image_dpi
+
+    @cbook.deprecated("3.4")
+    @property
+    def mathtext_parser(self):
+        return MathTextParser("Pdf")
 
     def finalize(self):
         self.file.output(*self.gc.finalize())
@@ -2020,9 +2024,8 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
 
     def draw_mathtext(self, gc, x, y, s, prop, angle):
         # TODO: fix positioning and encoding
-        width, height, descent, glyphs, rects, used_characters = \
-            self.mathtext_parser.parse(s, 72, prop)
-        self.file._character_tracker.merge(used_characters)
+        width, height, descent, glyphs, rects = \
+            self._text2path.mathtext_parser.parse(s, 72, prop)
 
         # When using Type 3 fonts, we can't use character codes higher
         # than 255, so we use the "Do" command to render those
@@ -2040,7 +2043,9 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         self.file.output(Op.begin_text)
         prev_font = None, None
         oldx, oldy = 0, 0
-        for ox, oy, fontname, fontsize, num, symbol_name in glyphs:
+        for font, fontsize, num, ox, oy in glyphs:
+            self.file._character_tracker.track(font, chr(num))
+            fontname = font.fname
             if is_opentype_cff_font(fontname):
                 fonttype = 42
             else:
@@ -2060,7 +2065,8 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         # If using Type 3 fonts, render all of the multi-byte characters
         # as XObjects using the 'Do' command.
         if global_fonttype == 3:
-            for ox, oy, fontname, fontsize, num, symbol_name in glyphs:
+            for font, fontsize, num, ox, oy in glyphs:
+                fontname = font.fname
                 if is_opentype_cff_font(fontname):
                     fonttype = 42
                 else:
@@ -2072,6 +2078,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                                      0.001 * fontsize, 0,
                                      0, 0.001 * fontsize,
                                      ox, oy, Op.concat_matrix)
+                    symbol_name = font.get_glyph_name(font.get_char_index(num))
                     name = self.file._get_xobject_symbol_name(
                         fontname, symbol_name)
                     self.file.output(Name(name), Op.use_xobject)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -65,8 +65,7 @@ class TextToPath:
         if ismath:
             prop = prop.copy()
             prop.set_size(self.FONT_SCALE)
-
-            width, height, descent, trash, used_characters = \
+            width, height, descent, *_ = \
                 self.mathtext_parser.parse(s, 72, prop)
             return width * scale, height * scale, descent * scale
 


### PR DESCRIPTION
A single mathtext "backend" yielding a list of glyphs and rectangles is
enough; renderer-specific logic can be implemented in the renderer
themselves.

(MathtextBackendAgg needs to stay separate because it uses a different
font hinting flag.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
