### PR TITLE
Deprecate the unneeded Fonts.destroy.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18003-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18003-AL.rst
@@ -1,0 +1,3 @@
+mathtext.Fonts.destroy
+~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated, because Fonts do not create reference loops anyways.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -398,6 +398,7 @@ class Fonts:
         self.mathtext_backend = mathtext_backend
         self.used_characters = {}
 
+    @cbook.deprecated("3.4")
     def destroy(self):
         """
         Fix any cyclical references before the object is about
@@ -519,7 +520,11 @@ class Fonts:
         """
         result = self.mathtext_backend.get_results(
             box, self.get_used_characters())
-        self.destroy()
+        if self.destroy != TruetypeFonts.destroy.__get__(self):
+            destroy = cbook._deprecate_method_override(
+                __class__.destroy, self, since="3.4")
+            if destroy:
+                destroy()
         return result
 
     def get_sized_alternatives_for_symbol(self, fontname, sym):
@@ -547,6 +552,7 @@ class TruetypeFonts(Fonts):
         self._fonts['default'] = default_font
         self._fonts['regular'] = default_font
 
+    @cbook.deprecated("3.4")
     def destroy(self):
         self.glyphd = None
         Fonts.destroy(self)


### PR DESCRIPTION
Neither `used_characters` nor `glyphd` cause circular references, so we
can let the normal refcount collector handle the destruction.

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
