### PR TITLE
Use argumentless `super()` more.

### DIFF
--- a/examples/specialty_plots/skewt.py
+++ b/examples/specialty_plots/skewt.py
@@ -46,7 +46,7 @@ class SkewXTick(maxis.XTick):
                 self.tick2line.get_visible() and needs_upper)
             self.label2.set_visible(
                 self.label2.get_visible() and needs_upper)
-            super(SkewXTick, self).draw(renderer)
+            super().draw(renderer)
 
     def get_view_interval(self):
         return self.axes.xaxis.get_view_interval()

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -169,7 +169,7 @@ class FigureCanvasTk(FigureCanvasBase):
        keys on apple keyboards."""
 
     def __init__(self, figure, master=None, resize_callback=None):
-        super(FigureCanvasTk, self).__init__(figure)
+        super().__init__(figure)
         self._idle = True
         self._idle_callback = None
         w, h = self.figure.bbox.size.astype(int)

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -6,7 +6,7 @@ from ._backend_tk import (
 
 class FigureCanvasTkAgg(FigureCanvasAgg, FigureCanvasTk):
     def draw(self):
-        super(FigureCanvasTkAgg, self).draw()
+        super().draw()
         _backend_tk.blit(self._tkphoto, self.renderer._renderer, (0, 1, 2, 3))
         self._master.update_idletasks()
 

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -9,7 +9,7 @@ from ._backend_tk import _BackendTk, FigureCanvasTk
 
 class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
     def __init__(self, *args, **kwargs):
-        super(FigureCanvasTkCairo, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._renderer = RendererCairo(self.figure.dpi)
 
     def draw(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1653,10 +1653,10 @@ class EventCollection(LineCollection):
 
     def get_linewidth(self):
         """Get the width of the lines used to mark each event."""
-        return super(EventCollection, self).get_linewidth()[0]
+        return super().get_linewidth()[0]
 
     def get_linewidths(self):
-        return super(EventCollection, self).get_linewidth()
+        return super().get_linewidth()
 
     def get_color(self):
         """Return the color of the lines used to mark each event."""

--- a/lib/matplotlib/tests/test_skew.py
+++ b/lib/matplotlib/tests/test_skew.py
@@ -36,7 +36,7 @@ class SkewXTick(maxis.XTick):
                 self.tick2line.get_visible() and needs_upper)
             self.label2.set_visible(
                 self.label2.get_visible() and needs_upper)
-            super(SkewXTick, self).draw(renderer)
+            super().draw(renderer)
 
     def get_view_interval(self):
         return self.axes.xaxis.get_view_interval()


### PR DESCRIPTION
## PR Summary

Related to #3192.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way