### PR TITLE
Cache realpath resolution in font_manager.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -161,6 +161,11 @@ OSXFontDirectories = [
 ]
 
 
+@lru_cache(64)
+def _cached_realpath(path):
+    return os.path.realpath(path)
+
+
 def get_fontext_synonyms(fontext):
     """
     Return a list of file extensions extensions that are synonyms for
@@ -1308,10 +1313,9 @@ class FontManager:
         rc_params = tuple(tuple(rcParams[key]) for key in [
             "font.serif", "font.sans-serif", "font.cursive", "font.fantasy",
             "font.monospace"])
-        filename = self._findfont_cached(
+        return self._findfont_cached(
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)
-        return os.path.realpath(filename)
 
     @lru_cache()
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
@@ -1382,7 +1386,7 @@ class FontManager:
             else:
                 raise ValueError("No valid font could be found")
 
-        return result
+        return _cached_realpath(result)
 
 
 @lru_cache()
@@ -1411,10 +1415,10 @@ if hasattr(os, "register_at_fork"):
 def get_font(filename, hinting_factor=None):
     # Resolving the path avoids embedding the font twice in pdf/ps output if a
     # single font is selected using two different relative paths.
-    filename = os.path.realpath(filename)
+    filename = _cached_realpath(filename)
     if hinting_factor is None:
         hinting_factor = rcParams['text.hinting_factor']
-    return _get_font(os.fspath(filename), hinting_factor,
+    return _get_font(filename, hinting_factor,
                      _kerning_factor=rcParams['text.kerning_factor'])
 
 


### PR DESCRIPTION
This shaves off ~33% runtime from
```python
from pylab import *
import timeit

tx = figtext(.5, .5, "foo\nbar baz")
gcf().canvas.draw()
gcf().patch.set_visible(False)
r = gcf()._cachedRenderer
n, t = timeit.Timer(lambda: tx.draw(r)).autorange(); print(t / n, n, t)
```
because previously the calls to realpath were not cached and filesystem
access is slow.

(The font cache is likely already in trouble if fonts move in the
filesystem within the execution of a program given that there are other
layers of cache, so I wouldn't overly worry about that.  At best we may
want to expose a manual function to invalidate all caches if someone
really runs into that problem.)

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
