### PR TITLE
FIX: Be sure matplotlib.backends is imported before we use it

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -227,7 +227,8 @@ def switch_backend(newbackend):
         The name of the backend to use.
     """
     global _backend_mod
-
+    # make sure the init is pulled up so we can assign to it later
+    import matplotlib.backends
     close("all")
 
     if newbackend is rcsetup._auto_backend_sentinel:


### PR DESCRIPTION
## PR Summary


If the user specifies the backend via `'module://XZY'` there in no
guarantee that they have imported `matplotilb.backends` (which is
an empty `__init__.py`) as part of their module which results in an
AttributeError when we monkeypatch the backend name into it.

closes #18022


## PR Checklist

- [ ] Has Pytest style unit tests (depends on import order)
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
