### PR TITLE
FIX: use internal _set_postion, not external

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -410,7 +410,7 @@ class Axes3D(Axes):
         box_aspect = 1
         pb = position.frozen()
         pb1 = pb.shrunk_to_aspect(box_aspect, pb, fig_aspect)
-        self.set_position(pb1.anchored(self.get_anchor(), pb), 'active')
+        self._set_position(pb1.anchored(self.get_anchor(), pb), 'active')
 
     @artist.allow_rasterization
     def draw(self, renderer):

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1011,3 +1011,19 @@ def test_equal_box_aspect():
     ax.set_zlim3d(XYZlim)
     ax.axis('off')
     ax.set_box_aspect((1, 1, 1))
+
+
+def test_colorbar_pos():
+    num_plots = 2
+    fig, axs = plt.subplots(1, num_plots, figsize=(4, 5),
+                            constrained_layout=True,
+                            subplot_kw={'projection': '3d'})
+    for ax in axs:
+        p_tri = ax.plot_trisurf(np.random.randn(5), np.random.randn(5),
+                                np.random.randn(5))
+
+    cbar = plt.colorbar(p_tri, ax=axs, orientation='horizontal')
+
+    fig.canvas.draw()
+    # check that actually on the bottom
+    assert cbar.ax.get_position().extents[1] < 0.2


### PR DESCRIPTION
## PR Summary

Closes #18033

We should always use `_set_position` internally so we don't signal that the user set the position.  


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
