### PR TITLE
Backport PR #18021: FIX: update num2julian and julian2num

### DIFF
--- a/doc/api/api_changes_3.4/deprecations.rst
+++ b/doc/api/api_changes_3.4/deprecations.rst
@@ -1,11 +1,19 @@
 Deprecations
 ------------
 
-Reverted deprecation of `~.dates.num2epoch` and `~.dates.epoch2num`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Reverted deprecation of ``num2epoch`` and ``epoch2num``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These two functions were deprecated in 3.3.0, and did not return
 an accurate Matplotlib datenum relative to the new Matplotlib epoch
 handling (`~.dates.get_epoch` and :rc:`date.epoch`).  This version
-reverts the deprecation and fixes those functions to work with
-`~.dates.get_epoch`.
+reverts the deprecation.
+
+Functions ``epoch2num`` and ``dates.julian2num`` use ``date.epoch`` rcParam
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now `~.dates.epoch2num` and (undocumented) ``julian2num`` return floating point
+days since `~.dates.get_epoch` as set by :rc:`date.epoch`, instead of
+floating point days since the old epoch of "0000-12-31T00:00:00".  If
+needed, you can translate from the new to old values as
+``old = new + mdates.date2num(np.datetime64('0000-12-31'))``

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -959,3 +959,17 @@ def test_epoch2num():
     mdates.set_epoch('1970-01-01T00:00:00')
     assert mdates.epoch2num(86400) == 1.0
     assert mdates.num2epoch(2.0) == 86400 * 2
+
+
+def test_julian2num():
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('0000-12-31')
+    # 2440587.5 is julian date for 1970-01-01T00:00:00
+    # https://en.wikipedia.org/wiki/Julian_day
+    assert mdates.julian2num(2440588.5) == 719164.0
+    assert mdates.num2julian(719165.0) == 2440589.5
+    # set back to the default
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('1970-01-01T00:00:00')
+    assert mdates.julian2num(2440588.5) == 1.0
+    assert mdates.num2julian(2.0) == 2440589.5


### PR DESCRIPTION
## PR Summary

Manual backport

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
