### PR TITLE
Rgba fix

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -316,7 +316,7 @@ def to_rgba_array(c, alpha=None):
     # `to_rgba(c, alpha)` (below) is expensive for such inputs, due to the need
     # to format the array in the ValueError message(!).
     if cbook._str_lower_equal(c, "none"):
-        return np.zeros((0, 4), float)
+        return np.zeros((1, 4), float)
     try:
         return np.array([to_rgba(c, alpha)], float)
     except (ValueError, TypeError):

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -232,6 +232,14 @@ def test_scatter3d():
     z[-1] = 0  # Check that scatter() copies the data.
 
 
+def test_scatter3d_nonfilledmarker():
+    # Check that scattering a non-filled marker works
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.scatter(np.arange(10), np.arange(10), np.arange(10), marker='x')
+    fig.canvas.draw()
+
+
 @mpl3d_image_comparison(['scatter3d_color.png'])
 def test_scatter3d_color():
     fig = plt.figure()


### PR DESCRIPTION
Fixes #18020.

I think the issue was changes made in https://github.com/matplotlib/matplotlib/pull/17543 exposed a problem with `to_rgba_array` returning a zero-sized array with `color='none'`. As far as I know `'none'` should be interpreted as RGBA 0, 0, 0, 0, but the documentation of `matplotlib.colors` doesn't seem to mention `'none'` at all.