### PR TITLE
Correctly handle 'none' facecolors in do_3d_projection

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -487,33 +487,28 @@ class Path3DCollection(PathCollection):
         xs, ys, zs = self._offsets3d
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs, renderer.M)
 
-        fcs = (_zalpha(self._facecolor3d, vzs) if self._depthshade else
-               self._facecolor3d)
-        fcs = mcolors.to_rgba_array(fcs, self._alpha)
-        self.set_facecolors(fcs)
-
-        ecs = (_zalpha(self._edgecolor3d, vzs) if self._depthshade else
-               self._edgecolor3d)
-
         # Sort the points based on z coordinates
         # Performance optimization: Create a sorted index array and reorder
         # points and point properties according to the index array
         z_markers_idx = np.argsort(vzs)[::-1]
 
-        # Re-order items
+        if len(self._facecolor3d):
+            fcs = (_zalpha(self._facecolor3d, vzs) if self._depthshade else
+                   self._facecolor3d)
+            fcs = mcolors.to_rgba_array(fcs, self._alpha)
+            fcs = fcs[z_markers_idx]
+            self.set_facecolors(fcs)
+
+        ecs = (_zalpha(self._edgecolor3d, vzs) if self._depthshade else
+               self._edgecolor3d)
+        ecs = ecs[z_markers_idx]
+        ecs = mcolors.to_rgba_array(ecs, self._alpha)
+        self.set_edgecolors(ecs)
+
         vzs = vzs[z_markers_idx]
         vxs = vxs[z_markers_idx]
         vys = vys[z_markers_idx]
-        fcs = fcs[z_markers_idx]
-        ecs = ecs[z_markers_idx]
         vps = np.column_stack((vxs, vys))
-
-        fcs = mcolors.to_rgba_array(fcs, self._alpha)
-        ecs = mcolors.to_rgba_array(ecs, self._alpha)
-
-        self.set_edgecolors(ecs)
-        self.set_facecolors(fcs)
-
         PathCollection.set_offsets(self, vps)
 
         return np.min(vzs) if vzs.size else np.nan

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -232,6 +232,14 @@ def test_scatter3d():
     z[-1] = 0  # Check that scatter() copies the data.
 
 
+def test_scatter3d_nonfilledmarker():
+    # Check that scattering a non-filled marker works
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.scatter(np.arange(10), np.arange(10), np.arange(10), marker='x')
+    fig.canvas.draw()
+
+
 @mpl3d_image_comparison(['scatter3d_color.png'])
 def test_scatter3d_color():
     fig = plt.figure()


### PR DESCRIPTION
Fixes #18020.

Changes made in #17543 meant that `_facecolor3d` can now be an empty array, therefore make sure `do_3d_projection` only handles the case where the facecolor is set.