### PR TITLE
Remove un-used trivial setters and getters

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -675,18 +675,6 @@ class Shadow(Patch):
         oy = renderer.points_to_pixels(self._oy)
         self._shadow_transform.clear().translate(ox, oy)
 
-    def _get_ox(self):
-        return self._ox
-
-    def _set_ox(self, ox):
-        self._ox = ox
-
-    def _get_oy(self):
-        return self._oy
-
-    def _set_oy(self, oy):
-        self._oy = oy
-
     def get_path(self):
         return self.patch.get_path()
 


### PR DESCRIPTION
These have been around for 13 years (https://github.com/matplotlib/matplotlib/commit/ad74c3fce3d1ad619b45f8a81cdc2c7189383faa) but seemingly never used.