### PR TITLE
Remove support for multiple-color strings in to_rgba_array

### DIFF
--- a/doc/api/next_api_changes/removals/18069.DS.rst
+++ b/doc/api/next_api_changes/removals/18069.DS.rst
@@ -1,0 +1,5 @@
+Removed support for single color strings in `~.colors.to_rgba_array`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Converting a string with single color characters (e.g. ``'rgb'``) in
+`~.colors.to_rgba_array`is no longer supported. Instead, the colors can be
+passed individually in a list (e.g. ``['r', 'g', 'b']``).

--- a/doc/api/next_api_changes/removals/18069.DS.rst
+++ b/doc/api/next_api_changes/removals/18069.DS.rst
@@ -1,5 +1,5 @@
 Removed support for single color strings in `~.colors.to_rgba_array`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Converting a string with single color characters (e.g. ``'rgb'``) in
-`~.colors.to_rgba_array`is no longer supported. Instead, the colors can be
-passed individually in a list (e.g. ``['r', 'g', 'b']``).
+Converting a string with single color characters (e.g. ``'cymk'``) in
+`~.colors.to_rgba_array` is no longer supported. Instead, the colors can be
+passed individually in a list (e.g. ``['c', 'y', 'm', 'k']``).

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -322,23 +322,10 @@ def to_rgba_array(c, alpha=None):
     except (ValueError, TypeError):
         pass
 
-    # Convert one at a time.
     if isinstance(c, str):
-        # Single string as color sequence.
-        # This is deprecated and will be removed in the future.
-        try:
-            result = np.array([to_rgba(cc, alpha) for cc in c])
-        except ValueError as err:
-            raise ValueError(
-                "'%s' is neither a valid single color nor a color sequence "
-                "consisting of single character color specifiers such as "
-                "'rgb'. Note also that the latter is deprecated." % c) from err
-        else:
-            cbook.warn_deprecated(
-                "3.2", message="Using a string of single character colors as "
-                "a color sequence is deprecated since %(since)s and will be "
-                "removed %(removal)s. Use an explicit list instead.")
-            return result
+        raise ValueError("Using a string of single character colors as "
+                         "a color sequence is not supported. The colors can "
+                         "be passed as an explicit list instead.")
 
     if len(c) == 0:
         return np.zeros((0, 4), float)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1057,17 +1057,11 @@ def test_to_rgba_array_single_str():
     # single color name is valid
     assert_array_equal(mcolors.to_rgba_array("red"), [(1, 0, 0, 1)])
 
-    # single char color sequence is deprecated
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
-                      match="Using a string of single character colors as a "
-                            "color sequence is deprecated"):
-        array = mcolors.to_rgba_array("rgb")
-    assert_array_equal(array, [(1, 0, 0, 1), (0, 0.5, 0, 1), (0, 0, 1, 1)])
-
+    # single char color sequence is invalid
     with pytest.raises(ValueError,
-                       match="neither a valid single color nor a color "
-                             "sequence"):
-        mcolors.to_rgba_array("rgbx")
+                       match="Using a string of single character colors as "
+                             "a color sequence is not supported."):
+        array = mcolors.to_rgba_array("rgb")
 
 
 def test_failed_conversions():


### PR DESCRIPTION
Deprecated in 3.2.