### PR TITLE
Remove deprecated animation code

### DIFF
--- a/doc/api/next_api_changes/removals/18071-DS.rst
+++ b/doc/api/next_api_changes/removals/18071-DS.rst
@@ -1,0 +1,9 @@
+`matplotlib.animation`
+~~~~~~~~~~~~~~~~~~~~~~
+
+The following `~.animation.MovieWriterRegistry` methods have been removed:
+
+- ``.set_dirty()`` - does nothing.
+- ``.esnure_not_dirty()`` - does nothing.
+- ``.reset_available_writers()`` - does nothing.
+- ``.avail()`` - use ``.list()`` instead to get a list of available writers.

--- a/doc/api/next_api_changes/removals/18071-DS.rst
+++ b/doc/api/next_api_changes/removals/18071-DS.rst
@@ -4,6 +4,6 @@
 The following `~.animation.MovieWriterRegistry` methods have been removed:
 
 - ``.set_dirty()`` - does nothing.
-- ``.esnure_not_dirty()`` - does nothing.
+- ``.ensure_not_dirty()`` - does nothing.
 - ``.reset_available_writers()`` - does nothing.
 - ``.avail()`` - use ``.list()`` instead to get a list of available writers.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -99,10 +99,6 @@ class MovieWriterRegistry:
     def __init__(self):
         self._registered = dict()
 
-    @cbook.deprecated("3.2")
-    def set_dirty(self):
-        """Sets a flag to re-setup the writers."""
-
     def register(self, name):
         """
         Decorator for registering a class under a name.
@@ -117,19 +113,6 @@ class MovieWriterRegistry:
             self._registered[name] = writer_cls
             return writer_cls
         return wrapper
-
-    @cbook.deprecated("3.2")
-    def ensure_not_dirty(self):
-        """If dirty, reasks the writers if they are available"""
-
-    @cbook.deprecated("3.2")
-    def reset_available_writers(self):
-        """Reset the available state of all registered writers"""
-
-    @cbook.deprecated("3.2")
-    @property
-    def avail(self):
-        return {name: self._registered[name] for name in self.list()}
 
     def is_available(self, name):
         """


### PR DESCRIPTION
This is everything deprecated in `animation.py` in the 3.2 release.