### PR TITLE
Set shading='auto' if invalid value passed to pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5549,6 +5549,15 @@ default: :rc:`scatter.edgecolors`
         # - reset shading if shading='auto' to flat or nearest
         #   depending on size;
 
+        _valid_shading = ['gouraud', 'nearest', 'flat', 'auto']
+        try:
+            cbook._check_in_list(_valid_shading, shading=shading)
+        except ValueError as err:
+            cbook._warn_external(f"shading value '{shading}' not in list of "
+                                 f"valid values {_valid_shading}. Setting "
+                                 "shading='auto'.")
+            shading = 'auto'
+
         if len(args) == 1:
             C = np.asanyarray(args[0])
             nrows, ncols = C.shape


### PR DESCRIPTION
Fixes #18076. 

If shading was an arbitrary value pcolormesh code still runs, but certain bits of crucial logic in `_pcolorargs` were completely skipped. This PR defaults to setting the shading value to `'auto'` for an invalid string, thus not stopping code (ie. keeping previous behaviour) when an invalid string is passed, but emitting a warning and choosing a reasonable default.

I think this PR should be backported to 3.3 as it fixes silent and broken behaviour (#18076). I can then open a new PR for 3.4 that deprecates invalid values, and eventually in 3.6 we can error on invalid values.