### PR TITLE
Reduce numerical precision in Type 1 fonts

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2383,3 +2383,11 @@ def _setup_new_guiapp():
     except OSError:
         _c_internal_utils.Win32_SetCurrentProcessExplicitAppUserModelID(
             "matplotlib")
+
+
+def format_approx(number, precision):
+    """
+    Format the number with at most the number of decimals given as precision.
+    Remove trailing zeros and possibly the decimal point.
+    """
+    return f'{number:.{precision}f}'.rstrip('0').rstrip('.') or '0'

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -741,3 +741,15 @@ def test_setattr_cm():
         assert a.static == 'static'
 
     verify_pre_post_state(a)
+
+
+def test_format_approx():
+    f = cbook.format_approx
+    assert f(0, 1) == '0'
+    assert f(0, 2) == '0'
+    assert f(0, 3) == '0'
+    assert f(-0.0123, 1) == '-0'
+    assert f(1e-7, 5) == '0'
+    assert f(0.0012345600001, 5) == '0.00123'
+    assert f(-0.0012345600001, 5) == '-0.00123'
+    assert f(0.0012345600001, 8) == f(0.0012345600001, 10) == '0.00123456'

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -29,7 +29,7 @@ def test_Type1Font():
         '+ /FontName /CMR10_Slant_1000 def',
          # Alters FontMatrix
          '- /FontMatrix [0.001 0 0 0.001 0 0 ]readonly def',
-         '+ /FontMatrix [0.001 0.0 0.001 0.001 0.0 0.0]readonly def',
+         '+ /FontMatrix [0.001 0 0.001 0.001 0 0]readonly def',
          # Alters ItalicAngle
          '-  /ItalicAngle 0 def',
          '+  /ItalicAngle -45.0 def'):
@@ -47,5 +47,23 @@ def test_Type1Font():
         '+ /FontName /CMR10_Extend_500 def',
          # Alters FontMatrix
          '- /FontMatrix [0.001 0 0 0.001 0 0 ]readonly def',
-         '+ /FontMatrix [0.0005 0.0 0.0 0.001 0.0 0.0]readonly def'):
+         '+ /FontMatrix [0.0005 0 0 0.001 0 0]readonly def'):
         assert line in diff, 'diff to condensed font must contain %s' % line
+
+
+def test_overprecision():
+    # We used to output too many digits in FontMatrix entries and
+    # ItalicAngle, which could make Type-1 parsers unhappy.
+    filename = os.path.join(os.path.dirname(__file__), 'cmr10.pfb')
+    font = t1f.Type1Font(filename)
+    slanted = font.transform({'slant': .167})
+    lines = slanted.parts[0].decode('ascii').splitlines()
+    matrix, = [line[line.index('[')+1:line.index(']')]
+               for line in lines if '/FontMatrix' in line]
+    angle, = [word
+              for line in lines if '/ItalicAngle' in line
+              for word in line.split() if word[0] in '-0123456789']
+    # the following used to include 0.00016700000000000002
+    assert matrix == '0.001 0 0.000167 0.001 0 0'
+    # and here we had -9.48090361795083
+    assert angle == '-9.4809'

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -29,6 +29,8 @@ import struct
 
 import numpy as np
 
+from matplotlib.cbook import format_approx
+
 
 # token types
 _TokenType = enum.Enum('_TokenType',
@@ -269,7 +271,7 @@ class Type1Font:
             array[::2] = newmatrix[0:3, 0]
             array[1::2] = newmatrix[0:3, 1]
             return (
-                '[' + ' '.join(f'{x:.5g}' for x in array) + ']'
+                '[%s]' % ' '.join(format_approx(x, 6) for x in array)
             ).encode('ascii')
 
         def replace(fun):

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -251,7 +251,10 @@ class Type1Font:
             return result
 
         def italicangle(angle):
-            return b'%a' % (float(angle) - np.arctan(slant) / np.pi * 180)
+            return b'%a' % round(
+                float(angle) - np.arctan(slant) / np.pi * 180,
+                5
+            )
 
         def fontmatrix(array):
             array = array.lstrip(b'[').rstrip(b']').split()
@@ -265,10 +268,9 @@ class Type1Font:
             newmatrix = np.dot(modifier, oldmatrix)
             array[::2] = newmatrix[0:3, 0]
             array[1::2] = newmatrix[0:3, 1]
-            # Not directly using `b'%a' % x for x in array` for now as that
-            # produces longer reprs on numpy<1.14, causing test failures.
-            as_string = '[' + ' '.join(str(x) for x in array) + ']'
-            return as_string.encode('latin-1')
+            return (
+                '[' + ' '.join(f'{x:.5g}' for x in array) + ']'
+            ).encode('ascii')
 
         def replace(fun):
             def replacer(tokens):


### PR DESCRIPTION
Fixes #16087

## PR Summary

Numbers such as

```
/ItalicAngle -9.48090361795083 def
/FontMatrix [0.001 0.0 0.00016700000000000002 0.001 0.0 0.0] readonly def
```

seem to confuse some PostScript parsers, so output fewer digits when changing the angle of a font.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
