### PR TITLE
Install on OpenBSD and FreeBSD

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -201,9 +201,9 @@ FreeType and Qhull
 Matplotlib depends on `FreeType <https://www.freetype.org/>`_ (>=
 2.3), a font rendering library, and on `Qhull
 <http://www.qhull.org/>`_ (>= 2015.2), a library for computing
-triangulations.  By default (except on AIX) Matplotlib downloads and
-builds its own copy of FreeType (this is necessary to run the test
-suite, because different versions of FreeType rasterize characters
+triangulations. By default (except on AIX, OpenBSD and FreeBSD) Matplotlib
+downloads and builds its own copy of FreeType (this is necessary to run the
+test suite, because different versions of FreeType rasterize characters
 differently), and uses its own copy of Qhull.
 
 To force Matplotlib to use a copy of FreeType or Qhull already installed in

--- a/setupext.py
+++ b/setupext.py
@@ -138,7 +138,8 @@ if os.path.exists(setup_cfg):
 options = {
     'backend': config.get('rc_options', 'backend', fallback=None),
     'system_freetype': config.getboolean(
-        'libs', 'system_freetype', fallback=sys.platform.startswith('aix')),
+        'libs', 'system_freetype',
+        fallback=sys.platform.startswith(('aix', 'openbsd', 'freebsd'))),
     'system_qhull': config.getboolean('libs', 'system_qhull',
                                       fallback=False),
 }


### PR DESCRIPTION
## PR Summary

This pull request fixes install on OpenBSD and FreeBSD. The related issue is #18057 and a related pull request is #17831 

It is tested on the following:

OpenBSD 6.7-CURRENT Python 3.8.3
FreeBSD 12.1-RELEASE-p7 Python 3.8.5

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
