### PR TITLE
Revert "Convert adjust_bbox to use ExitStack."

### DIFF
--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -125,7 +125,13 @@ def test_noop_tight_bbox():
     ax.get_yaxis().set_visible(False)
 
     data = np.arange(x_size * y_size).reshape(y_size, x_size)
-    ax.imshow(data)
+    ax.imshow(data, rasterized=True)
+
+    # When a rasterized Artist is included, a mixed-mode renderer does
+    # additional bbox adjustment. It should also be a no-op, and not affect the
+    # next save.
+    fig.savefig(BytesIO(), bbox_inches='tight', pad_inches=0, format='pdf')
+
     out = BytesIO()
     fig.savefig(out, bbox_inches='tight', pad_inches=0)
     out.seek(0)

--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -2,9 +2,6 @@
 Helper module for the *bbox_inches* parameter in `.Figure.savefig`.
 """
 
-import contextlib
-
-from matplotlib.cbook import _setattr_cm
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 
 
@@ -18,18 +15,42 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     changes, the scale of the original figure is conserved.  A
     function which restores the original values are returned.
     """
+    origBbox = fig.bbox
+    origBboxInches = fig.bbox_inches
+    orig_tight_layout = fig.get_tight_layout()
+    _boxout = fig.transFigure._boxout
 
-    stack = contextlib.ExitStack()
-
-    stack.callback(fig.set_tight_layout, fig.get_tight_layout())
     fig.set_tight_layout(False)
 
+    old_aspect = []
+    locator_list = []
+    sentinel = object()
     for ax in fig.axes:
-        stack.callback(ax.set_axes_locator, ax.get_axes_locator())
+        locator_list.append(ax.get_axes_locator())
         current_pos = ax.get_position(original=False).frozen()
         ax.set_axes_locator(lambda a, r, _pos=current_pos: _pos)
         # override the method that enforces the aspect ratio on the Axes
-        stack.enter_context(_setattr_cm(ax, apply_aspect=lambda pos: None))
+        if 'apply_aspect' in ax.__dict__:
+            old_aspect.append(ax.apply_aspect)
+        else:
+            old_aspect.append(sentinel)
+        ax.apply_aspect = lambda pos=None: None
+
+    def restore_bbox():
+        for ax, loc, aspect in zip(fig.axes, locator_list, old_aspect):
+            ax.set_axes_locator(loc)
+            if aspect is sentinel:
+                # delete our no-op function which un-hides the original method
+                del ax.apply_aspect
+            else:
+                ax.apply_aspect = aspect
+
+        fig.bbox = origBbox
+        fig.bbox_inches = origBboxInches
+        fig.set_tight_layout(orig_tight_layout)
+        fig.transFigure._boxout = _boxout
+        fig.transFigure.invalidate()
+        fig.patch.set_bounds(0, 0, 1, 1)
 
     if fixed_dpi is None:
         fixed_dpi = fig.dpi
@@ -38,25 +59,19 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
 
     _bbox = TransformedBbox(bbox_inches, tr)
 
-    stack.enter_context(
-        _setattr_cm(fig, bbox_inches=Bbox.from_bounds(
-            0, 0, bbox_inches.width, bbox_inches.height)))
+    fig.bbox_inches = Bbox.from_bounds(0, 0,
+                                       bbox_inches.width, bbox_inches.height)
     x0, y0 = _bbox.x0, _bbox.y0
     w1, h1 = fig.bbox.width * dpi_scale, fig.bbox.height * dpi_scale
-    stack.enter_context(
-        _setattr_cm(fig.transFigure,
-                    _boxout=Bbox.from_bounds(-x0, -y0, w1, h1)))
+    fig.transFigure._boxout = Bbox.from_bounds(-x0, -y0, w1, h1)
     fig.transFigure.invalidate()
-    stack.callback(fig.transFigure.invalidate)
 
-    stack.enter_context(
-        _setattr_cm(fig, bbox=TransformedBbox(fig.bbox_inches, tr)))
+    fig.bbox = TransformedBbox(fig.bbox_inches, tr)
 
-    stack.callback(fig.patch.set_bounds, 0, 0, 1, 1)
     fig.patch.set_bounds(x0 / w1, y0 / h1,
                          fig.bbox.width / w1, fig.bbox.height / h1)
 
-    return stack.close
+    return restore_bbox
 
 
 def process_figure_for_rasterizing(fig, bbox_inches_restore, fixed_dpi=None):


### PR DESCRIPTION
## PR Summary

With the `ExitStack` and context managers, it's expected that everything is called in pairs, i.e., `adjust_bbox` followed by `restore_bbox`. When saving, `BackendBases.print_figure` calls `adjust_bbox` before and `restore_bbox` after the renderer-specific method. In raster renderers, that's all that happens.

However, in mixed mode renderers, this is not the case. When it needs to rasterize (`MixedModeRendering.start_rasterizing`), it will change the DPI, restore the bbox, and re-adjust again. Internally, it hangs on to the new `restore_bbox`, but `print_figure` still has the original, which was cleared at the first `start_rasterizing` call, so when it calls `restore_bbox`, it does nothing because the stack is empty.

So all that means that we need to revert the original change, as it needs to be possible to call `restore_bbox` more than once. This has not been a direct revert, as other cleanups happened in the meantime.

Fixes #18061.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way