### PR TITLE
Privatize cbook.format_approx.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2385,7 +2385,7 @@ def _setup_new_guiapp():
             "matplotlib")
 
 
-def format_approx(number, precision):
+def _format_approx(number, precision):
     """
     Format the number with at most the number of decimals given as precision.
     Remove trailing zeros and possibly the decimal point.

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -744,7 +744,7 @@ def test_setattr_cm():
 
 
 def test_format_approx():
-    f = cbook.format_approx
+    f = cbook._format_approx
     assert f(0, 1) == '0'
     assert f(0, 2) == '0'
     assert f(0, 3) == '0'

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -29,7 +29,7 @@ import struct
 
 import numpy as np
 
-from matplotlib.cbook import format_approx
+from matplotlib.cbook import _format_approx
 
 
 # token types
@@ -271,7 +271,7 @@ class Type1Font:
             array[::2] = newmatrix[0:3, 0]
             array[1::2] = newmatrix[0:3, 1]
             return (
-                '[%s]' % ' '.join(format_approx(x, 6) for x in array)
+                '[%s]' % ' '.join(_format_approx(x, 6) for x in array)
             ).encode('ascii')
 
         def replace(fun):


### PR DESCRIPTION
## PR Summary

Small followup to #18080.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way