### PR TITLE
Use same Make as FreeType's configure to build it.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -597,7 +597,21 @@ class FreeType(SetupPackage):
                  "--with-png=no", "--with-harfbuzz=no", "--enable-static",
                  "--disable-shared"],
                 env=env, cwd=src_path)
-            subprocess.check_call(["make"], env=env, cwd=src_path)
+            if 'GNUMAKE' in env:
+                make = env['GNUMAKE']
+            elif 'MAKE' in env:
+                make = env['MAKE']
+            else:
+                try:
+                    output = subprocess.check_output(['make', '-v'],
+                                                     stderr=subprocess.DEVNULL)
+                except subprocess.CalledProcessError:
+                    output = b''
+                if b'GNU' not in output and b'makepp' not in output:
+                    make = 'gmake'
+                else:
+                    make = 'make'
+            subprocess.check_call([make], env=env, cwd=src_path)
         else:  # compilation on windows
             shutil.rmtree(src_path / "objs", ignore_errors=True)
             msbuild_platform = (


### PR DESCRIPTION
## PR Summary

Namely, it's necessary to use `gmake` on BSD, since their `make` does not work.
This translates the check from FreeType's `configure` shell script to our setup.

This fixes #18057 on FreeBSD, assuming you have `gmake` installed, and may or may not be a better fix than #18088 (I don't know whether requiring `gmake` is reasonable.)

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way