### PR TITLE
Improve saving animated GIF with ffmpeg

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -554,7 +554,9 @@ class FFMpegBase:
     @property
     def output_args(self):
         args = []
-        if not Path(self.outfile).suffix == '.gif':
+        if Path(self.outfile).suffix == '.gif':
+            self.codec = 'gif'
+        else:
             args.extend(['-vcodec', self.codec])
         extra_args = (self.extra_args if self.extra_args is not None
                       else mpl.rcParams[self._args_key])
@@ -564,6 +566,11 @@ class FFMpegBase:
         # OSX). Also fixes internet explorer. This is as of 2015/10/29.
         if self.codec == 'h264' and '-pix_fmt' not in extra_args:
             args.extend(['-pix_fmt', 'yuv420p'])
+        # For GIF, we're telling FFMPEG to split the video stream, to generate
+        # a palette, and then use it for encoding.
+        elif self.codec == 'gif' and '-filter_complex' not in extra_args:
+            args.extend(['-filter_complex',
+                         'split [a][b];[a] palettegen [p];[b][p] paletteuse'])
         if self.bitrate > 0:
             args.extend(['-b', '%dk' % self.bitrate])  # %dk: bitrate in kbps.
         args.extend(extra_args)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -293,7 +293,8 @@ class MovieWriter(AbstractMovieWriter):
                 'MovieWriter cannot be instantiated directly. Please use one '
                 'of its subclasses.')
 
-        super().__init__(fps=fps, metadata=metadata)
+        super().__init__(fps=fps, metadata=metadata, codec=codec,
+                         bitrate=bitrate)
 
         self.frame_format = 'rgba'
         self.extra_args = extra_args


### PR DESCRIPTION
## PR Summary
As of #17401, we enabled an error-free path to save animated GIFs with ffmpeg, which is the default writer. This means with matplotlib 3.3.0 the follow code works without error:
```python
import numpy as np
import matplotlib.pyplot as plt
import matplotlib.animation as animation

fig, ax = plt.subplots(figsize=(2, 2))
x = np.arange(0, 2*np.pi, 0.01)
line, = ax.plot(x, np.sin(x))

def animate(i):
    line.set_ydata(np.sin(x + i / 50))  # update the data.
    return line,

anim = animation.FuncAnimation(fig, animate, interval=20, blit=True, save_count=50)
anim.save('test.gif')
```
Unfortunately, it also produces this by default (notice the weird coloring):

![ffmpeg](https://user-images.githubusercontent.com/221526/88633417-3870ff00-d072-11ea-8a00-9aefb596959d.gif)

This is a consequence of GIF being a palette-d image format and the default palette used by ffmpeg being...suboptimal for matplotlib (I'm pretty sure anti-aliasing plays a role, otherwise there are only 3 colors in the original image). Luckily this [blog](https://engineering.giphy.com/how-to-make-gifs-with-ffmpeg/) from GIPHY, which helped me understand this, also provides some magic incantations for ffmpeg to get it to determine an optimal palette for us. The result is:

![ffmpeg](https://user-images.githubusercontent.com/221526/88633792-b46b4700-d072-11ea-9fd9-1d285ee07df8.gif)

Best of all, if I run that same animation through ffmpeg, imagemagick, and pillow we see:
```
 128K  ffmpeg.gif
 661K  pillow.gif
 231K  imagemagick.gif
```
So our default writer now produces our smallest animated GIFs.

I also fixed a bug where parameters to `save()` like `codec` were not being passed and set in the base class--thus the rcParam defaults were always used. (Introduced in #15961.) I tried to add a test for this, but couldn't figure out how since you can't pass them along with a class instance, which was the straightforward path to check they're set properly.

I'll leave it to @QuLogic to decide whether this belongs in 3.3.1.

## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
