### PR TITLE
Fix example code for enabling logging in API change notice

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -531,8 +531,11 @@ The following miscellaneous API elements have been removed
 
     import logging
     logger = logging.getLogger('matplotlib')
-    logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.INFO)
+    # configure log handling: Either include it into your ``logging`` hierarchy,
+    # e.g. by configuring a root looger using ``logging.basicConfig()``,
+    # or add a standalone handler to the matplotlib logger:
+    logger.addHandler(logging.StreamHandler())
 
 - ``__version__numpy__``
 - ``collections.CIRCLE_AREA_FACTOR``

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -531,7 +531,8 @@ The following miscellaneous API elements have been removed
 
     import logging
     logger = logging.getLogger('matplotlib')
-    logger.set_level(logging.INFO)
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.INFO)
 
 - ``__version__numpy__``
 - ``collections.CIRCLE_AREA_FACTOR``


### PR DESCRIPTION
## PR Summary

I stumbled across that API change when trying to figure out how to turn on logging. The code as provided does not work at all.
* `set_level` doesn't exist -> `setLevel`
* Nothing appears without setting a handler.

## PR Checklist
- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
