### PR TITLE
Error on unexpected kwargs in scale classes

### DIFF
--- a/doc/api/next_api_changes/removals/18095-DS.rst
+++ b/doc/api/next_api_changes/removals/18095-DS.rst
@@ -1,0 +1,5 @@
+`~matplotlib.scale` keyword arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.scale.ScaleBase`, `.scale.LinearScale` and `.scale.SymmetricalLogScale`
+now error if any unexpected keyword arguments are passed to their
+constructors.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -20,7 +20,6 @@ from matplotlib.ticker import (
     NullLocator, LogLocator, AutoLocator, AutoMinorLocator,
     SymmetricalLogLocator, LogitLocator)
 from matplotlib.transforms import Transform, IdentityTransform
-from matplotlib.cbook import warn_deprecated
 
 
 class ScaleBase:
@@ -41,7 +40,7 @@ class ScaleBase:
 
     """
 
-    def __init__(self, axis, **kwargs):
+    def __init__(self, axis):
         r"""
         Construct a new scale.
 
@@ -54,14 +53,6 @@ class ScaleBase:
         be used: a single scale object should be usable by multiple
         `~matplotlib.axis.Axis`\es at the same time.
         """
-        if kwargs:
-            warn_deprecated(
-                '3.2', removal='3.4',
-                message=(
-                    f"ScaleBase got an unexpected keyword argument "
-                    f"{next(iter(kwargs))!r}. This will become an error "
-                    "%(removal)s.")
-            )
 
     def get_transform(self):
         """
@@ -95,13 +86,12 @@ class LinearScale(ScaleBase):
 
     name = 'linear'
 
-    def __init__(self, axis, **kwargs):
+    def __init__(self, axis):
         # This method is present only to prevent inheritance of the base class'
         # constructor docstring, which would otherwise end up interpolated into
         # the docstring of Axis.set_scale.
         """
         """
-        super().__init__(axis, **kwargs)
 
     def set_default_locators_and_formatters(self, axis):
         # docstring inherited
@@ -480,15 +470,7 @@ class SymmetricalLogScale(ScaleBase):
         @cbook._rename_parameter("3.3", f"linthresh{axis_name}", "linthresh")
         @cbook._rename_parameter("3.3", f"subs{axis_name}", "subs")
         @cbook._rename_parameter("3.3", f"linscale{axis_name}", "linscale")
-        def __init__(*, base=10, linthresh=2, subs=None, linscale=1, **kwargs):
-            if kwargs:
-                warn_deprecated(
-                    '3.2', removal='3.4',
-                    message=(
-                        f"SymmetricalLogScale got an unexpected keyword "
-                        f"argument {next(iter(kwargs))!r}. This will become "
-                        "an error %(removal)s.")
-                )
+        def __init__(*, base=10, linthresh=2, subs=None, linscale=1):
             return base, linthresh, subs, linscale
 
         base, linthresh, subs, linscale = __init__(**kwargs)

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -1,4 +1,3 @@
-from matplotlib.cbook import MatplotlibDeprecationWarning
 import matplotlib.pyplot as plt
 from matplotlib.scale import (
     LogTransform, InvertedLogTransform,
@@ -106,17 +105,12 @@ def test_logscale_mask():
     ax.set(yscale="log")
 
 
-def test_extra_kwargs_raise_or_warn():
+def test_extra_kwargs_raise():
     fig, ax = plt.subplots()
 
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.set_yscale('linear', foo='mask')
-
-    with pytest.raises(TypeError):
-        ax.set_yscale('log', foo='mask')
-
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.set_yscale('symlog', foo='mask')
+    for scale in ['linear', 'log', 'symlog']:
+        with pytest.raises(TypeError):
+            ax.set_yscale(scale, foo='mask')
 
 
 def test_logscale_invert_transform():


### PR DESCRIPTION
Deprecated in 3.2. `ScaleBase.__init__` now does nothing, so also remove calls to that, but to keep the docstring I left in the actual method.

For the API change note, I put it in removals, but perhaps it should go in behaviour instead?