### PR TITLE
FIX: catch all multi-dim warnings pandas

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1321,7 +1321,7 @@ def _check_1d(x):
             with warnings.catch_warnings(record=True) as w:
                 warnings.filterwarnings(
                     "always",
-                    category=DeprecationWarning,
+                    category=Warning,
                     message='Support for multi-dimensional indexing')
 
                 ndim = x[:, None].ndim


### PR DESCRIPTION
## PR Summary

Pandas emits a warning, which we need to filter in `check_1d` in order to maintain back-compatibility.  They changed the warning type from `DeprecationWarning` to `FutureWarning`.  Its probably overly fussy to filter twice on each type of warning for different pandas versions, so just filter on a generic warning w/ the correct Warning text.

Note that CI is present broken because there is a new release of pandas today...

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
