### PR TITLE
Backport PR #18089 on branch v3.3.x

### DIFF
--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -125,7 +125,13 @@ def test_noop_tight_bbox():
     ax.get_yaxis().set_visible(False)
 
     data = np.arange(x_size * y_size).reshape(y_size, x_size)
-    ax.imshow(data)
+    ax.imshow(data, rasterized=True)
+
+    # When a rasterized Artist is included, a mixed-mode renderer does
+    # additional bbox adjustment. It should also be a no-op, and not affect the
+    # next save.
+    fig.savefig(BytesIO(), bbox_inches='tight', pad_inches=0, format='pdf')
+
     out = BytesIO()
     fig.savefig(out, bbox_inches='tight', pad_inches=0)
     out.seek(0)

--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -2,9 +2,6 @@
 Helper module for the *bbox_inches* parameter in `.Figure.savefig`.
 """
 
-import contextlib
-
-from matplotlib.cbook import _setattr_cm
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 
 
@@ -18,55 +15,63 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     changes, the scale of the original figure is conserved.  A
     function which restores the original values are returned.
     """
-    def no_op_apply_aspect(position=None):
-        return
+    origBbox = fig.bbox
+    origBboxInches = fig.bbox_inches
+    orig_tight_layout = fig.get_tight_layout()
+    _boxout = fig.transFigure._boxout
 
-    stack = contextlib.ExitStack()
-
-    stack.callback(fig.set_tight_layout, fig.get_tight_layout())
     fig.set_tight_layout(False)
 
+    old_aspect = []
+    locator_list = []
+    sentinel = object()
     for ax in fig.axes:
-        pos = ax.get_position(original=False).frozen()
+        locator_list.append(ax.get_axes_locator())
+        current_pos = ax.get_position(original=False).frozen()
+        ax.set_axes_locator(lambda a, r, _pos=current_pos: _pos)
+        # override the method that enforces the aspect ratio on the Axes
+        if 'apply_aspect' in ax.__dict__:
+            old_aspect.append(ax.apply_aspect)
+        else:
+            old_aspect.append(sentinel)
+        ax.apply_aspect = lambda pos=None: None
 
-        def _l(a, r, pos=pos):
-            return pos
+    def restore_bbox():
+        for ax, loc, aspect in zip(fig.axes, locator_list, old_aspect):
+            ax.set_axes_locator(loc)
+            if aspect is sentinel:
+                # delete our no-op function which un-hides the original method
+                del ax.apply_aspect
+            else:
+                ax.apply_aspect = aspect
 
-        stack.callback(ax.set_axes_locator, ax.get_axes_locator())
-        ax.set_axes_locator(_l)
+        fig.bbox = origBbox
+        fig.bbox_inches = origBboxInches
+        fig.set_tight_layout(orig_tight_layout)
+        fig.transFigure._boxout = _boxout
+        fig.transFigure.invalidate()
+        fig.patch.set_bounds(0, 0, 1, 1)
 
-        # override the method that enforces the aspect ratio
-        # on the Axes
-        stack.enter_context(_setattr_cm(ax, apply_aspect=no_op_apply_aspect))
-
-    if fixed_dpi is not None:
-        tr = Affine2D().scale(fixed_dpi)
-        dpi_scale = fixed_dpi / fig.dpi
-    else:
-        tr = Affine2D().scale(fig.dpi)
-        dpi_scale = 1.
+    if fixed_dpi is None:
+        fixed_dpi = fig.dpi
+    tr = Affine2D().scale(fixed_dpi)
+    dpi_scale = fixed_dpi / fig.dpi
 
     _bbox = TransformedBbox(bbox_inches, tr)
 
-    stack.enter_context(
-        _setattr_cm(fig, bbox_inches=Bbox.from_bounds(
-            0, 0, bbox_inches.width, bbox_inches.height)))
+    fig.bbox_inches = Bbox.from_bounds(0, 0,
+                                       bbox_inches.width, bbox_inches.height)
     x0, y0 = _bbox.x0, _bbox.y0
     w1, h1 = fig.bbox.width * dpi_scale, fig.bbox.height * dpi_scale
-    stack.enter_context(
-        _setattr_cm(fig.transFigure,
-                    _boxout=Bbox.from_bounds(-x0, -y0, w1, h1)))
+    fig.transFigure._boxout = Bbox.from_bounds(-x0, -y0, w1, h1)
     fig.transFigure.invalidate()
-    stack.callback(fig.transFigure.invalidate)
 
-    stack.enter_context(
-        _setattr_cm(fig, bbox=TransformedBbox(fig.bbox_inches, tr)))
+    fig.bbox = TransformedBbox(fig.bbox_inches, tr)
 
-    stack.callback(fig.patch.set_bounds, 0, 0, 1, 1)
     fig.patch.set_bounds(x0 / w1, y0 / h1,
                          fig.bbox.width / w1, fig.bbox.height / h1)
 
-    return stack.close
+    return restore_bbox
 
 
 def process_figure_for_rasterizing(fig, bbox_inches_restore, fixed_dpi=None):


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way