### PR TITLE
Improve rasterization demo

### DIFF
--- a/examples/misc/rasterization_demo.py
+++ b/examples/misc/rasterization_demo.py
@@ -28,7 +28,7 @@ xx = x*np.cos(theta) - y*np.sin(theta)  # rotate x by -theta
 yy = x*np.sin(theta) + y*np.cos(theta)  # rotate y by -theta
 
 # Plot the rasterized and non-rasterized plot
-fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
+fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, constrained_layout=True)
 
 # Create a pseudocolor non-rastertized plot with a non-regular rectangular grid
 ax1.set_aspect(1)
@@ -38,9 +38,7 @@ ax1.set_title("No Rasterization")
 # Create a pseudocolor rastertized plot with a non-regular rectangular grid
 ax2.set_aspect(1)
 ax2.set_title("Rasterization")
-m = ax2.pcolormesh(xx, yy, d)
-# Force rasterized drawing in vector backend output
-m.set_rasterized(True)
+m = ax2.pcolormesh(xx, yy, d, rasterized=True)
 
 # Create a pseudocolor non-rastertized plot with a non-regular rectangular
 # grid and an overlapped "Text"
@@ -53,10 +51,8 @@ ax3.set_title("No Rasterization")
 # Create a pseudocolor rastertized plot with a non-regular rectangular
 # grid and an overlapped "Text"
 ax4.set_aspect(1)
-m = ax4.pcolormesh(xx, yy, d)
-m.set_zorder(-20)
-ax4.text(0.5, 0.5, "Text", alpha=0.2,
-         zorder=-15,
+m = ax4.pcolormesh(xx, yy, d, zorder=-20)
+ax4.text(0.5, 0.5, "Text", alpha=0.2, zorder=-15,
          va="center", ha="center", size=50, transform=ax4.transAxes)
 # Set zorder value below which artists will be rasterized
 ax4.set_rasterization_zorder(-10)


### PR DESCRIPTION
## PR Summary

### This PR

Addresses part of the issues raised by @jklymak (https://github.com/matplotlib/matplotlib/pull/18012#pullrequestreview-454472078).

Not addressed are:

- `set_rasterization_zorder` (https://github.com/matplotlib/matplotlib/pull/18012#discussion_r459709549)
  Whether or not this is reasonable API or not would need to be discuessed separately.

- comparison of the file sizes (https://github.com/matplotlib/matplotlib/pull/18012#discussion_r459713906)
  As of now, the example generates only one file per type including some rastered and non-rastered artists. This cannot be compared. One would instead have to rewrite the example to create two versions of the same figure, one rasterized and one not.

### General comments on the example

**Note: The issues/changes discussed below would be a complete rewrite of the example. Therefore it's a bit out of scope.**

- The plotted 10x10 pcolormesh has only 100 elements and saving them in vector format is smaller than rasterizing them. In that sense, the example data are not a good example for rasterization. (And a file-size comparison is futile)
- I'm not clear what the example wants to present overall. There are four plots:
  1. pcolormesh non-rasterized
  2. pcolormesh rasterized
  3. pcolormesh and text non-rasterized
  4. pcolormesh and text rasterized (via zorder)

  In particular:

  - I would have used two plots (rasterized/non-rasterized), with only one Axes each.
  - I don't get the purpose of the text.
  - If `set_rasterization_zorder` should appear, it should be a separate plot including an explanation.

If there is interest / consensus that the example should be reworked fundamentally, I'd open a separate PR.

ping @anntzer as it seems that you've created the example back in 2009.