### PR TITLE
Fix FuncAnimation._draw_frame exception and testing

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1723,13 +1723,13 @@ class FuncAnimation(TimedAnimation):
 
         if self._blit:
 
-            err = RuntimeError('The animation function must return a '
-                                   'sequence of Artist objects.')
+            err = RuntimeError('The animation function must return a sequence '
+                               'of Artist objects.')
             try:
                 # check if a sequence
                 iter(self._drawn_artists)
             except TypeError:
-                raise err
+                raise err from None
 
             # check each item if is artist
             for i in self._drawn_artists:


### PR DESCRIPTION
## PR Summary

This test seems to be flaky on CI, though I cannot reproduce. While looking at it, I noticed that it does not actually work the way it's intended. When using `pytest.raises`, the last line _must_ be the exception-raising code. Everything else is ignored, so all the checks for other types of input in the test were not run.

Avoid that by parameterizing so that there's only one line in the context. If we're lucky, this will fix the flakiness, but I don't know.

Also, remove the context from the sequence check, because that adds no useful information.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way