### PR TITLE
FIX: Allow deepcopy on norms and scales

### DIFF
--- a/doc/api/scale_api.rst
+++ b/doc/api/scale_api.rst
@@ -3,6 +3,7 @@
 ********************
 
 .. automodule:: matplotlib.scale
+   :private-members: _CopyableTransformMixin
    :members:
    :undoc-members:
    :show-inheritance:

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -79,6 +79,17 @@ class ScaleBase:
         return vmin, vmax
 
 
+class _CopyableTransformMixin():
+    """
+    Mixin to support copy and deep copy on transforms.  This alows scales,
+    and hence norms, to be copyable.
+    """
+    def __deepcopy__(self, memo):
+        return self.frozen()
+
+    __copy__ = __deepcopy__
+
+
 class LinearScale(ScaleBase):
     """
     The default linear scale.
@@ -113,9 +124,9 @@ class LinearScale(ScaleBase):
         return IdentityTransform()
 
 
-class FuncTransform(Transform):
+class FuncTransform(_CopyableTransformMixin, Transform):
     """
-    A simple transform that takes and arbitrary function for the
+    A transform that takes and arbitrary function for the
     forward and inverse transform.
     """
 
@@ -191,7 +202,7 @@ class FuncScale(ScaleBase):
             axis.set_minor_locator(NullLocator())
 
 
-class LogTransform(Transform):
+class LogTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     @_api.rename_parameter("3.3", "nonpos", "nonpositive")
@@ -233,7 +244,7 @@ class LogTransform(Transform):
         return InvertedLogTransform(self.base)
 
 
-class InvertedLogTransform(Transform):
+class InvertedLogTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     def __init__(self, base):
@@ -359,7 +370,7 @@ class FuncScaleLog(LogScale):
         return self._transform
 
 
-class SymmetricalLogTransform(Transform):
+class SymmetricalLogTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     def __init__(self, base, linthresh, linscale):
@@ -391,7 +402,7 @@ class SymmetricalLogTransform(Transform):
                                                self.linscale)
 
 
-class InvertedSymmetricalLogTransform(Transform):
+class InvertedSymmetricalLogTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     def __init__(self, base, linthresh, linscale):
@@ -494,7 +505,7 @@ class SymmetricalLogScale(ScaleBase):
         return self._transform
 
 
-class LogitTransform(Transform):
+class LogitTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     @_api.rename_parameter("3.3", "nonpos", "nonpositive")
@@ -520,7 +531,7 @@ class LogitTransform(Transform):
         return "{}({!r})".format(type(self).__name__, self._nonpositive)
 
 
-class LogisticTransform(Transform):
+class LogisticTransform(_CopyableTransformMixin, Transform):
     input_dims = output_dims = 1
 
     @_api.rename_parameter("3.3", "nonpos", "nonpositive")

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -16,6 +16,7 @@ import matplotlib.cm as cm
 import matplotlib.colorbar as mcolorbar
 import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
+import matplotlib.scale as mscale
 from matplotlib.testing.decorators import image_comparison
 
 
@@ -1320,3 +1321,16 @@ def test_2d_to_rgba():
     rgba_1d = mcolors.to_rgba(color.reshape(-1))
     rgba_2d = mcolors.to_rgba(color.reshape((1, -1)))
     assert rgba_1d == rgba_2d
+
+
+def test_norm_deepcopy():
+    norm = mcolors.LogNorm()
+    norm.vmin = 0.0002
+    norm2 = copy.deepcopy(norm)
+    assert norm2.vmin == norm.vmin
+    assert isinstance(norm2._scale, mscale.LogScale)
+    norm = mcolors.Normalize()
+    norm.vmin = 0.0002
+    norm2 = copy.deepcopy(norm)
+    assert isinstance(norm2._scale, mscale.LinearScale)
+    assert norm2.vmin == norm.vmin

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -7,6 +7,7 @@ from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 import numpy as np
 from numpy.testing import assert_allclose
+import copy
 import io
 import pytest
 
@@ -210,3 +211,9 @@ def test_pass_scale():
     ax.set_yscale(scale)
     assert ax.xaxis.get_scale() == 'log'
     assert ax.yaxis.get_scale() == 'log'
+
+
+def test_scale_deepcopy():
+    sc = mscale.LogScale(axis='x', base=10)
+    sc2 = copy.deepcopy(sc)
+    assert str(sc.get_transform()) == str(sc2.get_transform())

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2062,6 +2062,12 @@ class IdentityTransform(Affine2DBase):
         # docstring inherited
         return self
 
+    def __deepcopy__(self, memo):
+        # The identity transform does not need to lock out deepcopy
+        return self
+
+    __copy__ = __deepcopy__
+
     __str__ = _make_str_method()
 
     def get_matrix(self):


### PR DESCRIPTION
## PR Summary

Closes #18119  

I *guess* its an API change to change the return type of `scale.linear.get_transform`?

This needs tests but the following now works instead of raising an error.  

```python
import matplotlib.scale as mscale
import copy

sc = mscale.LogScale(axis='x', base=10)
sc2 = copy.deepcopy(sc)

print(sc2)
print('deon')
import matplotlib.colors as mcolor
norm = mcolor.LogNorm()
norm.vmin = -10
norm2 = copy.deepcopy(norm)


print(norm2, norm2.vmin)
norm2.vmin = 3
print(norm2.vmin)

import matplotlib.pyplot as plt
import numpy as np
fig, ax = plt.subplots()
ax.plot(np.arange(10))
plt.show()
```

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
