### PR TITLE
Implement lazy autoscaling in mplot3d.

### DIFF
--- a/doc/api/next_api_changes/behavior/18127-ES.rst
+++ b/doc/api/next_api_changes/behavior/18127-ES.rst
@@ -1,0 +1,11 @@
+Autoscaling in Axes3D
+~~~~~~~~~~~~~~~~~~~~~
+
+In Matplotlib 3.2.0, autoscaling was made lazier for 2D Axes, i.e., limits
+would only be recomputed when actually rendering the canvas, or when the user
+queries the Axes limits. This performance improvement is now extended to
+`.Axes3D`. This also fixes some issues with autoscaling being triggered
+unexpectedly in Axes3D.
+
+Please see :ref:`the API change for 2D Axes <api-changes-3-2-0-autoscaling>`
+for further details.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -54,6 +54,8 @@ writer, without performing the availability check on subsequent writers, it is
 now possible to iterate over the registry, which will yield the names of the
 available classes.
 
+.. _api-changes-3-2-0-autoscaling:
+
 Autoscaling
 ~~~~~~~~~~~
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6717,34 +6717,24 @@ def test_ytickcolor_is_not_markercolor():
         assert tick.tick1line.get_markeredgecolor() != 'white'
 
 
+@pytest.mark.parametrize('axis', ('x', 'y'))
 @pytest.mark.parametrize('auto', (True, False, None))
-def test_unautoscaley(auto):
-    fig, ax = plt.subplots()
-    x = np.arange(100)
-    y = np.linspace(-.1, .1, 100)
-    ax.scatter(x, y)
-
-    post_auto = ax.get_autoscaley_on() if auto is None else auto
-
-    ax.set_ylim((-.5, .5), auto=auto)
-    assert post_auto == ax.get_autoscaley_on()
-    fig.canvas.draw()
-    assert_array_equal(ax.get_ylim(), (-.5, .5))
-
-
-@pytest.mark.parametrize('auto', (True, False, None))
-def test_unautoscalex(auto):
+def test_unautoscale(axis, auto):
     fig, ax = plt.subplots()
     x = np.arange(100)
     y = np.linspace(-.1, .1, 100)
     ax.scatter(y, x)
 
-    post_auto = ax.get_autoscalex_on() if auto is None else auto
+    get_autoscale_on = getattr(ax, f'get_autoscale{axis}_on')
+    set_lim = getattr(ax, f'set_{axis}lim')
+    get_lim = getattr(ax, f'get_{axis}lim')
 
-    ax.set_xlim((-.5, .5), auto=auto)
-    assert post_auto == ax.get_autoscalex_on()
+    post_auto = get_autoscale_on() if auto is None else auto
+
+    set_lim((-0.5, 0.5), auto=auto)
+    assert post_auto == get_autoscale_on()
     fig.canvas.draw()
-    assert_array_equal(ax.get_xlim(), (-.5, .5))
+    assert_array_equal(get_lim(), (-0.5, 0.5))
 
 
 @check_figures_equal(extensions=["png"])

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -895,6 +895,28 @@ def test_autoscale():
     assert ax.get_w_lims() == (0, 1, -.1, 1.1, -.4, 2.4)
 
 
+@pytest.mark.parametrize('axis', ('x', 'y', 'z'))
+@pytest.mark.parametrize('auto', (True, False, None))
+def test_unautoscale(axis, auto):
+    fig = plt.figure()
+    ax = fig.gca(projection='3d')
+
+    x = np.arange(100)
+    y = np.linspace(-0.1, 0.1, 100)
+    ax.scatter(x, y)
+
+    get_autoscale_on = getattr(ax, f'get_autoscale{axis}_on')
+    set_lim = getattr(ax, f'set_{axis}lim')
+    get_lim = getattr(ax, f'get_{axis}lim')
+
+    post_auto = get_autoscale_on() if auto is None else auto
+
+    set_lim((-0.5, 0.5), auto=auto)
+    assert post_auto == get_autoscale_on()
+    fig.canvas.draw()
+    np.testing.assert_array_equal(get_lim(), (-0.5, 0.5))
+
+
 @mpl3d_image_comparison(['axes3d_ortho.png'], remove_text=False)
 def test_axes3d_ortho():
     fig = plt.figure()


### PR DESCRIPTION
## PR Summary

Since `Axes3D` derives from 2D `Axes`, this lazy autoscale was partially implemented. This might cause extraneous re-scaling since the 3D case did not always turn it off. It might also cause re-scaling to be missed since 2D `Axes` does not check z.

Fixes #18112.

This is a regression in 3.2.0 when lazy autoscaling was put in, but it's half a new feature, so I'm not sure if it belongs in 3.3.1. ~~I should probably figure out how to update a test for this, and write an API change to match the 2D case.~~

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way