### PR TITLE
Sort 3d sizes along with other properties

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -481,6 +481,7 @@ class Path3DCollection(PathCollection):
         self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
         self._facecolor3d = self.get_facecolor()
         self._edgecolor3d = self.get_edgecolor()
+        self._sizes3d = self.get_sizes()
         self.stale = True
 
     def do_3d_projection(self, renderer):
@@ -495,6 +496,8 @@ class Path3DCollection(PathCollection):
         ecs = (_zalpha(self._edgecolor3d, vzs) if self._depthshade else
                self._edgecolor3d)
 
+        sizes = self._sizes3d
+
         # Sort the points based on z coordinates
         # Performance optimization: Create a sorted index array and reorder
         # points and point properties according to the index array
@@ -506,6 +509,8 @@ class Path3DCollection(PathCollection):
         vys = vys[z_markers_idx]
         fcs = fcs[z_markers_idx]
         ecs = ecs[z_markers_idx]
+        if len(sizes) > 1:
+            sizes = sizes[z_markers_idx]
         vps = np.column_stack((vxs, vys))
 
         fcs = mcolors.to_rgba_array(fcs, self._alpha)
@@ -513,6 +518,7 @@ class Path3DCollection(PathCollection):
 
         self.set_edgecolors(ecs)
         self.set_facecolors(fcs)
+        self.set_sizes(sizes)
 
         PathCollection.set_offsets(self, vps)
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -242,6 +242,30 @@ def test_scatter3d_color():
                color='b', marker='s')
 
 
+@check_figures_equal(extensions=['png'])
+def test_scatter3d_size(fig_ref, fig_test):
+    """Test that large markers in correct position (issue #18135)"""
+    x = np.arange(10)
+    x, y = np.meshgrid(x, x)
+    z = np.arange(100).reshape(10, 10)
+
+    s = np.full(z.shape, 5)
+    s[0, 0] = 100
+    s[-1, 0] = 100
+    s[0, -1] = 100
+    s[-1, -1] = 100
+
+    ax_ref = fig_ref.gca(projection='3d')
+    ax_test = fig_test.gca(projection='3d')
+
+    small = np.ma.masked_array(z, s == 100, dtype=float)
+    large = np.ma.masked_array(z, s != 100, dtype=float)
+
+    ax_ref.scatter(x, y, large, s=100, c="C0", alpha=1)
+    ax_ref.scatter(x, y, small, s=5, c="C0", alpha=1)
+    ax_test.scatter(x, y, z, s=s, c="C0", alpha=1)
+
+
 @pytest.mark.parametrize('azim', [-50, 130])  # yellow first, blue first
 @check_figures_equal(extensions=['png'])
 def test_marker_draw_order_data_reversed(fig_test, fig_ref, azim):


### PR DESCRIPTION
## PR Summary

Fixes #18135. The sizes of the points need to be updated when reordering along with the other properties.

![scatter3d_fixed](https://user-images.githubusercontent.com/17545360/89042449-ddbff780-d33e-11ea-86d6-8b238014a95c.png)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
