### PR TITLE
Fix nbagg in Chrome 84

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -189,8 +189,20 @@ mpl.figure.prototype._init_canvas = function () {
 
             // Keep the size of the canvas and rubber band canvas in sync with
             // the canvas container.
-            canvas.setAttribute('width', width * mpl.ratio);
-            canvas.setAttribute('height', height * mpl.ratio);
+            if (entry.devicePixelContentBoxSize) {
+                // Chrome 84 implements new version of spec.
+                canvas.setAttribute(
+                    'width',
+                    entry.devicePixelContentBoxSize[0].inlineSize
+                );
+                canvas.setAttribute(
+                    'height',
+                    entry.devicePixelContentBoxSize[0].blockSize
+                );
+            } else {
+                canvas.setAttribute('width', width * mpl.ratio);
+                canvas.setAttribute('height', height * mpl.ratio);
+            }
             canvas.setAttribute(
                 'style',
                 'width: ' + width + 'px; height: ' + height + 'px;'

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -172,9 +172,17 @@ mpl.figure.prototype._init_canvas = function () {
             var entry = entries[i];
             var width, height;
             if (entry.contentBoxSize) {
-                width = entry.contentBoxSize.inlineSize;
-                height = entry.contentBoxSize.blockSize;
+                if (entry.contentBoxSize instanceof Array) {
+                    // Chrome 84 implements new version of spec.
+                    width = entry.contentBoxSize[0].inlineSize;
+                    height = entry.contentBoxSize[0].blockSize;
+                } else {
+                    // Firefox implements old version of spec.
+                    width = entry.contentBoxSize.inlineSize;
+                    height = entry.contentBoxSize.blockSize;
+                }
             } else {
+                // Chrome <84 implements even older version of spec.
                 width = entry.contentRect.width;
                 height = entry.contentRect.height;
             }

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -274,6 +274,7 @@ mpl.figure.prototype._init_canvas = function () {
 
     // Disable right mouse context menu.
     this.rubberband_canvas.addEventListener('contextmenu', function (_e) {
+        event.preventDefault();
         return false;
     });
 


### PR DESCRIPTION
## PR Summary

We check attributes for Firefox, and old Chrome. Chrome 84 implements a new version of the `ResizeObserver` spec, which uses the same attribute names as Firefox, but a different type. Naturally, JS doesn't complain and just returns undefined...

Also, fix the menu showing up on right-click.

Fixes #18132.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way