### PR TITLE
Proof of concept: Type42 subsetting in pdf

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1148,15 +1148,21 @@ end"""
             wObject = self.reserveObject('Type 0 widths')
             toUnicodeMapObject = self.reserveObject('ToUnicode map')
 
-            print(f"SUBSET {filename} characters: {''.join(chr(c) for c in characters)}")
-            fontdata = self.getSubset(filename, ''.join(chr(c) for c in characters))
-            print(f'SUBSET {filename} {os.stat(filename).st_size} -> {len(fontdata)}')
+            print(f"SUBSET {filename} characters: "
+                  f"{''.join(chr(c) for c in characters)}")
+            fontdata = self.getSubset(
+                filename,
+                ''.join(chr(c) for c in characters)
+            )
+            print(f'SUBSET {filename} {os.stat(filename).st_size}'
+                  f' ↦ {len(fontdata)}')
 
             # reload the font object from the subset
-            # (all the necessary data could probably be obtained directly using fontLib.ttLib)
+            # (all the necessary data could probably be obtained directly
+            # using fontLib.ttLib)
             with tempfile.NamedTemporaryFile(suffix='.ttf') as tmp:
                 tmp.write(fontdata)
-                tmp.seek(0,0)
+                tmp.seek(0, 0)
                 font = FT2Font(tmp.name)
 
             cidFontDict = {
@@ -1313,9 +1319,11 @@ end"""
 
     @classmethod
     def getSubset(self, fontfile, characters):
-        """Read TTF font from the given file and subset it for the given characters.
+        """
+        Read TTF font from the given file and subset it for the given characters.
 
-        Returns a serialization of the subset font as bytes."""
+        Returns a serialization of the subset font as bytes.
+        """
 
         options = subset.Options(glyph_names=True, recommended_glyphs=True)
         options.drop_tables += ['FFTM']

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1320,8 +1320,9 @@ end"""
     @classmethod
     def getSubset(self, fontfile, characters):
         """
-        Read TTF font from the given file and subset it for the given characters.
+        Subset a TTF font
 
+        Reads the named fontfile and restricts the font to the characters.
         Returns a serialization of the subset font as bytes.
         """
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -15,11 +15,13 @@ import math
 import os
 import re
 import struct
+import tempfile
 import time
 import types
 import warnings
 import zlib
 
+from fontTools import subset
 import numpy as np
 from PIL import Image
 
@@ -36,7 +38,7 @@ from matplotlib.afm import AFM
 import matplotlib.type1font as type1font
 import matplotlib.dviread as dviread
 from matplotlib.ft2font import (FIXED_WIDTH, ITALIC, LOAD_NO_SCALE,
-                                LOAD_NO_HINTING, KERNING_UNFITTED)
+                                LOAD_NO_HINTING, KERNING_UNFITTED, FT2Font)
 from matplotlib.mathtext import MathTextParser
 from matplotlib.transforms import Affine2D, BboxBase
 from matplotlib.path import Path
@@ -1146,6 +1148,17 @@ end"""
             wObject = self.reserveObject('Type 0 widths')
             toUnicodeMapObject = self.reserveObject('ToUnicode map')
 
+            print(f"SUBSET {filename} characters: {''.join(chr(c) for c in characters)}")
+            fontdata = self.getSubset(filename, ''.join(chr(c) for c in characters))
+            print(f'SUBSET {filename} {os.stat(filename).st_size} -> {len(fontdata)}')
+
+            # reload the font object from the subset
+            # (all the necessary data could probably be obtained directly using fontLib.ttLib)
+            with tempfile.NamedTemporaryFile(suffix='.ttf') as tmp:
+                tmp.write(fontdata)
+                tmp.seek(0,0)
+                font = FT2Font(tmp.name)
+
             cidFontDict = {
                 'Type': Name('Font'),
                 'Subtype': Name('CIDFontType2'),
@@ -1170,21 +1183,12 @@ end"""
 
             # Make fontfile stream
             descriptor['FontFile2'] = fontfileObject
-            length1Object = self.reserveObject('decoded length of a font')
             self.beginStream(
                 fontfileObject.id,
                 self.reserveObject('length of font stream'),
-                {'Length1': length1Object})
-            with open(filename, 'rb') as fontfile:
-                length1 = 0
-                while True:
-                    data = fontfile.read(4096)
-                    if not data:
-                        break
-                    length1 += len(data)
-                    self.currentstream.write(data)
+                {'Length1': len(fontdata)})
+            self.currentstream.write(fontdata)
             self.endStream()
-            self.writeObject(length1Object, length1)
 
             # Make the 'W' (Widths) array, CidToGidMap and ToUnicode CMap
             # at the same time
@@ -1306,6 +1310,25 @@ end"""
             return embedTTFType3(font, characters, descriptor)
         elif fonttype == 42:
             return embedTTFType42(font, characters, descriptor)
+
+    @classmethod
+    def getSubset(self, fontfile, characters):
+        """Read TTF font from the given file and subset it for the given characters.
+
+        Returns a serialization of the subset font as bytes."""
+
+        options = subset.Options(glyph_names=True, recommended_glyphs=True)
+        options.drop_tables += ['FFTM']
+        font = subset.load_font(fontfile, options)
+        try:
+            subsetter = subset.Subsetter(options=options)
+            subsetter.populate(text=characters)
+            subsetter.subset(font)
+            fh = BytesIO()
+            font.save(fh, reorderTables=False)
+            return fh.getvalue()
+        finally:
+            font.close()
 
     def alphaState(self, alpha):
         """Return name of an ExtGState that sets alpha to the given value."""

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -16,7 +16,9 @@ def pytest_configure(config):
         ("markers", "style: Set alternate Matplotlib style temporarily."),
         ("markers", "baseline_images: Compare output against references."),
         ("markers", "pytz: Tests that require pytz to be installed."),
-        #("filterwarnings", "error"),  # fontTools.subset raises a pointless DeprecationWarning
+        ("filterwarnings", "error"),
+        ("filterwarnings",
+         "ignore:.*The py23 module has been deprecated:DeprecationWarning"),
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -16,7 +16,7 @@ def pytest_configure(config):
         ("markers", "style: Set alternate Matplotlib style temporarily."),
         ("markers", "baseline_images: Compare output against references."),
         ("markers", "pytz: Tests that require pytz to be installed."),
-        ("filterwarnings", "error"),
+        #("filterwarnings", "error"),  # fontTools.subset raises a pointless DeprecationWarning
     ]:
         config.addinivalue_line(key, value)
 

--- a/setup.py
+++ b/setup.py
@@ -279,6 +279,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     ],
     install_requires=[
         "cycler>=0.10",
+        "fonttools>=4.13.0,<5.0",
         "kiwisolver>=1.0.1",
         "numpy>=1.16",
         "pillow>=6.2.0",


### PR DESCRIPTION
## PR Summary

Use [fonttools](https://github.com/fonttools/fonttools) to subset TrueType fonts when embedding them in Type42 format. This is a somewhat hacky proof of concept, but it seems to work:

```py
import matplotlib
from matplotlib import pyplot as plt

matplotlib.rcParams['pdf.fonttype'] = 42
plt.plot([3,1,4,1,5,9,2])
plt.title(r'$\pi$')
plt.text(1,5,'Hellø World! ()℻ǘ ⇐⇑⇒⇓←↑→↓↴↵≀')
plt.savefig('foo.pdf')
```

outputs

```
SUBSET /Users/jks/matplotlib/lib/matplotlib/mpl-data/fonts/ttf/DejaVuSans-Oblique.ttf characters: π
SUBSET /Users/jks/matplotlib/lib/matplotlib/mpl-data/fonts/ttf/DejaVuSans-Oblique.ttf 633840 -> 3052
SUBSET /Users/jks/matplotlib/lib/matplotlib/mpl-data/fonts/ttf/DejaVuSans.ttf characters: ←↑→↓ !()0123456789↴℻↵≀H⇐⇑⇒⇓Wǘdelorø
SUBSET /Users/jks/matplotlib/lib/matplotlib/mpl-data/fonts/ttf/DejaVuSans.ttf 756072 -> 11340
```

and produces the attached file [foo.pdf](https://github.com/matplotlib/matplotlib/files/5010445/foo.pdf), which looks fine in at least Preview.app. The debug output shows the size reduction from the original font file to the subset (before compression).

Do people think this would be worth pursuing? The fonttools library would be a new dependency, but it has been around for a long time and seems to be under development. It does raise a DeprecationWarning that seems quite pointless (you can just comment out the problematic import with no effect) but we could probably send them a PR to fix that. The library can also read and subset OpenType fonts and read Type-1 fonts (but it doesn't seem to include subsetting support for those).

## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
