### PR TITLE
Catch Pandas AssertionError on deprecated multidimensional indexing. Closes #18158

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1323,11 +1323,8 @@ def _check_1d(x):
                     "always",
                     category=Warning,
                     message='Support for multi-dimensional indexing')
-                try:
-                    ndim = x[:, None].ndim
-                except AssertionError:
-                    # catch https://github.com/pandas-dev/pandas/issues/35527
-                    return np.asanyarray(x)
+
+                ndim = x[:, None].ndim
                 # we have definitely hit a pandas index or series object
                 # cast to a numpy array.
                 if len(w) > 0:
@@ -1338,7 +1335,10 @@ def _check_1d(x):
             if ndim < 2:
                 return np.atleast_1d(x)
             return x
-        except (IndexError, TypeError):
+        # In pandas 1.1.0, multidimensional indexing leads to an AssertionError for some
+        # Series objects, but should be IndexError as described in
+        # https://github.com/pandas-dev/pandas/issues/35527
+        except (AssertionError, IndexError, TypeError):
             return np.atleast_1d(x)
 
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1323,8 +1323,11 @@ def _check_1d(x):
                     "always",
                     category=Warning,
                     message='Support for multi-dimensional indexing')
-
-                ndim = x[:, None].ndim
+                try:
+                    ndim = x[:, None].ndim
+                except AssertionError:
+                    # catch https://github.com/pandas-dev/pandas/issues/35527
+                    return np.asanyarray(x)
                 # we have definitely hit a pandas index or series object
                 # cast to a numpy array.
                 if len(w) > 0:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1335,8 +1335,9 @@ def _check_1d(x):
             if ndim < 2:
                 return np.atleast_1d(x)
             return x
-        # In pandas 1.1.0, multidimensional indexing leads to an AssertionError for some
-        # Series objects, but should be IndexError as described in
+        # In pandas 1.1.0, multidimensional indexing leads to an
+        # AssertionError for some Series objects, but should be
+        # IndexError as described in
         # https://github.com/pandas-dev/pandas/issues/35527
         except (AssertionError, IndexError, TypeError):
             return np.atleast_1d(x)


### PR DESCRIPTION
## PR Summary
Fixes #18158 due to pandas-dev/pandas#35527
