### PR TITLE
allow webAgg to report middle click events

### DIFF
--- a/doc/api/next_api_changes/behavior/18172-IHI.rst
+++ b/doc/api/next_api_changes/behavior/18172-IHI.rst
@@ -1,0 +1,6 @@
+webAgg backend no longer reports a middle click as a right click
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously when using the webAgg backend the event passed to a callback
+by `fig.canvas.mpl_connect('mouse_button_event', callback)` on a middle click
+would report `MouseButton.RIGHT` instead of `MouseButton.MIDDLE`

--- a/doc/api/next_api_changes/behavior/18172-IHI.rst
+++ b/doc/api/next_api_changes/behavior/18172-IHI.rst
@@ -1,6 +1,6 @@
 webAgg backend no longer reports a middle click as a right click
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously when using the webAgg backend the event passed to a callback
-by `fig.canvas.mpl_connect('mouse_button_event', callback)` on a middle click
-would report `MouseButton.RIGHT` instead of `MouseButton.MIDDLE`
+by ``fig.canvas.mpl_connect('mouse_button_event', callback)`` on a middle click
+would report `.MouseButton.RIGHT` instead of `.MouseButton.MIDDLE`

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -260,14 +260,6 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         # off by 1
         button = event['button'] + 1
 
-        # The right mouse button pops up a context menu, which
-        # doesn't work very well, so use the middle mouse button
-        # instead.  It doesn't seem that it's possible to disable
-        # the context menu in recent versions of Chrome.  If this
-        # is resolved, please also adjust the docstring in MouseEvent.
-        if button == 2:
-            button = 3
-
         e_type = event['type']
         guiEvent = event.get('guiEvent', None)
         if e_type == 'button_press':


### PR DESCRIPTION
I removed the code in webAgg_core that prevented a user from being able to differentiate between middle click and right click events with a `mouse_button_event` callback. I removed this forcing of the reported button from 2->3. This code was originally added to account for difficulties in preventing the context menu in chrome 23 https://github.com/matplotlib/matplotlib/pull/1426#discussion_r1915509 which in modern chrome should be possible.  There was a comment asking to remove mention of this from the MouseEvent docstring, however the current docstring does not seem to mention this so I did not change anything there.

Closes: https://github.com/matplotlib/ipympl/issues/254
Closes: https://github.com/matplotlib/matplotlib/issues/18171

## PR Summary

## PR Checklist

- [ ] Has Pytest style unit tests (does remove code require writing a new test?)
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- na New features are documented, with examples if plot related
- na Documentation is sphinx and numpydoc compliant
- na Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- na? Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
