### PR TITLE
Fix the return value of Axes.get_navigate_mode.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2784,6 +2784,10 @@ class _Mode(str, Enum):
     def __str__(self):
         return self.value
 
+    @property
+    def _navigate_mode(self):
+        return self.name if self is not _Mode.NONE else None
+
 
 class NavigationToolbar2:
     """
@@ -3047,7 +3051,7 @@ class NavigationToolbar2:
             self.mode = _Mode.PAN
             self.canvas.widgetlock(self)
         for a in self.canvas.figure.get_axes():
-            a.set_navigate_mode(self.mode)
+            a.set_navigate_mode(self.mode._navigate_mode)
         self.set_message(self.mode)
 
     def press_pan(self, event):
@@ -3117,7 +3121,7 @@ class NavigationToolbar2:
             self.mode = _Mode.ZOOM
             self.canvas.widgetlock(self)
         for a in self.canvas.figure.get_axes():
-            a.set_navigate_mode(self.mode)
+            a.set_navigate_mode(self.mode._navigate_mode)
         self.set_message(self.mode)
 
     def press_zoom(self, event):

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -107,9 +107,11 @@ def test_location_event_position(x, y):
 def test_interactive_zoom():
     fig, ax = plt.subplots()
     ax.set(xscale="logit")
+    assert ax.get_navigate_mode() is None
 
     tb = NavigationToolbar2(fig.canvas)
     tb.zoom()
+    assert ax.get_navigate_mode() == 'ZOOM'
 
     xlim0 = ax.get_xlim()
     ylim0 = ax.get_ylim()
@@ -143,3 +145,6 @@ def test_interactive_zoom():
     # Absolute tolerance much less than original xmin (1e-7).
     assert ax.get_xlim() == pytest.approx(xlim0, rel=0, abs=1e-10)
     assert ax.get_ylim() == pytest.approx(ylim0, rel=0, abs=1e-10)
+
+    tb.zoom()
+    assert ax.get_navigate_mode() is None


### PR DESCRIPTION
## PR Summary

Fixes #18150.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way