### PR TITLE
Downgrade symbol substitution log to info level.

### DIFF
--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -857,8 +857,7 @@ class UnicodeFonts(TruetypeFonts):
                 fname = g[0].family_name
                 if fname in list(BakomaFonts._fontmap.values()):
                     fname = "Computer Modern"
-                _log.warning("Substituting symbol {} "
-                             "from {}".format(sym, fname))
+                _log.info("Substituting symbol %s from %s", sym, fname)
                 return g
 
             else:


### PR DESCRIPTION
## PR Summary

Another upside is that this warning is all over the docs build, so those will be shorter.

Fixes #17998.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way