### PR TITLE
Go back to checking figures for their manager in destroy.

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -71,9 +71,10 @@ class Gcf:
     @classmethod
     def destroy_fig(cls, fig):
         """Destroy figure *fig*."""
-        canvas = getattr(fig, "canvas", None)
-        manager = getattr(canvas, "manager", None)
-        cls.destroy(manager)
+        num = next((manager.num for manager in cls.figs.values()
+                    if manager.canvas.figure == fig), None)
+        if num is not None:
+            cls.destroy(num)
 
     @classmethod
     def destroy_all(cls):

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -60,6 +60,15 @@ def test_get_default_filename(tmpdir):
     assert filename == 'image.png'
 
 
+def test_canvas_change():
+    fig = plt.figure()
+    # Replaces fig.canvas
+    canvas = FigureCanvasBase(fig)
+    # Should still work.
+    plt.close(fig)
+    assert not plt.fignum_exists(fig.number)
+
+
 @pytest.mark.backend('pdf')
 def test_non_gui_warning(monkeypatch):
     plt.subplots()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -154,8 +154,13 @@ _test_timeout = 10  # Empirically, 1s is not enough on Travis.
 @pytest.mark.parametrize("toolbar", ["toolbar2", "toolmanager"])
 @pytest.mark.flaky(reruns=3)
 def test_interactive_backend(backend, toolbar):
-    if backend == "macosx" and toolbar == "toolmanager":
-        pytest.skip("toolmanager is not implemented for macosx.")
+    if backend == "macosx":
+        if toolbar == "toolmanager":
+            pytest.skip("toolmanager is not implemented for macosx.")
+        if toolbar == "toolbar2" and os.environ.get('TRAVIS'):
+            # See https://github.com/matplotlib/matplotlib/issues/18213
+            pytest.skip("toolbar2 for macosx is buggy on Travis.")
+
     proc = subprocess.run(
         [sys.executable, "-c", _test_script,
          json.dumps({"toolbar": toolbar})],


### PR DESCRIPTION
## PR Summary

This is a partial revert of a small part of #13581.

Fixes #18163.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way