### PR TITLE
TST: exercise pyinstaller in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,7 @@ install:
       python -c 'import wx' &&
       echo 'wxPython is available' ||
       echo 'wxPython is not available'
+    python -m pip install --upgrade pyinstaller
 
   # Set flag in a delayed manner to avoid issues with installing other packages
   - |
@@ -178,6 +179,13 @@ script:
     # causes the Travis VM to run out of memory (since so many copies of
     # inkscape and ghostscript are running at the same time).
     python -mpytest -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n2 --log-level=DEBUG
+
+  - |
+    mkdir pyinstaller_test
+    cd pyinstaller_test
+    echo "import matplotlib.pyplot" > main.py
+    pyinstaller main.py
+    ./dist/main/main
 
 before_cache: |
   rm -rf $HOME/.cache/matplotlib/tex.cache


### PR DESCRIPTION
## PR Summary

I am going to say this closes #3391 even though the original issue was targetting cx_freeze rather than pyinstaller.

This is waiting on https://github.com/pyinstaller/pyinstaller/issues/5004 to be fixed and release on the pyinstaller side.

A concern that @efiring brought up when this issue was initially created is that how should we deal with it when it fails.  I think the procedure should be to reach out to the pyinstaller folks and sort out if we should temporarily disable the test on our side or find some other way to do what we want to do.


## PR Checklist

- [x] Has Pytest style unit tests
