### PR TITLE
Allow savefig to save SVGs on FIPS enabled systems #18192

### DIFF
--- a/doc/api/next_api_changes/behavior/18193-BKB.rst
+++ b/doc/api/next_api_changes/behavior/18193-BKB.rst
@@ -1,0 +1,10 @@
+ID attribute of XML tags in SVG files now based on SHA256 rather than MD5
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Matplotlib generates unique ID attributes for various tags in SVG files.
+Matplotlib previously generated these unique IDs using the first 10
+characters of an MD5 hash. The MD5 hashing algorithm is not available in
+Python on systems with Federal Information Processing Standards (FIPS)
+enabled. Matplotlib now uses the first 10 characters of an SHA256 hash
+instead. SVG files that would otherwise match those saved with earlier
+versions of matplotlib, will have different ID attributes.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -452,7 +452,7 @@ class RendererSVG(RendererBase):
         salt = mpl.rcParams['svg.hashsalt']
         if salt is None:
             salt = str(uuid.uuid4())
-        m = hashlib.md5()
+        m = hashlib.sha256()
         m.update(salt.encode('utf8'))
         m.update(str(content).encode('utf8'))
         return '%s%s' % (type, m.hexdigest()[:10])


### PR DESCRIPTION
## PR Summary

This pull request resolves #18192.

If you use a FIPS (Federal Information Processing Standards) enabled system, then you cannot use `plt.savefig` to save an image in SVG format. This is because the `RenderSVG._make_id` method takes the first 10 characters of a `hashlib.md5` digest of entries in the SVG as the ID for entries in the SVG file. 

The Python docs for [hashlib](https://docs.python.org/3/library/hashlib.html) includes the following note:

> Constructors for hash algorithms that are always present in this module are sha1(), sha224(), sha256(), sha384(), sha512(), blake2b(), and blake2s(). md5() is normally available as well, though it may be missing if you are using a rare “FIPS compliant” build of Python.

## PR Checklist

- [na ] Has Pytest style unit tests
       - Not sure if this is applicable to my change
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [na] New features are documented, with examples if plot related 
- [x] Documentation is sphinx and numpydoc compliant
- [na] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
       - Not a major feature
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
