### PR TITLE
Force locator and formatter inheritence

### DIFF
--- a/doc/api/next_api_changes/behavior/18203-DS.rst
+++ b/doc/api/next_api_changes/behavior/18203-DS.rst
@@ -1,0 +1,5 @@
+Locators and formatters
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Axis locators and formatters must now be subclasses of
+`~matplotlib.ticker.Locator` and `~matplotlib.ticker.Formatter` respectively.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -577,10 +577,8 @@ class Ticker:
     @locator.setter
     def locator(self, locator):
         if not isinstance(locator, mticker.Locator):
-            cbook.warn_deprecated(
-                "3.2", message="Support for locators that do not subclass "
-                "matplotlib.ticker.Locator is deprecated since %(since)s and "
-                "support for them will be removed %(removal)s.")
+            raise TypeError('locator must be a subclass of '
+                            'matplotlib.ticker.Locator')
         self._locator = locator
 
     @property
@@ -590,10 +588,8 @@ class Ticker:
     @formatter.setter
     def formatter(self, formatter):
         if not isinstance(formatter, mticker.Formatter):
-            cbook.warn_deprecated(
-                "3.2", message="Support for formatters that do not subclass "
-                "matplotlib.ticker.Formatter is deprecated since %(since)s "
-                "and support for them will be removed %(removal)s.")
+            raise TypeError('formatter must be a subclass of '
+                            'matplotlib.ticker.Formatter')
         self._formatter = formatter
 
 


### PR DESCRIPTION
Deprecated in 3.2, locators and formatters are now forced to be sub-classes of their respective base class.