### PR TITLE
Fixes an issue where WxAgg NavigationToolbar2 broke custom toolbars

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1109,7 +1109,7 @@ cursord = {
 
 
 class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
-    def __init__(self, canvas):
+    def __init__(self, canvas, coordinates=True):
         wx.ToolBar.__init__(self, canvas.GetParent(), -1)
 
         if 'wxMac' in wx.PlatformInfo:
@@ -1131,9 +1131,11 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             self.Bind(wx.EVT_TOOL, getattr(self, callback),
                       id=self.wx_ids[text])
 
-        self.AddStretchableSpace()
-        self._label_text = wx.StaticText(self)
-        self.AddControl(self._label_text)
+        self._coordinates = coordinates
+        if self._coordinates:
+            self.AddStretchableSpace()
+            self._label_text = wx.StaticText(self)
+            self.AddControl(self._label_text)
 
         self.Realize()
 
@@ -1338,7 +1340,8 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         return self.GetTopLevelParent().GetStatusBar()
 
     def set_message(self, s):
-        self._label_text.SetLabel(s)
+        if self._coordinates:
+            self._label_text.SetLabel(s)
 
     def set_history_buttons(self):
         can_backward = self._nav_stack._pos > 0


### PR DESCRIPTION
## PR Summary

Fixes the issue in #18212 where the new coordinate readout in the WxAgg toolbar would lead to improper formatting when the toolbar was customized with additional buttons/widgets. To do so, this adds an optional coordinates keyword argument to the ``NavigationToolbar2Wx`` that if ``True`` (default) shows the coordinate display and if ``False`` removes it.

Buggy behavior (shows additional button on right):
<img width="500" alt="Screen Shot 2020-08-11 at 11 50 09 AM" src="https://user-images.githubusercontent.com/23534688/89926537-aec14580-dbca-11ea-9894-1d8ff4cdf113.png">

Fixed behavior with ``coordinates=False`` (shows additional button at the end of the standard buttons):
<img width="498" alt="Screen Shot 2020-08-11 at 11 50 30 AM" src="https://user-images.githubusercontent.com/23534688/89926630-ba147100-dbca-11ea-9859-660d06ae5e12.png">


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
