### PR TITLE
Use certifi when downloading bundled build requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -275,6 +275,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
 
     python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
     setup_requires=[
+        "certifi>=2020.06.20",
         "numpy>=1.15",
     ],
     install_requires=[

--- a/setupext.py
+++ b/setupext.py
@@ -42,6 +42,13 @@ def _get_hash(data):
     return hasher.hexdigest()
 
 
+@functools.lru_cache()
+def _get_ssl_context():
+    import certifi
+    import ssl
+    return ssl.create_default_context(cafile=certifi.where())
+
+
 def download_or_cache(url, sha):
     """
     Get bytes from the given url or local cache.
@@ -73,7 +80,8 @@ def download_or_cache(url, sha):
     # default User-Agent, but not (for example) wget; so I don't feel too
     # bad passing in an empty User-Agent.
     with urllib.request.urlopen(
-            urllib.request.Request(url, headers={"User-Agent": ""})) as req:
+            urllib.request.Request(url, headers={"User-Agent": ""}),
+            context=_get_ssl_context()) as req:
         data = req.read()
 
     file_sha = _get_hash(data)


### PR DESCRIPTION
## PR Summary

This should fix build on macOS.
cf https://github.com/QuLogic/matplotlib/runs/973372905?check_suite_focus=true vs https://github.com/QuLogic/matplotlib/runs/973391400?check_suite_focus=true

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way