### PR TITLE
Use CallbackRegistry in Widgets and some related cleanup

### DIFF
--- a/doc/api/next_api_changes/behavior/18226-ES.rst
+++ b/doc/api/next_api_changes/behavior/18226-ES.rst
@@ -1,0 +1,10 @@
+Widgets use ``CallbackRegistry`` to save callbacks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`.Widget`\s with event observers now use a `.CallbackRegistry` for storing
+callbacks. This is consistent with canvas event callbacks, and fixes some bugs
+in widget callback handling.
+
+Due to this change, callback methods are now stored as weak references, which
+means you must keep a reference to the associated object. Otherwise it may be
+garbage collected.

--- a/doc/api/next_api_changes/deprecations/18226-ES.rst
+++ b/doc/api/next_api_changes/deprecations/18226-ES.rst
@@ -1,0 +1,12 @@
+Widget class internals
+~~~~~~~~~~~~~~~~~~~~~~
+
+Several `.widgets.Widget` class internals have been privatized and deprecated:
+
+* ``AxesWidget.cids``
+* ``Button.cnt`` and ``Button.observers``
+* ``CheckButtons.cnt`` and ``CheckButtons.observers``
+* ``RadioButtons.cnt`` and ``RadioButtons.observers``
+* ``Slider.cnt`` and ``Slider.observers``
+* ``TextBox.cnt``, ``TextBox.change_observers`` and
+  ``TextBox.submit_observers``

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -112,7 +112,12 @@ class AxesWidget(Widget):
     def __init__(self, ax):
         self.ax = ax
         self.canvas = ax.figure.canvas
-        self.cids = []
+        self._cids = []
+
+    @cbook.deprecated("3.4")
+    @property
+    def cids(self):
+        return self._cids
 
     def connect_event(self, event, callback):
         """
@@ -122,11 +127,11 @@ class AxesWidget(Widget):
         function stores callback ids for later clean up.
         """
         cid = self.canvas.mpl_connect(event, callback)
-        self.cids.append(cid)
+        self._cids.append(cid)
 
     def disconnect_events(self):
         """Disconnect all events created by this widget."""
-        for c in self.cids:
+        for c in self._cids:
             self.canvas.mpl_disconnect(c)
 
 
@@ -175,8 +180,8 @@ class Button(AxesWidget):
                              horizontalalignment='center',
                              transform=ax.transAxes)
 
-        self.cnt = 0
-        self.observers = {}
+        self._cnt = 0
+        self._observers = {}
 
         self.connect_event('button_press_event', self._click)
         self.connect_event('button_release_event', self._release)
@@ -187,6 +192,16 @@ class Button(AxesWidget):
         ax.set_yticks([])
         self.color = color
         self.hovercolor = hovercolor
+
+    @cbook.deprecated("3.4")
+    @property
+    def cnt(self):
+        return self._cnt
+
+    @cbook.deprecated("3.4")
+    @property
+    def observers(self):
+        return self._observers
 
     def _click(self, event):
         if (self.ignore(event)
@@ -204,7 +219,7 @@ class Button(AxesWidget):
         if (not self.eventson
                 or event.inaxes != self.ax):
             return
-        for cid, func in self.observers.items():
+        for cid, func in self._observers.items():
             func(event)
 
     def _motion(self, event):
@@ -222,15 +237,15 @@ class Button(AxesWidget):
 
         Returns a connection id, which can be used to disconnect the callback.
         """
-        cid = self.cnt
-        self.observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._observers[cid] = func
+        self._cnt += 1
         return cid
 
     def disconnect(self, cid):
         """Remove the callback function with connection id *cid*."""
         try:
-            del self.observers[cid]
+            del self._observers[cid]
         except KeyError:
             pass
 
@@ -382,10 +397,20 @@ class Slider(AxesWidget):
                                    verticalalignment='center',
                                    horizontalalignment='left')
 
-        self.cnt = 0
-        self.observers = {}
+        self._cnt = 0
+        self._observers = {}
 
         self.set_val(valinit)
+
+    @cbook.deprecated("3.4")
+    @property
+    def cnt(self):
+        return self._cnt
+
+    @cbook.deprecated("3.4")
+    @property
+    def observers(self):
+        return self._observers
 
     def _value_in_bounds(self, val):
         """Makes sure *val* is with given bounds."""
@@ -469,7 +494,7 @@ class Slider(AxesWidget):
         self.val = val
         if not self.eventson:
             return
-        for cid, func in self.observers.items():
+        for cid, func in self._observers.items():
             func(val)
 
     def on_changed(self, func):
@@ -488,9 +513,9 @@ class Slider(AxesWidget):
         int
             Connection id (which can be used to disconnect *func*)
         """
-        cid = self.cnt
-        self.observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._observers[cid] = func
+        self._cnt += 1
         return cid
 
     def disconnect(self, cid):
@@ -503,7 +528,7 @@ class Slider(AxesWidget):
             Connection id of the observer to be removed
         """
         try:
-            del self.observers[cid]
+            del self._observers[cid]
         except KeyError:
             pass
 
@@ -600,8 +625,18 @@ class CheckButtons(AxesWidget):
 
         self.connect_event('button_press_event', self._clicked)
 
-        self.cnt = 0
-        self.observers = {}
+        self._cnt = 0
+        self._observers = {}
+
+    @cbook.deprecated("3.4")
+    @property
+    def cnt(self):
+        return self._cnt
+
+    @cbook.deprecated("3.4")
+    @property
+    def observers(self):
+        return self._observers
 
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
@@ -640,7 +675,7 @@ class CheckButtons(AxesWidget):
 
         if not self.eventson:
             return
-        for cid, func in self.observers.items():
+        for cid, func in self._observers.items():
             func(self.labels[index].get_text())
 
     def get_status(self):
@@ -655,15 +690,15 @@ class CheckButtons(AxesWidget):
 
         Returns a connection id, which can be used to disconnect the callback.
         """
-        cid = self.cnt
-        self.observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._observers[cid] = func
+        self._cnt += 1
         return cid
 
     def disconnect(self, cid):
         """Remove the observer with connection id *cid*."""
         try:
-            del self.observers[cid]
+            del self._observers[cid]
         except KeyError:
             pass
 
@@ -725,9 +760,9 @@ class TextBox(AxesWidget):
             self.DIST_FROM_LEFT, 0.5, initial, transform=self.ax.transAxes,
             verticalalignment='center', horizontalalignment='left')
 
-        self.cnt = 0
-        self.change_observers = {}
-        self.submit_observers = {}
+        self._cnt = 0
+        self._change_observers = {}
+        self._submit_observers = {}
 
         ax.set(
             xlim=(0, 1), ylim=(0, 1),  # s.t. cursor appears from first click.
@@ -749,6 +784,21 @@ class TextBox(AxesWidget):
         self.hovercolor = hovercolor
 
         self.capturekeystrokes = False
+
+    @cbook.deprecated("3.4")
+    @property
+    def cnt(self):
+        return self._cnt
+
+    @cbook.deprecated("3.4")
+    @property
+    def change_observers(self):
+        return self._change_observers
+
+    @cbook.deprecated("3.4")
+    @property
+    def submit_observers(self):
+        return self._submit_observers
 
     @property
     def text(self):
@@ -780,7 +830,7 @@ class TextBox(AxesWidget):
 
     def _notify_submit_observers(self):
         if self.eventson:
-            for cid, func in self.submit_observers.items():
+            for cid, func in self._submit_observers.items():
                 func(self.text)
 
     def _release(self, event):
@@ -836,7 +886,7 @@ class TextBox(AxesWidget):
 
     def _notify_change_observers(self):
         if self.eventson:
-            for cid, func in self.change_observers.items():
+            for cid, func in self._change_observers.items():
                 func(self.text)
 
     def begin_typing(self, x):
@@ -918,9 +968,9 @@ class TextBox(AxesWidget):
 
         A connection id is returned which can be used to disconnect.
         """
-        cid = self.cnt
-        self.change_observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._change_observers[cid] = func
+        self._cnt += 1
         return cid
 
     def on_submit(self, func):
@@ -930,14 +980,14 @@ class TextBox(AxesWidget):
 
         A connection id is returned which can be used to disconnect.
         """
-        cid = self.cnt
-        self.submit_observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._submit_observers[cid] = func
+        self._cnt += 1
         return cid
 
     def disconnect(self, cid):
         """Remove the observer with connection id *cid*."""
-        for reg in [self.change_observers, self.submit_observers]:
+        for reg in [self._change_observers, self._submit_observers]:
             try:
                 del reg[cid]
             except KeyError:
@@ -1022,8 +1072,18 @@ class RadioButtons(AxesWidget):
 
         self.connect_event('button_press_event', self._clicked)
 
-        self.cnt = 0
-        self.observers = {}
+        self._cnt = 0
+        self._observers = {}
+
+    @cbook.deprecated("3.4")
+    @property
+    def cnt(self):
+        return self._cnt
+
+    @cbook.deprecated("3.4")
+    @property
+    def observers(self):
+        return self._observers
 
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
@@ -1061,7 +1121,7 @@ class RadioButtons(AxesWidget):
 
         if not self.eventson:
             return
-        for cid, func in self.observers.items():
+        for cid, func in self._observers.items():
             func(self.labels[index].get_text())
 
     def on_clicked(self, func):
@@ -1070,15 +1130,15 @@ class RadioButtons(AxesWidget):
 
         Returns a connection id, which can be used to disconnect the callback.
         """
-        cid = self.cnt
-        self.observers[cid] = func
-        self.cnt += 1
+        cid = self._cnt
+        self._observers[cid] = func
+        self._cnt += 1
         return cid
 
     def disconnect(self, cid):
         """Remove the observer with connection id *cid*."""
         try:
-            del self.observers[cid]
+            del self._observers[cid]
         except KeyError:
             pass
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -311,14 +311,13 @@ class Slider(AxesWidget):
         super().__init__(ax)
 
         if slidermin is not None and not hasattr(slidermin, 'val'):
-            raise ValueError("Argument slidermin ({}) has no 'val'"
-                             .format(type(slidermin)))
+            raise ValueError(
+                f"Argument slidermin ({type(slidermin)}) has no 'val'")
         if slidermax is not None and not hasattr(slidermax, 'val'):
-            raise ValueError("Argument slidermax ({}) has no 'val'"
-                             .format(type(slidermax)))
-        if orientation not in ['horizontal', 'vertical']:
-            raise ValueError("Argument orientation ({}) must be either"
-                             "'horizontal' or 'vertical'".format(orientation))
+            raise ValueError(
+                f"Argument slidermax ({type(slidermax)}) has no 'val'")
+        cbook._check_in_list(['horizontal', 'vertical'],
+                             orientation=orientation)
 
         self.orientation = orientation
         self.closedmin = closedmin
@@ -629,8 +628,8 @@ class CheckButtons(AxesWidget):
         ValueError
             If *index* is invalid.
         """
-        if not 0 <= index < len(self.labels):
-            raise ValueError("Invalid CheckButton index: %d" % index)
+        if index not in range(len(self.labels)):
+            raise ValueError(f'Invalid CheckButton index: {index}')
 
         l1, l2 = self.lines[index]
         l1.set_visible(not l1.get_visible())
@@ -1045,8 +1044,8 @@ class RadioButtons(AxesWidget):
 
         Callbacks will be triggered if :attr:`eventson` is True.
         """
-        if 0 > index >= len(self.labels):
-            raise ValueError("Invalid RadioButton index: %d" % index)
+        if index not in range(len(self.labels)):
+            raise ValueError(f'Invalid RadioButton index: {index}')
 
         self.value_selected = self.labels[index].get_text()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -204,22 +204,17 @@ class Button(AxesWidget):
         return self._observers.callbacks['clicked']
 
     def _click(self, event):
-        if (self.ignore(event)
-                or event.inaxes != self.ax
-                or not self.eventson):
+        if self.ignore(event) or event.inaxes != self.ax or not self.eventson:
             return
         if event.canvas.mouse_grabber != self.ax:
             event.canvas.grab_mouse(self.ax)
 
     def _release(self, event):
-        if (self.ignore(event)
-                or event.canvas.mouse_grabber != self.ax):
+        if self.ignore(event) or event.canvas.mouse_grabber != self.ax:
             return
         event.canvas.release_mouse(self.ax)
-        if (not self.eventson
-                or event.inaxes != self.ax):
-            return
-        self._observers.process('clicked', event)
+        if self.eventson and event.inaxes == self.ax:
+            self._observers.process('clicked', event)
 
     def _motion(self, event):
         if self.ignore(event):
@@ -485,9 +480,8 @@ class Slider(AxesWidget):
         if self.drawon:
             self.ax.figure.canvas.draw_idle()
         self.val = val
-        if not self.eventson:
-            return
-        self._observers.process('changed', val)
+        if self.eventson:
+            self._observers.process('changed', val)
 
     def on_changed(self, func):
         """
@@ -659,9 +653,8 @@ class CheckButtons(AxesWidget):
         if self.drawon:
             self.ax.figure.canvas.draw()
 
-        if not self.eventson:
-            return
-        self._observers.process('clicked', self.labels[index].get_text())
+        if self.eventson:
+            self._observers.process('clicked', self.labels[index].get_text())
 
     def get_status(self):
         """
@@ -1079,9 +1072,8 @@ class RadioButtons(AxesWidget):
         if self.drawon:
             self.ax.figure.canvas.draw()
 
-        if not self.eventson:
-            return
-        self._observers.process('clicked', self.labels[index].get_text())
+        if self.eventson:
+            self._observers.process('clicked', self.labels[index].get_text())
 
     def on_clicked(self, func):
         """


### PR DESCRIPTION
## PR Summary

This came about from this Discourse post: https://discourse.matplotlib.org/t/have-a-button-disconnect-its-own-callback/21465
Using a `CallbackRegistry` simplifies processing, fixes memory leaks with weak references, and fixes bugs like being unable to disconnect a callback in its own code, as in the above post.

I also cleaned up some conditions and deprecated the old callback-related attributes.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way