### PR TITLE
Set pipefail when running flake8 linter.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -o pipefail
           flake8 --docstring-convention=all | \
             reviewdog -f=pep8 -name=flake8 \
               -tee -reporter=github-check -filter-mode nofilter


### PR DESCRIPTION
## PR Summary

This ensures that the lint will fail if flake8 is broken, otherwise default bash behaviour is to ignore it, if reviewdog exits cleanly.
See https://github.com/matplotlib/matplotlib/pull/18200#pullrequestreview-463721344

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way