### PR TITLE
Fix cibuildwheel trigger condition.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install cibuildwheel==1.5.5
 
-      - name: Build wheels
+      - name: Build wheels for CPython
         run: |
           python -m cibuildwheel --output-dir dist
         env:
@@ -38,8 +38,18 @@ jobs:
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install numpy==1.15
+
+      - name: Build wheels for PyPy
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "pp3?-*"
+          CIBW_BEFORE_BUILD: pip install numpy==1.15
+        if: >
+          runner.os != 'Windows' && (
+          startsWith(github.ref, 'refs/heads/v3.3') ||
+          startsWith(github.ref, 'refs/tags/v3.3') )
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -40,6 +40,18 @@ jobs:
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install numpy==1.15
 
+      - name: Build wheels for CPython 3.6
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp36-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_BEFORE_BUILD: pip install numpy==1.15
+        if: >
+          startsWith(github.ref, 'refs/heads/v3.3') ||
+          startsWith(github.ref, 'refs/tags/v3.3')
+
       - name: Build wheels for PyPy
         run: |
           python -m cibuildwheel --output-dir dist

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -37,6 +37,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_MANYLINUX_PYPY_X86_64_IMAGE: manylinux1
+          CIBW_BEFORE_BUILD: pip install numpy==1.15
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,6 +1,12 @@
 name: Build CI wheels
 
-on: [push, tags]
+on:
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.x
+    tags:
+      - v*
 
 jobs:
   build_wheels:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build wheels
         run: |
-          python -m cibuildwheel --output-dir wheelhouse
+          python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp3?-*"
           CIBW_SKIP: "cp35-* cp36-*"
@@ -44,4 +44,4 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./dist/*.whl

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v2
         name: Install Python


### PR DESCRIPTION
## PR Summary

I believe this should be the right [filters](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) for what we want. It should build on master, tags, and backport branches, but not doc-backport branches.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way