### PR TITLE
FIX: check we have a back button in tk toolbar before we touch it

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -635,14 +635,15 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             tkinter.messagebox.showerror("Error saving file", str(e))
 
     def set_history_buttons(self):
-        if self._nav_stack._pos > 0:
-            self._buttons['Back']['state'] = tk.NORMAL
-        else:
-            self._buttons['Back']['state'] = tk.DISABLED
-        if self._nav_stack._pos < len(self._nav_stack._elements) - 1:
-            self._buttons['Forward']['state'] = tk.NORMAL
-        else:
-            self._buttons['Forward']['state'] = tk.DISABLED
+        state_map = {True: tk.NORMAL, False: tk.DISABLED}
+        can_back = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
+
+        if "Back" in self._buttons:
+            self._buttons['Back']['state'] = state_map[can_back]
+
+        if "Forward" in self._buttons:
+            self._buttons['Forward']['state'] = state_map[can_forward]
 
 
 class ToolTip:

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -100,3 +100,16 @@ thread.join()
     except subprocess.CalledProcessError:
         pytest.fail("Subprocess failed to test intended behavior")
     assert proc.stdout.count("success") == 1
+
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+def test_missing_back_button():
+    from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk
+    class Toolbar(NavigationToolbar2Tk):
+        # only display the buttons we need
+        toolitems = [t for t in NavigationToolbar2Tk.toolitems if
+                     t[0] in ('Home', 'Pan', 'Zoom')]
+
+    fig = plt.figure()
+    # this should not raise
+    Toolbar(fig.canvas, fig.canvas.manager.window)


### PR DESCRIPTION
## PR Summary

We add one by default, but sub-classes may remove it.

closes #18232


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
