### PR TITLE
Fix reshape list of strings

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1377,7 +1377,10 @@ def _reshape_2D(X, name):
     result = []
     is_1d = True
     for xi in X:
-        if isinstance(xi, collections.abc.Iterable):
+        # check if this is iterable, except for strings which we
+        # treat as singletons.
+        if (isinstance(xi, collections.abc.Iterable) and
+                not isinstance(xi, str)):
             is_1d = False
         xi = np.asanyarray(xi)
         nd = np.ndim(xi)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -295,3 +295,7 @@ def test_overriding_units_in_plot(fig_test, fig_ref):
         # assert that we have not re-set the units attribute at all
         assert x_units is ax.xaxis.units
         assert y_units is ax.yaxis.units
+
+
+def test_category_hist():
+    

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -297,5 +297,8 @@ def test_overriding_units_in_plot(fig_test, fig_ref):
         assert y_units is ax.yaxis.units
 
 
-def test_category_hist():
-    
+def test_hist():
+    fig, ax = plt.subplots()
+    n, bins, patches = ax.hist(['a', 'b', 'a', 'c', 'ff'])
+    assert n.shape == (10,)
+    np.testing.assert_allclose(n, [2., 0., 0., 1., 0., 0., 1., 0., 0., 1.])

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -545,6 +545,12 @@ def test_reshape2d():
     assert len(xnew) == 1
     assert isinstance(xnew[0], ArraySubclass)
 
+    # check list of strings:
+    x = ['a', 'b', 'c', 'c', 'dd', 'e', 'f', 'ff', 'f']
+    xnew = cbook._reshape_2D(x, 'x')
+    assert len(xnew[0]) == len(x)
+    assert isinstance(xnew[0], np.ndarray)
+
 
 def test_contiguous_regions():
     a, b, c = 3, 4, 5


### PR DESCRIPTION
## PR Summary

Closes #18234

cbook._reshape_2D was altered to check for iterables in a list, which is great, except categorical strings are iterables.  This broke:

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
n, bins, patches = ax.hist(['a', 'b', 'b', 'c', 'd', 'ff', 'ff', 'a'])
plt.show()
```

## Before
![Figure_2](https://user-images.githubusercontent.com/1562854/90162461-814ed600-dd49-11ea-9ccd-6c492631afa4.png)
## After
![Figure_1](https://user-images.githubusercontent.com/1562854/90162467-83189980-dd49-11ea-9793-fb254ad21dc6.png)




## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
