### PR TITLE
MNT: do a better job guessing the GUI framework in use

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -232,10 +232,26 @@ def switch_backend(newbackend):
     close("all")
 
     if newbackend is rcsetup._auto_backend_sentinel:
+        current_framework = cbook._get_running_interactive_framework()
+        mapping = {'qt5': 'qt5agg',
+                   'qt4': 'qt4agg',
+                   'gtk3': 'gtk3agg',
+                   'wx': 'wxagg',
+                   'tk': 'tkagg',
+                   'macosx': 'macosx',
+                   'headless': 'agg'}
+
+        best_guess = mapping.get(current_framework, None)
+        if best_guess is not None:
+            candidates = [best_guess]
+        else:
+            candidates = []
+        candidates += ["macosx", "qt5agg", "gtk3agg", "tkagg", "wxagg"]
+
         # Don't try to fallback on the cairo-based backends as they each have
         # an additional dependency (pycairo) over the agg-based backend, and
         # are of worse quality.
-        for candidate in ["macosx", "qt5agg", "gtk3agg", "tkagg", "wxagg"]:
+        for candidate in candidates:
             try:
                 switch_backend(candidate)
             except ImportError:

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -228,3 +228,37 @@ def test_never_update(monkeypatch, capsys):
     # test framework doesn't see tkinter callback exceptions normally
     # see tkinter.Misc.report_callback_exception
     assert "Exception in Tkinter callback" not in capsys.readouterr().err
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="this a linux-only test")
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
+def test_lazy_linux_headless():
+    test_script = """
+import os
+import sys
+
+# make it look headless
+del os.environ['DISPLAY']
+
+# we should fast-track to Agg
+import matplotlib.pyplot as plt
+plt.get_backend() == 'agg'
+assert 'PyQt5' not in sys.modules
+
+# make sure we really have pyqt installed
+import PyQt5
+assert 'PyQt5' in sys.modules
+
+# try to switch and make sure we fail with ImportError
+try:
+    plt.switch_backend('qt5agg')
+except ImportError:
+    ...
+else:
+    sys.exit(1)
+
+"""
+    proc = subprocess.run([sys.executable, "-c", test_script])
+    if proc.returncode:
+        pytest.fail("The subprocess returned with non-zero exit status "
+                    f"{proc.returncode}.")


### PR DESCRIPTION
## PR Summary

We currently check the GUI framework and reject changing to
a different framework.  This adds the ability to check the running
framework before we start guessing frameworks to use.

This matters the most in the headless linux case where you have a lot of the GUI frameworks available.  Currently we try to import _all_ of them before we give up (despite the fact that it is check on our side that is failing them!)


## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
