### PR TITLE
Migrate tk backend tests into subprocesses

### DIFF
--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -1,12 +1,12 @@
 import os
 import subprocess
 import sys
-import tkinter
 
 import numpy as np
 import pytest
 
 from matplotlib import pyplot as plt
+_test_timeout = 10  # Empirically, 1s is not enough on Travis.
 
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
@@ -36,25 +36,42 @@ def test_blit():
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
 def test_figuremanager_preserves_host_mainloop():
-    success = False
+    script = """
+import tkinter
+import matplotlib.pyplot as plt
+success = False
 
-    def do_plot():
-        plt.figure()
-        plt.plot([1, 2], [3, 5])
-        plt.close()
-        root.after(0, legitimate_quit)
+def do_plot():
+    plt.figure()
+    plt.plot([1, 2], [3, 5])
+    plt.close()
+    root.after(0, legitimate_quit)
 
-    def legitimate_quit():
-        root.quit()
-        nonlocal success
-        success = True
+def legitimate_quit():
+    root.quit()
+    global success
+    success = True
 
-    root = tkinter.Tk()
-    root.after(0, do_plot)
-    root.mainloop()
+root = tkinter.Tk()
+root.after(0, do_plot)
+root.mainloop()
 
-    assert success
-
+if success:
+    print("success")
+"""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", script,],
+            env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+            timeout=_test_timeout,
+            stdout=subprocess.PIPE,
+            check=True,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError:
+        pytest.fail("Subprocess failed to test intended behavior")
+    else:
+        assert proc.stdout.count("success") == 1
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
 @pytest.mark.flaky(reruns=3)
@@ -90,7 +107,7 @@ thread.join()
             env={**os.environ,
                  "MPLBACKEND": "TkAgg",
                  "SOURCE_DATE_EPOCH": "0"},
-            timeout=10,
+            timeout=_test_timeout,
             stdout=subprocess.PIPE,
             universal_newlines=True,
             check=True
@@ -100,6 +117,52 @@ thread.join()
     except subprocess.CalledProcessError:
         pytest.fail("Subprocess failed to test intended behavior")
     assert proc.stdout.count("success") == 1
+
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+@pytest.mark.flaky(reruns=3)
+def test_never_update():
+    script = """
+import tkinter
+del tkinter.Misc.update
+del tkinter.Misc.update_idletasks
+
+import matplotlib.pyplot as plt
+fig = plt.figure()
+plt.show(block=False)
+
+# regression test on FigureCanvasTkAgg
+plt.draw()
+# regression test on NavigationToolbar2Tk
+fig.canvas.toolbar.configure_subplots()
+
+# check for update() or update_idletasks() in the event queue
+# functionally equivalent to tkinter.Misc.update
+# must pause >= 1 ms to process tcl idle events plus
+# extra time to avoid flaky tests on slow systems
+plt.pause(0.1)
+
+# regression test on FigureCanvasTk filter_destroy callback
+plt.close(fig)
+"""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", script,],
+            env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+            timeout=_test_timeout,
+            capture_output=True,
+            check=True,
+            universal_newlines=True,
+        )
+    except subprocess.CalledProcessError:
+        pytest.fail("Subprocess failed to test intended behavior")
+    else:
+        # test framework doesn't see tkinter callback exceptions normally
+        # see tkinter.Misc.report_callback_exception
+        assert "Exception in Tkinter callback" not in proc.stderr
+    finally:
+        # make sure we can see other issues
+        print(proc.stderr, file=sys.stderr)
 
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -62,7 +62,9 @@ if success:
     try:
         proc = subprocess.run(
             [sys.executable, "-c", script,],
-            env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+            env={**os.environ,
+                 "MPLBACKEND": "TkAgg",
+                 "SOURCE_DATE_EPOCH": "0"},
             timeout=_test_timeout,
             stdout=subprocess.PIPE,
             check=True,
@@ -149,7 +151,9 @@ plt.close(fig)
     try:
         proc = subprocess.run(
             [sys.executable, "-c", script,],
-            env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+            env={**os.environ,
+                 "MPLBACKEND": "TkAgg",
+                 "SOURCE_DATE_EPOCH": "0"},
             timeout=_test_timeout,
             capture_output=True,
             universal_newlines=True,

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -51,6 +51,8 @@ for bad_box in bad_boxes:
             check=True,
             universal_newlines=True,
         )
+    except subprocess.TimeoutExpired:
+        pytest.fail("Subprocess timed out")
     except subprocess.CalledProcessError:
         pytest.fail("Likely regression on out-of-bounds data access"
                     " in _tkagg.cpp")
@@ -95,6 +97,8 @@ if success:
             check=True,
             universal_newlines=True,
         )
+    except subprocess.TimeoutExpired:
+        pytest.fail("Subprocess timed out")
     except subprocess.CalledProcessError:
         pytest.fail("Subprocess failed to test intended behavior")
     else:
@@ -191,6 +195,7 @@ plt.close(fig)
         assert "Exception in Tkinter callback" not in proc.stderr
         # make sure we can see other issues
         print(proc.stderr, file=sys.stderr)
+        # Checking return code late so the Tkinter assertion happens first
         if proc.returncode:
             pytest.fail("Subprocess failed to test intended behavior")
 
@@ -226,3 +231,7 @@ print("success")
     else:
         assert proc.stdout.count("setup complete") == 1
         assert proc.stdout.count("success") == 1
+        # Checking return code late so the stdout assertions happen first
+        if proc.returncode:
+            pytest.fail("Subprocess failed to test intended behavior")
+

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -61,7 +61,7 @@ if success:
 """
     try:
         proc = subprocess.run(
-            [sys.executable, "-c", script,],
+            [sys.executable, "-c", script],
             env={**os.environ,
                  "MPLBACKEND": "TkAgg",
                  "SOURCE_DATE_EPOCH": "0"},
@@ -150,7 +150,7 @@ plt.close(fig)
 """
     try:
         proc = subprocess.run(
-            [sys.executable, "-c", script,],
+            [sys.executable, "-c", script],
             env={**os.environ,
                  "MPLBACKEND": "TkAgg",
                  "SOURCE_DATE_EPOCH": "0"},

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -73,6 +73,7 @@ if success:
     else:
         assert proc.stdout.count("success") == 1
 
+
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)
 @pytest.mark.flaky(reruns=3)
 def test_figuremanager_cleans_own_mainloop():
@@ -151,18 +152,18 @@ plt.close(fig)
             env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
             timeout=_test_timeout,
             capture_output=True,
-            check=True,
             universal_newlines=True,
         )
-    except subprocess.CalledProcessError:
-        pytest.fail("Subprocess failed to test intended behavior")
+    except subprocess.TimeoutExpired:
+        pytest.fail("Subprocess timed out")
     else:
         # test framework doesn't see tkinter callback exceptions normally
         # see tkinter.Misc.report_callback_exception
         assert "Exception in Tkinter callback" not in proc.stderr
-    finally:
         # make sure we can see other issues
         print(proc.stderr, file=sys.stderr)
+        if proc.returncode:
+            pytest.fail("Subprocess failed to test intended behavior")
 
 
 @pytest.mark.backend('TkAgg', skip_on_importerror=True)

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -234,4 +234,3 @@ print("success")
         # Checking return code late so the stdout assertions happen first
         if proc.returncode:
             pytest.fail("Subprocess failed to test intended behavior")
-

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -201,35 +201,6 @@ def test_webagg():
     assert proc.wait(timeout=_test_timeout) == 0
 
 
-@pytest.mark.backend('TkAgg', skip_on_importerror=True)
-def test_never_update(monkeypatch, capsys):
-    import tkinter
-    monkeypatch.delattr(tkinter.Misc, 'update')
-    monkeypatch.delattr(tkinter.Misc, 'update_idletasks')
-
-    import matplotlib.pyplot as plt
-    fig = plt.figure()
-    plt.show(block=False)
-
-    # regression test on FigureCanvasTkAgg
-    plt.draw()
-    # regression test on NavigationToolbar2Tk
-    fig.canvas.toolbar.configure_subplots()
-
-    # check for update() or update_idletasks() in the event queue
-    # functionally equivalent to tkinter.Misc.update
-    # must pause >= 1 ms to process tcl idle events plus
-    # extra time to avoid flaky tests on slow systems
-    plt.pause(0.1)
-
-    # regression test on FigureCanvasTk filter_destroy callback
-    plt.close(fig)
-
-    # test framework doesn't see tkinter callback exceptions normally
-    # see tkinter.Misc.report_callback_exception
-    assert "Exception in Tkinter callback" not in capsys.readouterr().err
-
-
 @pytest.mark.skipif(sys.platform != "linux", reason="this a linux-only test")
 @pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_lazy_linux_headless():


### PR DESCRIPTION
## PR Summary

This PR is a first attempt to fix #18246. Try to isolate suspected interactions between tests by using subprocesses liberally. The argument against this might be that subprocess tests are computationally expensive and we might better track down the weird interactions. I'm happy to go with this or try a different idea!

Eagerly making the pull request to engage CI.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
