### PR TITLE
Fix Path.get_extents for empty paths.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -600,7 +600,10 @@ class Path:
                 # as can the ends of the curve
                 xys.append(curve([0, *dzeros, 1]))
             xys = np.concatenate(xys)
-        return Bbox([xys.min(axis=0), xys.max(axis=0)])
+        if len(xys):
+            return Bbox([xys.min(axis=0), xys.max(axis=0)])
+        else:
+            return Bbox.null()
 
     def intersects_path(self, other, filled=True):
         """

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -19,6 +19,8 @@ def test_empty_closed_path():
     path = Path(np.zeros((0, 2)), closed=True)
     assert path.vertices.shape == (0, 2)
     assert path.codes is None
+    assert_array_equal(path.get_extents().extents,
+                       transforms.Bbox.null().extents)
 
 
 def test_readonly_path():


### PR DESCRIPTION
## PR Summary

Fixes #18254 

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way