### PR TITLE
Improve initial macosx device scale

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -154,13 +154,8 @@ _test_timeout = 10  # Empirically, 1s is not enough on Travis.
 @pytest.mark.parametrize("toolbar", ["toolbar2", "toolmanager"])
 @pytest.mark.flaky(reruns=3)
 def test_interactive_backend(backend, toolbar):
-    if backend == "macosx":
-        if toolbar == "toolmanager":
-            pytest.skip("toolmanager is not implemented for macosx.")
-        if toolbar == "toolbar2" and os.environ.get('TRAVIS'):
-            # See https://github.com/matplotlib/matplotlib/issues/18213
-            pytest.skip("toolbar2 for macosx is buggy on Travis.")
-
+    if backend == "macosx" and toolbar == "toolmanager":
+        pytest.skip("toolmanager is not implemented for macosx.")
     proc = subprocess.run(
         [sys.executable, "-c", _test_script,
          json.dumps({"toolbar": toolbar})],


### PR DESCRIPTION
## PR Summary
Fixes #18213. The problem is that the initial device scale in the macosx backend was set to 1.0--it would then update on the first display of a figure. This calls an API on window creation to update the device scale. This fixes the failing test for me locally.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
