### PR TITLE
Fix autoscaling to exclude inifinite data limits when possible. 

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2546,9 +2546,8 @@ class _AxesBase(martist.Artist):
             minimum_minpos = np.inf
             for ax in shared:
                 x_values.extend(getattr(ax.dataLim, interval))
-                minimum_minpos = np.min(
-                    [minimum_minpos, getattr(ax.dataLim, minpos)]
-                )
+                minimum_minpos = min(minimum_minpos,
+                                     getattr(ax.dataLim, minpos))
             x_values = np.extract(np.isfinite(x_values), x_values)
             if x_values.size >= 1:
                 x0, x1 = (x_values.min(), x_values.max())

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2557,7 +2557,16 @@ class _AxesBase(martist.Artist):
                 dl.extend(y_finite)
 
             bb = mtransforms.BboxBase.union(dl)
-            x0, x1 = getattr(bb, interval)
+            # Issue 18137
+            # bb can still have infinite limits, so instead compute
+            # finite limits for this 'axis'
+            x_values = [getattr(d, interval) for d in dl]
+            x_values = np.sort(np.unique(np.asarray(x_values).flatten()))
+            finite_x_values = np.extract(np.isfinite(x_values), x_values)
+            if finite_x_values.size >= 1:
+                x0, x1 = (finite_x_values.min(), finite_x_values.max())
+            else:
+                x0, x1 = (-np.inf, np.inf)
             # If x0 and x1 are non finite, use the locator to figure out
             # default limits.
             locator = axis.get_major_locator()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6480,3 +6480,12 @@ def test_relative_ticklabel_sizes(size):
     for name, axis in zip(['x', 'y'], [ax.xaxis, ax.yaxis]):
         for tick in axis.get_major_ticks():
             assert tick.label1.get_size() == axis._get_tick_label_size(name)
+
+
+def test_multiplot_autoscale():
+    fig = plt.figure()
+    ax1, ax2 = fig.subplots(2, 1, sharex='all')
+    ax1.scatter([1, 2, 3, 4], [2, 3, 2, 3])
+    ax2.axhspan(-5, 5)
+    xlim = ax1.get_xlim()
+    assert np.allclose(xlim, [0.5, 4.5])


### PR DESCRIPTION
Closes #18137

## PR Summary
The existing code will allow an infinite data limit from one subplot to 'clobber' a finite data limit from another subplot thus defeating the intent.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
