### PR TITLE
TkTimer interval=0 workaround

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -96,7 +96,7 @@ class TimerTk(TimerBase):
         # if _timer is None, this means that _timer_stop has been called; so
         # don't recreate the timer in that case.
         if not self._single and self._timer:
-            if self._interval:
+            if self._interval > 0:
                 self._timer = self.parent.after(self._interval, self._on_timer)
             else:
                 # Edge case: Tcl after 0 *prepends* events to the queue

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -96,7 +96,16 @@ class TimerTk(TimerBase):
         # if _timer is None, this means that _timer_stop has been called; so
         # don't recreate the timer in that case.
         if not self._single and self._timer:
-            self._timer = self.parent.after(self._interval, self._on_timer)
+            if self._interval:
+                self._timer = self.parent.after(self._interval, self._on_timer)
+            else:
+                # Edge case: Tcl after 0 *prepends* events to the queue
+                # so a 0 interval does not allow any other events to run.
+                # This incantation is cancellable and runs as fast as possible
+                # while also allowing events and drawing every frame. GH#18236
+                self._timer = self.parent.after_idle(
+                    lambda: self.parent.after(self._interval, self._on_timer)
+                )
         else:
             self._timer = None
 


### PR DESCRIPTION
## PR Summary
Fixes #18236 and closes #8107. See discussion in #18236 for reasoning. A legitimate alternative would be to set a floor of 1 ms interval, but this more closely respects a user's wish for no delay.
## PR Checklist

- [ ] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
