### PR TITLE
Fix imshow to work with subclasses of ndarray. Fix #18077

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -444,7 +444,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # of over numbers.
                 self.norm.autoscale_None(A)
                 dv = np.float64(self.norm.vmax) - np.float64(self.norm.vmin)
-                vmid = self.norm.vmin + dv / 2
+                vmid = np.float64(self.norm.vmin) + dv / 2
                 fact = 1e7 if scaled_dtype == np.float64 else 1e4
                 newmin = vmid - dv * fact
                 if newmin < a_min:


### PR DESCRIPTION
## PR Summary
In the internals of _ImageBase._make_image, the clip bounds arithmetic fails with ndarray subclasses that support masked arrays such as `unyt`.

## PR Checklist

- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant