### PR TITLE
Remove unused import to fix flake8.

### DIFF
--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 import pickle
-import platform
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## PR Summary

Previously, reviewdog would filter flake8 issues outside the diff. This caused issues like unused imports to be ignored, and the filtering was disabled. A recently merged PR was only linted _before_ that switch, and so an unused import slipped in.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way