### PR TITLE
Remove 3D attributes from renderer

### DIFF
--- a/doc/api/next_api_changes/deprecations/18302-ES.rst
+++ b/doc/api/next_api_changes/deprecations/18302-ES.rst
@@ -11,3 +11,10 @@ now deprecated:
 
 These attributes are all available via `.Axes3D`, which can be accessed via
 ``self.axes`` on all `.Artist`\s.
+
+``renderer`` argument of ``do_3d_projection`` method for ``Collection3D``/``Patch3D``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``renderer`` argument for the ``do_3d_projection`` method on
+``Collection3D`` and ``Patch3D`` is no longer necessary, and passing it during
+draw is deprecated.

--- a/doc/api/next_api_changes/deprecations/18302-ES.rst
+++ b/doc/api/next_api_changes/deprecations/18302-ES.rst
@@ -1,0 +1,13 @@
+3D properties on renderers
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The properties of the 3D Axes that were placed on the Renderer during draw are
+now deprecated:
+
+* ``renderer.M``
+* ``renderer.eye``
+* ``renderer.vvec``
+* ``renderer.get_axis_position``
+
+These attributes are all available via `.Axes3D`, which can be accessed via
+``self.axes`` on all `.Artist`\s.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -894,13 +894,6 @@ def rotate_axes(xs, ys, zs, zdir):
         return xs, ys, zs
 
 
-def _get_colors(c, num):
-    """Stretch the color argument to provide the required number *num*."""
-    return np.broadcast_to(
-        mcolors.to_rgba_array(c) if len(c) else [0, 0, 0, 0],
-        (num, 4))
-
-
 def _zalpha(colors, zs):
     """Modify the alphas of the color list according to depth."""
     # FIXME: This only works well if the points for *zs* are well-spaced

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -135,8 +135,7 @@ class Text3D(mtext.Text):
     def draw(self, renderer):
         position3d = np.array((self._x, self._y, self._z))
         proj = proj3d.proj_trans_points(
-            [position3d, position3d + self._dir_vec],
-            renderer.M)
+            [position3d, position3d + self._dir_vec], self.axes.M)
         dx = proj[0][1] - proj[0][0]
         dy = proj[1][1] - proj[1][0]
         angle = math.degrees(math.atan2(dy, dx))
@@ -213,7 +212,7 @@ class Line3D(lines.Line2D):
     @artist.allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_data(xs, ys)
         super().draw(renderer)
         self.stale = False
@@ -301,9 +300,8 @@ class Line3DCollection(LineCollection):
         """
         Project the points according to renderer matrix.
         """
-        xyslist = [
-            proj3d.proj_trans_points(points, renderer.M) for points in
-            self._segments3d]
+        xyslist = [proj3d.proj_trans_points(points, self.axes.M)
+                   for points in self._segments3d]
         segments_2d = [np.column_stack([xs, ys]) for xs, ys, zs in xyslist]
         LineCollection.set_segments(self, segments_2d)
 
@@ -351,7 +349,8 @@ class Patch3D(Patch):
     def do_3d_projection(self, renderer):
         s = self._segment3d
         xs, ys, zs = zip(*s)
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs, renderer.M)
+        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
+                                                        self.axes.M)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]))
         # FIXME: coloring
         self._facecolor2d = self._facecolor3d
@@ -375,7 +374,8 @@ class PathPatch3D(Patch3D):
     def do_3d_projection(self, renderer):
         s = self._segment3d
         xs, ys, zs = zip(*s)
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs, renderer.M)
+        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
+                                                        self.axes.M)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]), self._code3d)
         # FIXME: coloring
         self._facecolor2d = self._facecolor3d
@@ -483,7 +483,8 @@ class Patch3DCollection(PatchCollection):
 
     def do_3d_projection(self, renderer):
         xs, ys, zs = self._offsets3d
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs, renderer.M)
+        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
+                                                        self.axes.M)
 
         fcs = (_zalpha(self._facecolor3d, vzs) if self._depthshade else
                self._facecolor3d)
@@ -587,7 +588,8 @@ class Path3DCollection(PathCollection):
 
     def do_3d_projection(self, renderer):
         xs, ys, zs = self._offsets3d
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs, renderer.M)
+        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
+                                                        self.axes.M)
 
         fcs = (_zalpha(self._facecolor3d, vzs) if self._depthshade else
                self._facecolor3d)
@@ -769,7 +771,7 @@ class Poly3DCollection(PolyCollection):
             self.update_scalarmappable()
             self._facecolors3d = self._facecolors
 
-        txs, tys, tzs = proj3d._proj_transform_vec(self._vec, renderer.M)
+        txs, tys, tzs = proj3d._proj_transform_vec(self._vec, self.axes.M)
         xyzlist = [(txs[sl], tys[sl], tzs[sl]) for sl in self._segslices]
 
         # This extra fuss is to re-order face / edge colors
@@ -805,7 +807,7 @@ class Poly3DCollection(PolyCollection):
         # Return zorder value
         if self._sort_zpos is not None:
             zvec = np.array([[0], [0], [self._sort_zpos], [1]])
-            ztrans = proj3d._proj_transform_vec(zvec, renderer.M)
+            ztrans = proj3d._proj_transform_vec(zvec, self.axes.M)
             return ztrans[2][0]
         elif tzs.size > 0:
             # FIXME: Some results still don't look quite right.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -296,7 +296,8 @@ class Line3DCollection(LineCollection):
         self._segments3d = segments
         super().set_segments([])
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         """
         Project the points according to renderer matrix.
         """
@@ -314,7 +315,7 @@ class Line3DCollection(LineCollection):
     @artist.allow_rasterization
     def draw(self, renderer, project=False):
         if project:
-            self.do_3d_projection(renderer)
+            self.do_3d_projection()
         super().draw(renderer)
 
 
@@ -346,7 +347,8 @@ class Patch3D(Patch):
     def get_facecolor(self):
         return self._facecolor2d
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         s = self._segment3d
         xs, ys, zs = zip(*s)
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
@@ -371,7 +373,8 @@ class PathPatch3D(Patch3D):
         Patch3D.set_3d_properties(self, path.vertices, zs=zs, zdir=zdir)
         self._code3d = path.codes
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         s = self._segment3d
         xs, ys, zs = zip(*s)
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
@@ -481,7 +484,8 @@ class Patch3DCollection(PatchCollection):
         self._edgecolor3d = self.get_edgecolor()
         self.stale = True
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         xs, ys, zs = self._offsets3d
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
                                                         self.axes.M)
@@ -586,7 +590,8 @@ class Path3DCollection(PathCollection):
         super().set_linewidth(lw)
         self._linewidth3d = self.get_linewidth()
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         xs, ys, zs = self._offsets3d
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
                                                         self.axes.M)
@@ -762,7 +767,8 @@ class Poly3DCollection(PolyCollection):
         self._sort_zpos = val
         self.stale = True
 
-    def do_3d_projection(self, renderer):
+    @cbook._delete_parameter('3.4', 'renderer')
+    def do_3d_projection(self, renderer=None):
         """
         Perform the 3D projection for this object.
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -407,18 +407,30 @@ class Axes3D(Axes):
         }
 
         with cbook._setattr_cm(type(renderer), **props3d):
+            def do_3d_projection(artist):
+                if artist.__module__ == 'mpl_toolkits.mplot3d.art3d':
+                    # Our 3D Artists have deprecated the renderer parameter.
+                    return artist.do_3d_projection()
+
+                cbook.warn_deprecated(
+                    "3.4",
+                    message="The 'renderer' parameter of "
+                    "do_3d_projection() was deprecated in Matplotlib "
+                    "%(since)s and will be removed %(removal)s.")
+                return artist.do_3d_projection(renderer)
+
             # Calculate projection of collections and patches and zorder them.
             # Make sure they are drawn above the grids.
             zorder_offset = max(axis.get_zorder()
                                 for axis in self._get_axis_list()) + 1
             for i, col in enumerate(
                     sorted(self.collections,
-                           key=lambda col: col.do_3d_projection(renderer),
+                           key=do_3d_projection,
                            reverse=True)):
                 col.zorder = zorder_offset + i
             for i, patch in enumerate(
                     sorted(self.patches,
-                           key=lambda patch: patch.do_3d_projection(renderer),
+                           key=do_3d_projection,
                            reverse=True)):
                 patch.zorder = zorder_offset + i
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -189,7 +189,7 @@ class Axis(maxis.XAxis):
         maxs = maxs + deltas / 4.
 
         vals = mins[0], maxs[0], mins[1], maxs[1], mins[2], maxs[2]
-        tc = self.axes.tunit_cube(vals, renderer.M)
+        tc = self.axes.tunit_cube(vals, self.axes.M)
         avgz = [tc[p1][2] + tc[p2][2] + tc[p3][2] + tc[p4][2]
                 for p1, p2, p3, p4 in self._PLANES]
         highs = np.array([avgz[2*i] < avgz[2*i+1] for i in range(3)])
@@ -237,8 +237,8 @@ class Axis(maxis.XAxis):
         edgep2 = edgep1.copy()
         edgep2[juggled[1]] = maxmin[juggled[1]]
         pep = np.asarray(
-            proj3d.proj_trans_points([edgep1, edgep2], renderer.M))
-        centpt = proj3d.proj_transform(*centers, renderer.M)
+            proj3d.proj_trans_points([edgep1, edgep2], self.axes.M))
+        centpt = proj3d.proj_transform(*centers, self.axes.M)
         self.line.set_data(pep[0], pep[1])
         self.line.draw(renderer)
 
@@ -270,7 +270,7 @@ class Axis(maxis.XAxis):
         axmask = [True, True, True]
         axmask[index] = False
         lxyz = move_from_center(lxyz, centers, labeldeltas, axmask)
-        tlx, tly, tlz = proj3d.proj_transform(*lxyz, renderer.M)
+        tlx, tly, tlz = proj3d.proj_transform(*lxyz, self.axes.M)
         self.label.set_position((tlx, tly))
         if self.get_rotate_label(self.label.get_text()):
             angle = art3d._norm_text_angle(np.rad2deg(np.arctan2(dy, dx)))
@@ -291,7 +291,7 @@ class Axis(maxis.XAxis):
             outerindex = 1
 
         pos = move_from_center(outeredgep, centers, labeldeltas, axmask)
-        olx, oly, olz = proj3d.proj_transform(*pos, renderer.M)
+        olx, oly, olz = proj3d.proj_transform(*pos, self.axes.M)
         self.offsetText.set_text(self.major.formatter.get_offset())
         self.offsetText.set_position((olx, oly))
         angle = art3d._norm_text_angle(np.rad2deg(np.arctan2(dy, dx)))
@@ -374,11 +374,11 @@ class Axis(maxis.XAxis):
             pos[tickdir] = (
                 edgep1[tickdir]
                 + info['tick']['outward_factor'] * ticksign * tickdelta)
-            x1, y1, z1 = proj3d.proj_transform(*pos, renderer.M)
+            x1, y1, z1 = proj3d.proj_transform(*pos, self.axes.M)
             pos[tickdir] = (
                 edgep1[tickdir]
                 - info['tick']['inward_factor'] * ticksign * tickdelta)
-            x2, y2, z2 = proj3d.proj_transform(*pos, renderer.M)
+            x2, y2, z2 = proj3d.proj_transform(*pos, self.axes.M)
 
             # Get position of label
             default_offset = 8.  # A rough estimate
@@ -389,7 +389,7 @@ class Axis(maxis.XAxis):
             axmask[index] = False
             pos[tickdir] = edgep1[tickdir]
             pos = move_from_center(pos, centers, labeldeltas, axmask)
-            lx, ly, lz = proj3d.proj_transform(*pos, renderer.M)
+            lx, ly, lz = proj3d.proj_transform(*pos, self.axes.M)
 
             tick_update_position(tick, (x1, x2), (y1, y2), (lx, ly))
             tick.tick1line.set_linewidth(


### PR DESCRIPTION
## PR Summary

There's no need to do so, as artists have `.axes` property from which they can get the same information. Since this is a weird internal undocumented draw thing, I'm not sure if it needs a deprecation/API note.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way