### PR TITLE
Fix canvas redraws during motion in figures with a Button or TextBox

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -16,7 +16,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from . import cbook, ticker
+from . import cbook, ticker, colors
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
 from .transforms import blended_transform_factory
@@ -220,7 +220,7 @@ class Button(AxesWidget):
         if self.ignore(event):
             return
         c = self.hovercolor if event.inaxes == self.ax else self.color
-        if c != self.ax.get_facecolor():
+        if colors.to_rgba(c) != colors.to_rgba(self.ax.get_facecolor()):
             self.ax.set_facecolor(c)
             if self.drawon:
                 self.ax.figure.canvas.draw()
@@ -920,7 +920,7 @@ class TextBox(AxesWidget):
         if self.ignore(event):
             return
         c = self.hovercolor if event.inaxes == self.ax else self.color
-        if c != self.ax.get_facecolor():
+        if colors.to_rgba(c) != colors.to_rgba(self.ax.get_facecolor()):
             self.ax.set_facecolor(c)
             if self.drawon:
                 self.ax.figure.canvas.draw()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -220,7 +220,7 @@ class Button(AxesWidget):
         if self.ignore(event):
             return
         c = self.hovercolor if event.inaxes == self.ax else self.color
-        if colors.to_rgba(c) != colors.to_rgba(self.ax.get_facecolor()):
+        if not colors.same_color(c, self.ax.get_facecolor()):
             self.ax.set_facecolor(c)
             if self.drawon:
                 self.ax.figure.canvas.draw()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -920,7 +920,7 @@ class TextBox(AxesWidget):
         if self.ignore(event):
             return
         c = self.hovercolor if event.inaxes == self.ax else self.color
-        if colors.to_rgba(c) != colors.to_rgba(self.ax.get_facecolor()):
+        if not colors.same_color(c, self.ax.get_facecolor()):
             self.ax.set_facecolor(c)
             if self.drawon:
                 self.ax.figure.canvas.draw()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -16,7 +16,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from . import cbook, ticker, colors
+from . import cbook, colors, ticker
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
 from .transforms import blended_transform_factory


### PR DESCRIPTION
## PR Summary

Fix for issue #18303. During motion in figures with Button or TextBox widgets, the stored `color` and `hovercolor` values are compared with the current Axes facecolor. By default, the stored colors are each a string of a float, but the returned facecolor is frequently a tuple of RGBA values. The colors appear to mismatch, triggering a draw event with any motion in the figure. As a fix, convert both the color and facecolor values to RGBA format for comparison in case either value is stored in a different format.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
