### PR TITLE
Make Colorbar outline into a Spine.

### DIFF
--- a/doc/api/next_api_changes/behavior/18320-ES.rst
+++ b/doc/api/next_api_changes/behavior/18320-ES.rst
@@ -1,0 +1,6 @@
+``Colorbar`` outline is now a ``Spine``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The outline of `~matplotlib.colorbar.Colorbar` is now a `.Spine` and drawn as
+one, instead of a `.Polygon` drawn as an artist. This ensures it will always
+be drawn after all artists, consistent with Spines on normal Axes.


### PR DESCRIPTION
## PR Summary

This moves its draw to after all artists, which is consistent with normal Axes frames.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [x] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way