### PR TITLE
Capture output of CallbackRegistry exception test.

### DIFF
--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -226,16 +226,23 @@ class Test_callback_registry:
                        "callbacks")
 
 
-def test_callbackregistry_default_exception_handler(monkeypatch):
+def test_callbackregistry_default_exception_handler(capsys, monkeypatch):
     cb = cbook.CallbackRegistry()
     cb.connect("foo", lambda: None)
+
     monkeypatch.setattr(
         cbook, "_get_running_interactive_framework", lambda: None)
     with pytest.raises(TypeError):
         cb.process("foo", "argument mismatch")
+    outerr = capsys.readouterr()
+    assert outerr.out == outerr.err == ""
+
     monkeypatch.setattr(
         cbook, "_get_running_interactive_framework", lambda: "not-none")
     cb.process("foo", "argument mismatch")  # No error in that case.
+    outerr = capsys.readouterr()
+    assert outerr.out == ""
+    assert "takes 0 positional arguments but 1 was given" in outerr.err
 
 
 def raising_cb_reg(func):


### PR DESCRIPTION
## PR Summary

If running `pytest -s`, the default exception handler will print out the traceback, appearing as if there were an error. But this is exactly what this test is checking, so capture output and check it.

## PR Checklist

- [x] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way