### PR TITLE
Disable FH4 so that we don't require VCRUNTIME140_1.dll.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -39,6 +39,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install numpy==1.15
+          MPL_DISABLE_FH4: "yes"
 
       - name: Build wheels for CPython 3.6
         run: |
@@ -48,6 +49,7 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install numpy==1.15
+          MPL_DISABLE_FH4: "yes"
         if: >
           startsWith(github.ref, 'refs/heads/v3.3') ||
           startsWith(github.ref, 'refs/tags/v3.3')

--- a/setup.py
+++ b/setup.py
@@ -169,6 +169,14 @@ class BuildExtraLibraries(BuildExtCommand):
             self.compiler.compiler_so.remove('-Wstrict-prototypes')
         except (ValueError, AttributeError):
             pass
+        if (self.compiler.compiler_type == 'msvc' and
+                os.environ.get('MPL_DISABLE_FH4')):
+            # Disable FH4 Exception Handling implementation so that we don't
+            # require VCRUNTIME140_1.dll. For more details, see:
+            # https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/
+            # https://github.com/joerick/cibuildwheel/issues/423#issuecomment-677763904
+            for ext in self.extensions:
+                ext.extra_compile_args.append('/d2FH4-')
 
         env = self.add_optimization_flags()
         for package in good_packages:


### PR DESCRIPTION
## PR Summary

For more details, see:
https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/
https://github.com/joerick/cibuildwheel/issues/423#issuecomment-677763904

Fixes #18292.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [n/a] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [n/a] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way