### PR TITLE
Colorbar grid postion

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1582,9 +1582,7 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
         panchor = kw.pop('panchor', (1.0, 0.5))
 
         # for shrinking
-        wh_ratios = [(1-anchor[1])*(1-shrink),
-                     shrink, 
-                     anchor[1]*(1-shrink)]
+        wh_ratios = [(1-anchor[1])*(1-shrink), shrink, anchor[1]*(1-shrink)]
 
         gs = gs_from_subplotspec(1, 2,
                                  subplot_spec=parent.get_subplotspec(),
@@ -1601,9 +1599,7 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
         panchor = kw.pop('panchor', (0.5, 0.0))
 
         # for shrinking
-        wh_ratios = [(1-anchor[0])*(1-shrink),
-                     shrink, 
-                     anchor[0]*(1-shrink)]
+        wh_ratios = [(1-anchor[0])*(1-shrink), shrink, anchor[0]*(1-shrink)]
 
         gs = gs_from_subplotspec(2, 1,
                                  subplot_spec=parent.get_subplotspec(),

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1599,7 +1599,7 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
         panchor = kw.pop('panchor', (0.5, 0.0))
 
         # for shrinking
-        wh_ratios = [(1-anchor[0])*(1-shrink), shrink, anchor[0]*(1-shrink)]
+        wh_ratios = [anchor[0]*(1-shrink), shrink, (1-anchor[0])*(1-shrink)]
 
         gs = gs_from_subplotspec(2, 1,
                                  subplot_spec=parent.get_subplotspec(),

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1569,10 +1569,6 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
 
     x1 = 1 - fraction
 
-    # for shrinking
-    pad_s = (1 - shrink) * 0.5
-    wh_ratios = [pad_s, shrink, pad_s]
-
     # we need to none the tree of layoutboxes because
     # constrained_layout can't remove and replace the tree
     # hierarchy w/o a seg fault.
@@ -1582,6 +1578,14 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
     if orientation == 'vertical':
         pad = kw.pop('pad', 0.05)
         wh_space = 2 * pad / (1 - pad)
+        anchor = kw.pop('anchor', (0.0, 0.5))
+        panchor = kw.pop('panchor', (1.0, 0.5))
+
+        # for shrinking
+        wh_ratios = [(1-anchor[1])*(1-shrink),
+                     shrink, 
+                     anchor[1]*(1-shrink)]
+
         gs = gs_from_subplotspec(1, 2,
                                  subplot_spec=parent.get_subplotspec(),
                                  wspace=wh_space,
@@ -1590,11 +1594,17 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
                                   subplot_spec=gs[1],
                                   hspace=0.,
                                   height_ratios=wh_ratios)
-        anchor = (0.0, 0.5)
-        panchor = (1.0, 0.5)
     else:
         pad = kw.pop('pad', 0.15)
         wh_space = 2 * pad / (1 - pad)
+        anchor = kw.pop('anchor', (0.5, 1.0))
+        panchor = kw.pop('panchor', (0.5, 0.0))
+
+        # for shrinking
+        wh_ratios = [(1-anchor[0])*(1-shrink),
+                     shrink, 
+                     anchor[0]*(1-shrink)]
+
         gs = gs_from_subplotspec(2, 1,
                                  subplot_spec=parent.get_subplotspec(),
                                  hspace=wh_space,
@@ -1604,8 +1614,6 @@ def make_axes_gridspec(parent, *, fraction=0.15, shrink=1.0, aspect=20, **kw):
                                   wspace=0.,
                                   width_ratios=wh_ratios)
         aspect = 1 / aspect
-        anchor = (0.5, 1.0)
-        panchor = (0.5, 0.0)
 
     parent.set_subplotspec(gs[0])
     parent.update_params()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -613,3 +613,51 @@ def test_colorbar_int(clim):
     im = ax.imshow([[*map(np.int16, clim)]])
     fig.colorbar(im)
     assert (im.norm.vmin, im.norm.vmax) == clim
+
+
+def test_anchored_cbar_position_using_specgrid():
+    data = np.arange(1200).reshape(30, 40)
+    levels = [0, 200, 400, 600, 800, 1000, 1200]
+    shrink = 0.5
+    anchor_y = 0.3
+    # vertival
+    fig, ax = plt.subplots()
+    cs = ax.contourf(data, levels=levels)
+    cbar = plt.colorbar(
+            cs, ax=ax, use_gridspec=True,
+            orientation='vertical', anchor=(1, anchor_y), shrink=shrink)
+
+    # y1: the top of ax, y0: the bottom of ax, p0: the y postion of anchor
+    # cy1 : the top of colorbar ax, cy0: the bottom of colorbar ax
+    y1 = ax.get_position().y1
+    y0 = ax.get_position().y0
+    p0 = (y1 - y0) * anchor_y + y0
+    cy1 = cbar.ax.get_position().y1
+    cy0 = cbar.ax.get_position().y0
+
+    assert np.isclose(
+            [cy1, cy0],
+            [y1 * shrink + (1 - shrink) * p0, p0 * (1 - shrink) + y0 * shrink]
+            ).all()
+
+    # horizontal
+    shrink = 0.5
+    anchor_x = 0.3
+    fig, ax = plt.subplots()
+    cs = ax.contourf(data, levels=levels)
+    cbar = plt.colorbar(
+            cs, ax=ax, use_gridspec=True,
+            orientation='horizontal', anchor=(anchor_x, 1), shrink=shrink)
+
+    # x1: the right of ax, x0: the left of ax, p0: the x postion of anchor
+    # cx1 : the right of colorbar ax, cx0: the left of colorbar ax
+    x1 = ax.get_position().x1
+    x0 = ax.get_position().x0
+    p0 = (x1 - x0) * anchor_x + x0
+    cx1 = cbar.ax.get_position().x1
+    cx0 = cbar.ax.get_position().x0
+
+    assert np.isclose(
+            [cx1, cx0],
+            [x1 * shrink + (1 - shrink) * p0, p0 * (1 - shrink) + x0 * shrink]
+            ).all()


### PR DESCRIPTION
## PR Summary
I made a little change so that now the `anchor` argument in `make_axes_gridspec` mimic the behavior of that in `make_axes`.  Now the postion of colorbar is determined by `anchor` and `shrink`, should be very useful when `shrink` < 1.0

The effect is demostrated in the plot below. Now I can place the colorbar at different place with different shrinked size.

```python
import numpy as np
import matplotlib as mpl
import matplotlib,pyplot as plt

x = np.random.randn(100)
y = np.random.randn(100)
fig = plt.figure()
ax = fig.add_subplot()
mappable = ax.scatter(x,y, c=y)
ax.figure.colorbar(mappable, ax=ax, anchor=(0,0.3), shrink=0.5) 
```
![A good figure](https://gitee.com/shawn96/publicFiles/raw/master/Figure_1.png)

Before the change, we can achieve that using `ax.figure.colorbar(mappable, ax=ax, anchor=(0,0.3), use_gridspec=False) ` , however, this will create a colorbar as a `Axes` not a `Subplot`, when I use `subplots_ajust` to adjust the border margins, I got the following plot.
```python
fig = plt.figure()
ax = fig.add_subplot()
mappable = ax.scatter(x,y, c=y)
ax.figure.colorbar(mappable, ax=ax, anchor=(0,0.3), shrink=0.5, use_gridspec=False) 
ax.figure.subplots_adjust(bottom=0.1)
```
![A bad figure](https://gitee.com/shawn96/publicFiles/raw/master/BadFigure.png)

It seems the colorbar Axes is ignored and my plot is re-placed according to its `panchor` parameter that `make_axes` set. It bothers me when I have multiple plots and wanna adjust the plots  border margins and wspace, hspace.

`gridspec` offers a better approach and is the default setting when creating a colorbar, however, I want the colorbar to be 0.5 size and placed at the bottom right, which is mot implemented.

So this is what I did basically.


## PR Checklist

- [ ] Has Pytest style unit tests
- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [ ] New features are documented, with examples if plot related
- [ ] Documentation is sphinx and numpydoc compliant
- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [ ] Documented in doc/api/api_changes.rst if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
