### PR TITLE
DOCS: add action items to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,15 @@
 
 ## PR Checklist
 
-- [ ] Has Pytest style unit tests
-- [ ] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
-- [ ] New features are documented, with examples if plot related
-- [ ] Documentation is sphinx and numpydoc compliant
-- [ ] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
-- [ ] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way
+<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
+
+- [ ] Has pytest style unit tests (and `pytest` passes).
+- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
+- [ ] New features are documented, with examples if plot related.
+- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
+- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
+- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
+- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
 
 <!--
 Thank you so much for your PR!  To help us review your contribution, please


### PR DESCRIPTION
## PR Summary

Adds action items to each checkbox of the PR template.

Per the discussion in #17153, we should be putting any improvements for the developer documentation in to the dev docs themselves, not in the PR template. However, I pulled out a non-controversial (I think) quality of life improvement for new devs into this separate PR, since I still think this bit should be merged.

## PR Checklist

- [N/A] Has Pytest style unit tests
- [N/A] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [N/A] New features are documented, with examples if plot related
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [N/A] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
