### PR TITLE
Remove redundant angles in ellipse demo.

### DIFF
--- a/examples/shapes_and_collections/ellipse_demo.py
+++ b/examples/shapes_and_collections/ellipse_demo.py
@@ -47,7 +47,7 @@ import numpy as np
 from matplotlib.patches import Ellipse
 
 angle_step = 45  # degrees
-angles = np.arange(0, 360, angle_step)
+angles = np.arange(0, 180, angle_step)
 
 ax = plt.subplot(aspect='equal')
 


### PR DESCRIPTION
## PR Summary

Since ellipses are 180°-symmetric, they're actually overplotted twice (and 3 times for 0° before #16109.)

Apparently, I committed this ages ago and forgot to PR it.

## PR Checklist

- [n/a] Has Pytest style unit tests
- [x] Code is [Flake 8](http://flake8.pycqa.org/en/latest/) compliant
- [n/a] New features are documented, with examples if plot related
- [x] Documentation is sphinx and numpydoc compliant
- [n/a] Added an entry to doc/users/next_whats_new/ if major new feature (follow instructions in README.rst there)
- [n/a] Documented in doc/api/next_api_changes/* if API changed in a backward-incompatible way