### PR TITLE
Avoid triggering backend resolution during qt initial import.

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -42,13 +42,15 @@ elif "PySide.QtCore" in sys.modules:
     QT_API = QT_API_PYSIDE
 # Otherwise, check the QT_API environment variable (from Enthought).  This can
 # only override the binding, not the backend (in other words, we check that the
-# requested backend actually matches).
-elif mpl.rcParams["backend"] in ["Qt5Agg", "Qt5Cairo"]:
+# requested backend actually matches).  Use dict.__getitem__ to avoid
+# triggering backend resolution (which can result in a partially but
+# incompletely imported backend_qt5).
+elif dict.__getitem__(mpl.rcParams, "backend") in ["Qt5Agg", "Qt5Cairo"]:
     if QT_API_ENV in ["pyqt5", "pyside2"]:
         QT_API = _ETS[QT_API_ENV]
     else:
         QT_API = None
-elif mpl.rcParams["backend"] in ["Qt4Agg", "Qt4Cairo"]:
+elif dict.__getitem__(mpl.rcParams, "backend") in ["Qt4Agg", "Qt4Cairo"]:
     if QT_API_ENV in ["pyqt4", "pyside"]:
         QT_API = _ETS[QT_API_ENV]
     else:
@@ -150,8 +152,8 @@ if QT_API in [QT_API_PYQT5, QT_API_PYSIDE2]:
     _setup_pyqt5()
 elif QT_API in [QT_API_PYQTv2, QT_API_PYSIDE, QT_API_PYQT]:
     _setup_pyqt4()
-elif QT_API is None:
-    if mpl.rcParams["backend"] == "Qt4Agg":
+elif QT_API is None:  # See above re: dict.__getitem__.
+    if dict.__getitem__(mpl.rcParams, "backend") == "Qt4Agg":
         _candidates = [(_setup_pyqt4, QT_API_PYQTv2),
                        (_setup_pyqt4, QT_API_PYSIDE),
                        (_setup_pyqt4, QT_API_PYQT),


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/18326.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
