### PR TITLE
DOCS: describe shared axes behavior with units

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -286,6 +286,10 @@ class GridSpecBase:
             first column subplot are created. To later turn other subplots'
             ticklabels on, use `~matplotlib.axes.Axes.tick_params`.
 
+            When subplots have a shared axis that has units, calling
+            `~matplotlib.axis.Axis.set_units` will update each axis with the
+            new units.
+
         squeeze : bool, optional, default: True
             - If True, extra dimensions are squeezed out from the returned
               array of Axes:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1258,6 +1258,10 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         column subplot are created. To later turn other subplots' ticklabels
         on, use `~matplotlib.axes.Axes.tick_params`.
 
+        When subplots have a shared axis that has units, calling
+        `~matplotlib.axis.Axis.set_units` will update each axis with the
+        new units.
+
     squeeze : bool, default: True
         - If True, extra dimensions are squeezed out from the returned
           array of `~matplotlib.axes.Axes`:


### PR DESCRIPTION
## PR Summary
Closes #18345

## PR Checklist

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
