### PR TITLE
DOC: Add some types to Returns entries.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1788,8 +1788,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `~.Line2D`
+            Objects representing the plotted data.
 
         Other Parameters
         ----------------
@@ -1858,8 +1858,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `~.Line2D`
+            Objects representing the plotted data.
 
         Other Parameters
         ----------------
@@ -1911,8 +1911,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `~.Line2D`
+            Objects representing the plotted data.
 
         Other Parameters
         ----------------
@@ -1960,8 +1960,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `~.Line2D`
+            Objects representing the plotted data.
 
         Other Parameters
         ----------------
@@ -2202,8 +2202,8 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        lines
-            A list of `.Line2D` objects representing the plotted data.
+        list of `.Line2D`
+            Objects representing the plotted data.
 
         Other Parameters
         ----------------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -696,8 +696,8 @@ default: 'top'
 
         Returns
         -------
-        text
-            The `.Text` instance of the title.
+        `.Text`
+            The instance of the title.
 
         Other Parameters
         ----------------
@@ -2865,7 +2865,7 @@ def figaspect(arg):
 
     Returns
     -------
-    width, height
+    width, height : float
         The figure size in inches.
 
     Notes


### PR DESCRIPTION
## PR Summary

Just something I found stashed away for a long time.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).