### PR TITLE
Move PostScript Type3 subsetting to pure python.

### DIFF
--- a/lib/matplotlib/tests/baseline_images/test_backend_ps/type3.eps
+++ b/lib/matplotlib/tests/baseline_images/test_backend_ps/type3.eps
@@ -1,0 +1,112 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Orientation: portrait
+%%BoundingBox: 18.0 180.0 594.0 612.0
+%%EndComments
+%%BeginProlog
+/mpldict 11 dict def
+mpldict begin
+/d { bind def } bind def
+/m { moveto } d
+/l { lineto } d
+/r { rlineto } d
+/c { curveto } d
+/cl { closepath } d
+/ce { closepath eofill } d
+/box {
+      m
+      1 index 0 r
+      0 exch r
+      neg 0 r
+      cl
+    } d
+/clipbox {
+      box
+      clip
+      newpath
+    } d
+/sc { setcachedevice } d
+%!PS-Adobe-3.0 Resource-Font
+%%Creator: Converted from TrueType to Type 3 by Matplotlib.
+10 dict begin
+/FontName /DejaVuSans def
+/PaintType 0 def
+/FontMatrix [0.00048828125 0 0 0.00048828125 0 0] def
+/FontBBox [-2090 -948 3673 2524] def
+/FontType 3 def
+/Encoding [/I /J /slash] def
+/CharStrings 4 dict dup begin
+/.notdef 0 def
+/I{604 0 201 0 403 1493 sc
+201 1493 m
+403 1493 l
+403 0 l
+201 0 l
+201 1493 l
+
+ce} d
+/J{604 0 -106 -410 403 1493 sc
+201 1493 m
+403 1493 l
+403 104 l
+403 -76 369 -207 300 -288 c
+232 -369 122 -410 -29 -410 c
+-106 -410 l
+-106 -240 l
+-43 -240 l
+46 -240 109 -215 146 -165 c
+183 -115 201 -25 201 104 c
+201 1493 l
+
+ce} d
+/slash{690 0 0 -190 690 1493 sc
+520 1493 m
+690 1493 l
+170 -190 l
+0 -190 l
+520 1493 l
+
+ce} d
+end readonly def
+
+/BuildGlyph {
+ exch begin
+ CharStrings exch
+ 2 copy known not {pop /.notdef} if
+ true 3 1 roll get exec
+ end
+} d
+
+/BuildChar {
+ 1 index /Encoding get exch get
+ 1 index /BuildGlyph get exec
+} d
+
+FontName currentdict end definefont pop
+end
+%%EndProlog
+mpldict begin
+18 180 translate
+576 432 0 0 clipbox
+gsave
+0 0 m
+576 0 l
+576 432 l
+0 432 l
+cl
+1.000 setgray
+fill
+grestore
+0.000 setgray
+/DejaVuSans findfont
+12.000 scalefont
+setfont
+gsave
+288.000000 216.000000 translate
+0.000000 rotate
+0.000000 0 m /I glyphshow
+3.539062 0 m /slash glyphshow
+7.582031 0 m /J glyphshow
+grestore
+
+end
+showpage

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -157,3 +157,8 @@ def test_useafm():
     ax.set_axis_off()
     ax.axhline(.5)
     ax.text(.5, .5, "qk")
+
+
+@image_comparison(["type3.eps"])
+def test_type3_font():
+    plt.figtext(.5, .5, "I/J")

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -120,11 +120,8 @@ def test_find_ttc():
 
     fig, ax = plt.subplots()
     ax.text(.5, .5, "\N{KANGXI RADICAL DRAGON}", fontproperties=fp)
-    fig.savefig(BytesIO(), format="raw")
-    fig.savefig(BytesIO(), format="svg")
-    fig.savefig(BytesIO(), format="pdf")
-    with pytest.raises(RuntimeError):
-        fig.savefig(BytesIO(), format="ps")
+    for fmt in ["raw", "svg", "pdf", "ps"]:
+        fig.savefig(BytesIO(), format=fmt)
 
 
 def test_find_invalid(tmpdir):


### PR DESCRIPTION
... similarly to the change for pdf (#18181), but easier because there are no
baseline images for which we need to provide bug-level backcompat :-)

Drop the FontInfo metadata (which is explicitly optional in the
PostScript spec) to avoid having to figure out the correct encoding
(which can be quite obscure).

Replace the implementation of the `_sc` command from
`7 -1 roll{setcachedevice}{pop pop pop pop pop pop}ifelse` to a plain
`setcachedevice` (as I cannot see any case where the "other" branch is
taken).

Drop the splitting of long commands using `exec` (`_e`) -- this is only
needed for level-1 postscript, which has a small fixed stack size; we
output level-2 postscript (per backend_version) and I guess level-1 is
rarely in use nowadays anyways (probably the feature could be added back
if there's really demand for it, but let's not get ahead of ourselves).

Previously, some composite characters would be output in a "compressed"
form (e.g., accented characters would be recorded as "draw the accent,
then run the charproc for the unaccented character").  This is lost, but
I'd guess outputting .ps.gz is better if compression really matters.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
