### PR TITLE
FIX: make _reshape_2D accept pandas df with string indices

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1355,6 +1355,17 @@ def _reshape_2D(X, name):
 
     *name* is used to generate the error message for invalid inputs.
     """
+
+    # unpack if we have a values or to_numpy method.
+    try:
+        X = X.to_numpy()
+    except AttributeError:
+        try:
+            if isinstance(X.values, np.ndarray):
+                X = X.values
+        except AttributeError:
+            pass
+
     # Iterate over columns for ndarrays.
     if isinstance(X, np.ndarray):
         X = X.T

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -559,6 +559,23 @@ def test_reshape2d():
     assert isinstance(xnew[0], np.ndarray)
 
 
+def test_reshape2d_pandas(pd):
+    # seperate to allow the rest of the tests to run if no pandas...
+    X = np.arange(30).reshape(10, 3)
+    x = pd.DataFrame(X, columns=["a", "b", "c"])
+    Xnew = cbook._reshape_2D(x, 'x')
+    # Need to check each row because _reshape_2D returns a list of arrays:
+    for x, xnew in zip(X.T, Xnew):
+        np.testing.assert_array_equal(x, xnew)
+
+    X = np.arange(30).reshape(10, 3)
+    x = pd.DataFrame(X, columns=["a", "b", "c"])
+    Xnew = cbook._reshape_2D(x, 'x')
+    # Need to check each row because _reshape_2D returns a list of arrays:
+    for x, xnew in zip(X.T, Xnew):
+        np.testing.assert_array_equal(x, xnew)
+
+
 def test_contiguous_regions():
     a, b, c = 3, 4, 5
     # Starts and ends with True


### PR DESCRIPTION
Closes #18371

In #17289 we changed `_reshape_2D` (used by `violinplot` and `boxplot`).  It used to basically just call `np.asanyarray(X)` which works fine with pandas.  However, there is a ragged array deprecation, so #17289 now iterates over the columns using 
`for x in X` to get each column of the matrix individually.  

That is incompatible with Pandas data frame like `df = pd.DataFrame(np.random.randn(100, 3), columns=["a", "b", "c"])`, which return the error in #18371, which is a regression. 

Here we try to extract the matrix from X using `to_numpy()` or `values` before doing the rest of the manipulations.  

Note this still doesn't do the "right thing" for the column names, at least using box plot, but this fixes the regression.  If the folks who use boxplot or violinplot want to do something fancier with the column names they can try to make that work in some reasonable way, but I think such fancy pandas handling really belongs in pandas, or perhaps the structured data refactor. 