### PR TITLE
Fix Axis scale on twinned Axes.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -494,8 +494,8 @@ class _AxesBase(martist.Artist):
         self._anchor = 'C'
         self._stale_viewlim_x = False
         self._stale_viewlim_y = False
-        self._sharex = None
-        self._sharey = None
+        self._sharex = sharex
+        self._sharey = sharey
         self.set_label(label)
         self.set_figure(fig)
         self.set_box_aspect(box_aspect)
@@ -515,11 +515,6 @@ class _AxesBase(martist.Artist):
 
         self._rasterization_zorder = None
         self.cla()
-
-        if sharex is not None:
-            self.sharex(sharex)
-        if sharey is not None:
-            self.sharey(sharey)
 
         # funcs used to format x and y - fall back on major formatters
         self.fmt_xdata = None


### PR DESCRIPTION
## PR Summary

If `Axes._sharex` is not set, then the subsequent `Axes.cla` will change the Axis scale to linear. If `Axes._sharex` is set, then `Axes.cla` will call `Axes.sharex` just as was done here, but without resetting scale to linear.

Fixes #18385.

~~This won't pass yet, as it turns out that twinned Axes double-draw the frame, though if we really need to apply this quickly, I can increase the tolerance.~~

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).