### PR TITLE
fix cmr10 negative sign in cmsy10 (RuntimeWarning: Glyph 8722 missing)

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -519,6 +519,11 @@ class UnicodeFonts(TruetypeFonts):
             found_symbol = False
             font = self._get_font(new_fontname)
             if font is not None:
+                if font.family_name == "cmr10" and uniindex == 0x2212:
+                    # minus sign exists in cmsy10 (not cmr10)
+                    font = get_font(
+                        cbook._get_data_path("fonts/ttf/cmsy10.ttf"))
+                    uniindex = 0xa1
                 glyphindex = font.get_char_index(uniindex)
                 if glyphindex != 0:
                     found_symbol = True

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -388,5 +388,6 @@ def test_math_fontfamily():
 
 
 def test_mathtext_fontfamily():
-    fig = plt.figure(figsize=(10, 3))
-    fig.text(.5, .5, '$a-b$', fontsize=40, ha='center', math_fontfamily='cmr10')
+    mpl.rcParams['font.family'] = 'cmr10'
+    fig, ax = plt.subplots()
+    ax.plot(range(-1, 1), range(-1, 1))

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -385,3 +385,8 @@ def test_math_fontfamily():
              size=24, math_fontfamily='dejavusans')
     fig.text(0.2, 0.3, r"$This\ text\ should\ have\ another$",
              size=24, math_fontfamily='stix')
+
+
+def test_mathtext_fontfamily():
+    fig = plt.figure(figsize=(10, 3))
+    fig.text(.5, .5, '$a-b$', fontsize=40, ha='center', math_fontfamily='cmr10')

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -395,4 +395,4 @@ def test_mathtext_cmr10_minus_sign():
     ax.plot(range(-1, 1), range(-1, 1))
     with pytest.warns(None) as record:
         fig.canvas.draw()
-    assert len(record) == 0
+    assert len(record) == 0, "\n".join(str(e.message) for e in record)

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -391,6 +391,7 @@ def test_mathtext_cmr10_minus_sign():
     # cmr10 does not contain a minus sign and used to issue a warning
     # RuntimeWarning: Glyph 8722 missing from current font.
     mpl.rcParams['font.family'] = 'cmr10'
+    mpl.rcParams['axes.formatter.use_mathtext'] = True
     fig, ax = plt.subplots()
     ax.plot(range(-1, 1), range(-1, 1))
     with pytest.warns(None) as record:

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -395,4 +395,4 @@ def test_mathtext_cmr10_minus_sign():
     ax.plot(range(-1, 1), range(-1, 1))
     with pytest.warns(None) as record:
         fig.canvas.draw()
-    assert len(record) == 0    
+    assert len(record) == 0

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -387,7 +387,12 @@ def test_math_fontfamily():
              size=24, math_fontfamily='stix')
 
 
-def test_mathtext_fontfamily():
+def test_mathtext_cmr10_minus_sign():
+    # cmr10 does not contain a minus sign and used to issue a warning
+    # RuntimeWarning: Glyph 8722 missing from current font.
     mpl.rcParams['font.family'] = 'cmr10'
     fig, ax = plt.subplots()
     ax.plot(range(-1, 1), range(-1, 1))
+    with pytest.warns(None) as record:
+        fig.canvas.draw()
+    assert len(record) == 0    


### PR DESCRIPTION
## PR Summary
- fixes #17007 cmr10 negative sign `RuntimeWarning: Glyph 8722 missing from current font.`
- implementation suggested by https://github.com/matplotlib/matplotlib/issues/17007#issuecomment-685951519

## Code

Before this PR, this code would not render negative signs on the axes tick labels.

```python
import matplotlib
matplotlib.rcParams.update({
    'font.family': 'cmr10',
    'axes.formatter.use_mathtext: True
})
import matplotlib.pyplot as plt

plt.figure()
plt.plot(range(-1, 1), range(-1, 1))
plt.title(r"dash (-) $mathtext:negative (-)\bf{mathtext.bf:negative (-)}$")
plt.xlabel(r"dash (-) $mathtext:negative (-)\bf{mathtext.bf:negative (-)}$")
```

## PR Checklist
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).