### PR TITLE
Warn on non-increasing/decreasing pcolor coords

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5682,6 +5682,15 @@ default: :rc:`scatter.edgecolors`
                     # helper for below
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1)/2.
+                        if not (np.all(dX >= 0) or np.all(dX <= 0)):
+                            cbook._warn_external(
+                                f"The input coordinates to {funcname} are "
+                                "not all either increasing or decreasing, "
+                                "the automatically computed edges can "
+                                "produce misleading results in this case. "
+                                "It is recommended to supply the "
+                                f"quadrilateral edges to {funcname}"
+                                f" yourself. See help({funcname}).")
                         X = np.hstack((X[:, [0]] - dX[:, [0]],
                                        X[:, :-1] + dX,
                                        X[:, [-1]] + dX[:, [-1]]))

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1131,6 +1131,13 @@ def test_pcolorargs():
         x = np.ma.array(x, mask=(x < 0))
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])
+    # Expect a warning with non-increasing coordinates
+    x = [359, 0, 1]
+    y = [-10, 10]
+    X, Y = np.meshgrid(x, y)
+    Z = np.zeros(X.shape)
+    with pytest.warns(UserWarning, match="The input coordinates"):
+        ax.pcolormesh(X, Y, Z, shading='auto')
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR Summary
pcolor* will now automatically calculate bin edges for users if shading is 'auto' or 'nearest'. This can lead to surprising resulting edge calculations if the coordinate arrays are not sorted prior to calling the function.

Addresses part of #18317. This would be good to get into v3.3.2 for at least warning users about this use case and then leave the other potential screen-space interpolations for v3.4.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).


