### PR TITLE
DOC: Remove related topics entries from the sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -276,7 +276,7 @@ html_sidebars = {
         # 'sidebar_announcement.html',
         'sidebar_versions.html',
         'donate_sidebar.html'],
-    '**': ['localtoc.html', 'relations.html', 'pagesource.html']
+    '**': ['localtoc.html', 'pagesource.html']
 }
 
 # If false, no module index is generated.


### PR DESCRIPTION
## PR Summary

This PR removes the "Related Topics" section from the sidebar:

![grafik](https://user-images.githubusercontent.com/2836374/92169071-1ae64080-ee3b-11ea-99b6-e98a01d0be45.png)

This comes from the original sphinx theme on which the Matplotlib theme was based. I suppose nobody ever bothered to remove it, even though it does not add value for the Matplotlib docs and instead just increases clutter.

That section has two parts:
- the hierarchy to the current page. This is not needed because it's already available in the breadcrumbs at the top.
- the previous/next pages. Since our docs are not a continuous narrative, the previous and next pages are often actually not related.
