### PR TITLE
Avoid demo'ing passing kwargs to gca().

### DIFF
--- a/examples/mplot3d/2dcollections3d.py
+++ b/examples/mplot3d/2dcollections3d.py
@@ -10,8 +10,7 @@ selective axes of a 3D plot.
 import numpy as np
 import matplotlib.pyplot as plt
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Plot a sin curve using the x and y axes.
 x = np.linspace(0, 1, 100)

--- a/examples/mplot3d/contour3d.py
+++ b/examples/mplot3d/contour3d.py
@@ -11,13 +11,10 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
-# Plot contour curves
-cset = ax.contour(X, Y, Z, cmap=cm.coolwarm)
-
+cset = ax.contour(X, Y, Z, cmap=cm.coolwarm)  # Plot contour curves
 ax.clabel(cset, fontsize=9, inline=True)
 
 plt.show()

--- a/examples/mplot3d/contour3d_2.py
+++ b/examples/mplot3d/contour3d_2.py
@@ -11,8 +11,7 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
 cset = ax.contour(X, Y, Z, extend3d=True, cmap=cm.coolwarm)

--- a/examples/mplot3d/contour3d_3.py
+++ b/examples/mplot3d/contour3d_3.py
@@ -13,8 +13,7 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
 # Plot the 3D surface

--- a/examples/mplot3d/contourf3d.py
+++ b/examples/mplot3d/contourf3d.py
@@ -14,8 +14,7 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
 cset = ax.contourf(X, Y, Z, cmap=cm.coolwarm)

--- a/examples/mplot3d/contourf3d_2.py
+++ b/examples/mplot3d/contourf3d_2.py
@@ -13,8 +13,7 @@ from mpl_toolkits.mplot3d import axes3d
 import matplotlib.pyplot as plt
 from matplotlib import cm
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
 # Plot the 3D surface

--- a/examples/mplot3d/errorbar3d.py
+++ b/examples/mplot3d/errorbar3d.py
@@ -9,8 +9,7 @@ An example of using errorbars with upper and lower limits in mplot3d.
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # setting up a parametric curve
 t = np.arange(0, 2*np.pi+.1, 0.01)

--- a/examples/mplot3d/lines3d.py
+++ b/examples/mplot3d/lines3d.py
@@ -10,10 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-plt.rcParams['legend.fontsize'] = 10
-
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Prepare arrays x, y, z
 theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)

--- a/examples/mplot3d/lorenz_attractor.py
+++ b/examples/mplot3d/lorenz_attractor.py
@@ -54,8 +54,7 @@ for i in range(num_steps):
 
 
 # Plot
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 ax.plot(xs, ys, zs, lw=0.5)
 ax.set_xlabel("X Axis")

--- a/examples/mplot3d/offset.py
+++ b/examples/mplot3d/offset.py
@@ -17,8 +17,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 X, Y = np.mgrid[0:6*np.pi:0.25, 0:4*np.pi:0.25]
 Z = np.sqrt(np.abs(np.cos(X) + np.cos(Y)))

--- a/examples/mplot3d/polys3d.py
+++ b/examples/mplot3d/polys3d.py
@@ -24,8 +24,7 @@ def polygon_under_graph(xlist, ylist):
     return [(xlist[0], 0.), *zip(xlist, ylist), (xlist[-1], 0.)]
 
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Make verts a list such that verts[i] is a list of (x, y) pairs defining
 # polygon i.

--- a/examples/mplot3d/quiver3d.py
+++ b/examples/mplot3d/quiver3d.py
@@ -9,8 +9,7 @@ Demonstrates plotting directional arrows at points on a 3d meshgrid.
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Make the grid
 x, y, z = np.meshgrid(np.arange(-0.8, 1, 0.2),

--- a/examples/mplot3d/surface3d_3.py
+++ b/examples/mplot3d/surface3d_3.py
@@ -11,8 +11,7 @@ from matplotlib.ticker import LinearLocator
 import numpy as np
 
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Make data.
 X = np.arange(-5, 5, 0.25)

--- a/examples/mplot3d/text3d.py
+++ b/examples/mplot3d/text3d.py
@@ -7,20 +7,17 @@ Demonstrates the placement of text annotations on a 3D plot.
 
 Functionality shown:
 
-    - Using the text function with three types of 'zdir' values: None, an axis
-      name (ex. 'x'), or a direction tuple (ex. (1, 1, 0)).
-    - Using the text function with the color keyword.
-
-    - Using the text2D function to place text on a fixed position on the ax
-      object.
-
+- Using the text function with three types of 'zdir' values: None, an axis
+  name (ex. 'x'), or a direction tuple (ex. (1, 1, 0)).
+- Using the text function with the color keyword.
+- Using the text2D function to place text on a fixed position on the ax
+  object.
 """
 
 import matplotlib.pyplot as plt
 
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 # Demo 1: zdir
 zdirs = (None, 'x', 'y', 'z', (1, 1, 0), (1, 1, 1))

--- a/examples/mplot3d/tricontour3d.py
+++ b/examples/mplot3d/tricontour3d.py
@@ -35,8 +35,7 @@ triang.set_mask(np.hypot(x[triang.triangles].mean(axis=1),
                          y[triang.triangles].mean(axis=1))
                 < min_radius)
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.tricontour(triang, z, cmap=plt.cm.CMRmap)
 
 # Customize the view angle so it's easier to understand the plot.

--- a/examples/mplot3d/tricontourf3d.py
+++ b/examples/mplot3d/tricontourf3d.py
@@ -36,8 +36,7 @@ triang.set_mask(np.hypot(x[triang.triangles].mean(axis=1),
                          y[triang.triangles].mean(axis=1))
                 < min_radius)
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.tricontourf(triang, z, cmap=plt.cm.CMRmap)
 
 # Customize the view angle so it's easier to understand the plot.

--- a/examples/mplot3d/trisurf3d.py
+++ b/examples/mplot3d/trisurf3d.py
@@ -26,8 +26,7 @@ y = np.append(0, (radii*np.sin(angles)).flatten())
 # Compute z to make the pringle surface.
 z = np.sin(-x*y)
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 
 ax.plot_trisurf(x, y, z, linewidth=0.2, antialiased=True)
 

--- a/examples/mplot3d/voxels.py
+++ b/examples/mplot3d/voxels.py
@@ -29,8 +29,7 @@ colors[cube1] = 'blue'
 colors[cube2] = 'green'
 
 # and plot everything
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.voxels(voxels, facecolors=colors, edgecolor='k')
 
 plt.show()

--- a/examples/mplot3d/voxels_numpy_logo.py
+++ b/examples/mplot3d/voxels_numpy_logo.py
@@ -5,6 +5,7 @@
 
 Demonstrates using `.Axes3D.voxels` with uneven coordinates.
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -39,8 +40,7 @@ x[1::2, :, :] += 0.95
 y[:, 1::2, :] += 0.95
 z[:, :, 1::2] += 0.95
 
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.voxels(x, y, z, filled_2, facecolors=fcolors_2, edgecolors=ecolors_2)
 
 plt.show()

--- a/examples/mplot3d/voxels_rgb.py
+++ b/examples/mplot3d/voxels_rgb.py
@@ -33,8 +33,7 @@ colors[..., 1] = gc
 colors[..., 2] = bc
 
 # and plot everything
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.voxels(r, g, b, sphere,
           facecolors=colors,
           edgecolors=np.clip(2*colors - 0.5, 0, 1),  # brighter

--- a/examples/mplot3d/voxels_torus.py
+++ b/examples/mplot3d/voxels_torus.py
@@ -36,8 +36,7 @@ hsv[..., 2] = zc + 0.5
 colors = matplotlib.colors.hsv_to_rgb(hsv)
 
 # and plot everything
-fig = plt.figure()
-ax = fig.gca(projection='3d')
+ax = plt.figure().add_subplot(projection='3d')
 ax.voxels(x, y, z, sphere,
           facecolors=colors,
           edgecolors=np.clip(2*colors - 0.5, 0, 1),  # brighter

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -112,7 +112,7 @@ def test_bar3d_lightsource():
 @mpl3d_image_comparison(['contour3d.png'])
 def test_contour3d():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
     ax.contour(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
@@ -125,7 +125,7 @@ def test_contour3d():
 @mpl3d_image_comparison(['contourf3d.png'])
 def test_contourf3d():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
     ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
@@ -138,7 +138,7 @@ def test_contourf3d():
 @mpl3d_image_comparison(['contourf3d_fill.png'])
 def test_contourf3d_fill():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     X, Y = np.meshgrid(np.arange(-2, 2, 0.25), np.arange(-2, 2, 0.25))
     Z = X.clip(0, 0)
     # This produces holes in the z=0 surface that causes rendering errors if
@@ -168,7 +168,7 @@ def test_tricontour():
 @mpl3d_image_comparison(['lines3d.png'])
 def test_lines3d():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     theta = np.linspace(-4 * np.pi, 4 * np.pi, 100)
     z = np.linspace(-2, 2, 100)
     r = z ** 2 + 1
@@ -179,9 +179,9 @@ def test_lines3d():
 
 @check_figures_equal(extensions=["png"])
 def test_plot_scalar(fig_test, fig_ref):
-    ax1 = fig_test.gca(projection='3d')
+    ax1 = fig_test.add_subplot(projection='3d')
     ax1.plot([1], [1], "o")
-    ax2 = fig_ref.gca(projection='3d')
+    ax2 = fig_ref.add_subplot(projection='3d')
     ax2.plot(1, 1, "o")
 
 
@@ -213,11 +213,11 @@ def test_mixedsubplots():
 def test_tight_layout_text(fig_test, fig_ref):
     # text is currently ignored in tight layout. So the order of text() and
     # tight_layout() calls should not influence the result.
-    ax1 = fig_test.gca(projection='3d')
+    ax1 = fig_test.add_subplot(projection='3d')
     ax1.text(.5, .5, .5, s='some string')
     fig_test.tight_layout()
 
-    ax2 = fig_ref.gca(projection='3d')
+    ax2 = fig_ref.add_subplot(projection='3d')
     fig_ref.tight_layout()
     ax2.text(.5, .5, .5, s='some string')
 
@@ -274,7 +274,7 @@ def test_scatter3d_sorting(fig_ref, fig_test, depthshade):
         for a in [x, y, z, sizes, facecolors, edgecolors, linewidths]
     ]
 
-    ax_ref = fig_ref.gca(projection='3d')
+    ax_ref = fig_ref.add_subplot(projection='3d')
     sets = (np.unique(a) for a in [sizes, facecolors, edgecolors, linewidths])
     for s, fc, ec, lw in itertools.product(*sets):
         subset = (
@@ -294,7 +294,7 @@ def test_scatter3d_sorting(fig_ref, fig_test, depthshade):
         ax_ref.scatter(x, y, subset, s=s, fc=fc, ec=ec, lw=lw, alpha=1,
                        depthshade=depthshade)
 
-    ax_test = fig_test.gca(projection='3d')
+    ax_test = fig_test.add_subplot(projection='3d')
     ax_test.scatter(x, y, z, s=sizes, fc=facecolors, ec=edgecolors,
                     lw=linewidths, alpha=1, depthshade=depthshade)
 
@@ -360,7 +360,7 @@ def test_surface3d():
     plt.rcParams['pcolormesh.snap'] = False
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     X = np.arange(-5, 5, 0.25)
     Y = np.arange(-5, 5, 0.25)
     X, Y = np.meshgrid(X, Y)
@@ -375,7 +375,7 @@ def test_surface3d():
 @mpl3d_image_comparison(['surface3d_shaded.png'])
 def test_surface3d_shaded():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     X = np.arange(-5, 5, 0.25)
     Y = np.arange(-5, 5, 0.25)
     X, Y = np.meshgrid(X, Y)
@@ -389,7 +389,7 @@ def test_surface3d_shaded():
 @mpl3d_image_comparison(['text3d.png'], remove_text=False)
 def test_text3d():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     zdirs = (None, 'x', 'y', 'z', (1, 1, 0), (1, 1, 1))
     xs = (2, 6, 4, 9, 7, 2)
@@ -424,7 +424,7 @@ def test_trisurf3d():
     z = np.sin(-x*y)
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
 
 
@@ -442,7 +442,7 @@ def test_trisurf3d_shaded():
     z = np.sin(-x*y)
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     ax.plot_trisurf(x, y, z, color=[1, 0.5, 0], linewidth=0.2)
 
 
@@ -511,7 +511,7 @@ def test_quiver3d_empty(fig_test, fig_ref):
 @mpl3d_image_comparison(['quiver3d_masked.png'])
 def test_quiver3d_masked():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     # Using mgrid here instead of ogrid because masked_where doesn't
     # seem to like broadcasting very much...
@@ -529,7 +529,7 @@ def test_quiver3d_masked():
 @mpl3d_image_comparison(['poly3dcollection_closed.png'])
 def test_poly3dcollection_closed():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     poly1 = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
     poly2 = np.array([[0, 1, 1], [1, 1, 1], [1, 1, 0]], float)
@@ -551,7 +551,7 @@ def test_poly_collection_2d_to_3d_empty():
 @mpl3d_image_comparison(['poly3dcollection_alpha.png'])
 def test_poly3dcollection_alpha():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     poly1 = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
     poly2 = np.array([[0, 1, 1], [1, 1, 1], [1, 1, 0]], float)
@@ -577,7 +577,7 @@ def test_add_collection3d_zs_array():
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     norm = plt.Normalize(0, 2*np.pi)
     # 2D LineCollection from x & y values
@@ -605,7 +605,7 @@ def test_add_collection3d_zs_scalar():
     segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     norm = plt.Normalize(0, 2*np.pi)
     lc = LineCollection(segments, cmap='twilight', norm=norm)
@@ -818,7 +818,7 @@ def test_autoscale():
 @mpl3d_image_comparison(['axes3d_ortho.png'], remove_text=False)
 def test_axes3d_ortho():
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     ax.set_proj_type('ortho')
 
 
@@ -1074,7 +1074,7 @@ def test_quiver3D_smoke(fig_test, fig_ref):
     u = v = w = np.ones_like(x)
 
     for fig, length in zip((fig_ref, fig_test), (1, 1.0)):
-        ax = fig.gca(projection="3d")
+        ax = fig.add_subplot(projection="3d")
         ax.quiver(x, y, z, u, v, w, length=length, pivot=pivot)
 
 
@@ -1096,7 +1096,7 @@ def test_errorbar3d_errorevery():
     x, y, z = np.sin(t), np.cos(3*t), np.sin(5*t)
 
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     estep = 15
     i = np.arange(t.size)
@@ -1111,7 +1111,7 @@ def test_errorbar3d_errorevery():
 def test_errorbar3d():
     """Tests limits, color styling, and legend for 3d errorbars."""
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     d = [1, 2, 3, 4, 5]
     e = [.5, .5, .5, .5, .5]


### PR DESCRIPTION
Creating a new Axes with kwargs is better done with `add_subplot()`.

(`gca(**...)` is still present in a few tests that explicitly test that
functionality.)

xref #10700.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
