### PR TITLE
Always strip out date in postscript's test_savefig_to_stringio.

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -39,10 +39,8 @@ needs_usetex = pytest.mark.skipif(
     'eps afm',
     'eps with usetex'
 ])
-def test_savefig_to_stringio(format, use_log, rcParams, orientation,
-                             monkeypatch):
+def test_savefig_to_stringio(format, use_log, rcParams, orientation):
     mpl.rcParams.update(rcParams)
-    monkeypatch.setenv("SOURCE_DATE_EPOCH", "0")  # For reproducibility.
 
     fig, ax = plt.subplots()
 
@@ -70,12 +68,11 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation,
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()
 
-        if rcParams.get("ps.usedistiller") or rcParams.get("text.usetex"):
-            # Strip out CreationDate betcase ghostscript doesn't obey
-            # SOURCE_DATE_EPOCH.  Note that in usetex mode, we *always* call
-            # gs_distill, even if ps.usedistiller is unset.
-            s_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", s_val)
-            b_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", b_val)
+        # Strip out CreationDate: ghostscript and cairo don't obey
+        # SOURCE_DATE_EPOCH, and that environment variable is already tested in
+        # test_determinism.
+        s_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", s_val)
+        b_val = re.sub(b"(?<=\n%%CreationDate: ).*", b"", b_val)
 
         assert s_val == b_val.replace(b'\r\n', b'\n')
 


### PR DESCRIPTION
We already test that postscript output supports SOURCE_DATE_EPOCH in
test_determinism.  Removing the date in test_savefig_to_stringio in all
cases makes it easier to reuse the test in mplcairo, as cairo does not
support SOURCE_DATE_EPOCH (or manually setting the date in postscript
output in any case); the test is not about SOURCE_DATE_EPOCH support
anyways.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
