### PR TITLE
Decrease output when running `pytest -s`.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -441,6 +441,10 @@ class FileMovieWriter(MovieWriter):
         self._temp_paths = list()
         self.fname_format_str = '%s%%07d.%s'
 
+    def __del__(self):
+        if self._tmpdir:
+            self._tmpdir.cleanup()
+
     @cbook.deprecated("3.3")
     @property
     def clear_temp(self):

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -11,7 +11,6 @@ def test_simple():
 
 def test_override_builtins():
     import pylab
-
     ok_to_override = {
         '__name__',
         '__doc__',
@@ -23,15 +22,9 @@ def test_override_builtins():
         'sum',
         'divmod'
     }
-    overridden = False
-    for key in dir(pylab):
-        if key in dir(builtins):
-            if (getattr(pylab, key) != getattr(builtins, key) and
-                    key not in ok_to_override):
-                print("'%s' was overridden in globals()." % key)
-                overridden = True
-
-    assert not overridden
+    overridden = {key for key in {*dir(pylab)} & {*dir(builtins)}
+                  if getattr(pylab, key) != getattr(builtins, key)}
+    assert overridden <= ok_to_override
 
 
 def test_lazy_imports():

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -599,8 +599,7 @@ def test_text_as_text_opacity():
 def test_text_repr():
     # smoketest to make sure text repr doesn't error for category
     plt.plot(['A', 'B'], [1, 2])
-    txt = plt.text(['A'], 0.5, 'Boo')
-    print(txt)
+    repr(plt.text(['A'], 0.5, 'Boo'))
 
 
 def test_annotation_update():


### PR DESCRIPTION
The explicit cleanup() animation tmpdir on teardown avoids
emitting ResourceWarnings when running e.g. `pytest
lib/matplotlib/tests/test_animation.py -s`.

The call to print in test_text is unneeded.  The one in test_pylab
doesn't actually print normally, but I simplified the test while at it.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
