### PR TITLE
2-D array RGB and RGBA values not understood in plt.plot()

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -265,6 +265,10 @@ def _to_rgba_no_colorcycle(c, alpha=None):
                     f"Value must be within 0-1 range")
             return c, c, c, alpha if alpha is not None else 1.
         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")
+    # turn 2-D array into 1-D array
+    if isinstance(c, np.ndarray):
+        if c.ndim == 2 and c.shape[0] == 1:
+            c = c.reshape((-1))
     # tuple color.
     if not np.iterable(c):
         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -268,7 +268,7 @@ def _to_rgba_no_colorcycle(c, alpha=None):
     # turn 2-D array into 1-D array
     if isinstance(c, np.ndarray):
         if c.ndim == 2 and c.shape[0] == 1:
-            c = c.reshape((-1))
+            c = c.reshape(-1)
     # tuple color.
     if not np.iterable(c):
         raise ValueError(f"Invalid RGBA argument: {orig_c!r}")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6590,7 +6590,7 @@ def test_sharing_does_not_link_positions():
     init_pos = ax1.get_position()
     fig.subplots_adjust(left=0)
     assert (ax1.get_position().get_points() == init_pos.get_points()).all()
-    
+
 
 @check_figures_equal(extensions=["pdf"])
 def test_2dcolor_plot(fig_test, fig_ref):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6590,3 +6590,22 @@ def test_sharing_does_not_link_positions():
     init_pos = ax1.get_position()
     fig.subplots_adjust(left=0)
     assert (ax1.get_position().get_points() == init_pos.get_points()).all()
+    
+
+@check_figures_equal(extensions=["pdf"])
+def test_2dcolor_plot(fig_test, fig_ref):
+    color = np.array([0.1, 0.2, 0.3])
+    # plot with 1D-color:
+    axs = fig_test.subplots(5)
+    axs[0].plot([1, 2], [1, 2], c=color.reshape(-1))
+    axs[1].scatter([1, 2], [1, 2], c=color.reshape(-1))
+    axs[2].step([1, 2], [1, 2], c=color.reshape(-1))
+    axs[3].hist(np.arange(10), color=color.reshape(-1))
+    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape(-1))
+    # plot with 2D-color:
+    axs = fig_ref.subplots(5)
+    axs[0].plot([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[1].scatter([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[2].step([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[3].hist(np.arange(10), color=color.reshape((1, -1)))
+    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape((1, -1)))

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1211,3 +1211,10 @@ def test_colormap_bad_data_with_alpha():
     assert_array_equal(c[0, 0], (0, 0, 0, 0))
     c = cmap([[np.nan, 0.5], [0, 0]], alpha=np.full((2, 2), 0.5))
     assert_array_equal(c[0, 0], (0, 0, 0, 0))
+    
+    
+def test_2d_to_rgba():
+    color = np.array([0.1, 0.2, 0.3])
+    rgba_1d = mcolors.to_rgba(color.reshape(-1))
+    rgba_2d = mcolors.to_rgba(color.reshape((1, -1)))
+    assert rgba_1d == rgba_2d

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1211,8 +1211,8 @@ def test_colormap_bad_data_with_alpha():
     assert_array_equal(c[0, 0], (0, 0, 0, 0))
     c = cmap([[np.nan, 0.5], [0, 0]], alpha=np.full((2, 2), 0.5))
     assert_array_equal(c[0, 0], (0, 0, 0, 0))
-    
-    
+
+
 def test_2d_to_rgba():
     color = np.array([0.1, 0.2, 0.3])
     rgba_1d = mcolors.to_rgba(color.reshape(-1))


### PR DESCRIPTION
closes #18411

## PR Summary
This fixes the problem discussed in the linked issue in the most simple and general way.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [NA] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [NA] New features are documented, with examples if plot related.
- [NA] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [NA] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [NA] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
