### PR TITLE
DOC: fix date example

### DIFF
--- a/examples/text_labels_and_annotations/date.py
+++ b/examples/text_labels_and_annotations/date.py
@@ -17,7 +17,7 @@ types are "registered" with with the unit conversion mechanism described in
 The registration process also sets the default tick ``locator`` and
 ``formatter`` for the axis to be `~.matplotlib.dates.AutoDateLocator` and
 `~.matplotlib.dates.AutoDateFormatter`.  These can be changed manually with
-`.axis.set_major_locator` and `.axis.set_major_formatter`; see for example
+`.Axis.set_major_locator` and `.Axis.set_major_formatter`; see for example
 :doc:`/gallery/ticks_and_spines/date_demo_convert`.
 
 An alternative formatter is the `~.matplotlib.dates.ConciseDateFormatter`

--- a/examples/text_labels_and_annotations/date.py
+++ b/examples/text_labels_and_annotations/date.py
@@ -12,7 +12,7 @@ days since an epoch (by default 1970-01-01T00:00:00). The
 :mod:`matplotlib.dates` module provides the converter functions `.date2num`
 and `.num2date`, which convert `datetime.datetime` and `numpy.datetime64`
 objects to and from Matplotlib's internal representation.  These data
-types are "registered" with with the unit conversion mechanism described in
+types are registered with with the unit conversion mechanism described in
 :mod:`matplotlib.units`, so the conversion happens automatically for the user.
 The registration process also sets the default tick ``locator`` and
 ``formatter`` for the axis to be `~.matplotlib.dates.AutoDateLocator` and

--- a/examples/text_labels_and_annotations/date.py
+++ b/examples/text_labels_and_annotations/date.py
@@ -7,16 +7,22 @@ Show how to make date plots in Matplotlib using date tick locators and
 formatters.  See :doc:`/gallery/ticks_and_spines/major_minor_demo` for more
 information on controlling major and minor ticks.
 
-All Matplotlib date plotting is done by converting date instances into
-days since 0001-01-01 00:00:00 UTC plus one day (for historical reasons).
-The conversion, tick locating and formatting is done behind the scenes
-so this is most transparent to you.  The :mod:`matplotlib.dates` module
-provides the converter functions `.date2num` and `.num2date`, which convert
-`datetime.datetime` and `numpy.datetime64` objects to and from Matplotlib's
-internal representation.
+Matplotlib date plotting is done by converting date instances into
+days since an epoch (by default 1970-01-01T00:00:00). The
+:mod:`matplotlib.dates` module provides the converter functions `.date2num`
+and `.num2date`, which convert `datetime.datetime` and `numpy.datetime64`
+objects to and from Matplotlib's internal representation.  These data
+types are "registered" with with the unit conversion mechanism described in
+:mod:`matplotlib.units`, so the conversion happens automatically for the user.
+The registration process also sets the default tick ``locator`` and
+``formatter`` for the axis to be `~.matplotlib.dates.AutoDateLocator` and
+`~.matplotlib.dates.AutoDateFormatter`.  These can be changed manually with
+`.axis.set_major_locator` and `.axis.set_major_formatter`; see for example
+:doc:`/gallery/ticks_and_spines/date_demo_convert`.
 
-An alternative way of displaying dates can be seen at
-:doc:`/gallery/ticks_and_spines/date_concise_formatter`.
+An alternative formatter is the `~.matplotlib.dates.ConciseDateFormatter`
+as described at :doc:`/gallery/ticks_and_spines/date_concise_formatter`,
+which often removes the need to rotate the tick labels.
 """
 
 import numpy as np


### PR DESCRIPTION
## PR Summary

The description of the example at https://matplotlib.org/devdocs/gallery/text_labels_and_annotations/date.html#sphx-glr-gallery-text-labels-and-annotations-date-py wasn't up to date wrt to the epoch, and could use some links to the locator and formatter. 


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
