### PR TITLE
Support doubleclick in webagg/nbagg

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1411,9 +1411,6 @@ class MouseEvent(LocationEvent):
     ----------
     button : None or `MouseButton` or {'up', 'down'}
         The button pressed. 'up' and 'down' are used for scroll events.
-        Note that in the nbagg backend, both the middle and right clicks
-        return RIGHT since right clicking will bring up the context menu in
-        some browsers.
         Note that LEFT and RIGHT actually refer to the "primary" and
         "secondary" buttons, i.e. if the user inverts their left and right
         buttons ("left-handed setting") then the LEFT button will be the one

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -264,6 +264,9 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         guiEvent = event.get('guiEvent', None)
         if e_type == 'button_press':
             self.button_press_event(x, y, button, guiEvent=guiEvent)
+        elif e_type == 'dblclick':
+            self.button_press_event(x, y, button, dblclick=True,
+                                    guiEvent=guiEvent)
         elif e_type == 'button_release':
             self.button_release_event(x, y, button, guiEvent=guiEvent)
         elif e_type == 'motion_notify':
@@ -274,9 +277,9 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
             self.leave_notify_event()
         elif e_type == 'scroll':
             self.scroll_event(x, y, event['step'], guiEvent=guiEvent)
-    handle_button_press = handle_button_release = handle_motion_notify = \
-        handle_figure_enter = handle_figure_leave = handle_scroll = \
-        _handle_mouse
+    handle_button_press = handle_button_release = handle_dblclick = \
+        handle_figure_enter = handle_figure_leave = handle_motion_notify = \
+        handle_scroll = _handle_mouse
 
     def _handle_key(self, event):
         key = _handle_key(event['key'])

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -238,6 +238,10 @@ mpl.figure.prototype._init_canvas = function () {
         'mouseup',
         on_mouse_event_closure('button_release')
     );
+    rubberband_canvas.addEventListener(
+        'dblclick',
+        on_mouse_event_closure('dblclick')
+    );
     // Throttle sequential mouse events to 1 every 20ms.
     rubberband_canvas.addEventListener(
         'mousemove',


### PR DESCRIPTION
## PR Summary

Also, remove note about middle-clicks as that was fixed by #18172.

Fixes #18404.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [?] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).