### PR TITLE
Warn if an animation is gc'd before doing anything.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -1,3 +1,4 @@
+import gc
 import os
 from pathlib import Path
 import subprocess
@@ -73,6 +74,14 @@ def test_null_movie_writer():
     assert writer.args == ()
     assert writer.savefig_kwargs == savefig_kwargs
     assert writer._count == num_frames
+
+
+def test_animation_delete():
+    anim = make_animation(frames=5)
+
+    with pytest.warns(Warning, match='Animation was deleted'):
+        del anim
+        gc.collect()
 
 
 def test_movie_writer_dpi_default():


### PR DESCRIPTION
## PR Summary

Wording may be a bit terse, feel free to make suggestions.

Fixes #18438.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).