### PR TITLE
Normalize properties passed to ToolHandles.

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,3 +1,4 @@
+import matplotlib.colors as mcolors
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
@@ -105,7 +106,9 @@ def test_rectangle_handles():
         pass
 
     tool = widgets.RectangleSelector(ax, onselect=onselect,
-                                     maxdist=10, interactive=True)
+                                     maxdist=10, interactive=True,
+                                     marker_props={'markerfacecolor': 'r',
+                                                   'markeredgecolor': 'b'})
     tool.extents = (100, 150, 100, 150)
 
     assert tool.corners == (
@@ -132,6 +135,12 @@ def test_rectangle_handles():
     do_event(tool, 'onmove', xdata=100, ydata=100)
     do_event(tool, 'release', xdata=100, ydata=100)
     assert tool.extents == (10, 100, 10, 100)
+
+    # Check that marker_props worked.
+    assert mcolors.same_color(
+        tool._corner_handles.artist.get_markerfacecolor(), 'r')
+    assert mcolors.same_color(
+        tool._corner_handles.artist.get_markeredgecolor(), 'b')
 
 
 def check_span(*args, **kwargs):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1855,9 +1855,11 @@ class ToolHandles:
 
     def __init__(self, ax, x, y, marker='o', marker_props=None, useblit=True):
         self.ax = ax
-        props = dict(marker=marker, markersize=7, mfc='w', ls='none',
-                     alpha=0.5, visible=False, label='_nolegend_')
-        props.update(marker_props if marker_props is not None else {})
+        props = dict(marker=marker, markersize=7, markerfacecolor='w',
+                     linestyle='none', alpha=0.5, visible=False,
+                     label='_nolegend_')
+        props.update(cbook.normalize_kwargs(marker_props, Line2D._alias_map)
+                     if marker_props is not None else {})
         self._markers = Line2D(x, y, animated=useblit, **props)
         self.ax.add_line(self._markers)
         self.artist = self._markers
@@ -2024,9 +2026,11 @@ class RectangleSelector(_SelectorWidget):
         self.maxdist = maxdist
 
         if rectprops is None:
-            props = dict(mec='r')
+            props = dict(markeredgecolor='r')
         else:
-            props = dict(mec=rectprops.get('edgecolor', 'r'))
+            props = dict(markeredgecolor=rectprops.get('edgecolor', 'r'))
+        props.update(cbook.normalize_kwargs(marker_props, Line2D._alias_map)
+                     if marker_props is not None else {})
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
         xc, yc = self.corners
         self._corner_handles = ToolHandles(self.ax, xc, yc, marker_props=props,
@@ -2503,7 +2507,8 @@ class PolygonSelector(_SelectorWidget):
         self.ax.add_line(self.line)
 
         if markerprops is None:
-            markerprops = dict(mec='k', mfc=lineprops.get('color', 'k'))
+            markerprops = dict(markeredgecolor='k',
+                               markerfacecolor=lineprops.get('color', 'k'))
         self._polygon_handles = ToolHandles(self.ax, self._xs, self._ys,
                                             useblit=self.useblit,
                                             marker_props=markerprops)


### PR DESCRIPTION
## PR Summary

These can come in through with `RectangleSelector` or `PolygonSelector`, which also need normalization as they have defaults that could be overridden.

Fixes #12027.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).