### PR TITLE
Remove the private Axes._set_position.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -475,7 +475,7 @@ def _reposition_axes(fig, renderer, *, w_pad=0, h_pad=0, hspace=0, wspace=0):
 
         # transform from figure to panel for set_position:
         newbbox = trans_fig_to_panel.transform_bbox(bbox)
-        ax._set_position(newbbox)
+        ax.set_position(newbbox)
 
         # move the colorbars:
         # we need to keep track of oldw and oldh if there is more than
@@ -563,7 +563,7 @@ def _reposition_colorbar(cbax, renderer, *, offset=None):
 
     pbcb = trans_fig_to_panel.transform_bbox(pbcb)
     cbax.set_transform(fig.transPanel)
-    cbax._set_position(pbcb)
+    cbax.set_position(pbcb)
     cbax.set_aspect(aspect, anchor=anchor, adjustable='box')
     return offset
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -912,17 +912,6 @@ class _AxesBase(martist.Artist):
         matplotlib.transforms.Bbox.from_bounds
         matplotlib.transforms.Bbox.from_extents
         """
-        self._set_position(pos, which=which)
-        # because this is being called externally to the library we
-        # zero the constrained layout parts.
-
-    def _set_position(self, pos, which='both'):
-        """
-        Private version of set_position.
-
-        Call this internally to get the same functionality of `get_position`,
-        but not to take the axis out of the constrained_layout hierarchy.
-        """
         if not isinstance(pos, mtransforms.BboxBase):
             pos = mtransforms.Bbox.from_bounds(*pos)
         for ax in self._twinned_axes.get_siblings(self):
@@ -1604,7 +1593,7 @@ class _AxesBase(martist.Artist):
         aspect = self.get_aspect()
 
         if aspect == 'auto' and self._box_aspect is None:
-            self._set_position(position, which='active')
+            self.set_position(position, which='active')
             return
 
         fig_width, fig_height = self.get_figure().get_size_inches()
@@ -1617,21 +1606,21 @@ class _AxesBase(martist.Artist):
             box_aspect = aspect * self.get_data_ratio()
             pb = position.frozen()
             pb1 = pb.shrunk_to_aspect(box_aspect, pb, fig_aspect)
-            self._set_position(pb1.anchored(self.get_anchor(), pb), 'active')
+            self.set_position(pb1.anchored(self.get_anchor(), pb), 'active')
             return
 
         # The following is only seen if self._adjustable == 'datalim'
         if self._box_aspect is not None:
             pb = position.frozen()
             pb1 = pb.shrunk_to_aspect(self._box_aspect, pb, fig_aspect)
-            self._set_position(pb1.anchored(self.get_anchor(), pb), 'active')
+            self.set_position(pb1.anchored(self.get_anchor(), pb), 'active')
             if aspect == "auto":
                 return
 
         # reset active to original in case it had been changed by prior use
         # of 'box'
         if self._box_aspect is None:
-            self._set_position(position, which='active')
+            self.set_position(position, which='active')
         else:
             position = pb1.anchored(self.get_anchor(), pb)
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3288,8 +3288,8 @@ class NavigationToolbar2:
         for ax, (view, (pos_orig, pos_active)) in items:
             ax._set_view(view)
             # Restore both the original and modified positions
-            ax._set_position(pos_orig, 'original')
-            ax._set_position(pos_active, 'active')
+            ax.set_position(pos_orig, 'original')
+            ax.set_position(pos_active, 'active')
         self.canvas.draw_idle()
 
     def configure_subplots(self, *args):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -570,8 +570,8 @@ class ToolViewsPositions(ToolBase):
         if set(all_axes).issubset(pos):
             for a in all_axes:
                 # Restore both the original and modified positions
-                a._set_position(pos[a][0], 'original')
-                a._set_position(pos[a][1], 'active')
+                a.set_position(pos[a][0], 'original')
+                a.set_position(pos[a][1], 'active')
 
         self.figure.canvas.draw_idle()
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1367,7 +1367,7 @@ class Colorbar(ColorbarBase):
         except AttributeError:
             # use_gridspec was False
             pos = ax.get_position(original=True)
-            ax._set_position(pos)
+            ax.set_position(pos)
         else:
             # use_gridspec was True
             ax.set_subplotspec(subplotspec)
@@ -1473,7 +1473,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     for ax in parents:
         new_posn = shrinking_trans.transform(ax.get_position(original=True))
         new_posn = mtransforms.Bbox(new_posn)
-        ax._set_position(new_posn)
+        ax.set_position(new_posn)
         if parent_anchor is not False:
             ax.set_anchor(parent_anchor)
 
@@ -1573,7 +1573,7 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
 
     parent.set_subplotspec(ss_main)
     parent.update_params()
-    parent._set_position(parent.figbox)
+    parent.set_position(parent.figbox)
     parent.set_anchor(loc_settings["panchor"])
 
     fig = parent.get_figure()

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -492,16 +492,16 @@ class GridSpec(GridSpecBase):
                     if isinstance(ax._sharex, mpl.axes.SubplotBase):
                         if ax._sharex.get_subplotspec().get_gridspec() == self:
                             ax._sharex.update_params()
-                            ax._set_position(ax._sharex.figbox)
+                            ax.set_position(ax._sharex.figbox)
                     elif isinstance(ax._sharey, mpl.axes.SubplotBase):
                         if ax._sharey.get_subplotspec().get_gridspec() == self:
                             ax._sharey.update_params()
-                            ax._set_position(ax._sharey.figbox)
+                            ax.set_position(ax._sharey.figbox)
                 else:
                     ss = ax.get_subplotspec().get_topmost_subplotspec()
                     if ss.get_gridspec() == self:
                         ax.update_params()
-                        ax._set_position(ax.figbox)
+                        ax.set_position(ax.figbox)
 
     def get_subplot_params(self, figure=None):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -412,7 +412,7 @@ class Axes3D(Axes):
         box_aspect = 1
         pb = position.frozen()
         pb1 = pb.shrunk_to_aspect(box_aspect, pb, fig_aspect)
-        self._set_position(pb1.anchored(self.get_anchor(), pb), 'active')
+        self.set_position(pb1.anchored(self.get_anchor(), pb), 'active')
 
     @artist.allow_rasterization
     def draw(self, renderer):


### PR DESCRIPTION
The distinction between Axes.set_position and Axes._set_position is no
more since the constrained_layout rewrite went in.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
