### PR TITLE
FIX: allow manually placed axes in constrained_layout

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -209,7 +209,7 @@ def _make_layout_margins(fig, renderer, *, w_pad=0, h_pad=0,
 
     # for ax in [a for a in fig._localaxes if hasattr(a, 'get_subplotspec')]:
     for ax in fig.get_axes():
-        if not hasattr(ax, 'get_subplotspec'):
+        if not hasattr(ax, 'get_subplotspec') or not ax.get_in_layout():
             continue
 
         ss = ax.get_subplotspec()
@@ -320,7 +320,8 @@ def _match_submerged_margins(fig):
     for panel in fig.panels:
         _match_submerged_margins(panel)
 
-    axs = [a for a in fig.get_axes() if hasattr(a, 'get_subplotspec')]
+    axs = [a for a in fig.get_axes() if (hasattr(a, 'get_subplotspec')
+                                         and a.get_in_layout())]
 
     for ax1 in axs:
         ss1 = ax1.get_subplotspec()
@@ -457,7 +458,7 @@ def _reposition_axes(fig, renderer, *, w_pad=0, h_pad=0, hspace=0, wspace=0):
     # for ax in fig._localaxes:
     #     if not hasattr(a, 'get_subplotspec'):
     for ax in fig.get_axes():
-        if not hasattr(ax, 'get_subplotspec'):
+        if not hasattr(ax, 'get_subplotspec') or not ax.get_in_layout():
             continue
 
         # grid bbox is in Figure co-ordinates, but we specify in panel
@@ -578,7 +579,7 @@ def _reset_margins(fig):
     for span in fig.panels:
         _reset_margins(span)
     for ax in fig.axes:
-        if hasattr(ax, 'get_subplotspec'):
+        if hasattr(ax, 'get_subplotspec') and ax.get_in_layout():
             ss = ax.get_subplotspec()
             gs = ss.get_gridspec()
             if gs._layoutgrid is not None:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -914,7 +914,8 @@ class _AxesBase(martist.Artist):
         """
         self._set_position(pos, which=which)
         # because this is being called externally to the library we
-        # zero the constrained layout parts.
+        # don't let it be in the layout.
+        self.set_in_layout(False)
 
     def _set_position(self, pos, which='both'):
         """

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -487,3 +487,19 @@ def test_colorbars_no_overlapH():
         ax.tick_params(axis='both', direction='in')
         im = ax.imshow([[1, 2], [3, 4]])
         fig.colorbar(im, ax=ax, orientation="horizontal")
+
+
+def test_manually_set_position():
+    fig, axs = plt.subplots(1, 2, constrained_layout=True)
+    axs[0].set_position([0.2, 0.2, 0.3, 0.3])
+    fig.canvas.draw()
+    pp = axs[0].get_position()
+    np.testing.assert_allclose(pp, [[0.2, 0.2], [0.5, 0.5]])
+
+    fig, axs = plt.subplots(1, 2, constrained_layout=True)
+    axs[0].set_position([0.2, 0.2, 0.3, 0.3])
+    pc = axs[0].pcolormesh(np.random.rand(20, 20))
+    fig.colorbar(pc, ax=axs[0])
+    fig.canvas.draw()
+    pp = axs[0].get_position()
+    np.testing.assert_allclose(pp, [[0.2, 0.2], [0.44, 0.5]])


### PR DESCRIPTION
## PR Summary

Closes #18449

The constrained_layout rewrite took away the ability to manually place an axes after it was created.  This restores that ability.

Please see the description at https://github.com/matplotlib/matplotlib/pull/18449#issuecomment-690837903  This restores the old correct behaviour.

I guess its worth noting that we didn't use `ax.get_in_layout()` before (that I know of), but its a natural fit here (its inherited from `Artist`).  Note this also allows a user to manually take an axes out of constrained layout w/o moving it, but I don't think that "feature" is worth a lot of documentation verbiage.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
