### PR TITLE
nbagg: Use OutputArea event to trigger figure close.

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -48,11 +48,19 @@ mpl.mpl_figure_comm = function (comm, msg) {
         console.error('Failed to find cell for figure', id, fig);
         return;
     }
+    fig.cell_info[0].output_area.element.one(
+        'cleared',
+        { fig: fig },
+        fig._remove_fig_handler
+    );
 };
 
 mpl.figure.prototype.handle_close = function (fig, msg) {
     var width = fig.canvas.width / fig.ratio;
-    fig.root.removeEventListener('remove', this._remove_fig_handler);
+    fig.cell_info[0].output_area.element.off(
+        'cleared',
+        fig._remove_fig_handler
+    );
 
     // Update the output cell to use the data from the current canvas.
     fig.push_to_output();
@@ -171,13 +179,13 @@ mpl.figure.prototype._init_toolbar = function () {
     titlebar.insertBefore(buttongrp, titlebar.firstChild);
 };
 
-mpl.figure.prototype._remove_fig_handler = function () {
-    this.close_ws(this, {});
+mpl.figure.prototype._remove_fig_handler = function (event) {
+    var fig = event.data.fig;
+    fig.close_ws(fig, {});
 };
 
 mpl.figure.prototype._root_extra_style = function (el) {
     el.style.boxSizing = 'content-box'; // override notebook setting of border-box.
-    el.addEventListener('remove', this._remove_fig_handler);
 };
 
 mpl.figure.prototype._canvas_extra_style = function (el) {

--- a/requirements/testing/travis_extra.txt
+++ b/requirements/testing/travis_extra.txt
@@ -1,7 +1,7 @@
 # Extra pip requirements for the travis python 3.7+ builds
 
 ipykernel
-nbconvert[execute]
+nbconvert[execute]!=6.0.0,!=6.0.1
 nbformat!=5.0.0,!=5.0.1
 pandas!=0.25.0
 pikepdf


### PR DESCRIPTION
## PR Summary

When converting from jQuery to vanilla JavaScript, the trigger for the figure closure was set to a non-existent event name, as the 'remove' event is jQuery-specific.

As there is no DOM node removal event (unless using MutationObserver), connect this handler to the notebook's `Cell` `OutputArea`'s 'cleared' event. This is triggered both by re-running a cell, and by using the Clear Output menu option.

Fixes #18447.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).