### PR TITLE
Fix BoundingBox in EPS files.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -910,7 +910,7 @@ class FigureCanvasPS(FigureCanvasBase):
                       end="", file=fh)
             print(f"{dsc_comments}\n"
                   f"%%Orientation: {orientation.name}\n"
-                  f"%%BoundingBox: {bbox[0]} {bbox[1]} {bbox[2]} {bbox[3]}\n"
+                  f"{get_bbox_header(bbox)[0]}\n"
                   f"%%EndComments\n",
                   end="", file=fh)
 
@@ -1056,7 +1056,7 @@ class FigureCanvasPS(FigureCanvasBase):
                 f"""\
 %!PS-Adobe-3.0 EPSF-3.0
 {dsc_comments}
-%%BoundingBox: {bbox[0]} {bbox[1]} {bbox[2]} {bbox[3]}
+{get_bbox_header(bbox)[0]}
 %%EndComments
 %%BeginProlog
 /mpldict {len(psDefs)} dict def

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -113,6 +113,24 @@ def test_transparency():
     ax.text(.5, .5, "foo", color="r", alpha=0)
 
 
+def test_bbox():
+    fig, ax = plt.subplots()
+    with io.BytesIO() as buf:
+        fig.savefig(buf, format='eps')
+        buf = buf.getvalue()
+
+    bb = re.search(b'^%%BoundingBox: (.+) (.+) (.+) (.+)$', buf, re.MULTILINE)
+    assert bb
+    hibb = re.search(b'^%%HiResBoundingBox: (.+) (.+) (.+) (.+)$', buf,
+                     re.MULTILINE)
+    assert hibb
+
+    for i in range(1, 5):
+        # BoundingBox must use integers, and be ceil/floor of the hi res.
+        assert b'.' not in bb.group(i)
+        assert int(bb.group(i)) == pytest.approx(float(hibb.group(i)), 1)
+
+
 @needs_usetex
 def test_failing_latex():
     """Test failing latex subprocess call"""


### PR DESCRIPTION
## PR Summary

The elements should be integers; for floating point, the `HiResBoundingBox` can be used.

I believe this broke some time ago in d3aef44ca7d5516cf85e0d05a8c26ad2f96567e3, though it did not use `ceil` at the time, so this is slightly better.

This was reported on gitter.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).