### PR TITLE
Reuse InsetLocator to make twinned axes follow their parents.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -31,36 +31,12 @@ import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 import matplotlib.units as munits
 from matplotlib import _preprocess_data, rcParams
-from matplotlib.axes._base import _AxesBase, _process_plot_format
+from matplotlib.axes._base import (
+    _AxesBase, _TransformedBoundsLocator, _process_plot_format)
 from matplotlib.axes._secondary_axes import SecondaryAxis
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
 
 _log = logging.getLogger(__name__)
-
-
-class _InsetLocator:
-    """
-    Axes locator for `.Axes.inset_axes`.
-
-    The locater is a callable object used in `.Axes.set_aspect` to compute the
-    axes location depending on the renderer.
-    """
-
-    def __init__(self, bounds, transform):
-        """
-        *bounds* (a ``[l, b, w, h]`` rectangle) and *transform* together
-        specify the position of the inset axes.
-        """
-        self._bounds = bounds
-        self._transform = transform
-
-    def __call__(self, ax, renderer):
-        # Subtracting transFigure will typically rely on inverted(), freezing
-        # the transform; thus, this needs to be delayed until draw time as
-        # transFigure may otherwise change after this is evaluated.
-        return mtransforms.TransformedBbox(
-            mtransforms.Bbox.from_bounds(*self._bounds),
-            self._transform - ax.figure.transFigure)
 
 
 # The axes module contains all the wrappers to plotting functions.
@@ -365,7 +341,7 @@ class Axes(_AxesBase):
         kwargs.setdefault('label', 'inset_axes')
 
         # This puts the rectangle into figure-relative coordinates.
-        inset_locator = _InsetLocator(bounds, transform)
+        inset_locator = _TransformedBoundsLocator(bounds, transform)
         bounds = inset_locator(self, None).bounds
         inset_ax = Axes(self.figure, bounds, zorder=zorder, **kwargs)
         # this locator lets the axes move if in data coordinates.

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -3,8 +3,7 @@ import numpy as np
 import matplotlib.cbook as cbook
 import matplotlib.docstring as docstring
 import matplotlib.ticker as mticker
-from matplotlib.axes import _axes
-from matplotlib.axes._base import _AxesBase
+from matplotlib.axes._base import _AxesBase, _TransformedBoundsLocator
 
 
 class SecondaryAxis(_AxesBase):
@@ -114,13 +113,12 @@ class SecondaryAxis(_AxesBase):
         else:
             bounds = [self._pos, 0, 1e-10, 1]
 
-        secondary_locator = _axes._InsetLocator(bounds, self._parent.transAxes)
-
         # this locator lets the axes move in the parent axes coordinates.
         # so it never needs to know where the parent is explicitly in
         # figure coordinates.
-        # it gets called in `ax.apply_aspect() (of all places)
-        self.set_axes_locator(secondary_locator)
+        # it gets called in ax.apply_aspect() (of all places)
+        self.set_axes_locator(
+            _TransformedBoundsLocator(bounds, self._parent.transAxes))
 
     def apply_aspect(self, position=None):
         # docstring inherited.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2424,15 +2424,7 @@ default: 'top'
                                  "constrained_layout==False. ")
         self.subplotpars.update(left, bottom, right, top, wspace, hspace)
         for ax in self.axes:
-            if not isinstance(ax, SubplotBase):
-                # Check if sharing a subplots axis
-                if isinstance(ax._sharex, SubplotBase):
-                    ax._sharex.update_params()
-                    ax.set_position(ax._sharex.figbox)
-                elif isinstance(ax._sharey, SubplotBase):
-                    ax._sharey.update_params()
-                    ax.set_position(ax._sharey.figbox)
-            else:
+            if isinstance(ax, SubplotBase):
                 ax.update_params()
                 ax.set_position(ax.figbox)
         self.stale = True

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -486,18 +486,7 @@ class GridSpec(GridSpecBase):
                 raise AttributeError(f"{k} is an unknown keyword")
         for figmanager in _pylab_helpers.Gcf.figs.values():
             for ax in figmanager.canvas.figure.axes:
-                # copied from Figure.subplots_adjust
-                if not isinstance(ax, mpl.axes.SubplotBase):
-                    # Check if sharing a subplots axis
-                    if isinstance(ax._sharex, mpl.axes.SubplotBase):
-                        if ax._sharex.get_subplotspec().get_gridspec() == self:
-                            ax._sharex.update_params()
-                            ax._set_position(ax._sharex.figbox)
-                    elif isinstance(ax._sharey, mpl.axes.SubplotBase):
-                        if ax._sharey.get_subplotspec().get_gridspec() == self:
-                            ax._sharey.update_params()
-                            ax._set_position(ax._sharey.figbox)
-                else:
+                if isinstance(ax, mpl.axes.SubplotBase):
                     ss = ax.get_subplotspec().get_topmost_subplotspec()
                     if ss.get_gridspec() == self:
                         ax.update_params()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6513,3 +6513,12 @@ def test_multiplot_autoscale():
     ax2.axhspan(-5, 5)
     xlim = ax1.get_xlim()
     assert np.allclose(xlim, [0.5, 4.5])
+
+
+def test_sharing_does_not_link_positions():
+    fig = plt.figure()
+    ax0 = fig.add_subplot(221)
+    ax1 = fig.add_axes([.6, .6, .3, .3], sharex=ax0)
+    init_pos = ax1.get_position()
+    fig.subplots_adjust(left=0)
+    assert (ax1.get_position().get_points() == init_pos.get_points()).all()


### PR DESCRIPTION
From a positioning PoV, a twinned axes is just like an inset axes whose
position exactly matches the parent's position.  Doing so removes the
need for the heuristic in `Figure.subplots_adjust`/`GridSpec.update`
where a non-gridspec-managed Axes would track the position of any Axes
with which it shared either xaxis or yaxis, which was a proxy for
twinning (per 721b949).  This would cause incorrect behavior in rare
cases such as
```python
from pylab import *
ax = subplot(221)
axes([.6, .6, .3, .3], sharex=ax)
subplots_adjust(left=0)
```
where the `subplots_adjust` call would make the second axes go on top of
the first.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
