### PR TITLE
Fix huge imshow range

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1251,7 +1251,6 @@ def _make_norm_from_scale(scale_cls, base_norm_cls=None, *, init=None):
                 **{k: ba.arguments.pop(k) for k in ["vmin", "vmax", "clip"]})
             self._scale = scale_cls(axis=None, **ba.arguments)
             self._trf = self._scale.get_transform()
-            self._inv_trf = self._trf.inverted()
 
         def __call__(self, value, clip=None):
             value, is_scalar = self.process_value(value)
@@ -1283,7 +1282,10 @@ def _make_norm_from_scale(scale_cls, base_norm_cls=None, *, init=None):
                 raise ValueError("Invalid vmin or vmax")
             rescaled = value * (t_vmax - t_vmin)
             rescaled += t_vmin
-            return self._inv_trf.transform(rescaled).reshape(np.shape(value))
+            return (self._trf
+                    .inverted()
+                    .transform(rescaled)
+                    .reshape(np.shape(value)))
 
     Norm.__name__ = base_norm_cls.__name__
     Norm.__qualname__ = base_norm_cls.__qualname__

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -534,9 +534,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 resampled_masked = np.ma.masked_array(A_resampled, out_mask)
                 # we have re-set the vmin/vmax to account for small errors
                 # that may have moved input values in/out of range
+                s_vmin, s_vmax = vrange
+                if isinstance(self.norm, mcolors.LogNorm):
+                    if s_vmin < 0:
+                        s_vmin = max(s_vmin, np.finfo(scaled_dtype).eps)
                 with cbook._setattr_cm(self.norm,
-                                       vmin=vrange[0],
-                                       vmax=vrange[1],
+                                       vmin=s_vmin,
+                                       vmax=s_vmax,
                                        ):
                     output = self.norm(resampled_masked)
             else:

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1204,3 +1204,22 @@ def test_imshow_quantitynd():
     ax.imshow(arr)
     # executing the draw should not raise an exception
     fig.canvas.draw()
+
+
+@check_figures_equal(extensions=['png'])
+def test_huge_range_log(fig_test, fig_ref):
+    data = np.full((5, 5), -1, dtype=np.float64)
+    data[0:2, :] = 1E20
+
+    ax = fig_test.subplots()
+    im = ax.imshow(data, norm=colors.LogNorm(vmin=100, vmax=data.max()),
+                   interpolation='nearest', cmap='viridis')
+
+    data = np.full((5, 5), -1, dtype=np.float64)
+    data[0:2, :] = 1000
+
+    cm = copy(plt.get_cmap('viridis'))
+    cm.set_under('w')
+    ax = fig_ref.subplots()
+    im = ax.imshow(data, norm=colors.Normalize(vmin=100, vmax=data.max()),
+                   interpolation='nearest', cmap=cm)


### PR DESCRIPTION
## PR Summary
closes #18415

We need to special case when rescaling the user input for
interpolation with LogNorm.  The issue is that due to the inherent
precision limits of floating point math we can end up with errors on
the order if 1e-18 of the overall data range when rescaling.  If the
bottom vlim is close to 0 and the top is order 10e20 than this error
can result in the rescaled vmin being negative which then fails when
we (temporarily) change the vmin/vmax on the norm.

We started adjusting the vmin/vmax to work around the same issue with
float precision in #17636 / 3dea5c7 to make sure that values exactly
equal to the limits did not move across the boundary and get
erroneously mapped is over/under.

Long term we may want to add the ability for the norms to suggest to
their clients what the constraints on the vmin/vmax are, but
hard-coding a special case for LogNorm is the pragmatic solution.

There are still some issues with this sort of extreme data range.  With the default interpretation (anti-aliased) when zoomed out we will get stippling that disappears when you zoom in (because the interpolation kernels are not perfect and the constant background at -1 picks up noise on a scale big enough to get above 100 (this is because we shrink and re-scale the data to the [0, 1] range before interpolation and then scale back out to the full range at the end).   It is extra visible on this example because things are flipping between "bad" (defaults to white) and "good but small". 

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
