### PR TITLE
Improve formatting of defaults in docstrings.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -411,10 +411,9 @@ class FileMovieWriter(MovieWriter):
             The figure to grab the rendered frames from.
         outfile : str
             The filename of the resulting movie file.
-        dpi : float, optional
+        dpi : float, default: ``fig.dpi``
             The dpi of the output file. This, with the figure size,
             controls the size in pixels of the resulting movie file.
-            Default is ``fig.dpi``.
         frame_prefix : str, optional
             The filename prefix to use for temporary files.  If None (the
             default), files are written to a temporary directory which is
@@ -1006,7 +1005,7 @@ class Animation:
             encoder.  The default, None, means to use
             :rc:`animation.[name-of-encoder]_args` for the builtin writers.
 
-        metadata : Dict[str, str], default {}
+        metadata : Dict[str, str], default: {}
             Dictionary of keys and values for metadata to include in
             the output file. Some keys that may be of use include:
             title, artist, genre, subject, copyright, srcform, comment.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7393,9 +7393,8 @@ such objects
             spectrum.  'angle' returns the phase spectrum without unwrapping.
             'phase' returns the phase spectrum with unwrapping.
 
-        noverlap : int
-            The number of points of overlap between blocks.  The
-            default value is 128.
+        noverlap : int, default: 128
+            The number of points of overlap between blocks.
 
         scale : {'default', 'linear', 'dB'}
             The scaling of the values in the *spec*.  'linear' is no scaling.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -382,14 +382,14 @@ def to_filehandle(fname, flag='r', return_opened=False, encoding=None):
     fname : str or path-like or file-like
         If `str` or `os.PathLike`, the file is opened using the flags specified
         by *flag* and *encoding*.  If a file-like object, it is passed through.
-    flag : str, default 'r'
+    flag : str, default: 'r'
         Passed as the *mode* argument to `open` when *fname* is `str` or
         `os.PathLike`; ignored if *fname* is file-like.
-    return_opened : bool, default False
+    return_opened : bool, default: False
         If True, return both the file object and a boolean indicating whether
         this was a new file (that the caller needs to close).  If False, return
         only the new file.
-    encoding : str or None, default None
+    encoding : str or None, default: None
         Passed as the *mode* argument to `open` when *fname* is `str` or
         `os.PathLike`; ignored if *fname* is file-like.
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -990,7 +990,7 @@ class PathCollection(_CollectionWithSizes):
             the collection. If "sizes", the legend will show the different
             sizes. To set both, use *kwargs* to directly edit the `.Line2D`
             properties.
-        num : int, None, "auto" (default), array-like, or `~.ticker.Locator`,
+        num : int, None, "auto" (default), array-like, or `~.ticker.Locator`
             Target number of elements to create.
             If None, use all unique elements of the mappable array. If an
             integer, target to use *num* elements in the normed range.
@@ -1004,7 +1004,7 @@ class PathCollection(_CollectionWithSizes):
             The format or formatter to use for the labels. If a string must be
             a valid input for a `~.StrMethodFormatter`. If None (the default),
             use a `~.ScalarFormatter`.
-        func : function, default *lambda x: x*
+        func : function, default: ``lambda x: x``
             Function to calculate the labels.  Often the size (or color)
             argument to `~.Axes.scatter` will have been pre-processed by the
             user using a function ``s = f(x)`` to make the markers visible;

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -499,8 +499,8 @@ def num2date(x, tz=None):
         Number of days (fraction part represents hours, minutes, seconds)
         since the epoch.  See `.get_epoch` for the
         epoch, which can be changed by :rc:`date.epoch` or `.set_epoch`.
-    tz : str, optional
-        Timezone of *x* (defaults to :rc:`timezone`).
+    tz : str, default: :rc:`timezone`
+        Timezone of *x*.
 
     Returns
     -------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -673,10 +673,10 @@ class Figure(Artist):
         t : str
             The title text.
 
-        x : float, default 0.5
+        x : float, default: 0.5
             The x location of the text in figure coordinates.
 
-        y : float, default 0.98
+        y : float, default: 0.98
             The y location of the text in figure coordinates.
 
         horizontalalignment, ha : {'center', 'left', right'}, default: 'center'

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -293,14 +293,10 @@ def stride_windows(x, n, noverlap=None, axis=0):
     ----------
     x : 1D array or sequence
         Array or sequence containing the data.
-
     n : int
         The number of data points in each window.
-
-    noverlap : int
+    noverlap : int, default: 0 (no overlap)
         The overlap between adjacent windows.
-        Default is 0 (no overlap)
-
     axis : int
         The axis along which the windows will run.
 
@@ -629,7 +625,7 @@ NFFT : int, default: 256
     most efficient.  This should *NOT* be used to get zero padding, or the
     scaling of the result will be incorrect; use *pad_to* for this instead.
 
-detrend : {'none', 'mean', 'linear'} or callable, default 'none'
+detrend : {'none', 'mean', 'linear'} or callable, default: 'none'
     The function applied to each segment before fft-ing, designed to remove
     the mean or linear trend.  Unlike in MATLAB, where the *detrend* parameter
     is a vector, in Matplotlib is it a function.  The :mod:`~matplotlib.mlab`
@@ -669,9 +665,8 @@ def psd(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     %(PSD)s
 
-    noverlap : int
+    noverlap : int, default: 0 (no overlap)
         The number of points of overlap between segments.
-        The default value is 0 (no overlap).
 
     Returns
     -------
@@ -729,9 +724,8 @@ def csd(x, y, NFFT=None, Fs=None, detrend=None, window=None,
 
     %(PSD)s
 
-    noverlap : int
+    noverlap : int, default: 0 (no overlap)
         The number of points of overlap between segments.
-        The default value is 0 (no overlap).
 
     Returns
     -------
@@ -845,9 +839,8 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
 
     %(PSD)s
 
-    noverlap : int, optional
-        The number of points of overlap between blocks.  The default
-        value is 128.
+    noverlap : int, default: 128
+        The number of points of overlap between blocks.
     mode : str, default: 'psd'
         What sort of spectrum to use:
             'psd'
@@ -928,9 +921,8 @@ def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
 
     %(PSD)s
 
-    noverlap : int
-        The number of points of overlap between blocks.  The default value
-        is 0 (no overlap).
+    noverlap : int, default: 0 (no overlap)
+        The number of points of overlap between segments.
 
     Returns
     -------

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -394,7 +394,7 @@ class Patch3DCollection(PatchCollection):
         :class:`~matplotlib.collections.PatchCollection`. In addition,
         keywords *zs=0* and *zdir='z'* are available.
 
-        Also, the keyword argument "depthshade" is available to
+        Also, the keyword argument *depthshade* is available to
         indicate whether or not to shade the patches in order to
         give the appearance of depth (default is *True*).
         This is typically desired in scatter plots.
@@ -460,7 +460,7 @@ class Path3DCollection(PathCollection):
         :class:`~matplotlib.collections.PathCollection`. In addition,
         keywords *zs=0* and *zdir='z'* are available.
 
-        Also, the keyword argument "depthshade" is available to
+        Also, the keyword argument *depthshade* is available to
         indicate whether or not to shade the patches in order to
         give the appearance of depth (default is *True*).
         This is typically desired in scatter plots.


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
