### PR TITLE
CI: skip qt, cairo, pygobject related installs on OSX on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -133,19 +133,28 @@ install:
     # install was successful by trying to import the toolkit (sometimes, the
     # install appears to be successful but shared libraries cannot be loaded at
     # runtime, so an actual import is a better check).
-    python -mpip install --upgrade pycairo cairocffi>=0.8
-    python -mpip install --upgrade PyGObject &&
-      python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&
-      echo 'PyGObject is available' ||
-      echo 'PyGObject is not available'
-    python -mpip install --upgrade pyqt5 &&
-      python -c 'import PyQt5.QtCore' &&
-      echo 'PyQt5 is available' ||
-      echo 'PyQt5 is not available'
-    python -mpip install --upgrade pyside2 &&
-      python -c 'import PySide2.QtCore' &&
-      echo 'PySide2 is available' ||
-      echo 'PySide2 is not available'
+
+    # PyGObject, pycairo, and cariocffi do not install on OSX 10.12
+
+    # There are not functioning wheels available for OSX 10.12 (as of
+    # Sept 2020) for either pyqt5 (there are only wheels for 10.13+)
+    # or pyside2 (the latest version (5.13.2) with 10.12 wheels has a
+    # fatal to us bug, it was fixed in 5.14.0 which has 10.13 wheels)
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
+       python -mpip install --upgrade pycairo cairocffi>=0.8
+       python -mpip install --upgrade PyGObject &&
+         python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&
+         echo 'PyGObject is available' ||
+         echo 'PyGObject is not available'
+       python -mpip install --upgrade pyqt5 &&
+         python -c 'import PyQt5.QtCore' &&
+         echo 'PyQt5 is available' ||
+         echo 'PyQt5 is not available'
+       python -mpip install --upgrade pyside2 &&
+         python -c 'import PySide2.QtCore' &&
+         echo 'PySide2 is available' ||
+         echo 'PySide2 is not available'
+    fi
     python -mpip install --upgrade \
       -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 \
       wxPython &&


### PR DESCRIPTION
On 2020-09-12 pyqt5 replaced their wheels to have a minimum OSX version of 10.13 which caused us to fallback to trying to build pyqt5 from the tar.gz.  This in turn failed (because we do not have any of the qt development libraries installed and even if we did it would take a while).  We have always been installing pyside2 from wheels, but an older version (5.13.2) that has a fatal-to-us bug.  However the previously published pyqt5 wheels were, despite being labeled as 10.12 actually complied against 10.13 and failed to import.  This cause our test suite to decide that we did not have a valid qt binding and skip the qt tests.  Now that pyqt5 is (correctly) not installing we are falling back to pyside2 and hitting the bug in pyside2 (it is reported to fixed in the next release 5.14.0 but that only has wheels for 10.13).

This skips trying to install pycairo, pygobjoct, pyqt5, and pyside2 on OSX on travis because they all fail to install on OSX  0.12.  It will make our CI marginally faster and does not move the status quo of what we were actually testing.

We don't see this problem on 3.3.x because we only pin back to xcode9 on master branch via e993baf3bf006fa7ba434ce3524a42f2cb3a571e

We are catching "modern" osx on azure (where we are running a 10.15 and a "latest" in the matrix).