### PR TITLE
ENH: Use axis bounds for widget creation

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -44,6 +44,20 @@ def test_rectangle_selector():
     check_rectangle(rectprops=dict(fill=True))
 
 
+def test_rectangle_selector_limits():
+    fig, ax = plt.subplots(1, 1)
+    xlim, ylim = [-4, -3], [-2, -1]
+    ax.plot(xlim, ylim)
+    ax.set_aspect(1.0)
+    ax.figure.canvas.draw()
+    ax.autoscale_view()
+    assert_allclose(ax.get_xlim(), xlim)
+    assert_allclose(ax.get_ylim(), ylim)
+    _ = widgets.RectangleSelector(ax, lambda a, b: None)
+    assert_allclose(ax.get_xlim(), xlim)
+    assert_allclose(ax.get_ylim(), ylim)
+
+
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1997,13 +1997,18 @@ class RectangleSelector(_SelectorWidget):
             drawtype = 'line'
             self.visible = False
 
+        lim = ax.dataLim
+        if np.isfinite([lim.x0, lim.y0, lim.width, lim.height]).all():
+            xy = lim.x0 + lim.width / 2., lim.y0 + lim.height / 2.
+        else:
+            xy = 0, 0
         if drawtype == 'box':
             if rectprops is None:
                 rectprops = dict(facecolor='red', edgecolor='black',
                                  alpha=0.2, fill=True)
             rectprops['animated'] = self.useblit
             self.rectprops = rectprops
-            self.to_draw = self._shape_klass((0, 0), 0, 1, visible=False,
+            self.to_draw = self._shape_klass(xy, 0, 0, visible=False,
                                              **self.rectprops)
             self.ax.add_patch(self.to_draw)
         if drawtype == 'line':
@@ -2012,7 +2017,7 @@ class RectangleSelector(_SelectorWidget):
                                  linewidth=2, alpha=0.5)
             lineprops['animated'] = self.useblit
             self.lineprops = lineprops
-            self.to_draw = Line2D([0, 0], [0, 0], visible=False,
+            self.to_draw = Line2D(xy, xy, visible=False,
                                   **self.lineprops)
             self.ax.add_line(self.to_draw)
 


### PR DESCRIPTION
## PR Summary

Helps with but does not take care of #18477 -- this tries to choose a position/limits that will not mess with the plot limits, but there is still some weird patch/limit-computation stuff in #18477.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).