### PR TITLE
Clarify color priorities in collections

### DIFF
--- a/doc/users/next_whats_new/collection_color_handling.rst
+++ b/doc/users/next_whats_new/collection_color_handling.rst
@@ -1,0 +1,14 @@
+Collection color specification and mapping
+------------------------------------------
+
+Reworking the handling of color mapping and the keyword arguments for facecolor
+and edgecolor has resulted in three behavior changes:
+
+1.  Color mapping can be turned off by calling ``Collection.set_array(None)``.
+    Previously, this would have no effect.
+2.  When a mappable array is set, with ``facecolor='none'`` and
+    ``edgecolor='face'``, both the faces and the edges are left uncolored.
+    Previously the edges would be color-mapped.
+3.  When a mappable array is set, with ``facecolor='none'`` and
+    ``edgecolor='red'``, the edges are red.  This addresses Issue #1302.
+    Previously the edges would be color-mapped.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6154,7 +6154,7 @@ default: :rc:`scatter.edgecolors`
         if shading is None:
             shading = rcParams['pcolor.shading']
         shading = shading.lower()
-        kwargs.setdefault('edgecolors', 'None')
+        kwargs.setdefault('edgecolors', 'none')
 
         X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
                                             shading=shading, kwargs=kwargs)

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -366,7 +366,7 @@ class ScalarMappable:
 
         Parameters
         ----------
-        A : ndarray
+        A : ndarray or None
         """
         self._A = A
         self._update_dict['array'] = True

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4225,9 +4225,6 @@ default: 'arc3'
             self.get_linewidth() * dpi_cor,
             self.get_mutation_aspect())
 
-        # if not fillable:
-        #    self._fill = False
-
         return _path, fillable
 
     def draw(self, renderer):

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -8,10 +8,12 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
+import matplotlib.colors as mcolors
+import matplotlib.transforms as mtransforms
 from matplotlib.collections import (Collection, LineCollection,
                                     EventCollection, PolyCollection)
-import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 
 
 def generate_EventCollection_plot():
@@ -771,3 +773,98 @@ def test_legend_inverse_size_label_relationship():
     handle_sizes = [5 / x**2 for x in handle_sizes]
 
     assert_array_almost_equal(handle_sizes, legend_sizes, decimal=1)
+
+
+@pytest.mark.style('default')
+@pytest.mark.parametrize('pcfunc', [plt.pcolor, plt.pcolormesh])
+def test_color_logic(pcfunc):
+    z = np.arange(12).reshape(3, 4)
+    # Explicitly set an edgecolor.
+    pc = pcfunc(z, edgecolors='red', facecolors='none')
+    pc.update_scalarmappable()  # This is called in draw().
+    # Define 2 reference "colors" here for multiple use.
+    face_default = mcolors.to_rgba_array(pc._get_default_facecolor())
+    mapped = pc.get_cmap()(pc.norm((z.ravel())))
+    # Github issue #1302:
+    assert mcolors.same_color(pc.get_edgecolor(), 'red')
+    # Check setting attributes after initialization:
+    pc = pcfunc(z)
+    pc.set_facecolor('none')
+    pc.set_edgecolor('red')
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), 'none')
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    pc.set_alpha(0.5)
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 0.5]])
+    pc.set_alpha(None)  # restore default alpha
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Reset edgecolor to default.
+    pc.set_edgecolor(None)
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_edgecolor(), mapped)
+    pc.set_facecolor(None)  # restore default for facecolor
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), mapped)
+    assert mcolors.same_color(pc.get_edgecolor(), 'none')
+    # Turn off colormapping entirely:
+    pc.set_array(None)
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_edgecolor(), 'none')
+    assert mcolors.same_color(pc.get_facecolor(), face_default)  # not mapped
+    # Turn it back on by restoring the array (must be 1D!):
+    pc.set_array(z.ravel())
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), mapped)
+    assert mcolors.same_color(pc.get_edgecolor(), 'none')
+    # Give color via tuple rather than string.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=(0, 1, 0))
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), mapped)
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Provide an RGB array; mapping overrides it.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=np.ones((12, 3)))
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), mapped)
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Turn off the mapping.
+    pc.set_array(None)
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), np.ones((12, 3)))
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # And an RGBA array.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=np.ones((12, 4)))
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), mapped)
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Turn off the mapping.
+    pc.set_array(None)
+    pc.update_scalarmappable()
+    assert mcolors.same_color(pc.get_facecolor(), np.ones((12, 4)))
+    assert mcolors.same_color(pc.get_edgecolor(), [[1, 0, 0, 1]])
+
+
+def test_LineCollection_args():
+    with pytest.warns(MatplotlibDeprecationWarning):
+        lc = LineCollection(None, 2.2, 'r', zorder=3, facecolors=[0, 1, 0, 1])
+        assert lc.get_linewidth()[0] == 2.2
+        assert mcolors.same_color(lc.get_edgecolor(), 'r')
+        assert lc.get_zorder() == 3
+        assert mcolors.same_color(lc.get_facecolor(), [[0, 1, 0, 1]])
+    # To avoid breaking mplot3d, LineCollection internally sets the facecolor
+    # kwarg if it has not been specified.  Hence we need the following test
+    # for LineCollection._set_default().
+    lc = LineCollection(None, facecolor=None)
+    assert mcolors.same_color(lc.get_facecolor(), 'none')
+
+
+def test_array_wrong_dimensions():
+    z = np.arange(12).reshape(3, 4)
+    pc = plt.pcolor(z)
+    with pytest.raises(ValueError, match="^Collections can only map"):
+        pc.set_array(z)
+        pc.update_scalarmappable()
+    pc = plt.pcolormesh(z)
+    pc.set_array(z)  # 2D is OK for Quadmesh
+    pc.update_scalarmappable()

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -640,7 +640,7 @@ def _update_scalarmappable(sm):
     With ScalarMappable objects if the data, colormap, or norm are
     changed, we need to update the computed colors.  This is handled
     by the base class method update_scalarmappable.  This method works
-    by, detecting if work needs to be done, and if so stashing it on
+    by detecting if work needs to be done, and if so stashing it on
     the ``self._facecolors`` attribute.
 
     With 3D collections we internally sort the components so that
@@ -698,9 +698,9 @@ def _update_scalarmappable(sm):
     copy_state = sm._update_dict['array']
     ret = sm.update_scalarmappable()
     if copy_state:
-        if sm._is_filled:
+        if sm._face_is_mapped:
             sm._facecolor3d = sm._facecolors
-        elif sm._is_stroked:
+        elif sm._edge_is_mapped:  # Should this be plain "if"?
             sm._edgecolor3d = sm._edgecolors
 
 


### PR DESCRIPTION
## PR Summary
Color handling in collections is confusing: there are faces and edges, each of which can have a fixed color or a mapped color. Fixed colors (which can be single specifications or arrays matching the elements in the collection) are always available via initialization with defaults.  If the collection has a data array set, then it will be used to map colors for edges and/or faces, depending on how their respective fixed color attributes are set.  The purpose of this PR is to clarify the logic by consolidating it in a private function.  This closes #1302, and is an alternative to #12226.

Edited, 2020-09-25

Working with the collections code is complicated by the aliasing combined with the subclassing.  Here's how it looks to me:

1) The direct effect of the aliasing is to generate additional setters and getters for all of the aliases.  This is done in the Collection base class when the module is imported.  All of these additional getters and setters are inherited by subclasses.
2) The main motivation for the aliasing is to allow singular and plural forms of properties like colors, but abbreviations are also provided.  We want to move, though, towards favoring the *singular* forms, for consistency with things like Patches and Line2D objects.  The directly coded setters and getters are all singular; the aliases are plural or abbreviated.  Related private variables are a mixed bag, some singular (e.g., `_original_facecolor`), others plural (e.g., `_facecolors`).
3) The signature of `Collection.__init__` includes a trailing `**kwargs` after a long list of explicit keyword arguments, all of which are presently still the *plural* form.  When keywords are supplied to the `__init__` of a subclass, which always either inherits or calls `Collection.__init__`, any of those keywords that match the explicit signature are handled first, along with any un-supplied defaults from the signature.  Then, any that remain are handled through the `update` method inherited from `Artist`, which calls the setter, if any, matching the name of the kwarg.  For example, if the supposedly favored 'facecolor` kwarg is supplied, the initialization will first call `set_facecolor` with the default from the signature (named 'facecolors'), and then it will call `set_facecolor` again with the value supplied via the 'facecolor' kwarg.
4) The purpose of subclassing is to customize a base class, which by itself is typically not usable.  The customization can be via adding functionality (new methods), by overriding methods to modify their behavior, or by changing default values. New methods lack aliases unless they are explicitly generated, either directly, or via a decorator on the subclass.  Overridden methods are problematic because the aliases are still there, but they point to the implementations in the base class, not to the the overrides in the subclass.
5) Defaults usually fall into one of two categories: fixed values, like 'black', and values taken from rcParams.  The former are unambiguous; the latter can be implemented so that the values are frozen at import time, or so that they are taken at or near the time of instantiation of an object. The latter is preferred.  In the context of aliased collection properties, though, this means that they need to be retrieved by a method of the subclass, which is called by the setter defined in Collection.
6) The way to minimize confusion and clutter with argument handling in the subclass is to let `**kwargs` handle everything that does not require a subclass-specific fixed default.

I think this PR is now consistent with the above points with respect to LineCollection. 

A possible objection is that by trimming down the signature of `LineCollection.__init__`, we are breaking any code using positional calling for properties that were in the signature.  I think we should move in this direction anyway, making such properties keyword-only.  I have added a compatibility shim with a deprecation warning to handle existing code.

It also appears to me that confusion could be reduced with no backwards incompatibility for *public* attributes if we were to change all the signature forms to singular ('facecolors' -> 'facecolor'), and similarly for the private attributes that are still plural.



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
