### PR TITLE
Backport PR #18458: Fix huge imshow range

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -534,9 +534,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 resampled_masked = np.ma.masked_array(A_resampled, out_mask)
                 # we have re-set the vmin/vmax to account for small errors
                 # that may have moved input values in/out of range
+                s_vmin, s_vmax = vrange
+                if isinstance(self.norm, mcolors.LogNorm):
+                    if s_vmin < 0:
+                        s_vmin = max(s_vmin, np.finfo(scaled_dtype).eps)
                 with cbook._setattr_cm(self.norm,
-                                       vmin=vrange[0],
-                                       vmax=vrange[1],
+                                       vmin=s_vmin,
+                                       vmax=s_vmax,
                                        ):
                     output = self.norm(resampled_masked)
             else:

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1117,3 +1117,22 @@ def test_exact_vmin():
 @pytest.mark.flaky
 def test_https_imread_smoketest():
     v = mimage.imread('https://matplotlib.org/1.5.0/_static/logo2.png')
+
+
+@check_figures_equal(extensions=['png'])
+def test_huge_range_log(fig_test, fig_ref):
+    data = np.full((5, 5), -1, dtype=np.float64)
+    data[0:2, :] = 1E20
+
+    ax = fig_test.subplots()
+    im = ax.imshow(data, norm=colors.LogNorm(vmin=100, vmax=data.max()),
+                   interpolation='nearest', cmap='viridis')
+
+    data = np.full((5, 5), -1, dtype=np.float64)
+    data[0:2, :] = 1000
+
+    cm = copy(plt.get_cmap('viridis'))
+    cm.set_under('w')
+    ax = fig_ref.subplots()
+    im = ax.imshow(data, norm=colors.Normalize(vmin=100, vmax=data.max()),
+                   interpolation='nearest', cmap=cm)


### PR DESCRIPTION
Merge pull request #18458 from tacaswell/fix_huge_imshow_range

Fix huge imshow range

Conflicts:
	lib/matplotlib/colors.py
          - had spurious commit in the initial PR which re-factored
          code not on the 3.3.x branch
	lib/matplotlib/tests/test_image.py
          - conflicts from many tests added to bottom of test_image.py
          on default branch

