### PR TITLE
Fix doc build failure due to #18440

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -687,7 +687,7 @@ are:
    are updated automatically.
 
 The function `matplotlib.artist.kwdoc` and the decorator
-`matplotlib.docstring.dedent_interpd` facilitate this.  They combine Python
+``matplotlib.docstring.dedent_interpd`` facilitate this.  They combine Python
 string interpolation in the docstring with the Matplotlib artist introspection
 facility that underlies ``setp`` and ``getp``.  The ``kwdoc`` function gives
 the list of properties as a docstring. In order to use this in another


### PR DESCRIPTION
#18440 removed the dedent_intepd function and replaced it with a `Substitution` instance. API-wise this is transparent, but we cannot reference `detent_interpd` in Sphinx docs any more. This PR changes the only reference to a literal.
