### PR TITLE
Move cbook._check_in_list() to _api.check_in_list()

### DIFF
--- a/lib/matplotlib/_api.py
+++ b/lib/matplotlib/_api.py
@@ -1,0 +1,33 @@
+
+
+def check_in_list(_values, *, _print_supported_values=True, **kwargs):
+    """
+    For each *key, value* pair in *kwargs*, check that *value* is in *_values*.
+
+    Parameters
+    ----------
+    _values : iterable
+        Sequence of values to check on.
+    _print_supported_values : bool, default: True
+        Whether to print *_values* when raising ValueError.
+    **kwargs : dict
+        *key, value* pairs as keyword arguments to find in *_values*.
+
+    Raises
+    ------
+    ValueError
+        If any *value* in *kwargs* is not found in *_values*.
+
+    Examples
+    --------
+    >>> _api.check_in_list(["foo", "bar"], arg=arg, other_arg=other_arg)
+    """
+    values = _values
+    for key, val in kwargs.items():
+        if val not in values:
+            if _print_supported_values:
+                raise ValueError(
+                    f"{val!r} is not a valid value for {key}; "
+                    f"supported values are {', '.join(map(repr, values))}")
+            else:
+                raise ValueError(f"{val!r} is not a valid value for {key}")

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -35,7 +35,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib._animation_data import (
     DISPLAY_TEMPLATE, INCLUDED_FRAMES, JS_INCLUDE, STYLE_INCLUDE)
-from matplotlib import cbook
+from matplotlib import _api, cbook
 
 
 _log = logging.getLogger(__name__)
@@ -797,8 +797,8 @@ class HTMLWriter(FileMovieWriter):
         extra_args = ()  # Don't lookup nonexistent rcParam[args_key].
         self.embed_frames = embed_frames
         self.default_mode = default_mode.lower()
-        cbook._check_in_list(['loop', 'once', 'reflect'],
-                             default_mode=self.default_mode)
+        _api.check_in_list(['loop', 'once', 'reflect'],
+                           default_mode=self.default_mode)
 
         # Save embed limit, which is given in MB
         if embed_limit is None:
@@ -812,8 +812,7 @@ class HTMLWriter(FileMovieWriter):
 
     def setup(self, fig, outfile, dpi, frame_dir=None):
         outfile = Path(outfile)
-        cbook._check_in_list(['.html', '.htm'],
-                             outfile_extension=outfile.suffix)
+        _api.check_in_list(['.html', '.htm'], outfile_extension=outfile.suffix)
 
         self._saved_frames = []
         self._total_bytes = 0

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -30,7 +30,7 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 import matplotlib.units as munits
-from matplotlib import _preprocess_data, rcParams
+from matplotlib import _api, _preprocess_data, rcParams
 from matplotlib.axes._base import (
     _AxesBase, _TransformedBoundsLocator, _process_plot_format)
 from matplotlib.axes._secondary_axes import SecondaryAxis
@@ -2084,7 +2084,7 @@ class Axes(_AxesBase):
         -----
         .. [notes section required to get data note injection right]
         """
-        cbook._check_in_list(('pre', 'post', 'mid'), where=where)
+        _api.check_in_list(('pre', 'post', 'mid'), where=where)
         kwargs['drawstyle'] = 'steps-' + where
         return self.plot(x, y, *args, data=data, **kwargs)
 
@@ -2269,8 +2269,7 @@ class Axes(_AxesBase):
         # logic and drawing to bar(). It is considered internal and is
         # intentionally not mentioned in the docstring.
         orientation = kwargs.pop('orientation', 'vertical')
-        cbook._check_in_list(['vertical', 'horizontal'],
-                             orientation=orientation)
+        _api.check_in_list(['vertical', 'horizontal'], orientation=orientation)
         log = kwargs.pop('log', False)
         label = kwargs.pop('label', '')
         tick_labels = kwargs.pop('tick_label', None)
@@ -2334,7 +2333,7 @@ class Axes(_AxesBase):
 
         # We will now resolve the alignment and really have
         # left, bottom, width, height vectors
-        cbook._check_in_list(['center', 'edge'], align=align)
+        _api.check_in_list(['center', 'edge'], align=align)
         if align == 'center':
             if orientation == 'vertical':
                 try:
@@ -2680,8 +2679,7 @@ class Axes(_AxesBase):
         if not 1 <= len(args) <= 5:
             raise TypeError('stem expected between 1 and 5 positional '
                             'arguments, got {}'.format(args))
-        cbook._check_in_list(['horizontal', 'vertical'],
-                             orientation=orientation)
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
 
         if len(args) == 1:
             heads, = args
@@ -5467,7 +5465,7 @@ default: :rc:`scatter.edgecolors`
 
         _valid_shading = ['gouraud', 'nearest', 'flat', 'auto']
         try:
-            cbook._check_in_list(_valid_shading, shading=shading)
+            _api.check_in_list(_valid_shading, shading=shading)
         except ValueError as err:
             cbook._warn_external(f"shading value '{shading}' not in list of "
                                  f"valid values {_valid_shading}. Setting "
@@ -6487,11 +6485,10 @@ such objects
             bins = rcParams['hist.bins']
 
         # Validate string inputs here to avoid cluttering subsequent code.
-        cbook._check_in_list(['bar', 'barstacked', 'step', 'stepfilled'],
-                             histtype=histtype)
-        cbook._check_in_list(['left', 'mid', 'right'], align=align)
-        cbook._check_in_list(['horizontal', 'vertical'],
-                             orientation=orientation)
+        _api.check_in_list(['bar', 'barstacked', 'step', 'stepfilled'],
+                           histtype=histtype)
+        _api.check_in_list(['left', 'mid', 'right'], align=align)
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
 
         if histtype == 'barstacked' and not stacked:
             stacked = True
@@ -7574,7 +7571,7 @@ such objects
         """
         if marker is None and markersize is None and hasattr(Z, 'tocoo'):
             marker = 's'
-        cbook._check_in_list(["upper", "lower"], origin=origin)
+        _api.check_in_list(["upper", "lower"], origin=origin)
         if marker is None and markersize is None:
             Z = np.asarray(Z)
             mask = np.abs(Z) > precision

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -11,7 +11,7 @@ import types
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.cbook import _OrderedSet, _check_1d, index_of
 from matplotlib import docstring
 import matplotlib.colors as mcolors
@@ -1443,7 +1443,7 @@ class _AxesBase(martist.Artist):
         which the adjustments for aspect ratios are done sequentially
         and independently on each Axes as it is drawn.
         """
-        cbook._check_in_list(["box", "datalim"], adjustable=adjustable)
+        _api.check_in_list(["box", "datalim"], adjustable=adjustable)
         if share:
             axs = {*self._shared_x_axes.get_siblings(self),
                    *self._shared_y_axes.get_siblings(self)}
@@ -2941,7 +2941,7 @@ class _AxesBase(martist.Artist):
         """
         if len(kwargs):
             b = True
-        cbook._check_in_list(['x', 'y', 'both'], axis=axis)
+        _api.check_in_list(['x', 'y', 'both'], axis=axis)
         if axis in ['x', 'both']:
             self.xaxis.grid(b, which=which, **kwargs)
         if axis in ['y', 'both']:
@@ -3055,7 +3055,7 @@ class _AxesBase(martist.Artist):
             ax.locator_params(tight=True, nbins=4)
 
         """
-        cbook._check_in_list(['x', 'y', 'both'], axis=axis)
+        _api.check_in_list(['x', 'y', 'both'], axis=axis)
         update_x = axis in ['x', 'both']
         update_y = axis in ['y', 'both']
         if update_x:
@@ -3129,7 +3129,7 @@ class _AxesBase(martist.Artist):
         also be red.  Gridlines will be red and translucent.
 
         """
-        cbook._check_in_list(['x', 'y', 'both'], axis=axis)
+        _api.check_in_list(['x', 'y', 'both'], axis=axis)
         if axis in ['x', 'both']:
             xkw = dict(kwargs)
             xkw.pop('left', None)
@@ -3212,7 +3212,7 @@ class _AxesBase(martist.Artist):
         else:
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
-        cbook._check_in_list(('left', 'center', 'right'), loc=loc)
+        _api.check_in_list(('left', 'center', 'right'), loc=loc)
         if loc == 'left':
             kwargs.update(x=0, horizontalalignment='left')
         elif loc == 'right':
@@ -3555,7 +3555,7 @@ class _AxesBase(martist.Artist):
         else:
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
-        cbook._check_in_list(('bottom', 'center', 'top'), loc=loc)
+        _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         if loc == 'bottom':
             kwargs.update(y=0, horizontalalignment='left')
         elif loc == 'top':

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from matplotlib import _api
 import matplotlib.cbook as cbook
 import matplotlib.docstring as docstring
 import matplotlib.ticker as mticker
@@ -69,7 +70,7 @@ class SecondaryAxis(_AxesBase):
             either 'top' or 'bottom' for orientation='x' or
             'left' or 'right' for orientation='y' axis.
         """
-        cbook._check_in_list(self._locstrings, align=align)
+        _api.check_in_list(self._locstrings, align=align)
         if align == self._locstrings[1]:  # Need to change the orientation.
             self._locstrings = self._locstrings[::-1]
         self.spines[self._locstrings[0]].set_visible(True)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -9,6 +9,7 @@ import logging
 import numpy as np
 
 import matplotlib as mpl
+from matplotlib import _api
 import matplotlib.artist as martist
 import matplotlib.cbook as cbook
 import matplotlib.lines as mlines
@@ -206,7 +207,7 @@ class Tick(martist.Artist):
         else:
             mode = 'default'
             angle = labelrotation
-        cbook._check_in_list(['auto', 'default'], labelrotation=mode)
+        _api.check_in_list(['auto', 'default'], labelrotation=mode)
         self._labelrotation = (mode, angle)
 
     def apply_tickdir(self, tickdir):
@@ -456,7 +457,7 @@ class XTick(Tick):
         """Set tick direction. Valid values are 'in', 'out', 'inout'."""
         if tickdir is None:
             tickdir = mpl.rcParams['%s.direction' % self.__name__.lower()]
-        cbook._check_in_list(['in', 'out', 'inout'], tickdir=tickdir)
+        _api.check_in_list(['in', 'out', 'inout'], tickdir=tickdir)
         self._tickdir = tickdir
 
         if self._tickdir == 'in':
@@ -819,7 +820,7 @@ class Axis(martist.Artist):
         For documentation of keyword arguments, see
         :meth:`matplotlib.axes.Axes.tick_params`.
         """
-        cbook._check_in_list(['major', 'minor', 'both'], which=which)
+        _api.check_in_list(['major', 'minor', 'both'], which=which)
         kwtrans = self._translate_tick_kw(kw)
 
         # the kwargs are stored in self._major/minor_tick_kw so that any
@@ -1249,7 +1250,7 @@ class Axis(martist.Artist):
             elif which == 'both':
                 return self.get_majorticklabels() + self.get_minorticklabels()
             else:
-                cbook._check_in_list(['major', 'minor', 'both'], which=which)
+                _api.check_in_list(['major', 'minor', 'both'], which=which)
         if minor:
             return self.get_minorticklabels()
         return self.get_majorticklabels()
@@ -1429,7 +1430,7 @@ class Axis(martist.Artist):
                                      'grid will be enabled.')
             b = True
         which = which.lower()
-        cbook._check_in_list(['major', 'minor', 'both'], which=which)
+        _api.check_in_list(['major', 'minor', 'both'], which=which)
         gridkw = {'grid_' + item[0]: item[1] for item in kwargs.items()}
 
         if which in ['minor', 'both']:
@@ -2174,8 +2175,8 @@ class XAxis(Axis):
             can be used if you don't want any ticks. 'none' and 'both'
             affect only the ticks, not the labels.
         """
-        cbook._check_in_list(['top', 'bottom', 'both', 'default', 'none'],
-                             position=position)
+        _api.check_in_list(['top', 'bottom', 'both', 'default', 'none'],
+                           position=position)
         if position == 'top':
             self.set_tick_params(which='both', top=True, labeltop=True,
                                  bottom=False, labelbottom=False)
@@ -2461,8 +2462,8 @@ class YAxis(Axis):
             can be used if you don't want any ticks. 'none' and 'both'
             affect only the ticks, not the labels.
         """
-        cbook._check_in_list(['left', 'right', 'both', 'default', 'none'],
-                             position=position)
+        _api.check_in_list(['left', 'right', 'both', 'default', 'none'],
+                           position=position)
         if position == 'right':
             self.set_tick_params(which='both', right=True, labelright=True,
                                  left=False, labelleft=False)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -43,7 +43,7 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import (
-    backend_tools as tools, cbook, colors, textpath, tight_bbox,
+    _api, backend_tools as tools, cbook, colors, textpath, tight_bbox,
     transforms, widgets, get_backend, is_interactive, rcParams)
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_managers import ToolManager
@@ -914,7 +914,7 @@ class GraphicsContextBase:
 
     def set_capstyle(self, cs):
         """Set the capstyle to be one of ('butt', 'round', 'projecting')."""
-        cbook._check_in_list(['butt', 'round', 'projecting'], cs=cs)
+        _api.check_in_list(['butt', 'round', 'projecting'], cs=cs)
         self._capstyle = cs
 
     def set_clip_rectangle(self, rectangle):
@@ -982,7 +982,7 @@ class GraphicsContextBase:
 
     def set_joinstyle(self, js):
         """Set the join style to be one of ('miter', 'round', 'bevel')."""
-        cbook._check_in_list(['miter', 'round', 'bevel'], js=js)
+        _api.check_in_list(['miter', 'round', 'bevel'], js=js)
         self._joinstyle = js
 
     def set_linewidth(self, w):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -18,7 +18,7 @@ import time
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook, _path
+from matplotlib import _api, cbook, _path
 from matplotlib import _text_layout
 from matplotlib.afm import AFM
 from matplotlib.backend_bases import (
@@ -815,7 +815,7 @@ class FigureCanvasPS(FigureCanvasBase):
         if papertype is None:
             papertype = mpl.rcParams['ps.papersize']
         papertype = papertype.lower()
-        cbook._check_in_list(['auto', *papersize], papertype=papertype)
+        _api.check_in_list(['auto', *papersize], papertype=papertype)
 
         orientation = cbook._check_getitem(
             _Orientation, orientation=orientation.lower())

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -21,7 +21,7 @@ import numpy as np
 from PIL import Image
 import tornado
 
-from matplotlib import backend_bases, cbook
+from matplotlib import _api, backend_bases
 from matplotlib.backends import backend_agg
 from matplotlib.backend_bases import _Backend
 
@@ -165,7 +165,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         draw this mode may be changed if the resulting image has any
         transparent component.
         """
-        cbook._check_in_list(['full', 'diff'], mode=mode)
+        _api.check_in_list(['full', 'diff'], mode=mode)
         if self._current_image_mode != mode:
             self._current_image_mode = mode
             self.handle_send_image_mode(None)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2281,40 +2281,6 @@ def _check_isinstance(_types, **kwargs):
                     type_name(type(v))))
 
 
-def _check_in_list(_values, *, _print_supported_values=True, **kwargs):
-    """
-    For each *key, value* pair in *kwargs*, check that *value* is in *_values*.
-
-    Parameters
-    ----------
-    _values : iterable
-        Sequence of values to check on.
-    _print_supported_values : bool, default: True
-        Whether to print *_values* when raising ValueError.
-    **kwargs : dict
-        *key, value* pairs as keyword arguments to find in *_values*.
-
-    Raises
-    ------
-    ValueError
-        If any *value* in *kwargs* is not found in *_values*.
-
-    Examples
-    --------
-    >>> cbook._check_in_list(["foo", "bar"], arg=arg, other_arg=other_arg)
-    """
-    values = _values
-    for key, val in kwargs.items():
-        if val not in values:
-            if _print_supported_values:
-                raise ValueError(
-                    f"{val!r} is not a valid value for {key}; "
-                    f"supported values are {', '.join(map(repr, values))}")
-            else:
-                raise ValueError(
-                    f"{val!r} is not a valid value for {key}")
-
-
 def _check_shape(_shape, **kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* has the shape
@@ -2329,7 +2295,7 @@ def _check_shape(_shape, **kwargs):
     --------
     To check for (N, 2) shaped arrays
 
-    >>> cbook._check_in_list((None, 2), arg=arg, other_arg=other_arg)
+    >>> _api.check_in_list((None, 2), arg=arg, other_arg=other_arg)
     """
     target_shape = _shape
     for k, v in kwargs.items():

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -22,8 +22,7 @@ import numpy as np
 from numpy import ma
 
 import matplotlib as mpl
-import matplotlib.colors as colors
-import matplotlib.cbook as cbook
+from matplotlib import _api, colors, cbook
 from matplotlib._cm import datad
 from matplotlib._cm_listed import cmaps as cmaps_listed
 
@@ -201,7 +200,7 @@ def get_cmap(name=None, lut=None):
         name = mpl.rcParams['image.cmap']
     if isinstance(name, colors.Colormap):
         return name
-    cbook._check_in_list(sorted(_cmap_registry), name=name)
+    _api.check_in_list(sorted(_cmap_registry), name=name)
     if lut is None:
         return _cmap_registry[name]
     else:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -14,7 +14,7 @@ from numbers import Number
 import numpy as np
 
 import matplotlib as mpl
-from . import (_path, artist, cbook, cm, colors as mcolors, docstring,
+from . import (_api, _path, artist, cbook, cm, colors as mcolors, docstring,
                hatch as mhatch, lines as mlines, path as mpath, transforms)
 import warnings
 
@@ -570,8 +570,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         ----------
         offset_position : {'screen', 'data'}
         """
-        cbook._check_in_list(['screen', 'data'],
-                             offset_position=offset_position)
+        _api.check_in_list(['screen', 'data'], offset_position=offset_position)
         self._offset_position = offset_position
         self.stale = True
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -38,16 +38,11 @@ import textwrap
 import numpy as np
 
 import matplotlib as mpl
+from matplotlib import _api, cbook, collections, cm, colors, contour, ticker
 import matplotlib.artist as martist
-import matplotlib.cbook as cbook
-import matplotlib.collections as collections
-import matplotlib.colors as colors
-import matplotlib.contour as contour
-import matplotlib.cm as cm
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
 import matplotlib.spines as mspines
-import matplotlib.ticker as ticker
 import matplotlib.transforms as mtransforms
 from matplotlib import docstring
 
@@ -438,12 +433,12 @@ class ColorbarBase:
                  label='',
                  ):
         cbook._check_isinstance([colors.Colormap, None], cmap=cmap)
-        cbook._check_in_list(
+        _api.check_in_list(
             ['vertical', 'horizontal'], orientation=orientation)
-        cbook._check_in_list(
+        _api.check_in_list(
             ['auto', 'left', 'right', 'top', 'bottom'],
             ticklocation=ticklocation)
-        cbook._check_in_list(
+        _api.check_in_list(
             ['uniform', 'proportional'], spacing=spacing)
 
         self.ax = ax
@@ -785,9 +780,9 @@ class ColorbarBase:
             if loc is None:
                 loc = mpl.rcParams['%saxis.labellocation' % _pos_xy]
         if self.orientation == 'vertical':
-            cbook._check_in_list(('bottom', 'center', 'top'), loc=loc)
+            _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         else:
-            cbook._check_in_list(('left', 'center', 'right'), loc=loc)
+            _api.check_in_list(('left', 'center', 'right'), loc=loc)
         if loc in ['right', 'top']:
             kwargs[_pos_xy] = 1.
             kwargs['horizontalalignment'] = 'right'
@@ -1035,7 +1030,7 @@ class ColorbarBase:
         # Set the default value.
         extendlength = np.array([default, default])
         if isinstance(frac, str):
-            cbook._check_in_list(['auto'], extendfrac=frac.lower())
+            _api.check_in_list(['auto'], extendfrac=frac.lower())
             # Use the provided values when 'auto' is required.
             extendlength[:] = [automin, automax]
         elif frac is not None:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -78,7 +78,7 @@ from PIL.PngImagePlugin import PngInfo
 
 import matplotlib as mpl
 import numpy as np
-from matplotlib import cbook, scale
+from matplotlib import _api, cbook, scale
 from ._color_data import BASE_COLORS, TABLEAU_COLORS, CSS4_COLORS, XKCD_COLORS
 
 
@@ -2160,7 +2160,7 @@ def from_levels_and_colors(levels, colors, extend='neither'):
         'max': slice(0, -1),
         'neither': slice(0, None),
     }
-    cbook._check_in_list(slice_map, extend=extend)
+    _api.check_in_list(slice_map, extend=extend)
     color_slice = slice_map[extend]
 
     n_data_colors = len(levels) - 1

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -8,6 +8,7 @@ import numpy as np
 from numpy import ma
 
 import matplotlib as mpl
+from matplotlib import _api
 import matplotlib.path as mpath
 import matplotlib.ticker as ticker
 import matplotlib.cm as cm
@@ -787,7 +788,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         else:
             self.logscale = False
 
-        cbook._check_in_list([None, 'lower', 'upper', 'image'], origin=origin)
+        _api.check_in_list([None, 'lower', 'upper', 'image'], origin=origin)
         if self.extent is not None and len(self.extent) != 4:
             raise ValueError(
                 "If given, 'extent' must be None or (x0, x1, y0, y1)")

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -38,7 +38,7 @@ except ImportError:
     from dummy_threading import Timer
 
 import matplotlib as mpl
-from matplotlib import afm, cbook, ft2font, rcParams
+from matplotlib import _api, afm, cbook, ft2font, rcParams
 from matplotlib.fontconfig_pattern import (
     parse_fontconfig_pattern, generate_fontconfig_pattern)
 from matplotlib.rcsetup import _validators
@@ -851,7 +851,7 @@ class FontProperties:
         """
         if style is None:
             style = rcParams['font.style']
-        cbook._check_in_list(['normal', 'italic', 'oblique'], style=style)
+        _api.check_in_list(['normal', 'italic', 'oblique'], style=style)
         self._slant = style
     set_slant = set_style
 
@@ -861,7 +861,7 @@ class FontProperties:
         """
         if variant is None:
             variant = rcParams['font.variant']
-        cbook._check_in_list(['normal', 'small-caps'], variant=variant)
+        _api.check_in_list(['normal', 'small-caps'], variant=variant)
         self._variant = variant
 
     def set_weight(self, weight):
@@ -981,7 +981,7 @@ class FontProperties:
         valid_fonts = _validators['mathtext.fontset'].valid.values()
         # _check_in_list() Validates the parameter math_fontfamily as
         # if it were passed to rcParams['mathtext.fontset']
-        cbook._check_in_list(valid_fonts, math_fontfamily=fontfamily)
+        _api.check_in_list(valid_fonts, math_fontfamily=fontfamily)
         self._math_fontfamily = fontfamily
 
     def copy(self):

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -16,7 +16,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _pylab_helpers, cbook, tight_layout, rcParams
+from matplotlib import _api, _pylab_helpers, cbook, tight_layout, rcParams
 from matplotlib.transforms import Bbox
 import matplotlib._layoutgrid as layoutgrid
 
@@ -342,8 +342,8 @@ class GridSpecBase:
             cbook._warn_external(
                 "sharex argument to subplots() was an integer.  Did you "
                 "intend to use subplot() (without 's')?")
-        cbook._check_in_list(["all", "row", "col", "none"],
-                             sharex=sharex, sharey=sharey)
+        _api.check_in_list(["all", "row", "col", "none"],
+                           sharex=sharex, sharey=sharey)
         if subplot_kw is None:
             subplot_kw = {}
         # don't mutate kwargs passed by user...

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -13,6 +13,7 @@ import numpy as np
 import PIL.PngImagePlugin
 
 import matplotlib as mpl
+from matplotlib import _api
 import matplotlib.artist as martist
 from matplotlib.backend_bases import FigureCanvasBase
 import matplotlib.colors as mcolors
@@ -243,7 +244,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         cm.ScalarMappable.__init__(self, norm, cmap)
         if origin is None:
             origin = mpl.rcParams['image.origin']
-        cbook._check_in_list(["upper", "lower"], origin=origin)
+        _api.check_in_list(["upper", "lower"], origin=origin)
         self.origin = origin
         self.set_filternorm(filternorm)
         self.set_filterrad(filterrad)
@@ -767,7 +768,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         if s is None:
             s = mpl.rcParams['image.interpolation']
         s = s.lower()
-        cbook._check_in_list(_interpd_, interpolation=s)
+        _api.check_in_list(_interpd_, interpolation=s)
         self._interpolation = s
         self.stale = True
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -28,7 +28,7 @@ import time
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook, docstring, colors
+from matplotlib import _api, cbook, docstring, colors
 from matplotlib.artist import Artist, allow_rasterization
 from matplotlib.cbook import silent_list
 from matplotlib.font_manager import FontProperties
@@ -65,7 +65,7 @@ class DraggableLegend(DraggableOffsetBox):
         """
         self.legend = legend
 
-        cbook._check_in_list(["loc", "bbox"], update=update)
+        _api.check_in_list(["loc", "bbox"], update=update)
         self._update = update
 
         super().__init__(legend, legend._legend_box, use_blit=use_blit)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -10,7 +10,7 @@ import logging
 import numpy as np
 
 import matplotlib as mpl
-from . import artist, cbook, colors as mcolors, docstring, rcParams
+from . import _api, artist, cbook, colors as mcolors, docstring, rcParams
 from .artist import Artist, allow_rasterization
 from .cbook import (
     _to_unmasked_float_array, ls_mapper, ls_mapper_r, STEP_LOOKUP_MAP)
@@ -1041,8 +1041,8 @@ class Line2D(Artist):
         color : color
         """
         if not is_color_like(color) and color != 'auto':
-            cbook._check_in_list(get_named_colors_mapping(),
-                                 _print_supported_values=False, color=color)
+            _api.check_in_list(get_named_colors_mapping(),
+                               _print_supported_values=False, color=color)
         self._color = color
         self.stale = True
 
@@ -1074,7 +1074,7 @@ class Line2D(Artist):
         """
         if drawstyle is None:
             drawstyle = 'default'
-        cbook._check_in_list(self.drawStyles, drawstyle=drawstyle)
+        _api.check_in_list(self.drawStyles, drawstyle=drawstyle)
         if self._drawstyle != drawstyle:
             self.stale = True
             # invalidate to trigger a recache of the path
@@ -1134,7 +1134,7 @@ class Line2D(Artist):
             if ls in [' ', '', 'none']:
                 ls = 'None'
 
-            cbook._check_in_list([*self._lineStyles, *ls_mapper_r], ls=ls)
+            _api.check_in_list([*self._lineStyles, *ls_mapper_r], ls=ls)
             if ls not in self._lineStyles:
                 ls = ls_mapper_r[ls]
             self._linestyle = ls

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -130,7 +130,7 @@ from collections.abc import Sized
 
 import numpy as np
 
-from . import cbook, rcParams
+from . import _api, cbook, rcParams
 from .path import Path
 from .transforms import IdentityTransform, Affine2D
 
@@ -264,7 +264,7 @@ class MarkerStyle:
         """
         if fillstyle is None:
             fillstyle = rcParams['markers.fillstyle']
-        cbook._check_in_list(self.fillstyles, fillstyle=fillstyle)
+        _api.check_in_list(self.fillstyles, fillstyle=fillstyle)
         self._fillstyle = fillstyle
         self._recache()
 

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -58,6 +58,7 @@ from numbers import Number
 
 import numpy as np
 
+from matplotlib import _api
 import matplotlib.cbook as cbook
 from matplotlib import docstring
 
@@ -429,7 +430,7 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
 
     if mode is None or mode == 'default':
         mode = 'psd'
-    cbook._check_in_list(
+    _api.check_in_list(
         ['default', 'psd', 'complex', 'magnitude', 'angle', 'phase'],
         mode=mode)
 
@@ -447,7 +448,7 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
             sides = 'twosided'
         else:
             sides = 'onesided'
-    cbook._check_in_list(['default', 'onesided', 'twosided'], sides=sides)
+    _api.check_in_list(['default', 'onesided', 'twosided'], sides=sides)
 
     # zero pad x and y up to NFFT if they are shorter than NFFT
     if len(x) < NFFT:
@@ -562,7 +563,7 @@ def _single_spectrum_helper(
     Private helper implementing the commonality between the complex, magnitude,
     angle, and phase spectrums.
     """
-    cbook._check_in_list(['complex', 'magnitude', 'angle', 'phase'], mode=mode)
+    _api.check_in_list(['complex', 'magnitude', 'angle', 'phase'], mode=mode)
 
     if pad_to is None:
         pad_to = len(x)

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -24,7 +24,7 @@ Container classes for `.Artist`\s.
 
 import numpy as np
 
-from matplotlib import cbook, docstring, rcParams
+from matplotlib import _api, cbook, docstring, rcParams
 import matplotlib.artist as martist
 import matplotlib.path as mpath
 import matplotlib.text as mtext
@@ -99,7 +99,7 @@ def _get_packed_offsets(wd_list, total, sep, mode="fixed"):
         The left offsets of the boxes.
     """
     w_list, d_list = zip(*wd_list)  # d_list is currently not used.
-    cbook._check_in_list(["fixed", "expand", "equal"], mode=mode)
+    _api.check_in_list(["fixed", "expand", "equal"], mode=mode)
 
     if mode == "fixed":
         offsets_ = np.cumsum([0] + [w + sep for w in w_list])
@@ -155,7 +155,7 @@ def _get_aligned_offsets(hd_list, height, align="baseline"):
 
     if height is None:
         height = max(h for h, d in hd_list)
-    cbook._check_in_list(
+    _api.check_in_list(
         ["baseline", "left", "top", "right", "bottom", "center"], align=align)
 
     if align == "baseline":

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from matplotlib import cbook, rcParams
+from matplotlib import _api, rcParams
 from matplotlib.axes import Axes
 import matplotlib.axis as maxis
 from matplotlib.patches import Circle
@@ -115,7 +115,7 @@ class GeoAxes(Axes):
             .translate(0.5, 0.5)
 
     def get_xaxis_transform(self, which='grid'):
-        cbook._check_in_list(['tick1', 'tick2', 'grid'], which=which)
+        _api.check_in_list(['tick1', 'tick2', 'grid'], which=which)
         return self._xaxis_transform
 
     def get_xaxis_text1_transform(self, pad):
@@ -125,7 +125,7 @@ class GeoAxes(Axes):
         return self._xaxis_text2_transform, 'top', 'center'
 
     def get_yaxis_transform(self, which='grid'):
-        cbook._check_in_list(['tick1', 'tick2', 'grid'], which=which)
+        _api.check_in_list(['tick1', 'tick2', 'grid'], which=which)
         return self._yaxis_transform
 
     def get_yaxis_text1_transform(self, pad):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -3,7 +3,7 @@ import types
 
 import numpy as np
 
-from matplotlib import cbook, rcParams
+from matplotlib import _api, cbook, rcParams
 from matplotlib.axes import Axes
 import matplotlib.axis as maxis
 import matplotlib.markers as mmarkers
@@ -907,7 +907,7 @@ class PolarAxes(Axes):
             self._r_label_position + self.transData)
 
     def get_xaxis_transform(self, which='grid'):
-        cbook._check_in_list(['tick1', 'tick2', 'grid'], which=which)
+        _api.check_in_list(['tick1', 'tick2', 'grid'], which=which)
         return self._xaxis_transform
 
     def get_xaxis_text1_transform(self, pad):
@@ -922,7 +922,7 @@ class PolarAxes(Axes):
         elif which == 'grid':
             return self._yaxis_transform
         else:
-            cbook._check_in_list(['tick1', 'tick2', 'grid'], which=which)
+            _api.check_in_list(['tick1', 'tick2', 'grid'], which=which)
 
     def get_yaxis_text1_transform(self, pad):
         thetamin, thetamax = self._realViewLim.intervalx
@@ -1121,7 +1121,7 @@ class PolarAxes(Axes):
         elif direction in ('counterclockwise', 'anticlockwise', 1):
             mtx[0, 0] = 1
         else:
-            cbook._check_in_list(
+            _api.check_in_list(
                 [-1, 1, 'clockwise', 'counterclockwise', 'anticlockwise'],
                 direction=direction)
         self._direction.invalidate()

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -20,7 +20,7 @@ import weakref
 import numpy as np
 from numpy import ma
 
-from matplotlib import cbook, docstring, font_manager
+from matplotlib import _api, cbook, docstring, font_manager
 import matplotlib.artist as martist
 import matplotlib.collections as mcollections
 from matplotlib.patches import CirclePolygon
@@ -490,7 +490,7 @@ class Quiver(mcollections.PolyCollection):
         if pivot.lower() == 'mid':
             pivot = 'middle'
         self.pivot = pivot.lower()
-        cbook._check_in_list(self._PIVOT_VALS, pivot=self.pivot)
+        _api.check_in_list(self._PIVOT_VALS, pivot=self.pivot)
 
         self.transform = kw.pop('transform', ax.transData)
         kw.setdefault('facecolors', color)
@@ -744,7 +744,7 @@ class Quiver(mcollections.PolyCollection):
             # float first, as with 'mid'.
             X = X - X[:, 3, np.newaxis]
         elif self.pivot != 'tail':
-            cbook._check_in_list(["middle", "tip", "tail"], pivot=self.pivot)
+            _api.check_in_list(["middle", "tip", "tail"], pivot=self.pivot)
 
         tooshort = length < self.minlength
         if tooshort.any():

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -22,7 +22,7 @@ import re
 
 import numpy as np
 
-from matplotlib import animation, cbook
+from matplotlib import _api, animation, cbook
 from matplotlib.cbook import ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib.colors import is_color_like
@@ -590,13 +590,13 @@ def _deprecate_case_insensitive_join_cap(s):
 
 def validate_joinstyle(s):
     s = _deprecate_case_insensitive_join_cap(s)
-    cbook._check_in_list(['miter', 'round', 'bevel'], joinstyle=s)
+    _api.check_in_list(['miter', 'round', 'bevel'], joinstyle=s)
     return s
 
 
 def validate_capstyle(s):
     s = _deprecate_case_insensitive_join_cap(s)
-    cbook._check_in_list(['butt', 'round', 'projecting'], capstyle=s)
+    _api.check_in_list(['butt', 'round', 'projecting'], capstyle=s)
     return s
 
 

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -14,7 +14,7 @@ import numpy as np
 from numpy import ma
 
 import matplotlib as mpl
-from matplotlib import cbook, docstring
+from matplotlib import _api, cbook, docstring
 from matplotlib.ticker import (
     NullFormatter, ScalarFormatter, LogFormatterSciNotation, LogitFormatter,
     NullLocator, LogLocator, AutoLocator, AutoMinorLocator,
@@ -500,7 +500,7 @@ class LogitTransform(Transform):
     @cbook._rename_parameter("3.3", "nonpos", "nonpositive")
     def __init__(self, nonpositive='mask'):
         super().__init__()
-        cbook._check_in_list(['mask', 'clip'], nonpositive=nonpositive)
+        _api.check_in_list(['mask', 'clip'], nonpositive=nonpositive)
         self._nonpositive = nonpositive
         self._clip = {"clip": True, "mask": False}[nonpositive]
 
@@ -628,7 +628,7 @@ def scale_factory(scale, axis, **kwargs):
     axis : `matplotlib.axis.Axis`
     """
     scale = scale.lower()
-    cbook._check_in_list(_scale_mapping, scale=scale)
+    _api.check_in_list(_scale_mapping, scale=scale)
     return _scale_mapping[scale](axis, **kwargs)
 
 

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import matplotlib
-from matplotlib import cbook, docstring, rcParams
+from matplotlib import _api, cbook, docstring, rcParams
 from matplotlib.artist import allow_rasterization
 import matplotlib.transforms as mtransforms
 import matplotlib.patches as mpatches
@@ -400,8 +400,8 @@ class Spine(mpatches.Patch):
                 position = ('data', 0)
         assert len(position) == 2, 'position should be 2-tuple'
         position_type, amount = position
-        cbook._check_in_list(['axes', 'outward', 'data'],
-                             position_type=position_type)
+        _api.check_in_list(['axes', 'outward', 'data'],
+                           position_type=position_type)
         if self.spine_type in ['left', 'right']:
             base_transform = self.axes.get_yaxis_transform(which='grid')
         elif self.spine_type in ['top', 'bottom']:

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -8,7 +8,7 @@ http://stackoverflow.com/questions/2225995/how-can-i-create-stacked-line-graph-w
 """
 import numpy as np
 
-import matplotlib.cbook as cbook
+from matplotlib import _api
 
 __all__ = ['stackplot']
 
@@ -69,8 +69,8 @@ def stackplot(axes, x, *args,
     # We'll need a float buffer for the upcoming calculations.
     stack = np.cumsum(y, axis=0, dtype=np.promote_types(y.dtype, np.float32))
 
-    cbook._check_in_list(['zero', 'sym', 'wiggle', 'weighted_wiggle'],
-                         baseline=baseline)
+    _api.check_in_list(['zero', 'sym', 'wiggle', 'weighted_wiggle'],
+                       baseline=baseline)
     if baseline == 'zero':
         first_line = 0.
 

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -6,8 +6,7 @@ Streamline plotting for 2D vector fields.
 import numpy as np
 
 import matplotlib
-import matplotlib.cbook as cbook
-import matplotlib.cm as cm
+from matplotlib import _api, cbook, cm
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
@@ -103,8 +102,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     line_kw = {}
     arrow_kw = dict(arrowstyle=arrowstyle, mutation_scale=10 * arrowsize)
 
-    cbook._check_in_list(['both', 'forward', 'backward'],
-                         integration_direction=integration_direction)
+    _api.check_in_list(['both', 'forward', 'backward'],
+                       integration_direction=integration_direction)
 
     if integration_direction == 'both':
         maxlength /= 2.

--- a/lib/matplotlib/testing/jpl_units/Duration.py
+++ b/lib/matplotlib/testing/jpl_units/Duration.py
@@ -2,7 +2,7 @@
 
 import operator
 
-from matplotlib import cbook
+from matplotlib import _api
 
 
 class Duration:
@@ -21,7 +21,7 @@ class Duration:
         - frame     The frame of the duration.  Must be 'ET' or 'UTC'
         - seconds  The number of seconds in the Duration.
         """
-        cbook._check_in_list(self.allowed, frame=frame)
+        _api.check_in_list(self.allowed, frame=frame)
         self._frame = frame
         self._seconds = seconds
 

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -4,7 +4,7 @@ import operator
 import math
 import datetime as DT
 
-from matplotlib import cbook
+from matplotlib import _api
 from matplotlib.dates import date2num
 
 
@@ -59,7 +59,7 @@ class Epoch:
                 "dnum= %s\n"
                 "dt  = %s" % (sec, jd, daynum, dt))
 
-        cbook._check_in_list(self.allowed, frame=frame)
+        _api.check_in_list(self.allowed, frame=frame)
         self._frame = frame
 
         if dt is not None:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -9,7 +9,7 @@ import weakref
 
 import numpy as np
 
-from . import artist, cbook, docstring, rcParams
+from . import _api, artist, cbook, docstring, rcParams
 from .artist import Artist
 from .font_manager import FontProperties
 from .patches import FancyArrowPatch, FancyBboxPatch, Rectangle
@@ -256,7 +256,7 @@ class Text(Artist):
             aligned according to their horizontal and vertical alignments.  If
             ``"anchor"``, then alignment occurs before rotation.
         """
-        cbook._check_in_list(["anchor", "default", None], rotation_mode=m)
+        _api.check_in_list(["anchor", "default", None], rotation_mode=m)
         self._rotation_mode = m
         self.stale = True
 
@@ -956,7 +956,7 @@ class Text(Artist):
         ----------
         align : {'center', 'right', 'left'}
         """
-        cbook._check_in_list(['center', 'right', 'left'], align=align)
+        _api.check_in_list(['center', 'right', 'left'], align=align)
         self._horizontalalignment = align
         self.stale = True
 
@@ -972,7 +972,7 @@ class Text(Artist):
         ----------
         align : {'left', 'right', 'center'}
         """
-        cbook._check_in_list(['center', 'right', 'left'], align=align)
+        _api.check_in_list(['center', 'right', 'left'], align=align)
         self._multialignment = align
         self.stale = True
 
@@ -1194,7 +1194,7 @@ class Text(Artist):
         ----------
         align : {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
         """
-        cbook._check_in_list(
+        _api.check_in_list(
             ['top', 'bottom', 'center', 'baseline', 'center_baseline'],
             align=align)
         self._verticalalignment = align
@@ -1327,7 +1327,7 @@ class OffsetFrom:
         ----------
         unit : {'points', 'pixels'}
         """
-        cbook._check_in_list(["points", "pixels"], unit=unit)
+        _api.check_in_list(["points", "pixels"], unit=unit)
         self._unit = unit
 
     def get_unit(self):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -162,7 +162,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib import transforms as mtransforms
 
 _log = logging.getLogger(__name__)
@@ -2193,7 +2193,7 @@ class MaxNLocator(Locator):
             self._symmetric = kwargs.pop('symmetric')
         if 'prune' in kwargs:
             prune = kwargs.pop('prune')
-            cbook._check_in_list(['upper', 'lower', 'both', None], prune=prune)
+            _api.check_in_list(['upper', 'lower', 'both', None], prune=prune)
             self._prune = prune
         if 'min_n_ticks' in kwargs:
             self._min_n_ticks = max(1, kwargs.pop('min_n_ticks'))
@@ -2428,7 +2428,7 @@ class LogLocator(Locator):
         if subs is None:  # consistency with previous bad API
             self._subs = 'auto'
         elif isinstance(subs, str):
-            cbook._check_in_list(('all', 'auto'), subs=subs)
+            _api.check_in_list(('all', 'auto'), subs=subs)
             self._subs = subs
         else:
             try:

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -41,7 +41,7 @@ import math
 import numpy as np
 from numpy.linalg import inv
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib._path import (
     affine_transform, count_bboxes_overlapping_bbox, update_path_extents)
 from .path import Path
@@ -2920,5 +2920,5 @@ def offset_copy(trans, fig=None, x=0.0, y=0.0, units='inches'):
     elif units == 'inches':
         pass
     else:
-        cbook._check_in_list(['dots', 'points', 'inches'], units=units)
+        _api.check_in_list(['dots', 'points', 'inches'], units=units)
     return trans + ScaledTranslation(x, y, fig.dpi_scale_trans)

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -4,7 +4,7 @@ Interpolation inside triangular grids.
 
 import numpy as np
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.tri import Triangulation
 from matplotlib.tri.trifinder import TriFinder
 from matplotlib.tri.tritools import TriAnalyzer
@@ -475,7 +475,7 @@ class CubicTriInterpolator(TriInterpolator):
         elif kind == 'min_E':
             TE = _DOF_estimator_min_E(self)
         else:
-            cbook._check_in_list(['user', 'geom', 'min_E'], kind=kind)
+            _api.check_in_list(['user', 'geom', 'min_E'], kind=kind)
         return TE.compute_dof_from_df()
 
     @staticmethod

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.collections import PolyCollection, TriMesh
 from matplotlib.colors import Normalize
 from matplotlib.tri.triangulation import Triangulation
@@ -44,7 +44,7 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
 
     The remaining kwargs are the same as for `~.Axes.pcolor`.
     """
-    cbook._check_in_list(['flat', 'gouraud'], shading=shading)
+    _api.check_in_list(['flat', 'gouraud'], shading=shading)
 
     tri, args, kwargs = Triangulation.get_from_args_and_kwargs(*args, **kwargs)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -16,7 +16,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from . import cbook, colors, ticker
+from . import _api, cbook, colors, ticker
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
 from .transforms import blended_transform_factory
@@ -319,8 +319,7 @@ class Slider(AxesWidget):
         if slidermax is not None and not hasattr(slidermax, 'val'):
             raise ValueError(
                 f"Argument slidermax ({type(slidermax)}) has no 'val'")
-        cbook._check_in_list(['horizontal', 'vertical'],
-                             orientation=orientation)
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
 
         self.orientation = orientation
         self.closedmin = closedmin
@@ -1688,7 +1687,7 @@ class SpanSelector(_SelectorWidget):
 
         rectprops['animated'] = self.useblit
 
-        cbook._check_in_list(['horizontal', 'vertical'], direction=direction)
+        _api.check_in_list(['horizontal', 'vertical'], direction=direction)
         self.direction = direction
 
         self.rect = None
@@ -2019,7 +2018,7 @@ class RectangleSelector(_SelectorWidget):
         self.minspanx = minspanx
         self.minspany = minspany
 
-        cbook._check_in_list(['data', 'pixels'], spancoords=spancoords)
+        _api.check_in_list(['data', 'pixels'], spancoords=spancoords)
         self.spancoords = spancoords
         self.drawtype = drawtype
 
@@ -2103,8 +2102,8 @@ class RectangleSelector(_SelectorWidget):
             spanx = abs(self.eventpress.x - self.eventrelease.x)
             spany = abs(self.eventpress.y - self.eventrelease.y)
         else:
-            cbook._check_in_list(['data', 'pixels'],
-                                 spancoords=self.spancoords)
+            _api.check_in_list(['data', 'pixels'],
+                               spancoords=self.spancoords)
         # check if drawn distance (if it exists) is not too small in
         # either x or y-direction
         if (self.drawtype != 'none'

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -4,7 +4,7 @@ Helper classes to adjust the positions of multiple axes at drawing time.
 
 import numpy as np
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.axes import SubplotBase
 from matplotlib.gridspec import SubplotSpec, GridSpec
 import matplotlib.transforms as mtransforms
@@ -123,7 +123,7 @@ class Divider:
 
         """
         if len(anchor) != 2:
-            cbook._check_in_list(mtransforms.Bbox.coefs, anchor=anchor)
+            _api.check_in_list(mtransforms.Bbox.coefs, anchor=anchor)
         self._anchor = anchor
 
     def get_anchor(self):
@@ -258,8 +258,8 @@ class Divider:
         elif position == "top":
             self._vertical.append(size)
         else:
-            cbook._check_in_list(["left", "right", "bottom", "top"],
-                                 position=position)
+            _api.check_in_list(["left", "right", "bottom", "top"],
+                               position=position)
 
     def add_auto_adjustable_area(self, use_axes, pad=0.1, adjust_dirs=None):
         if adjust_dirs is None:
@@ -538,8 +538,8 @@ class AxesDivider(Divider):
         elif position == "top":
             ax = self.new_vertical(size, pad, pack_start=False, **kwargs)
         else:
-            cbook._check_in_list(["left", "right", "bottom", "top"],
-                                 position=position)
+            _api.check_in_list(["left", "right", "bottom", "top"],
+                               position=position)
         if add_to_figure:
             self._fig.add_axes(ax)
         return ax

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -4,8 +4,7 @@ import functools
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook
-import matplotlib.ticker as ticker
+from matplotlib import _api, cbook, ticker
 from matplotlib.gridspec import SubplotSpec
 
 from .axes_divider import Size, SubplotDivider, Divider
@@ -169,7 +168,7 @@ class Grid:
         self._horiz_pad_size, self._vert_pad_size = map(
             Size.Fixed, np.broadcast_to(axes_pad, 2))
 
-        cbook._check_in_list(["column", "row"], direction=direction)
+        _api.check_in_list(["column", "row"], direction=direction)
         self._direction = direction
 
         if axes_class is None:

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -11,7 +11,7 @@ values are used.
 
 from numbers import Number
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.axes import Axes
 
 
@@ -148,7 +148,7 @@ class MaxExtent(_Base):
 
     def __init__(self, artist_list, w_or_h):
         self._artist_list = artist_list
-        cbook._check_in_list(["width", "height"], w_or_h=w_or_h)
+        _api.check_in_list(["width", "height"], w_or_h=w_or_h)
         self._w_or_h = w_or_h
 
     def add_artist(self, a):
@@ -260,7 +260,7 @@ class GetExtentHelper:
     }
 
     def __init__(self, ax, direction):
-        cbook._check_in_list(self._get_func_map, direction=direction)
+        _api.check_in_list(self._get_func_map, direction=direction)
         self._ax_list = [ax] if isinstance(ax, Axes) else ax
         self._direction = direction
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -1,6 +1,8 @@
 import functools
 
-from matplotlib import artist as martist, cbook, transforms as mtransforms
+from matplotlib import _api, cbook
+import matplotlib.artist as martist
+import matplotlib.transforms as mtransforms
 from matplotlib.axes import subplot_class_factory
 from matplotlib.transforms import Bbox
 from .mpl_axes import Axes
@@ -87,7 +89,7 @@ class ParasiteAxesAuxTransBase:
                 self.transAxes, self.transData)
 
     def set_viewlim_mode(self, mode):
-        cbook._check_in_list([None, "equal", "transform"], mode=mode)
+        _api.check_in_list([None, "equal", "transform"], mode=mode)
         self._viewlim_mode = mode
 
     def get_viewlim_mode(self):
@@ -104,7 +106,7 @@ class ParasiteAxesAuxTransBase:
             self.axes.viewLim.set(
                 viewlim.transformed(self.transAux.inverted()))
         else:
-            cbook._check_in_list([None, "equal", "transform"], mode=mode)
+            _api.check_in_list([None, "equal", "transform"], mode=mode)
 
     def _pcolor(self, super_pcolor, *XYC, **kwargs):
         if len(XYC) == 1:

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -41,7 +41,7 @@ from the axis as some gridlines can never pass any axis.
 
 import numpy as np
 
-from matplotlib import cbook, rcParams
+from matplotlib import _api, cbook, rcParams
 import matplotlib.axes as maxes
 from matplotlib.path import Path
 from mpl_toolkits.axes_grid1 import mpl_axes
@@ -117,7 +117,7 @@ class AxisArtistHelper:
             nth_coord = along which coordinate value varies
             in 2d, nth_coord = 0 ->  x axis, nth_coord = 1 -> y axis
             """
-            cbook._check_in_list(["left", "right", "bottom", "top"], loc=loc)
+            _api.check_in_list(["left", "right", "bottom", "top"], loc=loc)
             self._loc = loc
 
             if nth_coord is None:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -19,6 +19,7 @@ import textwrap
 import numpy as np
 
 from matplotlib import artist
+from matplotlib import _api
 import matplotlib.axes as maxes
 import matplotlib.cbook as cbook
 import matplotlib.collections as mcoll
@@ -1358,7 +1359,7 @@ class Axes3D(Axes):
 
         .. versionadded:: 1.1.0
         """
-        cbook._check_in_list(['x', 'y', 'z', 'both'], axis=axis)
+        _api.check_in_list(['x', 'y', 'z', 'both'], axis=axis)
         if axis in ['x', 'y', 'both']:
             super().tick_params(axis, **kwargs)
         if axis in ['z', 'both']:
@@ -2650,7 +2651,7 @@ pivot='tail', normalize=False, **kwargs)
         shaft_dt = np.array([0., length], dtype=float)
         arrow_dt = shaft_dt * arrow_length_ratio
 
-        cbook._check_in_list(['tail', 'middle', 'tip'], pivot=pivot)
+        _api.check_in_list(['tail', 'middle', 'tip'], pivot=pivot)
         if pivot == 'tail':
             shaft_dt -= length
         elif pivot == 'middle':


### PR DESCRIPTION
## PR Summary

Start addresses the following section of #16181:

> Move all the internal `cbook` functions to (a/multiple) private module(s).
>   ```
>   from matplotlib import _api
> 
>   @_api.deprecated("3.2")
 >  def compare_versions(a, b):
 >  ```
 > reads better than the current
>   ```
>   from matplotlib import cbook
> 
>   @cbook._deprecated("3.2")
>   def compare_versions(a, b):
>   ```
>   and it does not pollute the namespace with the public package name.

This PR does:
- Move cbook._check_in_list() to _api.check_in_list()
