### PR TITLE
BUG: Fix all-masked imshow

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -470,8 +470,10 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # do not run the vmin/vmax through the same pipeline we can
                 # have values close or equal to the boundaries end up on the
                 # wrong side.
-                vrange = np.array([self.norm.vmin, self.norm.vmax],
-                                  dtype=scaled_dtype)
+                vmin, vmax = self.norm.vmin, self.norm.vmax
+                if vmin is np.ma.masked:
+                    vmin, vmax = a_min, a_max
+                vrange = np.array([vmin, vmax], dtype=scaled_dtype)
 
                 A_scaled -= a_min
                 vrange -= a_min

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -853,6 +853,14 @@ def test_mask_image():
     ax2.imshow(A, interpolation='nearest')
 
 
+def test_mask_image_all():
+    # Test behavior with an image that is entirely masked does not warn
+    data = np.full((2, 2), np.nan)
+    fig, ax = plt.subplots()
+    ax.imshow(data)
+    fig.canvas.draw_idle()  # would emit a warning
+
+
 @image_comparison(['imshow_endianess.png'], remove_text=True)
 def test_imshow_endianess():
     x = np.arange(10)


### PR DESCRIPTION
## PR Summary

Deal with `imshow`ing an array that is completely masked without emitting a warning. The added test/code emits 3 warnings on `master`, none of which are particularly informative. The test on `master` fails with:

<details>

```
lib/matplotlib/image.py:639: in draw
    im, l, b, trans = self.make_image(
lib/matplotlib/image.py:924: in make_image
    return self._make_image(self._A, bbox, transformed_bbox, clip,
lib/matplotlib/image.py:476: in _make_image
    vrange = np.array([vmin, vmax], dtype=scaled_dtype)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = masked

    def __float__(self):
        """
        Convert to float.
    
        """
        if self.size > 1:
            raise TypeError("Only length-1 arrays can be converted "
                            "to Python scalars")
        elif self._mask:
>           warnings.warn("Warning: converting a masked element to nan.", stacklevel=2)
E           UserWarning: Warning: converting a masked element to nan.
```

</details>

And on latest `NumPy` it also emits a warning later having to do with `np.clip` not liking `np.nan` values.

Alternatively, `imshow` with all data masked could emit a warning, but it seems like the existing code had a chance to do that but didn't (there is an existing `if a_min is np.ma.masked` on line 409) so I didn't implement it here.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
