### PR TITLE
TST: Add test for _repr_html_

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -13,6 +13,33 @@ from matplotlib import pyplot as plt
 from matplotlib import animation
 
 
+@pytest.fixture()
+def anim(request):
+    """Create a simple animation (with options)."""
+    fig, ax = plt.subplots()
+    line, = ax.plot([], [])
+
+    ax.set_xlim(0, 10)
+    ax.set_ylim(-1, 1)
+
+    def init():
+        line.set_data([], [])
+        return line,
+
+    def animate(i):
+        x = np.linspace(0, 10, 100)
+        y = np.sin(x + i)
+        line.set_data(x, y)
+        return line,
+
+    # "klass" can be passed to determine the class returned by the fixture
+    kwargs = dict(getattr(request, 'param', {}))  # make a copy
+    klass = kwargs.pop('klass', animation.FuncAnimation)
+    if 'frames' not in kwargs:
+        kwargs['frames'] = 5
+    return klass(fig=fig, func=animate, init_func=init, **kwargs)
+
+
 class NullMovieWriter(animation.AbstractMovieWriter):
     """
     A minimal MovieWriter.  It doesn't actually write anything.
@@ -116,32 +143,6 @@ WRITER_OUTPUT = [
 ]
 WRITER_OUTPUT += [
     (writer, Path(output)) for writer, output in WRITER_OUTPUT]
-
-
-@pytest.fixture()
-def anim(request):
-    fig, ax = plt.subplots()
-    line, = ax.plot([], [])
-
-    ax.set_xlim(0, 10)
-    ax.set_ylim(-1, 1)
-
-    def init():
-        line.set_data([], [])
-        return line,
-
-    def animate(i):
-        x = np.linspace(0, 10, 100)
-        y = np.sin(x + i)
-        line.set_data(x, y)
-        return line,
-
-    # "klass" can be passed to determine the class returned by the fixture
-    kwargs = dict(getattr(request, 'param', {}))  # make a copy
-    klass = kwargs.pop('klass', animation.FuncAnimation)
-    if 'frames' not in kwargs:
-        kwargs['frames'] = 5
-    return klass(fig=fig, func=animate, init_func=init, **kwargs)
 
 
 # Smoke test for saving animations.  In the future, we should probably

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -58,7 +58,7 @@ def test_null_movie_writer(anim):
     assert writer._count == anim.save_count
 
 
-@pytest.mark.parametrize('anim', [dict(fixture=dict)], indirect=['anim'])
+@pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_animation_delete(anim):
     anim = animation.FuncAnimation(**anim)
     with pytest.warns(Warning, match='Animation was deleted'):
@@ -136,19 +136,19 @@ def anim(request):
         line.set_data(x, y)
         return line,
 
-    # "fixture" can be passed to determine the class returned by the fixture
+    # "klass" can be passed to determine the class returned by the fixture
     kwargs = dict(getattr(request, 'param', {}))  # make a copy
-    fixture = kwargs.pop('fixture', animation.FuncAnimation)
+    klass = kwargs.pop('klass', animation.FuncAnimation)
     if 'frames' not in kwargs:
         kwargs['frames'] = 5
-    return fixture(fig=fig, func=animate, init_func=init, **kwargs)
+    return klass(fig=fig, func=animate, init_func=init, **kwargs)
 
 
 # Smoke test for saving animations.  In the future, we should probably
 # design more sophisticated tests which compare resulting frames a-la
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, output', WRITER_OUTPUT)
-@pytest.mark.parametrize('anim', [dict(fixture=dict)], indirect=['anim'])
+@pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_save_animation_smoketest(tmpdir, writer, output, anim):
     if not animation.writers.is_available(writer):
         pytest.skip("writer '%s' not available on this system" % writer)
@@ -186,7 +186,7 @@ def test_save_animation_smoketest(tmpdir, writer, output, anim):
     ('html5', '<video width'),
     ('jshtml', '<script ')
 ])
-@pytest.mark.parametrize('anim', [dict(fixture=dict)], indirect=['anim'])
+@pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_animation_repr_html(writer, html, want, anim):
     # create here rather than in the fixture otherwise we get __del__ warnings
     # about producing no output


### PR DESCRIPTION
## PR Summary

I got some TemporaryDirectory ResourceWarning's in a sphinx-gallery-based doc builds with matplotlib animations, so I started trying to replicate them with some minimal code. I couldn't, but it looked like there weren't any explicit `_repr_html_` tests in the `test_animation.py` code, so I figured I'd open a PR to add some basic ones (these were my minimal examples that showed no problems at the mpl end).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).