### PR TITLE
Add a dedicated ColormapRegistry class

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,7 +45,7 @@ per-file-ignores =
     setupext.py: E501
     tests.py: F401
 
-    lib/matplotlib/__init__.py: F401
+    lib/matplotlib/__init__.py: E402, F401
     lib/matplotlib/_api/__init__.py: F401
     lib/matplotlib/_cm.py: E122, E202, E203, E302
     lib/matplotlib/_mathtext.py: E221, E251

--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -52,6 +52,12 @@ Logging
 
 .. autofunction:: set_loglevel
 
+Colormaps
+=========
+
+.. autodata:: colormaps
+   :no-value:
+
 Miscellaneous
 =============
 

--- a/doc/users/next_whats_new/colormaps.rst
+++ b/doc/users/next_whats_new/colormaps.rst
@@ -1,4 +1,4 @@
-Colormaps registry
+Colormap registry
 ------------------
 
 Colormaps are now managed via `matplotlib.colormaps`, which is a

--- a/doc/users/next_whats_new/colormaps.rst
+++ b/doc/users/next_whats_new/colormaps.rst
@@ -1,0 +1,18 @@
+Colormaps registry
+------------------
+
+Colormaps are now managed via `matplotlib.colormaps`, which is a
+`.ColormapRegistry`.
+
+Colormaps can be obtained using item access::
+
+    import matplotlib as mpl
+    cmap = mpl.colormaps['viridis']
+
+To register new colormaps use::
+
+    mpl.colormaps.register(my_colormap)
+
+The use of `matplotlib.cm.get_cmap` and `matplotlib.cm.register_cmap` is
+discouraged in favor of the above. Within `.pyplot` the use of
+``plt.get_cmap()`` and ``plt.register_cmap()`` will continue to be supported.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1445,3 +1445,8 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
 _log.debug('interactive is %s', is_interactive())
 _log.debug('platform is %s', sys.platform)
 _log.debug('loaded modules: %s', list(sys.modules))
+
+
+# workaround: we must defer colormaps import to after loading rcParams, because
+# colormap creation depends on rcParams
+from matplotlib.cm import _colormaps as colormaps


### PR DESCRIPTION
## PR Summary

Following the thoughts in https://github.com/matplotlib/matplotlib/pull/16991#discussion_r415340436, this defines a Mapping subclass `ColorbarRegistry` with the following properties:

- read-only mapping: name -> `Colormap`. - Adding new colormaps is for now still done via `register_cmap()`. The class will grow the ability to add elements later, but that needs more API consideration.
- The returned `Colormaps` are copies, so that the global state is not affected by modification to the returned colormaps. - This is the goal for `get_cmap()` anyway (see its deprecation note).


This is a minimal version, that allows to get the registered colormap names. Closes #18490.

Still to be decided: Where should the instance `colormaps` instance live? In `cm`, in `matplotlib`? Should `cm` be integrated into `colors` anyway?


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
