### PR TITLE
Fix depth shading when edge/facecolor is none.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -809,7 +809,7 @@ def _zalpha(colors, zs):
     #        in all three dimensions. Otherwise, at certain orientations,
     #        the min and max zs are very close together.
     #        Should really normalize against the viewing depth.
-    if len(zs) == 0:
+    if len(colors) == 0 or len(zs) == 0:
         return np.zeros((0, 4))
     norm = Normalize(min(zs), max(zs))
     sats = 1 - norm(zs) * 0.7

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -237,8 +237,14 @@ def test_scatter3d():
 def test_scatter3d_color():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
+
+    # Check that 'none' color works; these two should overlay to produce the
+    # same as setting just `color`.
     ax.scatter(np.arange(10), np.arange(10), np.arange(10),
-               color='r', marker='o')
+               facecolor='r', edgecolor='none', marker='o')
+    ax.scatter(np.arange(10), np.arange(10), np.arange(10),
+               facecolor='none', edgecolor='r', marker='o')
+
     ax.scatter(np.arange(10, 20), np.arange(10, 20), np.arange(10, 20),
                color='b', marker='s')
 


### PR DESCRIPTION
## PR Summary

This causes a crash when re-broadcasting with the colour that is then (0, 4)-shaped.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).