### PR TITLE
Remove Locator.autoscale.

### DIFF
--- a/doc/api/next_api_changes/removals/18513-ES.rst
+++ b/doc/api/next_api_changes/removals/18513-ES.rst
@@ -1,0 +1,11 @@
+Locators
+~~~~~~~~
+The unused ``Locator.autoscale`` method has been removed (pass the axis limits
+to `.Locator.view_limits` instead). Any derived methods are also removed:
+
+* ``Locator.autoscale``
+* ``AutoDateLocator.autoscale``
+* ``RRuleLocator.autoscale``
+* ``RadialLocator.autoscale``
+* ``ThetaLocator.autoscale``
+* ``YearLocator.autoscale``

--- a/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/deprecations.rst
@@ -113,7 +113,7 @@ Deprecation of the constructor means that classes inheriting from
 
 Locators
 ~~~~~~~~
-The unused `.Locator.autoscale` method is deprecated (pass the axis limits to
+The unused ``Locator.autoscale`` method is deprecated (pass the axis limits to
 `.Locator.view_limits` instead).
 
 Animation

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1194,42 +1194,6 @@ class RRuleLocator(DateLocator):
     def _get_interval(self):
         return self.rule._rrule._interval
 
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        """
-        Set the view limits to include the data range.
-        """
-        dmin, dmax = self.datalim_to_dt()
-        delta = relativedelta(dmax, dmin)
-
-        # We need to cap at the endpoints of valid datetime
-        try:
-            start = dmin - delta
-        except ValueError:
-            start = _from_ordinalf(1.0)
-
-        try:
-            stop = dmax + delta
-        except ValueError:
-            # The magic number!
-            stop = _from_ordinalf(3652059.9999999)
-
-        self.rule.set(dtstart=start, until=stop)
-        dmin, dmax = self.datalim_to_dt()
-
-        vmin = self.rule.before(dmin, True)
-        if not vmin:
-            vmin = dmin
-
-        vmax = self.rule.after(dmax, True)
-        if not vmax:
-            vmax = dmax
-
-        vmin = date2num(vmin)
-        vmax = date2num(vmax)
-
-        return self.nonsingular(vmin, vmax)
-
 
 class AutoDateLocator(DateLocator):
     """
@@ -1362,12 +1326,6 @@ class AutoDateLocator(DateLocator):
             return 1. / MUSECONDS_PER_DAY
         else:
             return RRuleLocator.get_unit_generic(self._freq)
-
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        """Try to choose the view limits intelligently."""
-        dmin, dmax = self.datalim_to_dt()
-        return self.get_locator(dmin, dmax).autoscale()
 
     def get_locator(self, dmin, dmax):
         """Pick the best locator based on a distance."""
@@ -1537,24 +1495,6 @@ class YearLocator(DateLocator):
                     dt = self.tz.localize(dt, is_dst=True)
 
             ticks.append(dt)
-
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        """
-        Set the view limits to include the data range.
-        """
-        dmin, dmax = self.datalim_to_dt()
-
-        ymin = self.base.le(dmin.year)
-        ymax = self.base.ge(dmax.year)
-        vmin = dmin.replace(year=ymin, **self.replaced)
-        vmin = vmin.astimezone(self.tz)
-        vmax = dmax.replace(year=ymax, **self.replaced)
-        vmax = vmax.astimezone(self.tz)
-
-        vmin = date2num(vmin)
-        vmax = date2num(vmax)
-        return self.nonsingular(vmin, vmax)
 
 
 class MonthLocator(RRuleLocator):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -245,10 +245,6 @@ class ThetaLocator(mticker.Locator):
         else:
             return np.deg2rad(self.base())
 
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        return self.base.autoscale()
-
     @cbook.deprecated("3.3")
     def pan(self, numsteps):
         return self.base.pan(numsteps)
@@ -430,10 +426,6 @@ class RadialLocator(mticker.Locator):
             return self.base()
         else:
             return [tick for tick in self.base() if tick > rorigin]
-
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        return self.base.autoscale()
 
     @cbook.deprecated("3.3")
     def pan(self, numsteps):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1753,11 +1753,6 @@ class Locator(TickHelper):
         """
         return mtransforms.nonsingular(vmin, vmax)
 
-    @cbook.deprecated("3.2")
-    def autoscale(self):
-        """Autoscale the view limits."""
-        return self.view_limits(*self.axis.get_view_interval())
-
     @cbook.deprecated("3.3")
     def pan(self, numsteps):
         """Pan numticks (can be positive or negative)"""


### PR DESCRIPTION
## PR Summary

Previously deprecated in 3.2

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).