### PR TITLE
Remove deprecated backend code.

### DIFF
--- a/doc/api/next_api_changes/removals/18515-ES.rst
+++ b/doc/api/next_api_changes/removals/18515-ES.rst
@@ -1,0 +1,33 @@
+GTK
+~~~
+
+The following methods and properties have been removed:
+
+* ``ConfigureSubplotsGTK3.destroy`` method
+* ``ConfigureSubplotsGTK3.init_window`` method
+* ``ConfigureSubplotsGTK3.window`` property
+
+WX
+~~
+``FigureFrameWx.statusbar``, ``NavigationToolbar2Wx.set_status_bar``, and
+``NavigationToolbar2Wx.statbar`` have been removed. The status bar can be
+retrieved by calling standard wx methods (``frame.GetStatusBar()`` and
+``toolbar.GetTopLevelParent().GetStatusBar()``).
+
+``backend_wx.ConfigureSubplotsWx.configure_subplots`` and
+``backend_wx.ConfigureSubplotsWx.get_canvas`` have been removed.
+
+PGF
+~~~
+``backend_pgf.repl_escapetext`` and ``backend_pgf.repl_mathdefault`` have been
+removed.
+
+``RendererPgf.latexManager`` has been removed.
+
+FigureCanvas
+~~~~~~~~~~~~
+``FigureCanvasBase.draw_cursor`` and ``FigureCanvasMac.invalidate`` have been
+removed.
+
+The ``dryrun`` parameter to the various ``FigureCanvasFoo.print_foo`` methods
+has been removed.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2034,13 +2034,6 @@ class FigureCanvasBase:
             with self._idle_draw_cntx():
                 self.draw(*args, **kwargs)
 
-    @cbook.deprecated("3.2")
-    def draw_cursor(self, event):
-        """
-        Draw a cursor in the event.axes if inaxes is not None.  Use
-        native GUI drawing for efficiency if possible
-        """
-
     def get_width_height(self):
         """
         Return the figure width and height in points or pixels

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -247,8 +247,7 @@ class RendererAgg(RendererBase):
         d /= 64.0
         return w, h, d
 
-    @cbook._delete_parameter("3.2", "ismath")
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         # docstring inherited
         # todo, handle props, angle, origins
         size = prop.get_size_in_points()
@@ -525,15 +524,13 @@ class FigureCanvasAgg(FigureCanvasBase):
 
     @_check_savefig_extra_args(
         extra_kwargs=["quality", "optimize", "progressive"])
-    @cbook._delete_parameter("3.2", "dryrun")
     @cbook._delete_parameter("3.3", "quality",
                              alternative="pil_kwargs={'quality': ...}")
     @cbook._delete_parameter("3.3", "optimize",
                              alternative="pil_kwargs={'optimize': ...}")
     @cbook._delete_parameter("3.3", "progressive",
                              alternative="pil_kwargs={'progressive': ...}")
-    def print_jpg(self, filename_or_obj, *args, dryrun=False, pil_kwargs=None,
-                  **kwargs):
+    def print_jpg(self, filename_or_obj, *args, pil_kwargs=None, **kwargs):
         """
         Write the figure to a JPEG file.
 
@@ -569,8 +566,6 @@ class FigureCanvasAgg(FigureCanvasBase):
             FigureCanvasAgg.draw(self)
         finally:
             self.figure.set_facecolor((r, g, b, a))
-        if dryrun:
-            return
         if pil_kwargs is None:
             pil_kwargs = {}
         for k in ["quality", "optimize", "progressive"]:
@@ -594,11 +589,8 @@ class FigureCanvasAgg(FigureCanvasBase):
     print_jpeg = print_jpg
 
     @_check_savefig_extra_args
-    @cbook._delete_parameter("3.2", "dryrun")
-    def print_tif(self, filename_or_obj, *, dryrun=False, pil_kwargs=None):
+    def print_tif(self, filename_or_obj, *, pil_kwargs=None):
         FigureCanvasAgg.draw(self)
-        if dryrun:
-            return
         if pil_kwargs is None:
             pil_kwargs = {}
         pil_kwargs.setdefault("dpi", (self.figure.dpi, self.figure.dpi))

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -752,57 +752,6 @@ class SetCursorGTK3(backend_tools.SetCursorBase):
 
 
 class ConfigureSubplotsGTK3(backend_tools.ConfigureSubplotsBase, Gtk.Window):
-    @cbook.deprecated("3.2")
-    @property
-    def window(self):
-        if not hasattr(self, "_window"):
-            self._window = None
-        return self._window
-
-    @window.setter
-    @cbook.deprecated("3.2")
-    def window(self, window):
-        self._window = window
-
-    @cbook.deprecated("3.2")
-    def init_window(self):
-        if self.window:
-            return
-        self.window = Gtk.Window(title="Subplot Configuration Tool")
-
-        try:
-            self.window.window.set_icon_from_file(window_icon)
-        except Exception:
-            # we presumably already logged a message on the
-            # failure of the main plot, don't keep reporting
-            pass
-
-        self.vbox = Gtk.Box()
-        self.vbox.set_property("orientation", Gtk.Orientation.VERTICAL)
-        self.window.add(self.vbox)
-        self.vbox.show()
-        self.window.connect('destroy', self.destroy)
-
-        toolfig = Figure(figsize=(6, 3))
-        canvas = self.figure.canvas.__class__(toolfig)
-
-        toolfig.subplots_adjust(top=0.9)
-        SubplotTool(self.figure, toolfig)
-
-        w = int(toolfig.bbox.width)
-        h = int(toolfig.bbox.height)
-
-        self.window.set_default_size(w, h)
-
-        canvas.show()
-        self.vbox.pack_start(canvas, True, True, 0)
-        self.window.show()
-
-    @cbook.deprecated("3.2")
-    def destroy(self, *args):
-        self.window.destroy()
-        self.window = None
-
     def _get_canvas(self, fig):
         return self.canvas.__class__(fig)
 

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -68,10 +68,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
 
     # draw_idle is provided by _macosx.FigureCanvas
 
-    @cbook.deprecated("3.2", alternative="draw_idle()")
-    def invalidate(self):
-        return self.draw_idle()
-
     def blit(self, bbox=None):
         self.draw_idle()
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -77,16 +77,6 @@ NO_ESCAPE = r"(?<!\\)(?:\\\\)*"
 re_mathsep = re.compile(NO_ESCAPE + r"\$")
 
 
-@cbook.deprecated("3.2")
-def repl_escapetext(m):
-    return "\\" + m.group(1)
-
-
-@cbook.deprecated("3.2")
-def repl_mathdefault(m):
-    return m.group(0)[:-len(m.group(1))]
-
-
 _replace_escapetext = functools.partial(
     # When the next character is _, ^, $, or % (not preceded by an escape),
     # insert a backslash.
@@ -426,15 +416,11 @@ class RendererPgf(RendererBase):
         self.figure = figure
         self.image_counter = 0
 
-        self._latexManager = LatexManager._get_cached_or_new()  # deprecated
-
         if dummy:
             # dummy==True deactivate all methods
             for m in RendererPgf.__dict__:
                 if m.startswith("draw_"):
                     self.__dict__[m] = lambda *args, **kwargs: None
-
-    latexManager = cbook._deprecate_privatize_attribute("3.2")
 
     def draw_markers(self, gc, marker_path, marker_trans, path, trans,
                      rgbFace=None):
@@ -803,14 +789,7 @@ class FigureCanvasPgf(FigureCanvasBase):
         return 'pdf'
 
     @_check_savefig_extra_args
-    @cbook._delete_parameter("3.2", "dryrun")
-    def _print_pgf_to_fh(self, fh, *,
-                         dryrun=False, bbox_inches_restore=None):
-
-        if dryrun:
-            renderer = RendererPgf(self.figure, None, dummy=True)
-            self.figure.draw(renderer)
-            return
+    def _print_pgf_to_fh(self, fh, *, bbox_inches_restore=None):
 
         header_text = """%% Creator: Matplotlib, PGF backend
 %%
@@ -875,9 +854,6 @@ class FigureCanvasPgf(FigureCanvasBase):
         Output pgf macros for drawing the figure so it can be included and
         rendered in latex documents.
         """
-        if kwargs.get("dryrun", False):
-            self._print_pgf_to_fh(None, *args, **kwargs)
-            return
         with cbook.open_file_cm(fname_or_fh, "w", encoding="utf-8") as file:
             if not cbook.file_requires_unicode(file):
                 file = codecs.getwriter("utf-8")(file)
@@ -933,9 +909,6 @@ class FigureCanvasPgf(FigureCanvasBase):
 
     def print_pdf(self, fname_or_fh, *args, **kwargs):
         """Use LaTeX to compile a Pgf generated figure to PDF."""
-        if kwargs.get("dryrun", False):
-            self._print_pgf_to_fh(None, *args, **kwargs)
-            return
         with cbook.open_file_cm(fname_or_fh, "wb") as file:
             self._print_pdf_to_fh(file, *args, **kwargs)
 
@@ -961,9 +934,6 @@ class FigureCanvasPgf(FigureCanvasBase):
 
     def print_png(self, fname_or_fh, *args, **kwargs):
         """Use LaTeX to compile a pgf figure to pdf and convert it to png."""
-        if kwargs.get("dryrun", False):
-            self._print_pgf_to_fh(None, *args, **kwargs)
-            return
         with cbook.open_file_cm(fname_or_fh, "wb") as file:
             self._print_png_to_fh(file, *args, **kwargs)
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -827,11 +827,10 @@ class FigureCanvasPS(FigureCanvasBase):
                 orientation=orientation, papertype=papertype, **kwargs)
 
     @_check_savefig_extra_args
-    @cbook._delete_parameter("3.2", "dryrun")
     def _print_figure(
             self, outfile, format, *,
             dpi, dsc_comments, orientation, papertype,
-            dryrun=False, bbox_inches_restore=None):
+            bbox_inches_restore=None):
         """
         Render the figure to a filesystem path or a file-like object.
 
@@ -879,14 +878,7 @@ class FigureCanvasPS(FigureCanvasBase):
             rotation = 90
         bbox = (llx, lly, urx, ury)
 
-        if dryrun:
-            class NullWriter:
-                def write(self, *args, **kwargs):
-                    pass
-
-            self._pswriter = NullWriter()
-        else:
-            self._pswriter = StringIO()
+        self._pswriter = StringIO()
 
         # mixed mode rendering
         ps_renderer = RendererPS(width, height, self._pswriter, imagedpi=dpi)
@@ -895,9 +887,6 @@ class FigureCanvasPS(FigureCanvasBase):
             bbox_inches_restore=bbox_inches_restore)
 
         self.figure.draw(renderer)
-
-        if dryrun:  # return immediately if dryrun (tightbbox=True)
-            return
 
         def print_figure_impl(fh):
             # write the PostScript headers
@@ -1005,11 +994,10 @@ class FigureCanvasPS(FigureCanvasBase):
                     print_figure_impl(fh)
 
     @_check_savefig_extra_args
-    @cbook._delete_parameter("3.2", "dryrun")
     def _print_figure_tex(
             self, outfile, format, *,
             dpi, dsc_comments, orientation, papertype,
-            dryrun=False, bbox_inches_restore=None):
+            bbox_inches_restore=None):
         """
         If :rc:`text.usetex` is True, a temporary pair of tex/eps files
         are created to allow tex to manage the text layout via the PSFrags
@@ -1029,14 +1017,7 @@ class FigureCanvasPS(FigureCanvasBase):
         ury = lly + self.figure.bbox.height
         bbox = (llx, lly, urx, ury)
 
-        if dryrun:
-            class NullWriter:
-                def write(self, *args, **kwargs):
-                    pass
-
-            self._pswriter = NullWriter()
-        else:
-            self._pswriter = StringIO()
+        self._pswriter = StringIO()
 
         # mixed mode rendering
         ps_renderer = RendererPS(width, height, self._pswriter, imagedpi=dpi)
@@ -1045,9 +1026,6 @@ class FigureCanvasPS(FigureCanvasBase):
                                      bbox_inches_restore=bbox_inches_restore)
 
         self.figure.draw(renderer)
-
-        if dryrun:  # return immediately if dryrun (tightbbox=True)
-            return
 
         # write to a temp file, we'll move it to outfile when done
         with TemporaryDirectory() as tmpdir:

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -957,11 +957,6 @@ class FigureFrameWx(wx.Frame):
 
         self.Bind(wx.EVT_CLOSE, self._onClose)
 
-    @cbook.deprecated("3.2", alternative="self.GetStatusBar()")
-    @property
-    def statusbar(self):
-        return self.GetStatusBar()
-
     @property
     def toolmanager(self):
         return self.figmgr.toolmanager
@@ -1308,16 +1303,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         dc.SetBrush(wx.Brush(color))
         dc.DrawRectangle(rect)
 
-    @cbook.deprecated("3.2")
-    def set_status_bar(self, statbar):
-        self.GetTopLevelParent().SetStatusBar(statbar)
-
-    @cbook.deprecated("3.2",
-                      alternative="self.GetTopLevelParent().GetStatusBar()")
-    @property
-    def statbar(self):
-        return self.GetTopLevelParent().GetStatusBar()
-
     def set_message(self, s):
         if self._coordinates:
             self._label_text.SetLabel(s)
@@ -1450,27 +1435,6 @@ class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
         NavigationToolbar2Wx.configure_subplots(
             self._make_classic_style_pseudo_toolbar())
-
-    @cbook.deprecated("3.2")
-    def configure_subplots(self):
-        frame = wx.Frame(None, -1, "Configure subplots")
-        _set_frame_icon(frame)
-
-        toolfig = Figure((6, 3))
-        canvas = self.get_canvas(frame, toolfig)
-
-        # Now put all into a sizer
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        # This way of adding to sizer allows resizing
-        sizer.Add(canvas, 1, wx.LEFT | wx.TOP | wx.GROW)
-        frame.SetSizer(sizer)
-        frame.Fit()
-        SubplotTool(self.canvas.figure, toolfig)
-        frame.Show()
-
-    @cbook.deprecated("3.2")
-    def get_canvas(self, frame, fig):
-        return type(self.canvas)(frame, -1, fig)
 
 
 class SaveFigureWx(backend_tools.SaveFigureBase):


### PR DESCRIPTION
## PR Summary

Previously deprecated in 3.2.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).