### PR TITLE
Remove deprecated font-related things.

### DIFF
--- a/doc/api/next_api_changes/removals/18516-ES.rst
+++ b/doc/api/next_api_changes/removals/18516-ES.rst
@@ -3,7 +3,7 @@ Fonts
 ``font_manager.JSONEncoder`` has been removed. Use `.font_manager.json_dump` to
 dump a `.FontManager` instance.
 
-``font_manager.createFontList`` has been. `.font_manager.FontManager.addfont`
+``font_manager.createFontList`` has been removed. `.font_manager.FontManager.addfont`
 is now available to register a font at a given path.
 
 The ``as_str``, ``as_rgba_str``, ``as_array``, ``get_width`` and ``get_height``

--- a/doc/api/next_api_changes/removals/18516-ES.rst
+++ b/doc/api/next_api_changes/removals/18516-ES.rst
@@ -1,0 +1,11 @@
+Fonts
+~~~~~
+``font_manager.JSONEncoder`` has been removed. Use `.font_manager.json_dump` to
+dump a `.FontManager` instance.
+
+``font_manager.createFontList`` has been. `.font_manager.FontManager.addfont`
+is now available to register a font at a given path.
+
+The ``as_str``, ``as_rgba_str``, ``as_array``, ``get_width`` and ``get_height``
+methods of ``matplotlib.ft2font.FT2Image`` have been removed. Convert the
+``FT2Image`` to a NumPy array with ``np.asarray`` before processing it.

--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -1,7 +1,6 @@
 from docutils.parsers.rst import Directive
 
 from matplotlib import mathtext
-from matplotlib import cbook
 
 
 symbols = [
@@ -138,13 +137,6 @@ def run(state_machine):
 
     state_machine.insert_input(lines, "Symbol table")
     return []
-
-
-@cbook.deprecated("3.2", alternative="MathSymbolTableDirective")
-def math_symbol_table_directive(
-        name, arguments, options, content, lineno,
-        content_offset, block_text, state, state_machine):
-    return run(state_machine)
 
 
 class MathSymbolTableDirective(Directive):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -567,60 +567,6 @@ def afmFontProperty(fontpath, font):
     return FontEntry(fontpath, name, style, variant, weight, stretch, size)
 
 
-@cbook.deprecated("3.2", alternative="FontManager.addfont")
-def createFontList(fontfiles, fontext='ttf'):
-    """
-    Create a font lookup list.  The default is to create
-    a list of TrueType fonts.  An AFM font list can optionally be
-    created.
-    """
-
-    fontlist = []
-    #  Add fonts from list of known font files.
-    seen = set()
-    for fpath in fontfiles:
-        _log.debug('createFontDict: %s', fpath)
-        fname = os.path.split(fpath)[1]
-        if fname in seen:
-            continue
-        if fontext == 'afm':
-            try:
-                with open(fpath, 'rb') as fh:
-                    font = afm.AFM(fh)
-            except EnvironmentError:
-                _log.info("Could not open font file %s", fpath)
-                continue
-            except RuntimeError:
-                _log.info("Could not parse font file %s", fpath)
-                continue
-            try:
-                prop = afmFontProperty(fpath, font)
-            except KeyError as exc:
-                _log.info("Could not extract properties for %s: %s",
-                          fpath, exc)
-                continue
-        else:
-            try:
-                font = ft2font.FT2Font(fpath)
-            except (OSError, RuntimeError) as exc:
-                _log.info("Could not open font file %s: %s", fpath, exc)
-                continue
-            except UnicodeError:
-                _log.info("Cannot handle unicode filenames")
-                continue
-            try:
-                prop = ttfFontProperty(font)
-            except (KeyError, RuntimeError, ValueError,
-                    NotImplementedError) as exc:
-                _log.info("Could not extract properties for %s: %s",
-                          fpath, exc)
-                continue
-
-        fontlist.append(prop)
-        seen.add(fname)
-    return fontlist
-
-
 class FontProperties:
     """
     A class for storing and manipulating font properties.
@@ -1007,11 +953,6 @@ class _JSONEncoder(json.JSONEncoder):
             return d
         else:
             return super().default(o)
-
-
-@cbook.deprecated("3.2", alternative="json_dump")
-class JSONEncoder(_JSONEncoder):
-    pass
 
 
 def _json_decode(o):

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -99,103 +99,6 @@ static PyObject *PyFT2Image_draw_rect_filled(PyFT2Image *self, PyObject *args, P
     Py_RETURN_NONE;
 }
 
-const char *PyFT2Image_as_str__doc__ =
-    "s = image.as_str()\n"
-    "\n"
-    "[*Deprecated*]\n"
-    "Return the image buffer as a string\n"
-    "\n";
-
-static PyObject *PyFT2Image_as_str(PyFT2Image *self, PyObject *args, PyObject *kwds)
-{
-    if (PyErr_WarnEx(PyExc_FutureWarning,
-                     "FT2Image.as_str is deprecated since Matplotlib 3.2 and "
-                     "will be removed in Matplotlib 3.4; convert the FT2Image "
-                     "to a NumPy array with np.asarray instead.",
-                     1)) {
-        return NULL;
-    }
-    return PyBytes_FromStringAndSize((const char *)self->x->get_buffer(),
-                                     self->x->get_width() * self->x->get_height());
-}
-
-const char *PyFT2Image_as_rgba_str__doc__ =
-    "s = image.as_rgba_str()\n"
-    "\n"
-    "[*Deprecated*]\n"
-    "Return the image buffer as a RGBA string\n"
-    "\n";
-
-static PyObject *PyFT2Image_as_rgba_str(PyFT2Image *self, PyObject *args, PyObject *kwds)
-{
-    if (PyErr_WarnEx(PyExc_FutureWarning,
-                     "FT2Image.as_rgba_str is deprecated since Matplotlib 3.2 and "
-                     "will be removed in Matplotlib 3.4; convert the FT2Image "
-                     "to a NumPy array with np.asarray instead.",
-                     1)) {
-        return NULL;
-    }
-    npy_intp dims[] = {(npy_intp)self->x->get_height(), (npy_intp)self->x->get_width(), 4 };
-    numpy::array_view<unsigned char, 3> result(dims);
-
-    unsigned char *src = self->x->get_buffer();
-    unsigned char *end = src + (self->x->get_width() * self->x->get_height());
-    unsigned char *dst = result.data();
-
-    while (src != end) {
-        *dst++ = 0;
-        *dst++ = 0;
-        *dst++ = 0;
-        *dst++ = *src++;
-    }
-
-    return result.pyobj();
-}
-
-const char *PyFT2Image_as_array__doc__ =
-    "x = image.as_array()\n"
-    "\n"
-    "[*Deprecated*]\n"
-    "Return the image buffer as a width x height numpy array of ubyte \n"
-    "\n";
-
-static PyObject *PyFT2Image_as_array(PyFT2Image *self, PyObject *args, PyObject *kwds)
-{
-    if (PyErr_WarnEx(PyExc_FutureWarning,
-                     "FT2Image.as_array is deprecated since Matplotlib 3.2 and "
-                     "will be removed in Matplotlib 3.4; convert the FT2Image "
-                     "to a NumPy array with np.asarray instead.",
-                     1)) {
-        return NULL;
-    }
-    npy_intp dims[] = {(npy_intp)self->x->get_height(), (npy_intp)self->x->get_width() };
-    return PyArray_SimpleNewFromData(2, dims, NPY_UBYTE, self->x->get_buffer());
-}
-
-static PyObject *PyFT2Image_get_width(PyFT2Image *self, PyObject *args, PyObject *kwds)
-{
-    if (PyErr_WarnEx(PyExc_FutureWarning,
-                     "FT2Image.get_width is deprecated since Matplotlib 3.2 and "
-                     "will be removed in Matplotlib 3.4; convert the FT2Image "
-                     "to a NumPy array with np.asarray instead.",
-                     1)) {
-        return NULL;
-    }
-    return PyLong_FromLong(self->x->get_width());
-}
-
-static PyObject *PyFT2Image_get_height(PyFT2Image *self, PyObject *args, PyObject *kwds)
-{
-    if (PyErr_WarnEx(PyExc_FutureWarning,
-                     "FT2Image.get_height is deprecated since Matplotlib 3.2 and "
-                     "will be removed in Matplotlib 3.4; convert the FT2Image "
-                     "to a NumPy array with np.asarray instead.",
-                     1)) {
-        return NULL;
-    }
-    return PyLong_FromLong(self->x->get_height());
-}
-
 static int PyFT2Image_get_buffer(PyFT2Image *self, Py_buffer *buf, int flags)
 {
     FT2Image *im = self->x;
@@ -227,11 +130,6 @@ static PyTypeObject *PyFT2Image_init_type(PyObject *m, PyTypeObject *type)
     static PyMethodDef methods[] = {
         {"draw_rect", (PyCFunction)PyFT2Image_draw_rect, METH_VARARGS, PyFT2Image_draw_rect__doc__},
         {"draw_rect_filled", (PyCFunction)PyFT2Image_draw_rect_filled, METH_VARARGS, PyFT2Image_draw_rect_filled__doc__},
-        {"as_str", (PyCFunction)PyFT2Image_as_str, METH_NOARGS, PyFT2Image_as_str__doc__},
-        {"as_rgba_str", (PyCFunction)PyFT2Image_as_rgba_str, METH_NOARGS, PyFT2Image_as_rgba_str__doc__},
-        {"as_array", (PyCFunction)PyFT2Image_as_array, METH_NOARGS, PyFT2Image_as_array__doc__},
-        {"get_width", (PyCFunction)PyFT2Image_get_width, METH_NOARGS, NULL},
-        {"get_height", (PyCFunction)PyFT2Image_get_height, METH_NOARGS, NULL},
         {NULL}
     };
 


### PR DESCRIPTION
## PR Summary

Previously deprecated in 3.2.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).