### PR TITLE
Correctly position text with nonzero descent with afm fonts / ps output.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -541,7 +541,6 @@ grestore
             scale = 0.001 * fontsize
 
             thisx = 0
-            thisy = font.get_str_bbox_and_descent(s)[4] * scale
             last_name = None
             lines = []
             for c in s:
@@ -558,7 +557,7 @@ grestore
                 last_name = name
                 thisx += kern * scale
 
-                lines.append('%f %f m /%s glyphshow' % (thisx, thisy, name))
+                lines.append('%f 0 m /%s glyphshow' % (thisx, name))
 
                 thisx += width * scale
 

--- a/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
+++ b/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
@@ -1,0 +1,66 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Title: /home/antony/src/extern/matplotlib/result_images/test_backend_ps/useafm.eps
+%%Creator: matplotlib version 3.3.1.post1055+g4fc42b77b, http://matplotlib.org/
+%%CreationDate: Fri Sep 18 12:01:39 2020
+%%Orientation: portrait
+%%BoundingBox: 18 180 594 612
+%%HiResBoundingBox: 18.000000 180.000000 594.000000 612.000000
+%%EndComments
+%%BeginProlog
+/mpldict 7 dict def
+mpldict begin
+/m { moveto } bind def
+/l { lineto } bind def
+/r { rlineto } bind def
+/c { curveto } bind def
+/cl { closepath } bind def
+/box {
+      m
+      1 index 0 r
+      0 exch r
+      neg 0 r
+      cl
+    } bind def
+/clipbox {
+      box
+      clip
+      newpath
+    } bind def
+end
+%%EndProlog
+mpldict begin
+18 180 translate
+576 432 0 0 clipbox
+gsave
+0 0 m
+576 0 l
+576 432 l
+0 432 l
+cl
+1.000 setgray
+fill
+grestore
+1.000 setlinewidth
+1 setlinejoin
+2 setlinecap
+[] 0 setdash
+0.000 0.000 1.000 setrgbcolor
+gsave
+446.4 345.6 72 43.2 clipbox
+72 216 m
+518.4 216 l
+stroke
+grestore
+0.000 setgray
+gsave
+/Helvetica findfont
+12.0 scalefont
+setfont
+295.200000 216.000000 translate
+0.000000 rotate
+0.000000 0 m /q glyphshow
+6.672000 0 m /k glyphshow
+grestore
+
+end
+showpage

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -148,3 +148,12 @@ def test_partial_usetex(caplog):
     plt.savefig(io.BytesIO(), format="ps")
     assert caplog.records and all("as if usetex=False" in record.getMessage()
                                   for record in caplog.records)
+
+
+@image_comparison(["useafm.eps"])
+def test_useafm():
+    mpl.rcParams["ps.useafm"] = True
+    fig, ax = plt.subplots()
+    ax.set_axis_off()
+    ax.axhline(.5)
+    ax.text(.5, .5, "qk")


### PR DESCRIPTION
See e.g.
```
rcParams["ps.useafm"] = True
text(.5, .5, "qk")
axhline(.5)
savefig("/tmp/test.ps")
```
Previously the bottom of the tip of the "q" would be on the baseline;
now the baseline is correctly positioned.

(I picked a relatively generic name for the test because we could later
update the baseline image "in place" for more afm tests.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
