### PR TITLE
Remove mlab, toolkits, and misc deprecations

### DIFF
--- a/doc/api/figure_api.rst
+++ b/doc/api/figure_api.rst
@@ -16,7 +16,6 @@ Classes
    :template: autosummary.rst
    :nosignatures:
 
-   AxesStack
    Figure
    SubplotParams
 

--- a/doc/api/next_api_changes/removals/18522-ES.rst
+++ b/doc/api/next_api_changes/removals/18522-ES.rst
@@ -1,0 +1,3 @@
+``matplotlib.mlab``
+~~~~~~~~~~~~~~~~~~~
+``mlab.apply_window`` and ``mlab.stride_repeat`` have been removed.

--- a/doc/api/next_api_changes/removals/18522-ES.rst
+++ b/doc/api/next_api_changes/removals/18522-ES.rst
@@ -21,4 +21,19 @@ Formatters) is no longer supported. Pass a factor equal to 1 instead.
 
 Misc
 ~~~~
+``matplotlib.get_home`` has been removed; use standard library instead.
+
+``matplotlib.compare_versions`` has been removed; use comparison of
+``distutils.version.LooseVersion``\s instead.
+
+``matplotlib.checkdep_ps_distiller`` has been removed.
+
+``matplotlib.figure.AxesStack`` has been removed.
+
 ``BboxBase.is_unit`` has been removed; check the `.Bbox` extents if needed.
+
+``Affine2DBase.matrix_from_values(...)`` has been removed; use (for example)
+``Affine2D.from_values(...).get_matrix()`` instead.
+
+``style.core.is_style_file`` and ``style.core.iter_style_files`` have been
+removed.

--- a/doc/api/next_api_changes/removals/18522-ES.rst
+++ b/doc/api/next_api_changes/removals/18522-ES.rst
@@ -1,3 +1,16 @@
 ``matplotlib.mlab``
 ~~~~~~~~~~~~~~~~~~~
 ``mlab.apply_window`` and ``mlab.stride_repeat`` have been removed.
+
+axisartist
+~~~~~~~~~~
+``mpl_toolkits.axisartist.grid_finder.GridFinderBase`` has been removed; use
+`.GridFinder` instead.
+
+``axisartist.axis_artist.BezierPath`` has been removed; use
+`.patches.PathPatch` instead.
+
+Returning a factor equal to None from axisartist Locators (which are **not**
+the same as "standard" tick Locators), or passing a factor equal to None
+to axisartist Formatters (which are **not** the same as "standard" tick
+Formatters) is no longer supported. Pass a factor equal to 1 instead.

--- a/doc/api/next_api_changes/removals/18522-ES.rst
+++ b/doc/api/next_api_changes/removals/18522-ES.rst
@@ -2,6 +2,10 @@
 ~~~~~~~~~~~~~~~~~~~
 ``mlab.apply_window`` and ``mlab.stride_repeat`` have been removed.
 
+Axes3D
+~~~~~~
+``axes3d.unit_bbox`` has been removed; use ``Bbox.unit`` instead.
+
 axisartist
 ~~~~~~~~~~
 ``mpl_toolkits.axisartist.grid_finder.GridFinderBase`` has been removed; use
@@ -14,3 +18,7 @@ Returning a factor equal to None from axisartist Locators (which are **not**
 the same as "standard" tick Locators), or passing a factor equal to None
 to axisartist Formatters (which are **not** the same as "standard" tick
 Formatters) is no longer supported. Pass a factor equal to 1 instead.
+
+Misc
+~~~~
+``BboxBase.is_unit`` has been removed; check the `.Bbox` extents if needed.

--- a/doc/api/prev_api_changes/api_changes_2.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.1.0.rst
@@ -329,7 +329,7 @@ a previous axes instance currently reuses the earlier instance.  This
 behavior has been deprecated in Matplotlib 2.1. In a future version, a
 *new* instance will always be created and returned.  Meanwhile, in such
 a situation, a deprecation warning is raised by
-:class:`~matplotlib.figure.AxesStack`.
+``matplotlib.figure.AxesStack``.
 
 This warning can be suppressed, and the future behavior ensured, by passing
 a *unique* label to each axes instance.  See the docstring of

--- a/doc/users/prev_whats_new/whats_new_1.4.rst
+++ b/doc/users/prev_whats_new/whats_new_1.4.rst
@@ -114,13 +114,13 @@ Support for detrending and windowing 2D arrays in mlab
 Todd Jennings added support for 2D arrays in the
 :func:`~matplotlib.mlab.detrend_mean`, :func:`~matplotlib.mlab.detrend_none`,
 and :func:`~matplotlib.mlab.detrend`, as well as adding
-:func:`~matplotlib.mlab.apply_window` which support windowing 2D arrays.
+``matplotlib.mlab.apply_window`` which support windowing 2D arrays.
 
 Support for strides in mlab
 ```````````````````````````
-Todd Jennings added some functions to mlab to make it easier to use numpy
+Todd Jennings added some functions to mlab to make it easier to use NumPy
 strides to create memory-efficient 2D arrays.  This includes
-:func:`~matplotlib.mlab.stride_repeat`, which repeats an array to create a 2D
+``matplotlib.mlab.stride_repeat``, which repeats an array to create a 2D
 array, and :func:`~matplotlib.mlab.stride_windows`, which uses a moving window
 to create a 2D array from a 1D array.
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -135,23 +135,6 @@ __bibtex__ = r"""@Article{Hunter:2007,
 }"""
 
 
-@cbook.deprecated("3.2")
-def compare_versions(a, b):
-    """Return whether version *a* is greater than or equal to version *b*."""
-    if isinstance(a, bytes):
-        cbook.warn_deprecated(
-            "3.0", message="compare_versions arguments should be strs.")
-        a = a.decode('ascii')
-    if isinstance(b, bytes):
-        cbook.warn_deprecated(
-            "3.0", message="compare_versions arguments should be strs.")
-        b = b.decode('ascii')
-    if a:
-        return LooseVersion(a) >= LooseVersion(b)
-    else:
-        return False
-
-
 def _check_versions():
 
     # Quickfix to ensure Microsoft Visual C++ redistributable
@@ -382,26 +365,6 @@ def _get_executable_info(name):
         raise ValueError("Unknown executable: {!r}".format(name))
 
 
-@cbook.deprecated("3.2")
-def checkdep_ps_distiller(s):
-    if not s:
-        return False
-    try:
-        _get_executable_info("gs")
-    except ExecutableNotFoundError:
-        _log.warning(
-            "Setting rcParams['ps.usedistiller'] requires ghostscript.")
-        return False
-    if s == "xpdf":
-        try:
-            _get_executable_info("pdftops")
-        except ExecutableNotFoundError:
-            _log.warning(
-                "Setting rcParams['ps.usedistiller'] to 'xpdf' requires xpdf.")
-            return False
-    return s
-
-
 def checkdep_usetex(s):
     if not s:
         return False
@@ -419,20 +382,6 @@ def checkdep_usetex(s):
         _log.warning("usetex mode requires ghostscript.")
         return False
     return True
-
-
-@cbook.deprecated("3.2", alternative="os.path.expanduser('~')")
-@_logged_cached('$HOME=%s')
-def get_home():
-    """
-    Return the user's home directory.
-
-    If the user's home directory cannot be found, return None.
-    """
-    try:
-        return str(Path.home())
-    except Exception:
-        return None
 
 
 def _get_xdg_config_dir():

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -152,11 +152,6 @@ class _AxesStack(cbook.Stack):
         return a in self.as_list()
 
 
-@cbook.deprecated("3.2")
-class AxesStack(_AxesStack):
-    pass
-
-
 class SubplotParams:
     """
     A class to hold the parameters for a subplot.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -45,12 +45,6 @@ Spectral functions
 
 `stride_windows`
     Get all windows in an array in a memory-efficient manner
-
-`stride_repeat`
-    Repeat an array in a memory-efficient manner
-
-`apply_window`
-    Apply a window along a given axis
 """
 
 import functools
@@ -83,63 +77,6 @@ def window_none(x):
     window_hanning : Another window algorithm.
     """
     return x
-
-
-@cbook.deprecated("3.2")
-def apply_window(x, window, axis=0, return_window=None):
-    """
-    Apply the given window to the given 1D or 2D array along the given axis.
-
-    Parameters
-    ----------
-    x : 1D or 2D array or sequence
-        Array or sequence containing the data.
-
-    window : function or array.
-        Either a function to generate a window or an array with length
-        *x*.shape[*axis*]
-
-    axis : int
-        The axis over which to do the repetition.
-        Must be 0 or 1.  The default is 0
-
-    return_window : bool
-        If true, also return the 1D values of the window that was applied
-    """
-    x = np.asarray(x)
-
-    if x.ndim < 1 or x.ndim > 2:
-        raise ValueError('only 1D or 2D arrays can be used')
-    if axis+1 > x.ndim:
-        raise ValueError('axis(=%s) out of bounds' % axis)
-
-    xshape = list(x.shape)
-    xshapetarg = xshape.pop(axis)
-
-    if np.iterable(window):
-        if len(window) != xshapetarg:
-            raise ValueError('The len(window) must be the same as the shape '
-                             'of x for the chosen axis')
-        windowVals = window
-    else:
-        windowVals = window(np.ones(xshapetarg, dtype=x.dtype))
-
-    if x.ndim == 1:
-        if return_window:
-            return windowVals * x, windowVals
-        else:
-            return windowVals * x
-
-    xshapeother = xshape.pop()
-
-    otheraxis = (axis+1) % 2
-
-    windowValsRep = stride_repeat(windowVals, xshapeother, axis=otheraxis)
-
-    if return_window:
-        return windowValsRep * x, windowVals
-    else:
-        return windowValsRep * x
 
 
 def detrend(x, key=None, axis=None):
@@ -340,62 +277,6 @@ def stride_windows(x, n, noverlap=None, axis=0):
     else:
         shape = ((x.shape[-1]-noverlap)//step, n)
         strides = (step*x.strides[0], x.strides[0])
-    return np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
-
-
-@cbook.deprecated("3.2")
-def stride_repeat(x, n, axis=0):
-    """
-    Repeat the values in an array in a memory-efficient manner.  Array x is
-    stacked vertically n times.
-
-    .. warning::
-
-        It is not safe to write to the output array.  Multiple
-        elements may point to the same piece of memory, so
-        modifying one value may change others.
-
-    Parameters
-    ----------
-    x : 1D array or sequence
-        Array or sequence containing the data.
-
-    n : int
-        The number of time to repeat the array.
-
-    axis : int
-        The axis along which the data will run.
-
-    References
-    ----------
-    `stackoverflow: Repeat NumPy array without replicating data?
-    <http://stackoverflow.com/a/5568169>`_
-    """
-    if axis not in [0, 1]:
-        raise ValueError('axis must be 0 or 1')
-    x = np.asarray(x)
-    if x.ndim != 1:
-        raise ValueError('only 1-dimensional arrays can be used')
-
-    if n == 1:
-        if axis == 0:
-            return np.atleast_2d(x)
-        else:
-            return np.atleast_2d(x).T
-    if n < 1:
-        raise ValueError('n cannot be less than 1')
-
-    # np.lib.stride_tricks.as_strided easily leads to memory corruption for
-    # non integer shape and strides, i.e. n. See #3845.
-    n = int(n)
-
-    if axis == 0:
-        shape = (n, x.size)
-        strides = (0, x.strides[0])
-    else:
-        shape = (x.size, n)
-        strides = (x.strides[0], 0)
-
     return np.lib.stride_tricks.as_strided(x, shape=shape, strides=strides)
 
 

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -55,12 +55,6 @@ def _remove_blacklisted_style_params(d, warn=True):
     return o
 
 
-@cbook.deprecated("3.2")
-def is_style_file(filename):
-    """Return True if the filename looks like a style file."""
-    return STYLE_FILE_PATTERN.match(filename) is not None
-
-
 def _apply_style(d, warn=True):
     mpl.rcParams.update(_remove_blacklisted_style_params(d, warn=warn))
 
@@ -180,17 +174,6 @@ def update_user_library(library):
         styles = read_style_directory(stylelib_path)
         update_nested_dict(library, styles)
     return library
-
-
-@cbook.deprecated("3.2")
-def iter_style_files(style_dir):
-    """Yield file path and name of styles in the given directory."""
-    for path in os.listdir(style_dir):
-        filename = os.path.basename(path)
-        if is_style_file(filename):
-            match = STYLE_FILE_PATTERN.match(filename)
-            path = os.path.abspath(os.path.join(style_dir, path))
-            yield path, match.group(1)
 
 
 def read_style_directory(style_dir):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -241,11 +241,6 @@ class BboxBase(TransformNode):
     def __array__(self, *args, **kwargs):
         return self.get_points()
 
-    @cbook.deprecated("3.2")
-    def is_unit(self):
-        """Return whether this is the unit box (from (0, 0) to (1, 1))."""
-        return self.get_points().tolist() == [[0., 0.], [1., 1.]]
-
     @property
     def x0(self):
         """

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1773,19 +1773,6 @@ class Affine2DBase(AffineBase):
         mtx = self.get_matrix()
         return tuple(mtx[:2].swapaxes(0, 1).flat)
 
-    @staticmethod
-    @cbook.deprecated(
-        "3.2", alternative="Affine2D.from_values(...).get_matrix()")
-    def matrix_from_values(a, b, c, d, e, f):
-        """
-        Create a new transformation matrix as a 3x3 numpy array of the form::
-
-          a c e
-          b d f
-          0 0 1
-        """
-        return np.array([[a, c, e], [b, d, f], [0.0, 0.0, 1.0]], float)
-
     def transform_affine(self, points):
         mtx = self.get_matrix()
         if isinstance(points, np.ma.MaskedArray):

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -99,81 +99,12 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
 from matplotlib.transforms import (
-    Affine2D, Bbox, IdentityTransform, ScaledTranslation, TransformedPath)
+    Affine2D, Bbox, IdentityTransform, ScaledTranslation)
 
 from .axisline_style import AxislineStyle
 
 
-@cbook.deprecated("3.2", alternative="matplotlib.patches.PathPatch")
-class BezierPath(Line2D):
-
-    def __init__(self, path, *args, **kwargs):
-        """
-        Parameters
-        ----------
-        path : `~.path.Path`
-            The path to draw.
-        **kwargs
-            All remaining keyword arguments are passed to `.Line2D`.
-        """
-        super().__init__([], [], *args, **kwargs)
-        self._path = path
-        self._invalid = False
-
-    def recache(self):
-        self._transformed_path = TransformedPath(
-            self._path, self.get_transform())
-        self._invalid = False
-
-    def set_path(self, path):
-        self._path = path
-        self._invalid = True
-
-    def draw(self, renderer):
-        if self._invalid:
-            self.recache()
-
-        if not self._visible:
-            return
-        renderer.open_group('line2d', gid=self.get_gid())
-
-        gc = renderer.new_gc()
-        self._set_gc_clip(gc)
-
-        gc.set_foreground(self._color)
-        gc.set_antialiased(self._antialiased)
-        gc.set_linewidth(self._linewidth)
-        gc.set_alpha(self._alpha)
-        if self.is_dashed():
-            cap = self._dashcapstyle
-            join = self._dashjoinstyle
-        else:
-            cap = self._solidcapstyle
-            join = self._solidjoinstyle
-        gc.set_joinstyle(join)
-        gc.set_capstyle(cap)
-        gc.set_dashes(self._dashOffset, self._dashSeq)
-
-        if self._lineStyles[self._linestyle] != '_draw_nothing':
-            tpath, affine = (
-                self._transformed_path.get_transformed_path_and_affine())
-            renderer.draw_path(gc, tpath, affine.frozen())
-
-        gc.restore()
-        renderer.close_group('line2d')
-
-
 class AttributeCopier:
-    @cbook.deprecated("3.2")
-    def __init__(self, ref_artist, klass=martist.Artist):
-        self._klass = klass
-        self._ref_artist = ref_artist
-        super().__init__()
-
-    @cbook.deprecated("3.2")
-    def set_ref_artist(self, artist):
-        self._ref_artist = artist
-
     def get_ref_artist(self):
         """
         Return the underlying artist that actually defines some properties
@@ -181,8 +112,7 @@ class AttributeCopier:
         """
         raise RuntimeError("get_ref_artist must overridden")
 
-    @cbook._delete_parameter("3.2", "default_value")
-    def get_attribute_from_ref_artist(self, attr_name, default_value=None):
+    def get_attribute_from_ref_artist(self, attr_name):
         getter = methodcaller("get_" + attr_name)
         prop = getter(super())
         return getter(self.get_ref_artist()) if prop == "auto" else prop

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -5,17 +5,6 @@ from matplotlib.transforms import Bbox, Transform
 from .clip_path import clip_line_to_rect
 
 
-def _deprecate_factor_none(factor):
-    # After the deprecation period, calls to _deprecate_factor_none can just be
-    # removed.
-    if factor is None:
-        cbook.warn_deprecated(
-            "3.2", message="factor=None is deprecated since %(since)s and "
-            "support will be removed %(removal)s; use/return factor=1 instead")
-        factor = 1
-    return factor
-
-
 class ExtremeFinderSimple:
     """
     A helper class to figure out the range of grid lines that need to be drawn.
@@ -110,8 +99,8 @@ class GridFinder:
         lon_levs, lon_n, lon_factor = self.grid_locator1(lon_min, lon_max)
         lat_levs, lat_n, lat_factor = self.grid_locator2(lat_min, lat_max)
 
-        lon_values = lon_levs[:lon_n] / _deprecate_factor_none(lon_factor)
-        lat_values = lat_levs[:lat_n] / _deprecate_factor_none(lat_factor)
+        lon_values = lon_levs[:lon_n] / lon_factor
+        lat_values = lat_levs[:lat_n] / lat_factor
 
         lon_lines, lat_lines = self._get_raw_grid_lines(lon_values,
                                                         lat_values,
@@ -218,19 +207,6 @@ class GridFinder:
                 raise ValueError("Unknown update property '%s'" % k)
 
 
-@cbook.deprecated("3.2")
-class GridFinderBase(GridFinder):
-    def __init__(self,
-                 extreme_finder,
-                 grid_locator1=None,
-                 grid_locator2=None,
-                 tick_formatter1=None,
-                 tick_formatter2=None):
-        super().__init__((None, None), extreme_finder,
-                         grid_locator1, grid_locator2,
-                         tick_formatter1, tick_formatter2)
-
-
 class MaxNLocator(mticker.MaxNLocator):
     def __init__(self, nbins=10, steps=None,
                  trim=True,
@@ -250,7 +226,7 @@ class MaxNLocator(mticker.MaxNLocator):
 
     @cbook.deprecated("3.3")
     def set_factor(self, f):
-        self._factor = _deprecate_factor_none(f)
+        self._factor = f
 
 
 class FixedLocator:
@@ -265,7 +241,7 @@ class FixedLocator:
 
     @cbook.deprecated("3.3")
     def set_factor(self, f):
-        self._factor = _deprecate_factor_none(f)
+        self._factor = f
 
 
 # Tick Formatter

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -9,7 +9,7 @@ from matplotlib.path import Path
 from matplotlib.transforms import Affine2D, IdentityTransform
 from .axislines import AxisArtistHelper, GridHelperBase
 from .axis_artist import AxisArtist
-from .grid_finder import GridFinder, _deprecate_factor_none
+from .grid_finder import GridFinder
 
 
 class FixedAxisArtistHelper(AxisArtistHelper.Fixed):
@@ -131,12 +131,12 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         self.grid_info = {
             "extremes": (lon_min, lon_max, lat_min, lat_max),
-            "lon_info": (lon_levs, lon_n, _deprecate_factor_none(lon_factor)),
-            "lat_info": (lat_levs, lat_n, _deprecate_factor_none(lat_factor)),
+            "lon_info": (lon_levs, lon_n, lon_factor),
+            "lat_info": (lat_levs, lat_n, lat_factor),
             "lon_labels": grid_finder.tick_formatter1(
-                "bottom", _deprecate_factor_none(lon_factor), lon_levs),
+                "bottom", lon_factor, lon_levs),
             "lat_labels": grid_finder.tick_formatter2(
-                "bottom", _deprecate_factor_none(lat_factor), lat_levs),
+                "bottom", lat_factor, lat_levs),
             "line_xy": (xx, yy),
         }
 
@@ -182,13 +182,13 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         lat_levs, lat_n, lat_factor = self.grid_info["lat_info"]
         lat_levs = np.asarray(lat_levs)
-        yy0 = lat_levs / _deprecate_factor_none(lat_factor)
-        dy = 0.01 / _deprecate_factor_none(lat_factor)
+        yy0 = lat_levs / lat_factor
+        dy = 0.01 / lat_factor
 
         lon_levs, lon_n, lon_factor = self.grid_info["lon_info"]
         lon_levs = np.asarray(lon_levs)
-        xx0 = lon_levs / _deprecate_factor_none(lon_factor)
-        dx = 0.01 / _deprecate_factor_none(lon_factor)
+        xx0 = lon_levs / lon_factor
+        dx = 0.01 / lon_factor
 
         if None in self._extremes:
             e0, e1 = self._extremes

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -38,12 +38,6 @@ from . import proj3d
 from . import axis3d
 
 
-@cbook.deprecated("3.2", alternative="Bbox.unit()")
-def unit_bbox():
-    box = Bbox(np.array([[0, 0], [1, 1]]))
-    return box
-
-
 @cbook._define_aliases({
     "xlim3d": ["xlim"], "ylim3d": ["ylim"], "zlim3d": ["zlim"]})
 class Axes3D(Axes):


### PR DESCRIPTION
## PR Summary

Previously deprecated in 3.2.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).