### PR TITLE
Don't leak file paths into PostScript metadata

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -797,8 +797,9 @@ class FigureCanvasPS(FigureCanvasBase):
 
         dsc_comments = {}
         if isinstance(outfile, (str, os.PathLike)):
+            filename = pathlib.Path(outfile).name
             dsc_comments["Title"] = \
-                os.fspath(outfile).encode("ascii", "replace").decode("ascii")
+                filename.encode("ascii", "replace").decode("ascii")
         dsc_comments["Creator"] = (metadata or {}).get(
             "Creator",
             f"matplotlib version {mpl.__version__}, http://matplotlib.org/")

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -802,7 +802,7 @@ class FigureCanvasPS(FigureCanvasBase):
                 filename.encode("ascii", "replace").decode("ascii")
         dsc_comments["Creator"] = (metadata or {}).get(
             "Creator",
-            f"matplotlib version {mpl.__version__}, http://matplotlib.org/")
+            f"Matplotlib v{mpl.__version__}, https://matplotlib.org/")
         # See https://reproducible-builds.org/specs/source-date-epoch/
         source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
         dsc_comments["CreationDate"] = (

--- a/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
+++ b/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
@@ -1,7 +1,7 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%Title: useafm.eps
-%%Creator: matplotlib version 3.3.1.post1055+g4fc42b77b, http://matplotlib.org/
-%%CreationDate: Fri Sep 18 12:01:39 2020
+%%Creator: Matplotlib v3.3.2.post1066.dev0+g61d2a5649, https://matplotlib.org/
+%%CreationDate: Fri Sep 18 22:34:48 2020
 %%Orientation: portrait
 %%BoundingBox: 18 180 594 612
 %%HiResBoundingBox: 18.000000 180.000000 594.000000 612.000000

--- a/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
+++ b/lib/matplotlib/tests/baseline_images/test_backend_ps/useafm.eps
@@ -1,5 +1,5 @@
 %!PS-Adobe-3.0 EPSF-3.0
-%%Title: /home/antony/src/extern/matplotlib/result_images/test_backend_ps/useafm.eps
+%%Title: useafm.eps
 %%Creator: matplotlib version 3.3.1.post1055+g4fc42b77b, http://matplotlib.org/
 %%CreationDate: Fri Sep 18 12:01:39 2020
 %%Orientation: portrait

--- a/lib/matplotlib/tests/baseline_images/test_path/nan_path.eps
+++ b/lib/matplotlib/tests/baseline_images/test_path/nan_path.eps
@@ -1,9 +1,10 @@
 %!PS-Adobe-3.0 EPSF-3.0
 %%Title: nan_path.eps
-%%Creator: matplotlib version 2.0.0.post99.dev0+gcdc493d33, http://matplotlib.org/
-%%CreationDate: Tue Mar 14 16:50:24 2017
+%%Creator: Matplotlib v3.3.2.post1066.dev0+g61d2a5649, https://matplotlib.org/
+%%CreationDate: Fri Sep 18 22:34:54 2020
 %%Orientation: portrait
-%%BoundingBox: 75 223 536 568
+%%BoundingBox: 75 223 537 569
+%%HiResBoundingBox: 75.600000 223.200000 536.400000 568.800000
 %%EndComments
 %%BeginProlog
 /mpldict 7 dict def

--- a/lib/matplotlib/tests/baseline_images/test_path/nan_path.eps
+++ b/lib/matplotlib/tests/baseline_images/test_path/nan_path.eps
@@ -1,5 +1,5 @@
 %!PS-Adobe-3.0 EPSF-3.0
-%%Title: /home/tcaswell/source/p/matplotlib/result_images/test_path/nan_path.eps
+%%Title: nan_path.eps
 %%Creator: matplotlib version 2.0.0.post99.dev0+gcdc493d33, http://matplotlib.org/
 %%CreationDate: Tue Mar 14 16:50:24 2017
 %%Orientation: portrait


### PR DESCRIPTION
## PR Summary

And update Creator field to match other backends.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).