### PR TITLE
Templatize _image.resample to deduplicate it.

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -105,6 +105,19 @@ _get_transform_mesh(PyObject *py_affine, npy_intp *dims)
 }
 
 
+template<class T>
+static void
+resample(PyArrayObject* input, PyArrayObject* output, resample_params_t params)
+{
+    Py_BEGIN_ALLOW_THREADS
+    resample(
+        (T*)PyArray_DATA(input), PyArray_DIM(input, 1), PyArray_DIM(input, 0),
+        (T*)PyArray_DATA(output), PyArray_DIM(output, 1), PyArray_DIM(output, 0),
+        params);
+    Py_END_ALLOW_THREADS
+}
+
+
 static PyObject *
 image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
 {
@@ -216,56 +229,20 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
         }
 
         if (PyArray_DIM(input_array, 2) == 4) {
-            switch(PyArray_TYPE(input_array)) {
-            case NPY_BYTE:
+            switch (PyArray_TYPE(input_array)) {
             case NPY_UINT8:
-                Py_BEGIN_ALLOW_THREADS
-                resample(
-                    (agg::rgba8 *)PyArray_DATA(input_array),
-                    PyArray_DIM(input_array, 1),
-                    PyArray_DIM(input_array, 0),
-                    (agg::rgba8 *)PyArray_DATA(output_array),
-                    PyArray_DIM(output_array, 1),
-                    PyArray_DIM(output_array, 0),
-                    params);
-                Py_END_ALLOW_THREADS
+            case NPY_INT8:
+                resample<agg::rgba8>(input_array, output_array, params);
                 break;
             case NPY_UINT16:
             case NPY_INT16:
-                Py_BEGIN_ALLOW_THREADS
-                resample(
-                    (agg::rgba16 *)PyArray_DATA(input_array),
-                    PyArray_DIM(input_array, 1),
-                    PyArray_DIM(input_array, 0),
-                    (agg::rgba16 *)PyArray_DATA(output_array),
-                    PyArray_DIM(output_array, 1),
-                    PyArray_DIM(output_array, 0),
-                    params);
-                Py_END_ALLOW_THREADS
+                resample<agg::rgba16>(input_array, output_array, params);
                 break;
             case NPY_FLOAT32:
-                Py_BEGIN_ALLOW_THREADS
-                resample(
-                    (agg::rgba32 *)PyArray_DATA(input_array),
-                    PyArray_DIM(input_array, 1),
-                    PyArray_DIM(input_array, 0),
-                    (agg::rgba32 *)PyArray_DATA(output_array),
-                    PyArray_DIM(output_array, 1),
-                    PyArray_DIM(output_array, 0),
-                    params);
-                Py_END_ALLOW_THREADS
+                resample<agg::rgba32>(input_array, output_array, params);
                 break;
             case NPY_FLOAT64:
-                Py_BEGIN_ALLOW_THREADS
-                resample(
-                    (agg::rgba64 *)PyArray_DATA(input_array),
-                    PyArray_DIM(input_array, 1),
-                    PyArray_DIM(input_array, 0),
-                    (agg::rgba64 *)PyArray_DATA(output_array),
-                    PyArray_DIM(output_array, 1),
-                    PyArray_DIM(output_array, 0),
-                    params);
-                Py_END_ALLOW_THREADS
+                resample<agg::rgba64>(input_array, output_array, params);
                 break;
             default:
                 PyErr_SetString(
@@ -284,54 +261,18 @@ image_resample(PyObject *self, PyObject* args, PyObject *kwargs)
     } else { // NDIM == 2
         switch (PyArray_TYPE(input_array)) {
         case NPY_DOUBLE:
-            Py_BEGIN_ALLOW_THREADS
-            resample(
-                (double *)PyArray_DATA(input_array),
-                PyArray_DIM(input_array, 1),
-                PyArray_DIM(input_array, 0),
-                (double *)PyArray_DATA(output_array),
-                PyArray_DIM(output_array, 1),
-                PyArray_DIM(output_array, 0),
-                params);
-            Py_END_ALLOW_THREADS
+            resample<double>(input_array, output_array, params);
             break;
         case NPY_FLOAT:
-            Py_BEGIN_ALLOW_THREADS
-            resample(
-                (float *)PyArray_DATA(input_array),
-                PyArray_DIM(input_array, 1),
-                PyArray_DIM(input_array, 0),
-                (float *)PyArray_DATA(output_array),
-                PyArray_DIM(output_array, 1),
-                PyArray_DIM(output_array, 0),
-                params);
-            Py_END_ALLOW_THREADS
+            resample<float>(input_array, output_array, params);
             break;
         case NPY_UINT8:
-        case NPY_BYTE:
-            Py_BEGIN_ALLOW_THREADS
-            resample(
-                (unsigned char *)PyArray_DATA(input_array),
-                PyArray_DIM(input_array, 1),
-                PyArray_DIM(input_array, 0),
-                (unsigned char *)PyArray_DATA(output_array),
-                PyArray_DIM(output_array, 1),
-                PyArray_DIM(output_array, 0),
-                params);
-            Py_END_ALLOW_THREADS
+        case NPY_INT8:
+            resample<unsigned char>(input_array, output_array, params);
             break;
         case NPY_UINT16:
         case NPY_INT16:
-            Py_BEGIN_ALLOW_THREADS
-            resample(
-                (unsigned short *)PyArray_DATA(input_array),
-                PyArray_DIM(input_array, 1),
-                PyArray_DIM(input_array, 0),
-                (unsigned short *)PyArray_DATA(output_array),
-                PyArray_DIM(output_array, 1),
-                PyArray_DIM(output_array, 0),
-                params);
-            Py_END_ALLOW_THREADS
+            resample<unsigned short>(input_array, output_array, params);
             break;
         default:
             PyErr_SetString(PyExc_ValueError, "Unsupported dtype");


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
