### PR TITLE
Deprecate TextArea minimumdescent.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18528-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18528-AL.rst
@@ -1,0 +1,5 @@
+*minimumdescent* parameter/property of ``TextArea``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.offsetbox.TextArea` has behaved as if *minimumdescent* was always True
+(regardless of the value to which it was set) since Matplotlib 1.3, so the
+parameter/property is deprecated.

--- a/examples/misc/anchored_artists.py
+++ b/examples/misc/anchored_artists.py
@@ -21,7 +21,7 @@ from matplotlib.offsetbox import (
 class AnchoredText(AnchoredOffsetbox):
     def __init__(self, s, loc, pad=0.4, borderpad=0.5,
                  prop=None, frameon=True):
-        self.txt = TextArea(s, minimumdescent=False)
+        self.txt = TextArea(s)
         super().__init__(loc, pad=pad, borderpad=borderpad,
                          child=self.txt, prop=prop, frameon=frameon)
 
@@ -93,13 +93,10 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         """
         self.size_bar = AuxTransformBox(transform)
         self.size_bar.add_artist(Line2D([0, size], [0, 0], color="black"))
-
-        self.txt_label = TextArea(label, minimumdescent=False)
-
+        self.txt_label = TextArea(label)
         self._box = VPacker(children=[self.size_bar, self.txt_label],
                             align="center",
                             pad=0, sep=sep)
-
         super().__init__(loc, pad=pad, borderpad=borderpad,
                          child=self._box, prop=prop, frameon=frameon)
 

--- a/examples/text_labels_and_annotations/demo_annotation_box.py
+++ b/examples/text_labels_and_annotations/demo_annotation_box.py
@@ -26,7 +26,7 @@ xy = (0.5, 0.7)
 ax.plot(xy[0], xy[1], ".r")
 
 # Annotate the 1st position with a text box ('Test 1')
-offsetbox = TextArea("Test 1", minimumdescent=False)
+offsetbox = TextArea("Test 1")
 
 ab = AnnotationBbox(offsetbox, xy,
                     xybox=(-20, 40),
@@ -36,7 +36,7 @@ ab = AnnotationBbox(offsetbox, xy,
 ax.add_artist(ab)
 
 # Annotate the 1st position with another text box ('Test')
-offsetbox = TextArea("Test", minimumdescent=False)
+offsetbox = TextArea("Test")
 
 ab = AnnotationBbox(offsetbox, xy,
                     xybox=(1.02, xy[1]),

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -755,8 +755,7 @@ class Legend(Artist):
                 handle_list.append(None)
             else:
                 textbox = TextArea(lab, textprops=label_prop,
-                                   multilinebaseline=True,
-                                   minimumdescent=True)
+                                   multilinebaseline=True)
                 handlebox = DrawingArea(width=self.handlelength * fontsize,
                                         height=height,
                                         xdescent=0., ydescent=descent)
@@ -790,12 +789,6 @@ class Legend(Artist):
                                  children=[h, t] if markerfirst else [t, h],
                                  align="baseline")
                          for h, t in handles_and_labels[i0:i0 + di]]
-            # minimumdescent=False for the text of the last row of the column
-            if markerfirst:
-                itemBoxes[-1].get_children()[1].set_minimumdescent(False)
-            else:
-                itemBoxes[-1].get_children()[0].set_minimumdescent(False)
-
             # pack columnBox
             alignment = "baseline" if markerfirst else "right"
             columnbox.append(VPacker(pad=0,

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -775,6 +775,8 @@ class TextArea(OffsetBox):
     width and height of the TextArea instance is the width and height of its
     child text.
     """
+
+    @cbook._delete_parameter("3.4", "minimumdescent")
     def __init__(self, s,
                  textprops=None,
                  multilinebaseline=None,
@@ -794,8 +796,9 @@ class TextArea(OffsetBox):
             If `True`, baseline for multiline text is adjusted so that it is
             (approximately) center-aligned with singleline text.
 
-        minimumdescent : bool, optional
-            If `True`, the box has a minimum descent of "p".
+        minimumdescent : bool, default: True
+            If `True`, the box has a minimum descent of "p".  This is now
+            effectively always True.
         """
         if textprops is None:
             textprops = {}
@@ -835,16 +838,20 @@ class TextArea(OffsetBox):
         """
         return self._multilinebaseline
 
+    @cbook.deprecated("3.4")
     def set_minimumdescent(self, t):
         """
         Set minimumdescent.
 
         If True, extent of the single line text is adjusted so that
-        it has minimum descent of "p"
+        its descent is at least the one of the glyph "p".
         """
+        # The current implementation of Text._get_layout always behaves as if
+        # this is True.
         self._minimumdescent = t
         self.stale = True
 
+    @cbook.deprecated("3.4")
     def get_minimumdescent(self):
         """
         Get minimumdescent.
@@ -893,16 +900,8 @@ class TextArea(OffsetBox):
             yd_new = 0.5 * h - 0.5 * (h_ - d_)
             self._baseline_transform.translate(0, yd - yd_new)
             yd = yd_new
-
         else:  # single line
-
             h_d = max(h_ - d_, h - yd)
-
-            if self.get_minimumdescent():
-                # To have a minimum descent, i.e., "l" and "p" have same
-                # descents.
-                yd = max(yd, d_)
-
             h = h_d + yd
 
         ha = self._text.get_horizontalalignment()
@@ -1300,7 +1299,7 @@ class AnchoredText(AnchoredOffsetbox):
             raise ValueError(
                 'Mixing verticalalignment with AnchoredText is not supported.')
 
-        self.txt = TextArea(s, textprops=prop, minimumdescent=False)
+        self.txt = TextArea(s, textprops=prop)
         fp = self.txt._text.get_fontproperties()
         super().__init__(
             loc, pad=pad, borderpad=borderpad, child=self.txt, prop=fp,

--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -337,10 +337,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         else:
             textprops = {'color': color, 'fontproperties': fontproperties}
 
-        self.txt_label = TextArea(
-            label,
-            minimumdescent=False,
-            textprops=textprops)
+        self.txt_label = TextArea(label, textprops=textprops)
 
         if label_top:
             _box_children = [self.txt_label, self.size_bar]


### PR DESCRIPTION
The implementation of `Text._get_layout` has effectively enforced
`minimumudescent=True` (`d = max(d, lp_d)`) since ee3af298 (mpl 1.3).
(See also the images in the corresponding PR, #2070.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
