### PR TITLE
Consistent behavior of draw_if_interactive across interactive backends.

### DIFF
--- a/doc/api/next_api_changes/behavior/18532-AL.rst
+++ b/doc/api/next_api_changes/behavior/18532-AL.rst
@@ -1,0 +1,4 @@
+Consistent behavior of ``draw_if_interactive()`` across backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.pyplot.draw_if_interactive` no longer shows the window (if it was previously
+unshown) on the tk and nbagg backends, consistently with all other backends.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3514,12 +3514,9 @@ class _Backend:
     # For interactive backends, the `FigureManager` class must be overridden.
     FigureManager = FigureManagerBase
 
-    # The following methods must be left as None for non-interactive backends.
-    # For interactive backends, `trigger_manager_draw` should be a function
-    # taking a manager as argument and triggering a canvas draw, and `mainloop`
-    # should be a function taking no argument and starting the backend main
-    # loop.
-    trigger_manager_draw = None
+    # For interactive backends, `mainloop` should be a function taking no
+    # argument and starting the backend main loop.  It should be left as None
+    # for non-interactive backends.
     mainloop = None
 
     # The following methods will be automatically defined and exported, but
@@ -3543,10 +3540,10 @@ class _Backend:
 
     @classmethod
     def draw_if_interactive(cls):
-        if cls.trigger_manager_draw is not None and is_interactive():
+        if cls.mainloop is not None and is_interactive():
             manager = Gcf.get_active()
             if manager:
-                cls.trigger_manager_draw(manager)
+                manager.canvas.draw_idle()
 
     @classmethod
     def show(cls, *, block=None):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -884,10 +884,6 @@ class _BackendTk(_Backend):
             return manager
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.show()
-
-    @staticmethod
     def mainloop():
         managers = Gcf.get_all_fig_managers()
         if managers:

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -943,10 +943,6 @@ class _BackendGTK3(_Backend):
     FigureManager = FigureManagerGTK3
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.canvas.draw_idle()
-
-    @staticmethod
     def mainloop():
         if Gtk.main_level() == 0:
             cbook._setup_new_guiapp()

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -163,9 +163,5 @@ class _BackendMac(_Backend):
     FigureManager = FigureManagerMac
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.canvas.draw_idle()
-
-    @staticmethod
     def mainloop():
         _macosx.show()

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -240,10 +240,6 @@ class _BackendNbAgg(_Backend):
         return manager
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.show()
-
-    @staticmethod
     def show(block=None):
         ## TODO: something to do when keyword block==False ?
         from matplotlib._pylab_helpers import Gcf

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -1026,10 +1026,6 @@ class _BackendQT5(_Backend):
     FigureManager = FigureManagerQT
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.canvas.draw_idle()
-
-    @staticmethod
     def mainloop():
         old_signal = signal.getsignal(signal.SIGINT)
         # allow SIGINT exceptions to close the plot window.

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -307,10 +307,6 @@ class _BackendWebAgg(_Backend):
     FigureManager = core.FigureManagerWebAgg
 
     @staticmethod
-    def trigger_manager_draw(manager):
-        manager.canvas.draw_idle()
-
-    @staticmethod
     def show():
         WebAggApplication.initialize()
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1649,10 +1649,6 @@ class _BackendWx(_Backend):
     FigureManager = FigureManagerWx
     _frame_class = FigureFrameWx
 
-    @staticmethod
-    def trigger_manager_draw(manager):
-        manager.canvas.draw_idle()
-
     @classmethod
     def new_figure_manager(cls, num, *args, **kwargs):
         # Create a wx.App instance if it has not been created so far.


### PR DESCRIPTION
## PR Summary

Previously `draw_if_interactive` would call `show()` on tk and nbagg, but only
`draw_idle()` on the other backends.  I would guess this was an accident
of history.

Remove that discrepancy, and the customization point
(`trigger_manager_draw`) that I previously implemented to repro
the historical behavior. (`trigger_manager_draw` is in the private
`_Backend` class, so doesn't need a deprecation period.)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
