### PR TITLE
Add a code of conduct link to github

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+Matplotlib follows the Python Software Foundation Code of Conduct in everything we do,
+see https://www.python.org/psf/conduct/.


### PR DESCRIPTION
This is in a similar vein to the numpy equivalent: https://github.com/numpy/numpy/blob/master/.github/CODE_OF_CONDUCT.md

Fixes https://github.com/matplotlib/matplotlib/issues/18534