### PR TITLE
DOC: add code of conduct

### DIFF
--- a/doc/devel/conduct/CoC_reporting_manual.rst
+++ b/doc/devel/conduct/CoC_reporting_manual.rst
@@ -1,0 +1,220 @@
+:orphan:
+
+.. _CoC_reporting_manual:
+
+Matplotlib Code of Conduct - How to follow up on a report
+----------------------------------------------------
+
+This is the manual followed by Matplotlib's Code of Conduct Committee. It's used
+when we respond to an issue to make sure we're consistent and fair.
+
+Enforcing the Code of Conduct impacts our community today and for the future.
+It's an action that we do not take lightly. When reviewing enforcement
+measures, the Code of Conduct Committee will keep the following values and
+guidelines in mind:
+
+* Act in a personal manner rather than impersonal.  The Committee can engage
+  the parties to understand the situation, while respecting the privacy and any
+  necessary confidentiality of reporters.  However, sometimes it is necessary
+  to communicate with one or more individuals directly: the Committee's goal is
+  to improve the health of our community rather than only produce a formal
+  decision.
+
+* Emphasize empathy for individuals rather than judging behavior, avoiding
+  binary labels of "good" and "bad/evil". Overt, clear-cut aggression and
+  harassment exists and we will be address that firmly.  But many scenarios
+  that can prove challenging to resolve are those where normal disagreements
+  devolve into unhelpful or harmful behavior from multiple parties.
+  Understanding the full context and finding a path that re-engages all is
+  hard, but ultimately the most productive for our community.
+
+* We understand that email is a difficult medium and can be isolating.
+  Receiving criticism over email, without personal contact, can be
+  particularly painful.  This makes it especially important to keep an
+  atmosphere of open-minded respect of the views of others.  It also means
+  that we must be transparent in our actions, and that we will do everything
+  in our power to make sure that all our members are treated fairly and with
+  sympathy.
+
+* Discrimination can be subtle and it can be unconscious. It can show itself
+  as unfairness and hostility in otherwise ordinary interactions.  We know
+  that this does occur, and we will take care to look out for it.  We would
+  very much like to hear from you if you feel you have been treated unfairly,
+  and we will use these procedures to make sure that your complaint is heard
+  and addressed.
+
+* Help increase engagement in good discussion practice: try to identify where
+  discussion may have broken down and provide actionable information, pointers
+  and resources that can lead to positive change on these points.
+
+* Be mindful of the needs of new members: provide them with explicit support
+  and consideration, with the aim of increasing participation from
+  underrepresented groups in particular.
+
+* Individuals come from different cultural backgrounds and native languages.
+  Try to identify any honest misunderstandings caused by a non-native speaker
+  and help them understand the issue and what they can change to avoid causing
+  offence.  Complex discussion in a foreign language can be very intimidating,
+  and we want to grow our diversity also across nationalities and cultures.
+
+*Mediation*: voluntary, informal mediation is a tool at our disposal.  In
+contexts such as when two or more parties have all escalated to the point of
+inappropriate behavior (something sadly common in human conflict), it may be
+useful to facilitate a mediation process. This is only an example: the
+Committee can consider mediation in any case, mindful that the process is meant
+to be strictly voluntary and no party can be pressured to participate. If the
+Committee suggests mediation, it should:
+
+* Find a candidate who can serve as a mediator.
+* Obtain the agreement of the reporter(s). The reporter(s) have complete
+  freedom to decline the mediation idea, or to propose an alternate mediator.
+* Obtain the agreement of the reported person(s).
+* Settle on the mediator: while parties can propose a different mediator than
+  the suggested candidate, only if common agreement is reached on all terms can
+  the process move forward.
+* Establish a timeline for mediation to complete, ideally within two weeks.
+
+The mediator will engage with all the parties and seek a resolution that is
+satisfactory to all.  Upon completion, the mediator will provide a report
+(vetted by all parties to the process) to the Committee, with recommendations
+on further steps.  The Committee will then evaluate these results (whether
+satisfactory resolution was achieved or not) and decide on any additional
+action deemed necessary.
+
+
+How the committee will respond to reports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the committee (or a committee member) receives a report, they will first
+determine whether the report is about a clear and severe breach (as defined
+below).  If so, immediate action needs to be taken in addition to the regular
+report handling process.
+
+Clear and severe breach actions
++++++++++++++++++++++++++++++++
+
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse.  We will deal quickly with clear and
+severe breaches like personal threats, violent, sexist or racist language.
+
+When a member of the Code of Conduct committee becomes aware of a clear and
+severe breach, they will do the following:
+
+* Immediately disconnect the originator from all Matplotlib communication channels.
+* Reply to the reporter that their report has been received and that the
+  originator has been disconnected.
+* In every case, the moderator should make a reasonable effort to contact the
+  originator, and tell them specifically how their language or actions
+  qualify as a "clear and severe breach".  The moderator should also say
+  that, if the originator believes this is unfair or they want to be
+  reconnected to Matplotlib, they have the right to ask for a review, as below, by
+  the Code of Conduct Committee.
+  The moderator should copy this explanation to the Code of Conduct Committee.
+* The Code of Conduct Committee will formally review and sign off on all cases
+  where this mechanism has been applied to make sure it is not being used to
+  control ordinary heated disagreement.
+
+Report handling
++++++++++++++++
+
+When a report is sent to the committee they will immediately reply to the
+reporter to confirm receipt. This reply must be sent within 72 hours, and the
+group should strive to respond much quicker than that.
+
+If a report doesn't contain enough information, the committee will obtain all
+relevant data before acting. The committee is empowered to act on the Steering
+Council’s behalf in contacting any individuals involved to get a more complete
+account of events.
+
+The committee will then review the incident and determine, to the best of their
+ability:
+
+* What happened.
+* Whether this event constitutes a Code of Conduct violation.
+* Who are the responsible party(ies).
+* Whether this is an ongoing situation, and there is a threat to anyone's
+  physical safety.
+
+This information will be collected in writing, and whenever possible the
+group's deliberations will be recorded and retained (i.e. chat transcripts,
+email discussions, recorded conference calls, summaries of voice conversations,
+etc).
+
+It is important to retain an archive of all activities of this committee to
+ensure consistency in behavior and provide institutional memory for the
+project.  To assist in this, the default channel of discussion for this
+committee will be a private mailing list accessible to current and future
+members of the committee as well as members of the Steering Council upon
+justified request. If the Committee finds the need to use off-list
+communications (e.g. phone calls for early/rapid response), it should in all
+cases summarize these back to the list so there's a good record of the process.
+
+The Code of Conduct Committee should aim to have a resolution agreed upon within
+two weeks. In the event that a resolution can't be determined in that time, the
+committee will respond to the reporter(s) with an update and projected timeline
+for resolution.
+
+
+.. _CoC_resolutions:
+
+Resolutions
+~~~~~~~~~~~
+
+The committee must agree on a resolution by consensus. If the group cannot reach
+consensus and deadlocks for over a week, the group will turn the matter over to
+the Steering Council for resolution.
+
+
+Possible responses may include:
+
+* Taking no further action
+
+  - if we determine no violations have occurred.
+  - if the matter has been resolved publicly while the committee was considering responses.
+
+* Coordinating voluntary mediation: if all involved parties agree, the
+  Committee may facilitate a mediation process as detailed above.
+* Remind publicly, and point out that some behavior/actions/language have been
+  judged inappropriate and why in the current context, or can but hurtful to
+  some people, requesting the community to self-adjust.
+* A private reprimand from the committee to the individual(s) involved. In this
+  case, the group chair will deliver that reprimand to the individual(s) over
+  email, cc'ing the group.
+* A public reprimand. In this case, the committee chair will deliver that
+  reprimand in the same venue that the violation occurred, within the limits of
+  practicality. E.g., the original mailing list for an email violation, but
+  for a chat room discussion where the person/context may be gone, they can be
+  reached by other means. The group may choose to publish this message
+  elsewhere for documentation purposes.
+* A request for a public or private apology, assuming the reporter agrees to
+  this idea: they may at their discretion refuse further contact with the
+  violator. The chair will deliver this request. The committee may, if it
+  chooses, attach "strings" to this request: for example, the group may ask a
+  violator to apologize in order to retain one’s membership on a mailing list.
+* A "mutually agreed upon hiatus" where the committee asks the individual to
+  temporarily refrain from community participation. If the individual chooses
+  not to take a temporary break voluntarily, the committee may issue a
+  "mandatory cooling off period".
+* A permanent or temporary ban from some or all Matplotlib spaces (mailing lists,
+  gitter.im, etc.). The group will maintain records of all such bans so that
+  they may be reviewed in the future or otherwise maintained.
+
+Once a resolution is agreed upon, but before it is enacted, the committee will
+contact the original reporter and any other affected parties and explain the
+proposed resolution. The committee will ask if this resolution is acceptable,
+and must note feedback for the record.
+
+Finally, the committee will make a report to the Matplotlib Steering Council (as
+well as the Matplotlib core team in the event of an ongoing resolution, such as a
+ban).
+
+The committee will never publicly discuss the issue; all public statements will
+be made by the chair of the Code of Conduct Committee or the Matplotlib Steering
+Council.
+
+
+Conflicts of Interest
+~~~~~~~~~~~~~~~~~~~~~
+
+In the event of any conflict of interest, a committee member must immediately
+notify the other members, and recuse themselves if necessary.

--- a/doc/devel/conduct/CoC_reporting_manual.rst
+++ b/doc/devel/conduct/CoC_reporting_manual.rst
@@ -22,7 +22,7 @@ guidelines in mind:
 
 * Emphasize empathy for individuals rather than judging behavior, avoiding
   binary labels of "good" and "bad/evil". Overt, clear-cut aggression and
-  harassment exists and we will be address that firmly.  But many scenarios
+  harassment exists and we will address that firmly.  But many scenarios
   that can prove challenging to resolve are those where normal disagreements
   devolve into unhelpful or harmful behavior from multiple parties.
   Understanding the full context and finding a path that re-engages all is
@@ -48,8 +48,7 @@ guidelines in mind:
   and resources that can lead to positive change on these points.
 
 * Be mindful of the needs of new members: provide them with explicit support
-  and consideration, with the aim of increasing participation from
-  underrepresented groups in particular.
+  and consideration.
 
 * Individuals come from different cultural backgrounds and native languages.
   Try to identify any honest misunderstandings caused by a non-native speaker
@@ -177,16 +176,16 @@ Possible responses may include:
 * Coordinating voluntary mediation: if all involved parties agree, the
   Committee may facilitate a mediation process as detailed above.
 * Remind publicly, and point out that some behavior/actions/language have been
-  judged inappropriate and why in the current context, or can but hurtful to
+  judged inappropriate and why in the current context, or can be hurtful to
   some people, requesting the community to self-adjust.
 * A private reprimand from the committee to the individual(s) involved. In this
   case, the group chair will deliver that reprimand to the individual(s) over
   email, cc'ing the group.
 * A public reprimand. In this case, the committee chair will deliver that
   reprimand in the same venue that the violation occurred, within the limits of
-  practicality. E.g., the original mailing list for an email violation, but
-  for a chat room discussion where the person/context may be gone, they can be
-  reached by other means. The group may choose to publish this message
+  practicality. For example, the original mailing list for an email violation,
+  but for a chat room discussion where the person/context may be gone, they can
+  be reached by other means. The group may choose to publish this message
   elsewhere for documentation purposes.
 * A request for a public or private apology, assuming the reporter agrees to
   this idea: they may at their discretion refuse further contact with the

--- a/doc/devel/conduct/CoC_reporting_manual.rst
+++ b/doc/devel/conduct/CoC_reporting_manual.rst
@@ -3,10 +3,10 @@
 .. _CoC_reporting_manual:
 
 Matplotlib Code of Conduct - How to follow up on a report
-----------------------------------------------------
+---------------------------------------------------------
 
-This is the manual followed by Matplotlib's Code of Conduct Committee. It's used
-when we respond to an issue to make sure we're consistent and fair.
+This is the manual followed by Matplotlib's Code of Conduct Committee. It's
+used when we respond to an issue to make sure we're consistent and fair.
 
 Enforcing the Code of Conduct impacts our community today and for the future.
 It's an action that we do not take lightly. When reviewing enforcement
@@ -100,15 +100,16 @@ severe breaches like personal threats, violent, sexist or racist language.
 When a member of the Code of Conduct committee becomes aware of a clear and
 severe breach, they will do the following:
 
-* Immediately disconnect the originator from all Matplotlib communication channels.
+* Immediately disconnect the originator from all Matplotlib communication
+  channels.
 * Reply to the reporter that their report has been received and that the
   originator has been disconnected.
 * In every case, the moderator should make a reasonable effort to contact the
   originator, and tell them specifically how their language or actions
   qualify as a "clear and severe breach".  The moderator should also say
   that, if the originator believes this is unfair or they want to be
-  reconnected to Matplotlib, they have the right to ask for a review, as below, by
-  the Code of Conduct Committee.
+  reconnected to Matplotlib, they have the right to ask for a review, as below,
+  by the Code of Conduct Committee.
   The moderator should copy this explanation to the Code of Conduct Committee.
 * The Code of Conduct Committee will formally review and sign off on all cases
   where this mechanism has been applied to make sure it is not being used to
@@ -149,10 +150,10 @@ justified request. If the Committee finds the need to use off-list
 communications (e.g. phone calls for early/rapid response), it should in all
 cases summarize these back to the list so there's a good record of the process.
 
-The Code of Conduct Committee should aim to have a resolution agreed upon within
-two weeks. In the event that a resolution can't be determined in that time, the
-committee will respond to the reporter(s) with an update and projected timeline
-for resolution.
+The Code of Conduct Committee should aim to have a resolution agreed upon
+within two weeks. In the event that a resolution can't be determined in that
+time, the committee will respond to the reporter(s) with an update and
+projected timeline for resolution.
 
 
 .. _CoC_resolutions:
@@ -169,8 +170,9 @@ Possible responses may include:
 
 * Taking no further action
 
-  - if we determine no violations have occurred.
-  - if the matter has been resolved publicly while the committee was considering responses.
+  - if it is determined no violations have occurred.
+  - if the matter has been resolved publicly while the committee was
+    considering responses.
 
 * Coordinating voluntary mediation: if all involved parties agree, the
   Committee may facilitate a mediation process as detailed above.
@@ -195,22 +197,22 @@ Possible responses may include:
   temporarily refrain from community participation. If the individual chooses
   not to take a temporary break voluntarily, the committee may issue a
   "mandatory cooling off period".
-* A permanent or temporary ban from some or all Matplotlib spaces (mailing lists,
-  gitter.im, etc.). The group will maintain records of all such bans so that
-  they may be reviewed in the future or otherwise maintained.
+* A permanent or temporary ban from some or all Matplotlib spaces (mailing
+  lists, forums, chat rooms, etc.). The group will maintain records of all
+  such bans so that they may be reviewed in the future or otherwise maintained.
 
 Once a resolution is agreed upon, but before it is enacted, the committee will
 contact the original reporter and any other affected parties and explain the
 proposed resolution. The committee will ask if this resolution is acceptable,
 and must note feedback for the record.
 
-Finally, the committee will make a report to the Matplotlib Steering Council (as
-well as the Matplotlib core team in the event of an ongoing resolution, such as a
-ban).
+Finally, the committee will make a report to the Matplotlib Steering Council
+(as well as the Matplotlib core team in the event of an ongoing resolution,
+such as a ban).
 
 The committee will never publicly discuss the issue; all public statements will
-be made by the chair of the Code of Conduct Committee or the Matplotlib Steering
-Council.
+be made by the chair of the Code of Conduct Committee or the Matplotlib
+Steering Council.
 
 
 Conflicts of Interest

--- a/doc/devel/conduct/code_of_conduct.rst
+++ b/doc/devel/conduct/code_of_conduct.rst
@@ -1,0 +1,162 @@
+Matplotlib Code of Conduct
+==========================
+
+
+Introduction
+------------
+
+This code of conduct applies to all spaces managed by the Matplotlib project,
+including all public and private mailing lists, issue trackers, wikis, blogs,
+Twitter, and any other communication channel used by our community.  The
+Matplotlib project does not organise in-person events, however events related
+to our community should have a code of conduct similar in spirit to this one.
+
+This code of conduct should be honored by everyone who participates in
+the Matplotlib community formally or informally, or claims any affiliation with the
+project, in any project-related activities and especially when representing the
+project, in any role.
+
+This code is not exhaustive nor complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
+
+
+Specific Guidelines
+-------------------
+
+We strive to:
+
+1. Be open. We invite anyone to participate in our community. We prefer to use
+   public methods of communication for project-related messages, unless
+   discussing something sensitive. This applies to messages for help or
+   project-related support, too; not only is a public support request much more
+   likely to result in an answer to a question, it also ensures that any
+   inadvertent mistakes in answering are more easily detected and corrected.
+
+2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
+   conflict, and assume good intentions. We may all experience some frustration
+   from time to time, but we do not allow frustration to turn into a personal
+   attack. A community where people feel uncomfortable or threatened is not a
+   productive one.
+
+3. Be collaborative. Our work will be used by other people, and in turn we will
+   depend on the work of others. When we make something for the benefit of the
+   project, we are willing to explain to others how it works, so that they can
+   build on the work to make it even better. Any decision we make will affect
+   users and colleagues, and we take those consequences seriously when making
+   decisions.
+
+4. Be inquisitive. Nobody knows everything! Asking questions early avoids many
+   problems later, so we encourage questions, although we may direct them to
+   the appropriate forum. We will try hard to be responsive and helpful.
+
+5. Be careful in the words that we choose.  We are careful and respectful in
+   our communication and we take responsibility for our own speech. Be kind to
+   others. Do not insult or put down other participants.  We will not accept
+   harassment or other exclusionary behaviour, such as:
+
+    - Violent threats or language directed against another person.
+    - Sexist, racist, or otherwise discriminatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting (or threatening to post) other people's personally identifying information ("doxing").
+    - Sharing private content, such as emails sent privately or non-publicly,
+      or unlogged forums such as IRC channel history, without the sender's consent.
+    - Personal insults, especially those using racist or sexist terms.
+    - Unwelcome sexual attention.
+    - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
+    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    - Advocating for, or encouraging, any of the above behaviour.
+
+
+Diversity Statement
+-------------------
+
+The Matplotlib project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone enjoys being part of. Although
+we may not always be able to accommodate each individual's preferences, we try
+our best to treat everyone kindly.
+
+No matter how you identify yourself or how others perceive you: we welcome you.
+Though no list can hope to be comprehensive, we explicitly honour diversity in:
+age, culture, ethnicity, genotype, gender identity or expression, language,
+national origin, neurotype, phenotype, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, subculture and technical
+ability, to the extent that these do not conflict with this code of conduct.
+
+Though we welcome people fluent in all languages, Matplotlib development is
+conducted in English.
+
+Standards for behaviour in the Matplotlib community are detailed in the Code of
+Conduct above. Participants in our community should uphold these standards
+in all their interactions and help others to do so as well (see next section).
+
+
+Reporting Guidelines
+--------------------
+
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse.  We also recognize that sometimes
+people may have a bad day, or be unaware of some of the guidelines in this Code
+of Conduct. Please keep this in mind when deciding on how to respond to a
+breach of this Code.
+
+For clearly intentional breaches, report those to the Code of Conduct committee
+(see below). For possibly unintentional breaches, you may reply to the person
+and point out this code of conduct (either in public or in private, whatever is
+most appropriate). If you would prefer not to do that, please feel free to
+report to the Code of Conduct Committee directly, or ask the Committee for
+advice, in confidence.
+
+You can report issues to the Matplotlib Code of Conduct committee, at
+Matplotlib@numfocus.org. Currently, the committee consists of:
+
+- Stefan van der Walt
+- Melissa Weber Mendonça
+- Anirudh Subramanian
+
+If your report involves any members of the committee, or if they feel they have
+a conflict of interest in handling it, then they will recuse themselves from
+considering your report. Alternatively, if for any reason you feel
+uncomfortable making a report to the committee, then you can also contact:
+
+- Senior `NumFOCUS staff <https://numfocus.org/code-of-conduct#persons-responsible>`__: conduct@numfocus.org
+
+
+Incident reporting resolution & Code of Conduct enforcement
+-----------------------------------------------------------
+
+*This section summarizes the most important points, more details can be found
+in* :ref:`CoC_reporting_manual`.
+
+We will investigate and respond to all complaints. The Matplotlib Code of Conduct
+Committee and the Matplotlib Steering Committee (if involved) will protect the
+identity of the reporter, and treat the content of complaints as confidential
+(unless the reporter agrees otherwise).
+
+In case of severe and obvious breaches, e.g. personal threat or violent, sexist
+or racist language, we will immediately disconnect the originator from Matplotlib
+communication channels; please see the manual for details.
+
+In cases not involving clear severe and obvious breaches of this code of
+conduct, the process for acting on any received code of conduct violation
+report will be:
+
+1. acknowledge report is received
+2. reasonable discussion/feedback
+3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
+4. enforcement via transparent decision (see :ref:`CoC_resolutions`) by the
+   Code of Conduct Committee
+
+The committee will respond to any report as soon as possible, and at most
+within 72 hours.
+
+
+Endnotes
+--------
+
+We are thankful to the groups behind the following documents, from which we
+drew content and inspiration:
+
+- `The NumPy Code of Conduct <https://numpy.org/code-of-conduct/>`_
+- `The SciPy Code of Conduct <https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html>`_

--- a/doc/devel/conduct/code_of_conduct.rst
+++ b/doc/devel/conduct/code_of_conduct.rst
@@ -8,12 +8,13 @@ Introduction
 This code of conduct applies to all spaces managed by the Matplotlib project,
 including all public and private mailing lists, issue trackers, wikis, blogs,
 Twitter, and any other communication channel used by our community.  The
-Matplotlib project does not organise in-person events, however events related
-to our community should have a code of conduct similar in spirit to this one.
+Matplotlib project does not currently organise in-person events, however events
+related to our community should have a code of conduct similar in spirit to
+this one.
 
 This code of conduct should be honored by everyone who participates in
-the Matplotlib community formally or informally, or claims any affiliation with the
-project, in any project-related activities and especially when representing the
+the Matplotlib community formally or informally, or claims any affiliation with
+the project, in any project-related activities and when representing the
 project, in any role.
 
 This code is not exhaustive nor complete. It serves to distill our common
@@ -59,21 +60,25 @@ We strive to:
     - Violent threats or language directed against another person.
     - Sexist, racist, or otherwise discriminatory jokes and language.
     - Posting sexually explicit or violent material.
-    - Posting (or threatening to post) other people's personally identifying information ("doxing").
+    - Posting (or threatening to post) other people's personally identifying
+      information ("doxing").
     - Sharing private content, such as emails sent privately or non-publicly,
-      or unlogged forums such as IRC channel history, without the sender's consent.
+      or unlogged forums such as IRC channel history, without the sender's
+      consent.
     - Personal insults, especially those using racist or sexist terms.
     - Unwelcome sexual attention.
-    - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
-    - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+    - Excessive profanity. Please avoid swearwords; people differ greatly in
+      their sensitivity to swearing.
+    - Repeated harassment of others. In general, if someone asks you to stop,
+      then stop.
     - Advocating for, or encouraging, any of the above behaviour.
 
 
 Diversity Statement
 -------------------
 
-The Matplotlib project welcomes and encourages participation by everyone. We are
-committed to being a community that everyone enjoys being part of. Although
+The Matplotlib project welcomes and encourages participation by everyone. We
+are committed to being a community that everyone enjoys being part of. Although
 we may not always be able to accommodate each individual's preferences, we try
 our best to treat everyone kindly.
 
@@ -109,11 +114,10 @@ report to the Code of Conduct Committee directly, or ask the Committee for
 advice, in confidence.
 
 You can report issues to the Matplotlib Code of Conduct committee, at
-Matplotlib@numfocus.org. Currently, the committee consists of:
+matplotlib@numfocus.org. Currently, the committee consists of:
 
-- Stefan van der Walt
-- Melissa Weber Mendonça
-- Anirudh Subramanian
+- Thomas Caswell
+- Hannah Aizenman
 
 If your report involves any members of the committee, or if they feel they have
 a conflict of interest in handling it, then they will recuse themselves from
@@ -129,14 +133,14 @@ Incident reporting resolution & Code of Conduct enforcement
 *This section summarizes the most important points, more details can be found
 in* :ref:`CoC_reporting_manual`.
 
-We will investigate and respond to all complaints. The Matplotlib Code of Conduct
-Committee and the Matplotlib Steering Committee (if involved) will protect the
-identity of the reporter, and treat the content of complaints as confidential
-(unless the reporter agrees otherwise).
+We will investigate and respond to all complaints. The Matplotlib Code of
+Conduct Committee and the Matplotlib Steering Committee (if involved) will
+protect the identity of the reporter, and treat the content of complaints as
+confidential (unless the reporter agrees otherwise).
 
 In case of severe and obvious breaches, e.g. personal threat or violent, sexist
-or racist language, we will immediately disconnect the originator from Matplotlib
-communication channels; please see the manual for details.
+or racist language, we will immediately disconnect the originator from
+Matplotlib communication channels; please see the manual for details.
 
 In cases not involving clear severe and obvious breaches of this code of
 conduct, the process for acting on any received code of conduct violation
@@ -144,7 +148,8 @@ report will be:
 
 1. acknowledge report is received
 2. reasonable discussion/feedback
-3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
+3. mediation (if feedback didn't help, and only if both reporter and reportee
+   agree to this)
 4. enforcement via transparent decision (see :ref:`CoC_resolutions`) by the
    Code of Conduct Committee
 


### PR DESCRIPTION
## PR Summary

This is a stub that just copies the numpy CoC and does a search and replace for Matplotlib.  https://numpy.org/code-of-conduct/  I'm not particularly advocating for this, though it seems fine to me.  This is just to get the ball rolling; anyone can take this over if they like.  @dstansby @story645 

Codes of conduct (feel free to add more):

- Python: https://www.python.org/psf/conduct/
- Jupyter: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
  - Scipy: https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html (derives from jupyter)
    - Numpy: https://numpy.org/code-of-conduct/ (derives from scipy)
- nteract: https://github.com/nteract/nteract/blob/master/CODE_OF_CONDUCT.md

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
