### PR TITLE
Convert _math_style_dict into an Enum.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -3,6 +3,7 @@ Implementation details for :mod:`.mathtext`.
 """
 
 from collections import namedtuple
+import enum
 import functools
 from io import StringIO
 import logging
@@ -1944,8 +1945,11 @@ class Parser:
     The grammar is based directly on that in TeX, though it cuts a few corners.
     """
 
-    _math_style_dict = dict(displaystyle=0, textstyle=1,
-                            scriptstyle=2, scriptscriptstyle=3)
+    class _MathStyle(enum.Enum):
+        DISPLAYSTYLE = enum.auto()
+        TEXTSTYLE = enum.auto()
+        SCRIPTSTYLE = enum.auto()
+        SCRIPTSCRIPTSTYLE = enum.auto()
 
     _binary_operators = set('''
       + * -
@@ -2798,8 +2802,7 @@ class Parser:
 
         rule = float(rule)
 
-        # If style != displaystyle == 0, shrink the num and den
-        if style != self._math_style_dict['displaystyle']:
+        if style is not self._MathStyle.DISPLAYSTYLE:
             num.shrink()
             den.shrink()
         cnum = HCentered([num])
@@ -2848,8 +2851,8 @@ class Parser:
             state.font, state.fontsize, state.dpi)
         num, den = toks[0]
 
-        return self._genfrac('', '', thickness,
-                             self._math_style_dict['textstyle'], num, den)
+        return self._genfrac('', '', thickness, self._MathStyle.TEXTSTYLE,
+                             num, den)
 
     def dfrac(self, s, loc, toks):
         assert len(toks) == 1
@@ -2860,16 +2863,16 @@ class Parser:
             state.font, state.fontsize, state.dpi)
         num, den = toks[0]
 
-        return self._genfrac('', '', thickness,
-                             self._math_style_dict['displaystyle'], num, den)
+        return self._genfrac('', '', thickness, self._MathStyle.DISPLAYSTYLE,
+                             num, den)
 
     def binom(self, s, loc, toks):
         assert len(toks) == 1
         assert len(toks[0]) == 2
         num, den = toks[0]
 
-        return self._genfrac('(', ')', 0.0,
-                             self._math_style_dict['textstyle'], num, den)
+        return self._genfrac('(', ')', 0.0, self._MathStyle.TEXTSTYLE,
+                             num, den)
 
     def sqrt(self, s, loc, toks):
         root, body = toks[0]


### PR DESCRIPTION
## PR Summary

Instead of a weird `dict` thing.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).