### PR TITLE
Accept same types to errorevery as markevery

### DIFF
--- a/doc/users/next_whats_new/errorbar_errorevery.rst
+++ b/doc/users/next_whats_new/errorbar_errorevery.rst
@@ -1,0 +1,20 @@
+``errorbar`` *errorevery* parameter matches *markevery*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to the *markevery* parameter to `~.Axes.plot`, the *errorevery*
+parameter of `~.Axes.errorbar` now accept slices and NumPy fancy indexes (which
+must match the size of *x*).
+
+.. plot::
+
+    x = np.linspace(0, 1, 15)
+    y = x * (1-x)
+    yerr = y/6
+
+    fig, ax = plt.subplots(2, constrained_layout=True)
+    ax[0].errorbar(x, y, yerr, capsize=2)
+    ax[0].set_title('errorevery unspecified')
+
+    ax[1].errorbar(x, y, yerr, capsize=2,
+                   errorevery=[False, True, True, False, True] * 3)
+    ax[1].set_title('errorevery=[False, True, True, False, True] * 3')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3219,6 +3219,7 @@ class Axes(_AxesBase):
         base_style.pop('markerfacecolor', None)
         base_style.pop('markeredgewidth', None)
         base_style.pop('markeredgecolor', None)
+        base_style.pop('markevery', None)
         base_style.pop('linestyle', None)
 
         # Make the style dict for the line collections (the bars).

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3390,7 +3390,7 @@ def test_errorbar_with_prop_cycle(fig_test, fig_ref):
 
 
 @check_figures_equal()
-def test_errorbar_offsets(fig_test, fig_ref):
+def test_errorbar_every(fig_test, fig_ref):
     x = np.linspace(0, 1, 15)
     y = x * (1-x)
     yerr = y/6
@@ -3410,6 +3410,11 @@ def test_errorbar_offsets(fig_test, fig_ref):
         ax_ref.plot(x, y, c=color, zorder=2.1)
         ax_ref.errorbar(x[shift::4], y[shift::4], yerr[shift::4],
                         capsize=4, c=color, fmt='none')
+
+    # Check that markevery is propagated to line, without affecting errorbars.
+    ax_test.errorbar(x, y + 0.1, yerr, markevery=(1, 4), capsize=4, fmt='o')
+    ax_ref.plot(x[1::4], y[1::4] + 0.1, 'o', zorder=2.1)
+    ax_ref.errorbar(x, y + 0.1, yerr, capsize=4, fmt='none')
 
 
 @image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3389,6 +3389,23 @@ def test_errorbar_with_prop_cycle(fig_test, fig_ref):
     ax.set_xlim(1, 11)
 
 
+def test_errorbar_every_invalid():
+    x = np.linspace(0, 1, 15)
+    y = x * (1-x)
+    yerr = y/6
+
+    ax = plt.figure().subplots()
+
+    with pytest.raises(ValueError, match='not a tuple of two integers'):
+        ax.errorbar(x, y, yerr, errorevery=(1, 2, 3))
+    with pytest.raises(ValueError, match='not a tuple of two integers'):
+        ax.errorbar(x, y, yerr, errorevery=(1.3, 3))
+    with pytest.raises(ValueError, match='not a valid NumPy fancy index'):
+        ax.errorbar(x, y, yerr, errorevery=[False, True])
+    with pytest.raises(ValueError, match='not a recognized value'):
+        ax.errorbar(x, y, yerr, errorevery='foobar')
+
+
 @check_figures_equal()
 def test_errorbar_every(fig_test, fig_ref):
     x = np.linspace(0, 1, 15)
@@ -3401,7 +3418,7 @@ def test_errorbar_every(fig_test, fig_ref):
     for color, shift in zip('rgbk', [0, 0, 2, 7]):
         y += .02
 
-        # Using feature in question
+        # Check errorevery using an explicit offset and step.
         ax_test.errorbar(x, y, yerr, errorevery=(shift, 4),
                          capsize=4, c=color)
 
@@ -3415,6 +3432,22 @@ def test_errorbar_every(fig_test, fig_ref):
     ax_test.errorbar(x, y + 0.1, yerr, markevery=(1, 4), capsize=4, fmt='o')
     ax_ref.plot(x[1::4], y[1::4] + 0.1, 'o', zorder=2.1)
     ax_ref.errorbar(x, y + 0.1, yerr, capsize=4, fmt='none')
+
+    # Check that passing a slice to markevery/errorevery works.
+    ax_test.errorbar(x, y + 0.2, yerr, errorevery=slice(2, None, 3),
+                     markevery=slice(2, None, 3),
+                     capsize=4, c='C0', fmt='o')
+    ax_ref.plot(x[2::3], y[2::3] + 0.2, 'o', c='C0', zorder=2.1)
+    ax_ref.errorbar(x[2::3], y[2::3] + 0.2, yerr[2::3],
+                    capsize=4, c='C0', fmt='none')
+
+    # Check that passing an iterable to markevery/errorevery works.
+    ax_test.errorbar(x, y + 0.2, yerr, errorevery=[False, True, False] * 5,
+                     markevery=[False, True, False] * 5,
+                     capsize=4, c='C1', fmt='o')
+    ax_ref.plot(x[1::3], y[1::3] + 0.2, 'o', c='C1', zorder=2.1)
+    ax_ref.errorbar(x[1::3], y[1::3] + 0.2, yerr[1::3],
+                    capsize=4, c='C1', fmt='none')
 
 
 @image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])


### PR DESCRIPTION
## PR Summary

I did not add support for floating-point step sizes though, as errorbars are not continuous.

This also fixes a bug where passing `markevery` would crash, introduced in #17930, when the property dictionaries were changed around.

I haven't implemented for 3D, but will do that with #18436.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).