### PR TITLE
Support usetex in date Formatters

### DIFF
--- a/doc/users/next_whats_new/date_usetex.rst
+++ b/doc/users/next_whats_new/date_usetex.rst
@@ -1,0 +1,26 @@
+Date formatters now respect *usetex* rcParam
+--------------------------------------------
+
+The `.AutoDateFormatter` and `.ConciseDateFormatter` now respect
+:rc:`text.usetex`, and will thus use fonts consistent with TeX rendering of the
+default (non-date) formatter. TeX rendering may also be enabled/disabled by
+passing the *usetex* parameter when creating the formatter instance.
+
+In the following plot, both the x-axis (dates) and y-axis (numbers) now use the
+same (TeX) font:
+
+.. plot::
+
+    from datetime import datetime, timedelta
+    from matplotlib.dates import ConciseDateFormatter
+
+    plt.rc('text', usetex=True)
+
+    t0 = datetime(1968, 8, 1)
+    ts = [t0 + i * timedelta(days=1) for i in range(10)]
+
+    fig, ax = plt.subplots()
+    ax.plot(ts, range(10))
+    ax.xaxis.set_major_formatter(ConciseDateFormatter(ax.xaxis.get_major_locator()))
+    ax.set_xlabel('Date')
+    ax.set_ylabel('Value')

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -905,9 +905,19 @@ class AutoDateFormatter(ticker.Formatter):
 
     def __init__(self, locator, tz=None, defaultfmt='%Y-%m-%d'):
         """
-        Autoformat the date labels.  The default format is the one to use
-        if none of the values in ``self.scaled`` are greater than the unit
-        returned by ``locator._get_unit()``.
+        Autoformat the date labels.
+
+        Parameters
+        ----------
+        locator : `.ticker.Locator`
+            Locator that this axis is using.
+
+        tz : str, optional
+            Passed to `.dates.date2num`.
+
+        defaultfmt : str
+            The default format to use if none of the values in ``self.scaled``
+            are greater than the unit returned by ``locator._get_unit()``.
         """
         self._locator = locator
         self._tz = tz

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -162,7 +162,7 @@ import dateutil.parser
 import dateutil.tz
 import numpy as np
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.units as units
 import matplotlib.cbook as cbook
 import matplotlib.ticker as ticker
@@ -187,7 +187,7 @@ UTC = datetime.timezone.utc
 
 def _get_rc_timezone():
     """Retrieve the preferred timezone from the rcParams dictionary."""
-    s = matplotlib.rcParams['timezone']
+    s = mpl.rcParams['timezone']
     if s == 'UTC':
         return UTC
     return dateutil.tz.gettz(s)
@@ -281,7 +281,7 @@ def get_epoch():
     global _epoch
 
     if _epoch is None:
-        _epoch = matplotlib.rcParams['date.epoch']
+        _epoch = mpl.rcParams['date.epoch']
     return _epoch
 
 
@@ -913,7 +913,7 @@ class AutoDateFormatter(ticker.Formatter):
         self._tz = tz
         self.defaultfmt = defaultfmt
         self._formatter = DateFormatter(self.defaultfmt, tz)
-        rcParams = matplotlib.rcParams
+        rcParams = mpl.rcParams
         self.scaled = {
             DAYS_PER_YEAR: rcParams['date.autoformatter.year'],
             DAYS_PER_MONTH: rcParams['date.autoformatter.month'],

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -266,6 +266,26 @@ def test_date_formatter_callable():
     assert formatter([datetime.datetime(2014, 12, 25)]) == ['25-12//2014']
 
 
+@pytest.mark.parametrize('delta, expected', [
+    (datetime.timedelta(weeks=52 * 200),
+     [r'$\mathdefault{%d}$' % (year,) for year in range(1990, 2171, 20)]),
+    (datetime.timedelta(days=30),
+     [r'$\mathdefault{Jan %02d 1990}$' % (day,) for day in range(1, 32, 3)]),
+    (datetime.timedelta(hours=20),
+     [r'$\mathdefault{%02d:00:00}$' % (hour,) for hour in range(0, 21, 2)]),
+])
+def test_date_formatter_usetex(delta, expected):
+    d1 = datetime.datetime(1990, 1, 1)
+    d2 = d1 + delta
+
+    locator = mdates.AutoDateLocator(interval_multiples=False)
+    locator.create_dummy_axis()
+    locator.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
+
+    formatter = mdates.AutoDateFormatter(locator, usetex=True)
+    assert [formatter(loc) for loc in locator()] == expected
+
+
 def test_drange():
     """
     This test should check if drange works as expected, and if all the
@@ -501,6 +521,39 @@ def test_concise_formatter():
         d2 = d1 + t_delta
         strings = _create_auto_date_locator(d1, d2)
         assert strings == expected
+
+
+@pytest.mark.parametrize('t_delta, expected', [
+    (datetime.timedelta(weeks=52 * 200),
+     ['$\\mathdefault{%d}$' % (t, ) for t in range(1980, 2201, 20)]),
+    (datetime.timedelta(days=40),
+     ['$\\mathdefault{Jan}$', '$\\mathdefault{05}$', '$\\mathdefault{09}$',
+      '$\\mathdefault{13}$', '$\\mathdefault{17}$', '$\\mathdefault{21}$',
+      '$\\mathdefault{25}$', '$\\mathdefault{29}$', '$\\mathdefault{Feb}$',
+      '$\\mathdefault{05}$', '$\\mathdefault{09}$']),
+    (datetime.timedelta(hours=40),
+     ['$\\mathdefault{Jan{-}01}$', '$\\mathdefault{04:00}$',
+      '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
+      '$\\mathdefault{16:00}$', '$\\mathdefault{20:00}$',
+      '$\\mathdefault{Jan{-}02}$', '$\\mathdefault{04:00}$',
+      '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
+      '$\\mathdefault{16:00}$']),
+    (datetime.timedelta(seconds=2),
+     ['$\\mathdefault{59.5}$', '$\\mathdefault{00:00}$',
+      '$\\mathdefault{00.5}$', '$\\mathdefault{01.0}$',
+      '$\\mathdefault{01.5}$', '$\\mathdefault{02.0}$',
+      '$\\mathdefault{02.5}$']),
+])
+def test_concise_formatter_usetex(t_delta, expected):
+    d1 = datetime.datetime(1997, 1, 1)
+    d2 = d1 + t_delta
+
+    locator = mdates.AutoDateLocator(interval_multiples=True)
+    locator.create_dummy_axis()
+    locator.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
+
+    formatter = mdates.ConciseDateFormatter(locator, usetex=True)
+    assert formatter.format_ticks(locator()) == expected
 
 
 def test_concise_formatter_formats():


### PR DESCRIPTION
## PR Summary

And some small cleanup.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).