### PR TITLE
Remove incorrect override of pcolor/contour in parasite axes.

### DIFF
--- a/doc/api/next_api_changes/behavior/18560-AL.rst
+++ b/doc/api/next_api_changes/behavior/18560-AL.rst
@@ -1,0 +1,4 @@
+Parasite Axes pcolor and pcolormesh now defaults to placing grid edges at integers, not half-integers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is consistent with `~.Axes.pcolor` and `~.Axes.pcolormesh`.

--- a/examples/axisartist/demo_curvelinear_grid.py
+++ b/examples/axisartist/demo_curvelinear_grid.py
@@ -109,6 +109,11 @@ def curvelinear_test2(fig):
     ax1.parasites.append(ax2)
     ax2.plot(np.linspace(0, 30, 51), np.linspace(10, 10, 51), linewidth=2)
 
+    ax2.pcolor(np.linspace(0, 90, 4), np.linspace(0, 10, 4),
+               np.arange(9).reshape((3, 3)))
+    ax2.contour(np.linspace(0, 90, 4), np.linspace(0, 10, 4),
+                np.arange(16).reshape((4, 4)), colors="k")
+
 
 if __name__ == "__main__":
     fig = plt.figure(figsize=(7, 4))

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -7,8 +7,6 @@ from matplotlib.axes import subplot_class_factory
 from matplotlib.transforms import Bbox
 from .mpl_axes import Axes
 
-import numpy as np
-
 
 class ParasiteAxesBase:
 
@@ -107,72 +105,6 @@ class ParasiteAxesAuxTransBase:
                 viewlim.transformed(self.transAux.inverted()))
         else:
             _api.check_in_list([None, "equal", "transform"], mode=mode)
-
-    def _pcolor(self, super_pcolor, *XYC, **kwargs):
-        if len(XYC) == 1:
-            C = XYC[0]
-            ny, nx = C.shape
-
-            gx = np.arange(-0.5, nx)
-            gy = np.arange(-0.5, ny)
-
-            X, Y = np.meshgrid(gx, gy)
-        else:
-            X, Y, C = XYC
-
-        if "transform" in kwargs:
-            mesh = super_pcolor(X, Y, C, **kwargs)
-        else:
-            orig_shape = X.shape
-            xyt = np.column_stack([X.flat, Y.flat])
-            wxy = self.transAux.transform(xyt)
-            gx = wxy[:, 0].reshape(orig_shape)
-            gy = wxy[:, 1].reshape(orig_shape)
-            mesh = super_pcolor(gx, gy, C, **kwargs)
-            mesh.set_transform(self._parent_axes.transData)
-
-        return mesh
-
-    def pcolormesh(self, *XYC, **kwargs):
-        return self._pcolor(super().pcolormesh, *XYC, **kwargs)
-
-    def pcolor(self, *XYC, **kwargs):
-        return self._pcolor(super().pcolor, *XYC, **kwargs)
-
-    def _contour(self, super_contour, *XYCL, **kwargs):
-
-        if len(XYCL) <= 2:
-            C = XYCL[0]
-            ny, nx = C.shape
-
-            gx = np.arange(0., nx)
-            gy = np.arange(0., ny)
-
-            X, Y = np.meshgrid(gx, gy)
-            CL = XYCL
-        else:
-            X, Y = XYCL[:2]
-            CL = XYCL[2:]
-
-        if "transform" in kwargs:
-            cont = super_contour(X, Y, *CL, **kwargs)
-        else:
-            orig_shape = X.shape
-            xyt = np.column_stack([X.flat, Y.flat])
-            wxy = self.transAux.transform(xyt)
-            gx = wxy[:, 0].reshape(orig_shape)
-            gy = wxy[:, 1].reshape(orig_shape)
-            cont = super_contour(gx, gy, *CL, **kwargs)
-            for c in cont.collections:
-                c.set_transform(self._parent_axes.transData)
-
-        return cont
-
-    def contour(self, *XYCL, **kwargs):
-        return self._contour(super().contour, *XYCL, **kwargs)
-
-    def contourf(self, *XYCL, **kwargs):
-        return self._contour(super().contourf, *XYCL, **kwargs)
 
     def apply_aspect(self, position=None):
         self.update_viewlim()


### PR DESCRIPTION
The override of `pcolor`, `pcolormesh`, `contour`, and `contourf` in
parasite axes was actually incorrect.  Perhaps things were different
when that code went in, but nowadays things work just fine without any
need for overriding.

See e.g. the new version of demo_curvelinear_grid before and after the
changes.

old:
![old](https://user-images.githubusercontent.com/1322974/94133379-dc9fd800-fe60-11ea-8c29-d8c616c7e9a3.png)
new:
![new](https://user-images.githubusercontent.com/1322974/94133372-dad61480-fe60-11ea-903c-79104b8aabc3.png)

The default gridding of `pcolor`/`pcolormesh` changed to match the one
of normal Axes; I don't think this is worth going through a deprecation
period...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
