### PR TITLE
More generic value snapping for Slider widgets

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -283,4 +283,4 @@ per-file-ignores =
     examples/userdemo/connectionstyle_demo.py: E402
     examples/userdemo/custom_boxstyle01.py: E402
     examples/userdemo/pgf_preamble_sgskip.py: E402
-    examples/widgets/textbox.py: E402
+    examples/widgets/*.py: E402

--- a/doc/users/next_whats_new/slider_snap_to_array.rst
+++ b/doc/users/next_whats_new/slider_snap_to_array.rst
@@ -1,0 +1,6 @@
+Sliders can now snap to arbitrary values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `~matplotlib.widgets.Slider` UI widget now accepts arrays for *valstep*.
+This generalizes the previous behavior by allowing the slider to snap to
+arbitrary values.

--- a/examples/widgets/buttons.py
+++ b/examples/widgets/buttons.py
@@ -48,3 +48,16 @@ bprev = Button(axprev, 'Previous')
 bprev.on_clicked(callback.prev)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.Button

--- a/examples/widgets/check_buttons.py
+++ b/examples/widgets/check_buttons.py
@@ -41,3 +41,16 @@ def func(label):
 check.on_clicked(func)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.CheckButtons

--- a/examples/widgets/cursor.py
+++ b/examples/widgets/cursor.py
@@ -24,3 +24,16 @@ ax.set_ylim(-2, 2)
 cursor = Cursor(ax, useblit=True, color='red', linewidth=2)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.Cursor

--- a/examples/widgets/lasso_selector_demo_sgskip.py
+++ b/examples/widgets/lasso_selector_demo_sgskip.py
@@ -99,3 +99,17 @@ if __name__ == '__main__':
     ax.set_title("Press enter to accept selected points.")
 
     plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.LassoSelector
+matplotlib.path.Path

--- a/examples/widgets/multicursor.py
+++ b/examples/widgets/multicursor.py
@@ -22,3 +22,16 @@ ax2.plot(t, s2)
 
 multi = MultiCursor(fig.canvas, (ax1, ax2), color='r', lw=1)
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.MultiCursor

--- a/examples/widgets/polygon_selector_demo.py
+++ b/examples/widgets/polygon_selector_demo.py
@@ -91,3 +91,17 @@ if __name__ == '__main__':
     # After figure is closed print the coordinates of the selected points
     print('\nSelected points:')
     print(selector.xys[selector.ind])
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.PolygonSelector
+matplotlib.path.Path

--- a/examples/widgets/radio_buttons.py
+++ b/examples/widgets/radio_buttons.py
@@ -53,3 +53,16 @@ def stylefunc(label):
 radio3.on_clicked(stylefunc)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.RadioButtons

--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -57,3 +57,16 @@ toggle_selector.RS = RectangleSelector(ax, line_select_callback,
                                        interactive=True)
 fig.canvas.mpl_connect('key_press_event', toggle_selector)
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.RectangleSelector

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -63,3 +63,18 @@ radio.on_clicked(colorfunc)
 colorfunc(radio.value_selected)
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.Button
+matplotlib.widgets.RadioButtons
+matplotlib.widgets.Slider

--- a/examples/widgets/slider_snap_demo.py
+++ b/examples/widgets/slider_snap_demo.py
@@ -39,8 +39,9 @@ samp = Slider(
 sfreq = Slider(
     ax_freq, "Freq", 0, 10*np.pi,
     valinit=2*np.pi, valstep=np.pi,
-    initcolor='none' # Remove the line marking the valinit position.
+    initcolor='none'  # Remove the line marking the valinit position.
 )
+
 
 def update(val):
     amp = samp.val
@@ -63,3 +64,17 @@ button.on_clicked(reset)
 
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.Slider
+matplotlib.widgets.Button

--- a/examples/widgets/slider_snap_demo.py
+++ b/examples/widgets/slider_snap_demo.py
@@ -1,0 +1,67 @@
+"""
+==========================
+Slider Value Snapping Demo
+==========================
+
+You can snap slider values to a discrete values using the ``valstep`` argument.
+
+In this example the Freq slider is constrained to be multiples of pi, and the
+Amp slider uses an array as the ``valstep`` argument to more densely sample
+the first part of its range.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider, Button
+
+t = np.arange(0.0, 1.0, 0.001)
+a0 = 5
+f0 = 3
+s = a0 * np.sin(2 * np.pi * f0 * t)
+
+fig, ax = plt.subplots()
+plt.subplots_adjust(bottom=0.25)
+l, = plt.plot(t, s, lw=2)
+
+slider_bkd_color = 'lightgoldenrodyellow'
+ax_freq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=slider_bkd_color)
+ax_amp = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=slider_bkd_color)
+
+# define the values to use for snapping
+allowed_amplitudes = np.concatenate([np.linspace(.1, 5, 100), [6, 7, 8, 9]])
+
+# create the sliders
+samp = Slider(
+    ax_amp, "Amp", 0.1, 9.0,
+    valinit=a0, valstep=allowed_amplitudes,
+    color="green"
+)
+
+sfreq = Slider(
+    ax_freq, "Freq", 0, 10*np.pi,
+    valinit=2*np.pi, valstep=np.pi,
+    initcolor=None
+)
+# initcolor is set to None to remove the line marking the valinit position
+
+
+def update(val):
+    amp = samp.val
+    freq = sfreq.val
+    l.set_ydata(amp*np.sin(2*np.pi*freq*t))
+    fig.canvas.draw_idle()
+
+
+sfreq.on_changed(update)
+samp.on_changed(update)
+
+ax_reset = plt.axes([0.8, 0.025, 0.1, 0.04])
+button = Button(ax_reset, 'Reset', color=slider_bkd_color, hovercolor='0.975')
+
+
+def reset(event):
+    sfreq.reset()
+    samp.reset()
+button.on_clicked(reset)
+
+
+plt.show()

--- a/examples/widgets/slider_snap_demo.py
+++ b/examples/widgets/slider_snap_demo.py
@@ -1,9 +1,9 @@
 """
-==========================
-Slider Value Snapping Demo
-==========================
+===================================
+Snapping Sliders to Discrete Values
+===================================
 
-You can snap slider values to a discrete values using the ``valstep`` argument.
+You can snap slider values to discrete values using the ``valstep`` argument.
 
 In this example the Freq slider is constrained to be multiples of pi, and the
 Amp slider uses an array as the ``valstep`` argument to more densely sample
@@ -39,10 +39,8 @@ samp = Slider(
 sfreq = Slider(
     ax_freq, "Freq", 0, 10*np.pi,
     valinit=2*np.pi, valstep=np.pi,
-    initcolor=None
+    initcolor='none' # Remove the line marking the valinit position.
 )
-# initcolor is set to None to remove the line marking the valinit position
-
 
 def update(val):
     amp = samp.val

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -52,3 +52,16 @@ span = SpanSelector(ax1, onselect, 'horizontal', useblit=True,
 
 
 plt.show()
+
+#############################################################################
+#
+# ------------
+#
+# References
+# """"""""""
+#
+# The use of the following functions, methods, classes and modules is shown
+# in this example:
+
+import matplotlib
+matplotlib.widgets.SpanSelector

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -267,6 +267,17 @@ def test_slider_valmin_valmax():
     assert slider.val == slider.valmax
 
 
+def test_slider_valstep_snapping():
+    fig, ax = plt.subplots()
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=11.4, valstep=1)
+    assert slider.val == 11
+
+    slider = widgets.Slider(ax=ax, label='', valmin=0.0, valmax=24.0,
+                            valinit=11.4, valstep=[0, 1, 5.5, 19.7])
+    assert slider.val == 5.5
+
+
 def test_slider_horizontal_vertical():
     fig, ax = plt.subplots()
     slider = widgets.Slider(ax=ax, label='', valmin=0, valmax=24,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -255,7 +255,7 @@ class Slider(AxesWidget):
     def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt=None,
                  closedmin=True, closedmax=True, slidermin=None,
                  slidermax=None, dragging=True, valstep=None,
-                 orientation='horizontal', **kwargs):
+                 orientation='horizontal', *, initcolor='r', **kwargs):
         """
         Parameters
         ----------
@@ -295,12 +295,16 @@ class Slider(AxesWidget):
         dragging : bool, default: True
             If True the slider can be dragged by the mouse.
 
-        valstep : float or arraylike, default: None
+        valstep : float or array-like, default: None
             If a float, the slider will snap to multiples of *valstep*.
             If an array the slider will snap to the values in the array.
 
         orientation : {'horizontal', 'vertical'}, default: 'horizontal'
             The orientation of the slider.
+
+        initcolor : color, default: 'r'
+            The color of the line at the *valinit* position. Set to ``'none'``
+            for no line.
 
         Notes
         -----
@@ -338,10 +342,10 @@ class Slider(AxesWidget):
         self.valinit = valinit
         if orientation == 'vertical':
             self.poly = ax.axhspan(valmin, valinit, 0, 1, **kwargs)
-            self.hline = ax.axhline(valinit, 0, 1, color='r', lw=1)
+            self.hline = ax.axhline(valinit, 0, 1, color=initcolor, lw=1)
         else:
             self.poly = ax.axvspan(valmin, valinit, 0, 1, **kwargs)
-            self.vline = ax.axvline(valinit, 0, 1, color='r', lw=1)
+            self.vline = ax.axvline(valinit, 0, 1, color=initcolor, lw=1)
 
         if orientation == 'vertical':
             ax.set_ylim((valmin, valmax))


### PR DESCRIPTION
## PR Summary
Closes: https://github.com/matplotlib/matplotlib/issues/18562

Adds a `valsnap` argument to the Slider widget to allow specifying the values the slider should snap to. This overrides the `valstep` argument.

I also made a new slider demo to show the use of `valstep` and `valsnap` as I think they would get lost in the current [slider demo](https://matplotlib.org/3.3.1/gallery/widgets/slider_demo.html). For a point of context I have read through the existing tutorial multiple times, but never managed to encode that `valstep` existed until I started working on this PR

- I used `searchsorted` instead of `argmin` as it is significantly faster.
- This works for `idx=0` because then the indexing just becomes `-1` and we compare the largest and smallest elements of the array.
## PR Checklist
I have a few questions here:

1. Documentation:
   a. There isn't any narrative docs on widgets to add this to?
   b. Does this deserve it's own example (perhaps named `slider valstep and valsnap demo`) it feel weird to cram into the current 
2. naming. I chose `valsnap` because it was consistent with the other kwargs but if there are better ideas I'm happy to change it.
3. Should this get both a `whats_new` and a `next_api_changes`?
4. To get the number for `next_api_changes` is the best strategy to look through both open and closed PRs right before opening this?
   - Or I guess do what I've done here and wait until after opening the PR


<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
