### PR TITLE
DOC: prefer colormap over color map

### DIFF
--- a/doc/api/prev_api_changes/api_changes_2.0.1.rst
+++ b/doc/api/prev_api_changes/api_changes_2.0.1.rst
@@ -55,8 +55,8 @@ line width the final patterns would not change.
 There is no way to restore the old behavior.
 
 
-Deprecate 'Vega' color maps
----------------------------
+Deprecate 'Vega' colormaps
+--------------------------
 
 The "Vega" colormaps are deprecated in Matplotlib 2.0.1 and will be
 removed in Matplotlib 2.2. Use the "tab" colormaps instead: "tab10",

--- a/doc/api/prev_api_changes/api_changes_2.2.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.2.0.rst
@@ -110,8 +110,8 @@ The ``Axes.get_axis_bgcolor``, ``Axes.set_axis_bgcolor``,
 The unused ``FONT_SCALE`` and ``fontd`` attributes of the `.RendererSVG`
 class have been removed.
 
-color maps
-~~~~~~~~~~
+colormaps
+~~~~~~~~~
 
 The ``spectral`` colormap has been removed.  The ``Vega*`` colormaps, which
 were aliases for the ``tab*`` colormaps, have been removed.

--- a/doc/devel/color_changes.rst
+++ b/doc/devel/color_changes.rst
@@ -5,21 +5,21 @@ Default Color changes
 *********************
 
 As discussed at length elsewhere [insert links], ``jet`` is an
-empirically bad color map and should not be the default color map.
+empirically bad colormap and should not be the default colormap.
 Due to the position that changing the appearance of the plot breaks
 backward compatibility, this change has been put off for far longer
 than it should have been.  In addition to changing the default color
 map we plan to take the chance to change the default color-cycle on
-plots and to adopt a different color map for filled plots (``imshow``,
+plots and to adopt a different colormap for filled plots (``imshow``,
 ``pcolor``, ``contourf``, etc) and for scatter like plots.
 
 
 Default Heat Map Colormap
 -------------------------
 
-The choice of a new color map is fertile ground to bike-shedding ("No,
+The choice of a new colormap is fertile ground to bike-shedding ("No,
 it should be _this_ color") so we have a proposed set criteria (via
-Nathaniel Smith) to evaluate proposed color maps.
+Nathaniel Smith) to evaluate proposed colormaps.
 
 - it should be a sequential colormap, because diverging colormaps are
   really misleading unless you know where the "center" of the data is,
@@ -64,9 +64,9 @@ Default Scatter Colormap
 ------------------------
 
 For heat-map like applications it can be desirable to cover as much of
-the luminance scale as possible, however when color mapping markers,
+the luminance scale as possible, however when colormapping markers,
 having markers too close to white can be a problem.  For that reason
-we propose using a different (but maybe related) color map to the
+we propose using a different (but maybe related) colormap to the
 heat map for marker-based.  The design parameters are the same as
 above, only with a more limited luminance variation.
 
@@ -102,7 +102,7 @@ Example script
 Proposed Colormaps
 ++++++++++++++++++
 
-Color Cycle / Qualitative color map
+Color Cycle / Qualitative colormap
 -----------------------------------
 
 When plotting lines it is frequently desirable to plot multiple lines

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -331,7 +331,7 @@ visualisation of data from csv files or `pandas.DataFrame`\s. Main features:
 
 - Scatter, line, density, histogram, and box plot types
 - Settings for the marker size, line width, number of bins of histogram,
-  color map (from cmocean)
+  colormap (from cmocean)
 - Save figure as editable PDF
 - Code of the plotted graph is available so that it can be reused and modified
   outside of sviewgui

--- a/doc/users/dflt_style_changes.rst
+++ b/doc/users/dflt_style_changes.rst
@@ -28,8 +28,8 @@ persistently and selectively revert many of these changes.
 
 
 
-Colors, color cycles, and color maps
-====================================
+Colors, color cycles, and colormaps
+===================================
 
 Colors in default property cycle
 --------------------------------
@@ -117,7 +117,7 @@ in your :file:`matplotlibrc` file.
 Colormap
 --------
 
-The new default color map used by `matplotlib.cm.ScalarMappable` instances is
+The new default colormap used by `matplotlib.cm.ScalarMappable` instances is
 'viridis' (aka `option D <https://bids.github.io/colormap/>`__).
 
 .. plot::
@@ -144,7 +144,7 @@ For an introduction to color theory and how 'viridis' was generated
 watch Nathaniel Smith and Stéfan van der Walt's talk from SciPy2015.
 See `here for many more details <https://bids.github.io/colormap/>`__
 about the other alternatives and the tools used to create the color
-map.  For details on all of the color maps available in matplotlib see
+map.  For details on all of the colormaps available in matplotlib see
 :doc:`/tutorials/colors/colormaps`.
 
 .. raw:: html
@@ -846,7 +846,7 @@ Interpolation
 
 The default interpolation method for `~matplotlib.axes.Axes.imshow` is
 now ``'nearest'`` and by default it resamples the data (both up and down
-sampling) before color mapping.
+sampling) before colormapping.
 
 
 .. plot::
@@ -888,16 +888,16 @@ in your :file:`matplotlibrc` file.
 Colormapping pipeline
 ---------------------
 
-Previously, the input data was normalized, then color mapped, and then
+Previously, the input data was normalized, then colormapped, and then
 resampled to the resolution required for the screen.  This meant that
 the final resampling was being done in color space.  Because the color
-maps are not generally linear in RGB space, colors not in the color map
+maps are not generally linear in RGB space, colors not in the colormap
 may appear in the final image.  This bug was addressed by an almost
 complete overhaul of the image handling code.
 
 The input data is now normalized, then resampled to the correct
-resolution (in normalized dataspace), and then color mapped to
-RGB space.  This ensures that only colors from the color map appear
+resolution (in normalized dataspace), and then colormapped to
+RGB space.  This ensures that only colors from the colormap appear
 in the final image. (If your viewer subsequently resamples the image,
 the artifact may reappear.)
 

--- a/doc/users/next_whats_new/colormap_repr.rst
+++ b/doc/users/next_whats_new/colormap_repr.rst
@@ -2,5 +2,5 @@ IPython representations for Colormap objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `matplotlib.colors.Colormap` object now has image representations for
-IPython / Jupyter backends. Cells returning a color map on the last line will
-display an image of the color map.
+IPython / Jupyter backends. Cells returning a colormap on the last line will
+display an image of the colormap.

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -1980,7 +1980,7 @@ the `API changes <../../api/api_changes.html>`_.
 
 2008-04-20 Fix double-zoom bug. - MM
 
-2008-04-15 Speed up color mapping. - EF
+2008-04-15 Speed up colormapping. - EF
 
 2008-04-12 Speed up zooming and panning of dense images. - EF
 
@@ -3197,7 +3197,7 @@ the `API changes <../../api/api_changes.html>`_.
            a sequence of (x,y) tuples for specifying paths in
            collections, quiver, contour, pcolor, transforms.
            Fixed contour bug involving setting limits for
-           color mapping.  Added numpy-style all() to numerix. - EF
+           colormapping.  Added numpy-style all() to numerix. - EF
 
 2006-06-20 Added custom FigureClass hook to pylab interface - see
            examples/custom_figure_class.py

--- a/doc/users/prev_whats_new/whats_new_2.0.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.0.0.rst
@@ -187,11 +187,11 @@ Improved image support
 ----------------------
 
 Prior to version 2.0, matplotlib resampled images by first applying
-the color map and then resizing the result.  Since the resampling was
+the colormap and then resizing the result.  Since the resampling was
 performed on the colored image, this introduced colors in the output
-image that didn't actually exist in the color map.  Now, images are
+image that didn't actually exist in the colormap.  Now, images are
 resampled first (and entirely in floating-point, if the input image is
-floating-point), and then the color map is applied.
+floating-point), and then the colormap is applied.
 
 In order to make this important change, the image handling code was
 almost entirely rewritten.  As a side effect, image resampling uses

--- a/examples/images_contours_and_fields/image_masked.py
+++ b/examples/images_contours_and_fields/image_masked.py
@@ -45,7 +45,7 @@ Zm = np.ma.masked_where(Z > 1.2, Z)
 # set up the Axes objects
 fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(6, 5.4))
 
-# plot using 'continuous' color map
+# plot using 'continuous' colormap
 im = ax1.imshow(Zm, interpolation='bilinear',
                 cmap=palette,
                 norm=colors.Normalize(vmin=-1.0, vmax=1.0),

--- a/examples/mplot3d/surface3d.py
+++ b/examples/mplot3d/surface3d.py
@@ -1,9 +1,9 @@
 """
-======================
-3D surface (color map)
-======================
+=====================
+3D surface (colormap)
+=====================
 
-Demonstrates plotting a 3D surface colored with the coolwarm color map.
+Demonstrates plotting a 3D surface colored with the coolwarm colormap.
 The surface is made opaque by using antialiased=False.
 
 Also demonstrates using the LinearLocator and custom formatting for the

--- a/examples/mplot3d/surface3d_radial.py
+++ b/examples/mplot3d/surface3d_radial.py
@@ -4,7 +4,7 @@
 =================================
 
 Demonstrates plotting a surface defined in polar coordinates.
-Uses the reversed version of the YlGnBu color map.
+Uses the reversed version of the YlGnBu colormap.
 Also demonstrates writing axis labels with latex math mode.
 
 Example contributed by Armin Moser.

--- a/lib/matplotlib/_cm.py
+++ b/lib/matplotlib/_cm.py
@@ -54,7 +54,7 @@ def _prism_blue(x): return -1.1 * np.sin((x * 20.9) * np.pi)
 _prism_data = {'red': _prism_red, 'green': _prism_green, 'blue': _prism_blue}
 
 def _ch_helper(gamma, s, r, h, p0, p1, x):
-    """Helper function for generating picklable cubehelix color maps."""
+    """Helper function for generating picklable cubehelix colormaps."""
     # Apply gamma factor to emphasise low or high intensity values
     xg = x ** gamma
     # Calculate amplitude and angle of deviation from the black to white
@@ -1096,7 +1096,7 @@ _gist_stern_data = {
 def _gist_yarg(x): return 1 - x
 _gist_yarg_data = {'red': _gist_yarg, 'green': _gist_yarg, 'blue': _gist_yarg}
 
-# This bipolar color map was generated from CoolWarmFloat33.csv of
+# This bipolar colormap was generated from CoolWarmFloat33.csv of
 # "Diverging Color Maps for Scientific Visualization" by Kenneth Moreland.
 # <http://www.kennethmoreland.com/color-maps/>
 _coolwarm_data = {

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4472,7 +4472,7 @@ default: :rc:`scatter.edgecolors`
 
             - If *None*, no binning is applied; the color of each hexagon
               directly corresponds to its count value.
-            - If 'log', use a logarithmic scale for the color map.
+            - If 'log', use a logarithmic scale for the colormap.
               Internally, :math:`log_{10}(i+1)` is used to determine the
               hexagon color. This is equivalent to ``norm=LogNorm()``.
             - If an integer, divide the counts in the specified number
@@ -5239,7 +5239,7 @@ default: :rc:`scatter.edgecolors`
 
         The input may either be actual RGB(A) data, or 2D scalar data, which
         will be rendered as a pseudocolor image. For displaying a grayscale
-        image set up the color mapping using the parameters
+        image set up the colormapping using the parameters
         ``cmap='gray', vmin=0, vmax=255``.
 
         The number of pixels used to render an image is set by the axes size

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1795,7 +1795,7 @@ class PatchCollection(Collection):
     """
     A generic collection of patches.
 
-    This makes it easier to assign a color map to a heterogeneous
+    This makes it easier to assign a colormap to a heterogeneous
     collection of patches.
 
     This also may improve plotting speed, since PatchCollection will

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -136,7 +136,7 @@ _colormap_kw_doc = """
     *values*       None or a sequence which must be of length 1 less
                    than the sequence of *boundaries*. For each region
                    delimited by adjacent entries in *boundaries*, the
-                   color mapped to the corresponding value in values
+                   colormapped to the corresponding value in values
                    will be used.
     ============   ===================================================
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -703,14 +703,14 @@ class Colormap:
         raise NotImplementedError("Abstract class only")
 
     def is_gray(self):
-        """Return whether the color map is grayscale."""
+        """Return whether the colormap is grayscale."""
         if not self._isinit:
             self._init()
         return (np.all(self._lut[:, 0] == self._lut[:, 1]) and
                 np.all(self._lut[:, 0] == self._lut[:, 2]))
 
     def _resample(self, lutsize):
-        """Return a new color map with *lutsize* entries."""
+        """Return a new colormap with *lutsize* entries."""
         raise NotImplementedError()
 
     def reversed(self, name=None):
@@ -738,7 +738,7 @@ class Colormap:
                     (_REPR_PNG_SIZE[1], 1))
         pixels = self(X, bytes=True)
         png_bytes = io.BytesIO()
-        title = self.name + ' color map'
+        title = self.name + ' colormap'
         author = f'Matplotlib v{mpl.__version__}, https://matplotlib.org'
         pnginfo = PngInfo()
         pnginfo.add_text('Title', title)
@@ -766,7 +766,7 @@ class Colormap:
                 f'<strong>{self.name}</strong> '
                 '</div>'
                 '<div class="cmap"><img '
-                f'alt="{self.name} color map" '
+                f'alt="{self.name} colormap" '
                 f'title="{self.name}" '
                 'style="border: 1px solid #555;" '
                 f'src="data:image/png;base64,{png_base64}"></div>'
@@ -795,7 +795,7 @@ class LinearSegmentedColormap(Colormap):
 
     def __init__(self, name, segmentdata, N=256, gamma=1.0):
         """
-        Create color map from linear mapping segments
+        Create colormap from linear mapping segments
 
         segmentdata argument is a dictionary with a red, green and blue
         entries. Each entry should be a list of *x*, *y0*, *y1* tuples,
@@ -858,7 +858,7 @@ class LinearSegmentedColormap(Colormap):
         self._set_extremes()
 
     def set_gamma(self, gamma):
-        """Set a new gamma value and regenerate color map."""
+        """Set a new gamma value and regenerate colormap."""
         self._gamma = gamma
         self._init()
 
@@ -902,7 +902,7 @@ class LinearSegmentedColormap(Colormap):
         return LinearSegmentedColormap(name, cdict, N, gamma)
 
     def _resample(self, lutsize):
-        """Return a new color map with *lutsize* entries."""
+        """Return a new colormap with *lutsize* entries."""
         new_cmap = LinearSegmentedColormap(self.name, self._segmentdata,
                                            lutsize)
         new_cmap._rgba_over = self._rgba_over
@@ -1006,7 +1006,7 @@ class ListedColormap(Colormap):
         self._set_extremes()
 
     def _resample(self, lutsize):
-        """Return a new color map with *lutsize* entries."""
+        """Return a new colormap with *lutsize* entries."""
         colors = self(np.linspace(0, 1, lutsize))
         new_cmap = ListedColormap(colors, name=self.name)
         # Keep the over/under values too

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1191,7 +1191,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         Color argument processing for contouring.
 
-        Note that we base the color mapping on the contour levels
+        Note that we base the colormapping on the contour levels
         and layers, not on the actual range of the Z values.  This
         means we don't have to worry about bad values in Z, and we
         always have the full dynamic range available for the selected

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -462,7 +462,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 # would not full eliminate it and breaks a number of
                 # tests (due to the slightly different error bouncing
                 # some pixels across a boundary in the (very
-                # quantized) color mapping step).
+                # quantized) colormapping step).
                 offset = .1
                 frac = .8
                 # we need to run the vmin/vmax through the same rescaling

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2007,8 +2007,8 @@ def colormaps():
       for nominal data that has no inherent ordering, where color is used
       only to distinguish categories
 
-    Matplotlib ships with 4 perceptually uniform color maps which are
-    the recommended color maps for sequential data:
+    Matplotlib ships with 4 perceptually uniform colormaps which are
+    the recommended colormaps for sequential data:
 
       =========   ===================================================
       Colormap    Description
@@ -2087,7 +2087,7 @@ def colormaps():
       Colormap    Description
       =========   =======================================================
       autumn      sequential linearly-increasing shades of red-orange-yellow
-      bone        sequential increasing black-white color map with
+      bone        sequential increasing black-white colormap with
                   a tinge of blue, to emulate X-ray film
       cool        linearly-decreasing shades of cyan-magenta
       copper      sequential increasing shades of black-copper
@@ -2128,7 +2128,7 @@ def colormaps():
                     Language software
       ============  =======================================================
 
-    A set of cyclic color maps:
+    A set of cyclic colormaps:
 
       ================  =================================================
       Colormap          Description

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -547,7 +547,7 @@ def test_scatter_post_alpha():
 def test_scatter_alpha_array():
     x = np.arange(5)
     alpha = x / 5
-    # With color mapping.
+    # With colormapping.
     fig, (ax0, ax1) = plt.subplots(2)
     sc0 = ax0.scatter(x, x, c=x, alpha=alpha)
     sc1 = ax1.scatter(x, x, c=x)
@@ -555,14 +555,14 @@ def test_scatter_alpha_array():
     plt.draw()
     assert_array_equal(sc0.get_facecolors()[:, -1], alpha)
     assert_array_equal(sc1.get_facecolors()[:, -1], alpha)
-    # Without color mapping.
+    # Without colormapping.
     fig, (ax0, ax1) = plt.subplots(2)
     sc0 = ax0.scatter(x, x, color=['r', 'g', 'b', 'c', 'm'], alpha=alpha)
     sc1 = ax1.scatter(x, x, color='r', alpha=alpha)
     plt.draw()
     assert_array_equal(sc0.get_facecolors()[:, -1], alpha)
     assert_array_equal(sc1.get_facecolors()[:, -1], alpha)
-    # Without color mapping, and set alpha afterward.
+    # Without colormapping, and set alpha afterward.
     fig, (ax0, ax1) = plt.subplots(2)
     sc0 = ax0.scatter(x, x, color=['r', 'g', 'b', 'c', 'm'])
     sc0.set_alpha(alpha)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -21,10 +21,10 @@ def _get_cmap_norms():
     Helper function for _colorbar_extension_shape and
     colorbar_extension_length.
     """
-    # Create a color map and specify the levels it represents.
+    # Create a colormap and specify the levels it represents.
     cmap = cm.get_cmap("RdBu", lut=5)
     clevs = [-5., -2.5, -.5, .5, 1.5, 3.5]
-    # Define norms for the color maps.
+    # Define norms for the colormaps.
     norms = dict()
     norms['neither'] = BoundaryNorm(clevs, len(clevs) - 1)
     norms['min'] = BoundaryNorm([-10] + clevs[1:], len(clevs) - 1)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -983,7 +983,7 @@ def _azimuth2math(azimuth, elevation):
 
 def test_pandas_iterable(pd):
     # Using a list or series yields equivalent
-    # color maps, i.e the series isn't seen as
+    # colormaps, i.e the series isn't seen as
     # a single color
     lst = ['red', 'blue', 'green']
     s = pd.Series(lst)

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -91,7 +91,7 @@ colormap_kw_doc = '''
     *values*       None or a sequence which must be of length 1 less
                    than the sequence of *boundaries*. For each region
                    delimited by adjacent entries in *boundaries*, the
-                   color mapped to the corresponding value in values
+                   colormapped to the corresponding value in values
                    will be used.
     ============   ===================================================
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1458,7 +1458,7 @@ class Axes3D(Axes):
         Create a surface plot.
 
         By default it will be colored in shades of a solid color, but it also
-        supports color mapping by supplying the *cmap* argument.
+        supports colormapping by supplying the *cmap* argument.
 
         .. note::
 

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -32,7 +32,7 @@ people commonly use a specific argument to the %matplotlib magic:
 This turns on inline plotting, where plot graphics will appear in your
 notebook.  This has important implications for interactivity.  For inline plotting, commands in
 cells below the cell that outputs a plot will not affect the plot.  For example,
-changing the color map is not possible from cells below the cell that creates a plot.
+changing the colormap is not possible from cells below the cell that creates a plot.
 However, for other backends, such as Qt5, that open a separate window,
 cells below those that create the plot will change the plot - it is a
 live object in memory.


### PR DESCRIPTION
Fix this across the entire codebase and docs.

## PR Summary

In #15127 @dopplershift  pointed out all of the places I used 'color map' instead of 'colormap', so via ack + sed I fixed it everywhere.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [ x Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

