### PR TITLE
Fix stairs() tests

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -996,6 +996,8 @@ class StepPatch(PathPatch):
     The path is unclosed. It starts and stops at baseline.
     """
 
+    _edge_default = False
+
     @docstring.dedent_interpd
     def __init__(self, values, edges, *,
                  orientation='vertical', baseline=0, **kwargs):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1878,9 +1878,12 @@ def test_stairs_fill(fig_test, fig_ref):
 
 @check_figures_equal(extensions=['png'])
 def test_stairs_update(fig_test, fig_ref):
+    # fixed ylim because stairs() does autoscale, but updating data does not
+    ylim = -3, 4
     # Test
     test_ax = fig_test.add_subplot()
     h = test_ax.stairs([1, 2, 3])
+    test_ax.set_ylim(ylim)
     h.set_values([3, 2, 1])
     h.set_edges(np.arange(4)+2)
     h.set_data([1, 2, 1], np.arange(4)/2)
@@ -1891,9 +1894,10 @@ def test_stairs_update(fig_test, fig_ref):
     h.set_baseline(-2)
     assert h.get_baseline() == -2
 
-    # # Ref
+    # Ref
     ref_ax = fig_ref.add_subplot()
     h = ref_ax.stairs([1, 2, 3], baseline=-2)
+    ref_ax.set_ylim(ylim)
 
 
 def test_stairs_invalid_nan():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1806,14 +1806,13 @@ def test_hist_zorder(histtype, zorder):
         assert patch.get_zorder() == zorder
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_stairs(fig_test, fig_ref):
     import matplotlib.lines as mlines
     y = np.array([6, 14, 32, 37, 48, 32, 21,  4])  # hist
     x = np.array([1., 2., 3., 4., 5., 6., 7., 8., 9.])  # bins
 
-    fig_test, test_axes = plt.subplots(3, 2)
-    test_axes = test_axes.flatten()
+    test_axes = fig_test.subplots(3, 2).flatten()
     test_axes[0].stairs(y, x, baseline=None)
     test_axes[1].stairs(y, x, baseline=None, orientation='horizontal')
     test_axes[2].stairs(y, x)
@@ -1821,10 +1820,9 @@ def test_stairs(fig_test, fig_ref):
     test_axes[4].stairs(y, x)
     test_axes[4].semilogy()
     test_axes[5].stairs(y, x, orientation='horizontal')
-    test_axes[5].semilogy()
+    test_axes[5].semilogx()
 
-    fig_ref, ref_axes = plt.subplots(3, 2)
-    ref_axes = ref_axes.flatten()
+    ref_axes = fig_ref.subplots(3, 2).flatten()
     ref_axes[0].plot(x, np.append(y, y[-1]), drawstyle='steps-post')
     ref_axes[1].plot(np.append(y[0], y), x, drawstyle='steps-post')
 
@@ -1849,22 +1847,20 @@ def test_stairs(fig_test, fig_ref):
     ref_axes[5].semilogx()
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_stairs_fill(fig_test, fig_ref):
     h, bins = [1, 2, 3, 4, 2], [0, 1, 2, 3, 4, 5]
     bs = -2
     # Test
-    fig_test, test_axes = plt.subplots(2, 2)
-    test_axes = test_axes.flatten()
+    test_axes = fig_test.subplots(2, 2).flatten()
     test_axes[0].stairs(h, bins, fill=True)
     test_axes[1].stairs(h, bins, orientation='horizontal', fill=True)
     test_axes[2].stairs(h, bins, baseline=bs, fill=True)
     test_axes[3].stairs(h, bins, baseline=bs, orientation='horizontal',
-                          fill=True)
+                        fill=True)
 
     # # Ref
-    fig_ref, ref_axes = plt.subplots(2, 2)
-    ref_axes = ref_axes.flatten()
+    ref_axes = fig_ref.subplots(2, 2).flatten()
     ref_axes[0].fill_between(bins, np.append(h, h[-1]), step='post')
     ref_axes[0].set_ylim(0, None)
     ref_axes[1].fill_betweenx(bins, np.append(h, h[-1]), step='post')
@@ -1877,10 +1873,10 @@ def test_stairs_fill(fig_test, fig_ref):
     ref_axes[3].set_xlim(bs, None)
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_stairs_update(fig_test, fig_ref):
     # Test
-    fig_test, test_ax = plt.subplots()
+    test_ax = fig_test.add_subplot()
     h = test_ax.stairs([1, 2, 3])
     h.set_values([3, 2, 1])
     h.set_edges(np.arange(4)+2)
@@ -1893,30 +1889,30 @@ def test_stairs_update(fig_test, fig_ref):
     assert h.get_baseline() == -2
 
     # # Ref
-    fig_ref, ref_ax = plt.subplots()
+    ref_ax = fig_ref.add_subplot()
     h = ref_ax.stairs([1, 2, 3], baseline=-2)
 
 
-@pytest.mark.xfail
 def test_stairs_invalid_nan():
-    plt.stairs([1, 2], [0, np.nan, 1])
+    with pytest.raises(ValueError, match='Nan values in "edges"'):
+        plt.stairs([1, 2], [0, np.nan, 1])
 
 
-@pytest.mark.xfail
 def test_stairs_invalid_mismatch():
-    plt.stairs([1, 2], [0, 1])
+    with pytest.raises(ValueError, match='Size mismatch'):
+        plt.stairs([1, 2], [0, 1])
 
 
-@pytest.mark.xfail
 def test_stairs_invalid_update():
     h = plt.stairs([1, 2], [0, 1, 2])
-    h.set_edges([1, np.nan, 2])
+    with pytest.raises(ValueError, match='Nan values in "edges"'):
+        h.set_edges([1, np.nan, 2])
 
 
-@pytest.mark.xfail
 def test_stairs_invalid_update2():
     h = plt.stairs([1, 2], [0, 1, 2])
-    h.set_edges(np.arange(5))
+    with pytest.raises(ValueError, match='Size mismatch'):
+        h.set_edges(np.arange(5))
 
 
 @image_comparison(['test_stairs_options.png'], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1822,28 +1822,31 @@ def test_stairs(fig_test, fig_ref):
     test_axes[5].stairs(y, x, orientation='horizontal')
     test_axes[5].semilogx()
 
-    ref_axes = fig_ref.subplots(3, 2).flatten()
-    ref_axes[0].plot(x, np.append(y, y[-1]), drawstyle='steps-post')
-    ref_axes[1].plot(np.append(y[0], y), x, drawstyle='steps-post')
+    # defaults of `PathPatch` to be used for all following Line2D
+    style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
 
-    ref_axes[2].plot(x, np.append(y, y[-1]), drawstyle='steps-post')
-    ref_axes[2].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]]))
-    ref_axes[2].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]]))
+    ref_axes = fig_ref.subplots(3, 2).flatten()
+    ref_axes[0].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[1].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+
+    ref_axes[2].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[2].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
+    ref_axes[2].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
     ref_axes[2].set_ylim(0, None)
 
-    ref_axes[3].plot(np.append(y[0], y), x, drawstyle='steps-post')
-    ref_axes[3].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]]))
-    ref_axes[3].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]]))
+    ref_axes[3].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+    ref_axes[3].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
+    ref_axes[3].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
     ref_axes[3].set_xlim(0, None)
 
-    ref_axes[4].plot(x, np.append(y, y[-1]), drawstyle='steps-post')
-    ref_axes[4].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]]))
-    ref_axes[4].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]]))
+    ref_axes[4].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[4].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
+    ref_axes[4].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
     ref_axes[4].semilogy()
 
-    ref_axes[5].plot(np.append(y[0], y), x, drawstyle='steps-post')
-    ref_axes[5].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]]))
-    ref_axes[5].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]]))
+    ref_axes[5].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+    ref_axes[5].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
+    ref_axes[5].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
     ref_axes[5].semilogx()
 
 
@@ -1861,15 +1864,15 @@ def test_stairs_fill(fig_test, fig_ref):
 
     # # Ref
     ref_axes = fig_ref.subplots(2, 2).flatten()
-    ref_axes[0].fill_between(bins, np.append(h, h[-1]), step='post')
+    ref_axes[0].fill_between(bins, np.append(h, h[-1]), step='post', lw=0)
     ref_axes[0].set_ylim(0, None)
-    ref_axes[1].fill_betweenx(bins, np.append(h, h[-1]), step='post')
+    ref_axes[1].fill_betweenx(bins, np.append(h, h[-1]), step='post', lw=0)
     ref_axes[1].set_xlim(0, None)
     ref_axes[2].fill_between(bins, np.append(h, h[-1]),
-                             np.ones(len(h)+1)*bs, step='post')
+                             np.ones(len(h)+1)*bs, step='post', lw=0)
     ref_axes[2].set_ylim(bs, None)
     ref_axes[3].fill_betweenx(bins, np.append(h, h[-1]),
-                              np.ones(len(h)+1)*bs, step='post')
+                              np.ones(len(h)+1)*bs, step='post', lw=0)
     ref_axes[3].set_xlim(bs, None)
 
 


### PR DESCRIPTION
## PR Summary

CC @andrzejnovak 

Fixes:

- `check_figures_equal` tests did not test anything because fixture figures were not used. Instead the tests created new figures, which were not compared.
- Limited the `check_figures_equal` tests to png. - No need to additionally test vector backends, because this is about the logic creating the artist, not how it's drawn by a backend.
- Failure tests must assert with `pytest.raises`. `pytest.xfail` is only for excluding broken tests.
- Logic change: Don't draw an edge for filled `StepPatch` by default (`_edge_default = False`). This was proposed anyway in https://github.com/matplotlib/matplotlib/pull/18275#pullrequestreview-487347047 / https://github.com/matplotlib/matplotlib/pull/18275#issuecomment-692442104. IMHO it's the right thing to do as most of our patches behave that way; in particular bar charts which are closely related to the `StepPatch`.

Still there are two issues:

- `test_stairs`
  The actual/expected differ in the corners of the steps. - To be investigated.  
  difference:
  ![grafik](https://user-images.githubusercontent.com/2836374/94317868-7feb0d00-ff87-11ea-9606-9a1f094a1f57.png)
  expected:
  ![grafik](https://user-images.githubusercontent.com/2836374/94317935-a8730700-ff87-11ea-9acf-52a6189e897a.png)

- `test_stailrs_update`
   The axis limit is not updated by `h.set_baseline(-2)`. Should it be?
   actual: ![grafik](https://user-images.githubusercontent.com/2836374/94317177-0dc5f880-ff86-11ea-8bc5-b35e2d0488a9.png)
   expected: ![grafik](https://user-images.githubusercontent.com/2836374/94317212-19b1ba80-ff86-11ea-810f-ea79fc4ef071.png)
