### PR TITLE
Fix setting 0-timeout timer with Tornado.

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -512,7 +512,7 @@ class TimerTornado(backend_bases.TimerBase):
         else:
             self._timer = tornado.ioloop.PeriodicCallback(
                 self._on_timer,
-                self.interval)
+                max(self.interval, 1e-6))
             self._timer.start()
 
     def _timer_stop(self):


### PR DESCRIPTION
## PR Summary

It doesn't allow 0, so set a very small minimum.

Fixes #18580.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).