### PR TITLE
Fix docstring of zaxis_date.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -44,14 +44,23 @@ class _axis_method_wrapper:
 
     The docstring of ``get_foo`` is built by replacing "this Axis" by "the
     {attr_name}" (i.e., "the xaxis", "the yaxis") in the wrapped method's
-    docstring; additional replacements can by given in *doc_sub*.  The
-    docstring is also dedented to simplify further manipulations.
+    dedented docstring; additional replacements can by given in *doc_sub*.
     """
 
     def __init__(self, attr_name, method_name, *, doc_sub=None):
         self.attr_name = attr_name
         self.method_name = method_name
-        self.doc_sub = doc_sub
+        # Immediately put the docstring in ``self.__doc__`` so that docstring
+        # manipulations within the class body work as expected.
+        doc = inspect.getdoc(getattr(maxis.Axis, method_name))
+        self._missing_subs = []
+        if doc:
+            doc_sub = {"this Axis": f"the {self.attr_name}", **(doc_sub or {})}
+            for k, v in doc_sub.items():
+                if k not in doc:  # Delay raising error until we know qualname.
+                    self._missing_subs.append(k)
+                doc = doc.replace(k, v)
+        self.__doc__ = doc
 
     def __set_name__(self, owner, name):
         # This is called at the end of the class body as
@@ -65,22 +74,19 @@ class _axis_method_wrapper:
         wrapper.__module__ = owner.__module__
         wrapper.__name__ = name
         wrapper.__qualname__ = f"{owner.__qualname__}.{name}"
+        wrapper.__doc__ = self.__doc__
         # Manually copy the signature instead of using functools.wraps because
         # displaying the Axis method source when asking for the Axes method
         # source would be confusing.
-        wrapped_method = getattr(maxis.Axis, self.method_name)
-        wrapper.__signature__ = inspect.signature(wrapped_method)
-        doc = wrapped_method.__doc__
-        if doc:
-            doc_sub = {"this Axis": f"the {self.attr_name}",
-                       **(self.doc_sub or {})}
-            for k, v in doc_sub.items():
-                assert k in doc, \
-                    (f"The definition of {wrapper.__qualname__} expected that "
-                     f"the docstring of Axis.{self.method_name} contains "
-                     f"{k!r} as a substring.")
-                doc = doc.replace(k, v)
-            wrapper.__doc__ = inspect.cleandoc(doc)
+        wrapper.__signature__ = inspect.signature(
+            getattr(maxis.Axis, self.method_name))
+
+        if self._missing_subs:
+            raise ValueError(
+                "The definition of {} expected that the docstring of Axis.{} "
+                "contains {!r} as substrings".format(
+                    wrapper.__qualname__, self.method_name,
+                    ", ".join(map(repr, self._missing_subs))))
 
         setattr(owner, name, wrapper)
 


### PR DESCRIPTION
The docstring of zaxis_date appends an addendum to the other axis_dates
(about the fact that it doesn't actually work...), but previously the
docstring appending incorrectly went to `_axis_method_wrapper.__doc__`,
not `zaxis_date.__doc__`.  Perform docstring interpolation earlier to
fix that.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
