### PR TITLE
Collection private singular

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -166,10 +166,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
         # this is needed scaling the dash pattern by linewidth
         self._us_linestyles = [(0, None)]
         # list of dash patterns
-        self._linestyles = [(0, None)]
+        self._linestyle = [(0, None)]
         # list of unbroadcast/scaled linewidths
         self._us_lw = [0]
-        self._linewidths = [0]
+        self._linewidth = [0]
         # Flags: do colors come from mapping an array?
         self._face_is_mapped = True
         self._edge_is_mapped = False
@@ -378,9 +378,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         do_single_path_optimization = False
         if (len(paths) == 1 and len(trans) <= 1 and
                 len(facecolors) == 1 and len(edgecolors) == 1 and
-                len(self._linewidths) == 1 and
-                all(ls[1] is None for ls in self._linestyles) and
-                len(self._antialiaseds) == 1 and len(self._urls) == 1 and
+                len(self._linewidth) == 1 and
+                all(ls[1] is None for ls in self._linestyle) and
+                len(self._antialiased) == 1 and len(self._urls) == 1 and
                 self.get_hatch() is None):
             if len(trans):
                 combined_transform = transforms.Affine2D(trans[0]) + transform
@@ -399,9 +399,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         if do_single_path_optimization:
             gc.set_foreground(tuple(edgecolors[0]))
-            gc.set_linewidth(self._linewidths[0])
-            gc.set_dashes(*self._linestyles[0])
-            gc.set_antialiased(self._antialiaseds[0])
+            gc.set_linewidth(self._linewidth[0])
+            gc.set_dashes(*self._linestyle[0])
+            gc.set_antialiased(self._antialiased[0])
             gc.set_url(self._urls[0])
             renderer.draw_markers(
                 gc, paths[0], combined_transform.frozen(),
@@ -411,8 +411,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 gc, transform.frozen(), paths,
                 self.get_transforms(), offsets, transOffset,
                 self.get_facecolor(), self.get_edgecolor(),
-                self._linewidths, self._linestyles,
-                self._antialiaseds, self._urls,
+                self._linewidth, self._linestyle,
+                self._antialiased, self._urls,
                 self._offset_position)
 
         gc.restore()
@@ -611,7 +611,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._us_lw = np.atleast_1d(np.asarray(lw))
 
         # scale all of the dash patterns.
-        self._linewidths, self._linestyles = self._bcast_lwls(
+        self._linewidth, self._linestyle = self._bcast_lwls(
             self._us_lw, self._us_linestyles)
         self.stale = True
 
@@ -659,7 +659,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._us_linestyles = dashes
 
         # broadcast and scale the lw and dash patterns
-        self._linewidths, self._linestyles = self._bcast_lwls(
+        self._linewidth, self._linestyle = self._bcast_lwls(
             self._us_lw, self._us_linestyles)
 
     def set_capstyle(self, cs):
@@ -740,7 +740,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         """
         if aa is None:
             aa = mpl.rcParams['patch.antialiased']
-        self._antialiaseds = np.atleast_1d(np.asarray(aa, bool))
+        self._antialiased = np.atleast_1d(np.asarray(aa, bool))
         self.stale = True
 
     def set_color(self, c):
@@ -767,7 +767,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if c is None:
             c = self._get_default_facecolor()
 
-        self._facecolors = mcolors.to_rgba_array(c, self._alpha)
+        self._facecolor = mcolors.to_rgba_array(c, self._alpha)
         self.stale = True
 
     def set_facecolor(self, c):
@@ -788,13 +788,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._set_facecolor(c)
 
     def get_facecolor(self):
-        return self._facecolors
+        return self._facecolor
 
     def get_edgecolor(self):
-        if cbook._str_equal(self._edgecolors, 'face'):
+        if cbook._str_equal(self._edgecolor, 'face'):
             return self.get_facecolor()
         else:
-            return self._edgecolors
+            return self._edgecolor
 
     def _get_default_edgecolor(self):
         # This may be overridden in a subclass.
@@ -809,12 +809,12 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 c = 'none'
                 set_hatch_color = False
         if cbook._str_lower_equal(c, 'face'):
-            self._edgecolors = 'face'
+            self._edgecolor = 'face'
             self.stale = True
             return
-        self._edgecolors = mcolors.to_rgba_array(c, self._alpha)
-        if set_hatch_color and len(self._edgecolors):
-            self._hatch_color = tuple(self._edgecolors[0])
+        self._edgecolor = mcolors.to_rgba_array(c, self._alpha)
+        if set_hatch_color and len(self._edgecolor):
+            self._hatch_color = tuple(self._edgecolor[0])
         self.stale = True
 
     def set_edgecolor(self, c):
@@ -855,10 +855,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
     set_alpha.__doc__ = artist.Artist._set_alpha_for_array.__doc__
 
     def get_linewidth(self):
-        return self._linewidths
+        return self._linewidth
 
     def get_linestyle(self):
-        return self._linestyles
+        return self._linestyle
 
     def _set_mappable_flags(self):
         """
@@ -936,11 +936,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
             self._mapped_colors = self.to_rgba(self._A, self._alpha)
 
         if self._face_is_mapped:
-            self._facecolors = self._mapped_colors
+            self._facecolor = self._mapped_colors
         else:
             self._set_facecolor(self._original_facecolor)
         if self._edge_is_mapped:
-            self._edgecolors = self._mapped_colors
+            self._edgecolor = self._mapped_colors
         else:
             self._set_edgecolor(self._original_edgecolor)
         self.stale = True
@@ -954,13 +954,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
         """Copy properties from other to self."""
 
         artist.Artist.update_from(self, other)
-        self._antialiaseds = other._antialiaseds
+        self._antialiased = other._antialiased
         self._original_edgecolor = other._original_edgecolor
-        self._edgecolors = other._edgecolors
+        self._edgecolor = other._edgecolor
         self._original_facecolor = other._original_facecolor
-        self._facecolors = other._facecolors
-        self._linewidths = other._linewidths
-        self._linestyles = other._linestyles
+        self._facecolor = other._facecolor
+        self._linewidth = other._linewidth
+        self._linestyle = other._linestyle
         self._us_linestyles = other._us_linestyles
         self._pickradius = other._pickradius
         self._hatch = other._hatch
@@ -1542,7 +1542,7 @@ class LineCollection(Collection):
     set_colors = set_color
 
     def get_color(self):
-        return self._edgecolors
+        return self._edgecolor
 
     get_colors = get_color  # for compatibility with old versions
 
@@ -1957,7 +1957,7 @@ class TriMesh(Collection):
         verts = np.stack((tri.x[triangles], tri.y[triangles]), axis=-1)
 
         self.update_scalarmappable()
-        colors = self._facecolors[triangles]
+        colors = self._facecolor[triangles]
 
         gc = renderer.new_gc()
         self._set_gc_clip(gc)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -922,10 +922,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
             self._set_edgecolor(self._original_edgecolor)
         self.stale = True
 
-    @cbook.deprecated("3.4")
     def get_fill(self):
-        """Return whether facecolor is currently mapped."""
-        return self._face_is_mapped
+        """Return whether face is colored."""
+        fill = not (isinstance(self._original_facecolor, str)
+                    and self._original_facecolor == "none")
+        return fill
 
     def update_from(self, other):
         """Copy properties from other to self."""

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -593,10 +593,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def _get_default_linewidth(self):
         # This may be overridden in a subclass.
-        lw = mpl.rcParams['patch.linewidth']
-        if lw is None:
-            lw = mpl.rcParams['lines.linewidth']
-        return lw
+        return mpl.rcParams['patch.linewidth']  # validated as float
 
     def set_linewidth(self, lw):
         """
@@ -1420,6 +1417,7 @@ class LineCollection(Collection):
     _edge_default = True
 
     def __init__(self, segments,  # Can be None.
+                 *args,           # Deprecated.
                  zorder=2,        # Collection.zorder is 1
                  **kwargs
                  ):
@@ -1454,7 +1452,17 @@ class LineCollection(Collection):
         **kwargs
             Forwarded to `.Collection`.
         """
-
+        argnames = ["linewidths", "colors", "antialiaseds", "linestyles",
+                    "offsets", "transOffset", "norm", "cmap", "pickradius",
+                    "zorder", "facecolors"]
+        if args:
+            argkw = {name: val for name, val in zip(argnames, args)}
+            kwargs.update(argkw)
+            cbook.warn_deprecated(
+                "3.4", message="In a future release, all LineCollection "
+                "arguments other than the first, 'segments', will be "
+                "keyword-only arguments."
+                )
         super().__init__(
             zorder=zorder,
             **kwargs)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -788,18 +788,17 @@ class Collection(artist.Artist, cm.ScalarMappable):
         else:
             return self._edgecolors
 
-    def _set_edgecolor(self, c, default=None):
+    def _get_default_edgecolor(self):
+        return mpl.rcParams['patch.edgecolor']
+
+    def _set_edgecolor(self, c):
         set_hatch_color = True
         if c is None:
-            if default is None:
-                if (mpl.rcParams['patch.force_edgecolor'] or
-                        not self._face_is_mapped or self._edge_default):
-                    c = mpl.rcParams['patch.edgecolor']
-                else:
-                    c = 'none'
-                    set_hatch_color = False
+            if (mpl.rcParams['patch.force_edgecolor'] or self._edge_default):
+                c = self._get_default_edgecolor()
             else:
-                c = default
+                c = 'none'
+                set_hatch_color = False
         if isinstance(c, str) and c == 'face':
             self._edgecolors = 'face'
             self.stale = True
@@ -809,7 +808,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             self._hatch_color = tuple(self._edgecolors[0])
         self.stale = True
 
-    def set_edgecolor(self, c, default=None):
+    def set_edgecolor(self, c):
         """
         Set the edgecolor(s) of the collection.
 
@@ -825,7 +824,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if isinstance(c, str) and c.lower() in ("none", "face"):
             c = c.lower()
         self._original_edgecolor = c
-        self._set_edgecolor(c, default=default)
+        self._set_edgecolor(c)
 
     def set_alpha(self, alpha):
         """
@@ -1512,6 +1511,9 @@ class LineCollection(Collection):
                 segs[i] = segs[i] + offsets[io:io + 1]
         return segs
 
+    def _get_default_edgecolor(self):
+        return mpl.rcParams['lines.color']
+
     def set_color(self, c):
         """
         Set the color(s) of the LineCollection.
@@ -1523,7 +1525,7 @@ class LineCollection(Collection):
             sequence of rgba tuples; if it is a sequence the lines will
             cycle through the sequence.
         """
-        self.set_edgecolor(c, default=mpl.rcParams['lines.color'])
+        self.set_edgecolor(c)
 
     def get_color(self):
         return self._edgecolors

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -707,10 +707,8 @@ class HandlerPolyCollection(HandlerBase):
         legend_handle.set_edgecolor(first_color(edgecolor))
         facecolor = getattr(orig_handle, '_original_facecolor',
                             orig_handle.get_facecolor())
-        fillcolor = first_color(facecolor)
-        legend_handle.set_facecolor(fillcolor)
-        fill = not (isinstance(fillcolor, str) and fillcolor == "none")
-        legend_handle.set_fill(fill)
+        legend_handle.set_facecolor(first_color(facecolor))
+        legend_handle.set_fill(orig_handle.get_fill())
         legend_handle.set_hatch(orig_handle.get_hatch())
         legend_handle.set_linewidth(get_first(orig_handle.get_linewidths()))
         legend_handle.set_linestyle(get_first(orig_handle.get_linestyles()))

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -707,8 +707,10 @@ class HandlerPolyCollection(HandlerBase):
         legend_handle.set_edgecolor(first_color(edgecolor))
         facecolor = getattr(orig_handle, '_original_facecolor',
                             orig_handle.get_facecolor())
-        legend_handle.set_facecolor(first_color(facecolor))
-        legend_handle.set_fill(orig_handle.get_fill())
+        fillcolor = first_color(facecolor)
+        legend_handle.set_facecolor(fillcolor)
+        fill = not (isinstance(fillcolor, str) and fillcolor == "none")
+        legend_handle.set_fill(fill)
         legend_handle.set_hatch(orig_handle.get_hatch())
         legend_handle.set_linewidth(get_first(orig_handle.get_linewidths()))
         legend_handle.set_linestyle(get_first(orig_handle.get_linestyles()))

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4145,9 +4145,6 @@ default: 'arc3'
             self.get_linewidth() * dpi_cor,
             self.get_mutation_aspect())
 
-        # if not fillable:
-        #    self._fill = False
-
         return _path, fillable
 
     def draw(self, renderer):

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -117,7 +117,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         line_colors = []
         color = np.ma.masked_invalid(color)
     else:
-        line_kw['color'] = color
+        line_kw['colors'] = color
         arrow_kw['color'] = color
 
     if isinstance(linewidth, np.ndarray):

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -12,6 +12,7 @@ import matplotlib.transforms as mtransforms
 from matplotlib.collections import (Collection, LineCollection,
                                     EventCollection, PolyCollection)
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.cbook.deprecation import MatplotlibDeprecationWarning
 
 
 def generate_EventCollection_plot():
@@ -789,6 +790,15 @@ def test_color_logic(pcfunc):
     pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=np.ones((12, 4)))
     assert_array_equal(pc.get_facecolor(), np.ones((12, 4)))
     assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+
+
+def test_LineCollection_args():
+    with pytest.warns(MatplotlibDeprecationWarning):
+        lc = LineCollection(None, 2.2, 'r', zorder=3, facecolors=[0, 1, 0, 1])
+        assert lc.get_linewidth()[0] == 2.2
+        assert list(lc.get_edgecolor()[0]) == [1, 0, 0, 1]
+        assert lc.get_zorder() == 3
+        assert list(lc.get_facecolor()[0]) == [0, 1, 0, 1]
 
 
 def test_array_wrong_dimensions():

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -777,3 +777,18 @@ def test_color_logic(pcfunc):
     pc.update_scalarmappable()
     assert pc.get_facecolor().shape == (12, 4)  # color-mapped
     assert pc.get_edgecolor().shape == (1, 4)  # not color-mapped
+    # Give color via tuple rather than string.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=(0, 1, 0))
+    assert_array_equal(pc.get_facecolor(), [[0, 1, 0, 1]])
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+
+
+def test_array_wrong_dimensions():
+    z = np.arange(12).reshape(3, 4)
+    pc = plt.pcolor(z)
+    with pytest.raises(ValueError, match="^Collections can only map"):
+        pc.set_array(z)
+        pc.update_scalarmappable()
+    pc = plt.pcolormesh(z)
+    pc.set_array(z)  # 2D is OK for Quadmesh
+    pc.update_scalarmappable()

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -781,6 +781,14 @@ def test_color_logic(pcfunc):
     pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=(0, 1, 0))
     assert_array_equal(pc.get_facecolor(), [[0, 1, 0, 1]])
     assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Provide an RGB array.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=np.ones((12, 3)))
+    assert_array_equal(pc.get_facecolor(), np.ones((12, 4)))
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # And an RGBA array.
+    pc = pcfunc(z, edgecolors=(1, 0, 0), facecolors=np.ones((12, 4)))
+    assert_array_equal(pc.get_facecolor(), np.ones((12, 4)))
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
 
 
 def test_array_wrong_dimensions():

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -747,3 +747,33 @@ def test_legend_inverse_size_label_relationship():
     handle_sizes = [5 / x**2 for x in handle_sizes]
 
     assert_array_almost_equal(handle_sizes, legend_sizes, decimal=1)
+
+
+@pytest.mark.parametrize('pcfunc', [plt.pcolor, plt.pcolormesh])
+def test_color_logic(pcfunc):
+    z = np.arange(12).reshape(3, 4)
+    pc = pcfunc(z, edgecolors='red', facecolors='none')
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    # Check setting attributes after initialization:
+    pc = pcfunc(z)
+    pc.set_facecolor('none')
+    pc.set_edgecolor('red')
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 1]])
+    pc.set_alpha(0.5)
+    assert_array_equal(pc.get_edgecolor(), [[1, 0, 0, 0.5]])
+    pc.set_edgecolor(None)
+    pc.update_scalarmappable()
+    assert pc.get_edgecolor().shape == (12, 4)  # color-mapped
+    pc.set_facecolor(None)
+    pc.update_scalarmappable()
+    assert pc.get_facecolor().shape == (12, 4)  # color-mapped
+    assert pc.get_edgecolor().shape == (1, 4)  # no longer color-mapped
+    # Turn off colormapping entirely:
+    pc.set_array(None)
+    pc.update_scalarmappable()
+    assert pc.get_facecolor().shape == (1, 4)  # no longer color-mapped
+    # Turn it back on by restoring the array (must be 1D!):
+    pc.set_array(z.ravel())
+    pc.update_scalarmappable()
+    assert pc.get_facecolor().shape == (12, 4)  # color-mapped
+    assert pc.get_edgecolor().shape == (1, 4)  # not color-mapped

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -673,7 +673,7 @@ class Poly3DCollection(PolyCollection):
         # FIXME: This may no longer be needed?
         if self._A is not None:
             self.update_scalarmappable()
-            self._facecolors3d = self._facecolors
+            self._facecolors3d = self._facecolor
 
         txs, tys, tzs = proj3d._proj_transform_vec(self._vec, renderer.M)
         xyzlist = [(txs[sl], tys[sl], tzs[sl]) for sl in self._segslices]


### PR DESCRIPTION
## PR Summary
WIP: Possible follow-up to #18480.
Make private forms of attributes like "_facecolor" singular to match their setters.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
