### PR TITLE
bugfix #18600 by using the MarkerStyle copy constructor

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1299,8 +1299,7 @@ class Line2D(Artist):
         self._solidjoinstyle = other._solidjoinstyle
 
         self._linestyle = other._linestyle
-        self._marker = MarkerStyle(other._marker.get_marker(),
-                                   other._marker.get_fillstyle())
+        self._marker = MarkerStyle(marker=other._marker)
         self._drawstyle = other._drawstyle
 
     def set_dash_joinstyle(self, s):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -218,12 +218,9 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-
-            Another instance of *MarkerStyle* copies the details of that ``marker``.
-
-            *None* means no marker.
-
-            For other possible marker values see the module docstring `matplotlib.markers`.
+            - Another instance of *MarkerStyle* copies the details of that ``marker``.
+            - *None* means no marker.
+            - For other possible marker values see the module docstring `matplotlib.markers`.
 
         fillstyle : str, default: 'full'
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
@@ -289,12 +286,9 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-
-            Another instance of *MarkerStyle* copies the details of that ``marker``.
-
-            *None* means no marker.
-
-            For other possible marker values see the module docstring `matplotlib.markers`.
+            - Another instance of *MarkerStyle* copies the details of that ``marker``.
+            - *None* means no marker.
+            - For other possible marker values see the module docstring `matplotlib.markers`.
         """
         if (isinstance(marker, np.ndarray) and marker.ndim == 2 and
                 marker.shape[1] == 2):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -218,9 +218,11 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-            - Another instance of *MarkerStyle* copies the details of that ``marker``.
+            - Another instance of *MarkerStyle* copies the details of that
+              ``marker``.
             - *None* means no marker.
-            - For other possible marker values see the module docstring `matplotlib.markers`.
+            - For other possible marker values see the module docstring
+              `matplotlib.markers`.
 
         fillstyle : str, default: 'full'
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
@@ -286,9 +288,11 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-            - Another instance of *MarkerStyle* copies the details of that ``marker``.
+            - Another instance of *MarkerStyle* copies the details of that
+              ``marker``.
             - *None* means no marker.
-            - For other possible marker values see the module docstring `matplotlib.markers`.
+            - For other possible marker values see the module docstring
+              `matplotlib.markers`.
         """
         if (isinstance(marker, np.ndarray) and marker.ndim == 2 and
                 marker.shape[1] == 2):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -1,6 +1,6 @@
 r"""
 Functions to handle markers; used by the marker functionality of
-`~matplotlib.axes.Axes.plot` and `~matplotlib.axes.Axes.scatter`.
+`~matplotlib.axes.Axes.plot`, `~matplotlib.axes.Axes.scatter`, and `~matplotlib.axes.Axes.errorbar`.
 
 All possible markers are defined here:
 
@@ -216,9 +216,13 @@ class MarkerStyle:
         """
         Parameters
         ----------
-        marker : str or array-like or None, default: None
-            *None* means no marker. For other possible marker values see the
-            module docstring `matplotlib.markers`.
+        marker : str, array-like, Path, MarkerStyle, or None, default: None
+            
+            Another instance of *MarkerStyle* copies the details of that ``marker``.
+            
+            *None* means no marker.
+
+            For other possible marker values see the module docstring `matplotlib.markers`.
 
         fillstyle : str, default: 'full'
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
@@ -283,9 +287,13 @@ class MarkerStyle:
 
         Parameters
         ----------
-        marker : str or array-like or None, default: None
-            *None* means no marker. For other possible marker values see the
-            module docstring `matplotlib.markers`.
+        marker : str, array-like, Path, MarkerStyle, or None, default: None
+            
+            Another instance of *MarkerStyle* copies the details of that ``marker``.
+            
+            *None* means no marker.
+
+            For other possible marker values see the module docstring `matplotlib.markers`.
         """
         if (isinstance(marker, np.ndarray) and marker.ndim == 2 and
                 marker.shape[1] == 2):

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -1,6 +1,7 @@
 r"""
 Functions to handle markers; used by the marker functionality of
-`~matplotlib.axes.Axes.plot`, `~matplotlib.axes.Axes.scatter`, and `~matplotlib.axes.Axes.errorbar`.
+`~matplotlib.axes.Axes.plot`, `~matplotlib.axes.Axes.scatter`, and
+`~matplotlib.axes.Axes.errorbar`.
 
 All possible markers are defined here:
 
@@ -217,9 +218,9 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-            
+
             Another instance of *MarkerStyle* copies the details of that ``marker``.
-            
+
             *None* means no marker.
 
             For other possible marker values see the module docstring `matplotlib.markers`.
@@ -288,9 +289,9 @@ class MarkerStyle:
         Parameters
         ----------
         marker : str, array-like, Path, MarkerStyle, or None, default: None
-            
+
             Another instance of *MarkerStyle* copies the details of that ``marker``.
-            
+
             *None* means no marker.
 
             For other possible marker values see the module docstring `matplotlib.markers`.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1316,12 +1316,14 @@ def test_arc_ellipse():
 
     ax.add_patch(e2)
 
+
 def test_marker_as_MarkerStyle():
     fix, ax = plt.subplots()
     m = mmarkers.MarkerStyle('o')
-    plt.plot([1,2,3],[3,2,1], marker=m)
-    plt.scatter([1,2,3],[4,3,2], marker=m)
-    plt.errorbar([1,2,3],[5,4,3], marker=m)
+    plt.plot([1, 2, 3], [3, 2, 1], marker=m)
+    plt.scatter([1, 2, 3], [4, 3, 2], marker=m)
+    plt.errorbar([1, 2, 3],[5, 4, 3], marker=m)
+
 
 @image_comparison(['markevery'], remove_text=True)
 def test_markevery():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1316,6 +1316,12 @@ def test_arc_ellipse():
 
     ax.add_patch(e2)
 
+def test_marker_as_MarkerStyle():
+    fix, ax = plt.subplots()
+    m = mmarkers.MarkerStyle('o')
+    plt.plot([1,2,3],[3,2,1], marker=m)
+    plt.scatter([1,2,3],[4,3,2], marker=m)
+    plt.errorbar([1,2,3],[5,4,3], marker=m)
 
 @image_comparison(['markevery'], remove_text=True)
 def test_markevery():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1317,7 +1317,7 @@ def test_arc_ellipse():
     ax.add_patch(e2)
 
 
-def test_marker_as_MarkerStyle():
+def test_marker_as_markerstyle():
     fix, ax = plt.subplots()
     m = mmarkers.MarkerStyle('o')
     plt.plot([1, 2, 3], [3, 2, 1], marker=m)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1322,7 +1322,7 @@ def test_marker_as_MarkerStyle():
     m = mmarkers.MarkerStyle('o')
     plt.plot([1, 2, 3], [3, 2, 1], marker=m)
     plt.scatter([1, 2, 3], [4, 3, 2], marker=m)
-    plt.errorbar([1, 2, 3],[5, 4, 3], marker=m)
+    plt.errorbar([1, 2, 3], [5, 4, 3], marker=m)
 
 
 @image_comparison(['markevery'], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1320,9 +1320,9 @@ def test_arc_ellipse():
 def test_marker_as_markerstyle():
     fix, ax = plt.subplots()
     m = mmarkers.MarkerStyle('o')
-    plt.plot([1, 2, 3], [3, 2, 1], marker=m)
-    plt.scatter([1, 2, 3], [4, 3, 2], marker=m)
-    plt.errorbar([1, 2, 3], [5, 4, 3], marker=m)
+    ax.plot([1, 2, 3], [3, 2, 1], marker=m)
+    ax.scatter([1, 2, 3], [4, 3, 2], marker=m)
+    ax.errorbar([1, 2, 3], [5, 4, 3], marker=m)
 
 
 @image_comparison(['markevery'], remove_text=True)


### PR DESCRIPTION
#Deeper marker copies in Line2D update_from

Markers already support a copy construction: `MarkerStyle.set_marker`
accepts other instances of `MarkerStyle`.  However, Line2D, when
copying markers, instead construct the copy from the other instance's
`get_marker` and `get_fillstyle` methods.  This destroys (unsupported)
manipulations the user might make to the marker, as discovered in
issue #18600.

By switching constructors, we can get a more faithful copy without
explicitly relying on any of `MarkerStyle`'s private methods in places
they do not belong.

## PR Summary

This change is also more in line with the `self = other` style of the rest of the method's body.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
    - Some tests failed, but they also failed when I cloned `master`:
        - test_pcolormesh_alpha[pdf]
        - test_transparent_markers
        - test_xelatex[pdf]
        - test_pdflatex[pdf]
        - test_rcupdate
        - test_mixedmode[pdf]
        - 6 failed, 7729 passed, 89 skipped, 15 xfailed in 1031.87s (0:17:11)
    
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
