### PR TITLE
Revert "FIX: pin pytest"

### DIFF
--- a/requirements/testing/travis_all.txt
+++ b/requirements/testing/travis_all.txt
@@ -2,7 +2,7 @@
 
 certifi
 coverage
-pytest!=4.6.0,!=5.4.0,!=6.1.0
+pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures
 pytest-timeout


### PR DESCRIPTION
## PR Summary

This reverts PR https://github.com/matplotlib/matplotlib/pull/18594 / commit 14c19a97798128875f58a35c8d761356d3c7edb4, re: https://github.com/matplotlib/matplotlib/issues/18593.

The pytest-rerunfailures plugin version 9.1.1 has just been released which supports newest pytest 6.1:

* https://github.com/pytest-dev/pytest-rerunfailures/blob/master/CHANGES.rst#911-2020-09-29


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
