### PR TITLE
Add set_ & get_size_pixels

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -899,6 +899,55 @@ default: 'top'
         """
         return np.array(self.bbox_inches.p1)
 
+    def set_size_pixels(self, w, h=None, forward=True):
+        """
+        Set the figure size in pixels.
+
+        Call signatures::
+
+             fig.set_size_pixels(w, h)  # OR
+             fig.set_size_pixels((w, h))
+
+        Parameters
+        ----------
+        w : (float, float) or float
+            Width and height in pixels (if height not specified as a
+            separate argument) or width.
+        h : float
+            Height in pixels.
+        forward : bool, default: True
+            If ``True``, the canvas size is automatically updated, e.g.,
+            you can resize the figure window from the shell.
+
+        See Also
+        --------
+        matplotlib.figure.Figure.set_size_inches
+        matplotlib.figure.Figure.set_dpi
+        matplotlib.figure.Figure.set_figheight
+        """
+        if h is None:  # Got called with a single pair as argument.
+            w, h = w
+        size = np.array([w, h])
+        if not np.isfinite(size).all() or (size < 0).any():
+            raise ValueError(f'figure size must be positive finite not {size}')
+        self.set_size_inches(size / self.dpi, forward=forward)
+
+    def get_size_pixels(self):
+        """
+        Return the current size of the figure in pixels.
+
+        Returns
+        -------
+        ndarray
+           The size (width, height) of the figure in pixels.
+
+        See Also
+        --------
+        matplotlib.figure.Figure.get_size_inches
+        matplotlib.figure.Figure.get_dpi
+        """
+        return np.array(self.bbox_inches.p1) * self.dpi
+
     def get_edgecolor(self):
         """Get the edge color of the Figure rectangle."""
         return self.patch.get_edgecolor()


### PR DESCRIPTION
This is intended to forward a discussion, rather than as something ready to merge. So I've skipped most of the heavy lifting (tests, docs etc.) for now - I'm happy to do it if the feature is acceptable in principle.

Like other people (#12402, #12415, #9226, and doubtless others), I'm frustrated that matplotlib forces me to express things in inches in scenarios which are otherwise completely metric. I was about to make a PR with `set_size_mm`, basically the same idea as #12402.

Scanning those issues and PRs, I see the argument that inches (and the associated 'points') are commonly used in printing. However, the vast majority of plots I make are displayed on screen and never printed, so any physical measurement is a fiction anyway (even if I set `dpi` accurately for one monitor, moving the plot to my other monitor will make it wrong). The docstrings for get/set_size_inches tell me how to convert to & from pixels, but in practice I just fiddle with the numbers until it looks about right. I'd argue that the size in pixels is important enough to warrant convenience methods like this, rather than making the caller deal with dots-per-inch.

I see there has been discussion in the past of a more general units system, like CSS sizes, where you could specify '200 px' or '10 cm'. I agree with the principle of that, but I don't think I'd ever find the time to design, advocate & implement it.