### PR TITLE
Remove special styling of sidebar heading

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -245,20 +245,6 @@ div.sphinxsidebar {
 /*    margin-left: -100%; */
 }
 
-div.sphinxsidebar h4, div.sphinxsidebar h3 {
-    margin: 1em 0 0.5em 0;
-    font-size: 0.9em;
-    padding: 0.1em 0 0.1em 0.5em;
-    color: white;
-    border: 1px solid #86989B;
-    background-color: #AFC1C4;
-}
-
-div.sphinxsidebar h3 a {
-    /* workaround for table of contents heading, which is a link */
-    color: white !important;
-}
-
 div.sphinxsidebar ul {
     padding-left: 1.5em;
     margin-top: 10px;


### PR DESCRIPTION
## PR Summary

The previous styling looked a bit dated and is harder to read.

before / after:
![grafik](https://user-images.githubusercontent.com/2836374/94747106-75ad8200-037e-11eb-9b5d-445426a5636a.png) ![grafik](https://user-images.githubusercontent.com/2836374/94747188-8f4ec980-037e-11eb-8077-a93d6e1df537.png)
