### PR TITLE
Fix singleshot timers in wx.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -87,9 +87,6 @@ class TimerWx(TimerBase):
         if self._timer.IsRunning():
             self._timer_start()  # Restart with new interval.
 
-    def _timer_set_single_shot(self):
-        self._timer.Start()
-
 
 class RendererWx(RendererBase):
     """


### PR DESCRIPTION
## PR Summary

`TimerWx._timer_set_single_shot` currently tries to start the timer without interval or any other setting, which is not what this method is supposed to do; it should only modify settings on internal objects. Since single shot mode is fully handled in `TimerWx._timer_start`, this method is unnecessary.

Fixes #18620.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).