### PR TITLE
Support linestyle='none' in Patch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -409,6 +409,10 @@ class Patch(artist.Artist):
         ``'--'`` or  ``'dashed'``     dashed line
         ``'-.'`` or  ``'dashdot'``    dash-dotted line
         ``':'`` or ``'dotted'``       dotted line
+        ``'None'``                    draw nothing
+        ``'none'``                    draw nothing
+        ``' '``                       draw nothing
+        ``''``                        draw nothing
         ===========================   =================
 
         Alternatively a dash tuple of the following form can be provided::
@@ -424,6 +428,8 @@ class Patch(artist.Artist):
         """
         if ls is None:
             ls = "solid"
+        if ls in [' ', '', 'none']:
+            ls = 'None'
         self._linestyle = ls
         # get the unscaled dash pattern
         offset, ls = self._us_dashes = mlines._get_dash_pattern(ls)
@@ -540,7 +546,7 @@ class Patch(artist.Artist):
         gc.set_foreground(self._edgecolor, isRGBA=True)
 
         lw = self._linewidth
-        if self._edgecolor[3] == 0:
+        if self._edgecolor[3] == 0 or self._linestyle == 'None':
             lw = 0
         gc.set_linewidth(lw)
         gc.set_dashes(self._dashoffset, self._dashes)

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -238,6 +238,32 @@ def test_patch_linestyle_accents():
     fig.canvas.draw()
 
 
+@check_figures_equal(extensions=['png'])
+def test_patch_linestyle_none(fig_test, fig_ref):
+    circle = mpath.Path.unit_circle()
+
+    ax_test = fig_test.add_subplot()
+    ax_ref = fig_ref.add_subplot()
+    for i, ls in enumerate(['none', 'None', ' ', '']):
+        path = mpath.Path(circle.vertices + i, circle.codes)
+        patch = mpatches.PathPatch(path,
+                                   linewidth=3, linestyle=ls,
+                                   facecolor=(1, 0, 0),
+                                   edgecolor=(0, 0, 1))
+        ax_test.add_patch(patch)
+
+        patch = mpatches.PathPatch(path,
+                                   linewidth=3, linestyle='-',
+                                   facecolor=(1, 0, 0),
+                                   edgecolor='none')
+        ax_ref.add_patch(patch)
+
+    ax_test.set_xlim([-1, i + 1])
+    ax_test.set_ylim([-1, i + 1])
+    ax_ref.set_xlim([-1, i + 1])
+    ax_ref.set_ylim([-1, i + 1])
+
+
 def test_wedge_movement():
     param_dict = {'center': ((0, 0), (1, 1), 'set_center'),
                   'r': (5, 8, 'set_radius'),


### PR DESCRIPTION
## PR Summary

This rebases the branch in #5696 by @Rezangyal, plus a small cleanup, and adds a test.

Fixes #5519.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).