### PR TITLE
BLD: sync build and run time numpy pinning

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -42,7 +42,7 @@ jobs:
           CIBW_SKIP: "cp35-* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: pip install certifi numpy==1.15
+          CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
           MPL_DISABLE_FH4: "yes"
 
       - name: Build wheels for CPython 3.6
@@ -52,7 +52,7 @@ jobs:
           CIBW_BUILD: "cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: pip install certifi numpy==1.15
+          CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
           MPL_DISABLE_FH4: "yes"
         if: >
           startsWith(github.ref, 'refs/heads/v3.3') ||
@@ -63,7 +63,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "pp3?-*"
-          CIBW_BEFORE_BUILD: pip install certifi numpy==1.15
+          CIBW_BEFORE_BUILD: pip install certifi numpy==1.16
         if: >
           runner.os != 'Windows' && (
           startsWith(github.ref, 'refs/heads/v3.3') ||

--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
     setup_requires=[
         "certifi>=2020.06.20",
-        "numpy>=1.15",
+        "numpy>=1.16",
     ],
     install_requires=[
         "cycler>=0.10",


### PR DESCRIPTION
As of 60b03f1571c775f60bbd701d3381357a31eaf8bb the minimum version is
1.16.  This got missed as part of that PR.

:sheep: I missed this in https://github.com/matplotlib/matplotlib/pull/17662