### PR TITLE
nbagg: Don't close figures for bubbled events.

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -48,7 +48,7 @@ mpl.mpl_figure_comm = function (comm, msg) {
         console.error('Failed to find cell for figure', id, fig);
         return;
     }
-    fig.cell_info[0].output_area.element.one(
+    fig.cell_info[0].output_area.element.on(
         'cleared',
         { fig: fig },
         fig._remove_fig_handler
@@ -181,6 +181,10 @@ mpl.figure.prototype._init_toolbar = function () {
 
 mpl.figure.prototype._remove_fig_handler = function (event) {
     var fig = event.data.fig;
+    if (event.target !== this) {
+        // Ignore bubbled events from children.
+        return;
+    }
     fig.close_ws(fig, {});
 };
 


### PR DESCRIPTION
## PR Summary

In JavaScript, the event handlers are called for both the element and also bubbled up from any children. If the Matplotlib figure is the only thing in the output, that's fine, as closing the figure when one of the `canvas` or `div`s clears is the same as when the `OutputArea` is cleared. However, if there are other outputs, such as widgets, we do not want to close the figure if one of them is cleared.

As there's no way to clear just the figure output, only close the figure if the _entire_ `OutputArea` div is cleared (i.e., the element we've attached to).

Fixes #18638.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).