### PR TITLE
Propagate minpos from Collections to Axes.datalim

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2001,12 +2001,15 @@ class _AxesBase(martist.Artist):
             # pre-lazy-autoscale behavior, which is not really better).
             self._unstale_viewLim()
             datalim = collection.get_datalim(self.transData)
-            # By definition, p0 <= minpos <= p1, so minpos would be
-            # unnecessary. However, we add minpos to the call so that
-            # self.dataLim will update its own minpos. This ensures that log
-            # scales see the correct minimum.
-            self.update_datalim(
-                np.row_stack([datalim.p0, datalim.minpos, datalim.p1]))
+            points = datalim.get_points()
+            if not np.isinf(datalim.minpos).all():
+                # By definition, if minpos (minimum positive value) is set
+                # (i.e., non-inf), then min(points) <= minpos <= max(points),
+                # and minpos would be superfluous. However, we add minpos to
+                # the call so that self.dataLim will update its own minpos.
+                # This ensures that log scales see the correct minimum.
+                points = np.concatenate([points, [datalim.minpos]])
+            self.update_datalim(points)
 
         self.stale = True
         return collection

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2000,7 +2000,13 @@ class _AxesBase(martist.Artist):
             # Make sure viewLim is not stale (mostly to match
             # pre-lazy-autoscale behavior, which is not really better).
             self._unstale_viewLim()
-            self.update_datalim(collection.get_datalim(self.transData))
+            datalim = collection.get_datalim(self.transData)
+            # By definition, p0 <= minpos <= p1, so minpos would be
+            # unnecessary. However, we add minpos to the call so that
+            # self.dataLim will update its own minpos. This ensures that log
+            # scales see the correct minimum.
+            self.update_datalim(
+                np.row_stack([datalim.p0, datalim.minpos, datalim.p1]))
 
         self.stale = True
         return collection

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -274,11 +274,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 # can properly have the axes limits set by their shape +
                 # offset.  LineCollections that have no offsets can
                 # also use this algorithm (like streamplot).
-                result = mpath.get_path_collection_extents(
-                    transform.get_affine(), paths, self.get_transforms(),
+                return mpath.get_path_collection_extents(
+                    transform.get_affine() - transData, paths,
+                    self.get_transforms(),
                     transOffset.transform_non_affine(offsets),
                     transOffset.get_affine().frozen())
-                return result.transformed(transData.inverted())
             if not self._offsetsNone:
                 # this is for collections that have their paths (shapes)
                 # in physical, axes-relative, or figure-relative units
@@ -290,9 +290,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 # note A-B means A B^{-1}
                 offsets = np.ma.masked_invalid(offsets)
                 if not offsets.mask.all():
-                    points = np.row_stack((offsets.min(axis=0),
-                                           offsets.max(axis=0)))
-                    return transforms.Bbox(points)
+                    bbox = transforms.Bbox.null()
+                    bbox.update_from_data_xy(offsets)
+                    return bbox
         return transforms.Bbox.null()
 
     def get_window_extent(self, renderer):

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1042,4 +1042,4 @@ def get_path_collection_extents(
     extents, minpos = _path.get_path_collection_extents(
         master_transform, paths, np.atleast_3d(transforms),
         offsets, offset_transform)
-    return Bbox.from_extents(*extents)
+    return Bbox.from_extents(*extents, minpos=minpos)

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1039,6 +1039,7 @@ def get_path_collection_extents(
     from .transforms import Bbox
     if len(paths) == 0:
         raise ValueError("No paths provided")
-    return Bbox.from_extents(*_path.get_path_collection_extents(
+    extents, minpos = _path.get_path_collection_extents(
         master_transform, paths, np.atleast_3d(transforms),
-        offsets, offset_transform))
+        offsets, offset_transform)
+    return Bbox.from_extents(*extents)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -11,7 +11,7 @@ import matplotlib.collections as mcollections
 import matplotlib.transforms as mtransforms
 from matplotlib.collections import (Collection, LineCollection,
                                     EventCollection, PolyCollection)
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 
 def generate_EventCollection_plot():
@@ -299,6 +299,32 @@ def test_add_collection():
     bounds = ax.dataLim.bounds
     coll = ax.scatter([], [])
     assert ax.dataLim.bounds == bounds
+
+
+@pytest.mark.style('mpl20')
+@check_figures_equal(extensions=['png'])
+def test_collection_log_datalim(fig_test, fig_ref):
+    # Data limits should respect the minimum x/y when using log scale.
+    x_vals = [4.38462e-6, 5.54929e-6, 7.02332e-6, 8.88889e-6, 1.12500e-5,
+              1.42383e-5, 1.80203e-5, 2.28070e-5, 2.88651e-5, 3.65324e-5,
+              4.62363e-5, 5.85178e-5, 7.40616e-5, 9.37342e-5, 1.18632e-4]
+    y_vals = [0.0, 0.1, 0.182, 0.332, 0.604, 1.1, 2.0, 3.64, 6.64, 12.1, 22.0,
+              39.6, 71.3]
+
+    x, y = np.meshgrid(x_vals, y_vals)
+    x = x.flatten()
+    y = y.flatten()
+
+    ax_test = fig_test.subplots()
+    ax_test.set_xscale('log')
+    ax_test.set_yscale('log')
+    ax_test.margins = 0
+    ax_test.scatter(x, y)
+
+    ax_ref = fig_ref.subplots()
+    ax_ref.set_xscale('log')
+    ax_ref.set_yscale('log')
+    ax_ref.plot(x, y, marker="o", ls="")
 
 
 def test_quiver_limits():

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -808,13 +808,17 @@ class Bbox(BboxBase):
         return Bbox.from_extents(x0, y0, x0 + width, y0 + height)
 
     @staticmethod
-    def from_extents(*args):
+    def from_extents(*args, minpos=None):
         """
         Create a new Bbox from *left*, *bottom*, *right* and *top*.
 
-        The *y*-axis increases upwards.
+        The *y*-axis increases upwards. Optionally, passing *minpos* will set
+        that property on the returned Bbox.
         """
-        return Bbox(np.reshape(args, (2, 2)))
+        bbox = Bbox(np.reshape(args, (2, 2)))
+        if minpos is not None:
+            bbox._minpos[:] = minpos
+        return bbox
 
     def __format__(self, fmt):
         return (

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -812,8 +812,17 @@ class Bbox(BboxBase):
         """
         Create a new Bbox from *left*, *bottom*, *right* and *top*.
 
-        The *y*-axis increases upwards. Optionally, passing *minpos* will set
-        that property on the returned Bbox.
+        The *y*-axis increases upwards.
+
+        Parameters
+        ----------
+        left, bottom, right, top : float
+            The four extents of the bounding box.
+
+        minpos : float or None
+           If this is supplied, the Bbox will have a minimum positive value
+           set. This is useful when dealing with logarithmic scales and other
+           scales where negative bounds result in floating point errors.
         """
         bbox = Bbox(np.reshape(args, (2, 2)))
         if minpos is not None:
@@ -957,14 +966,35 @@ class Bbox(BboxBase):
 
     @property
     def minpos(self):
+        """
+        The minimum positive value in both directions within the Bbox.
+
+        This is useful when dealing with logarithmic scales and other scales
+        where negative bounds result in floating point errors, and will be used
+        as the minimum extent instead of *p0*.
+        """
         return self._minpos
 
     @property
     def minposx(self):
+        """
+        The minimum positive value in the *x*-direction within the Bbox.
+
+        This is useful when dealing with logarithmic scales and other scales
+        where negative bounds result in floating point errors, and will be used
+        as the minimum *x*-extent instead of *x0*.
+        """
         return self._minpos[0]
 
     @property
     def minposy(self):
+        """
+        The minimum positive value in the *y*-direction within the Bbox.
+
+        This is useful when dealing with logarithmic scales and other scales
+        where negative bounds result in floating point errors, and will be used
+        as the minimum *y*-extent instead of *y0*.
+        """
         return self._minpos[1]
 
     def get_points(self):

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -250,7 +250,8 @@ static PyObject *Py_update_path_extents(PyObject *self, PyObject *args, PyObject
         "NNi", outextents.pyobj(), outminpos.pyobj(), changed);
 }
 
-const char *Py_get_path_collection_extents__doc__ = "get_path_collection_extents(";
+const char *Py_get_path_collection_extents__doc__ = "get_path_collection_extents("
+    "master_transform, paths, transforms, offsets, offset_transform)";
 
 static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args, PyObject *kwds)
 {
@@ -295,7 +296,12 @@ static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args, 
     extents(1, 0) = e.x1;
     extents(1, 1) = e.y1;
 
-    return extents.pyobj();
+    npy_intp minposdims[] = { 2 };
+    numpy::array_view<double, 1> minpos(minposdims);
+    minpos(0) = e.xm;
+    minpos(1) = e.ym;
+
+    return Py_BuildValue("NN", extents.pyobj(), minpos.pyobj());
 }
 
 const char *Py_point_in_path_collection__doc__ =


### PR DESCRIPTION
## PR Summary

This is an attempt to fix #16552. I'm not sure if it's the best change, API-wise, but seems to work without breaking anything. Possibly could do with an API change note.

Essentially, we have the right information to do log auto-scaling correct, but that's thrown away at the `Collection.get_datalim`/`Axes.add_collection` interface. This propagates that information onto the `Bbox` that's passed between those two functions, and uses it when updating `Axes.dataLim`.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).