### PR TITLE
Axes.axline: implement support transform argument (for points but not slope)

### DIFF
--- a/doc/users/next_whats_new/axline_transform.rst
+++ b/doc/users/next_whats_new/axline_transform.rst
@@ -1,6 +1,7 @@
 axline supports *transform* parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The *transform* keyword argument only applies to the points *xy1*,
+`~.Axes.axline` now supports the *transform* parameter, which applies to
+the points *xy1*, *xy2*.
 *xy2*. The *slope* (if given) is always in data coordinates. This can
 be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
 slope.

--- a/doc/users/next_whats_new/axline_transform.rst
+++ b/doc/users/next_whats_new/axline_transform.rst
@@ -1,7 +1,6 @@
 axline supports *transform* parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `~.Axes.axline` now supports the *transform* parameter, which applies to
-the points *xy1*, *xy2*.
-*xy2*. The *slope* (if given) is always in data coordinates. This can
-be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
+the points *xy1*, *xy2*. The *slope* (if given) is always in data coordinates.
+This can be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
 slope.

--- a/doc/users/next_whats_new/axline_transform.rst
+++ b/doc/users/next_whats_new/axline_transform.rst
@@ -1,0 +1,6 @@
+axline supports *transform* parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *transform* keyword argument only applies to the points *xy1*,
+*xy2*. The *slope* (if given) is always in data coordinates. This can
+be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
+slope.

--- a/examples/pyplots/axline.py
+++ b/examples/pyplots/axline.py
@@ -27,6 +27,18 @@ plt.xlabel("t")
 plt.legend(fontsize=14)
 plt.show()
 
+# `~.axes.Axes.axline` can also be used with a `transform` parameter, which
+# applies to the point, but not to the slope. This can be useful for drawing
+# diagonal grid lines with a fixed slope, which stay in place when the
+# plot limits are moved.
+
+for pos in np.linspace(-2, 1, 10):
+    plt.axline((pos, 0), slope=0.5, color='k', transform=plt.gca().transAxes)
+
+plt.ylim([0, 1])
+plt.xlim([0, 1])
+plt.show()
+
 #############################################################################
 #
 # ------------

--- a/examples/pyplots/axline.py
+++ b/examples/pyplots/axline.py
@@ -28,7 +28,7 @@ plt.legend(fontsize=14)
 plt.show()
 
 ##############################################################################
-# `~.axes.Axes.axline` can also be used with a `transform` parameter, which
+# `~.axes.Axes.axline` can also be used with a ``transform`` parameter, which
 # applies to the point, but not to the slope. This can be useful for drawing
 # diagonal grid lines with a fixed slope, which stay in place when the
 # plot limits are moved.

--- a/examples/pyplots/axline.py
+++ b/examples/pyplots/axline.py
@@ -27,6 +27,7 @@ plt.xlabel("t")
 plt.legend(fontsize=14)
 plt.show()
 
+##############################################################################
 # `~.axes.Axes.axline` can also be used with a `transform` parameter, which
 # applies to the point, but not to the slope. This can be useful for drawing
 # diagonal grid lines with a fixed slope, which stay in place when the

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -855,8 +855,8 @@ class Axes(_AxesBase):
 
         datalim = [xy1] if xy2 is None else [xy1, xy2]
         if "transform" in kwargs:
-            #TODO: datalim = (kwargs["transform"]
-            # + self.transData.inverted()).transform(datalim)?
+            # if a transform is passed (i.e. line points are not in data space),
+            # data limits should not be adjusted.
             datalim = []
 
         line = mlines._AxLine(xy1, xy2, slope, **kwargs)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -855,7 +855,7 @@ class Axes(_AxesBase):
 
         datalim = [xy1] if xy2 is None else [xy1, xy2]
         if "transform" in kwargs:
-            # if a transform is passed (i.e. line points are not in data space),
+            # if a transform is passed (i.e. line points not in data space),
             # data limits should not be adjusted.
             datalim = []
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -880,8 +880,10 @@ class Axes(_AxesBase):
         """
         Add an infinitely long straight line.
 
-        The line is defined by one point in axes coordinates *xy1* and a
-        *slope* in data coordinates.
+        The line is defined by a *slope* in data coordinates, set by the
+        current x and y limits of the axes, and a point in axes-relative
+        coordinates, which is in the same place on the axes regardless of x
+        and y limits.
 
         This should only be used with linear scales; the *slope* has no clear
         meaning for all other scales, and thus the behavior is undefined.
@@ -890,6 +892,8 @@ class Axes(_AxesBase):
         ----------
         xy1 : (float, float)
             Point for the line to pass through, in axes coordinates.
+            ``(0, 0)`` is the bottom left corner of the axes, ``(1, 1)`` is
+            the upper right.
         slope : float
             The slope of the line, in data coordinates.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -808,11 +808,10 @@ class Axes(_AxesBase):
         all other scales, and thus the behavior is undefined. Please specify
         the line using the points *xy1*, *xy2* for non-linear scales.
 
-        As part of the ``kwargs``, a 'transform' can be passed. In the case
-        that a point and a slope are given, the transformation will only be
-        used for the point and not for the slope, i.e. the slope stays in data
-        coordinates. This can be used e.g. with ``ax.transAxes`` for drawing
-        grid lines with a fixed slope.
+        The *transform* keyword argument only applies to the points *xy1*,
+        *xy2*. The *slope* (if given) is always in data coordinates. This can
+        be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
+        slope.
 
         Parameters
         ----------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -843,11 +843,6 @@ class Axes(_AxesBase):
 
             >>> axline((0, 0), (1, 1), linewidth=4, color='r')
         """
-        if (xy2 is None and slope is None or
-                xy2 is not None and slope is not None):
-            raise TypeError(
-                "Exactly one of 'xy2' and 'slope' must be given")
-
         if slope is not None and (self.get_xscale() != 'linear' or
                                   self.get_yscale() != 'linear'):
             raise TypeError("'slope' cannot be used with non-linear scales")

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -876,6 +876,55 @@ class Axes(_AxesBase):
         self._request_autoscale_view()
         return line
 
+    def axline_transaxes(self, xy1, slope, **kwargs):
+        """
+        Add an infinitely long straight line.
+
+        The line is defined by one point in axes coordinates *xy1* and a
+        *slope* in data coordinates.
+
+        This should only be used with linear scales; the *slope* has no clear
+        meaning for all other scales, and thus the behavior is undefined.
+
+        Parameters
+        ----------
+        xy1 : (float, float)
+            Point for the line to pass through, in axes coordinates.
+        slope : float
+            The slope of the line, in data coordinates.
+
+        Returns
+        -------
+        `.Line2D`
+
+        Other Parameters
+        ----------------
+        **kwargs
+            Valid kwargs are `.Line2D` properties, with the exception of
+            'transform':
+
+            %(_Line2D_docstr)s
+
+        See Also
+        --------
+        axhline : for horizontal lines
+        axvline : for vertical lines
+
+        Examples
+        --------
+        Draw a thick red line passing through (0, 0)
+        (the lower left corner of the viewport) with slope 1::
+
+            >>> axline_transaxes((0, 0), 1, linewidth=4, color='r')
+        """
+        if "transform" in kwargs:
+            raise TypeError("'transform' is not allowed as a kwarg; "
+                            "axline_transaxes generates its own transform")
+
+        line = mlines._AxLineTransAxes(xy1, slope, **kwargs)
+        self.add_line(line)
+        return line
+
     @docstring.dedent_interpd
     def axhspan(self, ymin, ymax, xmin=0, xmax=1, **kwargs):
         """

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1430,7 +1430,7 @@ class _AxLine(Line2D):
                 if np.allclose(y1, y2):
                     raise ValueError(
                         f"Cannot draw a line through two identical points "
-                        f"(x={self.get_xdata()}, y={self.get_ydata()})")
+                        f"(x={(x1, x2)}, y={(y1, y2)})")
                 slope = np.inf
             else:
                 slope = dy / dx

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -17,9 +17,7 @@ from .cbook import (
 from .colors import is_color_like, get_named_colors_mapping
 from .markers import MarkerStyle
 from .path import Path
-from .transforms import (
-    Affine2D, Bbox, BboxTransformFrom, BboxTransformTo, TransformedPath,
-    AffineDeltaTransform)
+from .transforms import Bbox, BboxTransformTo, TransformedPath
 
 # Imported here for backward compatibility, even though they don't
 # really belong.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1456,14 +1456,18 @@ class _AxLineTransAxes(_AxLine):
         (vxlo, vylo), (vxhi, vyhi) = ax.transScale.transform(ax.viewLim)
         x, y = (ax.transAxes + ax.transData.inverted()).transform(self._xy1)
 
-        # find intersections with view limits in either direction,
-        # and draw between the middle two points.
-        _, start, stop, _ = sorted([
-            (vxlo, y + (vxlo - x) * self._slope),
-            (vxhi, y + (vxhi - x) * self._slope),
-            (x + (vylo - y) / self._slope, vylo),
-            (x + (vyhi - y) / self._slope, vyhi),
-        ])
+        if np.isclose(self._slope, 0):
+            start = vxlo, y
+            stop = vxhi, y
+        else:
+            # find intersections with view limits in either direction,
+            # and draw between the middle two points.
+            _, start, stop, _ = sorted([
+                (vxlo, y + (vxlo - x) * self._slope),
+                (vxhi, y + (vxhi - x) * self._slope),
+                (x + (vylo - y) / self._slope, vylo),
+                (x + (vyhi - y) / self._slope, vyhi),
+            ])
         return (BboxTransformTo(Bbox([start, stop]))
                 + ax.transLimits + ax.transAxes)
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1406,6 +1406,12 @@ class _AxLine(Line2D):
 
     def __init__(self, xy1, xy2, slope, **kwargs):
         super().__init__([0, 1], [0, 1], **kwargs)
+        
+        if (xy2 is None and slope is None or
+                xy2 is not None and slope is not None):
+            raise TypeError(
+                "Exactly one of 'xy2' and 'slope' must be given")
+
         self._slope = slope
         self._xy1 = xy1
         self._xy2 = xy2

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -18,7 +18,8 @@ from .colors import is_color_like, get_named_colors_mapping
 from .markers import MarkerStyle
 from .path import Path
 from .transforms import (
-    Affine2D, Bbox, BboxTransformFrom, BboxTransformTo, TransformedPath, AffineDeltaTransform)
+    Affine2D, Bbox, BboxTransformFrom, BboxTransformTo, TransformedPath,
+    AffineDeltaTransform)
 
 # Imported here for backward compatibility, even though they don't
 # really belong.
@@ -1455,7 +1456,8 @@ class _AxLineTransAxes(_AxLine):
         ax = self.axes
         x, y = self._xy1
 
-        dx, dy = AffineDeltaTransform(ax.transData + ax.transAxes.inverted()).transform([1, self._slope])
+        dx, dy = AffineDeltaTransform(ax.transData + ax.transAxes.inverted())\
+            .transform([1, self._slope])
         slope_axes = dy / dx
 
         start = 0, slope_axes * (0 - x) + y

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1418,10 +1418,7 @@ class _AxLine(Line2D):
 
     def get_transform(self):
         ax = self.axes
-        if self._transform is not None:
-            points_transform = self._transform + ax.transData.inverted()
-        else:
-            points_transform = ax.transScale
+        points_transform = self._transform + ax.transData.inverted()
 
         if self._xy2 is not None:
             # two points were given

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1415,7 +1415,6 @@ class _AxLine(Line2D):
         self._slope = slope
         self._xy1 = xy1
         self._xy2 = xy2
-        self._transform = kwargs.get("transform")
 
     def get_transform(self):
         ax = self.axes

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1406,64 +1406,60 @@ class _AxLine(Line2D):
     transform at draw time.
     """
 
+    def __init__(self, xy1, xy2, slope, **kwargs):
+        super().__init__([0, 1], [0, 1], **kwargs)
+        self._slope = slope
+        self._xy1 = xy1
+        self._xy2 = xy2
+        self._transform = kwargs.get("transform")
+
     def get_transform(self):
         ax = self.axes
-        (x1, y1), (x2, y2) = ax.transScale.transform([*zip(*self.get_data())])
-        dx = x2 - x1
-        dy = y2 - y1
-        if np.allclose(x1, x2):
-            if np.allclose(y1, y2):
-                raise ValueError(
-                    f"Cannot draw a line through two identical points "
-                    f"(x={self.get_xdata()}, y={self.get_ydata()})")
-            # First send y1 to 0 and y2 to 1.
-            return (Affine2D.from_values(1, 0, 0, 1 / dy, 0, -y1 / dy)
-                    + ax.get_xaxis_transform(which="grid"))
-        if np.allclose(y1, y2):
-            # First send x1 to 0 and x2 to 1.
-            return (Affine2D.from_values(1 / dx, 0, 0, 1, -x1 / dx, 0)
-                    + ax.get_yaxis_transform(which="grid"))
+        if self._transform is not None:
+            points_transform = self._transform + ax.transData.inverted()
+        else:
+            points_transform = ax.transScale
+
+        if self._xy2 is not None:
+            # two points were given
+            (x1, y1), (x2, y2) = \
+                points_transform.transform([self._xy1, self._xy2])
+            dx = x2 - x1
+            dy = y2 - y1
+            if np.allclose(x1, x2):
+                if np.allclose(y1, y2):
+                    raise ValueError(
+                        f"Cannot draw a line through two identical points "
+                        f"(x={self.get_xdata()}, y={self.get_ydata()})")
+                slope = np.inf
+            else:
+                slope = dy / dx
+        else:
+            # one point and a slope were given
+            x1, y1 = points_transform.transform(self._xy1)
+            slope = self._slope
         (vxlo, vylo), (vxhi, vyhi) = ax.transScale.transform(ax.viewLim)
         # General case: find intersections with view limits in either
         # direction, and draw between the middle two points.
-        _, start, stop, _ = sorted([
-            (vxlo, y1 + (vxlo - x1) * dy / dx),
-            (vxhi, y1 + (vxhi - x1) * dy / dx),
-            (x1 + (vylo - y1) * dx / dy, vylo),
-            (x1 + (vyhi - y1) * dx / dy, vyhi),
-        ])
-        return (BboxTransformFrom(Bbox([*zip(*self.get_data())]))
-                + BboxTransformTo(Bbox([start, stop]))
+        if np.isclose(slope, 0):
+            start = vxlo, y1
+            stop = vxhi, y1
+        elif np.isinf(slope):
+            start = x1, vylo
+            stop = x1, vyhi
+        else:
+            _, start, stop, _ = sorted([
+                (vxlo, y1 + (vxlo - x1) * slope),
+                (vxhi, y1 + (vxhi - x1) * slope),
+                (x1 + (vylo - y1) / slope, vylo),
+                (x1 + (vyhi - y1) / slope, vyhi),
+            ])
+        return (BboxTransformTo(Bbox([start, stop]))
                 + ax.transLimits + ax.transAxes)
 
     def draw(self, renderer):
         self._transformed_path = None  # Force regen.
         super().draw(renderer)
-
-
-class _AxLineTransAxes(_AxLine):
-    """
-    A helper class that implements `~.Axes.axline_transaxes`, by recomputing
-    the artist transform at draw time.
-    """
-
-    def __init__(self, xy1, slope, **kwargs):
-        super().__init__([0, 1], [0, 1], **kwargs)
-        self._slope = slope
-        self._xy1 = xy1
-
-    def get_transform(self):
-        ax = self.axes
-        x, y = self._xy1
-
-        dx, dy = AffineDeltaTransform(ax.transData + ax.transAxes.inverted())\
-            .transform([1, self._slope])
-        slope_axes = dy / dx
-
-        start = 0, slope_axes * (0 - x) + y
-        stop = 1, slope_axes * (1 - x) + y
-
-        return BboxTransformTo(Bbox([start, stop])) + ax.transAxes
 
 
 class VertexSelector:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1406,7 +1406,7 @@ class _AxLine(Line2D):
 
     def __init__(self, xy1, xy2, slope, **kwargs):
         super().__init__([0, 1], [0, 1], **kwargs)
-        
+
         if (xy2 is None and slope is None or
                 xy2 is not None and slope is not None):
             raise TypeError(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4123,6 +4123,10 @@ def test_axline_args():
     ax.set_yscale('log')
     with pytest.raises(TypeError):
         ax.axline((0, 0), slope=1)
+    ax.set_yscale('linear')
+    with pytest.raises(ValueError):
+        ax.axline((0, 0), (0, 0))  # two identical points are not allowed
+        plt.draw()
 
 
 @image_comparison(['vlines_basic', 'vlines_with_nan', 'vlines_masked'],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4072,6 +4072,19 @@ def test_axline(fig_test, fig_ref):
     ax.axvline(-0.5, color='C5')
 
 
+@check_figures_equal()
+def test_axline_transform(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.axline_transaxes((0, 0), slope=1)
+    ax.axline_transaxes((1, 0.5), slope=1, color='C1')
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.plot([-1, 1], [-1, 1])
+    ax.plot([0, 1], [-1, 0], color='C1')
+
+
 def test_axline_args():
     """Exactly one of *xy2* and *slope* must be specified."""
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4073,16 +4073,38 @@ def test_axline(fig_test, fig_ref):
 
 
 @check_figures_equal()
-def test_axline_transform(fig_test, fig_ref):
+def test_axline_transaxes(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
     ax.axline_transaxes((0, 0), slope=1)
     ax.axline_transaxes((1, 0.5), slope=1, color='C1')
+    ax.axline_transaxes((0.5, 0.5), slope=0, color='C2')
 
     ax = fig_ref.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
     ax.plot([-1, 1], [-1, 1])
     ax.plot([0, 1], [-1, 0], color='C1')
+    ax.plot([-1, 1], [0, 0], color='C2')
+
+
+@check_figures_equal()
+def test_axline_transaxes_panzoom(fig_test, fig_ref):
+    # test that it is robust against pan/zoom and
+    # figure resize after plotting
+    ax = fig_test.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.axline_transaxes((0, 0), slope=1)
+    ax.axline_transaxes((0.5, 0.5), slope=2, color='C1')
+    ax.axline_transaxes((0.5, 0.5), slope=0, color='C2')
+    ax.set(xlim=(0, 5), ylim=(0, 10))
+    fig_test.set_size_inches(3, 3)
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(0, 5), ylim=(0, 10))
+    fig_ref.set_size_inches(3, 3)
+    ax.plot([0, 5], [0, 5])
+    ax.plot([0, 5], [0, 10], color='C1')
+    ax.plot([0, 5], [5, 5], color='C2')
 
 
 def test_axline_args():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4076,15 +4076,17 @@ def test_axline(fig_test, fig_ref):
 def test_axline_transaxes(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.axline_transaxes((0, 0), slope=1)
-    ax.axline_transaxes((1, 0.5), slope=1, color='C1')
-    ax.axline_transaxes((0.5, 0.5), slope=0, color='C2')
+    ax.axline((0, 0), slope=1, transform=ax.transAxes)
+    ax.axline((1, 0.5), slope=1, color='C1', transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
+    ax.axline((0.5, 0), (0.5, 1), color='C3', transform=ax.transAxes)
 
     ax = fig_ref.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
     ax.plot([-1, 1], [-1, 1])
     ax.plot([0, 1], [-1, 0], color='C1')
     ax.plot([-1, 1], [0, 0], color='C2')
+    ax.plot([0, 0], [-1, 1], color='C3')
 
 
 @check_figures_equal()
@@ -4093,9 +4095,9 @@ def test_axline_transaxes_panzoom(fig_test, fig_ref):
     # figure resize after plotting
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.axline_transaxes((0, 0), slope=1)
-    ax.axline_transaxes((0.5, 0.5), slope=2, color='C1')
-    ax.axline_transaxes((0.5, 0.5), slope=0, color='C2')
+    ax.axline((0, 0), slope=1, transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=2, color='C1', transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
     ax.set(xlim=(0, 5), ylim=(0, 10))
     fig_test.set_size_inches(3, 3)
 


### PR DESCRIPTION
## PR Summary

for plotting  a line through a point in axes coordinates and with a slope in data coordinates
see #18625 for details and example.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
