### PR TITLE
Sync SubplotDivider API with SubplotBase API changes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18564-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18564-AL.rst
@@ -1,14 +1,17 @@
 Subplot-related attributes and methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Some ``SubplotBase`` attributes have been deprecated and/or moved to
-`.SubplotSpec`: ``get_geometry`` (use `.SubplotBase.get_subplotspec`
-instead), ``change_geometry`` (use `.SubplotBase.set_subplotspec` instead),
-``is_first_row``, ``is_last_row``, ``is_first_col``, ``is_last_col`` (use the
-corresponding methods on the `.SubplotSpec` instance instead), ``figbox`` (use
-``ax.get_subplotspec().get_geometry(ax.figure)`` instead to recompute the
-geometry, or ``ax.get_position()`` to read its current value), ``numRows``,
-``numCols`` (use the ``nrows`` and ``ncols`` attribute on the `.GridSpec`
-instead).
+Some ``SubplotBase`` methods and attributes have been deprecated and/or moved
+to `.SubplotSpec`: ``get_geometry`` (use `.SubplotBase.get_subplotspec`
+instead), ``change_geometry`` (use `.SubplotBase.set_subplotspec`
+instead), ``is_first_row``, ``is_last_row``, ``is_first_col``,
+``is_last_col`` (use the corresponding methods on the `.SubplotSpec`
+instance instead), ``update_params`` (now a no-op), ``figbox`` (use
+``ax.get_subplotspec().get_geometry(ax.figure)`` instead to recompute
+the geometry, or ``ax.get_position()`` to read its current value),
+``numRows``, ``numCols`` (use the ``nrows`` and ``ncols`` attribute on the
+`.GridSpec` instead).  Likewise, the ``get_geometry``, ``change_geometry``,
+``update_params``, and ``figbox`` methods/attributes of `.SubplotDivider` have
+been deprecated, with similar replacements.
 
 Axes constructor
 ~~~~~~~~~~~~~~~~

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -347,27 +347,33 @@ class SubplotDivider(Divider):
             (2, 3, 4)).
         """
         self.figure = fig
-        self._subplotspec = SubplotSpec._from_subplot_args(fig, args)
-        self.update_params()  # sets self.figbox
-        super().__init__(fig, pos=self.figbox.bounds,
+        super().__init__(fig, [0, 0, 1, 1],
                          horizontal=horizontal or [], vertical=vertical or [],
                          aspect=aspect, anchor=anchor)
+        self.set_subplotspec(SubplotSpec._from_subplot_args(fig, args))
 
     def get_position(self):
         """Return the bounds of the subplot box."""
-        self.update_params()  # update self.figbox
-        return self.figbox.bounds
+        return self.get_subplotspec().get_position(self.figure).bounds
 
+    @cbook.deprecated("3.4")
+    @property
+    def figbox(self):
+        return self.get_subplotspec().get_position(self.figure)
+
+    @cbook.deprecated("3.4")
     def update_params(self):
-        """Update the subplot position from fig.subplotpars."""
-        self.figbox = self.get_subplotspec().get_position(self.figure)
+        pass
 
+    @cbook.deprecated(
+        "3.4", alternative="get_subplotspec",
+        addendum="(get_subplotspec returns a SubplotSpec instance.)")
     def get_geometry(self):
         """Get the subplot geometry, e.g., (2, 2, 3)."""
         rows, cols, num1, num2 = self.get_subplotspec().get_geometry()
         return rows, cols, num1 + 1  # for compatibility
 
-    # COVERAGE NOTE: Never used internally or from examples
+    @cbook.deprecated("3.4", alternative="set_subplotspec")
     def change_geometry(self, numrows, numcols, num):
         """Change subplot geometry, e.g., from (1, 1, 1) to (2, 2, 3)."""
         self._subplotspec = GridSpec(numrows, numcols)[num-1]
@@ -381,6 +387,7 @@ class SubplotDivider(Divider):
     def set_subplotspec(self, subplotspec):
         """Set the SubplotSpec instance."""
         self._subplotspec = subplotspec
+        self.set_position(subplotspec.get_position(self.figure))
 
 
 class AxesDivider(Divider):


### PR DESCRIPTION
The deprecations parallel the ones in 261f706.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
