### PR TITLE
Small simplifications to BboxImage.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -24,8 +24,9 @@ import matplotlib._image as _image
 # For user convenience, the names from _image are also imported into
 # the image namespace:
 from matplotlib._image import *
-from matplotlib.transforms import (Affine2D, BboxBase, Bbox, BboxTransform,
-                                   IdentityTransform, TransformedBbox)
+from matplotlib.transforms import (
+    Affine2D, BboxBase, Bbox, BboxTransform, BboxTransformTo,
+    IdentityTransform, TransformedBbox)
 
 _log = logging.getLogger(__name__)
 
@@ -1377,12 +1378,7 @@ class BboxImage(_ImageBase):
             resample=resample,
             **kwargs
         )
-
         self.bbox = bbox
-        self._transform = IdentityTransform()
-
-    def get_transform(self):
-        return self._transform
 
     def get_window_extent(self, renderer=None):
         if renderer is None:
@@ -1416,7 +1412,7 @@ class BboxImage(_ImageBase):
         bbox_in._points /= [width, height]
         bbox_out = self.get_window_extent(renderer)
         clip = Bbox([[0, 0], [width, height]])
-        self._transform = BboxTransform(Bbox([[0, 0], [1, 1]]), clip)
+        self._transform = BboxTransformTo(clip)
         return self._make_image(
             self._A,
             bbox_in, bbox_out, clip, magnification, unsampled=unsampled)


### PR DESCRIPTION
self._transform/get_transform() can just be inherited from the base
Artist class.  A BboxTransform starting at the unit bbox is equivalent
to BboxTransformTo.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
