### PR TITLE
Define GridFinder.{,inv_}transform_xy as normal methods.

### DIFF
--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -176,24 +176,26 @@ class GridFinder:
         return gi
 
     def update_transform(self, aux_trans):
-        if isinstance(aux_trans, Transform):
-            def transform_xy(x, y):
-                ll1 = np.column_stack([x, y])
-                ll2 = aux_trans.transform(ll1)
-                lon, lat = ll2[:, 0], ll2[:, 1]
-                return lon, lat
+        if not isinstance(aux_trans, Transform) and len(aux_trans) != 2:
+            raise TypeError("'aux_trans' must be either a Transform instance "
+                            "or a pair of callables")
+        self._aux_transform = aux_trans
 
-            def inv_transform_xy(x, y):
-                ll1 = np.column_stack([x, y])
-                ll2 = aux_trans.inverted().transform(ll1)
-                lon, lat = ll2[:, 0], ll2[:, 1]
-                return lon, lat
-
+    def transform_xy(self, x, y):
+        aux_trf = self._aux_transform
+        if isinstance(aux_trf, Transform):
+            return aux_trf.transform(np.column_stack([x, y])).T
         else:
-            transform_xy, inv_transform_xy = aux_trans
+            transform_xy, inv_transform_xy = aux_trf
+            return transform_xy(x, y)
 
-        self.transform_xy = transform_xy
-        self.inv_transform_xy = inv_transform_xy
+    def inv_transform_xy(self, x, y):
+        aux_trf = self._aux_transform
+        if isinstance(aux_trf, Transform):
+            return aux_trf.inverted().transform(np.column_stack([x, y])).T
+        else:
+            transform_xy, inv_transform_xy = aux_trf
+            return inv_transform_xy(x, y)
 
     def update(self, **kw):
         for k in kw:


### PR DESCRIPTION
... rather than as dynamical attributes using local functions.

This way they show up in the docs, and avoid making GridFinder
unpicklable.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
