### PR TITLE
REORG: add a LineStyle class

### DIFF
--- a/examples/lines_bars_and_markers/linestyles.py
+++ b/examples/lines_bars_and_markers/linestyles.py
@@ -3,74 +3,28 @@
 Linestyles
 ==========
 
-Simple linestyles can be defined using the strings "solid", "dotted", "dashed"
-or "dashdot". More refined control can be achieved by providing a dash tuple
-``(offset, (on_off_seq))``. For example, ``(0, (3, 10, 1, 15))`` means
-(3pt line, 10pt space, 1pt line, 15pt space) with no offset. See also
-`.Line2D.set_linestyle`.
+The Matplotlib `~mpl._enums.LineStyle` specifies the dash pattern used to draw
+a given line. The simplest line styles can be accessed by name using the
+strings "solid", "dotted", "dashed" and "dashdot" (or their short names, "-",
+":", "--", and "-.", respectively).
 
-*Note*: The dash style can also be configured via `.Line2D.set_dashes`
-as shown in :doc:`/gallery/lines_bars_and_markers/line_demo_dash_control`
-and passing a list of dash sequences using the keyword *dashes* to the
-cycler in :doc:`property_cycle </tutorials/intermediate/color_cycle>`.
+The exact spacing of the dashes used can be controlled using the
+'lines.*_pattern' family of rc parameters. For example,
+:rc:`lines.dashdot_pattern` controls the exact spacing of dashed used whenever
+the '-.' `~mpl._enums.LineStyle` is specified.
+
+For more information about how to create custom `~mpl._enums.LineStyle`
+specifications, see `the LineStyle docs <mpl._enums.LineStyle>`.
+
+*Note*: For historical reasons, one can also specify the dash pattern for a
+particular line using `.Line2D.set_dashes` as shown in
+:doc:`/gallery/lines_bars_and_markers/line_demo_dash_control` (or by passing a
+list of dash sequences using the keyword *dashes* to the cycler in
+:doc:`property_cycle </tutorials/intermediate/color_cycle>`). This interface is
+strictly less expressive, and we recommend using LineStyle (or the keyword
+*linestyle* to the :doc:`property cycler
+</tutorials/intermediate/color_cycle>`).
 """
-import numpy as np
-import matplotlib.pyplot as plt
+from matplotlib._enums import LineStyle
 
-linestyle_str = [
-     ('solid', 'solid'),      # Same as (0, ()) or '-'
-     ('dotted', 'dotted'),    # Same as (0, (1, 1)) or '.'
-     ('dashed', 'dashed'),    # Same as '--'
-     ('dashdot', 'dashdot')]  # Same as '-.'
-
-linestyle_tuple = [
-     ('loosely dotted',        (0, (1, 10))),
-     ('dotted',                (0, (1, 1))),
-     ('densely dotted',        (0, (1, 1))),
-
-     ('loosely dashed',        (0, (5, 10))),
-     ('dashed',                (0, (5, 5))),
-     ('densely dashed',        (0, (5, 1))),
-
-     ('loosely dashdotted',    (0, (3, 10, 1, 10))),
-     ('dashdotted',            (0, (3, 5, 1, 5))),
-     ('densely dashdotted',    (0, (3, 1, 1, 1))),
-
-     ('dashdotdotted',         (0, (3, 5, 1, 5, 1, 5))),
-     ('loosely dashdotdotted', (0, (3, 10, 1, 10, 1, 10))),
-     ('densely dashdotdotted', (0, (3, 1, 1, 1, 1, 1)))]
-
-
-def plot_linestyles(ax, linestyles, title):
-    X, Y = np.linspace(0, 100, 10), np.zeros(10)
-    yticklabels = []
-
-    for i, (name, linestyle) in enumerate(linestyles):
-        ax.plot(X, Y+i, linestyle=linestyle, linewidth=1.5, color='black')
-        yticklabels.append(name)
-
-    ax.set_title(title)
-    ax.set(ylim=(-0.5, len(linestyles)-0.5),
-           yticks=np.arange(len(linestyles)),
-           yticklabels=yticklabels)
-    ax.tick_params(left=False, bottom=False, labelbottom=False)
-    ax.spines[:].set_visible(False)
-
-    # For each line style, add a text annotation with a small offset from
-    # the reference point (0 in Axes coords, y tick value in Data coords).
-    for i, (name, linestyle) in enumerate(linestyles):
-        ax.annotate(repr(linestyle),
-                    xy=(0.0, i), xycoords=ax.get_yaxis_transform(),
-                    xytext=(-6, -12), textcoords='offset points',
-                    color="blue", fontsize=8, ha="right", family="monospace")
-
-
-ax0, ax1 = (plt.figure(figsize=(10, 8))
-            .add_gridspec(2, 1, height_ratios=[1, 3])
-            .subplots())
-
-plot_linestyles(ax0, linestyle_str[::-1], title='Named linestyles')
-plot_linestyles(ax1, linestyle_tuple[::-1], title='Parametrized linestyles')
-
-plt.tight_layout()
-plt.show()
+LineStyle.demo()

--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -211,3 +211,7 @@ def warn_external(message, category=None):
             break
         frame = frame.f_back
     warnings.warn(message, category, stacklevel)
+
+
+def is_string_like(x):
+    return isinstance(x, (str, bytes, bytearray))

--- a/lib/matplotlib/_enums.py
+++ b/lib/matplotlib/_enums.py
@@ -11,7 +11,9 @@ they define.
 """
 
 from enum import Enum, auto
-from matplotlib import cbook, docstring
+from numbers import Number
+
+from matplotlib import _api, docstring
 
 
 class _AutoStringNameEnum(Enum):
@@ -28,12 +30,12 @@ def _deprecate_case_insensitive_join_cap(s):
     s_low = s.lower()
     if s != s_low:
         if s_low in ['miter', 'round', 'bevel']:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Case-insensitive capstyles are deprecated "
                 "since %(since)s and support for them will be removed "
                 "%(removal)s; please pass them in lowercase.")
         elif s_low in ['butt', 'round', 'projecting']:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Case-insensitive joinstyles are deprecated "
                 "since %(since)s and support for them will be removed "
                 "%(removal)s; please pass them in lowercase.")
@@ -206,3 +208,260 @@ CapStyle.input_description = "{" \
 
 docstring.interpd.update({'JoinStyle': JoinStyle.input_description,
                           'CapStyle': CapStyle.input_description})
+
+
+#: Maps short codes for line style to their full name used by backends.
+_ls_mapper = {'': 'None', ' ': 'None', 'none': 'None',
+              '-': 'solid', '--': 'dashed', '-.': 'dashdot', ':': 'dotted'}
+_deprecated_lineStyles = {
+    '-':    '_draw_solid',
+    '--':   '_draw_dashed',
+    '-.':   '_draw_dash_dot',
+    ':':    '_draw_dotted',
+    'None': '_draw_nothing',
+    ' ':    '_draw_nothing',
+    '':     '_draw_nothing',
+}
+
+
+class NamedLineStyle(str, _AutoStringNameEnum):
+    """
+    Describe if the line is solid or dashed, and the dash pattern, if any.
+
+    All lines in Matplotlib are considered either solid or "dashed". Some
+    common dashing patterns are built-in, and are sufficient for a majority of
+    uses:
+
+        ===============================   =================
+        Linestyle                         Description
+        ===============================   =================
+        ``'-'`` or ``'solid'``            solid line
+        ``'--'`` or  ``'dashed'``         dashed line
+        ``'-.'`` or  ``'dashdot'``        dash-dotted line
+        ``':'`` or ``'dotted'``           dotted line
+        ``'None'`` or ``' '`` or ``''``   draw nothing
+        ===============================   =================
+
+    However, for more fine-grained control, one can directly specify the
+    dashing pattern by specifying::
+
+        (offset, onoffseq)
+
+    where ``onoffseq`` is an even length tuple specifying the lengths of each
+    subsequent dash and space, and ``offset`` controls at which point in this
+    pattern the start of the line will begin (to allow you to e.g. prevent
+    corners from happening to land in between dashes).
+
+    For example, (5, 2, 1, 2) describes a sequence of 5 point and 1 point
+    dashes separated by 2 point spaces.
+
+    Setting ``onoffseq`` to ``None`` results in a solid *LineStyle*.
+
+    The default dashing patterns described in the table above are themselves
+    all described in this notation, and can therefore be customized by editing
+    the appropriate ``lines.*_pattern`` *rc* parameter, as described in
+    :doc:`/tutorials/introductory/customizing`.
+
+    .. plot::
+        :alt: Demo of possible LineStyle's.
+
+        from matplotlib._types import LineStyle
+        LineStyle.demo()
+
+    .. note::
+
+        In addition to directly taking a ``linestyle`` argument,
+        `~.lines.Line2D` exposes a ``~.lines.Line2D.set_dashes`` method that
+        can be used to create a new *LineStyle* by providing just the
+        ``onoffseq``, but does not let you customize the offset. This method is
+        called when using the keyword *dashes* to the cycler , as shown in
+        :doc:`property_cycle </tutorials/intermediate/color_cycle>`.
+    """
+    solid = auto()
+    dashed = auto()
+    dotted = auto()
+    dashdot = auto()
+    none = auto()
+    custom = auto()
+
+class LineStyle(str):
+
+    def __init__(self, ls, scale=1):
+        """
+        Parameters
+        ----------
+        ls : str or dash tuple
+            A description of the dashing pattern of the line. Allowed string
+            inputs are {'-', 'solid', '--', 'dashed', '-.', 'dashdot', ':',
+            'dotted', '', ' ', 'None', 'none'}. Alternatively, the dash tuple
+            (``offset``, ``onoffseq``) can be specified directly in points.
+        scale : float
+            Uniformly scale the internal dash sequence length by a constant
+            factor.
+        """
+
+        self._linestyle_spec = ls
+        if isinstance(ls, str):
+            if ls in [' ', '', 'None']:
+                ls = 'none'
+            if ls in _ls_mapper:
+                ls = _ls_mapper[ls]
+            Enum.__init__(self)
+            offset, onoffseq = None, None
+        else:
+            try:
+                offset, onoffseq = ls
+            except ValueError:  # not enough/too many values to unpack
+                raise ValueError('LineStyle should be a string or a 2-tuple, '
+                                 'instead received: ' + str(ls))
+        if offset is None:
+            _api.warn_deprecated(
+                "3.3", message="Passing the dash offset as None is deprecated "
+                "since %(since)s and support for it will be removed "
+                "%(removal)s; pass it as zero instead.")
+            offset = 0
+
+        if onoffseq is not None:
+            # normalize offset to be positive and shorter than the dash cycle
+            dsum = sum(onoffseq)
+            if dsum:
+                offset %= dsum
+            if len(onoffseq) % 2 != 0:
+                raise ValueError('LineStyle onoffseq must be of even length.')
+            if not all(isinstance(elem, Number) for elem in onoffseq):
+                raise ValueError('LineStyle onoffseq must be list of floats.')
+        self._us_offset = offset
+        self._us_onoffseq = onoffseq
+
+    def __hash__(self):
+        if self == LineStyle.custom:
+            return (self._us_offset, tuple(self._us_onoffseq)).__hash__()
+        return _AutoStringNameEnum.__hash__(self)
+
+
+    def get_dashes(self, lw=1):
+        """
+        Get the (scaled) dash sequence for this `.LineStyle`.
+        """
+        # defer lookup until draw time
+        if self._us_offset is None or self._us_onoffseq is None:
+            self._us_offset, self._us_onoffseq = \
+                    LineStyle._get_dash_pattern(self.name)
+            # normalize offset to be positive and shorter than the dash cycle
+            dsum = sum(self._us_onoffseq)
+            self._us_offset %= dsum
+        return self._scale_dashes(self._us_offset, self._us_onoffseq, lw)
+
+    @staticmethod
+    def _scale_dashes(offset, dashes, lw):
+        from . import rcParams
+        if not rcParams['lines.scale_dashes']:
+            return offset, dashes
+        scaled_offset = offset * lw
+        scaled_dashes = ([x * lw if x is not None else None for x in dashes]
+                          if dashes is not None else None)
+        return scaled_offset, scaled_dashes
+
+    @staticmethod
+    def _get_dash_pattern(style):
+        """Convert linestyle string to explicit dash pattern."""
+        # import must be local for validator code to live here
+        from . import rcParams
+        # un-dashed styles
+        if style in ['solid', 'None']:
+            offset = 0
+            dashes = None
+        # dashed styles
+        elif style in ['dashed', 'dashdot', 'dotted']:
+            offset = 0
+            dashes = tuple(rcParams['lines.{}_pattern'.format(style)])
+        return offset, dashes
+
+    @staticmethod
+    def from_dashes(seq):
+        """
+        Create a `.LineStyle` from a dash sequence (i.e. the ``onoffseq``).
+
+        The dash sequence is a sequence of floats of even length describing
+        the length of dashes and spaces in points.
+
+        Parameters
+        ----------
+        seq : sequence of floats (on/off ink in points) or (None, None)
+            If *seq* is empty or ``(None, None)``, the `.LineStyle` will be
+            solid.
+        """
+        if seq == (None, None) or len(seq) == 0:
+            return LineStyle('-')
+        else:
+            return LineStyle((0, seq))
+
+    @staticmethod
+    def demo():
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        linestyle_str = [
+            ('solid', 'solid'),      # Same as (0, ()) or '-'
+            ('dotted', 'dotted'),    # Same as (0, (1, 1)) or '.'
+            ('dashed', 'dashed'),    # Same as '--'
+            ('dashdot', 'dashdot')]  # Same as '-.'
+
+        linestyle_tuple = [
+            ('loosely dotted',        (0, (1, 10))),
+            ('dotted',                (0, (1, 1))),
+            ('densely dotted',        (0, (1, 1))),
+
+            ('loosely dashed',        (0, (5, 10))),
+            ('dashed',                (0, (5, 5))),
+            ('densely dashed',        (0, (5, 1))),
+
+            ('loosely dashdotted',    (0, (3, 10, 1, 10))),
+            ('dashdotted',            (0, (3, 5, 1, 5))),
+            ('densely dashdotted',    (0, (3, 1, 1, 1))),
+
+            ('dashdotdotted',         (0, (3, 5, 1, 5, 1, 5))),
+            ('loosely dashdotdotted', (0, (3, 10, 1, 10, 1, 10))),
+            ('densely dashdotdotted', (0, (3, 1, 1, 1, 1, 1)))]
+
+        def plot_linestyles(ax, linestyles, title):
+            X, Y = np.linspace(0, 100, 10), np.zeros(10)
+            yticklabels = []
+
+            for i, (name, linestyle) in enumerate(linestyles):
+                ax.plot(X, Y+i, linestyle=linestyle, linewidth=1.5,
+                        color='black')
+                yticklabels.append(name)
+
+            ax.set_title(title)
+            ax.set(ylim=(-0.5, len(linestyles)-0.5),
+                   yticks=np.arange(len(linestyles)),
+                   yticklabels=yticklabels)
+            ax.tick_params(left=False, bottom=False, labelbottom=False)
+            for spine in ax.spines.values():
+                spine.set_visible(False)
+
+            # For each line style, add a text annotation with a small offset
+            # from the reference point (0 in Axes coords, y tick value in Data
+            # coords).
+            for i, (name, linestyle) in enumerate(linestyles):
+                ax.annotate(repr(linestyle),
+                            xy=(0.0, i), xycoords=ax.get_yaxis_transform(),
+                            xytext=(-6, -12), textcoords='offset points',
+                            color="blue", fontsize=8, ha="right",
+                            family="monospace")
+
+        ax0, ax1 = (plt.figure(figsize=(10, 8))
+                    .add_gridspec(2, 1, height_ratios=[1, 3])
+                    .subplots())
+
+        plot_linestyles(ax0, linestyle_str[::-1], title='Named linestyles')
+        plot_linestyles(ax1, linestyle_tuple[::-1],
+                        title='Parametrized linestyles')
+
+        plt.tight_layout()
+        plt.show()
+
+
+LineStyle._ls_mapper = _ls_mapper
+LineStyle._deprecated_lineStyles = _deprecated_lineStyles

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1266,12 +1266,6 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
     return bxpstats
 
 
-#: Maps short codes for line style to their full name used by backends.
-ls_mapper = {'-': 'solid', '--': 'dashed', '-.': 'dashdot', ':': 'dotted'}
-#: Maps full names for line styles used by backends to their short codes.
-ls_mapper_r = {v: k for k, v in ls_mapper.items()}
-
-
 def contiguous_regions(mask):
     """
     Return a list of (ind0, ind1) such that ``mask[ind0:ind1].all()`` is

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -3,7 +3,7 @@ The rcsetup module contains the validation code for customization using
 Matplotlib's rc settings.
 
 Each rc setting is assigned a function used to validate any attempted changes
-to that setting.  The validation functions are defined in the rcsetup module,
+to that setting. The validation functions are defined in the rcsetup module,
 and are used to construct the rcParams global object which stores the settings
 and is referenced throughout Matplotlib.
 
@@ -23,10 +23,9 @@ import re
 import numpy as np
 
 from matplotlib import _api, animation, cbook
-from matplotlib.cbook import ls_mapper
 from matplotlib.colors import Colormap, is_color_like
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
-from matplotlib._enums import JoinStyle, CapStyle
+from matplotlib._enums import JoinStyle, CapStyle, LineStyle
 
 # Don't let the original cycler collide with our validating cycler
 from cycler import Cycler, cycler as ccycler
@@ -530,27 +529,18 @@ def validate_ps_distiller(s):
 
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle
-_validate_named_linestyle = ValidateInStrings(
-    'linestyle',
-    [*ls_mapper.keys(), *ls_mapper.values(), 'None', 'none', ' ', ''],
-    ignorecase=True)
-
-
 def _validate_linestyle(ls):
     """
     A validator for all possible line styles, the named ones *and*
     the on-off ink sequences.
     """
     if isinstance(ls, str):
-        try:  # Look first for a valid named line style, like '--' or 'solid'.
-            return _validate_named_linestyle(ls)
-        except ValueError:
-            pass
         try:
             ls = ast.literal_eval(ls)  # Parsing matplotlibrc.
         except (SyntaxError, ValueError):
             pass  # Will error with the ValueError at the end.
 
+<<<<<<< HEAD
     def _is_iterable_not_string_like(x):
         # Explicitly exclude bytes/bytearrays so that they are not
         # nonsensically interpreted as sequences of numbers (codepoints).
@@ -576,6 +566,21 @@ def _validate_linestyle(ls):
             and all(isinstance(elem, Number) for elem in ls)):
         return (0, ls)
     raise ValueError(f"linestyle {ls!r} is not a valid on-off ink sequence.")
+=======
+    try:
+        LineStyle(ls)
+    except ValueError as e:
+        # For backcompat, only in rc, we allow the user to pash only the
+        # onoffseq, and set the offset implicitly to 0
+        if (np.iterable(ls) and not isinstance(ls, (str, bytes, bytearray))
+                and len(ls) % 2 == 0
+                and all(isinstance(elem, Number) for elem in ls)):
+            try:
+                LineStyle((0, ls))
+            except ValueError:
+                raise e
+    return ls
+>>>>>>> b2d2793cc... GSOD: LineStyle class
 
 
 validate_fillstyle = ValidateInStrings(

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -16,7 +16,6 @@ directory.
 import ast
 from functools import lru_cache, reduce
 import logging
-from numbers import Number
 import operator
 import re
 
@@ -527,8 +526,6 @@ def validate_ps_distiller(s):
         return ValidateInStrings('ps.usedistiller', ['ghostscript', 'xpdf'])(s)
 
 
-# A validator dedicated to the named line styles, based on the items in
-# ls_mapper, and a list of possible strings read from Line2D.set_linestyle
 def _validate_linestyle(ls):
     """
     A validator for all possible line styles, the named ones *and*
@@ -539,48 +536,14 @@ def _validate_linestyle(ls):
             ls = ast.literal_eval(ls)  # Parsing matplotlibrc.
         except (SyntaxError, ValueError):
             pass  # Will error with the ValueError at the end.
-
-<<<<<<< HEAD
-    def _is_iterable_not_string_like(x):
-        # Explicitly exclude bytes/bytearrays so that they are not
-        # nonsensically interpreted as sequences of numbers (codepoints).
-        return np.iterable(x) and not isinstance(x, (str, bytes, bytearray))
-
-    # (offset, (on, off, on, off, ...))
-    if (_is_iterable_not_string_like(ls)
-            and len(ls) == 2
-            and isinstance(ls[0], (type(None), Number))
-            and _is_iterable_not_string_like(ls[1])
-            and len(ls[1]) % 2 == 0
-            and all(isinstance(elem, Number) for elem in ls[1])):
-        if ls[0] is None:
-            _api.warn_deprecated(
-                "3.3", message="Passing the dash offset as None is deprecated "
-                "since %(since)s and support for it will be removed "
-                "%(removal)s; pass it as zero instead.")
-            ls = (0, ls[1])
-        return ls
-    # For backcompat: (on, off, on, off, ...); the offset is implicitly None.
-    if (_is_iterable_not_string_like(ls)
-            and len(ls) % 2 == 0
-            and all(isinstance(elem, Number) for elem in ls)):
-        return (0, ls)
-    raise ValueError(f"linestyle {ls!r} is not a valid on-off ink sequence.")
-=======
     try:
         LineStyle(ls)
     except ValueError as e:
-        # For backcompat, only in rc, we allow the user to pash only the
-        # onoffseq, and set the offset implicitly to 0
-        if (np.iterable(ls) and not isinstance(ls, (str, bytes, bytearray))
-                and len(ls) % 2 == 0
-                and all(isinstance(elem, Number) for elem in ls)):
-            try:
-                LineStyle((0, ls))
-            except ValueError:
-                raise e
+        try:
+            LineStyle((0, ls))
+        except ValueError:
+            raise e
     return ls
->>>>>>> b2d2793cc... GSOD: LineStyle class
 
 
 validate_fillstyle = ValidateInStrings(


### PR DESCRIPTION
## PR Summary

WIP. Goes on top of #18544. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
