### PR TITLE
Remove unused/deprecated AVConv_ classes

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -186,7 +186,6 @@ on all systems.
 
    FFMpegWriter
    ImageMagickWriter
-   AVConvWriter
 
 The file-based writers save temporary files for each frame which are stitched
 into a single file at the end.  Although slower, these writers can be easier to
@@ -198,7 +197,6 @@ debug.
 
    FFMpegFileWriter
    ImageMagickFileWriter
-   AVConvFileWriter
 
 Fundamentally, a `MovieWriter` provides a way to grab sequential frames
 from the same underlying `~matplotlib.figure.Figure` object.  The base
@@ -283,7 +281,6 @@ and mixins
    :toctree: _as_gen
    :nosignatures:
 
-   AVConvBase
    FFMpegBase
    ImageMagickBase
 
@@ -298,6 +295,6 @@ Inheritance Diagrams
    :private-bases:
    :parts: 1
 
-.. inheritance-diagram:: matplotlib.animation.AVConvFileWriter matplotlib.animation.AVConvWriter matplotlib.animation.FFMpegFileWriter matplotlib.animation.FFMpegWriter matplotlib.animation.ImageMagickFileWriter matplotlib.animation.ImageMagickWriter
+.. inheritance-diagram:: matplotlib.animation.FFMpegFileWriter matplotlib.animation.FFMpegWriter matplotlib.animation.ImageMagickFileWriter matplotlib.animation.ImageMagickWriter
    :private-bases:
    :parts: 1

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -584,17 +584,6 @@ class FFMpegBase:
 
         return args + ['-y', self.outfile]
 
-    @classmethod
-    def isAvailable(cls):
-        return (
-            super().isAvailable()
-            # Ubuntu 12.04 ships a broken ffmpeg binary which we shouldn't use.
-            # NOTE: when removed, remove the same method in AVConvBase.
-            and b'LibAv' not in subprocess.run(
-                [cls.bin_path()], creationflags=subprocess_creation_flags,
-                stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE).stderr)
-
 
 # Combine FFMpeg options with pipe-based writing
 @writers.register('ffmpeg')
@@ -638,45 +627,6 @@ class FFMpegFileWriter(FFMpegBase, FileMovieWriter):
         return [self.bin_path(), '-r', str(self.fps),
                 '-i', self._base_temp_name(),
                 '-vframes', str(self._frame_counter)] + self.output_args
-
-
-# Base class of avconv information.  AVConv has identical arguments to FFMpeg.
-@cbook.deprecated('3.3')
-class AVConvBase(FFMpegBase):
-    """
-    Mixin class for avconv output.
-
-    To be useful this must be multiply-inherited from with a
-    `MovieWriterBase` sub-class.
-    """
-
-    _exec_key = 'animation.avconv_path'
-    _args_key = 'animation.avconv_args'
-
-    # NOTE : should be removed when the same method is removed in FFMpegBase.
-    isAvailable = classmethod(MovieWriter.isAvailable.__func__)
-
-
-# Combine AVConv options with pipe-based writing
-@writers.register('avconv')
-class AVConvWriter(AVConvBase, FFMpegWriter):
-    """
-    Pipe-based avconv writer.
-
-    Frames are streamed directly to avconv via a pipe and written in a single
-    pass.
-    """
-
-
-# Combine AVConv options with file-based writing
-@writers.register('avconv_file')
-class AVConvFileWriter(AVConvBase, FFMpegFileWriter):
-    """
-    File-based avconv writer.
-
-    Frames are written to temporary files on disk and then stitched
-    together at the end.
-    """
 
 
 # Base class for animated GIFs with ImageMagick


### PR DESCRIPTION
## PR Summary

Removes AVConvBase et al. and a related method in FFMpegBase that refers to a deprecated Ubuntu release. The deprecation warnings (which raise errors during tests) say that these classes will be removed by version 3.5, and they don't seem to be used by any other code in this version.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
