### PR TITLE
TST: Lock cache directory during cleanup. 

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -34,10 +34,14 @@ def make_test_filename(fname, purpose):
     return '%s-%s%s' % (base, purpose, ext)
 
 
-def get_cache_dir():
+def _get_cache_path():
     cache_dir = Path(mpl.get_cachedir(), 'test_cache')
     cache_dir.mkdir(parents=True, exist_ok=True)
-    return str(cache_dir)
+    return cache_dir
+
+
+def get_cache_dir():
+    return str(_get_cache_path())
 
 
 def get_file_hash(path, block_size=2 ** 20):
@@ -286,7 +290,7 @@ def convert(filename, cache):
     # Only convert the file if the destination doesn't already exist or
     # is out of date.
     if not newpath.exists() or newpath.stat().st_mtime < path.stat().st_mtime:
-        cache_dir = Path(get_cache_dir()) if cache else None
+        cache_dir = _get_cache_path() if cache else None
 
         if cache_dir is not None:
             _register_conversion_cache_cleaner_once()
@@ -318,7 +322,7 @@ def _clean_conversion_cache():
     max_cache_size = 2 * baseline_images_size
     # Reduce cache until it fits.
     cache_stat = {
-        path: path.stat() for path in Path(get_cache_dir()).glob("*")}
+        path: path.stat() for path in _get_cache_path().glob("*")}
     cache_size = sum(stat.st_size for stat in cache_stat.values())
     paths_by_atime = sorted(  # Oldest at the end.
         cache_stat, key=lambda path: cache_stat[path].st_atime, reverse=True)


### PR DESCRIPTION
## PR Summary

This prevents multiple processes from trying to cleanup the directory at the same time (e.g., using `pytest -nauto`).

Fixes #18641.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).