### PR TITLE
DOC: fix autoscale docstring

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2301,7 +2301,7 @@ class _AxesBase(martist.Artist):
 
     def set_autoscale_on(self, b):
         """
-        Set whether autoscaling is applied on plot commands
+        Set whether autoscaling is applied to axes on the next draw.
 
         Parameters
         ----------
@@ -2312,7 +2312,8 @@ class _AxesBase(martist.Artist):
 
     def set_autoscalex_on(self, b):
         """
-        Set whether autoscaling for the x-axis is applied on plot commands
+        Set whether autoscaling for the x-axis is applied to axes on the next
+        draw.
 
         Parameters
         ----------
@@ -2322,7 +2323,8 @@ class _AxesBase(martist.Artist):
 
     def set_autoscaley_on(self, b):
         """
-        Set whether autoscaling for the y-axis is applied on plot commands
+        Set whether autoscaling for the y-axis is applied to axes on the next
+        draw.
 
         Parameters
         ----------

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2301,7 +2301,8 @@ class _AxesBase(martist.Artist):
 
     def set_autoscale_on(self, b):
         """
-        Set whether autoscaling is applied to axes on the next draw.
+        Set whether autoscaling is applied to axes on the next draw or call to
+        `.Axes.autoscale_view`.
 
         Parameters
         ----------
@@ -2313,7 +2314,7 @@ class _AxesBase(martist.Artist):
     def set_autoscalex_on(self, b):
         """
         Set whether autoscaling for the x-axis is applied to axes on the next
-        draw.
+        draw or call to `.Axes.autoscale_view`.
 
         Parameters
         ----------
@@ -2324,7 +2325,7 @@ class _AxesBase(martist.Artist):
     def set_autoscaley_on(self, b):
         """
         Set whether autoscaling for the y-axis is applied to axes on the next
-        draw.
+        draw or call to `.Axes.autoscale_view`.
 
         Parameters
         ----------


### PR DESCRIPTION
## PR Summary

The previous versions made it sound like this would be applied per plot command, whereas the autoscale_on really is applied at draw time.

Closes #18662


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
