### PR TITLE
Small cleanups to parasite axes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18673-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18673-AL.rst
@@ -1,0 +1,3 @@
+``ParasiteAxesAuxTransBase.update_viewlim``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated; use ``apply_aspect`` instead.

--- a/examples/axes_grid1/parasite_simple2.py
+++ b/examples/axes_grid1/parasite_simple2.py
@@ -23,7 +23,6 @@ pm_to_kms = 1./206265.*2300*3.085e18/3.15e7/1.e5
 
 aux_trans = mtransforms.Affine2D().scale(pm_to_kms, 1.)
 ax_pm = ax_kms.twin(aux_trans)
-ax_pm.set_viewlim_mode("transform")
 
 for n, ds, dse, w, we in obs:
     time = ((2007 + (10. + 4/30.)/12) - 1988.5)

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -13,7 +13,6 @@ class ParasiteAxesBase:
     def get_images_artists(self):
         artists = {a for a in self.get_children() if a.get_visible()}
         images = {a for a in self.images if a.get_visible()}
-
         return list(images), list(artists - images)
 
     def __init__(self, parent_axes, **kwargs):
@@ -23,18 +22,8 @@ class ParasiteAxesBase:
 
     def cla(self):
         super().cla()
-
         martist.setp(self.get_children(), visible=False)
         self._get_lines = self._parent_axes._get_lines
-
-        # In mpl's Axes, zorders of x- and y-axis are originally set
-        # within Axes.draw().
-        if self._axisbelow:
-            self.xaxis.set_zorder(0.5)
-            self.yaxis.set_zorder(0.5)
-        else:
-            self.xaxis.set_zorder(2.5)
-            self.yaxis.set_zorder(2.5)
 
     def pick(self, mouseevent):
         # This most likely goes to Artist.pick (depending on axes_class given
@@ -74,17 +63,12 @@ class ParasiteAxesAuxTransBase:
         super().__init__(parent_axes, **kwargs)
 
     def _set_lim_and_transforms(self):
-
         self.transAxes = self._parent_axes.transAxes
-
-        self.transData = \
-            self.transAux + \
-            self._parent_axes.transData
-
+        self.transData = self.transAux + self._parent_axes.transData
         self._xaxis_transform = mtransforms.blended_transform_factory(
-                self.transData, self.transAxes)
+            self.transData, self.transAxes)
         self._yaxis_transform = mtransforms.blended_transform_factory(
-                self.transAxes, self.transData)
+            self.transAxes, self.transData)
 
     def set_viewlim_mode(self, mode):
         _api.check_in_list([None, "equal", "transform"], mode=mode)
@@ -93,7 +77,11 @@ class ParasiteAxesAuxTransBase:
     def get_viewlim_mode(self):
         return self._viewlim_mode
 
+    @cbook.deprecated("3.4", alternative="apply_aspect")
     def update_viewlim(self):
+        return self._update_viewlim()
+
+    def _update_viewlim(self):  # Inline after deprecation elapses.
         viewlim = self._parent_axes.viewLim.frozen()
         mode = self.get_viewlim_mode()
         if mode is None:
@@ -107,7 +95,7 @@ class ParasiteAxesAuxTransBase:
             _api.check_in_list([None, "equal", "transform"], mode=mode)
 
     def apply_aspect(self, position=None):
-        self.update_viewlim()
+        self._update_viewlim()
         super().apply_aspect()
 
 
@@ -204,9 +192,9 @@ class HostAxesBase:
 
         parasite_axes_class = parasite_axes_class_factory(axes_class)
 
-        ax2 = parasite_axes_class(self, sharex=self, frameon=False)
+        ax2 = parasite_axes_class(self, sharex=self)
         self.parasites.append(ax2)
-        ax2._remove_method = self._remove_twinx
+        ax2._remove_method = self._remove_any_twin
 
         self.axis["right"].set_visible(False)
 
@@ -214,11 +202,6 @@ class HostAxesBase:
         ax2.axis["left", "top", "bottom"].set_visible(False)
 
         return ax2
-
-    def _remove_twinx(self, ax):
-        self.parasites.remove(ax)
-        self.axis["right"].set_visible(True)
-        self.axis["right"].toggle(ticklabels=False, label=False)
 
     def twiny(self, axes_class=None):
         """
@@ -232,9 +215,9 @@ class HostAxesBase:
 
         parasite_axes_class = parasite_axes_class_factory(axes_class)
 
-        ax2 = parasite_axes_class(self, sharey=self, frameon=False)
+        ax2 = parasite_axes_class(self, sharey=self)
         self.parasites.append(ax2)
-        ax2._remove_method = self._remove_twiny
+        ax2._remove_method = self._remove_any_twin
 
         self.axis["top"].set_visible(False)
 
@@ -242,11 +225,6 @@ class HostAxesBase:
         ax2.axis["left", "right", "bottom"].set_visible(False)
 
         return ax2
-
-    def _remove_twiny(self, ax):
-        self.parasites.remove(ax)
-        self.axis["top"].set_visible(True)
-        self.axis["top"].toggle(ticklabels=False, label=False)
 
     def twin(self, aux_trans=None, axes_class=None):
         """
@@ -262,26 +240,28 @@ class HostAxesBase:
             parasite_axes_auxtrans_class_factory(axes_class)
 
         if aux_trans is None:
-            ax2 = parasite_axes_auxtrans_class(
-                self, mtransforms.IdentityTransform(), viewlim_mode="equal")
-        else:
-            ax2 = parasite_axes_auxtrans_class(
-                self, aux_trans, viewlim_mode="transform")
+            aux_trans = mtransforms.IdentityTransform()
+        ax2 = parasite_axes_auxtrans_class(
+            self, aux_trans, viewlim_mode="transform")
         self.parasites.append(ax2)
-        ax2._remove_method = self.parasites.remove
+        ax2._remove_method = self._remove_any_twin
 
         self.axis["top", "right"].set_visible(False)
 
         ax2.axis["top", "right"].set_visible(True)
         ax2.axis["left", "bottom"].set_visible(False)
 
-        def _remove_method(h):
-            self.parasites.remove(h)
-            self.axis["top", "right"].set_visible(True)
-            self.axis["top", "right"].toggle(ticklabels=False, label=False)
-        ax2._remove_method = _remove_method
-
         return ax2
+
+    def _remove_any_twin(self, ax):
+        self.parasites.remove(ax)
+        restore = ["top", "right"]
+        if ax._sharex:
+            restore.remove("top")
+        if ax._sharey:
+            restore.remove("right")
+        self.axis[tuple(restore)].set_visible(True)
+        self.axis[tuple(restore)].toggle(ticklabels=False, label=False)
 
     def get_tightbbox(self, renderer, call_axes_locator=True,
                       bbox_extra_artists=None):


### PR DESCRIPTION
Setting axis zorder in cla() is unnecessary since 51f8468 (zorders are
now set in set_axisbelow() instead of draw()).

Deprecate the peculiar `update_viewlim` API which is really just an
internal helper.

No need to explicitly set frameon=False, this is forced by the
ParasiteAxesBase constructor.

We can factor the various twin axes removers into a single one.  (Also,
avoiding local functions helps picklability, as usual.)

In twin() we can also use viewlim_mode="transform" when the transform is
None (IdentityTransform()), because that just means that we apply an
additional IdentityTransform() to the viewlims.

In parasite_simple2 we don't need to set viewlim_mode, this is already
done by `twin`.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
