### PR TITLE
wx backend API cleanups.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18680-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18680-AL.rst
@@ -1,0 +1,8 @@
+wx backend cleanups
+~~~~~~~~~~~~~~~~~~~
+The *origin* parameter to ``_FigureCanvasWxBase.gui_repaint`` is deprecated
+with no replacement; ``gui_repaint`` now automatically detects the case where
+it is used with the wx renderer.
+
+The ``NavigationToolbar2Wx.get_canvas`` method is deprecated; directly
+instantiate a canvas (``FigureCanvasWxAgg(frame, -1, figure)``) if needed.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -615,6 +615,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         wildcards = '|'.join(wildcards)
         return wildcards, extensions, filter_index
 
+    @cbook._delete_parameter("3.4", "origin")
     def gui_repaint(self, drawDC=None, origin='WX'):
         """
         Performs update of the displayed image on the GUI canvas, using the
@@ -632,7 +633,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # For 'WX' backend on Windows, the bitmap can not be in use by another
         # DC (see GraphicsContextWx._cache).
         bmp = (self.bitmap.ConvertToImage().ConvertToBitmap()
-               if wx.Platform == '__WXMSW__' and origin == 'WX'
+               if wx.Platform == '__WXMSW__'
+                  and isinstance(self.figure._cachedRenderer, RendererWx)
                else self.bitmap)
         drawDC.DrawBitmap(bmp, 0, 0)
         if self._rubberband_rect is not None:
@@ -1174,6 +1176,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         return wx.Bitmap.FromBufferRGBA(
             image.shape[1], image.shape[0], image.tobytes())
 
+    @cbook.deprecated("3.4")
     def get_canvas(self, frame, fig):
         return type(self.canvas)(frame, -1, fig)
 

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -30,7 +30,7 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
 
         self.bitmap = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
         self._isDrawn = True
-        self.gui_repaint(drawDC=drawDC, origin='WXAgg')
+        self.gui_repaint(drawDC=drawDC)
 
     def blit(self, bbox=None):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -38,7 +38,7 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
         self.figure.draw(self._renderer)
         self.bitmap = wxcairo.BitmapFromImageSurface(surface)
         self._isDrawn = True
-        self.gui_repaint(drawDC=drawDC, origin='WXCairo')
+        self.gui_repaint(drawDC=drawDC)
 
 
 @_BackendWx.export


### PR DESCRIPTION
- Deprecate origin kwarg to wx gui_repaint().  It's really just a
  slightly obscure way to add a special-path for the (long deprecated)
  wx backend, which can be done more explicitly.

- Deprecate unused NavigationToolbar2Wx.get_canvas.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
