### PR TITLE
Small simplification to triage_tests.py.

### DIFF
--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -76,19 +76,6 @@ class Thumbnail(QtWidgets.QFrame):
         self.parent.set_large_image(self.index)
 
 
-class ListWidget(QtWidgets.QListWidget):
-    """
-    The list of files on the left-hand side
-    """
-    def __init__(self, parent):
-        super().__init__()
-        self.parent = parent
-        self.currentRowChanged.connect(self.change_row)
-
-    def change_row(self, i):
-        self.parent.set_entry(i)
-
-
 class EventFilter(QtCore.QObject):
     # A hack keypresses can be handled globally and aren't swallowed
     # by the individual widgets
@@ -119,10 +106,12 @@ class Dialog(QtWidgets.QDialog):
         event_filter = EventFilter(self)
         self.installEventFilter(event_filter)
 
-        self.filelist = ListWidget(self)
+        # The list of files on the left-hand side.
+        self.filelist = QtWidgets.QListWidget()
         self.filelist.setMinimumWidth(400)
         for entry in entries:
             self.filelist.addItem(entry.display)
+        self.filelist.currentRowChanged.connect(self.set_entry)
 
         thumbnails_box = QtWidgets.QWidget()
         thumbnails_layout = QtWidgets.QVBoxLayout()


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
