### PR TITLE
Cleanup pgf examples

### DIFF
--- a/examples/userdemo/pgf_fonts.py
+++ b/examples/userdemo/pgf_fonts.py
@@ -8,8 +8,10 @@ Pgf Fonts
 import matplotlib.pyplot as plt
 plt.rcParams.update({
     "font.family": "serif",
-    "font.serif": [],                    # use latex default serif font
-    "font.sans-serif": ["DejaVu Sans"],  # use a specific sans-serif font
+    # Use LaTeX default serif font.
+    "font.serif": [],
+    # Use specific cursive fonts.
+    "font.cursive": ["Comic Neue", "Comic Sans MS"],
 })
 
 fig, ax = plt.subplots(figsize=(4.5, 2.5))
@@ -18,8 +20,8 @@ ax.plot(range(5))
 
 ax.text(0.5, 3., "serif")
 ax.text(0.5, 2., "monospace", family="monospace")
-ax.text(2.5, 2., "sans-serif", family="sans-serif")
-ax.text(2.5, 1., "comic sans", family="Comic Sans MS")
+ax.text(2.5, 2., "sans-serif", family="DejaVu Sans")  # Use specific sans font.
+ax.text(2.5, 1., "comic", family="cursive")
 ax.set_xlabel("µ is not $\\mu$")
 
 fig.tight_layout(pad=.5)

--- a/examples/userdemo/pgf_fonts.py
+++ b/examples/userdemo/pgf_fonts.py
@@ -12,14 +12,17 @@ plt.rcParams.update({
     "font.sans-serif": ["DejaVu Sans"],  # use a specific sans-serif font
 })
 
-plt.figure(figsize=(4.5, 2.5))
-plt.plot(range(5))
-plt.text(0.5, 3., "serif")
-plt.text(0.5, 2., "monospace", family="monospace")
-plt.text(2.5, 2., "sans-serif", family="sans-serif")
-plt.text(2.5, 1., "comic sans", family="Comic Sans MS")
-plt.xlabel("µ is not $\\mu$")
-plt.tight_layout(.5)
+fig, ax = plt.subplots(figsize=(4.5, 2.5))
 
-plt.savefig("pgf_fonts.pdf")
-plt.savefig("pgf_fonts.png")
+ax.plot(range(5))
+
+ax.text(0.5, 3., "serif")
+ax.text(0.5, 2., "monospace", family="monospace")
+ax.text(2.5, 2., "sans-serif", family="sans-serif")
+ax.text(2.5, 1., "comic sans", family="Comic Sans MS")
+ax.set_xlabel("µ is not $\\mu$")
+
+fig.tight_layout(pad=.5)
+
+fig.savefig("pgf_fonts.pdf")
+fig.savefig("pgf_fonts.png")

--- a/examples/userdemo/pgf_preamble_sgskip.py
+++ b/examples/userdemo/pgf_preamble_sgskip.py
@@ -19,12 +19,15 @@ plt.rcParams.update({
     ])
 })
 
-plt.figure(figsize=(4.5, 2.5))
-plt.plot(range(5))
-plt.xlabel("unicode text: я, ψ, €, ü")
-plt.ylabel(r"\url{https://matplotlib.org}")
-plt.legend(["unicode math: $λ=∑_i^∞ μ_i^2$"])
-plt.tight_layout(.5)
+fig, ax = plt.subplots(figsize=(4.5, 2.5))
 
-plt.savefig("pgf_preamble.pdf")
-plt.savefig("pgf_preamble.png")
+ax.plot(range(5))
+
+ax.set_xlabel("unicode text: я, ψ, €, ü")
+ax.set_ylabel(r"\url{https://matplotlib.org}")
+ax.legend(["unicode math: $λ=∑_i^∞ μ_i^2$"])
+
+fig.tight_layout(pad=.5)
+
+fig.savefig("pgf_preamble.pdf")
+fig.savefig("pgf_preamble.png")

--- a/examples/userdemo/pgf_texsystem.py
+++ b/examples/userdemo/pgf_texsystem.py
@@ -15,13 +15,16 @@ plt.rcParams.update({
     ]),
 })
 
-plt.figure(figsize=(4.5, 2.5))
-plt.plot(range(5))
-plt.text(0.5, 3., "serif", family="serif")
-plt.text(0.5, 2., "monospace", family="monospace")
-plt.text(2.5, 2., "sans-serif", family="sans-serif")
-plt.xlabel(r"µ is not $\mu$")
-plt.tight_layout(.5)
+fig, ax = plt.subplots(figsize=(4.5, 2.5))
 
-plt.savefig("pgf_texsystem.pdf")
-plt.savefig("pgf_texsystem.png")
+ax.plot(range(5))
+
+ax.text(0.5, 3., "serif", family="serif")
+ax.text(0.5, 2., "monospace", family="monospace")
+ax.text(2.5, 2., "sans-serif", family="sans-serif")
+ax.set_xlabel(r"µ is not $\mu$")
+
+fig.tight_layout(pad=.5)
+
+fig.savefig("pgf_texsystem.pdf")
+fig.savefig("pgf_texsystem.png")

--- a/tutorials/text/pgf.py
+++ b/tutorials/text/pgf.py
@@ -97,7 +97,7 @@ When saving to ``.pgf``, the font configuration Matplotlib used for the
 layout of the figure is included in the header of the text file.
 
 .. literalinclude:: ../../gallery/userdemo/pgf_fonts.py
-   :end-before: plt.savefig
+   :end-before: fig.savefig
 
 
 .. _pgf-preamble:
@@ -114,7 +114,7 @@ specified in the rc parameters, make sure to disable :rc:`pgf.rcfonts`.
 .. only:: html
 
     .. literalinclude:: ../../gallery/userdemo/pgf_preamble_sgskip.py
-        :end-before: plt.savefig
+        :end-before: fig.savefig
 
 .. only:: latex
 
@@ -133,7 +133,7 @@ Please note that when selecting pdflatex, the fonts and Unicode handling must
 be configured in the preamble.
 
 .. literalinclude:: ../../gallery/userdemo/pgf_texsystem.py
-   :end-before: plt.savefig
+   :end-before: fig.savefig
 
 
 .. _pgf-troubleshooting:


### PR DESCRIPTION
## PR Summary

Switch from pyplot to OO style, and swap a font selector so that it doesn't warn as much.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).