### PR TITLE
Numpydocify setp.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1558,7 +1558,7 @@ class ArtistInspector:
 
 def getp(obj, property=None):
     """
-    Return the value of an object's *property*, or print all of them.
+    Return the value of an `.Artist`'s *property*, or print all of them.
 
     Parameters
     ----------
@@ -1579,6 +1579,10 @@ def getp(obj, property=None):
         e.g.:
 
           linewidth or lw = 2
+
+    See Also
+    --------
+    setp
     """
     if property is None:
         insp = ArtistInspector(obj)
@@ -1593,52 +1597,61 @@ get = getp
 
 def setp(obj, *args, file=None, **kwargs):
     """
-    Set a property on an artist object.
+    Set one or more properties on an `.Artist`, or list allowed values.
 
-    matplotlib supports the use of :func:`setp` ("set property") and
-    :func:`getp` to set and get object properties, as well as to do
-    introspection on the object.  For example, to set the linestyle of a
-    line to be dashed, you can do::
+    Parameters
+    ----------
+    obj : `.Artist` or list of `.Artist`
+        The artist(s) whose properties are being set or queried.  When setting
+        properties, all artists are affected; when querying the allowed values,
+        only the first instance in the sequence is queried.
 
-      >>> line, = plot([1, 2, 3])
-      >>> setp(line, linestyle='--')
+        For example, two lines can be made thicker and red with a single call:
 
-    If you want to know the valid types of arguments, you can provide
-    the name of the property you want to set without a value::
+        >>> x = arange(0, 1, 0.01)
+        >>> lines = plot(x, sin(2*pi*x), x, sin(4*pi*x))
+        >>> setp(lines, linewidth=2, color='r')
 
-      >>> setp(line, 'linestyle')
+    file : file-like, default: `sys.stdout`
+        Where `setp` writes its output when asked to list allowed values.
+
+        >>> with open('output.log') as file:
+        ...     setp(line, file=file)
+
+        The default, ``None``, means `sys.stdout`.
+
+    *args, **kwargs
+        The properties to set.  The following combinations are supported:
+
+        - Set the linestyle of a line to be dashed:
+
+          >>> line, = plot([1, 2, 3])
+          >>> setp(line, linestyle='--')
+
+        - Set multiple properties at once:
+
+          >>> setp(line, linewidth=2, color='r')
+
+        - List allowed values for a line's linestyle:
+
+          >>> setp(line, 'linestyle')
           linestyle: {'-', '--', '-.', ':', '', (offset, on-off-seq), ...}
 
-    If you want to see all the properties that can be set, and their
-    possible values, you can do::
+        - List all properties that can be set, and their allowed values:
 
-      >>> setp(line)
-          ... long output listing omitted
+          >>> setp(line)
+          agg_filter: a filter function, ...
+          [long output listing omitted]
 
-    By default `setp` prints to `sys.stdout`, but this can be modified using
-    the *file* keyword-only argument::
+        `setp` also supports MATLAB style string/value pairs.  For example, the
+        following are equivalent:
 
-      >>> with fopen('output.log') as f:
-      >>>     setp(line, file=f)
+        >>> setp(lines, 'linewidth', 2, 'color', 'r')  # MATLAB style
+        >>> setp(lines, linewidth=2, color='r')        # Python style
 
-    :func:`setp` operates on a single instance or a iterable of
-    instances. If you are in query mode introspecting the possible
-    values, only the first instance in the sequence is used. When
-    actually setting values, all the instances will be set.  e.g.,
-    suppose you have a list of two lines, the following will make both
-    lines thicker and red::
-
-      >>> x = arange(0, 1, 0.01)
-      >>> y1 = sin(2*pi*x)
-      >>> y2 = sin(4*pi*x)
-      >>> lines = plot(x, y1, x, y2)
-      >>> setp(lines, linewidth=2, color='r')
-
-    :func:`setp` works with the MATLAB style string/value pairs or
-    with python kwargs.  For example, the following are equivalent::
-
-      >>> setp(lines, 'linewidth', 2, 'color', 'r')  # MATLAB style
-      >>> setp(lines, linewidth=2, color='r')        # python style
+    See Also
+    --------
+    getp
     """
 
     if isinstance(obj, Artist):


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
