### PR TITLE
Deprecate GraphicsContextPS.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18687-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18687-AL.rst
@@ -1,0 +1,3 @@
+GraphicsContextPS
+~~~~~~~~~~~~~~~~~
+... is deprecated.  The PostScript backend now uses `.GraphicsContextBase`.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -205,15 +205,29 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
             if store:
                 self.linewidth = linewidth
 
+    @staticmethod
+    def _linejoin_cmd(linejoin):
+        # Support for directly passing integer values is for backcompat.
+        linejoin = {'miter': 0, 'round': 1, 'bevel': 2, 0: 0, 1: 1, 2: 2}[
+            linejoin]
+        return f"{linejoin:d} setlinejoin\n"
+
     def set_linejoin(self, linejoin, store=True):
         if linejoin != self.linejoin:
-            self._pswriter.write("%d setlinejoin\n" % linejoin)
+            self._pswriter.write(self._linejoin_cmd(linejoin))
             if store:
                 self.linejoin = linejoin
 
+    @staticmethod
+    def _linecap_cmd(linecap):
+        # Support for directly passing integer values is for backcompat.
+        linecap = {'butt': 0, 'round': 1, 'projecting': 2, 0: 0, 1: 1, 2: 2}[
+            linecap]
+        return f"{linecap:d} setlinecap\n"
+
     def set_linecap(self, linecap, store=True):
         if linecap != self.linecap:
-            self._pswriter.write("%d setlinecap\n" % linecap)
+            self._pswriter.write(self._linecap_cmd(linecap))
             if store:
                 self.linecap = linecap
 
@@ -397,10 +411,8 @@ newpath
         stroke = lw > 0 and alpha > 0
         if stroke:
             ps_cmd.append('%.1f setlinewidth' % lw)
-            jint = gc.get_joinstyle()
-            ps_cmd.append('%d setlinejoin' % jint)
-            cint = gc.get_capstyle()
-            ps_cmd.append('%d setlinecap' % cint)
+            ps_cmd.append(self._linejoin_cmd(gc.get_joinstyle()))
+            ps_cmd.append(self._linecap_cmd(gc.get_capstyle()))
 
         ps_cmd.append(self._convert_path(marker_path, marker_trans,
                                          simplify=False))
@@ -595,10 +607,6 @@ gsave
 grestore
 """)
 
-    def new_gc(self):
-        # docstring inherited
-        return GraphicsContextPS()
-
     def draw_mathtext(self, gc, x, y, s, prop, angle):
         """Draw the math text using matplotlib.mathtext."""
         if debugPS:
@@ -703,10 +711,8 @@ grestore
 
         if mightstroke:
             self.set_linewidth(gc.get_linewidth())
-            jint = gc.get_joinstyle()
-            self.set_linejoin(jint)
-            cint = gc.get_capstyle()
-            self.set_linecap(cint)
+            self.set_linejoin(gc.get_joinstyle())
+            self.set_linecap(gc.get_capstyle())
             self.set_linedash(*gc.get_dashes())
             self.set_color(*gc.get_rgb()[:3])
         write('gsave\n')
@@ -759,6 +765,7 @@ def _is_transparent(rgb_or_rgba):
         return False
 
 
+@cbook.deprecated("3.4", alternative="GraphicsContextBase")
 class GraphicsContextPS(GraphicsContextBase):
     def get_capstyle(self):
         return {'butt': 0, 'round': 1, 'projecting': 2}[super().get_capstyle()]


### PR DESCRIPTION
The conversion functions (which is the only thing GraphicsContextPS
adds) are really internal to the PS format and can be done at the
renderer level instead, saving the need for an separate GraphicsContext
subclass.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
