### PR TITLE
Shorter property deprecation.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -805,10 +805,7 @@ class StandardPsFonts(Fonts):
         self.fonts['default'] = default_font
         self.fonts['regular'] = default_font
 
-    @cbook.deprecated("3.4")
-    @property
-    def pswriter(self):
-        return StringIO()
+    pswriter = cbook.deprecated("3.4")(property(lambda self: StringIO()))
 
     def _get_font(self, font):
         if font in self.fontmap:
@@ -1562,10 +1559,7 @@ class Glue(Node):
     it's easier to stick to what TeX does.)
     """
 
-    @cbook.deprecated("3.3")
-    @property
-    def glue_subtype(self):
-        return "normal"
+    glue_subtype = cbook.deprecated("3.3")(property(lambda self: "normal"))
 
     @cbook._delete_parameter("3.3", "copy")
     def __init__(self, glue_type, copy=False):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -778,11 +778,8 @@ class HTMLWriter(FileMovieWriter):
     """Writer for JavaScript-based HTML movies."""
 
     supported_formats = ['png', 'jpeg', 'tiff', 'svg']
-
-    @cbook.deprecated("3.3")
-    @property
-    def args_key(self):
-        return 'animation.html_args'
+    args_key = cbook.deprecated("3.3")(property(
+        lambda self: 'animation.html_args'))
 
     @classmethod
     def isAvailable(cls):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2709,6 +2709,9 @@ class FigureManagerBase:
             figure.canvas.mpl_disconnect(
                 figure.canvas.manager.button_press_handler_id)
     """
+
+    statusbar = cbook.deprecated("3.3")(property(lambda self: None))
+
     def __init__(self, canvas, num):
         self.canvas = canvas
         canvas.manager = self  # store a pointer to parent
@@ -2734,11 +2737,6 @@ class FigureManagerBase:
             # Called whenever the current axes is changed.
             if self.toolmanager is None and self.toolbar is not None:
                 self.toolbar.update()
-
-    @cbook.deprecated("3.3")
-    @property
-    def statusbar(self):
-        return None
 
     def show(self):
         """

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -91,40 +91,40 @@ def _cairo_font_args_from_font_prop(prop):
     return name, slant, weight
 
 
-class RendererCairo(RendererBase):
-    @cbook.deprecated("3.3")
-    @property
-    def fontweights(self):
-        return {
-            100:          cairo.FONT_WEIGHT_NORMAL,
-            200:          cairo.FONT_WEIGHT_NORMAL,
-            300:          cairo.FONT_WEIGHT_NORMAL,
-            400:          cairo.FONT_WEIGHT_NORMAL,
-            500:          cairo.FONT_WEIGHT_NORMAL,
-            600:          cairo.FONT_WEIGHT_BOLD,
-            700:          cairo.FONT_WEIGHT_BOLD,
-            800:          cairo.FONT_WEIGHT_BOLD,
-            900:          cairo.FONT_WEIGHT_BOLD,
-            'ultralight': cairo.FONT_WEIGHT_NORMAL,
-            'light':      cairo.FONT_WEIGHT_NORMAL,
-            'normal':     cairo.FONT_WEIGHT_NORMAL,
-            'medium':     cairo.FONT_WEIGHT_NORMAL,
-            'regular':    cairo.FONT_WEIGHT_NORMAL,
-            'semibold':   cairo.FONT_WEIGHT_BOLD,
-            'bold':       cairo.FONT_WEIGHT_BOLD,
-            'heavy':      cairo.FONT_WEIGHT_BOLD,
-            'ultrabold':  cairo.FONT_WEIGHT_BOLD,
-            'black':      cairo.FONT_WEIGHT_BOLD,
-        }
+# Mappings used for deprecated properties in RendererCairo, see below.
+_f_weights = {
+    100:          cairo.FONT_WEIGHT_NORMAL,
+    200:          cairo.FONT_WEIGHT_NORMAL,
+    300:          cairo.FONT_WEIGHT_NORMAL,
+    400:          cairo.FONT_WEIGHT_NORMAL,
+    500:          cairo.FONT_WEIGHT_NORMAL,
+    600:          cairo.FONT_WEIGHT_BOLD,
+    700:          cairo.FONT_WEIGHT_BOLD,
+    800:          cairo.FONT_WEIGHT_BOLD,
+    900:          cairo.FONT_WEIGHT_BOLD,
+    'ultralight': cairo.FONT_WEIGHT_NORMAL,
+    'light':      cairo.FONT_WEIGHT_NORMAL,
+    'normal':     cairo.FONT_WEIGHT_NORMAL,
+    'medium':     cairo.FONT_WEIGHT_NORMAL,
+    'regular':    cairo.FONT_WEIGHT_NORMAL,
+    'semibold':   cairo.FONT_WEIGHT_BOLD,
+    'bold':       cairo.FONT_WEIGHT_BOLD,
+    'heavy':      cairo.FONT_WEIGHT_BOLD,
+    'ultrabold':  cairo.FONT_WEIGHT_BOLD,
+    'black':      cairo.FONT_WEIGHT_BOLD,
+}
+_f_angles = {
+    'italic':  cairo.FONT_SLANT_ITALIC,
+    'normal':  cairo.FONT_SLANT_NORMAL,
+    'oblique': cairo.FONT_SLANT_OBLIQUE,
+}
 
-    @cbook.deprecated("3.3")
-    @property
-    def fontangles(self):
-        return {
-            'italic':  cairo.FONT_SLANT_ITALIC,
-            'normal':  cairo.FONT_SLANT_NORMAL,
-            'oblique': cairo.FONT_SLANT_OBLIQUE,
-        }
+
+class RendererCairo(RendererBase):
+    fontweights = cbook.deprecated("3.3")(property(lambda self: {*_f_weights}))
+    fontangles = cbook.deprecated("3.3")(property(lambda self: {*_f_angles}))
+    mathtext_parser = cbook.deprecated("3.4")(
+        property(lambda self: MathTextParser('Cairo')))
 
     def __init__(self, dpi):
         self.dpi = dpi
@@ -132,11 +132,6 @@ class RendererCairo(RendererBase):
         self.text_ctx = cairo.Context(
            cairo.ImageSurface(cairo.FORMAT_ARGB32, 1, 1))
         super().__init__()
-
-    @cbook.deprecated("3.4")
-    @property
-    def mathtext_parser(self):
-        return MathTextParser('Cairo')
 
     def set_ctx_from_surface(self, surface):
         self.gc.ctx = cairo.Context(surface)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -489,6 +489,9 @@ class FigureManagerGTK3(FigureManagerBase):
 
 
 class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
+    ctx = cbook.deprecated("3.3")(property(
+        lambda self: self.canvas.get_property("window").cairo_create()))
+
     def __init__(self, canvas, window):
         self.win = window
         GObject.GObject.__init__(self)
@@ -540,11 +543,6 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         self.show_all()
 
         NavigationToolbar2.__init__(self, canvas)
-
-    @cbook.deprecated("3.3")
-    @property
-    def ctx(self):
-        return self.canvas.get_property("window").cairo_create()
 
     def set_message(self, s):
         escaped = GLib.markup_escape_text(s)

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -961,6 +961,7 @@ class PdfPages:
         '_info_dict',
         '_metadata',
     )
+    metadata = cbook.deprecated('3.3')(property(lambda self: self._metadata))
 
     def __init__(self, filename, *, keep_empty=True, metadata=None):
         """
@@ -1005,11 +1006,6 @@ class PdfPages:
                     self._metadata[canonical] = self._metadata.pop(key)
         self._info_dict = _create_pdf_info_dict('pgf', self._metadata)
         self._file = BytesIO()
-
-    @cbook.deprecated('3.3')
-    @property
-    def metadata(self):
-        return self._metadata
 
     def _write_header(self, width_inches, height_inches):
         hyperref_options = ','.join(

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -223,6 +223,11 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
     _afm_font_dir = cbook._get_data_path("fonts/afm")
     _use_afm_rc_name = "ps.useafm"
 
+    mathtext_parser = cbook.deprecated("3.4")(property(
+        lambda self: MathTextParser("PS")))
+    used_characters = cbook.deprecated("3.3")(property(
+        lambda self: self._character_tracker.used_characters))
+
     def __init__(self, width, height, pswriter, imagedpi=72):
         # Although postscript itself is dpi independent, we need to inform the
         # image code about a requested dpi to generate high resolution images
@@ -248,16 +253,6 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
         self._path_collection_id = 0
 
         self._character_tracker = _backend_pdf_ps.CharacterTracker()
-
-    @cbook.deprecated("3.3")
-    @property
-    def mathtext_parser(self):
-        return MathTextParser("PS")
-
-    @cbook.deprecated("3.3")
-    @property
-    def used_characters(self):
-        return self._character_tracker.used_characters
 
     @cbook.deprecated("3.3")
     def track_characters(self, *args, **kwargs):

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -709,6 +709,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
     %(contour_set_attributes)s
     """
 
+    ax = cbook.deprecated("3.3")(property(lambda self: self.axes))
+
     def __init__(self, ax, *args,
                  levels=None, filled=False, linewidths=None, linestyles=None,
                  hatches=(None,), alpha=None, origin=None, extent=None,
@@ -906,11 +908,6 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             s = ", ".join(map(repr, kwargs))
             cbook._warn_external('The following kwargs were not used by '
                                  'contour: ' + s)
-
-    @cbook.deprecated("3.3")
-    @property
-    def ax(self):
-        return self.axes
 
     def get_transform(self):
         """

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -80,42 +80,25 @@ class TexManager:
         'computer modern sans serif': ('cmss', r'\usepackage{type1ec}'),
         'computer modern typewriter': ('cmtt', r'\usepackage{type1ec}')}
 
-    @cbook.deprecated("3.3", alternative="matplotlib.get_cachedir()")
-    @property
-    def cachedir(self):
-        return mpl.get_cachedir()
-
-    @cbook.deprecated("3.3")
-    @property
-    def rgba_arrayd(self):
-        return {}
+    cachedir = cbook.deprecated(
+        "3.3", alternative="matplotlib.get_cachedir()")(
+            property(lambda self: mpl.get_cachedir()))
+    rgba_arrayd = cbook.deprecated("3.3")(property(lambda self: {}))
+    _fonts = {}  # Only for deprecation period.
+    serif = cbook.deprecated("3.3")(property(
+        lambda self: self._fonts.get("serif", ('cmr', ''))))
+    sans_serif = cbook.deprecated("3.3")(property(
+        lambda self: self._fonts.get("sans-serif", ('cmss', ''))))
+    cursive = cbook.deprecated("3.3")(property(
+        lambda self:
+        self._fonts.get("cursive", ('pzc', r'\usepackage{chancery}'))))
+    monospace = cbook.deprecated("3.3")(property(
+        lambda self: self._fonts.get("monospace", ('cmtt', ''))))
 
     @functools.lru_cache()  # Always return the same instance.
     def __new__(cls):
         Path(cls.texcache).mkdir(parents=True, exist_ok=True)
         return object.__new__(cls)
-
-    _fonts = {}  # Only for deprecation period.
-
-    @cbook.deprecated("3.3")
-    @property
-    def serif(self):
-        return self._fonts.get("serif", ('cmr', ''))
-
-    @cbook.deprecated("3.3")
-    @property
-    def sans_serif(self):
-        return self._fonts.get("sans-serif", ('cmss', ''))
-
-    @cbook.deprecated("3.3")
-    @property
-    def cursive(self):
-        return self._fonts.get("cursive", ('pzc', r'\usepackage{chancery}'))
-
-    @cbook.deprecated("3.3")
-    @property
-    def monospace(self):
-        return self._fonts.get("monospace", ('cmtt', ''))
 
     def get_font_config(self):
         ff = rcParams['font.family']

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -108,15 +108,13 @@ class AxesWidget(Widget):
     active : bool
         If False, the widget does not respond to events.
     """
+
+    cids = cbook.deprecated("3.4")(property(lambda self: self._cids))
+
     def __init__(self, ax):
         self.ax = ax
         self.canvas = ax.figure.canvas
         self._cids = []
-
-    @cbook.deprecated("3.4")
-    @property
-    def cids(self):
-        return self._cids
 
     def connect_event(self, event, callback):
         """
@@ -152,6 +150,11 @@ class Button(AxesWidget):
     hovercolor
         The color of the button when hovering.
     """
+
+    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+        lambda self: len(self._observers.callbacks['clicked'])))
+    observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['clicked']))
 
     def __init__(self, ax, label, image=None,
                  color='0.85', hovercolor='0.95'):
@@ -190,17 +193,6 @@ class Button(AxesWidget):
         ax.set_yticks([])
         self.color = color
         self.hovercolor = hovercolor
-
-    @cbook.deprecated("3.4")
-    @property
-    def cnt(self):
-        # Not real, but close enough.
-        return len(self._observers.callbacks['clicked'])
-
-    @cbook.deprecated("3.4")
-    @property
-    def observers(self):
-        return self._observers.callbacks['clicked']
 
     def _click(self, event):
         if self.ignore(event) or event.inaxes != self.ax or not self.eventson:
@@ -250,6 +242,11 @@ class Slider(AxesWidget):
     val : float
         Slider value.
     """
+
+    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+        lambda self: len(self._observers.callbacks['changed'])))
+    observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['changed']))
 
     def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt=None,
                  closedmin=True, closedmax=True, slidermin=None,
@@ -386,17 +383,6 @@ class Slider(AxesWidget):
         self._observers = cbook.CallbackRegistry()
 
         self.set_val(valinit)
-
-    @cbook.deprecated("3.4")
-    @property
-    def cnt(self):
-        # Not real, but close enough.
-        return len(self._observers.callbacks['changed'])
-
-    @cbook.deprecated("3.4")
-    @property
-    def observers(self):
-        return self._observers.callbacks['changed']
 
     def _value_in_bounds(self, val):
         """Makes sure *val* is with given bounds."""
@@ -538,6 +524,11 @@ class CheckButtons(AxesWidget):
         each box, but have ``set_visible(False)`` when its box is not checked.
     """
 
+    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+        lambda self: len(self._observers.callbacks['clicked'])))
+    observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['clicked']))
+
     def __init__(self, ax, labels, actives=None):
         """
         Add check buttons to `matplotlib.axes.Axes` instance *ax*
@@ -604,17 +595,6 @@ class CheckButtons(AxesWidget):
         self.connect_event('button_press_event', self._clicked)
 
         self._observers = cbook.CallbackRegistry()
-
-    @cbook.deprecated("3.4")
-    @property
-    def cnt(self):
-        # Not real, but close enough.
-        return len(self._observers.callbacks['clicked'])
-
-    @cbook.deprecated("3.4")
-    @property
-    def observers(self):
-        return self._observers.callbacks['clicked']
 
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
@@ -696,10 +676,14 @@ class TextBox(AxesWidget):
         The color of the text box when hovering.
     """
 
-    @cbook.deprecated("3.3")
-    @property
-    def params_to_disable(self):
-        return [key for key in mpl.rcParams if 'keymap' in key]
+    params_to_disable = cbook.deprecated("3.3")(property(
+        lambda self: [key for key in mpl.rcParams if 'keymap' in key]))
+    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+        lambda self: sum(len(d) for d in self._observers.callbacks.values())))
+    change_observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['change']))
+    submit_observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['submit']))
 
     def __init__(self, ax, label, initial='',
                  color='.95', hovercolor='1', label_pad=.01):
@@ -752,22 +736,6 @@ class TextBox(AxesWidget):
         self.hovercolor = hovercolor
 
         self.capturekeystrokes = False
-
-    @cbook.deprecated("3.4")
-    @property
-    def cnt(self):
-        # Not real, but close enough.
-        return sum(len(d) for d in self._observers.callbacks.values())
-
-    @cbook.deprecated("3.4")
-    @property
-    def change_observers(self):
-        return self._observers.callbacks['change']
-
-    @cbook.deprecated("3.4")
-    @property
-    def submit_observers(self):
-        return self._observers.callbacks['submit']
 
     @property
     def text(self):
@@ -1025,16 +993,10 @@ class RadioButtons(AxesWidget):
 
         self._observers = cbook.CallbackRegistry()
 
-    @cbook.deprecated("3.4")
-    @property
-    def cnt(self):
-        # Not real, but close enough.
-        return len(self._observers.callbacks['clicked'])
-
-    @cbook.deprecated("3.4")
-    @property
-    def observers(self):
-        return self._observers.callbacks['clicked']
+    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+        lambda self: len(self._observers.callbacks['clicked'])))
+    observers = cbook.deprecated("3.4")(property(
+        lambda self: self._observers.callbacks['clicked']))
 
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
@@ -1159,17 +1121,17 @@ class SubplotTool(Widget):
             event.canvas.draw()
             self.targetfig.canvas.draw()
 
-    axleft = cbook.deprecated("3.3", name="axleft")(
+    axleft = cbook.deprecated("3.3")(
         property(lambda self: self.sliderleft.ax))
-    axright = cbook.deprecated("3.3", name="axright")(
+    axright = cbook.deprecated("3.3")(
         property(lambda self: self.sliderright.ax))
-    axbottom = cbook.deprecated("3.3", name="axbottom")(
+    axbottom = cbook.deprecated("3.3")(
         property(lambda self: self.sliderbottom.ax))
-    axtop = cbook.deprecated("3.3", name="axtop")(
+    axtop = cbook.deprecated("3.3")(
         property(lambda self: self.slidertop.ax))
-    axwspace = cbook.deprecated("3.3", name="axwspace")(
+    axwspace = cbook.deprecated("3.3")(
         property(lambda self: self.sliderwspace.ax))
-    axhspace = cbook.deprecated("3.3", name="axhspace")(
+    axhspace = cbook.deprecated("3.3")(
         property(lambda self: self.sliderhspace.ax))
 
     @cbook.deprecated("3.3")

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -184,20 +184,12 @@ class Axes3D(Axes):
     get_zgridlines = _axis_method_wrapper("zaxis", "get_gridlines")
     get_zticklines = _axis_method_wrapper("zaxis", "get_ticklines")
 
-    @cbook.deprecated("3.1", alternative="xaxis", pending=True)
-    @property
-    def w_xaxis(self):
-        return self.xaxis
-
-    @cbook.deprecated("3.1", alternative="yaxis", pending=True)
-    @property
-    def w_yaxis(self):
-        return self.yaxis
-
-    @cbook.deprecated("3.1", alternative="zaxis", pending=True)
-    @property
-    def w_zaxis(self):
-        return self.zaxis
+    w_xaxis = cbook.deprecated("3.1", alternative="xaxis", pending=True)(
+        property(lambda self: self.xaxis))
+    w_yaxis = cbook.deprecated("3.1", alternative="yaxis", pending=True)(
+        property(lambda self: self.yaxis))
+    w_zaxis = cbook.deprecated("3.1", alternative="zaxis", pending=True)(
+        property(lambda self: self.zaxis))
 
     def _get_axis_list(self):
         return super()._get_axis_list() + (self.zaxis, )


### PR DESCRIPTION
This lets us write deprecated properties with single-line lambdas, which
is quite a bit more compact (as shown by the line diff).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
