### PR TITLE
Catch TypeError when validating rcParams types.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -246,7 +246,7 @@ def _make_type_validator(cls, *, allow_none=False):
             return None
         try:
             return cls(s)
-        except ValueError as e:
+        except (TypeError, ValueError) as e:
             raise ValueError(
                 f'Could not convert {s!r} to {cls.__name__}') from e
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -254,9 +254,7 @@ def generate_validator_testcases(valid):
                      for _ in ('1.5, 2.5', [1.5, 2.5], [1.5, 2.5],
                                (1.5, 2.5), np.array((1.5, 2.5)))),
          'fail': ((_, ValueError)
-                  for _ in ('aardvark', ('a', 1),
-                            (1, 2, 3)
-                            ))
+                  for _ in ('aardvark', ('a', 1), (1, 2, 3), (None, ), None))
          },
         {'validator': validate_cycler,
          'success': (('cycler("color", "rgb")',


### PR DESCRIPTION
## PR Summary

From a `matplotlibrc` point of view, the only input would be strings, which could raise `ValueError`. But from a code point of view,
_anything_ could be assigned to `rcParams`. This raises a `TypeError` instead of the validator message.

That is, previously you would get:
```python
>>> plt.rcParams['patch.linewidth'] = None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../matplotlib/lib/matplotlib/__init__.py", line 632, in __setitem__
    cval = self.validate[key](val)
  File ".../matplotlib/lib/matplotlib/rcsetup.py", line 248, in validator
    return cls(s)
TypeError: float() argument must be a string or a number, not 'NoneType'
```
and now you get the validator message:
```python
>>> plt.rcParams['patch.linewidth'] = None
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../matplotlib/lib/matplotlib/__init__.py", line 634, in __setitem__
    raise ValueError(f"Key {key}: {ve}") from None
ValueError: Key patch.linewidth: Could not convert None to float
```

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).