### PR TITLE
clarify example in plot docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1418,10 +1418,14 @@ class Axes(_AxesBase):
           directly to *x*, *y*. A separate data set will be drawn for every
           column.
 
-          Example: an array ``a`` where the first column represents the *x*
-          values and the other columns are the *y* columns::
+          Example: For an array ``a`` with shape (N, m) calling::
 
-          >>> plot(a[0], a[1:])
+          >>> plot(a)
+
+          is equivalent to:
+
+          >>> for i in range(m):
+          ...     plot(a[:, i])
 
         - The third way is to specify multiple sets of *[x]*, *y*, *[fmt]*
           groups::


### PR DESCRIPTION
## PR Summary
This example from the plot docstring was unclear and/or incorrect. This modifies in a way that I at least find clearer.

```python
import numpy as np
import matplotlib.pyplot as plt

fig, (ax1, ax2, ax3) = plt.subplots(1,3, sharey=True, figsize=(10,5))
a = np.arange(6).reshape(3,2)
ax1.plot(a[0], a[1:], 'o-') #old example
ax2.plot(a, 'o-')
for i in range(2):
    ax3.plot(a[:, i], 'o-')
ax1.set_title('Old Example')
ax2.set_title('New Example - part 1')
ax3.set_title('New Example - part 2')
ax1.set_xlim(ax3.get_xlim())
```

![image](https://user-images.githubusercontent.com/10111092/95638440-a36f8680-0a62-11eb-9fe1-8e2b84390a46.png)


See discussion on gitter starting here: https://gitter.im/matplotlib/matplotlib?at=5f80c4dfdc95072254c78916
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [ ] (as yet undetermined, allowing CI to build) Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
