### PR TITLE
Use "Return whether ..." docstring for functions returning bool

### DIFF
--- a/examples/misc/custom_projection.py
+++ b/examples/misc/custom_projection.py
@@ -338,14 +338,16 @@ class GeoAxes(Axes):
     # so we override all of the following methods to disable it.
     def can_zoom(self):
         """
-        Return *True* if this axes supports the zoom box button functionality.
+        Return whether this axes supports the zoom box button functionality.
+
         This axes object does not support interactive zoom box.
         """
         return False
 
     def can_pan(self):
         """
-        Return *True* if this axes supports the pan/zoom button functionality.
+        Return whether this axes supports the pan/zoom button functionality.
+
         This axes object does not support interactive pan/zoom.
         """
         return False

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -711,7 +711,7 @@ URL_REGEX = re.compile(r'^http://|^https://|^ftp://|^file:')
 
 
 def is_url(filename):
-    """Return True if string is an http, ftp, or file URL path."""
+    """Return whether *filename* is an http, https, ftp, or file URL path."""
     return URL_REGEX.match(filename) is not None
 
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -188,7 +188,7 @@ class Artist:
         # TODO: add legend support
 
     def have_units(self):
-        """Return *True* if units are set on any axis."""
+        """Return whether units are set on any axis."""
         ax = self.axes
         return ax and any(axis.have_units() for axis in ax._get_axis_list())
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1921,7 +1921,7 @@ class _AxesBase(martist.Artist):
 
     def has_data(self):
         """
-        Return *True* if any artists have been added to axes.
+        Return whether any artists have been added to the axes.
 
         This should not be used to determine whether the *dataLim*
         need to be updated, and may not actually be useful for
@@ -2277,8 +2277,7 @@ class _AxesBase(martist.Artist):
 
     def in_axes(self, mouseevent):
         """
-        Return *True* if the given *mouseevent* (in display coords)
-        is in the Axes
+        Return whether the given event (in display coords) is in the Axes.
         """
         return self.patch.contains(mouseevent)[0]
 
@@ -3922,13 +3921,13 @@ class _AxesBase(martist.Artist):
 
     def can_zoom(self):
         """
-        Return *True* if this axes supports the zoom box button functionality.
+        Return whether this axes supports the zoom box button functionality.
         """
         return True
 
     def can_pan(self):
         """
-        Return *True* if this axes supports any pan/zoom button functionality.
+        Return whether this axes supports any pan/zoom button functionality.
         """
         return True
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -208,7 +208,7 @@ class ContourLabeler:
                 or (np.ptp(linecontour, axis=0) > 1.2 * labelwidth).any())
 
     def too_close(self, x, y, lw):
-        """Return *True* if a label is already near this location."""
+        """Return whether a label is already near this location."""
         thresh = (1.2 * lw) ** 2
         return any((x - loc[0]) ** 2 + (y - loc[1]) ** 2 < thresh
                    for loc in self.labelXYs)

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -202,7 +202,7 @@ class GeoAxes(Axes):
 
     def can_zoom(self):
         """
-        Return *True* if this axes supports the zoom box button functionality.
+        Return whether this axes supports the zoom box button functionality.
 
         This axes object does not support interactive zoom box.
         """
@@ -210,7 +210,7 @@ class GeoAxes(Axes):
 
     def can_pan(self):
         """
-        Return *True* if this axes supports the pan/zoom button functionality.
+        Return whether this axes supports the pan/zoom button functionality.
 
         This axes object does not support interactive pan/zoom.
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1420,7 +1420,7 @@ class PolarAxes(Axes):
 
     def can_zoom(self):
         """
-        Return *True* if this axes supports the zoom box button functionality.
+        Return whether this axes supports the zoom box button functionality.
 
         Polar axes do not support zoom boxes.
         """
@@ -1428,7 +1428,7 @@ class PolarAxes(Axes):
 
     def can_pan(self):
         """
-        Return *True* if this axes supports the pan/zoom button functionality.
+        Return whether this axes supports the pan/zoom button functionality.
 
         For polar axes, this is slightly misleading. Both panning and
         zooming are performed by the same button. Panning is performed

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -355,7 +355,7 @@ class Grid:
         return self.ny, self.nx
 
     def within_grid(self, xi, yi):
-        """Return True if point is a valid index of grid."""
+        """Return whether (*xi*, *yi*) is a valid index of the grid."""
         # Note that xi/yi can be floats; so, for example, we can't simply check
         # `xi < self.nx` since *xi* can be `self.nx - 1 < xi < self.nx`
         return 0 <= xi <= self.nx - 1 and 0 <= yi <= self.ny - 1

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1061,7 +1061,7 @@ class Axes3D(Axes):
 
     def can_zoom(self):
         """
-        Return *True* if this axes supports the zoom box button functionality.
+        Return whether this axes supports the zoom box button functionality.
 
         3D axes objects do not use the zoom box button.
         """
@@ -1069,7 +1069,7 @@ class Axes3D(Axes):
 
     def can_pan(self):
         """
-        Return *True* if this axes supports the pan/zoom button functionality.
+        Return whether this axes supports the pan/zoom button functionality.
 
         3D axes objects do not use the pan/zoom button.
         """


### PR DESCRIPTION
## PR Summary

Large parts of the code base already use that phrase. Let's get the rest of in line.

This is more natural language than "Return True if", and it includes the negative outcome, which the latter technically does not.