### PR TITLE
Use attributes Axes.x/yaxis instead of Axes.get_x/yaxis()

### DIFF
--- a/examples/lines_bars_and_markers/timeline.py
+++ b/examples/lines_bars_and_markers/timeline.py
@@ -83,12 +83,12 @@ for d, l, r in zip(dates, levels, names):
                 verticalalignment="bottom" if l > 0 else "top")
 
 # format xaxis with 4 month intervals
-ax.get_xaxis().set_major_locator(mdates.MonthLocator(interval=4))
-ax.get_xaxis().set_major_formatter(mdates.DateFormatter("%b %Y"))
+ax.xaxis.set_major_locator(mdates.MonthLocator(interval=4))
+ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %Y"))
 plt.setp(ax.get_xticklabels(), rotation=30, ha="right")
 
 # remove y axis and spines
-ax.get_yaxis().set_visible(False)
+ax.yaxis.set_visible(False)
 for spine in ["left", "top", "right"]:
     ax.spines[spine].set_visible(False)
 

--- a/examples/showcase/bachelors_degrees_by_gender.py
+++ b/examples/showcase/bachelors_degrees_by_gender.py
@@ -39,8 +39,8 @@ ax.spines['left'].set_visible(False)
 
 # Ensure that the axis ticks only show up on the bottom and left of the plot.
 # Ticks on the right and top of the plot are generally unnecessary.
-ax.get_xaxis().tick_bottom()
-ax.get_yaxis().tick_left()
+ax.xaxis.tick_bottom()
+ax.yaxis.tick_left()
 
 fig.subplots_adjust(left=.06, right=.75, bottom=.02, top=.94)
 # Limit the range of the plot to only where the data is.

--- a/examples/statistics/customized_violin.py
+++ b/examples/statistics/customized_violin.py
@@ -28,7 +28,7 @@ def adjacent_values(vals, q1, q3):
 
 
 def set_axis_style(ax, labels):
-    ax.get_xaxis().set_tick_params(direction='out')
+    ax.xaxis.set_tick_params(direction='out')
     ax.xaxis.set_ticks_position('bottom')
     ax.set_xticks(np.arange(1, len(labels) + 1))
     ax.set_xticklabels(labels)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1885,11 +1885,21 @@ class _AxesBase(martist.Artist):
         return cbook.silent_list('Line2D', self.lines)
 
     def get_xaxis(self):
-        """Return the XAxis instance."""
+        """
+        Return the XAxis instance.
+
+        The use of this function is discouraged. You should instead directly
+        access the attribute ``ax.xaxis``.
+        """
         return self.xaxis
 
     def get_yaxis(self):
-        """Return the YAxis instance."""
+        """
+        Return the YAxis instance.
+
+        The use of this function is discouraged. You should instead directly
+        access the attribute ``ax.yaxis``.
+        """
         return self.yaxis
 
     get_xgridlines = _axis_method_wrapper("xaxis", "get_gridlines")

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -137,12 +137,12 @@ class SubplotBase:
         if not lastrow:
             for label in self.get_xticklabels(which="both"):
                 label.set_visible(False)
-            self.get_xaxis().get_offset_text().set_visible(False)
+            self.xaxis.get_offset_text().set_visible(False)
             self.set_xlabel("")
         if not firstcol:
             for label in self.get_yticklabels(which="both"):
                 label.set_visible(False)
-            self.get_yaxis().get_offset_text().set_visible(False)
+            self.yaxis.get_offset_text().set_visible(False)
             self.set_ylabel("")
 
     def _make_twin_axes(self, *args, **kwargs):

--- a/lib/matplotlib/testing/jpl_units/StrConverter.py
+++ b/lib/matplotlib/testing/jpl_units/StrConverter.py
@@ -35,7 +35,7 @@ class StrConverter(units.ConversionInterface):
 
         # we delay loading to make matplotlib happy
         ax = axis.axes
-        if axis is ax.get_xaxis():
+        if axis is ax.xaxis:
             isXAxis = True
         else:
             isXAxis = False

--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -120,8 +120,8 @@ def test_noop_tight_bbox():
     ax = plt.Axes(fig, [0., 0., 1., 1.])
     fig.add_axes(ax)
     ax.set_axis_off()
-    ax.get_xaxis().set_visible(False)
-    ax.get_yaxis().set_visible(False)
+    ax.xaxis.set_visible(False)
+    ax.yaxis.set_visible(False)
 
     data = np.arange(x_size * y_size).reshape(y_size, x_size)
     ax.imshow(data, rasterized=True)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -135,7 +135,7 @@ def test_polar_units_2(fig_test, fig_ref):
     plt.figure(fig_test.number)
     # test {theta,r}units.
     plt.polar(xs_deg, ys_km, thetaunits="rad", runits="km")
-    assert isinstance(plt.gca().get_xaxis().get_major_formatter(),
+    assert isinstance(plt.gca().xaxis.get_major_formatter(),
                       units.UnitDblFormatter)
 
     ax = fig_ref.add_subplot(projection="polar")

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -27,10 +27,10 @@ def check_shared(axs, x_shared, y_shared):
 
 def check_visible(axs, x_visible, y_visible):
     for i, (ax, vx, vy) in enumerate(zip(axs, x_visible, y_visible)):
-        for l in ax.get_xticklabels() + [ax.get_xaxis().offsetText]:
+        for l in ax.get_xticklabels() + [ax.xaxis.offsetText]:
             assert l.get_visible() == vx, \
                     f"Visibility of x axis #{i} is incorrectly {vx}"
-        for l in ax.get_yticklabels() + [ax.get_yaxis().offsetText]:
+        for l in ax.get_yticklabels() + [ax.yaxis.offsetText]:
             assert l.get_visible() == vy, \
                     f"Visibility of y axis #{i} is incorrectly {vy}"
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -527,18 +527,18 @@ class TestScalarFormatter:
     @pytest.mark.parametrize('left, right, offset', offset_data)
     def test_offset_value(self, left, right, offset):
         fig, ax = plt.subplots()
-        formatter = ax.get_xaxis().get_major_formatter()
+        formatter = ax.xaxis.get_major_formatter()
 
         with (pytest.warns(UserWarning, match='Attempting to set identical')
               if left == right else nullcontext()):
             ax.set_xlim(left, right)
-        ax.get_xaxis()._update_ticks()
+        ax.xaxis._update_ticks()
         assert formatter.offset == offset
 
         with (pytest.warns(UserWarning, match='Attempting to set identical')
               if left == right else nullcontext()):
             ax.set_xlim(right, left)
-        ax.get_xaxis()._update_ticks()
+        ax.xaxis._update_ticks()
         assert formatter.offset == offset
 
     @pytest.mark.parametrize('use_offset', use_offset_data)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -259,8 +259,8 @@ def test_fill_facecolor():
     axins = zoomed_inset_axes(ax[0], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
-    plt.gca().axes.get_xaxis().set_ticks([])
-    plt.gca().axes.get_yaxis().set_ticks([])
+    plt.gca().axes.xaxis.set_ticks([])
+    plt.gca().axes.yaxis.set_ticks([])
     mark_inset(ax[0], axins, loc1=2, loc2=4, fc="b", ec="0.5")
 
     # fill with yellow by setting 'facecolor' field
@@ -276,8 +276,8 @@ def test_fill_facecolor():
     axins = zoomed_inset_axes(ax[1], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
-    plt.gca().axes.get_xaxis().set_ticks([])
-    plt.gca().axes.get_yaxis().set_ticks([])
+    plt.gca().axes.xaxis.set_ticks([])
+    plt.gca().axes.yaxis.set_ticks([])
     mark_inset(ax[1], axins, loc1=2, loc2=4, facecolor="y", ec="0.5")
 
     # fill with green by setting 'color' field
@@ -293,8 +293,8 @@ def test_fill_facecolor():
     axins = zoomed_inset_axes(ax[2], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
-    plt.gca().axes.get_xaxis().set_ticks([])
-    plt.gca().axes.get_yaxis().set_ticks([])
+    plt.gca().axes.xaxis.set_ticks([])
+    plt.gca().axes.yaxis.set_ticks([])
     mark_inset(ax[2], axins, loc1=2, loc2=4, color="g", ec="0.5")
 
     # fill with green but color won't show if set fill to False
@@ -310,8 +310,8 @@ def test_fill_facecolor():
     axins = zoomed_inset_axes(ax[3], 1, loc='upper right')
     axins.set_xlim(0, 0.2)
     axins.set_ylim(0, 0.2)
-    axins.get_xaxis().set_ticks([])
-    axins.get_yaxis().set_ticks([])
+    axins.xaxis.set_ticks([])
+    axins.yaxis.set_ticks([])
     mark_inset(ax[3], axins, loc1=2, loc2=4, fc="g", ec="0.5", fill=False)
 
 


### PR DESCRIPTION
## PR Summary

We're already largely doing this in code base and examples.

This PR changes some remaining usages and discourages the use of the
getters in their docstrings. For now I'm not going so far as to deprecate the
methods. Keeping them around does little harm.

*Note on API consistency*: While we generally use getters, I'm not too
worried that people may find this inconsistent. An axis is rather a
sub-part than a property. In particular, it will mostly be used as an
indirection to one of its properties, i.e. `ax.xaxis.get_units()`.
Here we still have a final getter call. IMHO it even looks better / more
pythonic than a method chain: `ax.get_xaxis().get_units()`.

I'm also not too worried that people may try to overwrite the plain
attributes `Axes.x/yaxis`. While one could turn them into properties
to protect overwriting, the attributes have already been used widely
in examples and we did not get any complaints.
