### PR TITLE
Allow setting default AutoMinorLocator 

### DIFF
--- a/doc/users/next_whats_new/auto_minor_tick.rst
+++ b/doc/users/next_whats_new/auto_minor_tick.rst
@@ -1,0 +1,5 @@
+rcParams for ``AutoMinorLocator`` divisions
+-------------------------------------------
+The rcParams :rc:`xtick.minor.ndivs` and :rc:`ytick.minor.ndivs` have been
+added to enable setting the default number of divisions; if set to ``auto``,
+the number of divisions will be chosen by the distance between major ticks.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -489,6 +489,7 @@
 #xtick.major.bottom:  True    # draw x axis bottom major ticks
 #xtick.minor.top:     True    # draw x axis top minor ticks
 #xtick.minor.bottom:  True    # draw x axis bottom minor ticks
+#xtick.minor.ndivs:   auto    # number of minor ticks between the major ticks on x-axis
 #xtick.alignment:     center  # alignment of xticks
 
 #ytick.left:          True    # draw ticks on the left side
@@ -510,6 +511,7 @@
 #ytick.major.right:   True    # draw y axis right major ticks
 #ytick.minor.left:    True    # draw y axis left minor ticks
 #ytick.minor.right:   True    # draw y axis right minor ticks
+#ytick.minor.ndivs:   auto    # number of minor ticks between the major ticks on y-axis
 #ytick.alignment:     center_baseline  # alignment of yticks
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -597,7 +597,7 @@ validate_dashlist = _listify_validator(validate_floatlist)
 
 def _validate_minor_tick_ndivs(n):
     """
-    Validate ndiv parameter related with the minor ticks.
+    Validate ndiv parameter related to the minor ticks.
     It controls the number of minor ticks to be placed between
     two major ticks.
     """
@@ -610,7 +610,7 @@ def _validate_minor_tick_ndivs(n):
     except (RuntimeError, ValueError):
         pass
 
-    raise ValueError("'tick.minor.ndivs' must be a 'auto' or non-negative int")
+    raise ValueError("'tick.minor.ndivs' must be 'auto' or non-negative int")
 
 
 _prop_validators = {
@@ -1119,8 +1119,8 @@ _validators = {
     "xtick.minor.bottom":  validate_bool,      # draw bottom minor xticks
     "xtick.major.top":     validate_bool,      # draw top major xticks
     "xtick.major.bottom":  validate_bool,      # draw bottom major xticks
-    "xtick.minor.ndivs":   _validate_minor_tick_ndivs,
     # number of minor xticks
+    "xtick.minor.ndivs":   _validate_minor_tick_ndivs,
     "xtick.labelsize":     validate_fontsize,  # fontsize of xtick labels
     "xtick.direction":     ["out", "in", "inout"],  # direction of xticks
     "xtick.alignment":     ["center", "right", "left"],
@@ -1142,8 +1142,8 @@ _validators = {
     "ytick.minor.right":   validate_bool,      # draw right minor yticks
     "ytick.major.left":    validate_bool,      # draw left major yticks
     "ytick.major.right":   validate_bool,      # draw right major yticks
-    "ytick.minor.ndivs":   _validate_minor_tick_ndivs,
     # number of minor yticks
+    "ytick.minor.ndivs":   _validate_minor_tick_ndivs,
     "ytick.labelsize":     validate_fontsize,  # fontsize of ytick labels
     "ytick.direction":     ["out", "in", "inout"],  # direction of yticks
     "ytick.alignment":     [

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -568,6 +568,14 @@ def _validate_greaterequal0_lessequal1(s):
         raise RuntimeError(f'Value must be >=0 and <=1; got {s}')
 
 
+def _validate_int_greaterequal0(s):
+    s = validate_int(s)
+    if s >= 0:
+        return s
+    else:
+        raise RuntimeError(f'Value must be >=0; got {s}')
+
+
 def validate_hatch(s):
     r"""
     Validate a hatch pattern.
@@ -585,6 +593,23 @@ def validate_hatch(s):
 
 validate_hatchlist = _listify_validator(validate_hatch)
 validate_dashlist = _listify_validator(validate_floatlist)
+
+
+def _validate_minor_tick_ndivs(n):
+    """
+    Validate ndiv parameter related with the minor ticks.
+    It controls the number of minor ticks to be placed between
+    two major ticks.
+    """
+    if isinstance(n, str):
+        n = n.lower()
+        if n == 'auto':
+            return n
+
+        raise ValueError("Value must be set to 'auto'")
+    else:
+        n = _validate_int_greaterequal0(n)
+        return n
 
 
 _prop_validators = {
@@ -1093,6 +1118,8 @@ _validators = {
     "xtick.minor.bottom":  validate_bool,      # draw bottom minor xticks
     "xtick.major.top":     validate_bool,      # draw top major xticks
     "xtick.major.bottom":  validate_bool,      # draw bottom major xticks
+    "xtick.minor.ndivs":   _validate_minor_tick_ndivs,
+    # number of minor xticks
     "xtick.labelsize":     validate_fontsize,  # fontsize of xtick labels
     "xtick.direction":     ["out", "in", "inout"],  # direction of xticks
     "xtick.alignment":     ["center", "right", "left"],
@@ -1114,6 +1141,8 @@ _validators = {
     "ytick.minor.right":   validate_bool,      # draw right minor yticks
     "ytick.major.left":    validate_bool,      # draw left major yticks
     "ytick.major.right":   validate_bool,      # draw right major yticks
+    "ytick.minor.ndivs":   _validate_minor_tick_ndivs,
+    # number of minor yticks
     "ytick.labelsize":     validate_fontsize,  # fontsize of ytick labels
     "ytick.direction":     ["out", "in", "inout"],  # direction of yticks
     "ytick.alignment":     [

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -601,15 +601,16 @@ def _validate_minor_tick_ndivs(n):
     It controls the number of minor ticks to be placed between
     two major ticks.
     """
-    if isinstance(n, str):
-        n = n.lower()
-        if n == 'auto':
-            return n
 
-        raise ValueError("Value must be set to 'auto'")
-    else:
+    if isinstance(n, str) and n.lower() == 'auto':
+        return n
+    try:
         n = _validate_int_greaterequal0(n)
         return n
+    except (RuntimeError, ValueError):
+        pass
+
+    raise ValueError("'tick.minor.ndivs' must be a 'auto' or non-negative int")
 
 
 _prop_validators = {

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -211,22 +211,16 @@ class TestAutoMinorLocator:
 
         assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
+    @pytest.mark.parametrize('use_rcparam', [False, True])
     @pytest.mark.parametrize(
-        'lim, ref, use_rcparam', [
+        'lim, ref', [
             ((0, 1.39),
              [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45, 0.5, 0.55, 0.65, 0.7,
-              0.75, 0.85, 0.9, 0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35], True),
-            ((0, 1.39),
-             [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45, 0.5, 0.55, 0.65, 0.7,
-              0.75, 0.85, 0.9, 0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35], False),
+              0.75, 0.85, 0.9, 0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35]),
             ((0, 0.139),
              [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045, 0.05, 0.055,
               0.065, 0.07, 0.075, 0.085, 0.09, 0.095, 0.105, 0.11, 0.115,
-              0.125, 0.13, 0.135], True),
-            ((0, 0.139),
-             [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045, 0.05, 0.055,
-              0.065, 0.07, 0.075, 0.085, 0.09, 0.095, 0.105, 0.11, 0.115,
-              0.125, 0.13, 0.135], False),
+              0.125, 0.13, 0.135]),
         ])
     def test_number_of_minor_ticks_auto(self, lim, ref, use_rcparam):
         if use_rcparam:
@@ -245,14 +239,12 @@ class TestAutoMinorLocator:
             assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
             assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
+    @pytest.mark.parametrize('use_rcparam', [False, True])
     @pytest.mark.parametrize(
-        'n, lim, ref, use_rcparam', [
-            (2, (0, 4), [0.5, 1.5, 2.5, 3.5], True),
-            (2, (0, 4), [0.5, 1.5, 2.5, 3.5], False),
-            (4, (0, 2), [0.25, 0.5, 0.75, 1.25, 1.5, 1.75], True),
-            (4, (0, 2), [0.25, 0.5, 0.75, 1.25, 1.5, 1.75], False),
-            (10, (0, 1), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], True),
-            (10, (0, 1), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], False),
+        'n, lim, ref', [
+            (2, (0, 4), [0.5, 1.5, 2.5, 3.5]),
+            (4, (0, 2), [0.25, 0.5, 0.75, 1.25, 1.5, 1.75]),
+            (10, (0, 1), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),
         ])
     def test_number_of_minor_ticks_int(self, n, lim, ref, use_rcparam):
         if use_rcparam:

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -212,120 +212,66 @@ class TestAutoMinorLocator:
         assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
     @pytest.mark.parametrize(
-        'lim, ref',
-        [
-            (
-                    (0, 1.39),
-                    [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45,
-                     0.5, 0.55, 0.65, 0.7, 0.75, 0.85, 0.9,
-                     0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35]
-            ),
-            (
-                    (0, 0.139),
-                    [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045,
-                     0.05, 0.055, 0.065, 0.07, 0.075, 0.085, 0.09,
-                     0.095, 0.105, 0.11, 0.115, 0.125, 0.13, 0.135]
-            ),
-        ],
-    )
-    def test_number_of_minor_ticks_rcparams_auto(self, lim, ref):
-        with mpl.rc_context({'xtick.minor.ndivs': 'auto', 'ytick.minor.ndivs': 'auto'}):
+        'lim, ref, use_rcparam', [
+            ((0, 1.39),
+             [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45, 0.5, 0.55, 0.65, 0.7,
+              0.75, 0.85, 0.9, 0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35], True),
+            ((0, 1.39),
+             [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45, 0.5, 0.55, 0.65, 0.7,
+              0.75, 0.85, 0.9, 0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35], False),
+            ((0, 0.139),
+             [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045, 0.05, 0.055,
+              0.065, 0.07, 0.075, 0.085, 0.09, 0.095, 0.105, 0.11, 0.115,
+              0.125, 0.13, 0.135], True),
+            ((0, 0.139),
+             [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045, 0.05, 0.055,
+              0.065, 0.07, 0.075, 0.085, 0.09, 0.095, 0.105, 0.11, 0.115,
+              0.125, 0.13, 0.135], False),
+        ])
+    def test_number_of_minor_ticks_auto(self, lim, ref, use_rcparam):
+        if use_rcparam:
+            context = {'xtick.minor.ndivs': 'auto', 'ytick.minor.ndivs': 'auto'}
+            kwargs = {}
+        else:
+            context = {}
+            kwargs = {'n': 'auto'}
+
+        with mpl.rc_context(context):
             fig, ax = plt.subplots()
             ax.set_xlim(*lim)
             ax.set_ylim(*lim)
-            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
-            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())
+            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(**kwargs))
+            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(**kwargs))
             assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
             assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
     @pytest.mark.parametrize(
-        'lim, ref',
-        [
-            (
-                    (0, 1.39),
-                    [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45,
-                     0.5, 0.55, 0.65, 0.7, 0.75, 0.85, 0.9,
-                     0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35]
-            ),
-            (
-                    (0, 0.139),
-                    [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045,
-                     0.05, 0.055, 0.065, 0.07, 0.075, 0.085, 0.09,
-                     0.095, 0.105, 0.11, 0.115, 0.125, 0.13, 0.135]
-            ),
-        ],
-    )
-    def test_number_of_minor_ticks_ndivs_auto(self, lim, ref):
-        fig, ax = plt.subplots()
-        ax.set_xlim(*lim)
-        ax.set_ylim(*lim)
-        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(n='auto'))
-        ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(n='auto'))
-        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
-        assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
+        'n, lim, ref, use_rcparam', [
+            (2, (0, 4), [0.5, 1.5, 2.5, 3.5], True),
+            (2, (0, 4), [0.5, 1.5, 2.5, 3.5], False),
+            (4, (0, 2), [0.25, 0.5, 0.75, 1.25, 1.5, 1.75], True),
+            (4, (0, 2), [0.25, 0.5, 0.75, 1.25, 1.5, 1.75], False),
+            (10, (0, 1), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], True),
+            (10, (0, 1), [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9], False),
+        ])
+    def test_number_of_minor_ticks_int(self, n, lim, ref, use_rcparam):
+        if use_rcparam:
+            context = {'xtick.minor.ndivs': n, 'ytick.minor.ndivs': n}
+            kwargs = {}
+        else:
+            context = {}
+            kwargs = {'n': n}
 
-    @pytest.mark.parametrize(
-        'n, lim, ref',
-        [
-            (
-                    2,
-                    (0, 4),
-                    [0.5, 1.5, 2.5, 3.5]
-            ),
-            (
-                    4,
-                    (0, 2),
-                    [0.25, 0.5, 0.75, 1.25, 1.5, 1.75]
-            ),
-            (
-                    10,
-                    (0, 1),
-                    [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-            ),
-        ],
-    )
-    def test_number_of_minor_ticks_rcparams_int(self, n, lim, ref):
-        with mpl.rc_context({'xtick.minor.ndivs': n, 'ytick.minor.ndivs': n}):
+        with mpl.rc_context(context):
             fig, ax = plt.subplots()
             ax.set_xlim(*lim)
             ax.set_ylim(*lim)
             ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
-            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(**kwargs))
             ax.yaxis.set_major_locator(mticker.MultipleLocator(1))
-            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())
+            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(**kwargs))
             assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
             assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
-
-    @pytest.mark.parametrize(
-        'n, lim, ref',
-        [
-            (
-                    2,
-                    (0, 4),
-                    [0.5, 1.5, 2.5, 3.5]
-            ),
-            (
-                    4,
-                    (0, 2),
-                    [0.25, 0.5, 0.75, 1.25, 1.5, 1.75]
-            ),
-            (
-                    10,
-                    (0, 1),
-                    [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-            ),
-        ],
-    )
-    def test_number_of_minor_ticks_ndivs_int(self, n, lim, ref):
-        fig, ax = plt.subplots()
-        ax.set_xlim(*lim)
-        ax.set_ylim(*lim)
-        ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
-        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(n))
-        ax.yaxis.set_major_locator(mticker.MultipleLocator(1))
-        ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(n))
-        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
-        assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
 
 class TestLogLocator:

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -211,6 +211,122 @@ class TestAutoMinorLocator:
 
         assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
 
+    @pytest.mark.parametrize(
+        'lim, ref',
+        [
+            (
+                    (0, 1.39),
+                    [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45,
+                     0.5, 0.55, 0.65, 0.7, 0.75, 0.85, 0.9,
+                     0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35]
+            ),
+            (
+                    (0, 0.139),
+                    [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045,
+                     0.05, 0.055, 0.065, 0.07, 0.075, 0.085, 0.09,
+                     0.095, 0.105, 0.11, 0.115, 0.125, 0.13, 0.135]
+            ),
+        ],
+    )
+    def test_number_of_minor_ticks_rcparams_auto(self, lim, ref):
+        with mpl.rc_context({'xtick.minor.ndivs': 'auto', 'ytick.minor.ndivs': 'auto'}):
+            fig, ax = plt.subplots()
+            ax.set_xlim(*lim)
+            ax.set_ylim(*lim)
+            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())
+            assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
+            assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
+
+    @pytest.mark.parametrize(
+        'lim, ref',
+        [
+            (
+                    (0, 1.39),
+                    [0.05, 0.1, 0.15, 0.25, 0.3, 0.35, 0.45,
+                     0.5, 0.55, 0.65, 0.7, 0.75, 0.85, 0.9,
+                     0.95, 1.05, 1.1, 1.15, 1.25, 1.3, 1.35]
+            ),
+            (
+                    (0, 0.139),
+                    [0.005, 0.01, 0.015, 0.025, 0.03, 0.035, 0.045,
+                     0.05, 0.055, 0.065, 0.07, 0.075, 0.085, 0.09,
+                     0.095, 0.105, 0.11, 0.115, 0.125, 0.13, 0.135]
+            ),
+        ],
+    )
+    def test_number_of_minor_ticks_ndivs_auto(self, lim, ref):
+        fig, ax = plt.subplots()
+        ax.set_xlim(*lim)
+        ax.set_ylim(*lim)
+        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(n='auto'))
+        ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(n='auto'))
+        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
+        assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
+
+    @pytest.mark.parametrize(
+        'n, lim, ref',
+        [
+            (
+                    2,
+                    (0, 4),
+                    [0.5, 1.5, 2.5, 3.5]
+            ),
+            (
+                    4,
+                    (0, 2),
+                    [0.25, 0.5, 0.75, 1.25, 1.5, 1.75]
+            ),
+            (
+                    10,
+                    (0, 1),
+                    [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+            ),
+        ],
+    )
+    def test_number_of_minor_ticks_rcparams_int(self, n, lim, ref):
+        with mpl.rc_context({'xtick.minor.ndivs': n, 'ytick.minor.ndivs': n}):
+            fig, ax = plt.subplots()
+            ax.set_xlim(*lim)
+            ax.set_ylim(*lim)
+            ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+            ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+            ax.yaxis.set_major_locator(mticker.MultipleLocator(1))
+            ax.yaxis.set_minor_locator(mticker.AutoMinorLocator())
+            assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
+            assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
+
+    @pytest.mark.parametrize(
+        'n, lim, ref',
+        [
+            (
+                    2,
+                    (0, 4),
+                    [0.5, 1.5, 2.5, 3.5]
+            ),
+            (
+                    4,
+                    (0, 2),
+                    [0.25, 0.5, 0.75, 1.25, 1.5, 1.75]
+            ),
+            (
+                    10,
+                    (0, 1),
+                    [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+            ),
+        ],
+    )
+    def test_number_of_minor_ticks_ndivs_int(self, n, lim, ref):
+        fig, ax = plt.subplots()
+        ax.set_xlim(*lim)
+        ax.set_ylim(*lim)
+        ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator(n))
+        ax.yaxis.set_major_locator(mticker.MultipleLocator(1))
+        ax.yaxis.set_minor_locator(mticker.AutoMinorLocator(n))
+        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), ref)
+        assert_almost_equal(ax.yaxis.get_ticklocs(minor=True), ref)
+
 
 class TestLogLocator:
     def test_basic(self):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2870,7 +2870,10 @@ class AutoMinorLocator(Locator):
         between major ticks.
 
         If *n* is omitted or None, the value stored in rcParams will be used.
-        In case *n* is set to 'auto', it will be set to 4 or 5.
+        In case *n* is set to 'auto', it will be set to 4 or 5. If the distance
+        between the major ticks equals 1, 2.5, 5 or 10 it can be perfectly
+        divided in 5 equidistant sub-intervals with a length multiple of
+        0.05. Otherwise it is divided in 4 sub-intervals.
         """
         self.ndivs = n
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2895,10 +2895,12 @@ class AutoMinorLocator(Locator):
             return []
 
         if self.ndivs is None:
-            if self.axis.axis_name == 'x':
-                self.ndivs = mpl.rcParams['xtick.minor.ndivs']
-            else:
+
+            if self.axis.axis_name == 'y':
                 self.ndivs = mpl.rcParams['ytick.minor.ndivs']
+            else:
+                # for x and z axis
+                self.ndivs = mpl.rcParams['xtick.minor.ndivs']
 
         if self.ndivs == 'auto':
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2869,7 +2869,8 @@ class AutoMinorLocator(Locator):
         major ticks; e.g., n=2 will place a single minor tick midway
         between major ticks.
 
-        If *n* is omitted or None, it will be set to 5 or 4.
+        If *n* is omitted or None, the value stored in rcParams will be used.
+        In case *n* is set to 'auto', it will be set to 4 or 5.
         """
         self.ndivs = n
 
@@ -2891,6 +2892,12 @@ class AutoMinorLocator(Locator):
             return []
 
         if self.ndivs is None:
+            if self.axis.axis_name == 'x':
+                self.ndivs = mpl.rcParams['xtick.minor.ndivs']
+            else:
+                self.ndivs = mpl.rcParams['ytick.minor.ndivs']
+
+        if self.ndivs == 'auto':
 
             majorstep_no_exponent = 10 ** (np.log10(majorstep) % 1)
 


### PR DESCRIPTION
## PR Summary


Pull request to resolve #14233 - Allow setting default AutoMinorLocator.
This PR is related to PR #16762 which is stale for a while and seems to abandoned by the developer. 
The behavior is similar to what is described in PR #16762 and Issue #14233 .
In this PR I include: 
- Validator of for the non-negative integers
- Validator for the new `rcParams` option `ndivs` for the number of minor ticks
- Automated tests for the new options

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
