### PR TITLE
Added the trace plot of the end point

### DIFF
--- a/examples/animation/double_pendulum.py
+++ b/examples/animation/double_pendulum.py
@@ -14,13 +14,15 @@ import numpy as np
 import matplotlib.pyplot as plt
 import scipy.integrate as integrate
 import matplotlib.animation as animation
+from collections import deque
 
 G = 9.8  # acceleration due to gravity, in m/s^2
 L1 = 1.0  # length of pendulum 1 in m
 L2 = 1.0  # length of pendulum 2 in m
 M1 = 1.0  # mass of pendulum 1 in kg
 M2 = 1.0  # mass of pendulum 2 in kg
-t_stop = 5  # how many seconds to simulate
+t_stop = 50  # how many seconds to simulate
+history_len = 500 #how many trace points to display (trail history)
 
 
 def derivs(state, t):
@@ -47,8 +49,8 @@ def derivs(state, t):
 
     return dydx
 
-# create a time array from 0..100 sampled at 0.05 second steps
-dt = 0.05
+# create a time array from 0..t_stop sampled at 0.02 second steps
+dt = 0.02
 t = np.arange(0, t_stop, dt)
 
 # th1 and th2 are the initial angles (degrees)
@@ -71,22 +73,28 @@ x2 = L2*sin(y[:, 2]) + x1
 y2 = -L2*cos(y[:, 2]) + y1
 
 fig = plt.figure(figsize=(5, 4))
-ax = fig.add_subplot(autoscale_on=False, xlim=(-2, 2), ylim=(-2, 1))
+ax = fig.add_subplot(autoscale_on=False, xlim=(-(L1+L2), (L1+L2)), ylim=(-(L1+L2), 1))
 ax.set_aspect('equal')
 ax.grid()
 
 line, = ax.plot([], [], 'o-', lw=2)
+trace, = ax.plot([], [], ',-', lw=1)
 time_template = 'time = %.1fs'
 time_text = ax.text(0.05, 0.9, '', transform=ax.transAxes)
+history_x, history_y = deque(maxlen=history_len), deque(maxlen=history_len)
 
 
 def animate(i):
     thisx = [0, x1[i], x2[i]]
     thisy = [0, y1[i], y2[i]]
 
+    history_x.appendleft(thisx[2])
+    history_y.appendleft(thisy[2])
+
     line.set_data(thisx, thisy)
+    trace.set_data(history_x, history_y)
     time_text.set_text(time_template % (i*dt))
-    return line, time_text
+    return line, trace, time_text
 
 
 ani = animation.FuncAnimation(

--- a/examples/animation/double_pendulum.py
+++ b/examples/animation/double_pendulum.py
@@ -22,7 +22,7 @@ L2 = 1.0  # length of pendulum 2 in m
 M1 = 1.0  # mass of pendulum 1 in kg
 M2 = 1.0  # mass of pendulum 2 in kg
 t_stop = 50  # how many seconds to simulate
-history_len = 500 #how many trace points to display (trail history)
+history_len = 500  # how many trajectory points to display
 
 
 def derivs(state, t):
@@ -73,7 +73,9 @@ x2 = L2*sin(y[:, 2]) + x1
 y2 = -L2*cos(y[:, 2]) + y1
 
 fig = plt.figure(figsize=(5, 4))
-ax = fig.add_subplot(autoscale_on=False, xlim=(-(L1+L2), (L1+L2)), ylim=(-(L1+L2), 1))
+ax = fig.add_subplot(autoscale_on=False,
+                     xlim=(-(L1+L2), (L1+L2)),
+                     ylim=(-(L1+L2), 1.))
 ax.set_aspect('equal')
 ax.grid()
 

--- a/examples/animation/double_pendulum.py
+++ b/examples/animation/double_pendulum.py
@@ -19,9 +19,10 @@ from collections import deque
 G = 9.8  # acceleration due to gravity, in m/s^2
 L1 = 1.0  # length of pendulum 1 in m
 L2 = 1.0  # length of pendulum 2 in m
+L = L1 + L2  # maximal length of the combined pendulum
 M1 = 1.0  # mass of pendulum 1 in kg
 M2 = 1.0  # mass of pendulum 2 in kg
-t_stop = 50  # how many seconds to simulate
+t_stop = 5  # how many seconds to simulate
 history_len = 500  # how many trajectory points to display
 
 
@@ -73,9 +74,7 @@ x2 = L2*sin(y[:, 2]) + x1
 y2 = -L2*cos(y[:, 2]) + y1
 
 fig = plt.figure(figsize=(5, 4))
-ax = fig.add_subplot(autoscale_on=False,
-                     xlim=(-(L1+L2), (L1+L2)),
-                     ylim=(-(L1+L2), 1.))
+ax = fig.add_subplot(autoscale_on=False, xlim=(-L, L), ylim=(-L, 1.))
 ax.set_aspect('equal')
 ax.grid()
 
@@ -89,6 +88,10 @@ history_x, history_y = deque(maxlen=history_len), deque(maxlen=history_len)
 def animate(i):
     thisx = [0, x1[i], x2[i]]
     thisy = [0, y1[i], y2[i]]
+
+    if i == 0:
+        history_x.clear()
+        history_y.clear()
 
     history_x.appendleft(thisx[2])
     history_y.appendleft(thisy[2])


### PR DESCRIPTION
## PR Summary

I have added a plot of the trajectory of the endpoint of the double pendulum. This illustrates nicely the chaotic behavior of the pendulum. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
