### PR TITLE
Remove the use_cmex font fallback mechanism.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -20,8 +20,7 @@ from pyparsing import (
 import matplotlib as mpl
 from . import cbook
 from ._mathtext_data import (
-    latex_to_bakoma, latex_to_cmex, latex_to_standard, stix_virtual_fonts,
-    tex2uni)
+    latex_to_bakoma, latex_to_standard, stix_virtual_fonts, tex2uni)
 from .afm import AFM
 from .font_manager import FontProperties, findfont, get_font
 from .ft2font import KERNING_DEFAULT
@@ -452,7 +451,7 @@ class UnicodeFonts(TruetypeFonts):
     This class will "fallback" on the Bakoma fonts when a required
     symbol can not be found in the font.
     """
-    use_cmex = True
+    use_cmex = True  # Unused; delete once mathtext becomes private.
 
     def __init__(self, *args, **kwargs):
         # This must come first so the backend's owner is set correctly
@@ -497,22 +496,13 @@ class UnicodeFonts(TruetypeFonts):
         return fontname, uniindex
 
     def _get_glyph(self, fontname, font_class, sym, fontsize, math=True):
-        found_symbol = False
-
-        if self.use_cmex:
-            uniindex = latex_to_cmex.get(sym)
-            if uniindex is not None:
-                fontname = 'ex'
-                found_symbol = True
-
-        if not found_symbol:
-            try:
-                uniindex = get_unicode_index(sym, math)
-                found_symbol = True
-            except ValueError:
-                uniindex = ord('?')
-                _log.warning(
-                    "No TeX to unicode mapping for {!a}.".format(sym))
+        try:
+            uniindex = get_unicode_index(sym, math)
+            found_symbol = True
+        except ValueError:
+            uniindex = ord('?')
+            found_symbol = False
+            _log.warning("No TeX to unicode mapping for {!a}.".format(sym))
 
         fontname, uniindex = self._map_virtual_font(
             fontname, font_class, uniindex)
@@ -574,7 +564,7 @@ class UnicodeFonts(TruetypeFonts):
 
 
 class DejaVuFonts(UnicodeFonts):
-    use_cmex = False
+    use_cmex = False  # Unused; delete once mathtext becomes private.
 
     def __init__(self, *args, **kwargs):
         # This must come first so the backend's owner is set correctly
@@ -677,7 +667,7 @@ class StixFonts(UnicodeFonts):
         4: 'STIXSizeFourSym',
         5: 'STIXSizeFiveSym',
     }
-    use_cmex = False
+    use_cmex = False  # Unused; delete once mathtext becomes private.
     cm_fallback = False
     _sans = False
 

--- a/lib/matplotlib/_mathtext_data.py
+++ b/lib/matplotlib/_mathtext_data.py
@@ -236,7 +236,7 @@ latex_to_bakoma = {
     '\\_'                        : ('cmtt10', 0x5f)
 }
 
-latex_to_cmex = {
+latex_to_cmex = {  # Unused; delete once mathtext becomes private.
     r'\__sqrt__'   : 112,
     r'\bigcap'     : 92,
     r'\bigcup'     : 91,


### PR DESCRIPTION
The `use_cmex` flag and `latex_to_cmex` table is a
fallback-to-computermodern mathtext system that is strictly less
powerful than the `mathtext.fallback_to_cm` (now `mathtext.fallback`)
system.  Also, the `latex_to_cmex` table was incomplete.

Previously, with something like
```
rcParams["mathtext.fontset"] = "custom"; figtext(.5, .5, r"$\leftangle\langle$")
```
`\leftangle` would get unconditionally replaced by a Computer Modern
glyph, whereas `\langle` would stay as DejaVu Sans (as DejaVu provides
that glyph).  With this patch, both glyphs now use DejaVu.

Conversely, if one forces the use of a font which does not contain the
`\langle` glyph (e.g. adding `rcParams["mathtext.rm"] = "Comic Sans
MS"`), then both `\leftangle` and `\langle` get substituted to use
Computer Modern; this is not changed by this PR (except that now *both*
fallbacks can be controlled by `rcParams["mathtext.fallback"]`.

`latex_to_cmex` and `use_cmex` were marked as deprecated, but with no
actual deprecation machinery as they can all go away once `mathtext`
fully goes private anyways.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
