### PR TITLE
Remove extra newlines in contour(f) docs.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6246,7 +6246,6 @@ default: :rc:`scatter.edgecolors`
         Call signature::
 
             contour([X, Y,] Z, [levels], **kwargs)
-
         """ + mcontour.QuadContourSet._contour_doc
 
     @_preprocess_data()
@@ -6261,7 +6260,6 @@ default: :rc:`scatter.edgecolors`
         Call signature::
 
             contourf([X, Y,] Z, [levels], **kwargs)
-
         """ + mcontour.QuadContourSet._contour_doc
 
     def clabel(self, CS, levels=None, **kwargs):

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1555,7 +1555,6 @@ class QuadContourSet(ContourSet):
         return np.meshgrid(x, y)
 
     _contour_doc = """
-
         `.contour` and `.contourf` draw contour lines and filled contours,
         respectively.  Except as noted, function signatures and return values
         are the same for both versions.


### PR DESCRIPTION
## PR Summary

Followup to #18708.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).