### PR TITLE
Use ax.add_image rather than ax.images.append in NonUniformImage example

### DIFF
--- a/examples/images_contours_and_fields/image_nonuniform.py
+++ b/examples/images_contours_and_fields/image_nonuniform.py
@@ -31,7 +31,7 @@ ax = axs[0, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),
                      cmap=cm.Purples)
 im.set_data(x, y, z)
-ax.images.append(im)
+ax.add_image(im)
 ax.set_xlim(-4, 4)
 ax.set_ylim(-4, 4)
 ax.set_title(interp)
@@ -40,7 +40,7 @@ ax = axs[0, 1]
 im = NonUniformImage(ax, interpolation=interp, extent=(-64, 64, -4, 4),
                      cmap=cm.Purples)
 im.set_data(x2, y, z)
-ax.images.append(im)
+ax.add_image(im)
 ax.set_xlim(-64, 64)
 ax.set_ylim(-4, 4)
 ax.set_title(interp)
@@ -51,7 +51,7 @@ ax = axs[1, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),
                      cmap=cm.Purples)
 im.set_data(x, y, z)
-ax.images.append(im)
+ax.add_image(im)
 ax.set_xlim(-4, 4)
 ax.set_ylim(-4, 4)
 ax.set_title(interp)
@@ -60,7 +60,7 @@ ax = axs[1, 1]
 im = NonUniformImage(ax, interpolation=interp, extent=(-64, 64, -4, 4),
                      cmap=cm.Purples)
 im.set_data(x2, y, z)
-ax.images.append(im)
+ax.add_image(im)
 ax.set_xlim(-64, 64)
 ax.set_ylim(-4, 4)
 ax.set_title(interp)


### PR DESCRIPTION
add_image sets up a few additional things on the artist (it makes
`remove()` work and generates a label), and avoids directly manipulating
the `.images` attribute, which may become read-only in the future (#18216).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
