### PR TITLE
TST: skip if known-bad version of imagemagick

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -191,6 +191,11 @@ def test_save_animation_smoketest(tmpdir, writer, output, anim):
 def test_animation_repr_html(writer, html, want, anim):
     # create here rather than in the fixture otherwise we get __del__ warnings
     # about producing no output
+    if writer == 'imagemagick':
+        ret = subprocess.run(['convert', '--version'], capture_output=True)
+        if b'7.0.10-34' in ret.stdout:
+            # see https://github.com/ImageMagick/ImageMagick/issues/2720
+            pytest.skip("Known bad version of imagemagick")
     anim = animation.FuncAnimation(**anim)
     with plt.rc_context({'animation.writer': writer,
                          'animation.html': html}):


### PR DESCRIPTION

## PR Summary

xref https://github.com/ImageMagick/ImageMagick/issues/2720


This should un-break OSX on azure and travis, prevent breakage on other CI as the imagemagick update makes its way through packaging.