### PR TITLE
Fix deprecation warning in GitHub Actions.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,7 +22,7 @@ jobs:
           curl -sfL \
             https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
               sh -s -- -b $HOME/bin
-          echo ::add-path::$HOME/bin
+          echo $HOME/bin >> $GITHUB_PATH
 
       - name: Run flake8
         env:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -18,11 +18,11 @@ jobs:
 
       - name: Set up reviewdog
         run: |
-          mkdir -p $HOME/bin
+          mkdir -p "$HOME/bin"
           curl -sfL \
             https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
-              sh -s -- -b $HOME/bin
-          echo $HOME/bin >> $GITHUB_PATH
+              sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Run flake8
         env:


### PR DESCRIPTION
## PR Summary

See GitHub's post about switching away from add-path:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).