### PR TITLE
DOCS: document log locator's `numticks`

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2353,6 +2353,8 @@ class LogLocator(Locator):
 
         Parameters
         ----------
+        base : float, default: 10.0
+            The base of the log used, so ticks are placed at ``base**n``.
         subs : None or str or sequence of float, default: (1.0,)
             Gives the multiples of integer powers of the base at which
             to place ticks.  The default places ticks only at
@@ -2364,7 +2366,11 @@ class LogLocator(Locator):
             placed only between integer powers; with ``'all'``, the
             integer powers are included.  A value of None is
             equivalent to ``'auto'``.
-
+        numticks : None or int, default: None
+            The maximum number of ticks to allow on a given axis. The default
+            of ``None`` will try to choose intelligently as long as this
+            Locator has already been assigned to an axis using
+            `~.axis.Axis.get_tick_space`, but otherwise falls back to 9.
         """
         if numticks is None:
             if mpl.rcParams['_internal.classic_mode']:


### PR DESCRIPTION
## PR Summary

Add some docs to `LogLocator`. I don't have the time right now to figure out all the corner cases of how the other parameters work, but I think this is strictly speaking an improvement.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
