### PR TITLE
Doc update antialiasing

### DIFF
--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -119,19 +119,26 @@ plt.show()
 # is given here, where the anti-aliasing returns white pixels in data space,
 # and (imperceptible) purple pixels in RGBA space:
 
-fig, axs = plt.subplots(1, 2, figsize=(3.5, 2), sharex=True, sharey=True,
+fig, axs = plt.subplots(1, 3, figsize=(5.5, 2), sharex=True, sharey=True,
                         constrained_layout=True)
-aa = np.ones_like(a)
+f0 = 10
+k = 100
+a = np.sin(np.pi * 2 * (f0 * R + k * R**2 / 2))
+
+aa = a
+aa[np.sqrt(R) < 0.6] = 1
 aa[np.sqrt(R) < 0.5] = -1
 
 norm = mcolors.Normalize(vmin=-1, vmax=1)
 cmap = cm.RdBu_r
 a_rgba = cmap(norm(aa))
 
-axs[0].imshow(aa, interpolation=interp, cmap='RdBu_r')
-axs[0].set_title('Data antialiasing')
-pc = axs[1].imshow(a_rgba, interpolation=interp)
-axs[1].set_title('RGBA antialiasing')
+axs[0].imshow(aa, interpolation='nearest', cmap='RdBu_r')
+axs[0].set_title('No antialiasing')
+axs[1].imshow(aa, interpolation=interp, cmap='RdBu_r')
+axs[1].set_title('Data antialiasing')
+pc = axs[2].imshow(a_rgba, interpolation=interp)
+axs[2].set_title('RGBA antialiasing')
 plt.show()
 
 

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -18,6 +18,8 @@ Other anti-aliasing filters can be specified in `.Axes.imshow` using the
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import matplotlib.cm as cm
 
 ###############################################################################
 # First we generate a 500x500 px image with varying frequency content:
@@ -72,6 +74,65 @@ for ax, interp in zip(axs, ['hanning', 'lanczos']):
     ax.set_title(f"interpolation='{interp}'")
 plt.show()
 
+###############################################################################
+# Data antialiasing and RGBA antialiasing
+# ----------------------------------------
+#
+# The examples above all used grayscale.  When colormapping is added there
+# is the complication that downsampling and the antialiasing filters are
+# applied to the data in Matplotlib, before the data is mapped to
+# colors.  So in the following note how the corners fade to white, the middle
+# of the colormap, because the data is being smoothed and the high and low
+# values are averaging out to the middle of the colormap.
+
+f0 = 10
+k = 150
+a = np.sin(np.pi * 2 * (f0 * R + k * R**2 / 2))
+
+fig, axs = plt.subplots(1, 2, figsize=(7, 4), sharex=True, sharey=True,
+                        constrained_layout=True)
+for ax, interp in zip(axs, ['nearest', 'antialiased']):
+    ax.imshow(a, interpolation=interp, cmap='RdBu_r', vmin=-1, vmax=1)
+    ax.set_title(f"'{interp}'", fontsize='small')
+plt.show()
+
+###############################################################################
+# Sometimes, however, we want the antialiasing to occur in RGBA space.  In
+# this case purple is actually the perceptual mixture of red and blue.
+# Matplotlib doesn't allow this to be directly achieved, but we can pass
+# RGBA data to `~.Axes.imshow`, and then the antialiasing filter will be
+# applied to the RGBA data:
+
+fig, axs = plt.subplots(1, 2, figsize=(7, 4), sharex=True, sharey=True,
+                        constrained_layout=True)
+norm = mcolors.Normalize(vmin=-1, vmax=1)
+cmap = cm.RdBu_r
+a_rgba = cmap(norm(a))
+for ax, interp in zip(axs, ['nearest', 'antialiased']):
+    ax.imshow(a_rgba, interpolation=interp)
+    ax.set_title(f"'{interp}'", fontsize='small')
+plt.show()
+
+###############################################################################
+# A concrete example of where antialiasing in data space may not be desirable
+# is given here, where the anti-aliasing returns white pixels in data space,
+# and (imperceptible) purple pixels in RGBA space:
+
+fig, axs = plt.subplots(1, 2, figsize=(3.5, 2), sharex=True, sharey=True,
+                        constrained_layout=True)
+aa = np.ones_like(a)
+aa[np.sqrt(R)<0.5] = -1
+
+norm = mcolors.Normalize(vmin=-1, vmax=1)
+cmap = cm.RdBu_r
+a_rgba = cmap(norm(aa))
+
+axs[0].imshow(aa, interpolation=interp, cmap='RdBu_r')
+axs[0].set_title('Data antialiasing')
+axs[1].imshow(a_rgba, interpolation=interp)
+axs[1].set_title('RGBA antialiasing')
+plt.show()
+
 
 #############################################################################
 #
@@ -84,4 +145,4 @@ plt.show()
 # in this example:
 
 import matplotlib
-matplotlib.axes.Axes.imshow
+matplotlib.axes.Axes.imshow;

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -93,7 +93,7 @@ fig, axs = plt.subplots(1, 2, figsize=(7, 4), sharex=True, sharey=True,
                         constrained_layout=True)
 for ax, interp in zip(axs, ['nearest', 'antialiased']):
     pc = ax.imshow(a, interpolation=interp, cmap='RdBu_r', vmin=-1, vmax=1)
-    ax.set_title(f"'{interp}'", fontsize='small')
+    ax.set_title(f"'{interp}'")
 fig.colorbar(pc, ax=axs)
 plt.show()
 
@@ -111,15 +111,23 @@ cmap = cm.RdBu_r
 a_rgba = cmap(norm(a))
 for ax, interp in zip(axs, ['nearest', 'antialiased']):
     pc = ax.imshow(a_rgba, interpolation=interp)
-    ax.set_title(f"'{interp}'", fontsize='small')
+    ax.set_title(f"'{interp}'")
 plt.show()
 
 ###############################################################################
 # A concrete example of where antialiasing in data space may not be desirable
-# is given here, where the anti-aliasing returns white pixels in data space,
-# and (imperceptible) purple pixels in RGBA space:
+# is given here.  The middle circle is all -1 (maps to blue), and the outer
+# large circle is all +1 (maps to red). Data anti-aliasing smooths the
+# large jumps from -1 to +1 and makes some zeros in between that map to white.
+# While this is an accurate smoothing of the data, it is not a perceptually
+# correct antialiasing of the border between red and blue.  The RGBA
+# anti-aliasing smooths in colorspace instead, and creates some purple pixels
+# on the border between the two circles.  While purple is not in the colormap,
+# it indeed makes the transition between the two circles look correct.
+# The same can be argued for the striped region, where the background fades to
+# purple rather than fading to white.
 
-fig, axs = plt.subplots(1, 3, figsize=(5.5, 2), sharex=True, sharey=True,
+fig, axs = plt.subplots(1, 3, figsize=(5.5, 2.3), sharex=True, sharey=True,
                         constrained_layout=True)
 f0 = 10
 k = 100

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -92,8 +92,9 @@ a = np.sin(np.pi * 2 * (f0 * R + k * R**2 / 2))
 fig, axs = plt.subplots(1, 2, figsize=(7, 4), sharex=True, sharey=True,
                         constrained_layout=True)
 for ax, interp in zip(axs, ['nearest', 'antialiased']):
-    ax.imshow(a, interpolation=interp, cmap='RdBu_r', vmin=-1, vmax=1)
+    pc = ax.imshow(a, interpolation=interp, cmap='RdBu_r', vmin=-1, vmax=1)
     ax.set_title(f"'{interp}'", fontsize='small')
+fig.colorbar(pc, ax=axs)
 plt.show()
 
 ###############################################################################
@@ -109,7 +110,7 @@ norm = mcolors.Normalize(vmin=-1, vmax=1)
 cmap = cm.RdBu_r
 a_rgba = cmap(norm(a))
 for ax, interp in zip(axs, ['nearest', 'antialiased']):
-    ax.imshow(a_rgba, interpolation=interp)
+    pc = ax.imshow(a_rgba, interpolation=interp)
     ax.set_title(f"'{interp}'", fontsize='small')
 plt.show()
 
@@ -121,7 +122,7 @@ plt.show()
 fig, axs = plt.subplots(1, 2, figsize=(3.5, 2), sharex=True, sharey=True,
                         constrained_layout=True)
 aa = np.ones_like(a)
-aa[np.sqrt(R)<0.5] = -1
+aa[np.sqrt(R) < 0.5] = -1
 
 norm = mcolors.Normalize(vmin=-1, vmax=1)
 cmap = cm.RdBu_r
@@ -129,7 +130,7 @@ a_rgba = cmap(norm(aa))
 
 axs[0].imshow(aa, interpolation=interp, cmap='RdBu_r')
 axs[0].set_title('Data antialiasing')
-axs[1].imshow(a_rgba, interpolation=interp)
+pc = axs[1].imshow(a_rgba, interpolation=interp)
 axs[1].set_title('RGBA antialiasing')
 plt.show()
 
@@ -145,4 +146,4 @@ plt.show()
 # in this example:
 
 import matplotlib
-matplotlib.axes.Axes.imshow;
+matplotlib.axes.Axes.imshow


### PR DESCRIPTION
## PR Summary

Partially addresses #18735 by discussing colormapping in the context of anti-aliasing images...



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
