### PR TITLE
Return bytestring when fname is None in savefig

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -14,6 +14,7 @@
     Control the default spacing between subplots.
 """
 
+import io
 import inspect
 import logging
 from numbers import Integral
@@ -2930,10 +2931,13 @@ class Figure(FigureBase):
 
         Parameters
         ----------
-        fname : str or path-like or file-like
+        fname : str or path-like or file-like or None
             A path, or a Python file-like object, or
             possibly some backend-dependent object such as
             `matplotlib.backends.backend_pdf.PdfPages`.
+
+            If *fname* is explicitly set as None, returns a bytestring have
+            been written to a file.
 
             If *format* is set, it determines the output format, and the file
             is saved as *fname*.  Note that *fname* is used verbatim, and there
@@ -3041,6 +3045,11 @@ class Figure(FigureBase):
             Additional keyword arguments that are passed to
             `PIL.Image.Image.save` when saving the figure.
         """
+
+        if (fname is None):
+            in_memory_file = io.BytesIO()
+            self.savefig(in_memory_file, **kwargs)
+            return in_memory_file.getvalue()
 
         kwargs.setdefault('dpi', mpl.rcParams['savefig.dpi'])
         if transparent is None:


### PR DESCRIPTION
## PR Summary
This PR addresses #18614. I reproduced the code from https://github.com/matplotlib/matplotlib/pull/6909. However, the tests are not passing, and I am getting the following error on each of the failed tests:

`FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpev0li8x_/f.png'`

and I am unable to figure out how to fix this. Further, the codecov/patch check is failing as well.

Also, as @efiring had suggested in https://github.com/matplotlib/matplotlib/pull/6909, the tests need to be simplified. I was thinking of including a basic assertion test to check whether a bytestring is indeed returned when the fname is explicitly set to `None`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
