### PR TITLE
Support `ax.grid(visible=<bool>)`.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2976,8 +2976,6 @@ class _AxesBase(martist.Artist):
         use `.set_axisbelow` or, for more control, call the
         `~.Artist.set_zorder` method of each axis.
         """
-        if len(kwargs):
-            b = True
         _api.check_in_list(['x', 'y', 'both'], axis=axis)
         if axis in ['x', 'both']:
             self.xaxis.grid(b, which=which, **kwargs)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -790,10 +790,10 @@ class Axis(martist.Artist):
         self.callbacks = cbook.CallbackRegistry()
 
         # whether the grids are on
-        self._gridOnMajor = (
+        self._major_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'major'))
-        self._gridOnMinor = (
+        self._minor_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
 
@@ -1398,7 +1398,6 @@ class Axis(martist.Artist):
             # Update the new tick label properties from the old.
             tick = self._get_tick(major=True)
             self.majorTicks.append(tick)
-            tick.gridline.set_visible(self._gridOnMajor)
             self._copy_tick_props(self.majorTicks[0], tick)
 
         return self.majorTicks[:numticks]
@@ -1412,7 +1411,6 @@ class Axis(martist.Artist):
             # Update the new tick label properties from the old.
             tick = self._get_tick(major=False)
             self.minorTicks.append(tick)
-            tick.gridline.set_visible(self._gridOnMinor)
             self._copy_tick_props(self.minorTicks[0], tick)
 
         return self.minorTicks[:numticks]
@@ -1437,32 +1435,37 @@ class Axis(martist.Artist):
             Define the line properties of the grid, e.g.::
 
                 grid(color='r', linestyle='-', linewidth=2)
-
         """
-        if len(kwargs):
-            if not b and b is not None:  # something false-like but not None
+        if b is not None:
+            if 'visible' in kwargs and bool(b) != bool(kwargs['visible']):
+                raise ValueError(
+                    "'b' and 'visible' specify inconsistent grid visibilities")
+            if kwargs and not b:  # something false-like but not None
                 cbook._warn_external('First parameter to grid() is false, '
                                      'but line properties are supplied. The '
                                      'grid will be enabled.')
-            b = True
+                b = True
         which = which.lower()
         _api.check_in_list(['major', 'minor', 'both'], which=which)
         gridkw = {'grid_' + item[0]: item[1] for item in kwargs.items()}
+        if 'grid_visible' in gridkw:
+            forced_visibility = True
+            gridkw['gridOn'] = gridkw.pop('grid_visible')
+        else:
+            forced_visibility = False
 
         if which in ['minor', 'both']:
-            if b is None:
-                self._gridOnMinor = not self._gridOnMinor
-            else:
-                self._gridOnMinor = b
-            self.set_tick_params(which='minor', gridOn=self._gridOnMinor,
-                                 **gridkw)
+            if b is None and not forced_visibility:
+                gridkw['gridOn'] = not self._minor_tick_kw['gridOn']
+            elif b is not None:
+                gridkw['gridOn'] = b
+            self.set_tick_params(which='minor', **gridkw)
         if which in ['major', 'both']:
-            if b is None:
-                self._gridOnMajor = not self._gridOnMajor
-            else:
-                self._gridOnMajor = b
-            self.set_tick_params(which='major', gridOn=self._gridOnMajor,
-                                 **gridkw)
+            if b is None and not forced_visibility:
+                gridkw['gridOn'] = not self._major_tick_kw['gridOn']
+            elif b is not None:
+                gridkw['gridOn'] = b
+            self.set_tick_params(which='major', **gridkw)
         self.stale = True
 
     def update_units(self, data):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4577,25 +4577,35 @@ def test_twin_spines_on_top():
     ax2.fill_between("i", "j", color='#7FC97F', alpha=.5, data=data)
 
 
-def test_rcparam_grid_minor():
-    orig_grid = matplotlib.rcParams['axes.grid']
-    orig_locator = matplotlib.rcParams['axes.grid.which']
+@pytest.mark.parametrize("grid_which, major_visible, minor_visible", [
+    ("both", True, True),
+    ("major", True, False),
+    ("minor", False, True),
+])
+def test_rcparam_grid_minor(grid_which, major_visible, minor_visible):
+    mpl.rcParams.update({"axes.grid": True, "axes.grid.which": grid_which})
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    assert all(tick.gridline.get_visible() == major_visible
+               for tick in ax.xaxis.majorTicks)
+    assert all(tick.gridline.get_visible() == minor_visible
+               for tick in ax.xaxis.minorTicks)
 
-    matplotlib.rcParams['axes.grid'] = True
 
-    values = (
-        ('both', (True, True)),
-        ('major', (True, False)),
-        ('minor', (False, True))
-        )
-
-    for locator, result in values:
-        matplotlib.rcParams['axes.grid.which'] = locator
-        fig, ax = plt.subplots()
-        assert (ax.xaxis._gridOnMajor, ax.xaxis._gridOnMinor) == result
-
-    matplotlib.rcParams['axes.grid'] = orig_grid
-    matplotlib.rcParams['axes.grid.which'] = orig_locator
+def test_grid():
+    fig, ax = plt.subplots()
+    ax.grid()
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=False)
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=True)
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid()
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
 
 
 def test_vline_limit():

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -439,9 +439,9 @@ class GridHelperRectlinear(GridHelperBase):
         if axis in ["both", "y"]:
             x1, x2 = self.axes.get_xlim()
             locs = []
-            if self.axes.yaxis._gridOnMajor:
+            if self.axes.yaxis._major_tick_kw["gridOn"]:
                 locs.extend(self.axes.yaxis.major.locator())
-            if self.axes.yaxis._gridOnMinor:
+            if self.axes.yaxis._minor_tick_kw["gridOn"]:
                 locs.extend(self.axes.yaxis.minor.locator())
 
             for y in locs:
@@ -533,17 +533,17 @@ class Axes(maxes.Axes):
         """
         Toggle the gridlines, and optionally set the properties of the lines.
         """
-        # their are some discrepancy between the behavior of grid in
-        # axes_grid and the original mpl's grid, because axes_grid
-        # explicitly set the visibility of the gridlines.
+        # There are some discrepancies in the behavior of grid() between
+        # axes_grid and Matplotlib, because axes_grid explicitly sets the
+        # visibility of the gridlines.
         super().grid(b, which=which, axis=axis, **kwargs)
         if not self._axisline_on:
             return
         if b is None:
-            b = (self.axes.xaxis._gridOnMinor
-                 or self.axes.xaxis._gridOnMajor
-                 or self.axes.yaxis._gridOnMinor
-                 or self.axes.yaxis._gridOnMajor)
+            b = (self.axes.xaxis._minor_tick_kw["gridOn"]
+                 or self.axes.xaxis._major_tick_kw["gridOn"]
+                 or self.axes.yaxis._minor_tick_kw["gridOn"]
+                 or self.axes.yaxis._major_tick_kw["gridOn"])
         self.gridlines.set(which=which, axis=axis, visible=b)
         self.gridlines.set(**kwargs)
 


### PR DESCRIPTION
Remove the separate _gridOnMajor/_gridOnMinor attributes and store
visibility together with all other grid attributes in the
_major_tick_kw/_minor_tick_kw dicts under the "gridOn" key.  This makes
it possible to update just that entry in `Axis.grid`.

Also, don't normalize `b` to True `if len(kwargs)` in `Axes.grid`:
we need to keep it as `None`, normalizing it only to True/False in
`Axis.grid` (which handles that just fine), so that `Axis.grid` can
handle the consistency checks between `b` and `visible`.

Closes https://github.com/matplotlib/matplotlib/issues/18758.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
