### PR TITLE
BF: text not drawn shouldn't count for tightbbox

### DIFF
--- a/doc/api/next_api_changes/behavior/18772-BGB.rst
+++ b/doc/api/next_api_changes/behavior/18772-BGB.rst
@@ -1,0 +1,12 @@
+Annotations with ``annotation_clip`` no longer affect ``tight_layout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, `.text.Annotation.get_tightbbox` always returned the full
+`.text.Annotation.get_window_extent` of the object, independent of the value
+of ``annotation_clip``. `.text.Annotation.get_tightbbox` now correctly takes
+this extra clipping box into account, meaning that `~.text.Annotation`\s that
+are not drawn because of ``annotation_clip`` will not count towards the axes
+bounding box calculations, such as those done by `~.pyplot.tight_layout`.
+
+This is now consistent with the API described in `~.artist.Artist`, which
+specifies that ``get_window_extent`` should return the full extents and
+``get_tightbbox`` should "account for any clipping".

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -288,13 +288,16 @@ def test_badsubplotgrid():
 
 
 def test_collapsed():
-    # test that if a call to tight_layout will collapses the axes that
-    # it does not get applied:
+    # test that if the amount of space required to make all the axes
+    # decorations fit would mean that the actual Axes would end up with size
+    # zero (i.e. margins add up to more than the available width) that a call
+    # to tight_layout will not get applied:
     fig, ax = plt.subplots(tight_layout=True)
     ax.set_xlim([0, 1])
     ax.set_ylim([0, 1])
 
-    ax.annotate('BIG LONG STRING', xy=(1.25, 2), xytext=(10.5, 1.75),)
+    ax.annotate('BIG LONG STRING', xy=(1.25, 2), xytext=(10.5, 1.75),
+                annotation_clip=False)
     p1 = ax.get_position()
     with pytest.warns(UserWarning):
         plt.tight_layout()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -874,7 +874,7 @@ class Text(Artist):
         """
         #return _unit_box
         if not self.get_visible():
-            return Bbox.unit()
+            return Bbox.null()
         if dpi is None:
             dpi = self.figure.dpi
         if self.get_text() == '':
@@ -1958,8 +1958,8 @@ class Annotation(Text, _AnnotationBase):
         """
         # This block is the same as in Text.get_window_extent, but we need to
         # set the renderer before calling update_positions().
-        if not self.get_visible():
-            return Bbox.unit()
+        if not self.get_visible() or not self._check_xy(renderer):
+            return Bbox.null()
         if renderer is not None:
             self._renderer = renderer
         if self._renderer is None:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -874,7 +874,7 @@ class Text(Artist):
         """
         #return _unit_box
         if not self.get_visible():
-            return Bbox.null()
+            return Bbox.unit()
         if dpi is None:
             dpi = self.figure.dpi
         if self.get_text() == '':
@@ -1959,7 +1959,7 @@ class Annotation(Text, _AnnotationBase):
         # This block is the same as in Text.get_window_extent, but we need to
         # set the renderer before calling update_positions().
         if not self.get_visible() or not self._check_xy(renderer):
-            return Bbox.null()
+            return Bbox.unit()
         if renderer is not None:
             self._renderer = renderer
         if self._renderer is None:
@@ -1976,6 +1976,12 @@ class Annotation(Text, _AnnotationBase):
             bboxes.append(self.arrow_patch.get_window_extent())
 
         return Bbox.union(bboxes)
+
+    def get_tightbbox(self, renderer):
+        # docstring inherited
+        if not self._check_xy(renderer):
+            return Bbox.null()
+        return super().get_tightbbox(renderer)
 
 
 docstring.interpd.update(Annotation=Annotation.__init__.__doc__)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -68,8 +68,17 @@ def auto_adjust_subplotpars(
 
     if ax_bbox_list is None:
         ax_bbox_list = [
-            Bbox.union([ax.get_position(original=True) for ax in subplots])
-            for subplots in subplot_list]
+            [ax.get_position(original=True) for ax in subplots]
+            for subplots in subplot_list
+        ]
+        ax_bbox_list = [
+            Bbox.union([
+                b for b in bbox_list
+                if np.isfinite(b.width) and np.isfinite(b.height)
+                    and (b.width != 0 or b.height != 0)
+            ])
+            for bbox_list in ax_bbox_list
+        ]
 
     for subplots, ax_bbox, (num1, num2) in zip(subplot_list,
                                                ax_bbox_list,

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -68,17 +68,8 @@ def auto_adjust_subplotpars(
 
     if ax_bbox_list is None:
         ax_bbox_list = [
-            [ax.get_position(original=True) for ax in subplots]
-            for subplots in subplot_list
-        ]
-        ax_bbox_list = [
-            Bbox.union([
-                b for b in bbox_list
-                if np.isfinite(b.width) and np.isfinite(b.height)
-                    and (b.width != 0 or b.height != 0)
-            ])
-            for bbox_list in ax_bbox_list
-        ]
+            Bbox.union([ax.get_position(original=True) for ax in subplots])
+            for subplots in subplot_list]
 
     for subplots, ax_bbox, (num1, num2) in zip(subplot_list,
                                                ax_bbox_list,


### PR DESCRIPTION
## PR Summary

In short, there is a difference between our treatment of `Annotation` objects at draw time versus when computing `get_tightbbox`.

If <strike>a `Text` is the empty string `''`, or</strike> an `Annotation` has `annotation_clip=None` and its position (*in data space*) is outside the data limits of its parent `Axes`, then that annotation is simply not drawn (`Annotation.draw` simply returns immediately). 

On the other hand, this check is missing `Annotation.get_window_extents`. `Annotation.get_tightbbox` should check for this condition and return a `Bbox.null`, so that e.g. `tight_layout` correctly excludes them from the `Bbox` calculation.

Edit: The bug this is solving is that 

```python
fig, ax = plt.subplots()
ax.annotate('test', xy=[-1, -1])
plt.tight_layout()
```

returns 

![image](https://user-images.githubusercontent.com/1475390/96496911-b9b5d900-11fe-11eb-90bf-b55cdefdae2f.png)

instead of 

![image](https://user-images.githubusercontent.com/1475390/96497007-e10ca600-11fe-11eb-9ec9-ca2b8054f670.png)

because of the "invisible" text box down in the bottom-left hand corner, whose existence should not have been included in `tight_layout` (via `tightbbox`) due to the default value of `annotation_clip`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
