### PR TITLE
Update to latest cibuildwheel release.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==1.5.5
+          python -m pip install cibuildwheel==1.6.3
 
       - name: Copy setup.cfg to configure wheel
         run: |
@@ -39,7 +39,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
         env:
           CIBW_BUILD: "cp3?-*"
-          CIBW_SKIP: "cp35-* cp36-*"
+          CIBW_SKIP: "cp35-* cp36-* cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install certifi numpy==1.16


### PR DESCRIPTION
## PR Summary

This updates PyPy, and so should [fix v.3.3.x wheels on macOS](https://github.com/QuLogic/matplotlib/runs/1278690889?check_suite_focus=true).

While that also adds 3.9 support, we currently will skip it until NumPy releases its wheels.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and `pydocstyle<4` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).