### PR TITLE
Backport PR #18769 on branch v3.3.x

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2885,8 +2885,6 @@ class _AxesBase(martist.Artist):
         use `.set_axisbelow` or, for more control, call the
         `~.Artist.set_zorder` method of each axis.
         """
-        if len(kwargs):
-            b = True
         cbook._check_in_list(['x', 'y', 'both'], axis=axis)
         if axis in ['x', 'both']:
             self.xaxis.grid(b, which=which, **kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4310,26 +4310,35 @@ def test_twin_spines_on_top():
     ax2.fill_between("i", "j", color='#7FC97F', alpha=.5, data=data)
 
 
-def test_rcparam_grid_minor():
-    orig_grid = matplotlib.rcParams['axes.grid']
-    orig_locator = matplotlib.rcParams['axes.grid.which']
+@pytest.mark.parametrize("grid_which, major_visible, minor_visible", [
+    ("both", True, True),
+    ("major", True, False),
+    ("minor", False, True),
+])
+def test_rcparam_grid_minor(grid_which, major_visible, minor_visible):
+    mpl.rcParams.update({"axes.grid": True, "axes.grid.which": grid_which})
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    assert all(tick.gridline.get_visible() == major_visible
+               for tick in ax.xaxis.majorTicks)
+    assert all(tick.gridline.get_visible() == minor_visible
+               for tick in ax.xaxis.minorTicks)
 
-    matplotlib.rcParams['axes.grid'] = True
 
-    values = (
-        (('both'), (True, True)),
-        (('major'), (True, False)),
-        (('minor'), (False, True))
-        )
-
-    for locator, result in values:
-        matplotlib.rcParams['axes.grid.which'] = locator
-        fig = plt.figure()
-        ax = fig.add_subplot(1, 1, 1)
-        assert (ax.xaxis._gridOnMajor, ax.xaxis._gridOnMinor) == result
-
-    matplotlib.rcParams['axes.grid'] = orig_grid
-    matplotlib.rcParams['axes.grid.which'] = orig_locator
+def test_grid():
+    fig, ax = plt.subplots()
+    ax.grid()
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=False)
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=True)
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid()
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
 
 
 def test_vline_limit():

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -439,9 +439,9 @@ class GridHelperRectlinear(GridHelperBase):
         if axis in ["both", "y"]:
             x1, x2 = self.axes.get_xlim()
             locs = []
-            if self.axes.yaxis._gridOnMajor:
+            if self.axes.yaxis._major_tick_kw["gridOn"]:
                 locs.extend(self.axes.yaxis.major.locator())
-            if self.axes.yaxis._gridOnMinor:
+            if self.axes.yaxis._minor_tick_kw["gridOn"]:
                 locs.extend(self.axes.yaxis.minor.locator())
 
             for y in locs:
@@ -533,17 +533,17 @@ class Axes(maxes.Axes):
         """
         Toggle the gridlines, and optionally set the properties of the lines.
         """
-        # their are some discrepancy between the behavior of grid in
-        # axes_grid and the original mpl's grid, because axes_grid
-        # explicitly set the visibility of the gridlines.
+        # There are some discrepancies in the behavior of grid() between
+        # axes_grid and Matplotlib, because axes_grid explicitly sets the
+        # visibility of the gridlines.
         super().grid(b, which=which, axis=axis, **kwargs)
         if not self._axisline_on:
             return
         if b is None:
-            b = (self.axes.xaxis._gridOnMinor
-                 or self.axes.xaxis._gridOnMajor
-                 or self.axes.yaxis._gridOnMinor
-                 or self.axes.yaxis._gridOnMajor)
+            b = (self.axes.xaxis._minor_tick_kw["gridOn"]
+                 or self.axes.xaxis._major_tick_kw["gridOn"]
+                 or self.axes.yaxis._minor_tick_kw["gridOn"]
+                 or self.axes.yaxis._major_tick_kw["gridOn"])
         self.gridlines.set(which=which, axis=axis, visible=b)
         self.gridlines.set(**kwargs)
 


### PR DESCRIPTION
## PR Summary

Conflicts are in Axes, due to `cbook` -> `_api`, and in `test_axes` due to minor cleanups of `subplots` and extraneous parentheses. There should not have been any functional conflicts.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).