### PR TITLE
Cmap cleanup

### DIFF
--- a/doc/users/next_whats_new/2019-06-28-AL.rst
+++ b/doc/users/next_whats_new/2019-06-28-AL.rst
@@ -1,5 +1,5 @@
-`.Colormap.set_extremes` and `.Colormap.with_extremes`
-``````````````````````````````````````````````````````
+``Colormap.set_extremes`` and ``Colormap.with_extremes``
+````````````````````````````````````````````````````````
 
 Because the `.Colormap.set_bad`, `.Colormap.set_under` and `.Colormap.set_over`
 methods modify the colormap in place, the user must be careful to first make a

--- a/examples/color/custom_cmap.py
+++ b/examples/color/custom_cmap.py
@@ -90,9 +90,9 @@ fig, axs = plt.subplots(2, 2, figsize=(6, 9))
 fig.subplots_adjust(left=0.02, bottom=0.06, right=0.95, top=0.94, wspace=0.05)
 for n_bin, ax in zip(n_bins, axs.ravel()):
     # Create the colormap
-    cm = LinearSegmentedColormap.from_list(cmap_name, colors, N=n_bin)
+    cmap = LinearSegmentedColormap.from_list(cmap_name, colors, N=n_bin)
     # Fewer bins will result in "coarser" colomap interpolation
-    im = ax.imshow(Z, origin='lower', cmap=cm)
+    im = ax.imshow(Z, origin='lower', cmap=cmap)
     ax.set_title("N bins: %s" % n_bin)
     fig.colorbar(im, ax=ax)
 

--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -16,12 +16,12 @@ import numpy as np
 np.random.seed(19680801)
 
 fig, axs = plt.subplots(2, 2)
-cm = ['RdBu_r', 'viridis']
+cmaps = ['RdBu_r', 'viridis']
 for col in range(2):
     for row in range(2):
         ax = axs[row, col]
         pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
-                            cmap=cm[col])
+                            cmap=cmaps[col])
         fig.colorbar(pcm, ax=ax)
 plt.show()
 
@@ -31,12 +31,12 @@ plt.show()
 # `.Figure.colorbar` with a list of axes instead of a single axes.
 
 fig, axs = plt.subplots(2, 2)
-cm = ['RdBu_r', 'viridis']
+cmaps = ['RdBu_r', 'viridis']
 for col in range(2):
     for row in range(2):
         ax = axs[row, col]
         pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
-                            cmap=cm[col])
+                            cmap=cmaps[col])
     fig.colorbar(pcm, ax=axs[:, col], shrink=0.6)
 plt.show()
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -132,22 +132,22 @@ def test_colormap_dict_deprecate():
     # Make sure we warn on get and set access into cmap_d
     with pytest.warns(cbook.MatplotlibDeprecationWarning,
                       match="The global colormaps dictionary is no longer"):
-        cm = plt.cm.cmap_d['viridis']
+        cmap = plt.cm.cmap_d['viridis']
 
     with pytest.warns(cbook.MatplotlibDeprecationWarning,
                       match="The global colormaps dictionary is no longer"):
-        plt.cm.cmap_d['test'] = cm
+        plt.cm.cmap_d['test'] = cmap
 
 
 def test_colormap_copy():
-    cm = plt.cm.Reds
-    cm_copy = copy.copy(cm)
+    cmap = plt.cm.Reds
+    copied_cmap = copy.copy(cmap)
     with np.errstate(invalid='ignore'):
-        ret1 = cm_copy([-1, 0, .5, 1, np.nan, np.inf])
-    cm2 = copy.copy(cm_copy)
-    cm2.set_bad('g')
+        ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
+    cmap2 = copy.copy(copied_cmap)
+    cmap2.set_bad('g')
     with np.errstate(invalid='ignore'):
-        ret2 = cm_copy([-1, 0, .5, 1, np.nan, np.inf])
+        ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     assert_array_equal(ret1, ret2)
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -865,7 +865,7 @@ def test_imshow_endianess():
                   remove_text=True, style='mpl20')
 def test_imshow_masked_interpolation():
 
-    cm = plt.get_cmap('viridis').with_extremes(over='r', under='b', bad='k')
+    cmap = plt.get_cmap('viridis').with_extremes(over='r', under='b', bad='k')
 
     N = 20
     n = colors.Normalize(vmin=0, vmax=N*N-1)
@@ -892,7 +892,7 @@ def test_imshow_masked_interpolation():
 
     for interp, ax in zip(interps, ax_grid.ravel()):
         ax.set_title(interp)
-        ax.imshow(data, norm=n, cmap=cm, interpolation=interp)
+        ax.imshow(data, norm=n, cmap=cmap, interpolation=interp)
         ax.axis('off')
 
 
@@ -1213,8 +1213,8 @@ def test_huge_range_log(fig_test, fig_ref):
     data = np.full((5, 5), -1, dtype=np.float64)
     data[0:2, :] = 1000
 
-    cm = copy(plt.get_cmap('viridis'))
-    cm.set_under('w')
+    cmap = copy(plt.get_cmap('viridis'))
+    cmap.set_under('w')
     ax = fig_ref.subplots()
     im = ax.imshow(data, norm=colors.Normalize(vmin=100, vmax=data.max()),
-                   interpolation='nearest', cmap=cm)
+                   interpolation='nearest', cmap=cmap)


### PR DESCRIPTION
## PR Summary

- Minor style fix for #14645 (Don't use links in titles)
- Use `cmap` as a canonical variable name for a colormap, not `cm`. --> More readable; and we do it in most places already. This fixes the few remaining places.
