### PR TITLE
Add improved modification of QuiverKey properties

### DIFF
--- a/doc/api/next_api_changes/behavior/18794-ES.rst
+++ b/doc/api/next_api_changes/behavior/18794-ES.rst
@@ -1,0 +1,16 @@
+``QuiverKey`` properties are now modifiable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `.QuiverKey` object returned by `.pyplot.quiverkey` and
+`.axes.Axes.quiverkey` formerly saved various properties as attributes during
+initialization. However, modifying these attributes may or may not have had an
+effect on the final result.
+
+Now all such properties have getters and setters, and may be modified after
+creation:
+
+- `.QuiverKey.label` -> `.QuiverKey.get_label` / `.QuiverKey.set_label`
+- `.QuiverKey.labelcolor` -> `.QuiverKey.get_labelcolor` /
+  `.QuiverKey.set_labelcolor`
+- `.QuiverKey.labelpos` -> `.QuiverKey.get_labelpos` /
+  `.QuiverKey.set_labelpos`

--- a/doc/api/next_api_changes/behavior/18794-ES.rst
+++ b/doc/api/next_api_changes/behavior/18794-ES.rst
@@ -9,8 +9,16 @@ effect on the final result.
 Now all such properties have getters and setters, and may be modified after
 creation:
 
+- `.QuiverKey.X` -> `.QuiverKey.get_x` / `.QuiverKey.set_x` /
+  `.QuiverKey.get_position` / `.QuiverKey.set_position`
+- `.QuiverKey.Y` -> `.QuiverKey.get_y` / `.QuiverKey.set_y` /
+  `.QuiverKey.get_position` / `.QuiverKey.set_position`
 - `.QuiverKey.label` -> `.QuiverKey.get_label` / `.QuiverKey.set_label`
 - `.QuiverKey.labelcolor` -> `.QuiverKey.get_labelcolor` /
   `.QuiverKey.set_labelcolor`
 - `.QuiverKey.labelpos` -> `.QuiverKey.get_labelpos` /
   `.QuiverKey.set_labelpos`
+- `.QuiverKey.labelsep` is now read-only as it used a different unit (pixels)
+  than the constructor (inches), and was automatically overwritten;
+  `.QuiverKey.get_labelsep` and `.QuiverKey.set_labelsep` have been added which
+  use inches

--- a/doc/api/next_api_changes/deprecations/18794-ES.rst
+++ b/doc/api/next_api_changes/deprecations/18794-ES.rst
@@ -1,0 +1,10 @@
+``QuiverKey`` internal Artists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Access to the following `.quiver.QuiverKey` internal Artists is now deprecated.
+You may instead use `.quiver.QuiverKey`-level methods to modify these Artists.
+
+- ``QuiverKey.text``
+- ``QuiverKey.vector``
+- ``QuiverKey.verts``
+

--- a/doc/users/next_whats_new/quiverkey.rst
+++ b/doc/users/next_whats_new/quiverkey.rst
@@ -1,0 +1,16 @@
+``QuiverKey`` properties are now modifiable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `.QuiverKey` object returned by `.pyplot.quiverkey` and
+`.axes.Axes.quiverkey` formerly saved various properties as attributes during
+initialization. However, modifying these attributes may or may not have had an
+effect on the final result.
+
+Now all such properties have getters and setters, and may be modified after
+creation:
+
+- `.QuiverKey.label` -> `.QuiverKey.get_label` / `.QuiverKey.set_label`
+- `.QuiverKey.labelcolor` -> `.QuiverKey.get_labelcolor` /
+  `.QuiverKey.set_labelcolor`
+- `.QuiverKey.labelpos` -> `.QuiverKey.get_labelpos` /
+  `.QuiverKey.set_labelpos`

--- a/doc/users/next_whats_new/quiverkey.rst
+++ b/doc/users/next_whats_new/quiverkey.rst
@@ -9,8 +9,16 @@ effect on the final result.
 Now all such properties have getters and setters, and may be modified after
 creation:
 
+- `.QuiverKey.X` -> `.QuiverKey.get_x` / `.QuiverKey.set_x` /
+  `.QuiverKey.get_position` / `.QuiverKey.set_position`
+- `.QuiverKey.Y` -> `.QuiverKey.get_y` / `.QuiverKey.set_y` /
+  `.QuiverKey.get_position` / `.QuiverKey.set_position`
 - `.QuiverKey.label` -> `.QuiverKey.get_label` / `.QuiverKey.set_label`
 - `.QuiverKey.labelcolor` -> `.QuiverKey.get_labelcolor` /
   `.QuiverKey.set_labelcolor`
 - `.QuiverKey.labelpos` -> `.QuiverKey.get_labelpos` /
   `.QuiverKey.set_labelpos`
+- `.QuiverKey.labelsep` is now read-only as it used a different unit (pixels)
+  than the constructor (inches), and was automatically overwritten;
+  `.QuiverKey.get_labelsep` and `.QuiverKey.set_labelsep` have been added which
+  use inches

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -198,6 +198,11 @@ class QuiverKey(martist.Artist):
     valign = {'N': 'bottom', 'S': 'top', 'E': 'center', 'W': 'center'}
     pivot = {'N': 'middle', 'S': 'middle', 'E': 'tip', 'W': 'tail'}
 
+    text = cbook._deprecate_privatize_attribute(
+        '3.4', alternative='QuiverKey methods')
+    vector = cbook._deprecate_privatize_attribute('3.4')
+    verts = cbook._deprecate_privatize_attribute('3.4')
+
     def __init__(self, Q, X, Y, U, label,
                  *, angle=0, coordinates='axes', color=None, labelsep=0.1,
                  labelpos='N', labelcolor=None, fontproperties=None,
@@ -275,7 +280,7 @@ class QuiverKey(martist.Artist):
         self.fontproperties = fontproperties or dict()
         self.kw = kwargs
         _fp = self.fontproperties
-        self.text = mtext.Text(
+        self._text = mtext.Text(
             x=X, y=Y, text=label,
             horizontalalignment=self.halign[self._labelpos],
             verticalalignment=self.valign[self._labelpos],
@@ -287,7 +292,7 @@ class QuiverKey(martist.Artist):
 
     def get_x(self):
         """Return the *x* position of the QuiverKey."""
-        return self.text.get_position()[0]
+        return self._text.get_position()[0]
 
     def set_x(self, x):
         """
@@ -298,14 +303,14 @@ class QuiverKey(martist.Artist):
         x : float
             The *x* location of the key.
         """
-        self.text.set_x(x)
+        self._text.set_x(x)
         self.stale = True
 
     X = property(get_x, set_x)
 
     def get_y(self):
         """Return the *y* position of the QuiverKey."""
-        return self.text.get_position()[1]
+        return self._text.get_position()[1]
 
     def set_y(self, y):
         """
@@ -316,14 +321,14 @@ class QuiverKey(martist.Artist):
         y : float
             The *y* location of the key.
         """
-        self.text.set_y(y)
+        self._text.set_y(y)
         self.stale = True
 
     Y = property(get_y, set_y)
 
     def get_position(self):
         """Return the (x, y) position of the QuiverKey."""
-        return self.text.get_position()
+        return self._text.get_position()
 
     def set_position(self, xy):
         """
@@ -334,27 +339,27 @@ class QuiverKey(martist.Artist):
         xy : (float, float)
             The (*x*, *y*) position of the QuiverKey.
         """
-        self.text.set_position(xy)
+        self._text.set_position(xy)
         self.stale = True
 
     def get_label(self):
         """Return the label string."""
-        return self.text.get_text()
+        return self._text.get_text()
 
     def set_label(self, text):
         """Set the label string."""
-        self.text.set_text(text)
+        self._text.set_text(text)
         self.stale = True
 
     label = property(get_label, set_label, doc="The label string.")
 
     def get_labelcolor(self):
         """Return the label color."""
-        return self.text.get_color()
+        return self._text.get_color()
 
     def set_labelcolor(self, labelcolor):
         """Set the label color."""
-        self.text.set_color(labelcolor)
+        self._text.set_color(labelcolor)
         self.stale = True
 
     labelcolor = property(get_labelcolor, set_labelcolor,
@@ -376,8 +381,8 @@ class QuiverKey(martist.Artist):
         """
         _api.check_in_list(['N', 'S', 'E', 'W'], labelpos=labelpos)
         self._labelpos = labelpos
-        self.text.set_horizontalalignment(self.halign[labelpos])
-        self.text.set_verticalalignment(self.valign[labelpos])
+        self._text.set_horizontalalignment(self.halign[labelpos])
+        self._text.set_verticalalignment(self.valign[labelpos])
         self._update_text_transform()
         self._initialized = False
         self.stale = True
@@ -417,19 +422,19 @@ class QuiverKey(martist.Artist):
                 v = self.U * np.sin(np.radians(self.angle))
                 angle = (self.Q.angles if isinstance(self.Q.angles, str)
                          else 'uv')
-                self.verts = self.Q._make_verts(
+                self._verts = self.Q._make_verts(
                     np.array([u]), np.array([v]), angle)
             kwargs = self.Q.polykw
             kwargs.update(self.kw)
-            self.vector = mcollections.PolyCollection(
-                                        self.verts,
+            self._vector = mcollections.PolyCollection(
+                                        self._verts,
                                         offsets=[(self.X, self.Y)],
                                         transOffset=self.get_transform(),
                                         **kwargs)
             if self.color is not None:
-                self.vector.set_color(self.color)
-            self.vector.set_transform(self.Q.get_transform())
-            self.vector.set_figure(self.get_figure())
+                self._vector.set_color(self.color)
+            self._vector.set_transform(self.Q.get_transform())
+            self._vector.set_figure(self.get_figure())
             self._initialized = True
 
     def _update_text_transform(self):
@@ -442,16 +447,16 @@ class QuiverKey(martist.Artist):
             y = self._labelsep_inches
         elif self._labelpos == 'S':
             y = -self._labelsep_inches
-        self.text.set_transform(
+        self._text.set_transform(
             transforms.offset_copy(
                 self.get_transform(), self.figure, x=x, y=y))
 
     @martist.allow_rasterization
     def draw(self, renderer):
         self._init()
-        self.vector.draw(renderer)
+        self._vector.draw(renderer)
         self._update_text_transform()
-        self.text.draw(renderer)
+        self._text.draw(renderer)
         self.stale = False
 
     def _set_transform(self):
@@ -464,7 +469,7 @@ class QuiverKey(martist.Artist):
 
     def set_figure(self, fig):
         super().set_figure(fig)
-        self.text.set_figure(fig)
+        self._text.set_figure(fig)
 
     def contains(self, mouseevent):
         inside, info = self._default_contains(mouseevent)
@@ -472,8 +477,8 @@ class QuiverKey(martist.Artist):
             return inside, info
         # Maybe the dictionary should allow one to
         # distinguish between a text hit and a vector hit.
-        if (self.text.contains(mouseevent)[0] or
-                self.vector.contains(mouseevent)[0]):
+        if (self._text.contains(mouseevent)[0] or
+                self._vector.contains(mouseevent)[0]):
             return True, {}
         return False, {}
 

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -33,7 +33,7 @@ Plot a 2D field of arrows.
 
 Call signature::
 
-  quiver([X, Y], U, V, [C], **kw)
+  quiver([X, Y], U, V, [C], **kwargs)
 
 *X*, *Y* define the arrow locations, *U*, *V* define the arrow directions, and
 *C* optionally sets the color.
@@ -201,7 +201,7 @@ class QuiverKey(martist.Artist):
     def __init__(self, Q, X, Y, U, label,
                  *, angle=0, coordinates='axes', color=None, labelsep=0.1,
                  labelpos='N', labelcolor=None, fontproperties=None,
-                 **kw):
+                 **kwargs):
         """
         Add a key to a quiver plot.
 
@@ -278,7 +278,7 @@ class QuiverKey(martist.Artist):
         self.labelpos = labelpos
         self.labelcolor = labelcolor
         self.fontproperties = fontproperties or dict()
-        self.kw = kw
+        self.kw = kwargs
         _fp = self.fontproperties
         # boxprops = dict(facecolor='red')
         self.text = mtext.Text(
@@ -312,13 +312,13 @@ class QuiverKey(martist.Artist):
                          else 'uv')
                 self.verts = self.Q._make_verts(
                     np.array([u]), np.array([v]), angle)
-            kw = self.Q.polykw
-            kw.update(self.kw)
+            kwargs = self.Q.polykw
+            kwargs.update(self.kw)
             self.vector = mcollections.PolyCollection(
                                         self.verts,
                                         offsets=[(self.X, self.Y)],
                                         transOffset=self.get_transform(),
-                                        **kw)
+                                        **kwargs)
             if self.color is not None:
                 self.vector.set_color(self.color)
             self.vector.set_transform(self.Q.get_transform())
@@ -463,7 +463,7 @@ class Quiver(mcollections.PolyCollection):
     def __init__(self, ax, *args,
                  scale=None, headwidth=3, headlength=5, headaxislength=4.5,
                  minshaft=1, minlength=1, units='width', scale_units=None,
-                 angles='uv', width=None, color='k', pivot='tail', **kw):
+                 angles='uv', width=None, color='k', pivot='tail', **kwargs):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -492,12 +492,12 @@ class Quiver(mcollections.PolyCollection):
         self.pivot = pivot.lower()
         _api.check_in_list(self._PIVOT_VALS, pivot=self.pivot)
 
-        self.transform = kw.pop('transform', ax.transData)
-        kw.setdefault('facecolors', color)
-        kw.setdefault('linewidths', (0,))
+        self.transform = kwargs.pop('transform', ax.transData)
+        kwargs.setdefault('facecolors', color)
+        kwargs.setdefault('linewidths', (0,))
         super().__init__([], offsets=self.XY, transOffset=self.transform,
-                         closed=False, **kw)
-        self.polykw = kw
+                         closed=False, **kwargs)
+        self.polykw = kwargs
         self.set_UVC(U, V, C)
         self._initialized = False
 
@@ -768,7 +768,7 @@ Plot a 2D field of barbs.
 
 Call signature::
 
-  barbs([X, Y], U, V, [C], **kw)
+  barbs([X, Y], U, V, [C], **kwargs)
 
 Where *X*, *Y* define the barb locations, *U*, *V* define the barb
 directions, and *C* optionally sets the color.
@@ -920,7 +920,7 @@ class Barbs(mcollections.PolyCollection):
     def __init__(self, ax, *args,
                  pivot='tip', length=7, barbcolor=None, flagcolor=None,
                  sizes=None, fill_empty=False, barb_increments=None,
-                 rounding=True, flip_barb=False, **kw):
+                 rounding=True, flip_barb=False, **kwargs):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -932,7 +932,7 @@ class Barbs(mcollections.PolyCollection):
         self.barb_increments = barb_increments or dict()
         self.rounding = rounding
         self.flip = np.atleast_1d(flip_barb)
-        transform = kw.pop('transform', ax.transData)
+        transform = kwargs.pop('transform', ax.transData)
         self._pivot = pivot
         self._length = length
         barbcolor = barbcolor
@@ -944,22 +944,22 @@ class Barbs(mcollections.PolyCollection):
         # rest of the barb by default
 
         if None in (barbcolor, flagcolor):
-            kw['edgecolors'] = 'face'
+            kwargs['edgecolors'] = 'face'
             if flagcolor:
-                kw['facecolors'] = flagcolor
+                kwargs['facecolors'] = flagcolor
             elif barbcolor:
-                kw['facecolors'] = barbcolor
+                kwargs['facecolors'] = barbcolor
             else:
                 # Set to facecolor passed in or default to black
-                kw.setdefault('facecolors', 'k')
+                kwargs.setdefault('facecolors', 'k')
         else:
-            kw['edgecolors'] = barbcolor
-            kw['facecolors'] = flagcolor
+            kwargs['edgecolors'] = barbcolor
+            kwargs['facecolors'] = flagcolor
 
         # Explicitly set a line width if we're not given one, otherwise
         # polygons are not outlined and we get no barbs
-        if 'linewidth' not in kw and 'lw' not in kw:
-            kw['linewidth'] = 1
+        if 'linewidth' not in kwargs and 'lw' not in kwargs:
+            kwargs['linewidth'] = 1
 
         # Parse out the data arrays from the various configurations supported
         x, y, u, v, c = _parse_args(*args, caller_name='barbs()')
@@ -970,7 +970,7 @@ class Barbs(mcollections.PolyCollection):
         # Make a collection
         barb_size = self._length ** 2 / 4  # Empirically determined
         super().__init__([], (barb_size,), offsets=xy, transOffset=transform,
-                         **kw)
+                         **kwargs)
         self.set_transform(transforms.IdentityTransform())
 
         self.set_UVC(u, v, c)

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -251,14 +251,11 @@ class QuiverKey(martist.Artist):
         """
         super().__init__()
         self.Q = Q
-        self.X = X
-        self.Y = Y
         self.U = U
         self.angle = angle
         self.coord = coordinates
         self.color = color
         self._labelsep_inches = labelsep
-        self.labelsep = (self._labelsep_inches * Q.axes.figure.dpi)
 
         # try to prevent closure over the real self
         weak_self = weakref.ref(self)
@@ -266,7 +263,6 @@ class QuiverKey(martist.Artist):
         def on_dpi_change(fig):
             self_weakref = weak_self()
             if self_weakref is not None:
-                self_weakref.labelsep = self_weakref._labelsep_inches * fig.dpi
                 # simple brute force update works because _init is called at
                 # the start of draw.
                 self_weakref._initialized = False
@@ -279,9 +275,8 @@ class QuiverKey(martist.Artist):
         self.fontproperties = fontproperties or dict()
         self.kw = kwargs
         _fp = self.fontproperties
-        # boxprops = dict(facecolor='red')
         self.text = mtext.Text(
-            text=label,  # bbox=boxprops,
+            x=X, y=Y, text=label,
             horizontalalignment=self.halign[self._labelpos],
             verticalalignment=self.valign[self._labelpos],
             fontproperties=font_manager.FontProperties._from_any(_fp),
@@ -289,6 +284,58 @@ class QuiverKey(martist.Artist):
 
         self._initialized = False
         self.zorder = Q.zorder + 0.1
+
+    def get_x(self):
+        """Return the *x* position of the QuiverKey."""
+        return self.text.get_position()[0]
+
+    def set_x(self, x):
+        """
+        Set the *x* position of the QuiverKey.
+
+        Parameters
+        ----------
+        x : float
+            The *x* location of the key.
+        """
+        self.text.set_x(x)
+        self.stale = True
+
+    X = property(get_x, set_x)
+
+    def get_y(self):
+        """Return the *y* position of the QuiverKey."""
+        return self.text.get_position()[1]
+
+    def set_y(self, y):
+        """
+        Set the *y* position of the QuiverKey.
+
+        Parameters
+        ----------
+        y : float
+            The *y* location of the key.
+        """
+        self.text.set_y(y)
+        self.stale = True
+
+    Y = property(get_y, set_y)
+
+    def get_position(self):
+        """Return the (x, y) position of the QuiverKey."""
+        return self.text.get_position()
+
+    def set_position(self, xy):
+        """
+        Set the position of the QuiverKey.
+
+        Parameters
+        ----------
+        xy : (float, float)
+            The (*x*, *y*) position of the QuiverKey.
+        """
+        self.text.set_position(xy)
+        self.stale = True
 
     def get_label(self):
         """Return the label string."""
@@ -331,10 +378,26 @@ class QuiverKey(martist.Artist):
         self._labelpos = labelpos
         self.text.set_horizontalalignment(self.halign[labelpos])
         self.text.set_verticalalignment(self.valign[labelpos])
+        self._update_text_transform()
         self._initialized = False
         self.stale = True
 
     labelpos = property(get_labelpos, set_labelpos, doc="The label position.")
+
+    def get_labelsep(self):
+        """Return the distance between the arrow and label in inches."""
+        return self._labelsep_inches
+
+    def set_labelsep(self, labelsep):
+        """Set the distance between the arrow and label in inches."""
+        self._labelsep_inches = labelsep
+        self._update_text_transform()
+        self.stale = True
+
+    @property
+    def labelsep(self):
+        """Return the distance between the arrow and label in pixels."""
+        return self._labelsep_inches * self.Q.axes.figure.dpi
 
     def remove(self):
         # docstring inherited
@@ -369,29 +432,25 @@ class QuiverKey(martist.Artist):
             self.vector.set_figure(self.get_figure())
             self._initialized = True
 
-    def _text_x(self, x):
+    def _update_text_transform(self):
+        x = y = 0
         if self._labelpos == 'E':
-            return x + self.labelsep
+            x = self._labelsep_inches
         elif self._labelpos == 'W':
-            return x - self.labelsep
-        else:
-            return x
-
-    def _text_y(self, y):
-        if self._labelpos == 'N':
-            return y + self.labelsep
+            x = -self._labelsep_inches
+        elif self._labelpos == 'N':
+            y = self._labelsep_inches
         elif self._labelpos == 'S':
-            return y - self.labelsep
-        else:
-            return y
+            y = -self._labelsep_inches
+        self.text.set_transform(
+            transforms.offset_copy(
+                self.get_transform(), self.figure, x=x, y=y))
 
     @martist.allow_rasterization
     def draw(self, renderer):
         self._init()
         self.vector.draw(renderer)
-        x, y = self.get_transform().transform((self.X, self.Y))
-        self.text.set_x(self._text_x(x))
-        self.text.set_y(self._text_y(y))
+        self._update_text_transform()
         self.text.draw(renderer)
         self.stale = False
 

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -106,11 +106,14 @@ def test_quiver_with_key():
     fig, ax = plt.subplots()
     ax.margins(0.1)
     Q = draw_quiver(ax)
-    qk = ax.quiverkey(Q, 0.5, 0.95, 2, '',
+    qk = ax.quiverkey(Q, 0, 0, 2, '',
                       angle=-10, coordinates='figure',
-                      labelpos='W', labelcolor='b',
+                      labelpos='N', labelcolor='b',
                       fontproperties={'weight': 'bold', 'size': 'large'})
+    qk.set_x(0.5)
+    qk.set_y(0.95)
     qk.set_label(r'$2\, \mathrm{m}\, \mathrm{s}^{-1}$')
+    qk.set_labelpos('W')
     qk.set_labelcolor('k')  # Go back to default to keep same test image.
 
 

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -249,7 +249,7 @@ def test_quiverkey_angles():
     qk = ax.quiverkey(q, 1, 1, 2, 'Label')
     # The arrows are only created when the key is drawn
     fig.canvas.draw()
-    assert len(qk.verts) == 1
+    assert len(qk._verts) == 1
 
 
 def test_quiver_setuvc_numbers():

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -106,12 +106,12 @@ def test_quiver_with_key():
     fig, ax = plt.subplots()
     ax.margins(0.1)
     Q = draw_quiver(ax)
-    ax.quiverkey(Q, 0.5, 0.95, 2,
-                 r'$2\, \mathrm{m}\, \mathrm{s}^{-1}$',
-                 angle=-10,
-                 coordinates='figure',
-                 labelpos='W',
-                 fontproperties={'weight': 'bold', 'size': 'large'})
+    qk = ax.quiverkey(Q, 0.5, 0.95, 2, '',
+                      angle=-10, coordinates='figure',
+                      labelpos='W', labelcolor='b',
+                      fontproperties={'weight': 'bold', 'size': 'large'})
+    qk.set_label(r'$2\, \mathrm{m}\, \mathrm{s}^{-1}$')
+    qk.set_labelcolor('k')  # Go back to default to keep same test image.
 
 
 @image_comparison(['quiver_single_test_image.png'], remove_text=True)
@@ -140,8 +140,8 @@ def test_quiver_key_pivot():
     ax.set_ylim(-2, 11)
     ax.quiverkey(q, 0.5, 1, 1, 'N', labelpos='N')
     ax.quiverkey(q, 1, 0.5, 1, 'E', labelpos='E')
-    ax.quiverkey(q, 0.5, 0, 1, 'S', labelpos='S')
-    ax.quiverkey(q, 0, 0.5, 1, 'W', labelpos='W')
+    ax.quiverkey(q, 0.5, 0, 1, 'S').set_labelpos('S')
+    ax.quiverkey(q, 0, 0.5, 1, 'W').set_labelpos('W')
 
 
 @image_comparison(['quiver_key_xy.png'], remove_text=True)


### PR DESCRIPTION
## PR Summary

`QuiverKey` previously had several attributes that were saved from the constructor, but these were never linked to the internal Artists that were actually drawn.

This adds getters and setters for said properties, and instead of a separate copy of the information, just grabs/sets it on the internal Text child. Additionally, it deprecates access to these internal children; other than `.text`, they were always overwritten in `draw`, so there was no way to make real use of them.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).