### PR TITLE
Deprecate ps.useafm for mathtext

### DIFF
--- a/doc/api/next_api_changes/deprecations/18798-JKS.rst
+++ b/doc/api/next_api_changes/deprecations/18798-JKS.rst
@@ -1,0 +1,8 @@
+``ps.useafm`` deprecated for mathtext
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Outputting mathtext using only standard PostScript fonts has likely
+been broken for a while (issue `#18722
+<https://github.com/matplotlib/matplotlib/issues/18722>`_). In
+Matplotlib 3.5, the setting ``ps.useafm`` will have no effect on
+mathtext.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -433,6 +433,19 @@ class MathTextParser:
         The results are cached, so multiple calls to `parse`
         with the same expression should be fast.
         """
+        if _force_standard_ps_fonts:
+            cbook.warn_deprecated(
+                "3.4",
+                removal="3.5",
+                message=(
+                    "Mathtext using only standard PostScript fonts has "
+                    "been likely to produce wrong output for a while, "
+                    "has been deprecated in %(since)s and will be removed "
+                    "in %(removal)s, after which ps.useafm will have no "
+                    "effect on mathtext."
+                )
+            )
+
         # lru_cache can't decorate parse() directly because the ps.useafm and
         # mathtext.fontset rcParams also affect the parse (e.g. by affecting
         # the glyph metrics).

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import cbook, patheffects
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
 needs_ghostscript = pytest.mark.skipif(
@@ -59,6 +60,8 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
             allowable_exceptions.append(mpl.ExecutableNotFoundError)
         if rcParams.get("text.usetex"):
             allowable_exceptions.append(RuntimeError)
+        if rcParams.get("ps.useafm"):
+            allowable_exceptions.append(MatplotlibDeprecationWarning)
         try:
             fig.savefig(s_buf, format=format, orientation=orientation)
             fig.savefig(b_buf, format=format, orientation=orientation)


### PR DESCRIPTION
## PR Summary

See #18722 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
