### PR TITLE
Use data to set default limits when appropriate

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6824,3 +6824,46 @@ def test_ylabel_ha_with_position(ha):
     ax.set_ylabel("test", y=1, ha=ha)
     ax.yaxis.set_label_position("right")
     assert ax.yaxis.get_label().get_ha() == ha
+
+
+def test_axhline_with_date_xaxis():
+    fig, ax = plt.subplots()
+    ax.axhline(1.5)
+    x = [datetime.datetime(2020, 1, i) for i in range(1, 3)]
+    y = [1, 2]
+    ax.plot(x, y)
+    assert ax.get_xlim() == (18262.0, 18263.0)
+
+
+def test_axvline_with_date_yaxis():
+    fig, ax = plt.subplots()
+    ax.axvline(1.5)
+    x = [1, 2]
+    y = [datetime.datetime(2020, 1, i) for i in range(1, 3)]
+    ax.plot(x, y)
+    assert ax.get_ylim() == (18262.0, 18263.0)
+
+
+def test_two_spans():
+    fig, ax = plt.subplots()
+    ax.axhline(1)
+    ax.axhline(2)
+    assert ax.get_ylim() == (1.0, 2.0)
+
+
+def test_axhspan_with_date_xaxis():
+    fig, ax = plt.subplots()
+    ax.axhspan(1, 2)
+    x = [datetime.datetime(2020, 1, i) for i in range(1, 3)]
+    y = [1, 2]
+    ax.plot(x, y)
+    assert ax.get_xlim() == (18262.0, 18263.0)
+
+
+def test_axvspan_with_date_yaxis():
+    fig, ax = plt.subplots()
+    ax.axvspan(1, 2)
+    x = [1, 2]
+    y = [datetime.datetime(2020, 1, i) for i in range(1, 3)]
+    ax.plot(x, y)
+    assert ax.get_ylim() == (18262.0, 18263.0)


### PR DESCRIPTION
## PR Summary
Closes #7742

This is the third attempt at solving #7742. The first two attempts,  #8210 and #18771, made use of `ignore_existing_data_limits`, but this attribute will be deprecated as discussed in #17106.

The difficulty with date-like data is the hard-code default limits of (2000, 2010). So, this approach modifies `set_default_intervals` to use the actual data instead of these hard-coded values when appropriate.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
