### PR TITLE
make FancyArrow animatable

### DIFF
--- a/doc/users/next_whats_new/animatable_FancyArrow.rst
+++ b/doc/users/next_whats_new/animatable_FancyArrow.rst
@@ -1,0 +1,5 @@
+``set_data`` method for ``FancyArrow`` patch
+--------------------------------------------
+
+`.FancyArrow`, the patch returned by ``ax.arrow``, now has a ``set_data``
+method that allows for animating the arrow.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5035,12 +5035,6 @@ default: :rc:`scatter.edgecolors`
 
         Parameters
         ----------
-        x, y : float
-            The x and y coordinates of the arrow base.
-
-        dx, dy : float
-            The length of the arrow along x and y direction.
-
         %(FancyArrow)s
 
         Returns

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1339,17 +1339,17 @@ class FancyArrow(Polygon):
 
             %(Patch_kwdoc)s
         """
-        self.x = x
-        self.y = y
-        self.dx = dx
-        self.dy = dy
-        self.width = width
-        self.length_includes_head = length_includes_head
-        self.head_width = head_width
-        self.head_length = head_length
-        self.shape = shape
-        self.overhang = overhang
-        self.head_starts_at_zero = head_starts_at_zero
+        self._x = x
+        self._y = y
+        self._dx = dx
+        self._dy = dy
+        self._width = width
+        self._length_includes_head = length_includes_head
+        self._head_width = head_width
+        self._head_length = head_length
+        self._shape = shape
+        self._overhang = overhang
+        self._head_starts_at_zero = head_starts_at_zero
         self._make_verts()
         super().__init__(self.verts, closed=True, **kwargs)
 
@@ -1377,35 +1377,35 @@ class FancyArrow(Polygon):
             Length of arrow head.
         """
         if x is not None:
-            self.x = x
+            self._x = x
         if y is not None:
-            self.y = y
+            self._y = y
         if dx is not None:
-            self.dx = dx
+            self._dx = dx
         if dy is not None:
-            self.dy = dy
+            self._dy = dy
         if width is not None:
-            self.width = width
+            self._width = width
         if head_width is not None:
-            self.head_width = head_width
+            self._head_width = head_width
         if head_length is not None:
-            self.head_length = head_length
+            self._head_length = head_length
         self._make_verts()
         self.set_xy(self.verts)
 
     def _make_verts(self):
-        if self.head_width is None:
-            head_width = 3 * self.width
+        if self._head_width is None:
+            head_width = 3 * self._width
         else:
-            head_width = self.head_width
-        if self.head_length is None:
+            head_width = self._head_width
+        if self._head_length is None:
             head_length = 1.5 * head_width
         else:
-            head_length = self.head_length
+            head_length = self._head_length
 
-        distance = np.hypot(self.dx, self.dy)
+        distance = np.hypot(self._dx, self._dy)
 
-        if self.length_includes_head:
+        if self._length_includes_head:
             length = distance
         else:
             length = distance + head_length
@@ -1413,7 +1413,8 @@ class FancyArrow(Polygon):
             self.verts = np.empty([0, 2])  # display nothing if empty
         else:
             # start by drawing horizontal arrow, point at (0, 0)
-            hw, hl, hs, lw = head_width, head_length, self.overhang, self.width
+            hw, hl = head_width, head_length
+            hs, lw = self._overhang, self._width
             left_half_arrow = np.array([
                 [0.0, 0.0],                 # tip
                 [-hl, -hw / 2],             # leftmost
@@ -1422,19 +1423,19 @@ class FancyArrow(Polygon):
                 [-length, 0],
             ])
             # if we're not including the head, shift up by head length
-            if not self.length_includes_head:
+            if not self._length_includes_head:
                 left_half_arrow += [head_length, 0]
             # if the head starts at 0, shift up by another head length
-            if self.head_starts_at_zero:
+            if self._head_starts_at_zero:
                 left_half_arrow += [head_length / 2, 0]
             # figure out the shape, and complete accordingly
-            if self.shape == 'left':
+            if self._shape == 'left':
                 coords = left_half_arrow
             else:
                 right_half_arrow = left_half_arrow * [1, -1]
-                if self.shape == 'right':
+                if self._shape == 'right':
                     coords = right_half_arrow
-                elif self.shape == 'full':
+                elif self._shape == 'full':
                     # The half-arrows contain the midpoint of the stem,
                     # which we can omit from the full arrow. Including it
                     # twice caused a problem with xpdf.
@@ -1443,15 +1444,15 @@ class FancyArrow(Polygon):
                 else:
                     raise ValueError("Got unknown shape: %s" % self.shape)
             if distance != 0:
-                cx = self.dx / distance
-                sx = self.dy / distance
+                cx = self._dx / distance
+                sx = self._dy / distance
             else:
                 # Account for division by zero
                 cx, sx = 0, 1
             M = [[cx, sx], [-sx, cx]]
             self.verts = np.dot(coords, M) + [
-                self.x + self.dx,
-                self.y + self.dy,
+                self._x + self._dx,
+                self._y + self._dy,
             ]
 
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1305,6 +1305,12 @@ class FancyArrow(Polygon):
         """
         Parameters
         ----------
+        x, y : float
+            The x and y coordinates of the arrow base.
+
+        dx, dy : float
+            The length of the arrow along x and y direction.
+
         width : float, default: 0.001
             Width of full arrow tail.
 

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -522,7 +522,37 @@ def test_fancyarrow_units():
     dtime = datetime(2000, 1, 1)
     fig, ax = plt.subplots()
     arrow = FancyArrowPatch((0, dtime), (0.01, dtime))
-    ax.add_patch(arrow)
+
+
+def test_fancyarrow_setdata():
+    fig, ax = plt.subplots()
+    arrow = ax.arrow(0, 0, 10, 10, head_length=5, head_width=1, width=.5)
+    expected1 = np.array(
+      [[13.54, 13.54],
+       [10.35,  9.65],
+       [10.18,  9.82],
+       [0.18, -0.18],
+       [-0.18,  0.18],
+       [9.82, 10.18],
+       [9.65, 10.35],
+       [13.54, 13.54]]
+    )
+    assert np.allclose(expected1, np.round(arrow.verts, 2))
+
+    expected2 = np.array(
+      [[16.71, 16.71],
+       [16.71, 15.29],
+       [16.71, 15.29],
+       [1.71,  0.29],
+       [0.29,  1.71],
+       [15.29, 16.71],
+       [15.29, 16.71],
+       [16.71, 16.71]]
+    )
+    arrow.set_data(
+        x=1, y=1, dx=15, dy=15, width=2, head_width=2, head_length=1
+    )
+    assert np.allclose(expected2, np.round(arrow.verts, 2))
 
 
 @image_comparison(["large_arc.svg"], style="mpl20")


### PR DESCRIPTION
## PR Summary
Addresses point 7 of https://github.com/matplotlib/matplotlib/issues/5699 

Makes the `FancyArrow` Patch animatable. While `FancyArrowPatch` is somewhat animatable with `set_positions` there is no easy way to animate the Polygon that is returned from `plt.arrow`. This PR addresses that gap allowing things like this:

```python
%matplotlib ipympl
import ipywidgets as widgets
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
arrow = ax.arrow(0, 0, 0.5, 0.5)
ax.set_xlim([0, 1])
ax.set_ylim([0, 1])
width_slider = widgets.FloatSlider(min=0, max=0.5, step=0.02, description="width")
x_slider = widgets.FloatSlider(min=0, max=0.5, step=0.02, description="x")

def f(change):
    arrow.set_data(x=x_slider.value, width=width_slider.value)

width_slider.observe(f, names="value")
x_slider.observe(f, names="value")
display(widgets.VBox([x_slider, width_slider]))
```

![fancy-arrow-anim](https://user-images.githubusercontent.com/10111092/97095248-0ba99500-162b-11eb-9c8d-e050c6dd9521.gif)



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
