### PR TITLE
Change LogFormatter coeff computation

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -882,6 +882,13 @@ class TestLogFormatter:
         temp_lf.axis = FakeAxis()
         assert temp_lf(val) == str(val)
 
+    @pytest.mark.parametrize('val', [1e-323, 2e-323, 10e-323, 11e-323])
+    def test_LogFormatter_call_tiny(self, val):
+        # test coeff computation in __call__
+        temp_lf = mticker.LogFormatter()
+        temp_lf.axis = FakeAxis()
+        temp_lf(val)
+
 
 class TestLogitFormatter:
     @staticmethod

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1070,7 +1070,7 @@ class LogFormatter(Formatter):
         fx = math.log(x) / math.log(b)
         is_x_decade = is_close_to_int(fx)
         exponent = round(fx) if is_x_decade else np.floor(fx)
-        coeff = round(x / b ** exponent)
+        coeff = round(b ** (fx - exponent))
 
         if self.labelOnlyBase and not is_x_decade:
             return ''
@@ -1154,7 +1154,7 @@ class LogFormatterMathtext(LogFormatter):
         fx = math.log(x) / math.log(b)
         is_x_decade = is_close_to_int(fx)
         exponent = round(fx) if is_x_decade else np.floor(fx)
-        coeff = round(x / b ** exponent)
+        coeff = round(b ** (fx - exponent))
         if is_x_decade:
             fx = round(fx)
 
@@ -1186,7 +1186,7 @@ class LogFormatterSciNotation(LogFormatterMathtext):
         """Return string for non-decade locations."""
         b = float(base)
         exponent = math.floor(fx)
-        coeff = b ** fx / b ** exponent
+        coeff = b ** (fx - exponent)
         if is_close_to_int(coeff):
             coeff = round(coeff)
         return r'$\mathdefault{%s%g\times%s^{%d}}$' \


### PR DESCRIPTION
## PR Summary

Changes `coeff` computation in `LogFormatter.__call__`, `LogFormatterMathtext.__call__`, and `LogFormatterSciNotation` to avoid underflow/overflow and adds a simple test.

Closes #18800.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).