### PR TITLE
MAINT: deprecate validCap, validJoin

### DIFF
--- a/doc/api/next_api_changes/deprecations/18817-BGB.rst
+++ b/doc/api/next_api_changes/deprecations/18817-BGB.rst
@@ -1,0 +1,3 @@
+Line2D and Patch no longer duplicate ``validJoin`` and ``validCap``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Validation of joinstyle and capstyles is now centralized in ``rcsetup``.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -13,8 +13,10 @@ import os
 import shutil
 import subprocess
 import sys
+import warnings
 
 import matplotlib
+from matplotlib._api import MatplotlibDeprecationWarning
 import sphinx
 
 from datetime import datetime
@@ -108,6 +110,11 @@ autosummary_generate = True
 
 autodoc_docstring_signature = True
 autodoc_default_options = {'members': None, 'undoc-members': None}
+
+# make sure to ignore warnings that stem from simply inspecting deprecated
+# class-level attributes
+warnings.filterwarnings('ignore', category=MatplotlibDeprecationWarning,
+                        module='sphinx.util.inspect')
 
 # missing-references names matches sphinx>=3 behavior, so we can't be nitpicky
 # for older sphinxes.

--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -19,8 +19,42 @@ from .deprecation import (
     deprecated, warn_deprecated,
     _rename_parameter, _delete_parameter, _make_keyword_only,
     _deprecate_method_override, _deprecate_privatize_attribute,
-    _suppress_matplotlib_deprecation_warning,
+    suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning)
+
+
+class classproperty:
+    """
+    Like `property`, but also triggers on access via the class, and it is the
+    *class* that's passed as argument.
+
+    Examples
+    --------
+    ::
+
+        class C:
+            @classproperty
+            def foo(cls):
+                return cls.__name__
+
+        assert C.foo == "C"
+    """
+
+    def __init__(self, fget, fset=None, fdel=None, doc=None):
+        self._fget = fget
+        if fset is not None or fdel is not None:
+            raise ValueError('classproperty only implements fget.')
+        self.fset = fset
+        self.fdel = fdel
+        # docs are ignored for now
+        self._doc = doc
+
+    def __get__(self, instance, owner):
+        return self._fget(owner)
+
+    @property
+    def fget(self):
+        return self._fget
 
 
 def check_in_list(_values, *, _print_supported_values=True, **kwargs):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -29,11 +29,13 @@ import numpy as np
 
 import matplotlib
 from matplotlib import _c_internal_utils
-from matplotlib._api import warn_external as _warn_external
+from matplotlib._api import (
+    warn_external as _warn_external, classproperty as _classproperty)
 from matplotlib._api.deprecation import (
     deprecated, warn_deprecated,
     _rename_parameter, _delete_parameter, _make_keyword_only,
     _deprecate_method_override, _deprecate_privatize_attribute,
+    suppress_matplotlib_deprecation_warning as
     _suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning, mplDeprecation)
 
@@ -2260,30 +2262,6 @@ def _check_isinstance(_types, **kwargs):
                     ", ".join(names[:-1]) + " or " + names[-1]
                     if len(names) > 1 else names[0],
                     type_name(type(v))))
-
-
-class _classproperty:
-    """
-    Like `property`, but also triggers on access via the class, and it is the
-    *class* that's passed as argument.
-
-    Examples
-    --------
-    ::
-
-        class C:
-            @classproperty
-            def foo(cls):
-                return cls.__name__
-
-        assert C.foo == "C"
-    """
-
-    def __init__(self, fget):
-        self._fget = fget
-
-    def __get__(self, instance, owner):
-        return self._fget(owner)
 
 
 def _backend_module_name(name):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -3,7 +3,6 @@ The 2D line class which can draw with a variety of line styles, markers and
 colors.
 """
 
-# TODO: expose cap and join style attrs
 from numbers import Integral, Number, Real
 import logging
 
@@ -251,8 +250,16 @@ class Line2D(Artist):
     fillStyles = MarkerStyle.fillstyles
 
     zorder = 2
-    validCap = ('butt', 'round', 'projecting')
-    validJoin = ('miter', 'round', 'bevel')
+
+    @_api.deprecated("3.4")
+    @_api.classproperty
+    def validCap(cls):
+        return ('butt', 'round', 'projecting')
+
+    @_api.deprecated("3.4")
+    @_api.classproperty
+    def validJoin(cls):
+        return ('miter', 'round', 'bevel')
 
     def __str__(self):
         if self._label != "":

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -33,8 +33,18 @@ class Patch(artist.Artist):
     are *None*, they default to their rc params setting.
     """
     zorder = 1
-    validCap = mlines.Line2D.validCap
-    validJoin = mlines.Line2D.validJoin
+
+    @_api.deprecated("3.4")
+    @_api.classproperty
+    def validCap(cls):
+        with _api.suppress_matplotlib_deprecation_warning():
+            return mlines.Line2D.validCap
+
+    @_api.deprecated("3.4")
+    @_api.classproperty
+    def validJoin(cls):
+        with _api.suppress_matplotlib_deprecation_warning():
+            return mlines.Line2D.validJoin
 
     # Whether to draw an edge by default.  Set on a
     # subclass-by-subclass basis.

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -19,3 +19,16 @@ def test_check_shape(target, test_shape):
     data = np.zeros(test_shape)
     with pytest.raises(ValueError, match=error_pattern):
         _api.check_shape(target, aardvark=data)
+
+
+def test_classproperty_deprecation():
+    class A:
+        @_api.deprecated("0.0.0")
+        @_api.classproperty
+        def f(cls):
+            pass
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        A.f
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        a = A()
+        a.f


### PR DESCRIPTION
## PR Summary

Needed for #18544 (GSOD). Some new machinery was needed to add the deprecation while keeping the existing API (namely, the ability to access `validJoin` as a class property directly, i.e. `Line2D.validJoin`), so I pulled the necessary code out into this PR.

These properties already have long-existing comments marking them as "only there for backwards compatibility", and deprecation was initially suggested by @QuLogic.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
