### PR TITLE
Simplify LogFormatterExponent implementation.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1117,16 +1117,11 @@ class LogFormatterExponent(LogFormatter):
     """
     Format values for log axis using ``exponent = log_base(value)``.
     """
+
     def _num_to_string(self, x, vmin, vmax):
         fx = math.log(x) / math.log(self._base)
-        if abs(fx) > 10000:
-            s = '%1.0g' % fx
-        elif abs(fx) < 1:
-            s = '%1.0g' % fx
-        else:
-            fd = math.log(vmax - vmin) / math.log(self._base)
-            s = self._pprint_val(fx, fd)
-        return s
+        return (f"{fx:1.0g}" if abs(fx) < 1 else
+                f"{fx:1.2f}".rstrip("0").rstrip("."))
 
 
 class LogFormatterMathtext(LogFormatter):


### PR DESCRIPTION
The previous implementation seemed to occasionally confuse linear and
log scales.

- `fx = log(x) / log(base)` is likely never >10000 (likely that was a
  confusion with linear scales), so remove the
  `abs(fx) > 10000` branch.

- In the last (`_pprint_val` branch), likewise `fd` is likely mostly
  between 1 and 10, so we can use the corresponding format in
  `LogFormatter._pprint_val`, i.e. "1.2f".  The other relevant branches
  in `_pprint_val` are `x` being an integer (but in that case formatting
  with "1.2f" and stripping trailing zeroes and dots yields the same
  result), and the `d < 1` case does not matter either because in that
  case, `vmax - vmin < base` and thus `x < base`, thus `fx < 1` which
  was handled above.

In other words, this PR may change the behavior of the formatter for
extremely large values of `x` (e.g. `x > base**10000`), but these were
likely unintended anyways.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
