### PR TITLE
Warn in pgf backend when unknown font is requested.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -134,7 +134,7 @@ def _font_properties_str(prop):
           and mpl.rcParams["pgf.texsystem"] != "pdflatex"):
         commands.append(r"\setmainfont{%s}\rmfamily" % family)
     else:
-        pass  # print warning?
+        _log.warning("Ignoring unknown font: %s", family)
 
     size = prop.get_size_in_points()
     commands.append(r"\fontsize{%f}{%f}" % (size, size * 1.2))

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -328,3 +328,13 @@ def test_png():
     # Just a smoketest.
     fig, ax = plt.subplots()
     fig.savefig(BytesIO(), format="png", backend="pgf")
+
+
+@needs_xelatex
+def test_unknown_font(caplog):
+    with caplog.at_level("WARNING"):
+        mpl.rcParams["font.family"] = "this-font-does-not-exist"
+        plt.figtext(.5, .5, "hello, world")
+        plt.savefig(BytesIO(), format="pgf")
+    assert "Ignoring unknown font: this-font-does-not-exist" in [
+        r.getMessage() for r in caplog.records]


### PR DESCRIPTION
## PR Summary

Closes the second half of https://github.com/matplotlib/matplotlib/issues/18808.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
