### PR TITLE
Fix ax.set_xticklabels(fontproperties=fp)

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1766,10 +1766,10 @@ class Axis(martist.Artist):
             tick_label = formatter(loc, pos)
             # deal with label1
             tick.label1.set_text(tick_label)
-            tick.label1.update(kwargs)
+            tick.label1.update(kwargs.copy())
             # deal with label2
             tick.label2.set_text(tick_label)
-            tick.label2.update(kwargs)
+            tick.label2.update(kwargs.copy())
             # only return visible tick labels
             if tick.label1.get_visible():
                 ret.append(tick.label1)


### PR DESCRIPTION
## PR Summary

Only one label is changed on an axis when set `fontproperties` using set_xticklabels().

```python
from matplotlib import pyplot as plt
from matplotlib.font_manager import FontProperties

fig = plt.figure()
ax = plt.gca()
ax.set_xticklabels(["label1", "label2"], fontproperties=FontProperties(weight="bold"))

plt.show()
```

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).