### PR TITLE
MNT: make sure we do not mutate input in Text.update

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -8,10 +8,12 @@ import pytest
 
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseEvent
+from matplotlib.font_manager import FontProperties
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.text import Text
 
 
 needs_usetex = pytest.mark.skipif(
@@ -697,3 +699,13 @@ def test_transform_rotates_text():
                    transform_rotates_text=True)
     result = text.get_rotation()
     assert_almost_equal(result, 30)
+
+
+def test_update_mutate_input():
+    inp = dict(fontproperties=FontProperties(weight="bold"),
+               bbox=None)
+    cache = dict(inp)
+    t = Text()
+    t.update(inp)
+    assert inp['fontproperties'] == cache['fontproperties']
+    assert inp['bbox'] == cache['bbox']

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -172,6 +172,8 @@ class Text(Artist):
 
     def update(self, kwargs):
         # docstring inherited
+        # make a copy so we do not mutate user input!
+        kwargs = dict(kwargs)
         sentinel = object()  # bbox can be None, so use another sentinel.
         # Update fontproperties first, as it has lowest priority.
         fontproperties = kwargs.pop("fontproperties", sentinel)


### PR DESCRIPTION
## PR Summary

We take in a dictionary (called kwargs rather than collecting kwargs)
which we mutate in the method.  We pop bbox and fontproperties keys
out of the user supplied dictionary (to make sure the precedence and
default behaviors are correct) which is propagated back out to user
code.

This makes an internal copy of the dictionary before we mutate it.

closes #18838

@shevawen Can you please confirm that this fixes your problem?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
