### PR TITLE
Add tutorial about autoscaling

### DIFF
--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -7,10 +7,11 @@ scale ranges automatically with respect to supplied data - autoscaling.
 This tutorial shows concepts of individual autoscaling options and
 investigates cornerstone examples regarding the needs for manual adjustments.
 """
+The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``) or Matplotlib can set them automatically based on the data already on the axes.  There are a number of options to this autoscaling behaviour, discussed below.
 
 ###############################################################################
-# We will start with a simple line plot showing that the autoscaling feature
-# extends the visible range slightly beyond the real data range (-2π, 2π).
+# We will start with a simple line plot showing that autoscaling 
+# extends the visible range 5% beyond the real data range (-2π, 2π).
 
 import numpy as np
 import matplotlib as mpl
@@ -27,15 +28,13 @@ fig.show()
 # Margins
 # -------
 # The relative measure of the extend is called margin and can be set by
-# :func:`~matplotlib.axes.Axes.margins`.
-# We can check that the default value is (0.05, 0.05).
+# `~matplotlib.axes.Axes.margins`.
+# The default value is (0.05, 0.05):
 
 ax.margins()
 
 ###############################################################################
-# Margin scales with respect to the data interval so setting a larger margin
-# ensures more space between actual data and plot edges, hence plotted curve
-# will appear smaller.
+# The margins can be made larger:
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
@@ -118,11 +117,10 @@ fig.show()
 # Controlling autoscale
 # ---------------------
 #
-# We have figured out how to control the margins of the plot. Now, we will
-# investigate how to disable autoscaling. By default, the scales are
+# It is possible to disable autoscaling. By default, the limits are
 # recalculated every time you add a new curve to the plot (see next figure).
-# This ensures the visibility of the data. However, there are cases when you
-# don't want to automatically adjust viewport to data.
+# However, there are cases when you don't want to automatically adjust the 
+viewport to new data.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].plot(x, y)
@@ -134,12 +132,11 @@ fig.show()
 
 
 ###############################################################################
-# There are multiple reasons to do that so there are multiple ways of
-# disabling the autoscale feature. One of the cases is manually setting the
+# One way to disable autoscaling is to manually setting the
 # axis limit. Let's say that we want to see only a part of the data in
 # greater detail. Setting the ``xlim`` persists even if we add more curves to
-# the data. To recalculate the new limits we shall call `.Axes.autoscale`
-# manually to toggle the functionality.
+# the data. To recalculate the new limits  calling `.Axes.autoscale` will
+# manually toggle the functionality.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].plot(x, y)
@@ -165,9 +162,9 @@ print(ax[1].get_autoscale_on())  # True means enabled -> recalculated
 # of autoscaling. A combination of arguments ``enable``, and ``axis`` sets the
 # autoscaling feature for the selected axis (or both). The argument ``tight``
 # sets the margin of the selected axis to zero. To preserve settings of either
-# ``enable`` or ``tight`` you can set the opposite one to None, that way
-# it should not be modified. However, setting ``enable`` to None and tight
-# to True affects both axes regardless of the ``axis`` argument.
+# ``enable`` or ``tight`` you can set the opposite one to *None*, that way
+# it should not be modified. However, setting ``enable`` to *None* and tight
+# to *True* affects both axes regardless of the ``axis`` argument.
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
@@ -182,8 +179,8 @@ print(ax.margins())
 # Autoscale works out of the box for all lines, patches, and images added to
 # the axes. One of the artists that it won't work with is a `.Collection`.
 # After adding a collection to the axes, one has to manually trigger the
-# :func:`~matplotlib.axes.Axes.autoscale_view()` to propagate recalculated
-# limits to the figure.
+# `~matplotlib.axes.Axes.autoscale_view()` to recalculate
+# axes limits.
 
 fig, ax = plt.subplots()
 collection = mpl.collections.StarPolygonCollection(

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -2,19 +2,12 @@
 Autoscaling
 ===========
 
-Axis scales define the overall look of a plot, some default options
-scale ranges automatically with respect to supplied data - autoscaling.
-This tutorial shows concepts of individual autoscaling options and
-investigates cornerstone examples regarding the needs for manual adjustments.
-The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``)
-or Matplotlib can set them automatically based on the data already on the
-axes. There are a number of options to this autoscaling behaviour,
-discussed below.
+The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``) or Matplotlib can set them automatically based on the data already on the axes.  There are a number of options to this autoscaling behaviour, discussed below.
 """
 
 ###############################################################################
 # We will start with a simple line plot showing that autoscaling
-# extends the visible range 5% beyond the real data range (-2π, 2π).
+# extends the axis limits 5% beyond the data limits (-2π, 2π).
 
 import numpy as np
 import matplotlib as mpl
@@ -30,14 +23,12 @@ fig.show()
 ###############################################################################
 # Margins
 # -------
-# The relative measure of the extend is called margin and can be set by
-# `~matplotlib.axes.Axes.margins`.
-# The default value is (0.05, 0.05):
+# The default margin around the data limits is 5%:
 
 ax.margins()
 
 ###############################################################################
-# The margins can be made larger:
+# The margins can be made larger using `~matplotlib.axes.Axes.margins`:
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
@@ -45,8 +36,8 @@ ax.margins(0.2, 0.2)
 fig.show()
 
 ###############################################################################
-# In general, margins shall be in range (-0.5, ∞), negative margins crop the
-# plot showing only a part of the data. Using a single number for margins
+# In general, margins can be in the range (-0.5, ∞), where negative margins set the axes limits to 
+# a fraction of the data range, and allow a zoom effect. Using a single number for margins
 # affects both axes, a single margin can be customized using keyword
 # arguments ``x`` or ``y``, but positional and keyword interface cannot be
 # combined
@@ -57,18 +48,11 @@ ax.margins(y=-0.2)
 fig.show()
 
 ###############################################################################
-# There is the last keyword argument for margins call, the ``tight`` option. In
-# the case of a simple :func:`~matplotlib.axes.Axes.plot` call, this parameter
-# does not change anything, it is passed to the
-# :meth:`~matplotlib.axes.Axes.autoscale_view`, which requires more advanced
-# discussion.
 #
-# Margins can behave differently for certain plots, this is determined by
-# the sticky edges property, which is of interest in the next section.
 #
 # Sticky edges
 # ------------
-# Margin must not be applied for certain :class:`.Artist`, for example, setting
+# Some :class:`.Artist` objects do not allow margins.  For example, setting
 # ``margin=0.2`` on ``plt.imshow`` does not affect the resulting plot.
 #
 
@@ -84,16 +68,13 @@ ax[1].set_title("margins(0.2)")
 fig.show()
 
 ###############################################################################
-# This override of margins is determined by so-called sticky edges. That is a
-# property of :class:`.Artist` class, which can suppress adding margins to data
-# limits. The effect of sticky edges can be disabled by changing
-# :class:`~matplotlib.axes.Axes` property
-# `~matplotlib.axes.Axes.use_sticky_edges`.
-#
-# Settings of sticky edges of individual artists can be investigating by
-# accessing them directly, `.Artist.sticky_edges`. Moreover, the values of
+# This override of margins is determined by "sticky edges", a
+# property of :class:`.Artist` class that can suppress adding margins to axis
+# limits. The effect of sticky edges can be disabled on an Axes by changing
+#  `~matplotlib.axes.Axes.use_sticky_edges`.
+# Artists have a property `.Artist.sticky_edges`, and the values of
 # sticky edges can be changed by writing to ``Artist.sticky_edges.x`` or
-# ``.Artist.sticky_edges.y``
+# ``.Artist.sticky_edges.y``.
 #
 # The following example shows how overriding works and when it is needed.
 

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -186,7 +186,8 @@ print(ax.margins())
 # limits to the figure.
 
 fig, ax = plt.subplots()
-collection = mpl.collections.StarPolygonCollection(5, 0, [250, ],
+collection = mpl.collections.StarPolygonCollection(
+    5, 0, [250, ],  # five point star, zero angle, size 250px
     offsets=np.column_stack([x, y]),  # Set the positions
     transOffset=ax.transData,  # Propagate transformations of the Axes
 )

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -1,0 +1,195 @@
+"""
+Autoscaling
+===========
+
+Axis scales define the overall look of a plot, there are some default options
+that scale ranges automatically with respect to supplied data - autoscaling.
+This tutorial shows concepts of individual autoscaling options and
+investigates cornerstone examples regarding needs of manual adjustments.
+"""
+
+###############################################################################
+# We will start with a simple line plot showing that the autoscaling feature
+# extends the visible range slightly beyond real data range (-2π, 2π).
+
+import numpy as np
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+
+x = np.linspace(-2 * np.pi, 2 * np.pi, 100)
+y = np.sinc(x)
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+fig.show()
+
+###############################################################################
+# Margins
+# -------
+# The relative measure of extend is called margin and can be set by
+# :func:`~matplotlib.axes.Axes.margins`.
+# We can check that default value is (0.05, 0.05).
+
+ax.margins()
+
+###############################################################################
+# Margin scales with respect to the data interval so setting larger margin
+# ensures more space between acutal data and plot edges, hence plotted curve
+# will appear smaller.
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+ax.margins(0.2, 0.2)
+fig.show()
+
+###############################################################################
+# In general, margins shall be in range (-0.5, ∞), negative margins crop the
+# plot showing only a part of the data. Using a single number for margins
+# affects both axes, single margin can be customized by means of keyword
+# arguments ``x`` or ``y``, but positional and keyword interface cannot be
+# combined
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+ax.margins(y=-0.2)
+fig.show()
+
+###############################################################################
+# There is a last keyword argument for margins call, the ``tight`` option. In
+# case of simple :func:`~matplotlib.axes.Axes.plot` call, this parameter does
+# not change anything, it is passed to the
+# :meth:`~matplotlib.axes.Axes.autoscale_view`, which requires more advanced
+# discussion.
+#
+# Margins can behave differently for certain plots, this is determined by
+# sticky edges property, which is of interest in next section.
+#
+# Sticky edges
+# ------------
+# Margin must not be applied for certain :class:`.Artist`, for example setting
+# ``margin=0.2`` on ``plt.imshow`` does not affect the resulting plot.
+#
+
+xx, yy = np.meshgrid(x, x)
+zz = np.sinc(np.sqrt((xx - 1)**2 + (yy - 1)**2))
+
+fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
+ax[0].imshow(zz)
+ax[0].set_title("margins unchanged")
+ax[1].imshow(zz)
+ax[1].margins(0.2)
+ax[1].set_title("margins(0.2)")
+fig.show()
+
+###############################################################################
+# This override of margins is determined by so-called sticky edges. That is a
+# property of :class:`.Artist` class, which can suppress adding margins to data
+# limits. The effect of sticky edges can be disabled by changing
+# :class:`~matplotlib.axes.Axes` property
+# `~matplotlib.axes.Axes.use_sticky_edges`.
+#
+# Settings of sticky edges of individual artists can be investigating by
+# accessing them directly, `.Artist.sticky_edges`. Moreover, values of sticky
+# edges can be changed by writing to ``Artist.sticky_edges.x`` or
+# ``.Artist.sticky_edges.y``
+#
+# Following example shows how overriding works and when it is needed.
+
+fig, ax = plt.subplots(ncols=3, figsize=(16, 10))
+ax[0].imshow(zz)
+ax[0].margins(0.2)
+ax[0].set_title("use_sticky_edges unchanged\nmargins(0.2)")
+ax[1].imshow(zz)
+ax[1].margins(0.2)
+ax[1].use_sticky_edges = False
+ax[1].set_title("use_sticky_edges=False\nmargins(0.2)")
+ax[2].imshow(zz)
+ax[2].margins(-0.2)
+ax[2].set_title("use_sticky_edges unchanged\nmargins(-0.2)")
+fig.show()
+
+###############################################################################
+# We can see that setting ``use_sticky_edges`` to False renders the image with
+# requested margins. Additionally, as is stated, sticky edges count for adding
+# a margin, therefore negative margin is not affected by its state, rendering
+# the third image within narrower limits and without changing the
+# `~matplotlib.axes.Axes.use_sticky_edges` property.
+#
+# Controlling autoscale
+# ---------------------
+#
+# We have figured out how to control the margins of the plot. Now, we will
+# investigate how to disable autoscaling. By default, the scales are
+# recalculated every time you add a new curve to the plot (see next figure).
+# This ensures visibility of the data. However, there are cases when you
+# don't want to automatically adjust viewport to data.
+
+fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
+ax[0].plot(x, y)
+ax[0].set_title("Single curve")
+ax[1].plot(x, y)
+ax[1].plot(x * 2.0, y)
+ax[1].set_title("Two curves")
+fig.show()
+
+
+###############################################################################
+# There are multiple reasons to do that so there are multiple ways of
+# disabling the autoscale feature. One of the cases is manually setting the
+# axis limit. Let's say that we want to see only a part of the data in
+# greater detail. Setting the ``xlim`` persists even if we add more curves to
+# the data. To recalcuate the new limits we shall call `.Axes.autoscale`
+# manually to toggle the functionality.
+
+fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
+ax[0].plot(x, y)
+ax[0].set_xlim(left=-1, right=1)
+ax[0].plot(x + np.pi * 0.5, y)
+ax[0].set_title("set_xlim(left=-1, right=1)\n")
+ax[1].plot(x, y)
+ax[1].set_xlim(left=-1, right=1)
+ax[1].plot(x + np.pi * 0.5, y)
+ax[1].autoscale()
+ax[1].set_title("set_xlim(left=-1, right=1)\nautoscale()")
+fig.show()
+
+###############################################################################
+# We can check that first plot has autoscale disabled and that the second plot
+# has it enabled again by using `.Axes.get_autoscale_on()`:
+
+print(ax[0].get_autoscale_on())  # False means disabled
+print(ax[1].get_autoscale_on())  # True means enabled -> recalculated
+
+###############################################################################
+# Arguments of the autoscale function give us precise control over the process
+# of autoscaling. Combination of arguments ``enable``, and ``axis`` sets the
+# autoscaling feature for selected axis (or both). The argument ``tight`` sets
+# the margin of the selected axis to zero. To preserve settings of either
+# ``enable`` or ``tight`` you can set the opposite one to None, that way
+# it should not be modified. However, setting ``enable`` to None and tight
+# to True affects both axes regardless of the ``axis`` argument.
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+ax.margins(0.2, 0.2)
+ax.autoscale(enable=None, axis="x", tight=True)
+fig.show()
+print(ax.margins())
+
+###############################################################################
+# Working with collections
+# ------------------------
+# Autoscale works out of the box for all lines, patches and images added to
+# the axes. One of artists that it won't work is `.Collection`. After adding
+# a collection to the axes, one has to manually trigger the
+# :func:`~matplotlib.axes.Axes.autoscale_view()` to popagate recalculated
+# limits to the figure.
+
+fig, ax = plt.subplots()
+collection = mpl.collections.StarPolygonCollection(5, 0, [250, ],
+    offsets=np.column_stack([x, y]),  # Set the positions
+    transOffset=ax.transData,  # Propagate transformations of the Axes
+)
+ax.add_collection(collection)
+ax.autoscale_view()
+fig.show()

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -6,11 +6,14 @@ Axis scales define the overall look of a plot, some default options
 scale ranges automatically with respect to supplied data - autoscaling.
 This tutorial shows concepts of individual autoscaling options and
 investigates cornerstone examples regarding the needs for manual adjustments.
+The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``)
+or Matplotlib can set them automatically based on the data already on the
+axes. There are a number of options to this autoscaling behaviour,
+discussed below.
 """
-The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``) or Matplotlib can set them automatically based on the data already on the axes.  There are a number of options to this autoscaling behaviour, discussed below.
 
 ###############################################################################
-# We will start with a simple line plot showing that autoscaling 
+# We will start with a simple line plot showing that autoscaling
 # extends the visible range 5% beyond the real data range (-2π, 2π).
 
 import numpy as np
@@ -119,8 +122,8 @@ fig.show()
 #
 # It is possible to disable autoscaling. By default, the limits are
 # recalculated every time you add a new curve to the plot (see next figure).
-# However, there are cases when you don't want to automatically adjust the 
-viewport to new data.
+# However, there are cases when you don't want to automatically adjust the
+# viewport to new data.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].plot(x, y)

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -20,7 +20,6 @@ y = np.sinc(x)
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
-fig.show()
 
 ###############################################################################
 # Margins
@@ -35,7 +34,6 @@ ax.margins()
 fig, ax = plt.subplots()
 ax.plot(x, y)
 ax.margins(0.2, 0.2)
-fig.show()
 
 ###############################################################################
 # In general, margins can be in the range (-0.5, ∞), where negative margins set
@@ -47,7 +45,6 @@ fig.show()
 fig, ax = plt.subplots()
 ax.plot(x, y)
 ax.margins(y=-0.2)
-fig.show()
 
 ###############################################################################
 # Sticky edges
@@ -66,7 +63,6 @@ ax[0].set_title("default margins")
 ax[1].imshow(zz)
 ax[1].margins(0.2)
 ax[1].set_title("margins(0.2)")
-fig.show()
 
 ###############################################################################
 # This override of margins is determined by "sticky edges", a
@@ -90,7 +86,6 @@ ax[1].set_title("use_sticky_edges=False\nmargins(0.2)")
 ax[2].imshow(zz)
 ax[2].margins(-0.2)
 ax[2].set_title("use_sticky_edges unchanged\nmargins(-0.2)")
-fig.show()
 
 ###############################################################################
 # We can see that setting ``use_sticky_edges`` to *False* renders the image with
@@ -112,8 +107,6 @@ ax[0].set_title("Single curve")
 ax[1].plot(x, y)
 ax[1].plot(x * 2.0, y)
 ax[1].set_title("Two curves")
-fig.show()
-
 
 ###############################################################################
 # However, there are cases when you don't want to automatically adjust the
@@ -135,7 +128,6 @@ ax[1].set_xlim(left=-1, right=1)
 ax[1].plot(x + np.pi * 0.5, y)
 ax[1].autoscale()
 ax[1].set_title("set_xlim(left=-1, right=1)\nautoscale()")
-fig.show()
 
 ###############################################################################
 # We can check that the first plot has autoscale disabled and that the second
@@ -157,7 +149,7 @@ fig, ax = plt.subplots()
 ax.plot(x, y)
 ax.margins(0.2, 0.2)
 ax.autoscale(enable=None, axis="x", tight=True)
-fig.show()
+
 print(ax.margins())
 
 ###############################################################################
@@ -178,4 +170,3 @@ collection = mpl.collections.StarPolygonCollection(
 )
 ax.add_collection(collection)
 ax.autoscale_view()
-fig.show()

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -78,18 +78,18 @@ ax[1].set_title("margins(0.2)")
 fig, ax = plt.subplots(ncols=3, figsize=(16, 10))
 ax[0].imshow(zz)
 ax[0].margins(0.2)
-ax[0].set_title("use_sticky_edges unchanged\nmargins(0.2)")
+ax[0].set_title("default use_sticky_edges\nmargins(0.2)")
 ax[1].imshow(zz)
 ax[1].margins(0.2)
 ax[1].use_sticky_edges = False
 ax[1].set_title("use_sticky_edges=False\nmargins(0.2)")
 ax[2].imshow(zz)
 ax[2].margins(-0.2)
-ax[2].set_title("use_sticky_edges unchanged\nmargins(-0.2)")
+ax[2].set_title("default use_sticky_edges\nmargins(-0.2)")
 
 ###############################################################################
-# We can see that setting ``use_sticky_edges`` to *False* renders the image with
-# requested margins.
+# We can see that setting ``use_sticky_edges`` to *False* renders the image
+# with requested margins.
 #
 # While sticky edges don't increase the axis limits through extra margins,
 # negative margins are still taken into accout. This can be seen in

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -2,7 +2,9 @@
 Autoscaling
 ===========
 
-The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``) or Matplotlib can set them automatically based on the data already on the axes.  There are a number of options to this autoscaling behaviour, discussed below.
+The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``)
+or Matplotlib can set them automatically based on the data already on the axes.
+There are a number of options to this autoscaling behaviour, discussed below.
 """
 
 ###############################################################################
@@ -36,11 +38,11 @@ ax.margins(0.2, 0.2)
 fig.show()
 
 ###############################################################################
-# In general, margins can be in the range (-0.5, ∞), where negative margins set the axes limits to 
-# a fraction of the data range, and allow a zoom effect. Using a single number for margins
-# affects both axes, a single margin can be customized using keyword
-# arguments ``x`` or ``y``, but positional and keyword interface cannot be
-# combined
+# In general, margins can be in the range (-0.5, ∞), where negative margins set
+# the axes limits to a fraction of the data range, and allow a zoom effect.
+# Using a single number for margins affects both axes, a single margin can be
+# customized using keyword arguments ``x`` or ``y``, but positional and keyword
+# interface cannot be combined.
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
@@ -48,8 +50,6 @@ ax.margins(y=-0.2)
 fig.show()
 
 ###############################################################################
-#
-#
 # Sticky edges
 # ------------
 # Some :class:`.Artist` objects do not allow margins.  For example, setting
@@ -71,7 +71,7 @@ fig.show()
 # This override of margins is determined by "sticky edges", a
 # property of :class:`.Artist` class that can suppress adding margins to axis
 # limits. The effect of sticky edges can be disabled on an Axes by changing
-#  `~matplotlib.axes.Axes.use_sticky_edges`.
+# `~matplotlib.axes.Axes.use_sticky_edges`.
 # Artists have a property `.Artist.sticky_edges`, and the values of
 # sticky edges can be changed by writing to ``Artist.sticky_edges.x`` or
 # ``.Artist.sticky_edges.y``.
@@ -160,6 +160,7 @@ print(ax.margins())
 ###############################################################################
 # Working with collections
 # ------------------------
+#
 # Autoscale works out of the box for all lines, patches, and images added to
 # the axes. One of the artists that it won't work with is a `.Collection`.
 # After adding a collection to the axes, one has to manually trigger the

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -2,15 +2,15 @@
 Autoscaling
 ===========
 
-Axis scales define the overall look of a plot, there are some default options
-that scale ranges automatically with respect to supplied data - autoscaling.
+Axis scales define the overall look of a plot, some default options
+scale ranges automatically with respect to supplied data - autoscaling.
 This tutorial shows concepts of individual autoscaling options and
-investigates cornerstone examples regarding needs of manual adjustments.
+investigates cornerstone examples regarding the needs for manual adjustments.
 """
 
 ###############################################################################
 # We will start with a simple line plot showing that the autoscaling feature
-# extends the visible range slightly beyond real data range (-2π, 2π).
+# extends the visible range slightly beyond the real data range (-2π, 2π).
 
 import numpy as np
 import matplotlib as mpl
@@ -26,15 +26,15 @@ fig.show()
 ###############################################################################
 # Margins
 # -------
-# The relative measure of extend is called margin and can be set by
+# The relative measure of the extend is called margin and can be set by
 # :func:`~matplotlib.axes.Axes.margins`.
-# We can check that default value is (0.05, 0.05).
+# We can check that the default value is (0.05, 0.05).
 
 ax.margins()
 
 ###############################################################################
-# Margin scales with respect to the data interval so setting larger margin
-# ensures more space between acutal data and plot edges, hence plotted curve
+# Margin scales with respect to the data interval so setting a larger margin
+# ensures more space between actual data and plot edges, hence plotted curve
 # will appear smaller.
 
 fig, ax = plt.subplots()
@@ -45,7 +45,7 @@ fig.show()
 ###############################################################################
 # In general, margins shall be in range (-0.5, ∞), negative margins crop the
 # plot showing only a part of the data. Using a single number for margins
-# affects both axes, single margin can be customized by means of keyword
+# affects both axes, a single margin can be customized using keyword
 # arguments ``x`` or ``y``, but positional and keyword interface cannot be
 # combined
 
@@ -55,18 +55,18 @@ ax.margins(y=-0.2)
 fig.show()
 
 ###############################################################################
-# There is a last keyword argument for margins call, the ``tight`` option. In
-# case of simple :func:`~matplotlib.axes.Axes.plot` call, this parameter does
-# not change anything, it is passed to the
+# There is the last keyword argument for margins call, the ``tight`` option. In
+# the case of a simple :func:`~matplotlib.axes.Axes.plot` call, this parameter
+# does not change anything, it is passed to the
 # :meth:`~matplotlib.axes.Axes.autoscale_view`, which requires more advanced
 # discussion.
 #
 # Margins can behave differently for certain plots, this is determined by
-# sticky edges property, which is of interest in next section.
+# the sticky edges property, which is of interest in the next section.
 #
 # Sticky edges
 # ------------
-# Margin must not be applied for certain :class:`.Artist`, for example setting
+# Margin must not be applied for certain :class:`.Artist`, for example, setting
 # ``margin=0.2`` on ``plt.imshow`` does not affect the resulting plot.
 #
 
@@ -89,11 +89,11 @@ fig.show()
 # `~matplotlib.axes.Axes.use_sticky_edges`.
 #
 # Settings of sticky edges of individual artists can be investigating by
-# accessing them directly, `.Artist.sticky_edges`. Moreover, values of sticky
-# edges can be changed by writing to ``Artist.sticky_edges.x`` or
+# accessing them directly, `.Artist.sticky_edges`. Moreover, the values of
+# sticky edges can be changed by writing to ``Artist.sticky_edges.x`` or
 # ``.Artist.sticky_edges.y``
 #
-# Following example shows how overriding works and when it is needed.
+# The following example shows how overriding works and when it is needed.
 
 fig, ax = plt.subplots(ncols=3, figsize=(16, 10))
 ax[0].imshow(zz)
@@ -121,7 +121,7 @@ fig.show()
 # We have figured out how to control the margins of the plot. Now, we will
 # investigate how to disable autoscaling. By default, the scales are
 # recalculated every time you add a new curve to the plot (see next figure).
-# This ensures visibility of the data. However, there are cases when you
+# This ensures the visibility of the data. However, there are cases when you
 # don't want to automatically adjust viewport to data.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
@@ -138,7 +138,7 @@ fig.show()
 # disabling the autoscale feature. One of the cases is manually setting the
 # axis limit. Let's say that we want to see only a part of the data in
 # greater detail. Setting the ``xlim`` persists even if we add more curves to
-# the data. To recalcuate the new limits we shall call `.Axes.autoscale`
+# the data. To recalculate the new limits we shall call `.Axes.autoscale`
 # manually to toggle the functionality.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
@@ -154,17 +154,17 @@ ax[1].set_title("set_xlim(left=-1, right=1)\nautoscale()")
 fig.show()
 
 ###############################################################################
-# We can check that first plot has autoscale disabled and that the second plot
-# has it enabled again by using `.Axes.get_autoscale_on()`:
+# We can check that the first plot has autoscale disabled and that the second
+# plot has it enabled again by using `.Axes.get_autoscale_on()`:
 
 print(ax[0].get_autoscale_on())  # False means disabled
 print(ax[1].get_autoscale_on())  # True means enabled -> recalculated
 
 ###############################################################################
 # Arguments of the autoscale function give us precise control over the process
-# of autoscaling. Combination of arguments ``enable``, and ``axis`` sets the
-# autoscaling feature for selected axis (or both). The argument ``tight`` sets
-# the margin of the selected axis to zero. To preserve settings of either
+# of autoscaling. A combination of arguments ``enable``, and ``axis`` sets the
+# autoscaling feature for the selected axis (or both). The argument ``tight``
+# sets the margin of the selected axis to zero. To preserve settings of either
 # ``enable`` or ``tight`` you can set the opposite one to None, that way
 # it should not be modified. However, setting ``enable`` to None and tight
 # to True affects both axes regardless of the ``axis`` argument.
@@ -179,10 +179,10 @@ print(ax.margins())
 ###############################################################################
 # Working with collections
 # ------------------------
-# Autoscale works out of the box for all lines, patches and images added to
-# the axes. One of artists that it won't work is `.Collection`. After adding
-# a collection to the axes, one has to manually trigger the
-# :func:`~matplotlib.axes.Axes.autoscale_view()` to popagate recalculated
+# Autoscale works out of the box for all lines, patches, and images added to
+# the axes. One of the artists that it won't work with is a `.Collection`.
+# After adding a collection to the axes, one has to manually trigger the
+# :func:`~matplotlib.axes.Axes.autoscale_view()` to propagate recalculated
 # limits to the figure.
 
 fig, ax = plt.subplots()

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -39,7 +39,7 @@ fig.show()
 
 ###############################################################################
 # In general, margins can be in the range (-0.5, ∞), where negative margins set
-# the axes limits to a fraction of the data range, and allow a zoom effect.
+# the axes limits to a subrange of the data range, i.e. they clip data.
 # Using a single number for margins affects both axes, a single margin can be
 # customized using keyword arguments ``x`` or ``y``, but positional and keyword
 # interface cannot be combined.
@@ -52,8 +52,9 @@ fig.show()
 ###############################################################################
 # Sticky edges
 # ------------
-# Some :class:`.Artist` objects do not allow margins.  For example, setting
-# ``margin=0.2`` on ``plt.imshow`` does not affect the resulting plot.
+# There are plot elements (`.Artist`\s) that are usually used without margins.
+# For example false-color images (e.g. created with `.Axes.imshow`) are not
+# considered in the margins calculation.
 #
 
 xx, yy = np.meshgrid(x, x)
@@ -61,7 +62,7 @@ zz = np.sinc(np.sqrt((xx - 1)**2 + (yy - 1)**2))
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].imshow(zz)
-ax[0].set_title("margins unchanged")
+ax[0].set_title("default margins")
 ax[1].imshow(zz)
 ax[1].margins(0.2)
 ax[1].set_title("margins(0.2)")
@@ -69,7 +70,7 @@ fig.show()
 
 ###############################################################################
 # This override of margins is determined by "sticky edges", a
-# property of :class:`.Artist` class that can suppress adding margins to axis
+# property of `.Artist` class that can suppress adding margins to axis
 # limits. The effect of sticky edges can be disabled on an Axes by changing
 # `~matplotlib.axes.Axes.use_sticky_edges`.
 # Artists have a property `.Artist.sticky_edges`, and the values of
@@ -92,19 +93,18 @@ ax[2].set_title("use_sticky_edges unchanged\nmargins(-0.2)")
 fig.show()
 
 ###############################################################################
-# We can see that setting ``use_sticky_edges`` to False renders the image with
-# requested margins. Additionally, as is stated, sticky edges count for adding
-# a margin, therefore negative margin is not affected by its state, rendering
-# the third image within narrower limits and without changing the
-# `~matplotlib.axes.Axes.use_sticky_edges` property.
+# We can see that setting ``use_sticky_edges`` to *False* renders the image with
+# requested margins.
+#
+# While sticky edges don't increase the axis limits through extra margins,
+# negative margins are still taken into accout. This can be seen in
+# the reduced limits of the third image.
 #
 # Controlling autoscale
 # ---------------------
 #
-# It is possible to disable autoscaling. By default, the limits are
-# recalculated every time you add a new curve to the plot (see next figure).
-# However, there are cases when you don't want to automatically adjust the
-# viewport to new data.
+# By default, the limits are
+# recalculated every time you add a new curve to the plot:
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].plot(x, y)
@@ -116,11 +116,14 @@ fig.show()
 
 
 ###############################################################################
-# One way to disable autoscaling is to manually setting the
+# However, there are cases when you don't want to automatically adjust the
+# viewport to new data.
+#
+# One way to disable autoscaling is to manually set the
 # axis limit. Let's say that we want to see only a part of the data in
 # greater detail. Setting the ``xlim`` persists even if we add more curves to
 # the data. To recalculate the new limits  calling `.Axes.autoscale` will
-# manually toggle the functionality.
+# toggle the functionality manually.
 
 fig, ax = plt.subplots(ncols=2, figsize=(12, 8))
 ax[0].plot(x, y)


### PR DESCRIPTION
## PR Summary
I hope I have covered basic usage of autoscaling. Maybe there is a need to go more into details, but I suggest to do it in another tutorial, along with suggestions from #18401 

Closes #17417 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
