### PR TITLE
Add CPython 3.9 wheels.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,6 +34,16 @@ jobs:
         run: |
           cp setup.cfg.template setup.cfg
 
+      - name: Build wheels for CPython 3.9
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp39-*"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
+          CIBW_MANYLINUX_I686_IMAGE: manylinux1
+          CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.3
+          MPL_DISABLE_FH4: "yes"
+
       - name: Build wheels for CPython
         run: |
           python -m cibuildwheel --output-dir dist


### PR DESCRIPTION
## PR Summary

Note, this does mean that our Python 3.9 wheels will be built against NumPy 1.19, because there are no older wheels available.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).