### PR TITLE
Fix sphinx formatting issues

### DIFF
--- a/lib/matplotlib/_layoutgrid.py
+++ b/lib/matplotlib/_layoutgrid.py
@@ -285,7 +285,7 @@ class LayoutGrid:
             existing minimum it updates the margin size. Fraction of
             figure size.
 
-        cell: int
+        cell : int
             Cell column or row to edit.
         """
 
@@ -315,11 +315,11 @@ class LayoutGrid:
 
         Parameters
         ----------
-        todo: string (one of 'left', 'right', 'bottom', 'top')
-            margin to alter.
+        todo : {'left', 'right', 'bottom', 'top'}
+            The margin to alter.
 
-        size: float
-            Minimum size of the margin .  If it is larger than the
+        size : float
+            Minimum size of the margin.  If it is larger than the
             existing minimum it updates the margin size. Fraction of
             figure size.
         """
@@ -333,11 +333,11 @@ class LayoutGrid:
 
         Parameters
         ----------
-        margin: dict
+        margin : dict
             size of margins in a dict with keys 'left', 'right', 'bottom',
             'top'
 
-        ss: SubplotSpec
+        ss : SubplotSpec
             defines the subplotspec these margins should be applied to
         """
 

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -81,10 +81,10 @@ class Fonts:
         """
         Parameters
         ----------
-        default_font_prop: `~.font_manager.FontProperties`
+        default_font_prop : `~.font_manager.FontProperties`
             The default non-math font, or the base font for Unicode (generic)
             font rendering.
-        mathtext_backend: `MathtextBackend` subclass
+        mathtext_backend : `MathtextBackend` subclass
             Backend to which rendering is actually delegated.
         """
         self.default_font_prop = default_font_prop

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1012,7 +1012,7 @@ class Axes(_AxesBase):
         See Also
         --------
         vlines : vertical lines
-        axhline: horizontal line across the Axes
+        axhline : horizontal line across the Axes
         """
 
         # We do the conversion first since not all unitized data is uniform
@@ -1089,7 +1089,7 @@ class Axes(_AxesBase):
         See Also
         --------
         hlines : horizontal lines
-        axvline: vertical line across the Axes
+        axvline : vertical line across the Axes
         """
 
         # We do the conversion first since not all unitized data is uniform
@@ -2221,7 +2221,7 @@ class Axes(_AxesBase):
 
         See Also
         --------
-        barh: Plot a horizontal bar plot.
+        barh : Plot a horizontal bar plot.
 
         Notes
         -----
@@ -2490,7 +2490,7 @@ class Axes(_AxesBase):
 
         See Also
         --------
-        bar: Plot a vertical bar plot.
+        bar : Plot a vertical bar plot.
 
         Notes
         -----
@@ -2831,7 +2831,7 @@ class Axes(_AxesBase):
         shadow : bool, default: False
             Draw a shadow beneath the pie.
 
-        normalize: None or bool, default: None
+        normalize : None or bool, default: None
             When *True*, always make a full pie by normalizing x so that
             ``sum(x) == 1``. *False* makes a partial pie if ``sum(x) <= 1``
             and raises a `ValueError` for ``sum(x) > 1``.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -451,9 +451,9 @@ class Op(Operator, Enum):
 
         Parameters
         ----------
-        fill: bool
+        fill : bool
             Fill the path with the fill color.
-        stroke: bool
+        stroke : bool
             Stroke the outline of the path with the line color.
         """
         if stroke:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -836,7 +836,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         Parameters
         ----------
-        alpha: float or array of float or None
+        alpha : float or array of float or None
             If not None, *alpha* values must be between 0 and 1, inclusive.
             If an array is provided, its length must match the number of
             elements in the collection.  Masked values and nans are not
@@ -1369,7 +1369,7 @@ class LineCollection(Collection):
         """
         Parameters
         ----------
-        segments: list of array-like
+        segments : list of array-like
             A sequence of (*line0*, *line1*, *line2*), where::
 
                 linen = (x0, y0), (x1, y1), ... (xm, ym)

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -275,7 +275,7 @@ def get_epoch():
 
     Returns
     -------
-    epoch: str
+    epoch : str
         String for the epoch (parsable by `numpy.datetime64`).
     """
     global _epoch

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1288,26 +1288,26 @@ class FancyArrow(Polygon):
         """
         Parameters
         ----------
-        width: float, default: 0.001
+        width : float, default: 0.001
             Width of full arrow tail.
 
-        length_includes_head: bool, default: False
+        length_includes_head : bool, default: False
             True if head is to be counted in calculating the length.
 
-        head_width: float or None, default: 3*width
+        head_width : float or None, default: 3*width
             Total width of the full arrow head.
 
-        head_length: float or None, default: 1.5*head_width
+        head_length : float or None, default: 1.5*head_width
             Length of arrow head.
 
-        shape: ['full', 'left', 'right'], default: 'full'
+        shape : {'full', 'left', 'right'}, default: 'full'
             Draw the left-half, right-half, or full arrow.
 
-        overhang: float, default: 0
+        overhang : float, default: 0
             Fraction that the arrow is swept back (0 overhang means
             triangular shape). Can be negative or greater than one.
 
-        head_starts_at_zero: bool, default: False
+        head_starts_at_zero : bool, default: False
             If True, the head starts being drawn at coordinate 0
             instead of ending at coordinate 0.
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1699,7 +1699,7 @@ class Axes3D(Axes):
 
         Parameters
         ----------
-        polygons: list of (M_i, 3) array-like, or (..., M, 3) array-like
+        polygons : list of (M_i, 3) array-like, or (..., M, 3) array-like
             A sequence of polygons to compute normals for, which can have
             varying numbers of vertices. If the polygons all have the same
             number of vertices and array is passed, then the operation will
@@ -1707,7 +1707,7 @@ class Axes3D(Axes):
 
         Returns
         -------
-        normals: (..., 3) array-like
+        normals : (..., 3) array-like
             A normal vector estimated for the polygon.
 
         """


### PR DESCRIPTION
## PR Summary

numpydoc style requires a space between parameter name and colon.