### PR TITLE
Improve pgf special escapes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18856-AL.rst
+++ b/doc/api/next_api_changes/deprecations/18856-AL.rst
@@ -1,0 +1,3 @@
+backend_pgf deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~
+``backend_pgf.re_mathsep`` is deprecated.

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -67,8 +67,10 @@ def create_figure():
 
 
 @pytest.mark.parametrize('plain_text, escaped_text', [
-    (r'quad_sum: $\sum x_i^2$', r'quad\_sum: \(\displaystyle \sum x_i^2\)'),
+    (r'quad_sum: $\sum x_i^2$', r'quad\_sum: $\sum x_i^2$'),
     (r'no \$splits \$ here', r'no \$splits \$ here'),
+    ('2$', r'2\$'),
+    ('$2', r'\$2'),
     ('with_underscores', r'with\_underscores'),
     ('% not a comment', r'\% not a comment'),
     ('^not', r'\^not'),


### PR DESCRIPTION
- In common_texification.py, when splitting math and non-math segments,
  match *two* dollar signs surrounding a math segment rather than single
  dollar signs; this lets us correctly handle e.g. `$2` which we
  explicitly support in other backends as being plain text, not
  unbalanced math (the previous implementation would handle that as
  math).
- Instead of adding `\displaystyle` in front of each and every math block,
  use the TeX-provided `\everymath` mechanism to just register that
  once (this basically auto-prepends `\displaystyle` before every math
  block).
- Define `\mathdefault` as a noop (which is consistent with what
  texmanager does) instead of stripping it out, which would allow e.g.
  for the possibility that someone redefines `\mathdefault` in whatever
  way they want.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
