### PR TITLE
Remove "Demo" from example titles

### DIFF
--- a/examples/axes_grid1/demo_anchored_direction_arrows.py
+++ b/examples/axes_grid1/demo_anchored_direction_arrows.py
@@ -1,7 +1,7 @@
 """
-=============================
-Demo Anchored Direction Arrow
-=============================
+========================
+Anchored Direction Arrow
+========================
 
 """
 import matplotlib.pyplot as plt

--- a/examples/axes_grid1/demo_axes_divider.py
+++ b/examples/axes_grid1/demo_axes_divider.py
@@ -1,7 +1,7 @@
 """
-=================
-Demo Axes Divider
-=================
+============
+Axes Divider
+============
 
 Axes divider to calculate location of axes and
 create a divider for them using existing axes instances.

--- a/examples/axes_grid1/demo_axes_grid2.py
+++ b/examples/axes_grid1/demo_axes_grid2.py
@@ -1,7 +1,7 @@
 """
-===============
-Demo Axes Grid2
-===============
+==========
+Axes Grid2
+==========
 
 Grid of images with shared xaxis and yaxis.
 """

--- a/examples/axes_grid1/demo_axes_rgb.py
+++ b/examples/axes_grid1/demo_axes_rgb.py
@@ -1,9 +1,11 @@
 """
-=======
-RGBAxes
-=======
+==================================
+Showing RGB channels using RGBAxes
+==================================
 
-RGBAxes to show RGB composite images.
+`~.axes_grid1.axes_rgb.RGBAxes` creates a layout of 4 Axes for displaying RGB
+channels: one large Axes for the RGB image and 3 smaller Axes for the R, G, B
+channels.
 """
 
 import numpy as np

--- a/examples/axes_grid1/demo_axes_rgb.py
+++ b/examples/axes_grid1/demo_axes_rgb.py
@@ -1,7 +1,7 @@
 """
-=============
-Demo Axes RGB
-=============
+=======
+RGBAxes
+=======
 
 RGBAxes to show RGB composite images.
 """

--- a/examples/images_contours_and_fields/barb_demo.py
+++ b/examples/images_contours_and_fields/barb_demo.py
@@ -1,9 +1,9 @@
 """
-=========
-Barb Demo
-=========
+==========
+Wind Barbs
+==========
 
-Demonstration of wind barb plots
+Demonstration of wind barb plots.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/text_labels_and_annotations/demo_text_path.py
+++ b/examples/text_labels_and_annotations/demo_text_path.py
@@ -1,11 +1,11 @@
 """
-==============
-Demo Text Path
-==============
+======================
+Using a text as a Path
+======================
 
-Use a text as `.Path`. The tool that allows for such conversion is a
-`~matplotlib.textpath.TextPath`. The resulting path can be employed
-e.g. as a clip path for an image.
+`~matplotlib.textpath.TextPath` creates a `.Path` that is the outline of the
+characters of a text. The resulting path can be employed e.g. as a clip path
+for an image.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -1,7 +1,7 @@
 r"""
-=======================
-Demo Text Rotation Mode
-=======================
+==================
+Text Rotation Mode
+==================
 
 This example illustrates the effect of ``rotation_mode`` on the positioning
 of rotated text.

--- a/examples/text_labels_and_annotations/fancyarrow_demo.py
+++ b/examples/text_labels_and_annotations/fancyarrow_demo.py
@@ -1,7 +1,9 @@
 """
-===============
-Fancyarrow Demo
-===============
+================================
+Annotation arrow style reference
+================================
+
+Overview of the arrow styles available in `~.Axes.annotate`.
 
 """
 import matplotlib.patches as mpatches

--- a/examples/text_labels_and_annotations/fancytextbox_demo.py
+++ b/examples/text_labels_and_annotations/fancytextbox_demo.py
@@ -1,8 +1,9 @@
 """
-=================
-Fancytextbox Demo
-=================
+==================
+Styling text boxes
+==================
 
+This example shows how to style text boxes using *bbox* parameters.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/text_labels_and_annotations/mathtext_demo.py
+++ b/examples/text_labels_and_annotations/mathtext_demo.py
@@ -1,7 +1,7 @@
 """
-=============
-Mathtext Demo
-=============
+========
+Mathtext
+========
 
 Use Matplotlib's internal LaTeX parser and layout engine.  For true LaTeX
 rendering, see the text.usetex option.

--- a/examples/text_labels_and_annotations/stix_fonts_demo.py
+++ b/examples/text_labels_and_annotations/stix_fonts_demo.py
@@ -1,7 +1,7 @@
 """
-===============
-STIX Fonts Demo
-===============
+==========
+STIX Fonts
+==========
 
 Demonstration of `STIX Fonts <https://www.stixfonts.org/>`_ used in LaTeX
 rendering.

--- a/examples/ticks_and_spines/colorbar_tick_labelling_demo.py
+++ b/examples/ticks_and_spines/colorbar_tick_labelling_demo.py
@@ -1,7 +1,7 @@
 """
-============================
-Colorbar Tick Labelling Demo
-============================
+=======================
+Colorbar Tick Labelling
+=======================
 
 Produce custom labelling for a colorbar.
 

--- a/examples/ticks_and_spines/date_demo_rrule.py
+++ b/examples/ticks_and_spines/date_demo_rrule.py
@@ -1,12 +1,16 @@
 """
-===============
-Date Demo Rrule
-===============
+=========================================
+Placing date ticks using recurrence rules
+=========================================
 
-Show how to use an rrule instance to make a custom date ticker - here
-we put a tick mark on every 5th easter
+The `iCalender RFC`_ specifies *recurrence rules* (rrules), that define
+date sequences. You can use rrules in Matplotlib to place date ticks.
 
-See https://dateutil.readthedocs.io/en/stable/ for help with rrules
+This example sets custom date ticks on every 5th easter.
+
+See https://dateutil.readthedocs.io/en/stable/rrule.html for help with rrules.
+
+.. _iCalender RFC: https://tools.ietf.org/html/rfc5545
 """
 import matplotlib.pyplot as plt
 from matplotlib.dates import (YEARLY, DateFormatter,

--- a/examples/ticks_and_spines/spine_placement_demo.py
+++ b/examples/ticks_and_spines/spine_placement_demo.py
@@ -1,7 +1,7 @@
 """
-====================
-Spine Placement Demo
-====================
+===============
+Spine Placement
+===============
 
 Adjusting the location and appearance of axis spines.
 

--- a/examples/user_interfaces/wxcursor_demo_sgskip.py
+++ b/examples/user_interfaces/wxcursor_demo_sgskip.py
@@ -1,7 +1,7 @@
 """
-=============
-WXcursor Demo
-=============
+=====================
+Adding a cursor in WX
+=====================
 
 Example to draw a cursor and report the data coords in wx.
 """

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -1,7 +1,7 @@
 """
-====================
-Connectionstyle Demo
-====================
+=================================
+Connection styles for annotations
+=================================
 
 When creating an annotation using `~.Axes.annotate`, the arrow shape can be
 controlled via the *connectionstyle* parameter of *arrowprops*. For further

--- a/examples/widgets/lasso_selector_demo_sgskip.py
+++ b/examples/widgets/lasso_selector_demo_sgskip.py
@@ -1,7 +1,7 @@
 """
-===================
-Lasso Selector Demo
-===================
+==============
+Lasso Selector
+==============
 
 Interactively selecting data points with the lasso tool.
 

--- a/examples/widgets/polygon_selector_demo.py
+++ b/examples/widgets/polygon_selector_demo.py
@@ -1,7 +1,7 @@
 """
-=====================
-Polygon Selector Demo
-=====================
+================
+Polygon Selector
+================
 
 Shows how one can select indices of a polygon interactively.
 """

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -1,7 +1,7 @@
 """
-===========
-Slider Demo
-===========
+======
+Slider
+======
 
 Using the slider widget to control visual properties of your plot.
 


### PR DESCRIPTION
## PR Summary

In the context of example titles "Demo" is a fill word without meaning. All examples are demos.

This PR removes some usages of "Demo". If possible, the title is changed to something more meaningful. (Which is also the reason, I'm only doing part of the examples. Good titles need a bit of thought for every single case).