### PR TITLE
Resolve mathtext.fontset at FontProperties creation time.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -897,8 +897,6 @@ class FontProperties:
 
         The default font is :rc:`mathtext.fontset`.
         """
-        if self._math_fontfamily is None:
-            return rcParams['mathtext.fontset']
         return self._math_fontfamily
 
     def set_math_fontfamily(self, fontfamily):
@@ -921,13 +919,12 @@ class FontProperties:
         .text.Text.get_math_fontfamily
         """
         if fontfamily is None:
-            self._math_fontfamily = None
-            return
-
-        valid_fonts = _validators['mathtext.fontset'].valid.values()
-        # _check_in_list() Validates the parameter math_fontfamily as
-        # if it were passed to rcParams['mathtext.fontset']
-        _api.check_in_list(valid_fonts, math_fontfamily=fontfamily)
+            fontfamily = rcParams['mathtext.fontset']
+        else:
+            valid_fonts = _validators['mathtext.fontset'].valid.values()
+            # _check_in_list() Validates the parameter math_fontfamily as
+            # if it were passed to rcParams['mathtext.fontset']
+            _api.check_in_list(valid_fonts, math_fontfamily=fontfamily)
         self._math_fontfamily = fontfamily
 
     def copy(self):


### PR DESCRIPTION
... instead of delaying it until rendering time.  This makes it
consistent with the behavior of `rcParams["font.family"]`.  (While lazy
resolution may be useful too, it seems better to be consistent with
family, whose behavior is constrained by backcompat, whereas
mathtext_fontfamily has not been released yet.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
