### PR TITLE
Expand ScalarMappable.set_array to accept array-like inputs

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -373,8 +373,8 @@ class ScalarMappable:
 
         A = cbook.safe_masked_invalid(A, copy=True)
         if not np.can_cast(A.dtype, float, "same_kind"):
-            raise TypeError("Image data of dtype {} cannot be converted to "
-                            "float".format(A.dtype))
+            raise TypeError(f"Image data of dtype {A.dtype} cannot be "
+                            "converted to float")
 
         self._A = A
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -370,7 +370,7 @@ class ScalarMappable:
         if A is None:
             self._A = None
             return
-            
+
         A = cbook.safe_masked_invalid(A, copy=True)
         if not np.can_cast(A.dtype, float, "same_kind"):
             raise TypeError("Image data of dtype {} cannot be converted to "

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -361,12 +361,19 @@ class ScalarMappable:
 
     def set_array(self, A):
         """
-        Set the image array from numpy array *A*.
+        Set the image array from array-like *A*.
 
         Parameters
         ----------
-        A : ndarray or None
+        A : array-like or None
         """
+        A = cbook.safe_masked_invalid(A, copy=True) if A is not None else None
+
+        if (A is not None and A.dtype != np.uint8 and
+                not np.can_cast(A.dtype, float, "same_kind")):
+            raise TypeError("Image data of dtype {} cannot be converted to "
+                            "float".format(A.dtype))
+
         self._A = A
 
     def get_array(self):

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -367,10 +367,12 @@ class ScalarMappable:
         ----------
         A : array-like or None
         """
-        A = cbook.safe_masked_invalid(A, copy=True) if A is not None else None
-
-        if (A is not None and A.dtype != np.uint8 and
-                not np.can_cast(A.dtype, float, "same_kind")):
+        if A is None:
+            self._A = None
+            return
+            
+        A = cbook.safe_masked_invalid(A, copy=True)
+        if not np.can_cast(A.dtype, float, "same_kind"):
             raise TypeError("Image data of dtype {} cannot be converted to "
                             "float".format(A.dtype))
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1346,8 +1346,7 @@ class FigureImage(_ImageBase):
 
     def set_data(self, A):
         """Set the image array."""
-        cm.ScalarMappable.set_array(self,
-                                    cbook.safe_masked_invalid(A, copy=True))
+        cm.ScalarMappable.set_array(self, A)
         self.stale = True
 
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -677,6 +677,22 @@ def test_collection_set_verts_array():
         assert np.array_equal(ap._codes, atp._codes)
 
 
+def test_collection_set_array():
+    vals = [*range(10)]
+
+    # Test set_array with list
+    c = Collection()
+    c.set_array(vals)
+
+    # Test set_array with wrong dtype
+    with pytest.raises(TypeError, match="^Image data of dtype"):
+        c.set_array("wrong_input")
+
+    # Test if array kwarg is copied
+    vals[5] = 45
+    assert np.not_equal(vals, c.get_array()).any()
+
+
 def test_blended_collection_autolim():
     a = [1, 2, 4]
     height = .2


### PR DESCRIPTION
## PR Summary
`imshow` allows `set_array` to pass lists, `Collection` does not. (Since `_ImageBase` overrides `set_array` of `ScalarMappable`, adding the ability to pass `array-like` inputs, and copy the input so changing list after calling function doesn't affect the plots)
This PR expands the `ScalarMappable` class to make a copy of the original input and casting it to arrays.

Fixes #18841 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
