### PR TITLE
Slightly compress down the pgf tests.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -163,16 +163,11 @@ def test_rcupdate():
 @pytest.mark.style('default')
 @pytest.mark.backend('pgf')
 def test_pathclip():
-    rc_xelatex = {'font.family': 'serif',
-                  'pgf.rcfonts': False}
-    mpl.rcParams.update(rc_xelatex)
-
-    plt.figure()
+    mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
     plt.plot([0., 1e100], [0., 1e100])
     plt.xlim(0, 1)
     plt.ylim(0, 1)
-    # this test passes if compiling/saving to pdf works (no image comparison)
-    plt.savefig(os.path.join(result_dir, "pgf_pathclip.pdf"))
+    plt.savefig(BytesIO(), format="pdf")  # No image comparison.
 
 
 # test mixed mode rendering
@@ -180,12 +175,8 @@ def test_pathclip():
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_mixedmode.pdf'], style='default')
 def test_mixedmode():
-    rc_xelatex = {'font.family': 'serif',
-                  'pgf.rcfonts': False}
-    mpl.rcParams.update(rc_xelatex)
-
+    mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
     Y, X = np.ogrid[-1:1:40j, -1:1:40j]
-    plt.figure()
     plt.pcolor(X**2 + Y**2).set_rasterized(True)
 
 
@@ -194,15 +185,11 @@ def test_mixedmode():
 @pytest.mark.style('default')
 @pytest.mark.backend('pgf')
 def test_bbox_inches():
-    rc_xelatex = {'font.family': 'serif',
-                  'pgf.rcfonts': False}
-    mpl.rcParams.update(rc_xelatex)
-
+    mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
     fig, (ax1, ax2) = plt.subplots(1, 2)
     ax1.plot(range(5))
     ax2.plot(range(5))
     plt.tight_layout()
-
     bbox = ax1.get_window_extent().transformed(fig.dpi_scale_trans.inverted())
     compare_figure('pgf_bbox_inches.pdf', savefig_kwargs={'bbox_inches': bbox},
                    tol=0)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
