### PR TITLE
Improvements and bugfixes for hexbin marginals

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4603,6 +4603,9 @@ default: :rc:`scatter.edgecolors`
             y = np.log10(y)
         if extent is not None:
             xmin, xmax, ymin, ymax = extent
+            if xmin > xmax or ymin > ymax:
+                raise ValueError("extent values in wrong order. Should be"
+                                 " (left, right, bottom, top)")
         else:
             xmin, xmax = (np.min(x), np.max(x)) if len(x) else (0, 1)
             ymin, ymax = (np.min(y), np.max(y)) if len(y) else (0, 1)


### PR DESCRIPTION
## PR Summary
The marginals functionality for hexbin had a couple of hidden bugs and issues:

1.  Providing `hexbin` with a tuple for the `gridsize` resulted in an error.
2. It was possible to give the `extents` in the wrong order. This did not raise an error, but broke the marginals. (https://github.com/matplotlib/matplotlib/pull/27607)
3. The marginals were taking into account points outside of the specified limits.
4. The bins for the marginals were not aligned in any way to the 2D hexagonal bins.
5. The marginals tried using `reduce_C_function` even when `C` was not provided. With the default `reduce_C_function`, this meant applying `np.mean` to a set of ones, resulting in only binary values in the marginal. 

This PR fixes these issues. It makes marginals work with tuple `gridsize`, raises a `ValueError` when the `extents` are in the wrong order, ignores points outside the extents, aligns the bins of the marginals to the hexagonal bins and uses summation when `C` is not provided.

In addition I changed the formatting of the code for the y marginal to match that of the x marginal so that it's easier to compare (and diff) them. You could consider somehow merging the two with a function, since most of the code is actually quite repetitive.

What would really be useful would be some unit tests for the hexbin marginals, but maybe someone else can help with that?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
