### PR TITLE
Remove fallback to nonexistent setDevicePixelRatioF.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -17,7 +17,7 @@ from matplotlib.backends.qt_editor._formsubplottool import UiSubplotTool
 from . import qt_compat
 from .qt_compat import (
     QtCore, QtGui, QtWidgets, __version__, QT_API,
-    _devicePixelRatioF, _isdeleted, _setDevicePixelRatioF,
+    _devicePixelRatioF, _isdeleted, _setDevicePixelRatio,
 )
 
 backend_version = __version__
@@ -707,7 +707,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         if QtCore.qVersion() >= '5.':
             name = name.replace('.png', '_large.png')
         pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))
-        _setDevicePixelRatioF(pm, _devicePixelRatioF(self))
+        _setDevicePixelRatio(pm, _devicePixelRatioF(self))
         if self.palette().color(self.backgroundRole()).value() < 128:
             icon_color = self.palette().color(self.foregroundRole())
             mask = pm.createMaskFromColor(QtGui.QColor('black'),

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -11,7 +11,7 @@ from .backend_agg import FigureCanvasAgg
 from .backend_qt5 import (
     QtCore, QtGui, QtWidgets, _BackendQT5, FigureCanvasQT, FigureManagerQT,
     NavigationToolbar2QT, backend_version)
-from .qt_compat import QT_API, _setDevicePixelRatioF
+from .qt_compat import QT_API, _setDevicePixelRatio
 
 
 class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
@@ -64,7 +64,7 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
             qimage = QtGui.QImage(buf, buf.shape[1], buf.shape[0],
                                   QtGui.QImage.Format_ARGB32_Premultiplied)
-            _setDevicePixelRatioF(qimage, self._dpi_ratio)
+            _setDevicePixelRatio(qimage, self._dpi_ratio)
             # set origin using original QT coordinates
             origin = QtCore.QPoint(rect.left(), rect.top())
             painter.drawImage(origin, qimage)

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -2,7 +2,7 @@ import ctypes
 
 from .backend_cairo import cairo, FigureCanvasCairo, RendererCairo
 from .backend_qt5 import QtCore, QtGui, _BackendQT5, FigureCanvasQT
-from .qt_compat import QT_API, _setDevicePixelRatioF
+from .qt_compat import QT_API, _setDevicePixelRatio
 
 
 class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
@@ -33,7 +33,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         # QImage under PySide on Python 3.
         if QT_API == 'PySide':
             ctypes.c_long.from_address(id(buf)).value = 1
-        _setDevicePixelRatioF(qimage, dpi_ratio)
+        _setDevicePixelRatio(qimage, dpi_ratio)
         painter = QtGui.QPainter(self)
         painter.eraseRect(event.rect())
         painter.drawImage(0, 0, qimage)

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -206,15 +206,12 @@ def _devicePixelRatioF(obj):
         return 1
 
 
-def _setDevicePixelRatioF(obj, val):
+def _setDevicePixelRatio(obj, val):
     """
-    Call obj.setDevicePixelRatioF(val) with graceful fallback for older Qt.
+    Call obj.setDevicePixelRatio(val) with graceful fallback for older Qt.
 
     This can be replaced by the direct call when we require Qt>=5.6.
     """
-    if hasattr(obj, 'setDevicePixelRatioF'):
-        # Not available on Qt<5.6
-        obj.setDevicePixelRatioF(val)
-    elif hasattr(obj, 'setDevicePixelRatio'):
+    if hasattr(obj, 'setDevicePixelRatio'):
         # Not available on Qt4 or some older Qt5.
         obj.setDevicePixelRatio(val)


### PR DESCRIPTION
setDevicePixelRatioF never existed, per https://github.com/matplotlib/matplotlib/pull/15656#issuecomment-712934812.  I'll let @timhoffm sort out the situation wrt devicePixelRatioF :) (https://github.com/matplotlib/matplotlib/pull/15656#issuecomment-713121375)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
