### PR TITLE
Implementing ticklabels keyword in plt.colorbar()

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -422,6 +422,7 @@ class ColorbarBase:
                  extend=None,
                  spacing='uniform',  # uniform or proportional
                  ticks=None,
+                 ticklabels=None,
                  format=None,
                  drawedges=False,
                  filled=True,
@@ -463,6 +464,7 @@ class ColorbarBase:
              'min': slice(1, None), 'max': slice(0, -1)},
             extend=extend)
         self.spacing = spacing
+        self.ticklabels = ticklabels
         self.orientation = orientation
         self.drawedges = drawedges
         self.filled = filled
@@ -543,6 +545,8 @@ class ColorbarBase:
         self.outline.set_xy(xy)
         self.patch.set_xy(xy)
         self.update_ticks()
+        if self.ticklabels:
+            self.set_ticklabels(self.ticklabels)
         if self.filled:
             self._add_solids(X, Y, self._values[:, np.newaxis])
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -727,8 +727,8 @@ class ColorbarBase:
         # check if explitic ticks have been supplied
         if self._ticks is None:
             cbook._warn_external('To set explicit ticklabels, call colorbar() '
-                                 'with ticks keyword or use set_ticks() method '
-                                 'first.')
+                                 'with ticks keyword or use set_ticks() '
+                                 'method first.')
         # check if length of ticks and ticklabels match
         elif len(self._ticks) != len(self._ticklabels):
             cbook._warn_external('The ticklabels need to be of the same '
@@ -744,8 +744,8 @@ class ColorbarBase:
         else:
             cbook._warn_external('To set ticklabels, ticks of the same '
                                  'length need to be set explicitly first. '
-                                 'This can be done through plt.colorbar(ticks) '
-                                 'or set_ticks().')
+                                 'This can be done through '
+                                 'plt.colorbar(ticks) or set_ticks().')
         self.stale = True
 
     def minorticks_on(self):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -464,7 +464,7 @@ class ColorbarBase:
              'min': slice(1, None), 'max': slice(0, -1)},
             extend=extend)
         self.spacing = spacing
-        self.ticklabels = ticklabels
+        self._ticklabels = ticklabels
         self.orientation = orientation
         self.drawedges = drawedges
         self.filled = filled
@@ -545,8 +545,8 @@ class ColorbarBase:
         self.outline.set_xy(xy)
         self.patch.set_xy(xy)
         self.update_ticks()
-        if self.ticklabels:
-            self.set_ticklabels(self.ticklabels)
+        if self._ticklabels:
+            self.set_ticklabels(self._ticklabels)
         if self.filled:
             self._add_solids(X, Y, self._values[:, np.newaxis])
 
@@ -725,7 +725,9 @@ class ColorbarBase:
             if update_ticks:
                 self.update_ticks()
         else:
-            cbook._warn_external("set_ticks() must have been called.")
+            cbook._warn_external('To set ticklabels, ticks with the same \
+                length need to be set explicitly first. This can be done \
+                through plt.colorbar(ticks) or set_ticks().')
         self.stale = True
 
     def minorticks_on(self):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -703,7 +703,7 @@ class ColorbarBase:
             self.stale = True
         else:
             cbook._warn_external('The ticks need to be an array of values '
-                'or an instance of ticker.Locator')
+                                 'or an instance of ticker.Locator')
 
     def get_ticks(self, minor=False):
         """Return the x ticks as a list of locations."""
@@ -726,12 +726,13 @@ class ColorbarBase:
         """
         # check if explitic ticks have been supplied
         if self._ticks is None:
-            cbook._warn_external('To set explicit ticklabels, call colorbar()'
-                'with ticks keyword or use set_ticks() method first.')
+            cbook._warn_external('To set explicit ticklabels, call colorbar() '
+                                 'with ticks keyword or use set_ticks() method '
+                                 'first.')
         # check if length of ticks and ticklabels match
         elif len(self._ticks) != len(self._ticklabels):
             cbook._warn_external('The ticklabels need to be of the same '
-                'length as the ticks.')
+                                 'length as the ticks.')
         # check if objects in list have valid type
         elif not all(type(item) in [str, float, int] for item in ticklabels):
             cbook._warn_external('ticklabels need to be a list of str')
@@ -742,8 +743,9 @@ class ColorbarBase:
                 self.update_ticks()
         else:
             cbook._warn_external('To set ticklabels, ticks of the same '
-                'length need to be set explicitly first. This can be done '
-                'through plt.colorbar(ticks) or set_ticks().')
+                                 'length need to be set explicitly first. '
+                                 'This can be done through plt.colorbar(ticks) '
+                                 'or set_ticks().')
         self.stale = True
 
     def minorticks_on(self):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -501,7 +501,7 @@ class ColorbarBase:
 
         self.set_label(label)
         self._reset_locator_formatter_scale()
-        
+
         if np.iterable(ticks):
             self.locator = ticker.FixedLocator(ticks, nbins=len(ticks))
         else:

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -464,7 +464,7 @@ class ColorbarBase:
              'min': slice(1, None), 'max': slice(0, -1)},
             extend=extend)
         self.spacing = spacing
-        self._ticks = None
+        self._ticks = ticks
         self._ticklabels = ticklabels
         self.orientation = orientation
         self.drawedges = drawedges
@@ -501,9 +501,11 @@ class ColorbarBase:
 
         self.set_label(label)
         self._reset_locator_formatter_scale()
-
-        if ticks:
-            self.set_ticks(ticks)
+        
+        if np.iterable(ticks):
+            self.locator = ticker.FixedLocator(ticks, nbins=len(ticks))
+        else:
+            self.locator = ticks    # Handle default in _ticker()
 
         if isinstance(format, str):
             self.formatter = ticker.FormatStrFormatter(format)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -707,7 +707,7 @@ def test_anchored_cbar_position_using_specgrid():
             [x1 * shrink + (1 - shrink) * p0, p0 * (1 - shrink) + x0 * shrink])
 
 
-def test_colorbar_ticklabels():
+def test_colorbar_ticklabels_2():
     fig = plt.figure()
     plt.imshow(np.arange(100).reshape((10, 10)))
     ticklabels = ['cat', 'dog']
@@ -715,3 +715,26 @@ def test_colorbar_ticklabels():
     fig.canvas.draw()
     for i, item in enumerate(cbar.ax.yaxis.get_ticklabels()):
         assert ticklabels[i] == item.get_text()
+
+
+def test_colorbar_ticklabels_3():
+    fig = plt.figure()
+    plt.imshow(np.arange(100).reshape((10, 10)))
+    ticklabels = ['cat', 'dog', 'elephant']
+    with pytest.warns(
+            UserWarning, match='The ticklabels need to be of the same '
+            'length as the ticks.'):
+        plt.colorbar(ticks=[10, 90], ticklabels=ticklabels)
+        fig.canvas.draw()
+
+
+def test_colorbar_ticklabels_no_ticks():
+    fig = plt.figure()
+    plt.imshow(np.arange(100).reshape((10, 10)))
+    ticklabels = ['cat', 'dog', 'dog']
+    with pytest.warns(
+            UserWarning, match='To set explicit ticklabels, call colorbar() '
+            'with ticks keyword or use set_ticks() '
+            'method first.'):
+        plt.colorbar(ticks=None, ticklabels=ticklabels)
+        fig.canvas.draw()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -705,3 +705,13 @@ def test_anchored_cbar_position_using_specgrid():
     np.testing.assert_allclose(
             [cx1, cx0],
             [x1 * shrink + (1 - shrink) * p0, p0 * (1 - shrink) + x0 * shrink])
+
+
+def test_colorbar_ticklabels():
+    fig = plt.figure()
+    plt.imshow(np.arange(100).reshape((10, 10)))
+    ticklabels = ['cat', 'dog']
+    cbar = plt.colorbar(ticks=[10, 90], ticklabels=ticklabels)
+    fig.canvas.draw()
+    for i, item in enumerate(cbar.ax.yaxis.get_ticklabels()):
+        assert ticklabels[i] == item.get_text()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -733,8 +733,8 @@ def test_colorbar_ticklabels_no_ticks():
     plt.imshow(np.arange(100).reshape((10, 10)))
     ticklabels = ['cat', 'dog', 'dog']
     with pytest.warns(
-            UserWarning, match='To set explicit ticklabels, call colorbar\\(\\) '
-            'with ticks keyword or use set_ticks\\(\\) '
+            UserWarning, match='To set explicit ticklabels, call colorbar'
+            '\\(\\) with ticks keyword or use set_ticks\\(\\) '
             'method first.'):
         plt.colorbar(ticks=None, ticklabels=ticklabels)
         fig.canvas.draw()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -733,8 +733,8 @@ def test_colorbar_ticklabels_no_ticks():
     plt.imshow(np.arange(100).reshape((10, 10)))
     ticklabels = ['cat', 'dog', 'dog']
     with pytest.warns(
-            UserWarning, match='To set explicit ticklabels, call colorbar() '
-            'with ticks keyword or use set_ticks() '
+            UserWarning, match='To set explicit ticklabels, call colorbar\\(\\) '
+            'with ticks keyword or use set_ticks\\(\\) '
             'method first.'):
         plt.colorbar(ticks=None, ticklabels=ticklabels)
         fig.canvas.draw()

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -55,33 +55,33 @@ make_axes_kw_doc = '''
 
 colormap_kw_doc = '''
 
-    ===========   ====================================================
-    Property      Description
-    ===========   ====================================================
-    *extend*      [ 'neither' | 'both' | 'min' | 'max' ]
-                  If not 'neither', make pointed end(s) for out-of-
-                  range values.  These are set for a given colormap
-                  using the colormap set_under and set_over methods.
-    *spacing*     [ 'uniform' | 'proportional' ]
-                  Uniform spacing gives each discrete color the same
-                  space; proportional makes the space proportional to
-                  the data interval.
-    *ticks*       [ None | list of ticks | Locator object ]
-                  If None, ticks are determined automatically from the
-                  input.
-    *ticklabels*  sequence of str
-                  List of texts for tick labels; must include values
-                  for non-visible labels.
-    *format*      [ None | format string | Formatter object ]
-                  If None, the
-                  :class:`~matplotlib.ticker.ScalarFormatter` is used.
-                  If a format string is given, e.g., '%.3f', that is
-                  used. An alternative
-                  :class:`~matplotlib.ticker.Formatter` object may be
-                  given instead.
-    *drawedges*   bool
-                  Whether to draw lines at color boundaries.
-    ===========   ====================================================
+    ============   ====================================================
+    Property       Description
+    ============   ====================================================
+    *extend*       [ 'neither' | 'both' | 'min' | 'max' ]
+                   If not 'neither', make pointed end(s) for out-of-
+                   range values.  These are set for a given colormap
+                   using the colormap set_under and set_over methods.
+    *spacing*      [ 'uniform' | 'proportional' ]
+                   Uniform spacing gives each discrete color the same
+                   space; proportional makes the space proportional to
+                   the data interval.
+    *ticks*        [ None | list of ticks | Locator object ]
+                   If None, ticks are determined automatically from the
+                   input.
+    *ticklabels*   sequence of str
+                   List of texts for tick labels; must include values
+                   for non-visible labels.
+    *format*       [ None | format string | Formatter object ]
+                   If None, the
+                   :class:`~matplotlib.ticker.ScalarFormatter` is used.
+                   If a format string is given, e.g., '%.3f', that is
+                   used. An alternative
+                   :class:`~matplotlib.ticker.Formatter` object may be
+                   given instead.
+    *drawedges*    bool
+                   Whether to draw lines at color boundaries.
+    ============   ====================================================
 
     The following will probably be useful only in the context of
     indexed colors (that is, when the mappable has norm=NoNorm()),

--- a/lib/mpl_toolkits/axes_grid1/colorbar.py
+++ b/lib/mpl_toolkits/axes_grid1/colorbar.py
@@ -69,6 +69,9 @@ colormap_kw_doc = '''
     *ticks*       [ None | list of ticks | Locator object ]
                   If None, ticks are determined automatically from the
                   input.
+    *ticklabels*  sequence of str
+                  List of texts for tick labels; must include values
+                  for non-visible labels.
     *format*      [ None | format string | Formatter object ]
                   If None, the
                   :class:`~matplotlib.ticker.ScalarFormatter` is used.


### PR DESCRIPTION
## PR Summary
This adds the ticklabels keyword to the plt.colorbar() function. Tests and documentation has been added. Please review the documentation, as I am unsure if this has been done correctly. 


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
