### PR TITLE
Introduce variable since which mpl version the minimal python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,17 +8,19 @@ setup.cfg.template for more information.
 # and/or pip.
 import sys
 
-min_version = (3, 7)
+py_min_version = (3, 7)  # minimal supported python version
+since_mpl_version = (3, 4)  # py_min_version is required since this mpl version
 
-if sys.version_info < min_version:
+if sys.version_info < py_min_version:
     error = """
-Beginning with Matplotlib 3.4, Python {0} or above is required.
-You are using Python {1}.
+Beginning with Matplotlib {0}, Python {1} or above is required.
+You are using Python {2}.
 
 This may be due to an out of date pip.
 
 Make sure you have pip >= 9.0.1.
-""".format('.'.join(str(n) for n in min_version),
+""".format('.'.join(str(n) for n in since_mpl_version),
+           '.'.join(str(n) for n in py_min_version),
            '.'.join(str(n) for n in sys.version_info[:3]))
     sys.exit(error)
 
@@ -281,7 +283,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     ext_modules=[Extension("", [])],
     package_data=package_data,
 
-    python_requires='>={}'.format('.'.join(str(n) for n in min_version)),
+    python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
     setup_requires=[
         "certifi>=2020.06.20",
         "numpy>=1.16",


### PR DESCRIPTION
Introduce variable since which mpl version the minimal python version requirement holds.

By introducing a variable instead of a hard-coded value in the error message, I hope that we remember to update `since_mpl_version` when we update `py_min_version`.

Followed from #18888, where it was noticed that the values were out of sync.

