### PR TITLE
Move cbook._suppress_matplotlib_deprecation_warning() from cbook to _api

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -104,7 +104,7 @@ import warnings
 
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
-from . import cbook, docstring, rcsetup
+from . import _api, cbook, docstring, rcsetup
 from matplotlib.cbook import MatplotlibDeprecationWarning, sanitize_sequence
 from matplotlib.cbook import mplDeprecation  # deprecated
 from matplotlib.rcsetup import validate_backend, cycler
@@ -665,7 +665,7 @@ class RcParams(MutableMapping, dict):
     def __repr__(self):
         class_name = self.__class__.__name__
         indent = len(class_name) + 1
-        with cbook._suppress_matplotlib_deprecation_warning():
+        with _api.suppress_matplotlib_deprecation_warning():
             repr_split = pprint.pformat(dict(self), indent=1,
                                         width=80 - indent).split('\n')
         repr_indented = ('\n' + ' ' * indent).join(repr_split)
@@ -676,7 +676,7 @@ class RcParams(MutableMapping, dict):
 
     def __iter__(self):
         """Yield sorted list of keys."""
-        with cbook._suppress_matplotlib_deprecation_warning():
+        with _api.suppress_matplotlib_deprecation_warning():
             yield from sorted(dict.__iter__(self))
 
     def __len__(self):
@@ -840,10 +840,10 @@ def rc_params_from_file(fname, fail_on_error=False, use_default_template=True):
     if not use_default_template:
         return config_from_file
 
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         config = RcParams({**rcParamsDefault, **config_from_file})
 
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         if config['datapath'] is None:
             config['datapath'] = _get_data_path()
         else:
@@ -874,7 +874,7 @@ dict.update(rcParamsDefault, rcsetup._hardcoded_defaults)
 rcParams = RcParams()  # The global instance.
 dict.update(rcParams, dict.items(rcParamsDefault))
 dict.update(rcParams, _rc_params_in_file(matplotlib_fname()))
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     rcParamsOrig = RcParams(rcParams.copy())
     # This also checks that all rcParams are indeed listed in the template.
     # Assiging to rcsetup.defaultParams is left only for backcompat.
@@ -982,7 +982,7 @@ def rcdefaults():
     """
     # Deprecation warnings were already handled when creating rcParamsDefault,
     # no need to reemit them here.
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rcParams.clear()
         rcParams.update({k: v for k, v in rcParamsDefault.items()
@@ -998,7 +998,7 @@ def rc_file_defaults():
     """
     # Deprecation warnings were already handled when creating rcParamsOrig, no
     # need to reemit them here.
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rcParams.update({k: rcParamsOrig[k] for k in rcParamsOrig
                          if k not in STYLE_BLACKLIST})
@@ -1023,7 +1023,7 @@ def rc_file(fname, *, use_default_template=True):
     """
     # Deprecation warnings were already handled in rc_params_from_file, no need
     # to reemit them here.
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         from .style.core import STYLE_BLACKLIST
         rc_from_file = rc_params_from_file(
             fname, use_default_template=use_default_template)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -35,8 +35,6 @@ from matplotlib._api.deprecation import (
     deprecated, warn_deprecated,
     _rename_parameter, _delete_parameter, _make_keyword_only,
     _deprecate_method_override, _deprecate_privatize_attribute,
-    suppress_matplotlib_deprecation_warning as
-    _suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning, mplDeprecation)
 
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -384,7 +384,7 @@ class GlueSpec:
         return cls._types[glue_type]
 
 
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     GlueSpec._types = {k: GlueSpec(**v._asdict())
                        for k, v in _mathtext._GlueSpec._named.items()}
 

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -19,7 +19,7 @@ import re
 import warnings
 
 import matplotlib as mpl
-from matplotlib import cbook, rc_params_from_file, rcParamsDefault
+from matplotlib import _api, cbook, rc_params_from_file, rcParamsDefault
 
 _log = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ def use(style):
         elif style == 'default':
             # Deprecation warnings were already handled when creating
             # rcParamsDefault, no need to reemit them here.
-            with cbook._suppress_matplotlib_deprecation_warning():
+            with _api.suppress_matplotlib_deprecation_warning():
                 _apply_style(rcParamsDefault, warn=False)
         elif style in library:
             _apply_style(library[style])

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -6,7 +6,7 @@ import locale
 import logging
 
 import matplotlib as mpl
-from matplotlib import cbook
+from matplotlib import _api
 
 _log = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ def setup():
 
     mpl.use('Agg')
 
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         mpl.rcdefaults()  # Start with all defaults
 
     # These settings *must* be hardcoded for running the comparison tests and

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import matplotlib
-from matplotlib import cbook
+from matplotlib import _api, cbook
 
 
 def pytest_configure(config):
@@ -79,7 +79,7 @@ def mpl_test_settings(request):
             style, = style_marker.args
 
         matplotlib.testing.setup()
-        with cbook._suppress_matplotlib_deprecation_warning():
+        with _api.suppress_matplotlib_deprecation_warning():
             if backend is not None:
                 # This import must come after setup() so it doesn't load the
                 # default backend prematurely.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5664,7 +5664,7 @@ def test_ls_ds_conflict():
     # Passing the drawstyle with the linestyle is deprecated since 3.1.
     # We still need to test this until it's removed from the code.
     # But we don't want to see the deprecation warning in the test.
-    with matplotlib.cbook._suppress_matplotlib_deprecation_warning(), \
+    with matplotlib._api.suppress_matplotlib_deprecation_warning(), \
          pytest.raises(ValueError):
         plt.plot(range(32), linestyle='steps-pre:', drawstyle='steps-post')
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -329,14 +329,14 @@ pass_mapping = (
 @pytest.mark.parametrize('inp, kwargs_to_norm', fail_mapping)
 def test_normalize_kwargs_fail(inp, kwargs_to_norm):
     with pytest.raises(TypeError), \
-         cbook._suppress_matplotlib_deprecation_warning():
+         _api.suppress_matplotlib_deprecation_warning():
         cbook.normalize_kwargs(inp, **kwargs_to_norm)
 
 
 @pytest.mark.parametrize('inp, expected, kwargs_to_norm',
                          pass_mapping)
 def test_normalize_kwargs_pass(inp, expected, kwargs_to_norm):
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         # No other warning should be emitted.
         assert expected == cbook.normalize_kwargs(inp, **kwargs_to_norm)
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -8,7 +8,7 @@ import pytest
 import matplotlib as mpl
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.pyplot as plt
-from matplotlib import cbook, mathtext
+from matplotlib import _api, mathtext
 
 
 # If test is removed, use None as placeholder
@@ -357,7 +357,7 @@ def test_math_to_image(tmpdir):
 
 
 def test_mathtext_to_png(tmpdir):
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         mt = mathtext.MathTextParser('bitmap')
         mt.to_png(str(tmpdir.join('example.png')), '$x^2$')
         mt.to_png(io.BytesIO(), '$x^2$')

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -10,7 +10,7 @@ from cycler import cycler, Cycler
 import pytest
 
 import matplotlib as mpl
-from matplotlib import cbook
+from matplotlib import _api
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np
@@ -125,7 +125,7 @@ def test_Bug_2543():
     # We filter warnings at this stage since a number of them are raised
     # for deprecated rcparams as they should. We don't want these in the
     # printed in the test suite.
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         with mpl.rc_context():
             _copy = mpl.rcParams.copy()
             for key in _copy:

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib as mpl
-from matplotlib import cbook
+from matplotlib import _api
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
@@ -454,7 +454,7 @@ class TestIndexFormatter:
                                           (2, 'label2'),
                                           (2.5, '')])
     def test_formatting(self, x, label):
-        with cbook._suppress_matplotlib_deprecation_warning():
+        with _api.suppress_matplotlib_deprecation_warning():
             formatter = mticker.IndexFormatter(['label0', 'label1', 'label2'])
         assert formatter(x) == label
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1660,7 +1660,7 @@ def _if_refresh_overridden_call_and_emit_deprec(locator):
             "%(removal)s.  You are using a third-party locator that overrides "
             "the refresh() method; this locator should instead perform any "
             "required processing in __call__().")
-    with cbook._suppress_matplotlib_deprecation_warning():
+    with _api.suppress_matplotlib_deprecation_warning():
         locator.refresh()
 
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -835,7 +835,7 @@ class TextBox(AxesWidget):
         else:
             # If not using toolmanager, disable all keypress-related rcParams.
             # Avoid spurious warnings if keymaps are getting deprecated.
-            with cbook._suppress_matplotlib_deprecation_warning():
+            with _api.suppress_matplotlib_deprecation_warning():
                 stack.enter_context(mpl.rc_context(
                     {k: [] for k in mpl.rcParams if k.startswith("keymap.")}))
 

--- a/lib/mpl_toolkits/axes_grid/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid/parasite_axes.py
@@ -1,4 +1,4 @@
-from matplotlib import cbook
+from matplotlib import _api
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
     parasite_axes_auxtrans_class_factory, subplot_class_factory)
@@ -8,5 +8,5 @@ from mpl_toolkits.axisartist.axislines import Axes
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -166,7 +166,7 @@ def parasite_axes_auxtrans_class_factory(axes_class=None):
 
 
 # Also deprecated.
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
 
 

--- a/lib/mpl_toolkits/axisartist/__init__.py
+++ b/lib/mpl_toolkits/axisartist/__init__.py
@@ -1,4 +1,4 @@
-from matplotlib import cbook
+from matplotlib import _api
 from .axislines import (
     Axes, AxesZero, AxisArtistHelper, AxisArtistHelperRectlinear,
     GridHelperBase, GridHelperRectlinear, Subplot, SubplotZero)
@@ -13,5 +13,5 @@ from mpl_toolkits.axes_grid1.parasite_axes import (
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/axisartist/parasite_axes.py
+++ b/lib/mpl_toolkits/axisartist/parasite_axes.py
@@ -1,4 +1,4 @@
-from matplotlib import cbook
+from matplotlib import _api
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
     parasite_axes_auxtrans_class_factory, subplot_class_factory)
@@ -8,5 +8,5 @@ from .axislines import Axes
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with cbook._suppress_matplotlib_deprecation_warning():
+with _api.suppress_matplotlib_deprecation_warning():
     ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/tests/test_axisartist_axislines.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axislines.py
@@ -1,5 +1,5 @@
 import numpy as np
-from matplotlib import cbook
+from matplotlib import _api
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 from matplotlib.transforms import IdentityTransform
@@ -86,7 +86,7 @@ def test_ParasiteAxesAuxTrans(parasite_cls):
         ax1 = SubplotHost(fig, 1, 3, i+1)
         fig.add_subplot(ax1)
 
-        with cbook._suppress_matplotlib_deprecation_warning():
+        with _api.suppress_matplotlib_deprecation_warning():
             ax2 = parasite_cls(ax1, IdentityTransform())
         ax1.parasites.append(ax2)
         if name.startswith('pcolor'):


### PR DESCRIPTION
## PR Summary

Followup of moving all API helpers to `matplotlib._api` (#18657). 
This cleans up internal usages.