### PR TITLE
Make docs fail on Warning (and fix all existing warnings)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,7 +20,6 @@ from matplotlib._api import MatplotlibDeprecationWarning
 import sphinx
 
 from datetime import datetime
-import warnings
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -35,6 +34,9 @@ sys.path.append('.')
 # docs build to fail. This is especially useful for getting rid of deprecated
 # usage in the gallery.
 warnings.filterwarnings('error', append=True)
+#TODO remove when GridSpec allows rect again
+warnings.filterwarnings('ignore', message='(\n|.)*This figure includes Axes '
+                        'that are not compatible with tight_layout.*')
 
 # Strip backslahes in function's signature
 # To be removed when numpydoc > 0.9.x
@@ -116,8 +118,8 @@ autosummary_generate = True
 
 # we should ignore warnings coming from importing deprecated modules for
 # autodoc purposes, as this will disappear automatically when they are removed
-warnings.filterwarnings('ignore', message='.*module was deprecated.*',
-                        category=MatplotlibDeprecationWarning)
+warnings.filterwarnings('ignore', category=MatplotlibDeprecationWarning,
+                        message=r'(\n|.)*module was deprecated.*')
 
 autodoc_docstring_signature = True
 autodoc_default_options = {'members': None, 'undoc-members': None}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,9 +34,6 @@ sys.path.append('.')
 # docs build to fail. This is especially useful for getting rid of deprecated
 # usage in the gallery.
 warnings.filterwarnings('error', append=True)
-#TODO remove when GridSpec allows rect again
-warnings.filterwarnings('ignore', message='(\n|.)*This figure includes Axes '
-                        'that are not compatible with tight_layout.*')
 
 # Strip backslahes in function's signature
 # To be removed when numpydoc > 0.9.x
@@ -119,6 +116,7 @@ autosummary_generate = True
 # we should ignore warnings coming from importing deprecated modules for
 # autodoc purposes, as this will disappear automatically when they are removed
 warnings.filterwarnings('ignore', category=MatplotlibDeprecationWarning,
+                        module='importlib',  # used by sphinx.autodoc.importer
                         message=r'(\n|.)*module was deprecated.*')
 
 autodoc_docstring_signature = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,7 @@ from matplotlib._api import MatplotlibDeprecationWarning
 import sphinx
 
 from datetime import datetime
+import warnings
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
@@ -29,6 +30,11 @@ sys.path.append('.')
 
 # General configuration
 # ---------------------
+
+# Unless we catch the warning explicitly somewhere, a warning should cause the
+# docs build to fail. This is especially useful for getting rid of deprecated
+# usage in the gallery.
+warnings.filterwarnings('error', append=True)
 
 # Strip backslahes in function's signature
 # To be removed when numpydoc > 0.9.x
@@ -108,6 +114,11 @@ os.environ.pop("DISPLAY", None)
 
 autosummary_generate = True
 
+# we should ignore warnings coming from importing deprecated modules for
+# autodoc purposes, as this will disappear automatically when they are removed
+warnings.filterwarnings('ignore', message='.*module was deprecated.*',
+                        category=MatplotlibDeprecationWarning)
+
 autodoc_docstring_signature = True
 autodoc_default_options = {'members': None, 'undoc-members': None}
 
@@ -155,6 +166,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images'),
     'matplotlib_animations': True,
+    'abort_on_example_error': True,
 }
 
 plot_gallery = 'True'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,7 +166,6 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images'),
     'matplotlib_animations': True,
-    'abort_on_example_error': True,
 }
 
 plot_gallery = 'True'

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -91,6 +91,7 @@ Optional, but recommended:
 *  `optipng <http://optipng.sourceforge.net>`_
 *  the font "Humor Sans" (aka the "XKCD" font), or the free alternative
    `Comic Neue <http://comicneue.com/>`_.
+*  the font "Times New Roman"
 
 .. note::
 

--- a/examples/animation/rain.py
+++ b/examples/animation/rain.py
@@ -25,10 +25,10 @@ ax.set_ylim(0, 1), ax.set_yticks([])
 
 # Create rain data
 n_drops = 50
-rain_drops = np.zeros(n_drops, dtype=[('position', float, 2),
-                                      ('size',     float, 1),
-                                      ('growth',   float, 1),
-                                      ('color',    float, 4)])
+rain_drops = np.zeros(n_drops, dtype=[('position', float, (2,)),
+                                      ('size',     float),
+                                      ('growth',   float),
+                                      ('color',    float, (4,))])
 
 # Initialize the raindrops in random positions and with
 # random growth rates.

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -5,8 +5,6 @@ Contourf Demo
 
 How to use the `.axes.Axes.contourf` method to create filled contour plots.
 """
-import copy
-
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -89,10 +87,7 @@ fig2.colorbar(CS3)
 # Illustrate all 4 possible "extend" settings:
 extends = ["neither", "both", "min", "max"]
 cmap = plt.cm.get_cmap("winter")
-# we need a copy of the colormap to modify it
-cmap = copy.copy(cmap)
-cmap.set_under("magenta")
-cmap.set_over("yellow")
+cmap = cmap.with_extremes(under="magenta", over="yellow")
 # Note: contouring simply excludes masked or nan regions, so
 # instead of using the "bad" colormap value for them, it draws
 # nothing at all in them.  Therefore the following would have

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -5,6 +5,7 @@ Contourf Demo
 
 How to use the `.axes.Axes.contourf` method to create filled contour plots.
 """
+import copy
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -88,6 +89,8 @@ fig2.colorbar(CS3)
 # Illustrate all 4 possible "extend" settings:
 extends = ["neither", "both", "min", "max"]
 cmap = plt.cm.get_cmap("winter")
+# we need a copy of the colormap to modify it
+cmap = copy.copy(cmap)
 cmap.set_under("magenta")
 cmap.set_over("yellow")
 # Note: contouring simply excludes masked or nan regions, so

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -55,15 +55,16 @@ _annotate(ax, x, y, "shading='flat'")
 # -----------------------------
 #
 # Often, however, data is provided where *X* and *Y* match the shape of *Z*.
-# As of Matplotlib v3.3, ``shading='flat'`` is deprecated when this is the
-# case, a warning is raised, and the last row and column of *Z* are dropped.
-# This dropping of the last row and column is what Matplotlib did silently
-# previous to v3.3, and is compatible with what Matlab does.
+# While this makes sense for other ``shading`` types, it is no longer permitted
+# when ``shading='flat'`` (and will raise a MatplotlibDeprecationWarning as of
+# Matplotlib v3.3). Historically, Matplotlib silently dropped the last row and
+# column of *Z* in this case, to match Matlab's behavior. If this behavior is
+# still desired, simply drop the last row and column manually:
 
 x = np.arange(ncols)  # note *not* ncols + 1 as before
 y = np.arange(nrows)
 fig, ax = plt.subplots()
-ax.pcolormesh(x, y, Z, shading='flat', vmin=Z.min(), vmax=Z.max())
+ax.pcolormesh(x, y, Z[:-1, :-1], shading='flat', vmin=Z.min(), vmax=Z.max())
 _annotate(ax, x, y, "shading='flat': X, Y, C same shape")
 
 ###############################################################################

--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -51,11 +51,12 @@ ax.pcolormesh(X, Y, Z)
 # ---------------------
 #
 # Often a user wants to pass *X* and *Y* with the same sizes as *Z* to
-# `.axes.Axes.pcolormesh`.  This is also allowed if ``shading='auto'`` is
-# passed (default set by :rc:`pcolor.shading`).  Pre Matplotlib 3.3,
+# `.axes.Axes.pcolormesh`. This is also allowed if ``shading='auto'`` is
+# passed (default set by :rc:`pcolor.shading`). Pre Matplotlib 3.3,
 # ``shading='flat'`` would drop the last column and row of *Z*; while that
 # is still allowed for back compatibility purposes, a DeprecationWarning is
-# raised.
+# raised. If this is really what you want, then simply drop the last row and
+# column of Z manually:
 
 x = np.arange(10)  # len = 10
 y = np.arange(6)  # len = 6
@@ -64,7 +65,8 @@ X, Y = np.meshgrid(x, y)
 fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
 axs[0].pcolormesh(X, Y, Z, vmin=np.min(Z), vmax=np.max(Z), shading='auto')
 axs[0].set_title("shading='auto' = 'nearest'")
-axs[1].pcolormesh(X, Y, Z, vmin=np.min(Z), vmax=np.max(Z), shading='flat')
+axs[1].pcolormesh(X, Y, Z[:-1, :-1], vmin=np.min(Z), vmax=np.max(Z),
+                  shading='flat')
 axs[1].set_title("shading='flat'")
 
 ###############################################################################

--- a/examples/specialty_plots/advanced_hillshading.py
+++ b/examples/specialty_plots/advanced_hillshading.py
@@ -25,7 +25,7 @@ def display_colorbar():
     # Use a proxy artist for the colorbar...
     im = ax.imshow(z, cmap=cmap)
     im.remove()
-    fig.colorbar(im)
+    fig.colorbar(im, ax=ax)
 
     ax.set_title('Using a colorbar with a shaded plot', size='x-large')
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -137,7 +137,8 @@ if __name__ == "__main__":
 
     # Plot a demonstration figure for every available style sheet.
     for style_label in style_list:
-        with plt.style.context(style_label):
-            fig = plot_figure(style_label=style_label)
+        with plt.rc_context({"figure.max_open_warning": len(style_list)}):
+            with plt.style.context(style_label):
+                fig = plot_figure(style_label=style_label)
 
     plt.show()

--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -57,7 +57,8 @@ ax.set_ylabel('PSD')
 ax.set_title('Random spectrum')
 
 
-def safe_inverse(x):
+def one_over(x):
+    """Vectorized 1/x, treating x==0 manually"""
     x = np.array(x).astype(float)
     near_zero = np.isclose(x, 0)
     x[near_zero] = np.inf
@@ -66,10 +67,10 @@ def safe_inverse(x):
 
 
 # the function "1/x" is its own inverse
-forward = safe_inverse
+inverse = one_over
 
 
-secax = ax.secondary_xaxis('top', functions=(forward, safe_inverse))
+secax = ax.secondary_xaxis('top', functions=(one_over, inverse))
 secax.set_xlabel('period [s]')
 plt.show()
 

--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -57,15 +57,19 @@ ax.set_ylabel('PSD')
 ax.set_title('Random spectrum')
 
 
-def forward(x):
-    return 1 / x
+def safe_inverse(x):
+    x = np.array(x).astype(float)
+    near_zero = np.isclose(x, 0)
+    x[near_zero] = np.inf
+    x[~near_zero] = 1 / x[~near_zero]
+    return x
 
 
-def inverse(x):
-    return 1 / x
+# the function "1/x" is its own inverse
+forward = safe_inverse
 
 
-secax = ax.secondary_xaxis('top', functions=(forward, inverse))
+secax = ax.secondary_xaxis('top', functions=(forward, safe_inverse))
 secax.set_xlabel('period [s]')
 plt.show()
 

--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -30,8 +30,10 @@ class LatexPreviewSubplot(maxes.Axes):
         super().__init__(*args, **kwargs)
 
     def draw(self, renderer):
-        with plt.rc_context({"text.latex.preview": self.preview}):
-            super().draw(renderer)
+        from matplotlib import _api  # internal, *do not use*
+        with _api.suppress_matplotlib_deprecation_warning():
+            with plt.rc_context({"text.latex.preview": self.preview}):
+                super().draw(renderer)
 
 
 def test_window_extent(ax, usetex, preview):

--- a/examples/ticks_and_spines/date_precision_and_epochs.py
+++ b/examples/ticks_and_spines/date_precision_and_epochs.py
@@ -18,6 +18,7 @@ microseconds.
 
 """
 import datetime
+import warnings
 import numpy as np
 
 import matplotlib
@@ -113,25 +114,32 @@ print('After Roundtrip:  ', date2)
 # --------
 #
 # This all of course has an effect on plotting.  With the old default epoch
-# the times were rounded, leading to jumps in the data:
+# the times were rounded during the internal ``date2num`` conversion, leading
+# to jumps in the data:
 
 _reset_epoch_for_tutorial()  # Don't do this.  Just for this tutorial.
 mdates.set_epoch(old_epoch)
 
 x = np.arange('2000-01-01T00:00:00.0', '2000-01-01T00:00:00.000100',
               dtype='datetime64[us]')
+# simulate the plot being made using the old epoch
+xold = np.array([mdates.num2date(mdates.date2num(d)) for d in x])
 y = np.arange(0, len(x))
-fig, ax = plt.subplots(constrained_layout=True)
-ax.plot(x, y)
-ax.set_title('Epoch: ' + mdates.get_epoch())
-plt.setp(ax.xaxis.get_majorticklabels(), rotation=40)
-plt.show()
 
-#############################################################################
-# For a more recent epoch, the plot is smooth:
-
+# resetting the Epoch so plots are comparable
 _reset_epoch_for_tutorial()  # Don't do this.  Just for this tutorial.
 mdates.set_epoch(new_epoch)
+
+fig, ax = plt.subplots(constrained_layout=True)
+ax.plot(xold, y)
+ax.set_title('Epoch: ' + mdates.get_epoch())
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", message=".*dates far from the epoch.*")
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=40)
+    plt.show()
+
+#############################################################################
+# For dates plotted using the more recent epoch, the plot is smooth:
 
 fig, ax = plt.subplots(constrained_layout=True)
 ax.plot(x, y)

--- a/examples/ticks_and_spines/date_precision_and_epochs.py
+++ b/examples/ticks_and_spines/date_precision_and_epochs.py
@@ -18,7 +18,6 @@ microseconds.
 
 """
 import datetime
-import warnings
 import numpy as np
 
 import matplotlib
@@ -133,10 +132,8 @@ mdates.set_epoch(new_epoch)
 fig, ax = plt.subplots(constrained_layout=True)
 ax.plot(xold, y)
 ax.set_title('Epoch: ' + mdates.get_epoch())
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", message=".*dates far from the epoch.*")
-    plt.setp(ax.xaxis.get_majorticklabels(), rotation=40)
-    plt.show()
+plt.setp(ax.xaxis.get_majorticklabels(), rotation=40)
+plt.show()
 
 #############################################################################
 # For dates plotted using the more recent epoch, the plot is smooth:

--- a/examples/userdemo/colormap_normalizations.py
+++ b/examples/userdemo/colormap_normalizations.py
@@ -29,10 +29,10 @@ fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolor(X, Y, Z,
                    norm=colors.LogNorm(vmin=Z.min(), vmax=Z.max()),
-                   cmap='PuBu_r')
+                   cmap='PuBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='max')
 
-pcm = ax[1].pcolor(X, Y, Z, cmap='PuBu_r')
+pcm = ax[1].pcolor(X, Y, Z, cmap='PuBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='max')
 
 
@@ -46,10 +46,10 @@ Z1 = (1 + np.sin(Y * 10.)) * X**2
 fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolormesh(X, Y, Z1, norm=colors.PowerNorm(gamma=1. / 2.),
-                       cmap='PuBu_r')
+                       cmap='PuBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='max')
 
-pcm = ax[1].pcolormesh(X, Y, Z1, cmap='PuBu_r')
+pcm = ax[1].pcolormesh(X, Y, Z1, cmap='PuBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='max')
 
 ###############################################################################
@@ -70,10 +70,11 @@ fig, ax = plt.subplots(2, 1)
 pcm = ax[0].pcolormesh(X, Y, Z1,
                        norm=colors.SymLogNorm(linthresh=0.03, linscale=0.03,
                                               vmin=-1.0, vmax=1.0, base=10),
-                       cmap='RdBu_r')
+                       cmap='RdBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 
-pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1))
+pcm = ax[1].pcolormesh(X, Y, Z1, cmap='RdBu_r', vmin=-np.max(Z1),
+                       shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='both')
 
 
@@ -108,10 +109,11 @@ fig, ax = plt.subplots(2, 1)
 
 pcm = ax[0].pcolormesh(X, Y, Z,
                        norm=MidpointNormalize(midpoint=0.),
-                       cmap='RdBu_r')
+                       cmap='RdBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z))
+pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z),
+                       shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='both')
 
 ###############################################################################
@@ -126,16 +128,17 @@ bounds = np.linspace(-1, 1, 10)
 norm = colors.BoundaryNorm(boundaries=bounds, ncolors=256)
 pcm = ax[0].pcolormesh(X, Y, Z,
                        norm=norm,
-                       cmap='RdBu_r')
+                       cmap='RdBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='both', orientation='vertical')
 
 # uneven bounds changes the colormapping:
 bounds = np.array([-0.25, -0.125, 0, 0.5, 1])
 norm = colors.BoundaryNorm(boundaries=bounds, ncolors=256)
-pcm = ax[1].pcolormesh(X, Y, Z, norm=norm, cmap='RdBu_r')
+pcm = ax[1].pcolormesh(X, Y, Z, norm=norm, cmap='RdBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='both', orientation='vertical')
 
-pcm = ax[2].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z1))
+pcm = ax[2].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z1),
+                       shading='nearest')
 fig.colorbar(pcm, ax=ax[2], extend='both', orientation='vertical')
 
 plt.show()

--- a/examples/userdemo/colormap_normalizations_symlognorm.py
+++ b/examples/userdemo/colormap_normalizations_symlognorm.py
@@ -30,10 +30,11 @@ fig, ax = plt.subplots(2, 1)
 pcm = ax[0].pcolormesh(X, Y, Z,
                        norm=colors.SymLogNorm(linthresh=0.03, linscale=0.03,
                                               vmin=-1.0, vmax=1.0, base=10),
-                       cmap='RdBu_r')
+                       cmap='RdBu_r', shading='nearest')
 fig.colorbar(pcm, ax=ax[0], extend='both')
 
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z))
+pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', vmin=-np.max(Z),
+                       shading='nearest')
 fig.colorbar(pcm, ax=ax[1], extend='both')
 
 plt.show()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -524,7 +524,11 @@ class Axes(_AxesBase):
             ax.set_xlabel('frequency [Hz]')
 
             def invert(x):
-                return 1 / x
+                x = np.array(x).astype(float)
+                near_zero = np.isclose(x, 0)
+                x[near_zero] = np.inf
+                x[~near_zero] = 1 / x[~near_zero]
+                return x
 
             secax = ax.secondary_xaxis('top', functions=(invert, invert))
             secax.set_xlabel('Period [s]')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -524,12 +524,14 @@ class Axes(_AxesBase):
             ax.set_xlabel('frequency [Hz]')
 
             def invert(x):
+                # 1/x with special treatment of x == 0
                 x = np.array(x).astype(float)
                 near_zero = np.isclose(x, 0)
                 x[near_zero] = np.inf
                 x[~near_zero] = 1 / x[~near_zero]
                 return x
 
+            # the inverse of 1/x is itself
             secax = ax.secondary_xaxis('top', functions=(invert, invert))
             secax.set_xlabel('Period [s]')
             plt.show()

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -3,5 +3,6 @@ from matplotlib._api.deprecation import (
     MatplotlibDeprecationWarning, mplDeprecation, warn_deprecated, deprecated)
 
 warn_deprecated("3.4",
-                "The module matplotlib.cbook.deprecation is considered "
-                "internal and it will be made private in the future.")
+                message="The module matplotlib.cbook.deprecation is "
+                "considered internal and it will be made private in the "
+                "future.")

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -198,88 +198,15 @@ ax2 = fig.add_subplot(gs1[1])
 example_plot(ax1)
 example_plot(ax2)
 
-gs1.tight_layout(fig, rect=[0, 0, 0.5, 1])
+gs1.tight_layout(fig, rect=[0, 0, 0.5, 1.0])
 
 ###############################################################################
-# For example, this can be used for a figure with multiple gridspecs.
+# However, we do not recommend that this be used to manually construct more
+# complicated layouts, like having one GridSpec in the left and one in the
+# right side of the figure. For these use cases, one should instead take
+# advantage of :doc:`/gallery/subplots_axes_and_figures/gridspec_nested`, or
+# the :doc:`/users/next_whats_new/subfigures`.
 
-fig = plt.figure()
-
-gs1 = gridspec.GridSpec(2, 1)
-ax1 = fig.add_subplot(gs1[0])
-ax2 = fig.add_subplot(gs1[1])
-
-example_plot(ax1)
-example_plot(ax2)
-
-gs1.tight_layout(fig, rect=[0, 0, 0.5, 1])
-
-gs2 = gridspec.GridSpec(3, 1)
-
-for ss in gs2:
-    ax = fig.add_subplot(ss)
-    example_plot(ax)
-    ax.set_title("")
-    ax.set_xlabel("")
-
-ax.set_xlabel("x-label", fontsize=12)
-
-gs2.tight_layout(fig, rect=[0.5, 0, 1, 1], h_pad=0.5)
-
-# We may try to match the top and bottom of two grids ::
-top = min(gs1.top, gs2.top)
-bottom = max(gs1.bottom, gs2.bottom)
-
-gs1.update(top=top, bottom=bottom)
-gs2.update(top=top, bottom=bottom)
-plt.show()
-
-###############################################################################
-# While this should be mostly good enough, adjusting top and bottom may
-# require adjustment of hspace also.  To update hspace & vspace, we call
-# `.GridSpec.tight_layout` again with updated rect argument. Note that the
-# rect argument specifies the area including the ticklabels, etc.  Thus, we
-# will increase the bottom (which is 0 for the normal case) by the difference
-# between the *bottom* from above and the bottom of each gridspec. Same thing
-# for the top.
-
-fig = plt.gcf()
-
-gs1 = gridspec.GridSpec(2, 1)
-ax1 = fig.add_subplot(gs1[0])
-ax2 = fig.add_subplot(gs1[1])
-
-example_plot(ax1)
-example_plot(ax2)
-
-gs1.tight_layout(fig, rect=[0, 0, 0.5, 1])
-
-gs2 = gridspec.GridSpec(3, 1)
-
-for ss in gs2:
-    ax = fig.add_subplot(ss)
-    example_plot(ax)
-    ax.set_title("")
-    ax.set_xlabel("")
-
-ax.set_xlabel("x-label", fontsize=12)
-
-gs2.tight_layout(fig, rect=[0.5, 0, 1, 1], h_pad=0.5)
-
-top = min(gs1.top, gs2.top)
-bottom = max(gs1.bottom, gs2.bottom)
-
-gs1.update(top=top, bottom=bottom)
-gs2.update(top=top, bottom=bottom)
-
-top = min(gs1.top, gs2.top)
-bottom = max(gs1.bottom, gs2.bottom)
-
-gs1.tight_layout(fig, rect=[None, 0 + (bottom-gs1.bottom),
-                            0.5, 1 - (gs1.top-top)])
-gs2.tight_layout(fig, rect=[0.5, 0 + (bottom-gs2.bottom),
-                            None, 1 - (gs2.top-top)],
-                 h_pad=0.5)
 
 ###############################################################################
 # Legends and Annotations

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -205,7 +205,7 @@ gs1.tight_layout(fig, rect=[0, 0, 0.5, 1.0])
 # complicated layouts, like having one GridSpec in the left and one in the
 # right side of the figure. For these use cases, one should instead take
 # advantage of :doc:`/gallery/subplots_axes_and_figures/gridspec_nested`, or
-# the :doc:`/users/next_whats_new/subfigures`.
+# the :doc:`/gallery/subplots_axes_and_figures/subfigures`.
 
 
 ###############################################################################


### PR DESCRIPTION
## PR Summary

Whenever possible, I removed the deprecated/warning code altogether in favor of a more "recommended" solution. Whenever the example was explicitly there to document the deprecated behavior, I made sure to ignore the warning in a way that will cause CI to break if the deprecation is carried out but the example not removed.

Only two types of warnings have to be silenced globally (importing deprecated modules in autodoc, autosummary of deprecated class properties), but I currently also manually silence `tight_layout` as a workaround until I get some clarity on #18904.

With the new configuration, any warning or error during docs build will cause CI to fail, however every warning and error will be shown in the output if there are multiple, both for gallery examples/tutorials and for API docs.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
