### PR TITLE
Added Aria-Labels to all inputs with tooltips for generated HTML animations: issue #17910

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -53,6 +53,7 @@ per-file-ignores =
     lib/matplotlib/_mathtext.py: E221, E251
     lib/matplotlib/_mathtext_data.py: E203, E261
     lib/matplotlib/animation.py: F401
+    lib/matplotlib/_animation_data.py: E501
     lib/matplotlib/axes/__init__.py: F401, F403
     lib/matplotlib/axes/_axes.py: F401
     lib/matplotlib/backends/backend_*.py: F401

--- a/lib/matplotlib/_animation_data.py
+++ b/lib/matplotlib/_animation_data.py
@@ -198,26 +198,26 @@ DISPLAY_TEMPLATE = """
            name="points" min="0" max="1" step="1" value="0"
            oninput="anim{id}.set_frame(parseInt(this.value));"></input>
     <div class="anim-buttons">
-      <button title="Decrease speed" onclick="anim{id}.slower()">
+      <button title="Decrease speed" aria-label="Decrease speed" onclick="anim{id}.slower()">
           <i class="fa fa-minus"></i></button>
-      <button title="First frame" onclick="anim{id}.first_frame()">
+      <button title="First frame" aria-label="First frame" onclick="anim{id}.first_frame()">
         <i class="fa fa-fast-backward"></i></button>
-      <button title="Previous frame" onclick="anim{id}.previous_frame()">
+      <button title="Previous frame" aria-label="Previous frame" onclick="anim{id}.previous_frame()">
           <i class="fa fa-step-backward"></i></button>
-      <button title="Play backwards" onclick="anim{id}.reverse_animation()">
+      <button title="Play backwards" aria-label="Play backwards" onclick="anim{id}.reverse_animation()">
           <i class="fa fa-play fa-flip-horizontal"></i></button>
-      <button title="Pause" onclick="anim{id}.pause_animation()">
+      <button title="Pause" aria-label="Pause" onclick="anim{id}.pause_animation()">
           <i class="fa fa-pause"></i></button>
-      <button title="Play" onclick="anim{id}.play_animation()">
+      <button title="Play" aria-label="Play" onclick="anim{id}.play_animation()">
           <i class="fa fa-play"></i></button>
-      <button title="Next frame" onclick="anim{id}.next_frame()">
+      <button title="Next frame" aria-label="Next frame" onclick="anim{id}.next_frame()">
           <i class="fa fa-step-forward"></i></button>
-      <button title="Last frame" onclick="anim{id}.last_frame()">
+      <button title="Last frame" aria-label="Last frame" onclick="anim{id}.last_frame()">
           <i class="fa fa-fast-forward"></i></button>
-      <button title="Increase speed" onclick="anim{id}.faster()">
+      <button title="Increase speed" aria-label="Increase speed" onclick="anim{id}.faster()">
           <i class="fa fa-plus"></i></button>
     </div>
-    <form title="Repetition mode" action="#n" name="_anim_loop_select{id}"
+    <form title="Repetition mode" aria-label="Repetition mode" action="#n" name="_anim_loop_select{id}"
           class="anim-state">
       <input type="radio" name="state" value="once" id="_anim_radio1_{id}"
              {once_checked}>


### PR DESCRIPTION

## PR Summary
Added aria label attributes to generated HTML to increase accessibility for screenreaders.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
