### PR TITLE
Factor out common functionality in HostAxes.twin{,x,y}.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -248,21 +248,11 @@ class HostAxesBase:
         The y-axis of self will have ticks on the left and the returned axes
         will have ticks on the right.
         """
-        if axes_class is None:
-            axes_class = self._get_base_axes()
-
-        parasite_axes_class = parasite_axes_class_factory(axes_class)
-
-        ax2 = parasite_axes_class(self, sharex=self)
-        self.parasites.append(ax2)
-        ax2._remove_method = self._remove_any_twin
-
+        ax = self._add_twin_axes(axes_class, sharex=self)
         self.axis["right"].set_visible(False)
-
-        ax2.axis["right"].set_visible(True)
-        ax2.axis["left", "top", "bottom"].set_visible(False)
-
-        return ax2
+        ax.axis["right"].set_visible(True)
+        ax.axis["left", "top", "bottom"].set_visible(False)
+        return ax
 
     def twiny(self, axes_class=None):
         """
@@ -271,21 +261,11 @@ class HostAxesBase:
         The x-axis of self will have ticks on the bottom and the returned axes
         will have ticks on the top.
         """
-        if axes_class is None:
-            axes_class = self._get_base_axes()
-
-        parasite_axes_class = parasite_axes_class_factory(axes_class)
-
-        ax2 = parasite_axes_class(self, sharey=self)
-        self.parasites.append(ax2)
-        ax2._remove_method = self._remove_any_twin
-
+        ax = self._add_twin_axes(axes_class, sharey=self)
         self.axis["top"].set_visible(False)
-
-        ax2.axis["top"].set_visible(True)
-        ax2.axis["left", "right", "bottom"].set_visible(False)
-
-        return ax2
+        ax.axis["top"].set_visible(True)
+        ax.axis["left", "right", "bottom"].set_visible(False)
+        return ax
 
     def twin(self, aux_trans=None, axes_class=None):
         """
@@ -294,23 +274,27 @@ class HostAxesBase:
         While self will have ticks on the left and bottom axis, the returned
         axes will have ticks on the top and right axis.
         """
-        if axes_class is None:
-            axes_class = self._get_base_axes()
-
-        parasite_axes_class = parasite_axes_class_factory(axes_class)
-
         if aux_trans is None:
             aux_trans = mtransforms.IdentityTransform()
-        ax2 = parasite_axes_class(self, aux_trans, viewlim_mode="transform")
-        self.parasites.append(ax2)
-        ax2._remove_method = self._remove_any_twin
-
+        ax = self._add_twin_axes(
+            axes_class, aux_transform=aux_trans, viewlim_mode="transform")
         self.axis["top", "right"].set_visible(False)
+        ax.axis["top", "right"].set_visible(True)
+        ax.axis["left", "bottom"].set_visible(False)
+        return ax
 
-        ax2.axis["top", "right"].set_visible(True)
-        ax2.axis["left", "bottom"].set_visible(False)
+    def _add_twin_axes(self, axes_class, **kwargs):
+        """
+        Helper for `.twinx`/`.twiny`/`.twin`.
 
-        return ax2
+        *kwargs* are forwarded to the parasite axes constructor.
+        """
+        if axes_class is None:
+            axes_class = self._get_base_axes()
+        ax = parasite_axes_class_factory(axes_class)(self, **kwargs)
+        self.parasites.append(ax)
+        ax._remove_method = self._remove_any_twin
+        return ax
 
     def _remove_any_twin(self, ax):
         self.parasites.remove(ax)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
