### PR TITLE
Fix typo in error message: interable -> iterable.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1852,7 +1852,7 @@ class _AxesBase(martist.Artist):
                     xmin, xmax, ymin, ymax = limits
                 except (TypeError, ValueError) as err:
                     raise TypeError('the first argument to axis() must be an '
-                                    'interable of the form '
+                                    'iterable of the form '
                                     '[xmin, xmax, ymin, ymax]') from err
             else:
                 xmin = kwargs.pop('xmin', None)


### PR DESCRIPTION
## PR Summary

This PR fixes a typo in an error message for `plt.axes()`.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).