### PR TITLE
Set clip path for PostScript texts.

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -8,7 +8,7 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import cbook, patheffects
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 from matplotlib.cbook import MatplotlibDeprecationWarning
 
 
@@ -165,3 +165,11 @@ def test_useafm():
 @image_comparison(["type3.eps"])
 def test_type3_font():
     plt.figtext(.5, .5, "I/J")
+
+
+@check_figures_equal(extensions=["eps"])
+def test_text_clip(fig_test, fig_ref):
+    ax = fig_test.add_subplot()
+    # Fully clipped-out text should not appear.
+    ax.text(0, 0, "hello", transform=fig_test.transFigure, clip_on=True)
+    fig_ref.add_subplot()


### PR DESCRIPTION
## PR Summary

The clip path/clip box were simply not set at all before.

Also move `_convert_path`/`_get_clip_cmd` (previously `_get_clip_path`)
above the block where all `draw_foo`s are defined, rather than being in
the middle of them.

Closes https://github.com/matplotlib/matplotlib/issues/4321.

Goes on top of https://github.com/matplotlib/matplotlib/pull/18894.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
