### PR TITLE
Strictly increasing check with test coverage for streamplot grid

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -25,8 +25,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     Parameters
     ----------
-    x, y : 1D arrays
-        An evenly spaced grid.
+    x, y : 1D/2D arrays
+        Evenly spaced strictly increasing arrays to make a grid.
     u, v : 2D arrays
         *x* and *y*-velocities. The number of rows and columns must match
         the length of *y* and *x*, respectively.
@@ -332,6 +332,11 @@ class Grid:
             y = y_col
         else:
             raise ValueError("'y' can have at maximum 2 dimensions")
+
+        if not (np.diff(x) > 0).all():
+            raise ValueError("'x' must be strictly increasing")
+        if not (np.diff(y) > 0).all():
+            raise ValueError("'y' must be strictly increasing")
 
         self.nx = len(x)
         self.ny = len(y)

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -2,6 +2,7 @@ import sys
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+import pytest
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.transforms as mtransforms
@@ -114,3 +115,49 @@ def test_streamplot_limits():
     # datalim.
     assert_array_almost_equal(ax.dataLim.bounds, (20, 30, 15, 6),
                               decimal=1)
+
+
+def test_streamplot_grid():
+    u = np.ones((2, 2))
+    v = np.zeros((2, 2))
+
+    # Test for same rows and columns
+    x = np.array([[10, 20], [10, 30]])
+    y = np.array([[10, 10], [20, 20]])
+
+    with pytest.raises(ValueError, match="The rows of 'x' must be equal"):
+        plt.streamplot(x, y, u, v)
+
+    x = np.array([[10, 20], [10, 20]])
+    y = np.array([[10, 10], [20, 30]])
+
+    with pytest.raises(ValueError, match="The columns of 'y' must be equal"):
+        plt.streamplot(x, y, u, v)
+
+    x = np.array([[10, 20], [10, 20]])
+    y = np.array([[10, 10], [20, 20]])
+    plt.streamplot(x, y, u, v)
+
+    # Test for maximum dimensions
+    x = np.array([0, 10])
+    y = np.array([[[0, 10]]])
+
+    with pytest.raises(ValueError, match="'y' can have at maximum "
+                                         "2 dimensions"):
+        plt.streamplot(x, y, u, v)
+
+    # Test for equal spacing
+    u = np.ones((3, 3))
+    v = np.zeros((3, 3))
+    x = np.array([0, 10, 20])
+    y = np.array([0, 10, 30])
+
+    with pytest.raises(ValueError, match="'y' values must be equally spaced"):
+        plt.streamplot(x, y, u, v)
+
+    # Test for strictly increasing
+    x = np.array([0, 20, 40])
+    y = np.array([0, 20, 10])
+
+    with pytest.raises(ValueError, match="'y' must be strictly increasing"):
+        plt.streamplot(x, y, u, v)


### PR DESCRIPTION
## PR Summary
This PR fixes #18898, adds check for strictly increasing `x` and `y` in `matplotlib.streamplot.Grid`, and adds test coverage for it.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
