### PR TITLE
DOC: Fix latexpdf build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -352,8 +352,43 @@ latex_elements = {}
 latex_elements['babel'] = r'\usepackage{babel}'
 
 # Font configuration
-# Sphinx default since 2.x is GNU FreeFont
-latex_elements['fontpkg'] = r'\setmainfont{DejaVu Serif}'
+# Sphinx 2.0 adopts GNU FreeFont by default, but it does not have all
+# the Unicode codepoints needed for the section about Mathtext
+# "Writing mathematical expressions"
+latex_elements['fontpkg'] = r"""
+\setmainfont{XITS}[
+  Extension      = .otf,
+  UprightFont    = *-Regular,
+  ItalicFont     = *-Italic,
+  BoldFont       = *-Bold,
+  BoldItalicFont = *-BoldItalic,
+]
+\setsansfont{FreeSans}[
+  Extension      = .otf,
+  UprightFont    = *,
+  ItalicFont     = *Oblique,
+  BoldFont       = *Bold,
+  BoldItalicFont = *BoldOblique,
+]
+\setmonofont{FreeMono}[
+  Extension      = .otf,
+  UprightFont    = *,
+  ItalicFont     = *Oblique,
+  BoldFont       = *Bold,
+  BoldItalicFont = *BoldOblique,
+]
+% needed for \mathbb (blackboard alphabet) to actually work
+\usepackage{unicode-math}
+\setmathfont{XITS Math}
+"""
+# Sphinx <1.8.0 or >=2.0.0 does this by default, but the 1.8.x series
+# did not for latex_engine = 'xelatex' (as it used Latin Modern font).
+# We need this for code-blocks as FreeMono has wide glyphs.
+latex_elements['fvset'] = r'\fvset{fontsize=\small}'
+# Fix fancyhdr complaining about \headheight being too small
+latex_elements['passoptionstopackages'] = r"""
+    \PassOptionsToPackage{headheight=14pt}{geometry}
+"""
 
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r"""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -422,6 +422,9 @@ latex_elements['preamble'] = r"""
 latex_elements['maxlistdepth'] = '10'
 latex_elements['pointsize'] = '11pt'
 
+# Better looking general index in PDF
+latex_elements['printindex'] = r'\footnotesize\raggedright\printindex'
+
 # Documents to append as an appendix to all manuals.
 latex_appendices = []
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -352,6 +352,12 @@ latex_elements = {}
 latex_elements['babel'] = r'\usepackage{babel}'
 
 # Font configuration
+# Fix fontspec converting " into right curly quotes in PDF
+# cf https://github.com/sphinx-doc/sphinx/pull/6888/
+latex_elements['fontenc'] = r'''
+\usepackage{fontspec}
+\defaultfontfeatures[\rmfamily,\sffamily,\ttfamily]{}
+'''
 # Sphinx 2.0 adopts GNU FreeFont by default, but it does not have all
 # the Unicode codepoints needed for the section about Mathtext
 # "Writing mathematical expressions"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -358,32 +358,52 @@ latex_elements['fontenc'] = r'''
 \usepackage{fontspec}
 \defaultfontfeatures[\rmfamily,\sffamily,\ttfamily]{}
 '''
+
 # Sphinx 2.0 adopts GNU FreeFont by default, but it does not have all
 # the Unicode codepoints needed for the section about Mathtext
 # "Writing mathematical expressions"
-latex_elements['fontpkg'] = r"""
-\setmainfont{XITS}[
+fontpkg = r"""
+\IfFontExistsTF{XITS}{
+ \setmainfont{XITS}
+}{
+ \setmainfont{XITS}[
+  Extension      = .otf,
   UprightFont    = *-Regular,
   ItalicFont     = *-Italic,
   BoldFont       = *-Bold,
   BoldItalicFont = *-BoldItalic,
-]
-\setsansfont{FreeSans}[
+]}
+\IfFontExistsTF{FreeSans}{
+ \setsansfont{FreeSans}
+}{
+ \setsansfont{FreeSans}[
+  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,
   BoldItalicFont = *BoldOblique,
-]
-\setmonofont{FreeMono}[
+]}
+\IfFontExistsTF{FreeMono}{
+ \setmonofont{FreeMono}
+}{
+ \setmonofont{FreeMono}[
+  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,
   BoldItalicFont = *BoldOblique,
-]
+]}
 % needed for \mathbb (blackboard alphabet) to actually work
 \usepackage{unicode-math}
-\setmathfont{XITS Math}
+\IfFontExistsTF{XITS Math}{
+ \setmathfont{XITS Math}
+}{
+ \setmathfont{XITSMath-Regular}[
+  Extension      = .otf,
+]}
 """
+latex_elements['fontpkg'] = fontpkg
+
 # Sphinx <1.8.0 or >=2.0.0 does this by default, but the 1.8.x series
 # did not for latex_engine = 'xelatex' (as it used Latin Modern font).
 # We need this for code-blocks as FreeMono has wide glyphs.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -363,21 +363,18 @@ latex_elements['fontenc'] = r'''
 # "Writing mathematical expressions"
 latex_elements['fontpkg'] = r"""
 \setmainfont{XITS}[
-  Extension      = .otf,
   UprightFont    = *-Regular,
   ItalicFont     = *-Italic,
   BoldFont       = *-Bold,
   BoldItalicFont = *-BoldItalic,
 ]
 \setsansfont{FreeSans}[
-  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,
   BoldItalicFont = *BoldOblique,
 ]
 \setmonofont{FreeMono}[
-  Extension      = .otf,
   UprightFont    = *,
   ItalicFont     = *Oblique,
   BoldFont       = *Bold,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -342,7 +342,19 @@ latex_documents = [
 # the title page.
 latex_logo = None
 
+# Use Unicode aware LaTeX engine
+latex_engine = 'xelatex'  # or 'lualatex'
+
 latex_elements = {}
+
+# Keep babel usage also with xelatex (Sphinx default is polyglossia)
+# If this key is removed or changed, latex build directory must be cleaned
+latex_elements['babel'] = r'\usepackage{babel}'
+
+# Font configuration
+# Sphinx default since 2.x is GNU FreeFont
+latex_elements['fontpkg'] = r'\setmainfont{DejaVu Serif}'
+
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r"""
    % One line per author on title page
@@ -354,11 +366,6 @@ latex_elements['preamble'] = r"""
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
-
-   \usepackage{amsmath}
-   \usepackage{amsfonts}
-   \usepackage{amssymb}
-   \usepackage{txfonts}
 
    % The enumitem package provides unlimited nesting of lists and
    % enums.  Sphinx may use this in the future, in which case this can
@@ -392,13 +399,6 @@ texinfo_documents = [
 # numpydoc config
 
 numpydoc_show_class_members = False
-
-latex_engine = 'xelatex'  # or 'lualatex'
-
-latex_elements = {
-    'babel': r'\usepackage{babel}',
-    'fontpkg': r'\setmainfont{DejaVu Serif}',
-}
 
 html4_writer = True
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -360,20 +360,31 @@ latex_elements['preamble'] = r"""
    % One line per author on title page
    \DeclareRobustCommand{\and}%
      {\end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}}%
-   % In the parameters section, place a newline after the Parameters
-   % header.  (This is stolen directly from Numpy's conf.py, since it
-   % affects Numpy-style docstrings).
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
-
-   % The enumitem package provides unlimited nesting of lists and
-   % enums.  Sphinx may use this in the future, in which case this can
-   % be removed.  See
-   % https://bitbucket.org/birkenfeld/sphinx/issue/777/latex-output-too-deeply-nested
-   \usepackage{enumitem}
-   \setlistdepth{2048}
+   % But expdlist old LaTeX package requires fixes:
+   % 1) remove extra space
+   \usepackage{etoolbox}
+   \makeatletter
+   \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+   \makeatother
+   % 2) fix bug in expdlist's way of breaking the line after long item label
+   \makeatletter
+   \def\breaklabel{%
+       \def\@breaklabel{%
+           \leavevmode\par
+           % now a hack because Sphinx inserts \leavevmode after term node
+           \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+      }%
+   }
+   \makeatother
 """
+# Sphinx 1.5 provides this to avoid "too deeply nested" LaTeX error
+# and usage of "enumitem" LaTeX package is unneeded.
+# Value can be increased but do not set it to something such as 2048
+# which needlessly would trigger creation of thousands of TeX macros
+latex_elements['maxlistdepth'] = '10'
 latex_elements['pointsize'] = '11pt'
 
 # Documents to append as an appendix to all manuals.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -398,12 +398,13 @@ latex_elements['preamble'] = r"""
    % One line per author on title page
    \DeclareRobustCommand{\and}%
      {\end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}}%
+   \usepackage{etoolbox}
+   \AtBeginEnvironment{sphinxthebibliography}{\appendix\part{Appendices}}
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
    % But expdlist old LaTeX package requires fixes:
    % 1) remove extra space
-   \usepackage{etoolbox}
    \makeatletter
    \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
    \makeatother

--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -100,38 +100,28 @@ symbols = [
 
 
 def run(state_machine):
-    def get_n(n, l):
-        part = []
-        for x in l:
-            part.append(x)
-            if len(part) == n:
-                yield part
-                part = []
-        yield part
+    def render_symbol(sym):
+        if sym.startswith("\\"):
+            sym = sym[1:]
+            if sym not in {*mathtext.Parser._overunder_functions,
+                           *mathtext.Parser._function_names}:
+                sym = chr(mathtext.tex2uni[sym])
+        return f'\\{sym}' if sym in ('\\', '|') else sym
 
     lines = []
     for category, columns, syms in symbols:
         syms = sorted(syms.split())
+        columns = min(columns, len(syms))
         lines.append("**%s**" % category)
         lines.append('')
         max_width = max(map(len, syms)) * 2 + 16
         header = "    " + (('=' * max_width) + ' ') * columns
         lines.append(header)
-        for part in get_n(columns, syms):
-            line = (
-                "    " +
-                " ".join(
-                    "{} ``{}``".format(
-                        sym
-                        if not sym.startswith("\\")
-                        else sym[1:]
-                        if (sym[1:] in mathtext.Parser._overunder_functions
-                            or sym[1:] in mathtext.Parser._function_names)
-                        else chr(mathtext.tex2uni[sym[1:]]),
-                        sym)
-                    .rjust(max_width)
-                    for sym in part))
-            lines.append(line)
+        for part in range(0, len(syms), columns):
+            row = " ".join(
+                f"{render_symbol(sym)} ``{sym}``".rjust(max_width)
+                for sym in syms[part:part + columns])
+            lines.append(f"    {row}")
         lines.append(header)
         lines.append('')
 

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -94,7 +94,7 @@ produces
 
 .. math::
 
-    \frac{3}{4} \binom{3}{4} \genfrac{}{}{0}{}{3}{4}
+    \frac{3}{4} \binom{3}{4} \genfrac{}{}{0pt}{}{3}{4}
 
 Fractions can be arbitrarily nested::
 


### PR DESCRIPTION
## PR Summary

This is a rebase of #15797, plus additional fixes for new errors and a patch for macOS font paths.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).