### PR TITLE
Deprecate AxisArtist.ZORDER

### DIFF
--- a/doc/api/next_api_changes/deprecations/18949-TH.rst
+++ b/doc/api/next_api_changes/deprecations/18949-TH.rst
@@ -1,0 +1,3 @@
+``AxisArtist.ZORDER``
+~~~~~~~~~~~~~~~~~~~~~
+use ``AxisArtist.zorder`` instead.

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -629,7 +629,12 @@ class AxisArtist(martist.Artist):
     is constant) line, ticks, ticklabels, and axis label.
     """
 
-    zorder = ZORDER = 2.5  # ZORDER is a backcompat alias.
+    zorder = 2.5
+
+    @_api.deprecated("3.4")
+    @_api.classproperty
+    def ZORDER(cls):
+        return cls.zorder
 
     @property
     def LABELPAD(self):


### PR DESCRIPTION
## PR Summary

Due to conversion to a property, setting ZORDER now raises an error. However, before that you could set ZORDER, but it would not have had any effect. Therefore, I accept the change to raising and I do not introduce a deprecated setter property.