### PR TITLE
PR: Remove modality of figure options

### DIFF
--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -716,7 +716,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         image = str(cbook._get_data_path('images/matplotlib.png'))
         dia = SubplotToolQt(self.canvas.figure, self.canvas.parent())
         dia.setWindowIcon(QtGui.QIcon(image))
-        dia.exec_()
+        dia.show()
 
     def save_figure(self, *args):
         filetypes = self.canvas.get_supported_filetypes_grouped()
@@ -820,7 +820,7 @@ class SubplotToolQt(QtWidgets.QDialog):
             QtGui.QFontMetrics(text.document().defaultFont())
             .size(0, text.toPlainText()).height() + 20)
         text.setMaximumSize(size)
-        dialog.exec_()
+        dialog.show()
 
     def _on_value_changed(self):
         spinboxes = self._spinboxes

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -605,6 +605,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
         self.coordinates = coordinates
         self._actions = {}  # mapping of toolitem method names to QActions.
+        self._subplot_dialog = None
 
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:
@@ -714,9 +715,10 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
     def configure_subplots(self):
         image = str(cbook._get_data_path('images/matplotlib.png'))
-        dia = SubplotToolQt(self.canvas.figure, self.canvas.parent())
-        dia.setWindowIcon(QtGui.QIcon(image))
-        dia.show()
+        self._subplot_dialog = SubplotToolQt(
+            self.canvas.figure, self.canvas.parent())
+        self._subplot_dialog.setWindowIcon(QtGui.QIcon(image))
+        self._subplot_dialog.show()
 
     def save_figure(self, *args):
         filetypes = self.canvas.get_supported_filetypes_grouped()
@@ -800,13 +802,14 @@ class SubplotToolQt(QtWidgets.QDialog):
         self._figure = targetfig
         self._defaults = {spinbox: vars(self._figure.subplotpars)[attr]
                           for attr, spinbox in self._spinboxes.items()}
+        self._export_values_dialog = None
 
     def _export_values(self):
         # Explicitly round to 3 decimals (which is also the spinbox precision)
         # to avoid numbers of the form 0.100...001.
-        dialog = QtWidgets.QDialog()
+        self._export_values_dialog = QtWidgets.QDialog()
         layout = QtWidgets.QVBoxLayout()
-        dialog.setLayout(layout)
+        self._export_values_dialog.setLayout(layout)
         text = QtWidgets.QPlainTextEdit()
         text.setReadOnly(True)
         layout.addWidget(text)
@@ -820,7 +823,7 @@ class SubplotToolQt(QtWidgets.QDialog):
             QtGui.QFontMetrics(text.document().defaultFont())
             .size(0, text.toPlainText()).height() + 20)
         text.setMaximumSize(size)
-        dialog.show()
+        self._export_values_dialog.show()
 
     def _on_value_changed(self):
         spinboxes = self._spinboxes

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -527,6 +527,12 @@ def fedit(data, title="", comment="", icon=None, parent=None, apply=None):
     if QtWidgets.QApplication.startingUp():
         _app = QtWidgets.QApplication([])
     dialog = FormDialog(data, title, comment, icon, parent, apply)
+
+    if parent is not None:
+        if hasattr(parent, "_fedit_dialog"):
+            parent._fedit_dialog.close()
+        parent._fedit_dialog = dialog
+
     dialog.show()
 
 

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -478,6 +478,7 @@ class FormDialog(QtWidgets.QDialog):
 
     def accept(self):
         self.data = self.formwidget.get()
+        self.apply_callback(self.data)
         super().accept()
 
     def reject(self):
@@ -526,8 +527,7 @@ def fedit(data, title="", comment="", icon=None, parent=None, apply=None):
     if QtWidgets.QApplication.startingUp():
         _app = QtWidgets.QApplication([])
     dialog = FormDialog(data, title, comment, icon, parent, apply)
-    if dialog.exec_():
-        return dialog.get()
+    dialog.show()
 
 
 if __name__ == "__main__":

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -259,10 +259,8 @@ def figure_edit(axes, parent=None):
         if not (axes.get_xlim() == orig_xlim and axes.get_ylim() == orig_ylim):
             figure.canvas.toolbar.push_current()
 
-    data = _formlayout.fedit(
+    _formlayout.fedit(
         datalist, title="Figure options", parent=parent,
         icon=QtGui.QIcon(
             str(cbook._get_data_path('images', 'qt4_editor_options.svg'))),
         apply=apply_callback)
-    if data is not None:
-        apply_callback(data)


### PR DESCRIPTION
## PR Summary
The figure options dialogue is no longer modal, which means the figure can be interacted with while the dialogue is open, and it fixes https://github.com/matplotlib/matplotlib/issues/18965

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
