### PR TITLE
Remove unnecessary calls to lower().

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2601,9 +2601,9 @@ class _AxesBase(martist.Artist):
                     for ax in self._shared_y_axes.get_siblings(self)
                     if hasattr(ax, "lines")
                     for artist in ax.get_children()]))
-        if self.get_xscale().lower() == 'log':
+        if self.get_xscale() == 'log':
             x_stickies = x_stickies[x_stickies > 0]
-        if self.get_yscale().lower() == 'log':
+        if self.get_yscale() == 'log':
             y_stickies = y_stickies[y_stickies > 0]
 
         def handle_single_axis(scale, autoscaleon, shared_axes, interval,

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -98,11 +98,10 @@ class Tick(martist.Artist):
         self.set_figure(axes.figure)
         self.axes = axes
 
-        name = self.__name__.lower()
-
         self._loc = loc
         self._major = major
 
+        name = self.__name__
         major_minor = "major" if major else "minor"
 
         if size is None:
@@ -448,7 +447,7 @@ class XTick(Tick):
     def apply_tickdir(self, tickdir):
         """Set tick direction. Valid values are 'in', 'out', 'inout'."""
         if tickdir is None:
-            tickdir = mpl.rcParams['%s.direction' % self.__name__.lower()]
+            tickdir = mpl.rcParams[f'{self.__name__}.direction']
         _api.check_in_list(['in', 'out', 'inout'], tickdir=tickdir)
         self._tickdir = tickdir
 
@@ -520,7 +519,7 @@ class YTick(Tick):
 
     def apply_tickdir(self, tickdir):
         if tickdir is None:
-            tickdir = mpl.rcParams['%s.direction' % self.__name__.lower()]
+            tickdir = mpl.rcParams[f'{self.__name__}.direction']
         self._tickdir = tickdir
 
         if self._tickdir == 'in':

--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -149,10 +149,9 @@ class BlockingMouseInput(BlockingInput):
         if event.key is None:
             # At least in OSX gtk backend some keys return None.
             return
-        key = event.key.lower()
-        if key in ['backspace', 'delete']:
+        if event.key in ['backspace', 'delete']:
             self.mouse_event_pop(event)
-        elif key in ['escape', 'enter']:
+        elif event.key in ['escape', 'enter']:
             self.mouse_event_stop(event)
         else:
             self.mouse_event_add(event)


### PR DESCRIPTION
`get_xscale()` returns "log" (lowercase) even after `set_xscale("LOG")`.

The `__name__` of `XTick`/`YTick` instances are already lowercase, no
need to lowercase them again.

Special (backspace/delete/...) keys are always in lowercase already.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
