### PR TITLE
Scalar mappable

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -991,10 +991,10 @@ class Artist:
                         raise AttributeError(f"{type(self).__name__!r} object "
                                              f"has no property {k!r}")
                     # allow batch update properties
-                    if isinstance(v, dict):
+                    try:
                         ret.append(func(**v))
                     # traditional updater
-                    else:
+                    except:
                         ret.append(func(v))
         if ret:
             self.pchanged()

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -990,7 +990,12 @@ class Artist:
                     if not callable(func):
                         raise AttributeError(f"{type(self).__name__!r} object "
                                              f"has no property {k!r}")
-                    ret.append(func(v))
+                    # allow batch update properties
+                    if isinstance(v, dict):
+                        ret.append(func(**v))
+                    # traditional updater
+                    else:
+                        ret.append(func(v))
         if ret:
             self.pchanged()
             self.stale = True

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -155,7 +155,7 @@ class ScalarMappable:
     RGBA colors from the given colormap.
 
     """
-    def __init__(self, norm=None, cmap=None):
+    def __init__(self, norm=None, cmap=None, data=None):
         """
 
         Parameters
@@ -167,7 +167,13 @@ class ScalarMappable:
             initializes its scaling based on the first data processed.
         cmap : str or `~matplotlib.colors.Colormap`
             The colormap used to map normalized data values to RGBA colors.
+
+        data : np.ndarray or list of list
+            Sorted rbg values of the colors to be represented
         """
+        if not data is None:
+            cmap = colors.ListedColormap(data)
+            norm = colors.Normalize(vmin = 0, vmax = 1)
         self._A = None
         self.norm = None  # So that the setter knows we're initializing.
         self.set_norm(norm)  # The Normalize instance of this ScalarMappable.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -173,7 +173,7 @@ class ScalarMappable:
         """
         if not data is None:
             cmap = colors.ListedColormap(data)
-            norm = colors.Normalize(vmin = 0, vmax = 1)
+            norm = colors.Normalize(vmin=0, vmax=1)
         self._A = None
         self.norm = None  # So that the setter knows we're initializing.
         self.set_norm(norm)  # The Normalize instance of this ScalarMappable.


### PR DESCRIPTION
## PR Summary
Added `nested list` or `np.ndarray` input to scalarmappable.  Working with colorbars requires a mappable. When venturing into custom colormaps, I noticed I was using some boilerplate to allow a `plt.cm.Scalarmappable` to be created from `np.ndarray`, this PR adds this feature to `Scalarmappable`. 

# Example

``` 
import matplotlib.pyplot as plt


c = [[0.0, 0.0, 0.0, 1.0], 
     [0.4287313725490196, 0.0, 0.613078431372549, 1.0],
     [0.0, 0.18301960784313726, 0.8667, 1.0], 
     [0.0, 0.6444666666666666, 0.7333666666666667, 1.0], 
     [0.0, 0.6091549019607843, 0.07319803921568624, 1.0], 
     [0.0, 0.8849960784313726, 0.0, 1.0], 
     [0.7999666666666666, 0.9777666666666667, 0.0, 1.0], 
     [1.0, 0.6784313725490196, 0.0, 1.0], 
     [0.8928372549019608, 0.0, 0.0, 1.0],
     [0.8, 0.8, 0.8, 1.0]]
hh = plt.cm.ScalarMappable(data = c)
fig, ax = plt.subplots()
fig.colorbar(hh, cax = ax)
fig.show()
```

![image](https://user-images.githubusercontent.com/19485143/99553653-ac873800-29be-11eb-814d-03f2070d9c99.png)

Let me know what you think. 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
