### PR TITLE
Simplify contour_label_demo.

### DIFF
--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -27,31 +27,21 @@ Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (Z1 - Z2) * 2
 
 ###############################################################################
-# Make contour labels using creative float classes
-# Follows suggestion of Manuel Metz
-
-# Define a class that forces representation of float to look a certain way
-# This remove trailing zero so '1.0' becomes '1'
+# Make contour labels wuth custom level formatters
 
 
-class nf(float):
-    def __repr__(self):
-        s = f'{self:.1f}'
-        return f'{self:.0f}' if s[-1] == '0' else s
+# This custom formatter removes trailing zeros, e.g. "1.0" becomes "1", and
+# then adds a percent sign.
+def fmt(x):
+    s = f"{x:.1f}"
+    if s.endswith("0"):
+        s = f"{x:.0f}"
+    return rf"{s} \%" if plt.rcParams["text.usetex"] else f"{s} %"
 
 
 # Basic contour plot
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z)
-
-# Recast levels to new class
-CS.levels = [nf(val) for val in CS.levels]
-
-# Label levels with specially formatted floats
-if plt.rcParams["text.usetex"]:
-    fmt = r'%r \%%'
-else:
-    fmt = '%r %%'
 
 ax.clabel(CS, CS.levels, inline=True, fmt=fmt, fontsize=10)
 


### PR DESCRIPTION
Using a custom float subclass is very overkill, one can simply use a
custom formatter.

xref https://github.com/matplotlib/matplotlib/issues/18974.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
