### PR TITLE
API: Remove deprecated axes kwargs collision detection

### DIFF
--- a/doc/api/next_api_changes/deprecations/18978-LPS.rst
+++ b/doc/api/next_api_changes/deprecations/18978-LPS.rst
@@ -1,0 +1,5 @@
+pyplot.gca()
+~~~~~~~~~~~~
+
+Passing keyword arguments to ``.pyplot.gca`` will not be supported in a future
+release.

--- a/doc/api/next_api_changes/development/18978-LPS.rst
+++ b/doc/api/next_api_changes/development/18978-LPS.rst
@@ -1,0 +1,8 @@
+Changes to _AxesStack, preparing for its removal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The behavior of the internal ``.figure._AxesStack`` class has changed
+significantly in the process of removing the old behavior of gca() with regard
+to keyword arguments. When the deprecated behavior has been fully removed and
+gca() no longer takes keyword arguments, the ``.figure._AxesStack`` class will
+be removed.

--- a/doc/users/next_whats_new/axes_kwargs_collision.rst
+++ b/doc/users/next_whats_new/axes_kwargs_collision.rst
@@ -1,0 +1,18 @@
+Changes to behavior of Axes creation methods (gca(), add_axes(), add_subplot())
+-------------------------------------------------------------------------------
+
+The behavior of the functions to create new axes (``.pyplot.subplot``,
+``.figure.Figure.add_axes``, ``.figure.Figure.add_subplot``) has changed. In
+the past, these functions would detect if you were attempting to create Axes
+with the same keyword arguments as already-existing axes in the current figure,
+and if so, they would return the existing Axes. Now, these functions will
+always create new Axes.
+
+Correspondingly, the behavior of the functions to get the current Axes
+(``.pyplot.gca``, ``.figure.Figure.gca``) has changed. In the past, these
+functions accepted keyword arguments. If the keyword arguments matched an
+already-existing Axes, then that Axes would be returned, otherwise new Axes
+would be created with those keyword arguments. Now, an exception is raised if
+there are Axes and the current Axes were not created with the same keyword
+arguments. In a future release, these functions will not accept keyword
+arguments at all.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2410,10 +2410,13 @@ def polar(*args, **kwargs):
     """
     # If an axis already exists, check if it has a polar projection
     if gcf().get_axes():
-        if not isinstance(gca(), PolarAxes):
+        ax = gca()
+        if isinstance(ax, PolarAxes):
+            return ax
+        else:
             cbook._warn_external('Trying to create polar plot on an axis '
                                  'that does not have a polar projection.')
-    ax = gca(polar=True)
+    ax = axes(polar=True)
     ret = ax.plot(*args, **kwargs)
     return ret
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2387,28 +2387,36 @@ def test_as_mpl_axes_api():
     # testing axes creation with plt.axes
     ax = plt.axes([0, 0, 1, 1], projection=prj)
     assert type(ax) == PolarAxes
-    ax_via_gca = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     plt.close()
 
     # testing axes creation with gca
-    ax = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        ax = plt.gca(projection=prj)
     assert type(ax) == mpl.axes._subplots.subplot_class_factory(PolarAxes)
-    ax_via_gca = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     # try getting the axes given a different polar projection
-    with pytest.warns(UserWarning) as rec:
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'), \
+        pytest.raises(
+            ValueError, match=r'arguments passed to gca\(\) did not match'):
         ax_via_gca = plt.gca(projection=prj2)
-        assert len(rec) == 1
-        assert 'Requested projection is different' in str(rec[0].message)
-    assert ax_via_gca is not ax
-    assert ax.get_theta_offset() == 0
-    assert ax_via_gca.get_theta_offset() == np.pi
     # try getting the axes given an == (not is) polar projection
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
         ax_via_gca = plt.gca(projection=prj3)
-        assert len(rec) == 1
-        assert 'Requested projection is different' in str(rec[0].message)
     assert ax_via_gca is ax
     plt.close()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2408,9 +2408,7 @@ def test_as_mpl_axes_api():
     # try getting the axes given a different polar projection
     with pytest.warns(
             MatplotlibDeprecationWarning,
-            match=r'Calling gca\(\) with keyword arguments is deprecated'), \
-        pytest.raises(
-            ValueError, match=r'arguments passed to gca\(\) did not match'):
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
         ax_via_gca = plt.gca(projection=prj2)
     # try getting the axes given an == (not is) polar projection
     with pytest.warns(

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -8,6 +8,7 @@ import warnings
 
 import matplotlib as mpl
 from matplotlib import cbook, rcParams
+from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -154,30 +155,44 @@ def test_gca():
         assert fig.add_axes() is None
 
     ax0 = fig.add_axes([0, 0, 1, 1])
-    assert fig.gca(projection='rectilinear') is ax0
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        assert fig.gca(projection='rectilinear') is ax0
     assert fig.gca() is ax0
 
     ax1 = fig.add_axes(rect=[0.1, 0.1, 0.8, 0.8])
-    assert fig.gca(projection='rectilinear') is ax1
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        assert fig.gca(projection='rectilinear') is ax1
     assert fig.gca() is ax1
 
     ax2 = fig.add_subplot(121, projection='polar')
     assert fig.gca() is ax2
-    assert fig.gca(polar=True) is ax2
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        assert fig.gca(polar=True) is ax2
 
     ax3 = fig.add_subplot(122)
     assert fig.gca() is ax3
 
     # the final request for a polar axes will end up creating one
     # with a spec of 111.
-    with pytest.warns(UserWarning):
-        # Changing the projection will throw a warning
-        assert fig.gca(polar=True) is not ax3
-    assert fig.gca(polar=True) is not ax2
-    assert fig.gca().get_subplotspec().get_geometry() == (1, 1, 0, 0)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'), \
+        pytest.raises(
+            ValueError, match=r'arguments passed to gca\(\) did not match'):
+        # Changing the projection will raise an exception
+        fig.gca(polar=True)
 
     fig.sca(ax1)
-    assert fig.gca(projection='rectilinear') is ax1
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
+        assert fig.gca(projection='rectilinear') is ax1
     assert fig.gca() is ax1
 
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -182,9 +182,7 @@ def test_gca():
     # with a spec of 111.
     with pytest.warns(
             MatplotlibDeprecationWarning,
-            match=r'Calling gca\(\) with keyword arguments is deprecated'), \
-        pytest.raises(
-            ValueError, match=r'arguments passed to gca\(\) did not match'):
+            match=r'Calling gca\(\) with keyword arguments is deprecated'):
         # Changing the projection will raise an exception
         fig.gca(polar=True)
 


### PR DESCRIPTION
## PR Summary

In Matplotlib 2.1, the behavior of reusing existing axes when created with the same arguments was deprecated (see #9037). This behavior is now removed.

Functions that create new axes (`axes`, `add_axes`, `subplot`, etc.) will now always create new axes, regardless of whether the kwargs passed to them match already existing axes.

Passing kwargs to `gca` is deprecated. If `gca` is called with kwargs that do not match the current axes, then an exception is raised.

Fixes #18832.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
