### PR TITLE
DOC: fix typos

### DIFF
--- a/LICENSE/LICENSE_BAKOMA
+++ b/LICENSE/LICENSE_BAKOMA
@@ -2,7 +2,7 @@
 			BaKoMa Fonts Licence
 			--------------------
 
-  This licence covers two font packs (known as BaKoMa Fonts Colelction,
+  This licence covers two font packs (known as BaKoMa Fonts Collection,
   which is available at `CTAN:fonts/cm/ps-type1/bakoma/'):
 
     1) BaKoMa-CM (1.1/12-Nov-94)

--- a/doc/_static/fa/LICENSE
+++ b/doc/_static/fa/LICENSE
@@ -1,4 +1,4 @@
-Font Awsome SVG Icons are covered by CC BY 4.0 License.
+Font Awesome SVG Icons are covered by CC BY 4.0 License.
 
 https://fontawesome.com/license/free
 

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -243,7 +243,7 @@ mpl_interactions
 ================
 `mpl_interactions <https://mpl-interactions.readthedocs.io/en/latest/>`_
 makes it easy to create interactive plots controlled by sliders and other
-widgets. It also provides several handy capabilties such as manual
+widgets. It also provides several handy capabilities such as manual
 image segmentation, comparing cross-sections of arrays, and using the
 scroll wheel to zoom.
 

--- a/examples/animation/animated_histogram.py
+++ b/examples/animation/animated_histogram.py
@@ -23,7 +23,7 @@ n, _ = np.histogram(data, HIST_BINS)
 
 ###############################################################################
 # To animate the histogram, we need an ``animate`` function, which generates
-# a random set of numbers and updates the heights of rectanges. We utilize a
+# a random set of numbers and updates the heights of rectangles. We utilize a
 # python closure to track an instance of `.BarContainer` whose `.Rectangle`
 # patches we shall update.
 

--- a/examples/axisartist/demo_curvelinear_grid2.py
+++ b/examples/axisartist/demo_curvelinear_grid2.py
@@ -1,6 +1,6 @@
 """
 ======================
-Demo Curvelinear Grid2
+Demo Curvilinear Grid2
 ======================
 
 Custom grid and ticklines.

--- a/examples/axisartist/demo_curvelinear_grid2.py
+++ b/examples/axisartist/demo_curvelinear_grid2.py
@@ -1,6 +1,6 @@
 """
 ======================
-Demo Curvilinear Grid2
+Demo CurveLinear Grid2
 ======================
 
 Custom grid and ticklines.

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -27,7 +27,7 @@ Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (Z1 - Z2) * 2
 
 ###############################################################################
-# Make contour labels wuth custom level formatters
+# Make contour labels with custom level formatters
 
 
 # This custom formatter removes trailing zeros, e.g. "1.0" becomes "1", and

--- a/examples/misc/packed_bubbles.py
+++ b/examples/misc/packed_bubbles.py
@@ -115,7 +115,7 @@ class BubbleChart:
                         # calculate direction vector
                         dir_vec = rest_bub[colliding, :2] - self.bubbles[i, :2]
                         dir_vec = dir_vec / np.sqrt(dir_vec.dot(dir_vec))
-                        # calculate orthagonal vector
+                        # calculate orthogonal vector
                         orth = np.array([dir_vec[1], -dir_vec[0]])
                         # test which direction to go
                         new_point1 = (self.bubbles[i, :2] + orth *

--- a/examples/shapes_and_collections/hatch_demo.py
+++ b/examples/shapes_and_collections/hatch_demo.py
@@ -4,7 +4,7 @@ Hatch demo
 ==========
 
 Hatches can be added to most polygons in Matplotlib, including `~.Axes.bar`,
-`~.Axes.fill_between`, `~.Axes.contourf`, and childern of `~.patches.Polygon`.
+`~.Axes.fill_between`, `~.Axes.contourf`, and children of `~.patches.Polygon`.
 They are currently supported in the PS, PDF, SVG, OSX, and Agg backends. The WX
 and Cairo backends do not currently support hatching.
 

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -4,7 +4,7 @@ Hatch style reference
 =====================
 
 Hatches can be added to most polygons in Matplotlib, including `~.Axes.bar`,
-`~.Axes.fill_between`, `~.Axes.contourf`, and childern of `~.patches.Polygon`.
+`~.Axes.fill_between`, `~.Axes.contourf`, and children of `~.patches.Polygon`.
 They are currently supported in the PS, PDF, SVG, OSX, and Agg backends. The WX
 and Cairo backends do not currently support hatching.
 

--- a/examples/statistics/time_series_histogram.py
+++ b/examples/statistics/time_series_histogram.py
@@ -42,7 +42,7 @@ x = np.linspace(0, 4 * np.pi, num_points)
 Y = np.cumsum(np.random.randn(num_series, num_points), axis=-1)
 # Generate sinusoidal signals
 num_signal = int(round(SNR * num_series))
-phi = (np.pi / 8) * np.random.randn(num_signal, 1)  # small random offest
+phi = (np.pi / 8) * np.random.randn(num_signal, 1)  # small random offset
 Y[-num_signal:] = (
     np.sqrt(np.arange(num_points))[None, :]  # random walk RMS scaling factor
     * (np.sin(x[None, :] - phi)

--- a/examples/subplots_axes_and_figures/subfigures.py
+++ b/examples/subplots_axes_and_figures/subfigures.py
@@ -8,7 +8,7 @@ This can be achieved with
 :doc:`nested gridspecs</gallery/subplots_axes_and_figures/gridspec_nested>`,
 but having a virtual figure with its own artists is helpful, so
 Matplotlib also has "subfigures", accessed by calling
-`matplotlib.figure.Figure.add_subfigure` in a way that is analagous to
+`matplotlib.figure.Figure.add_subfigure` in a way that is analogous to
 `matplotlib.figure.Figure.add_subplot`, or
 `matplotlib.figure.Figure.subfigures` to make an array of subfigures.  Note
 that subfigures can also have their own child subfigures.
@@ -73,7 +73,7 @@ for a in axs[:, 0]:
 for a in axs[:, 1:].flat:
     a.plot(np.arange(10))
 
-# make the subfigure in the empy gridspec slots:
+# make the subfigure in the empty gridspec slots:
 subfig = fig.add_subfigure(gridspec[:, 0])
 
 axsLeft = subfig.subplots(1, 2, sharey=True)

--- a/examples/text_labels_and_annotations/titles_demo.py
+++ b/examples/text_labels_and_annotations/titles_demo.py
@@ -49,7 +49,7 @@ ax.xaxis.set_label_position('top')
 ax.set_xlabel('X-label')
 ax.set_title('Manual y', y=1.0, pad=-14)
 
-plt.rcParams['axes.titley'] = 1.0    # y is in axes-relative co-ordinates.
+plt.rcParams['axes.titley'] = 1.0    # y is in axes-relative coordinates.
 plt.rcParams['axes.titlepad'] = -14  # pad is in points...
 ax = axs[1]
 ax.plot(range(10))

--- a/examples/ticks_and_spines/date_concise_formatter.py
+++ b/examples/ticks_and_spines/date_concise_formatter.py
@@ -44,7 +44,7 @@ axs[0].set_title('Default Date Formatter')
 plt.show()
 
 #############################################################################
-# The default date formater is quite verbose, so we have the option of
+# The default date formatter is quite verbose, so we have the option of
 # using `~.dates.ConciseDateFormatter`, as shown below.  Note that
 # for this example the labels do not need to be rotated as they do for the
 # default formatter because the labels are as small as possible.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -882,7 +882,7 @@ dict.update(rcParams, _rc_params_in_file(matplotlib_fname()))
 with cbook._suppress_matplotlib_deprecation_warning():
     rcParamsOrig = RcParams(rcParams.copy())
     # This also checks that all rcParams are indeed listed in the template.
-    # Assiging to rcsetup.defaultParams is left only for backcompat.
+    # Assigning to rcsetup.defaultParams is left only for backcompat.
     defaultParams = rcsetup.defaultParams = {
         # We want to resolve deprecated rcParams, but not backend...
         key: [(rcsetup._auto_backend_sentinel if key == "backend" else

--- a/lib/matplotlib/_animation_data.py
+++ b/lib/matplotlib/_animation_data.py
@@ -30,7 +30,7 @@ href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.cs
     if (isInternetExplorer()) {
         // switch from oninput to onchange because IE <= 11 does not conform
         // with W3C specification. It ignores oninput and onchange behaves
-        // like oninput. In contrast, Mircosoft Edge behaves correctly.
+        // like oninput. In contrast, Microsoft Edge behaves correctly.
         slider.setAttribute('onchange', slider.getAttribute('oninput'));
         slider.setAttribute('oninput', null);
     }

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -32,7 +32,7 @@ often just set to 1 for an equal grid.
 Subplotspecs that are derived from this gridspec can contain either a
 ``SubPanel``, a ``GridSpecFromSubplotSpec``, or an axes.  The ``SubPanel`` and
 ``GridSpecFromSubplotSpec`` are dealt with recursively and each contain an
-analagous layout.
+analogous layout.
 
 Each ``GridSpec`` has a ``_layoutgrid`` attached to it.  The ``_layoutgrid``
 has the same logical layout as the ``GridSpec``.   Each row of the grid spec
@@ -460,8 +460,8 @@ def _reposition_axes(fig, renderer, *, w_pad=0, h_pad=0, hspace=0, wspace=0):
         if not hasattr(ax, 'get_subplotspec') or not ax.get_in_layout():
             continue
 
-        # grid bbox is in Figure co-ordinates, but we specify in panel
-        # co-ordinates...
+        # grid bbox is in Figure coordinates, but we specify in panel
+        # coordinates...
         ss = ax.get_subplotspec()
         gs = ss.get_gridspec()
         nrows, ncols = gs.get_geometry()

--- a/lib/matplotlib/_layoutgrid.py
+++ b/lib/matplotlib/_layoutgrid.py
@@ -1,6 +1,6 @@
 """
 A layoutgrid is a nrows by ncols set of boxes, meant to be used by
-`._constrained_layout`, each box is analagous to a subplotspec element of
+`._constrained_layout`, each box is analogous to a subplotspec element of
 a gridspec.
 
 Each box is defined by left[ncols], right[ncols], bottom[nrows] and top[nrows],
@@ -28,7 +28,7 @@ _log = logging.getLogger(__name__)
 
 class LayoutGrid:
     """
-    Analagous to a gridspec, and contained in another LayoutGrid.
+    Analogous to a gridspec, and contained in another LayoutGrid.
     """
 
     def __init__(self, parent=None, parent_pos=(0, 0),

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -778,7 +778,7 @@ class _AxesBase(martist.Artist):
             The transform used for drawing x-axis labels, which will add
             *pad_points* of padding (in points) between the axes and the label.
             The x-direction is in data coordinates and the y-direction is in
-            axis corrdinates
+            axis coordinates
         valign : {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
             The text vertical alignment.
         halign : {'center', 'left', 'right'}
@@ -804,7 +804,7 @@ class _AxesBase(martist.Artist):
             The transform used for drawing secondary x-axis labels, which will
             add *pad_points* of padding (in points) between the axes and the
             label.  The x-direction is in data coordinates and the y-direction
-            is in axis corrdinates
+            is in axis coordinates
         valign : {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
             The text vertical alignment.
         halign : {'center', 'left', 'right'}
@@ -854,7 +854,7 @@ class _AxesBase(martist.Artist):
             The transform used for drawing y-axis labels, which will add
             *pad_points* of padding (in points) between the axes and the label.
             The x-direction is in axis coordinates and the y-direction is in
-            data corrdinates
+            data coordinates
         valign : {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
             The text vertical alignment.
         halign : {'center', 'left', 'right'}
@@ -880,7 +880,7 @@ class _AxesBase(martist.Artist):
             The transform used for drawing secondart y-axis labels, which will
             add *pad_points* of padding (in points) between the axes and the
             label.  The x-direction is in axis coordinates and the y-direction
-            is in data corrdinates
+            is in data coordinates
         valign : {'center', 'top', 'bottom', 'baseline', 'center_baseline'}
             The text vertical alignment.
         halign : {'center', 'left', 'right'}

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -259,7 +259,7 @@ class RendererBase:
                 antialiaseds, urls, offset_position):
             path, transform = path_id
             # Only apply another translation if we have an offset, else we
-            # resuse the inital transform.
+            # reuse the initial transform.
             if xo != 0 or yo != 0:
                 # The transformation can be used by multiple paths. Since
                 # translate is a inplace operation, we need to copy the
@@ -2602,7 +2602,7 @@ def key_press_handler(event, canvas=None, toolbar=None):
                 _log.warning(str(exc))
                 ax.set_xscale('linear')
             ax.figure.canvas.draw_idle()
-    # enable nagivation for all axes that contain the event (default key 'a')
+    # enable navigation for all axes that contain the event (default key 'a')
     elif event.key in all_keys:
         for a in canvas.figure.get_axes():
             if (event.x is not None and event.y is not None

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -131,7 +131,7 @@ def register_cmap(name=None, cmap=None, *, override_builtin=False):
     Notes
     -----
     Registering a colormap stores a reference to the colormap object
-    which can currently be modified and inadvertantly change the global
+    which can currently be modified and inadvertently change the global
     colormap state. This behavior is deprecated and in Matplotlib 3.5
     the registered colormap will be immutable.
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -119,7 +119,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             See :doc:`/gallery/lines_bars_and_markers/joinstyle` for
             a demonstration of each of the allowed values.
         antialiaseds : bool or list of bool, default: :rc:`patch.antialiased`
-            Whether each pach in the collection should be drawn with
+            Whether each patch in the collection should be drawn with
             antialiasing.
         offsets : (float, float) or list thereof, default: (0, 0)
             A vector by which to translate each patch after rendering (default
@@ -1491,7 +1491,7 @@ class LineCollection(Collection):
 
 class EventCollection(LineCollection):
     """
-    A collection of locations along a single axis at which an "event" occured.
+    A collection of locations along a single axis at which an "event" occurred.
 
     The events are given by a 1-dimensional array. They do not have an
     amplitude and are displayed as parallel lines.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -54,7 +54,7 @@ location : None or {'left', 'right', 'top', 'bottom'}
     *orientation* if it is set (vertical colorbars on the right, horizontal
     ones at the bottom), or default to 'right' if *orientation* is unset.
 orientation : None or {'vertical', 'horizontal'}
-    The orientation of the colorbar.  It is preferrable to set the *location*
+    The orientation of the colorbar.  It is preferable to set the *location*
     of the colorbar, as that also determines the *orientation*; passing
     incompatible values for *location* and *orientation* raises an exception.
 fraction : float, default: 0.15

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -10,7 +10,7 @@ and for mapping numbers to colors in a 1-D array of colors called a colormap.
 Mapping data onto colors using a colormap typically involves two steps: a data
 array is first mapped onto the range 0-1 using a subclass of `Normalize`,
 then this number is mapped to a color using a subclass of `Colormap`.  Two
-sublasses of `Colormap` provided here:  `LinearSegmentedColormap`, which uses
+subclasses of `Colormap` provided here:  `LinearSegmentedColormap`, which uses
 piecewise-linear interpolation to define colormaps, and `ListedColormap`, which
 makes a colormap from a list of colors.
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -247,7 +247,7 @@ def set_epoch(epoch):
     If microsecond accuracy is desired, the date being plotted needs to be
     within approximately 70 years of the epoch. Matplotlib internally
     represents dates as days since the epoch, so floating point dynamic
-    range needs to be within a factor fo 2^52.
+    range needs to be within a factor of 2^52.
 
     `~.dates.set_epoch` must be called before any dates are converted
     (i.e. near the import section) or a RuntimeError will be raised.

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -214,7 +214,7 @@ class GridSpecBase:
                 gs = ax.get_subplotspec().get_gridspec()
                 if hasattr(gs, 'get_topmost_subplotspec'):
                     # This is needed for colorbar gridspec layouts.
-                    # This is probably OK becase this whole logic tree
+                    # This is probably OK because this whole logic tree
                     # is for when the user is doing simple things with the
                     # add_subplot command.  For complicated layouts
                     # like subgridspecs the proper gridspec is passed in...
@@ -759,7 +759,7 @@ class SubplotSpec:
     def colspan(self):
         """The columns spanned by this subplot, as a `range` object."""
         ncols = self.get_gridspec().ncols
-        # We explicitly support num2 refering to a column on num1's *left*, so
+        # We explicitly support num2 referring to a column on num1's *left*, so
         # we must sort the column indices here so that the range makes sense.
         c1, c2 = sorted([self.num1 % ncols, self.num2 % ncols])
         return range(c1, c2 + 1)

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -998,7 +998,7 @@ class AuxTransformBox(OffsetBox):
         ub = mtransforms.Bbox.union(bboxes)
         # adjust ref_offset_transform
         self.ref_offset_transform.translate(-ub.x0, -ub.y0)
-        # restor offset transform
+        # restore offset transform
         self.offset_transform.set_matrix(_off)
 
         return ub.width, ub.height, 0., 0.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1124,7 +1124,7 @@ class Polygon(Patch):
                 xy = np.concatenate([xy, [xy[0]]])
         else:
             # if we aren't closed, and the last vertex matches the first, then
-            # we assume we have an unecessary CLOSEPOLY vertex and remove it
+            # we assume we have an unnecessary CLOSEPOLY vertex and remove it
             if nverts > 2 and (xy[0] == xy[-1]).all():
                 xy = xy[:-1]
         self._path = Path(xy, closed=self._closed)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -559,7 +559,7 @@ def test_reshape2d():
 
 
 def test_reshape2d_pandas(pd):
-    # seperate to allow the rest of the tests to run if no pandas...
+    # separate to allow the rest of the tests to run if no pandas...
     X = np.arange(30).reshape(10, 3)
     x = pd.DataFrame(X, columns=["a", "b", "c"])
     Xnew = cbook._reshape_2D(x, 'x')

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -286,7 +286,7 @@ class TestLegendFunction:
         lns, = ax.plot(th, np.sin(th), label='sin')
         lnc, = ax.plot(th, np.cos(th), label='cos')
         with mock.patch('matplotlib.legend.Legend') as Legend:
-            # labels of lns, lnc are overwritten with explict ('a', 'b')
+            # labels of lns, lnc are overwritten with explicit ('a', 'b')
             ax.legend(labels=('a', 'b'), handles=(lnc, lns))
         Legend.assert_called_with(ax, (lnc, lns), ('a', 'b'))
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -144,7 +144,7 @@ def test_nested_ion_ioff():
         assert mpl.is_interactive()
     assert not mpl.is_interactive()
 
-    # redunant contexts
+    # redundant contexts
     with plt.ion():
         with plt.ion():
             assert mpl.is_interactive()

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -190,7 +190,7 @@ def test_table_cells():
     table[2, 1] = cell2
     assert table[2, 1] is cell2
 
-    # make sure gettitem support has not broken
+    # make sure getitem support has not broken
     # properties and setp
     table.properties()
     plt.setp(table)

--- a/matplotlibrc.template
+++ b/matplotlibrc.template
@@ -405,7 +405,7 @@
 #axes.prop_cycle: cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
                   # color cycle for plot lines as list of string color specs:
                   # single letter, long name, or web-style hex
-                  # As opposed to all other paramters in this file, the color
+                  # As opposed to all other parameters in this file, the color
                   # values must be enclosed in quotes for this parameter,
                   # e.g. '1f77b4', instead of 1f77b4.
                   # See also https://matplotlib.org/tutorials/intermediate/color_cycle.html

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -564,7 +564,7 @@ fig.suptitle('subplot2grid')
 # for each column, and ``bottom`` and ``top`` variables for each row, and
 # further it has a margin for each of left, right, bottom and top.  In each
 # row, the bottom/top margins are widened until all the decorators
-# in that row are accomodated.  Similarly for columns and the left/right
+# in that row are accommodated.  Similarly for columns and the left/right
 # margins.
 #
 #

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -566,7 +566,7 @@ coordinates, or you may use Parasite Axes for convenience.::
    :align: center
    :scale: 50
 
-   Demo Curvilinear Grid
+   Demo CurveLinear Grid
 
 FloatingAxis
 ============

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -121,7 +121,7 @@ and ticks.
    :align: center
    :scale: 50
 
-   Demo Curvelinear Grid
+   Demo Curvilinear Grid
 
 Floating Axes
 -------------
@@ -566,7 +566,7 @@ coordinates, or you may use Parasite Axes for convenience.::
    :align: center
    :scale: 50
 
-   Demo Curvelinear Grid
+   Demo Curvilinear Grid
 
 FloatingAxis
 ============

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -121,7 +121,7 @@ and ticks.
    :align: center
    :scale: 50
 
-   Demo Curvilinear Grid
+   Demo CurveLinear Grid
 
 Floating Axes
 -------------

--- a/versioneer.py
+++ b/versioneer.py
@@ -1051,7 +1051,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
         # TAG-NUM-gHEX
         mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
         if not mo:
-            # unparseable. Maybe git-describe is misbehaving?
+            # unparsable. Maybe git-describe is misbehaving?
             pieces["error"] = ("unable to parse git-describe output: '%s'"
                                % describe_out)
             return pieces


### PR DESCRIPTION
Found using `codespell v2.0.dev`  
```
codespell -q 3 -S ./extern,./doc/users/credits.rst,./doc/api/prev_api_changes,./doc/users/prev_whats_new -L afe,ans,axises,ba,coo,flate,fo,hist,inout,ment,nd,offsetp,oly,ot,te,thisy,vas,whis,wit
```