### PR TITLE
Cleanup Firefox SVG example.

### DIFF
--- a/examples/showcase/firefox.py
+++ b/examples/showcase/firefox.py
@@ -22,50 +22,38 @@ def svg_parse(path):
                 'Q': (Path.CURVE3,)*2,
                 'C': (Path.CURVE4,)*3,
                 'Z': (Path.CLOSEPOLY,)}
-    path_re = re.compile(r'([MLHVCSQTAZ])([^MLHVCSQTAZ]+)', re.IGNORECASE)
-    float_re = re.compile(r'(?:[\s,]*)([+-]?\d+(?:\.\d+)?)')
     vertices = []
     codes = []
-    last = (0, 0)
-    for cmd, values in path_re.findall(path):
-        points = [float(v) for v in float_re.findall(values)]
-        points = np.array(points).reshape((len(points)//2, 2))
+    cmd_values = re.split("([A-Za-z])", path)[1:]  # Split over commands.
+    for cmd, values in zip(cmd_values[::2], cmd_values[1::2]):
+        # Numbers are separated either by commas, or by +/- signs (but not at
+        # the beginning of the string).
+        points = ([*map(float, re.split(",|(?<!^)(?=[+-])", values))] if values
+                  else [(0., 0.)])  # Only for "z/Z" (CLOSEPOLY).
+        points = np.reshape(points, (-1, 2))
         if cmd.islower():
-            points += last
-        cmd = cmd.capitalize()
-        last = points[-1]
-        codes.extend(commands[cmd])
-        vertices.extend(points.tolist())
-    return codes, vertices
+            points += vertices[-1][-1]
+        codes.extend(commands[cmd.upper()])
+        vertices.append(points)
+    return np.array(codes), np.concatenate(vertices)
 
-# SVG to matplotlib
+
+# SVG to Matplotlib
 codes, verts = svg_parse(firefox)
-verts = np.array(verts)
 path = Path(verts, codes)
 
-# Make upside down
-verts[:, 1] *= -1
-xmin, xmax = verts[:, 0].min()-1, verts[:, 0].max()+1
-ymin, ymax = verts[:, 1].min()-1, verts[:, 1].max()+1
+xmin, ymin = verts.min(axis=0) - 1
+xmax, ymax = verts.max(axis=0) + 1
 
-fig = plt.figure(figsize=(5, 5))
-ax = fig.add_axes([0.0, 0.0, 1.0, 1.0], frameon=False, aspect=1)
+fig = plt.figure(figsize=(5, 5), facecolor="0.75")  # gray background
+ax = fig.add_axes([0, 0, 1, 1], frameon=False, aspect=1,
+                  xlim=(xmin, xmax),  # centering
+                  ylim=(ymax, ymin),  # centering, upside down
+                  xticks=[], yticks=[])  # no ticks
 
 # White outline (width = 6)
-patch = patches.PathPatch(path, facecolor='None', edgecolor='w', lw=6)
-ax.add_patch(patch)
-
+ax.add_patch(patches.PathPatch(path, facecolor='none', edgecolor='w', lw=6))
 # Actual shape with black outline
-patch = patches.PathPatch(path, facecolor='orange', edgecolor='k', lw=2)
-ax.add_patch(patch)
+ax.add_patch(patches.PathPatch(path, facecolor='orange', edgecolor='k', lw=2))
 
-# Centering
-ax.set_xlim(xmin, xmax)
-ax.set_ylim(ymin, ymax)
-
-# No ticks
-ax.set_xticks([])
-ax.set_yticks([])
-
-# Display
-plt.show()
+plt.show()  # Display


### PR DESCRIPTION
In the SVG parser: simplify the regexes; do not drop "z" codes (they
were previously dropped because they are immediately followed by another
code, and thus did not match `path_re`; things only worked because the
SVG source was careful to explicitly move back to the start point before
issuing CLOSEPOLYs) but instead include them explicitly.

Don't rely on later in-place modification of `verts` propagating back to
`path`, but modify it first.

Make the figure background gray (as was the case for the classic style);
that makes the white outline visible again (otherwise that white outline
doesn't really make sense).  Also just generally compress the rest of
the code down.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
