### PR TITLE
The Artist property rasterized cannot be None anymore

### DIFF
--- a/doc/api/next_api_changes/behavior/18988-TH.rst
+++ b/doc/api/next_api_changes/behavior/18988-TH.rst
@@ -1,5 +1,5 @@
 The Artist property *rasterized* cannot be *None* anymore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-It is now a bool only. Before the default was non and `Artist.set_rasterized`
+It is now a bool only. Before the default was non and `.Artist.set_rasterized`
 documented to accept *None*. However, *None* did not have a special meaning
 and was treated as *False*.

--- a/doc/api/next_api_changes/behavior/18988-TH.rst
+++ b/doc/api/next_api_changes/behavior/18988-TH.rst
@@ -1,0 +1,5 @@
+The Artist property *rasterized* cannot be *None* anymore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is now a bool only. Before the default was non and `Artist.set_rasterized`
+documented to accept *None*. However, *None* did not have a special meaning
+and was treated as *False.

--- a/doc/api/next_api_changes/behavior/18988-TH.rst
+++ b/doc/api/next_api_changes/behavior/18988-TH.rst
@@ -2,4 +2,4 @@ The Artist property *rasterized* cannot be *None* anymore
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 It is now a bool only. Before the default was non and `Artist.set_rasterized`
 documented to accept *None*. However, *None* did not have a special meaning
-and was treated as *False.
+and was treated as *False*.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -113,7 +113,7 @@ class Artist:
         self._label = ''
         self._picker = None
         self._contains = None
-        self._rasterized = None
+        self._rasterized = False
         self._agg_filter = None
         # Normally, artist classes need to be queried for mouseover info if and
         # only if they override get_cursor_data.
@@ -898,7 +898,7 @@ class Artist:
 
         Parameters
         ----------
-        rasterized : bool or None
+        rasterized : bool
         """
         if rasterized and not hasattr(self.draw, "_supports_rasterization"):
             cbook._warn_external(


### PR DESCRIPTION
## PR Summary

It is now a bool only. Before the default was *None* and
`Artist.set_rasterized` documented to accept *None*. However, *None*
did not have a special meaning and was treated as *False*.

This is:
- partly a documentation change: We don't document `set_rasterized` to accept *None*. However as with most bools, we just check the truthiness, so *None* is further accepted implicitly.
- a change of the default value from *None* to *False*. Technically, this is an API change. But it's very unlikely that a user will have queried `get_rasterized() is None` because *None* has no special meaning.

Because of the above I dare go without deprecation.