### PR TITLE
Fix the doc of GraphicsContextBase.set_clip_rectangle.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -924,19 +924,11 @@ class GraphicsContextBase:
         self._capstyle = cs
 
     def set_clip_rectangle(self, rectangle):
-        """
-        Set the clip rectangle with sequence (left, bottom, width, height)
-        """
+        """Set the clip rectangle to a `.Bbox` or None."""
         self._cliprect = rectangle
 
     def set_clip_path(self, path):
-        """
-        Set the clip path and transformation.
-
-        Parameters
-        ----------
-        path : `~matplotlib.transforms.TransformedPath` or None
-        """
+        """Set the clip path to a `.TransformedPath` or None."""
         cbook._check_isinstance((transforms.TransformedPath, None), path=path)
         self._clippath = path
 


### PR DESCRIPTION
The parameter is always a bbox, not a tuple, as shown by both all call
sites and the changelog for mpl 0.98.0 (before which it was a tuple).

Also shorten the doc for set_clip_path at the same time.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
