### PR TITLE
Deprecate event processing wrapper methods on FigureManagerBase.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19008-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19008-AL.rst
@@ -1,0 +1,5 @@
+``FigureManagerBase.key_press`` and ``button_press``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These methods, which incorrectly did nothing when using ``toolmanager``, are
+deprecated in favor of directly passing the event to the `.CallbackRegistry`
+via ``self.canvas.callbacks.process(event.name, event)``.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2714,11 +2714,9 @@ class FigureManagerBase:
         self.button_press_handler_id = None
         if rcParams['toolbar'] != 'toolmanager':
             self.key_press_handler_id = self.canvas.mpl_connect(
-                'key_press_event',
-                self.key_press)
+                'key_press_event', key_press_handler)
             self.button_press_handler_id = self.canvas.mpl_connect(
-                'button_press_event',
-                self.button_press)
+                'button_press_event', button_press_handler)
 
         self.toolmanager = (ToolManager(canvas.figure)
                             if mpl.rcParams['toolbar'] == 'toolmanager'
@@ -2758,6 +2756,8 @@ class FigureManagerBase:
     def resize(self, w, h):
         """For GUI backends, resize the window (in pixels)."""
 
+    @_api.deprecated(
+        "3.4", alternative="self.canvas.callbacks.process(event.name, event)")
     def key_press(self, event):
         """
         Implement the default Matplotlib key bindings defined at
@@ -2766,6 +2766,8 @@ class FigureManagerBase:
         if rcParams['toolbar'] != 'toolmanager':
             key_press_handler(event)
 
+    @_api.deprecated(
+        "3.4", alternative="self.canvas.callbacks.process(event.name, event)")
     def button_press(self, event):
         """The default Matplotlib button actions for extra mouse buttons."""
         if rcParams['toolbar'] != 'toolmanager':


### PR DESCRIPTION
Calling the standard handlers (`key_press_handler`,
`button_press_handler`) directly is just fine.  If someone wants to
simulate a key or button event they should pass the event to the
CallbackRegistry (as noted in the API changes note) so that things also
work when using toolmanager.

(The wrapper methods made more sense before https://github.com/matplotlib/matplotlib/pull/17110, where they also needed to adjust the call signature.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
