### PR TITLE
Simplify tk tooltip setup.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -631,7 +631,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
                     command=getattr(self, callback),
                 )
                 if tooltip_text is not None:
-                    ToolTip.createToolTip(button, tooltip_text)
+                    add_tooltip(button, tooltip_text)
 
         self._label_font = tkinter.font.Font(root=window, size=10)
 
@@ -892,62 +892,44 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         state_map = {True: tk.NORMAL, False: tk.DISABLED}
         can_back = self._nav_stack._pos > 0
         can_forward = self._nav_stack._pos < len(self._nav_stack) - 1
-
         if "Back" in self._buttons:
             self._buttons['Back']['state'] = state_map[can_back]
-
         if "Forward" in self._buttons:
             self._buttons['Forward']['state'] = state_map[can_forward]
 
 
-class ToolTip:
-    """
-    Tooltip recipe from
-    http://www.voidspace.org.uk/python/weblog/arch_d7_2006_07_01.shtml#e387
-    """
-    @staticmethod
-    def createToolTip(widget, text):
-        toolTip = ToolTip(widget)
-        def enter(event):
-            toolTip.showtip(text)
-        def leave(event):
-            toolTip.hidetip()
-        widget.bind('<Enter>', enter)
-        widget.bind('<Leave>', leave)
+def add_tooltip(widget, text):
+    tipwindow = None
 
-    def __init__(self, widget):
-        self.widget = widget
-        self.tipwindow = None
-        self.id = None
-        self.x = self.y = 0
-
-    def showtip(self, text):
+    def showtip(event):
         """Display text in tooltip window."""
-        self.text = text
-        if self.tipwindow or not self.text:
+        nonlocal tipwindow
+        if tipwindow or not text:
             return
-        x, y, _, _ = self.widget.bbox("insert")
-        x = x + self.widget.winfo_rootx() + self.widget.winfo_width()
-        y = y + self.widget.winfo_rooty()
-        self.tipwindow = tw = tk.Toplevel(self.widget)
-        tw.wm_overrideredirect(1)
-        tw.wm_geometry("+%d+%d" % (x, y))
-        try:
-            # For Mac OS
-            tw.tk.call("::tk::unsupported::MacWindowStyle",
-                       "style", tw._w,
-                       "help", "noActivates")
+        x, y, _, _ = widget.bbox("insert")
+        x = x + widget.winfo_rootx() + widget.winfo_width()
+        y = y + widget.winfo_rooty()
+        tipwindow = tk.Toplevel(widget)
+        tipwindow.overrideredirect(1)
+        tipwindow.geometry(f"+{x}+{y}")
+        try:  # For Mac OS
+            tipwindow.tk.call("::tk::unsupported::MacWindowStyle",
+                              "style", tipwindow._w,
+                              "help", "noActivates")
         except tk.TclError:
             pass
-        label = tk.Label(tw, text=self.text, justify=tk.LEFT,
+        label = tk.Label(tipwindow, text=text, justify=tk.LEFT,
                          relief=tk.SOLID, borderwidth=1)
         label.pack(ipadx=1)
 
-    def hidetip(self):
-        tw = self.tipwindow
-        self.tipwindow = None
-        if tw:
-            tw.destroy()
+    def hidetip(event):
+        nonlocal tipwindow
+        if tipwindow:
+            tipwindow.destroy()
+        tipwindow = None
+
+    widget.bind("<Enter>", showtip)
+    widget.bind("<Leave>", hidetip)
 
 
 @backend_tools._register_tool_class(FigureCanvasTk)
@@ -1002,7 +984,7 @@ class ToolbarTk(ToolContainerBase, tk.Frame):
                                               lambda: self._button_click(name))
         button.pack_configure(before=before)
         if description is not None:
-            ToolTip.createToolTip(button, description)
+            add_tooltip(button, description)
         self._toolitems.setdefault(name, [])
         self._toolitems[name].append(button)
 


### PR DESCRIPTION
The whole module is private, so we can just clean it up directly.

Instead of creating and hiding a new tip window each time, we can just
create a single one and show/hide it as needed.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
