### PR TITLE
Update event handling docs.

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -70,16 +70,16 @@
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89"
     ],
     "matplotlib.axes.Axes.lines": [
-      "doc/tutorials/intermediate/artists.rst:427",
-      "doc/tutorials/intermediate/artists.rst:92"
+      "doc/tutorials/intermediate/artists.rst:425",
+      "doc/tutorials/intermediate/artists.rst:91"
     ],
     "matplotlib.axes.Axes.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:175",
-      "doc/tutorials/intermediate/artists.rst:411"
+      "doc/tutorials/intermediate/artists.rst:174",
+      "doc/tutorials/intermediate/artists.rst:409"
     ],
     "matplotlib.axes.Axes.patches": [
-      "doc/tutorials/intermediate/artists.rst:450"
+      "doc/tutorials/intermediate/artists.rst:448"
     ],
     "matplotlib.axes.Axes.transAxes": [
       "lib/mpl_toolkits/axes_grid1/anchored_artists.py:docstring of mpl_toolkits.axes_grid1.anchored_artists.AnchoredDirectionArrows.__init__:8",
@@ -97,13 +97,13 @@
       "doc/api/prev_api_changes/api_changes_0.99.x.rst:23"
     ],
     "matplotlib.axes.Axes.xaxis": [
-      "doc/tutorials/intermediate/artists.rst:594"
+      "doc/tutorials/intermediate/artists.rst:593"
     ],
     "matplotlib.axes.Axes.yaxis": [
-      "doc/tutorials/intermediate/artists.rst:594"
+      "doc/tutorials/intermediate/artists.rst:593"
     ],
     "matplotlib.axis.Axis.label": [
-      "doc/tutorials/intermediate/artists.rst:641"
+      "doc/tutorials/intermediate/artists.rst:640"
     ],
     "matplotlib.cm.ScalarMappable.callbacksSM": [
       "doc/api/prev_api_changes/api_changes_0.98.0.rst:10"
@@ -116,11 +116,11 @@
     ],
     "matplotlib.figure.Figure.patch": [
       "doc/api/prev_api_changes/api_changes_0.98.x.rst:89",
-      "doc/tutorials/intermediate/artists.rst:175",
-      "doc/tutorials/intermediate/artists.rst:308"
+      "doc/tutorials/intermediate/artists.rst:174",
+      "doc/tutorials/intermediate/artists.rst:307"
     ],
     "matplotlib.figure.Figure.transFigure": [
-      "doc/tutorials/intermediate/artists.rst:357"
+      "doc/tutorials/intermediate/artists.rst:356"
     ],
     "max": [
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.Bbox.p1:4"
@@ -246,8 +246,8 @@
       "doc/api/mathtext_api.rst:12"
     ],
     "matplotlib.axes.Subplot": [
-      "doc/tutorials/intermediate/artists.rst:36",
-      "doc/tutorials/intermediate/artists.rst:59"
+      "doc/tutorials/intermediate/artists.rst:35",
+      "doc/tutorials/intermediate/artists.rst:58"
     ],
     "matplotlib.axes._axes.Axes": [
       "doc/api/artist_api.rst:189",
@@ -265,11 +265,11 @@
     "matplotlib.backend_bases.FigureCanvas": [
       "doc/tutorials/intermediate/artists.rst:20",
       "doc/tutorials/intermediate/artists.rst:22",
-      "doc/tutorials/intermediate/artists.rst:28"
+      "doc/tutorials/intermediate/artists.rst:27"
     ],
     "matplotlib.backend_bases.Renderer": [
       "doc/tutorials/intermediate/artists.rst:22",
-      "doc/tutorials/intermediate/artists.rst:28"
+      "doc/tutorials/intermediate/artists.rst:27"
     ],
     "matplotlib.backend_bases._Backend": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ShowBase:1"
@@ -502,6 +502,8 @@
     "matplotlib.axes.Axes.transAxes": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:219",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:220",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.FigureBase.legend:220",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.SubFigure.legend:220",
       "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:178",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:220",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:219"
@@ -580,12 +582,6 @@
     ],
     "matplotlib.dates.MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:122"
-    ],
-    "matplotlib.lines.Line2D.pick": [
-      "doc/users/event_handling.rst:480"
-    ],
-    "matplotlib.patches.Rectangle.contains": [
-      "doc/users/event_handling.rst:164"
     ],
     "option_scale_image": [
       "lib/matplotlib/backends/backend_cairo.py:docstring of matplotlib.backends.backend_cairo.RendererCairo.draw_image:22",
@@ -723,6 +719,9 @@
     "ImageComparisonTest": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:706"
     ],
+    "Line2D.pick": [
+      "doc/users/event_handling.rst:438"
+    ],
     "MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:119"
     ],
@@ -747,6 +746,9 @@
     ],
     "Quiver.pivot": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:44"
+    ],
+    "Rectangle.contains": [
+      "doc/users/event_handling.rst:150"
     ],
     "Size.from_any": [
       "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid.__init__:61",
@@ -786,7 +788,7 @@
     ],
     "autoscale_view": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.autoscale:19",
-      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.plot:121"
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.plot:128"
     ],
     "ax.transAxes": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.indicate_inset:19",
@@ -798,6 +800,8 @@
     "axes.bbox": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:128",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:129",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.FigureBase.legend:129",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.SubFigure.legend:129",
       "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:87",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:129",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:128"
@@ -844,6 +848,8 @@
     "figure.bbox": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.legend:128",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.Figure.legend:129",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.FigureBase.legend:129",
+      "lib/matplotlib/figure.py:docstring of matplotlib.figure.SubFigure.legend:129",
       "lib/matplotlib/legend.py:docstring of matplotlib.legend.Legend:87",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.figlegend:129",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:128"

--- a/doc/users/event_handling.rst
+++ b/doc/users/event_handling.rst
@@ -11,11 +11,11 @@ developers to have an API for interacting with the figure via key
 presses and mouse movements that is "GUI neutral" so we don't have to
 repeat a lot of code across the different user interfaces.  Although
 the event handling API is GUI neutral, it is based on the GTK model,
-which was the first user interface matplotlib supported.  The events
-that are triggered are also a bit richer vis-a-vis matplotlib than
+which was the first user interface Matplotlib supported.  The events
+that are triggered are also a bit richer vis-a-vis Matplotlib than
 standard GUI events, including information like which
-:class:`matplotlib.axes.Axes` the event occurred in.  The events also
-understand the matplotlib coordinate system, and report event
+`~.axes.Axes` the event occurred in.  The events also
+understand the Matplotlib coordinate system, and report event
 locations in both pixel and data coordinates.
 
 .. _event-connections:
@@ -25,7 +25,7 @@ Event connections
 
 To receive events, you need to write a callback function and then
 connect your function to the event manager, which is part of the
-:class:`~matplotlib.backend_bases.FigureCanvasBase`.  Here is a simple
+`~.FigureCanvasBase`.  Here is a simple
 example that prints the location of the mouse click and which button
 was pressed::
 
@@ -39,10 +39,8 @@ was pressed::
 
     cid = fig.canvas.mpl_connect('button_press_event', onclick)
 
-The ``FigureCanvas`` method
-:meth:`~matplotlib.backend_bases.FigureCanvasBase.mpl_connect` returns
-a connection id which is simply an integer.  When you want to
-disconnect the callback, just call::
+The `.FigureCanvasBase.mpl_connect` method returns a connection id (an
+integer), which can be used to disconnect the callback via ::
 
     fig.canvas.mpl_disconnect(cid)
 
@@ -53,7 +51,6 @@ disconnect the callback, just call::
    callback will vanish.
 
    This does not affect free functions used as callbacks.
-
 
 Here are the events that you can connect to, the class instances that
 are sent back to you when the event occurs, and the event descriptions:
@@ -78,45 +75,37 @@ Event name             Class            Description
 'axes_leave_event'     `.LocationEvent` mouse leaves an axes
 ====================== ================ ======================================
 
+Matplotlib attaches some keypress callbacks by default for interactivity; they
+are documented in the :ref:`key-event-handling` section.
+
 .. _event-attributes:
 
 Event attributes
 ================
 
-All matplotlib events inherit from the base class
-:class:`matplotlib.backend_bases.Event`, which store the attributes:
+All Matplotlib events inherit from the base class
+`matplotlib.backend_bases.Event`, which stores the attributes:
 
     ``name``
-	the event name
-
+        the event name
     ``canvas``
-	the FigureCanvas instance generating the event
-
+        the FigureCanvas instance generating the event
     ``guiEvent``
-	the GUI event that triggered the matplotlib event
-
+        the GUI event that triggered the Matplotlib event
 
 The most common events that are the bread and butter of event handling
 are key press/release events and mouse press/release and movement
-events.  The :class:`~matplotlib.backend_bases.KeyEvent` and
-:class:`~matplotlib.backend_bases.MouseEvent` classes that handle
+events.  The `.KeyEvent` and `.MouseEvent` classes that handle
 these events are both derived from the LocationEvent, which has the
 following attributes
 
-    ``x``
-        x position - pixels from left of canvas
-
-    ``y``
-        y position - pixels from bottom of canvas
-
+    ``x``, ``y``
+        mouse x and y position in pixels from left and bottom of canvas
     ``inaxes``
-        the :class:`~matplotlib.axes.Axes` instance if mouse is over axes
-
-    ``xdata``
-        x coord of mouse in data coords
-
-    ``ydata``
-        y coord of mouse in data coords
+        the `~.axes.Axes` instance over which the mouse is, if any; else None
+    ``xdata``, ``ydata``
+        mouse x and y position in data coordinates, if the mouse is over an
+        axes
 
 Let's look a simple example of a canvas, where a simple line segment
 is created every time a mouse is pressed::
@@ -138,22 +127,19 @@ is created every time a mouse is pressed::
             self.line.set_data(self.xs, self.ys)
             self.line.figure.canvas.draw()
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    fig, ax = plt.subplots()
     ax.set_title('click to build line segments')
     line, = ax.plot([0], [0])  # empty line
     linebuilder = LineBuilder(line)
 
     plt.show()
 
-
-The :class:`~matplotlib.backend_bases.MouseEvent` that we just used is a
-:class:`~matplotlib.backend_bases.LocationEvent`, so we have access to
-the data and pixel coordinates in event.x and event.xdata.  In
-addition to the ``LocationEvent`` attributes, it has
+The `.MouseEvent` that we just used is a `.LocationEvent`, so we have access to
+the data and pixel coordinates via ``(event.x, event.y)`` and ``(event.xdata,
+event.ydata)``.  In addition to the ``LocationEvent`` attributes, it also has
 
     ``button``
-        button pressed None, 1, 2, 3, 'up', 'down' (up and down are used for scroll events)
+        the button pressed: None, `.MouseButton`, 'up', or 'down' (up and down are used for scroll events)
 
     ``key``
         the key pressed: None, any character, 'shift', 'win', or 'control'
@@ -162,12 +148,12 @@ Draggable rectangle exercise
 ----------------------------
 
 Write draggable rectangle class that is initialized with a
-:class:`~matplotlib.patches.Rectangle` instance but will move its x,y
+`.Rectangle` instance but will move its ``xy``
 location when dragged.  Hint: you will need to store the original
 ``xy`` location of the rectangle which is stored as rect.xy and
 connect to the press, motion and release mouse events.  When the mouse
 is pressed, check to see if the click occurs over your rectangle (see
-:meth:`matplotlib.patches.Rectangle.contains`) and if it does, store
+`.Rectangle.contains`) and if it does, store
 the rectangle xy and the location of the mouse click in data coords.
 In the motion event callback, compute the deltax and deltay of the
 mouse movement, and add those deltas to the origin of the rectangle
@@ -185,7 +171,7 @@ Here is the solution::
             self.press = None
 
         def connect(self):
-            'connect to all the events we need'
+            """Connect to all the events we need."""
             self.cidpress = self.rect.figure.canvas.mpl_connect(
                 'button_press_event', self.on_press)
             self.cidrelease = self.rect.figure.canvas.mpl_connect(
@@ -194,43 +180,41 @@ Here is the solution::
                 'motion_notify_event', self.on_motion)
 
         def on_press(self, event):
-            'on button press we will see if the mouse is over us and store some data'
-            if event.inaxes != self.rect.axes: return
-
+            """Check whether mouse is over us; if so, store some data."""
+            if event.inaxes != self.rect.axes:
+                return
             contains, attrd = self.rect.contains(event)
-            if not contains: return
+            if not contains:
+                return
             print('event contains', self.rect.xy)
-            x0, y0 = self.rect.xy
-            self.press = x0, y0, event.xdata, event.ydata
+            self.press = self.rect.xy, (event.xdata, event.ydata)
 
         def on_motion(self, event):
-            'on motion we will move the rect if the mouse is over us'
-            if self.press is None: return
-            if event.inaxes != self.rect.axes: return
-            x0, y0, xpress, ypress = self.press
+            """Move the rectangle if the mouse is over us."""
+            if self.press is None or event.inaxes != self.rect.axes:
+                return
+            (x0, y0), (xpress, ypress) = self.press
             dx = event.xdata - xpress
             dy = event.ydata - ypress
-            #print('x0=%f, xpress=%f, event.xdata=%f, dx=%f, x0+dx=%f' %
-            #      (x0, xpress, event.xdata, dx, x0+dx))
+            # print(f'x0={x0}, xpress={xpress}, event.xdata={event.xdata}, '
+            #       f'dx={dx}, x0+dx={x0+dx}')
             self.rect.set_x(x0+dx)
             self.rect.set_y(y0+dy)
 
             self.rect.figure.canvas.draw()
 
-
         def on_release(self, event):
-            'on release we reset the press data'
+            """Clear button press information."""
             self.press = None
             self.rect.figure.canvas.draw()
 
         def disconnect(self):
-            'disconnect all the stored connection ids'
+            """Disconnect all callbacks."""
             self.rect.figure.canvas.mpl_disconnect(self.cidpress)
             self.rect.figure.canvas.mpl_disconnect(self.cidrelease)
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    fig, ax = plt.subplots()
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -252,13 +236,14 @@ Extra credit solution::
 
     class DraggableRectangle:
         lock = None  # only one can be animated at a time
+
         def __init__(self, rect):
             self.rect = rect
             self.press = None
             self.background = None
 
         def connect(self):
-            'connect to all the events we need'
+            """Connect to all the events we need."""
             self.cidpress = self.rect.figure.canvas.mpl_connect(
                 'button_press_event', self.on_press)
             self.cidrelease = self.rect.figure.canvas.mpl_connect(
@@ -267,14 +252,15 @@ Extra credit solution::
                 'motion_notify_event', self.on_motion)
 
         def on_press(self, event):
-            'on button press we will see if the mouse is over us and store some data'
-            if event.inaxes != self.rect.axes: return
-            if DraggableRectangle.lock is not None: return
+            """Check whether mouse is over us; if so, store some data."""
+            if (event.inaxes != self.rect.axes
+                    or DraggableRectangle.lock is not None):
+                return
             contains, attrd = self.rect.contains(event)
-            if not contains: return
+            if not contains:
+                return
             print('event contains', self.rect.xy)
-            x0, y0 = self.rect.xy
-            self.press = x0, y0, event.xdata, event.ydata
+            self.press = self.rect.xy, (event.xdata, event.ydata)
             DraggableRectangle.lock = self
 
             # draw everything but the selected rectangle and store the pixel buffer
@@ -291,11 +277,11 @@ Extra credit solution::
             canvas.blit(axes.bbox)
 
         def on_motion(self, event):
-            'on motion we will move the rect if the mouse is over us'
-            if DraggableRectangle.lock is not self:
+            """Move the rectangle if the mouse is over us."""
+            if (event.inaxes != self.rect.axes
+                    or DraggableRectangle.lock is not self):
                 return
-            if event.inaxes != self.rect.axes: return
-            x0, y0, xpress, ypress = self.press
+            (x0, y0), (xpress, ypress) = self.press
             dx = event.xdata - xpress
             dy = event.ydata - ypress
             self.rect.set_x(x0+dx)
@@ -313,7 +299,7 @@ Extra credit solution::
             canvas.blit(axes.bbox)
 
         def on_release(self, event):
-            'on release we reset the press data'
+            """Clear button press information."""
             if DraggableRectangle.lock is not self:
                 return
 
@@ -328,13 +314,12 @@ Extra credit solution::
             self.rect.figure.canvas.draw()
 
         def disconnect(self):
-            'disconnect all the stored connection ids'
+            """Disconnect all callbacks."""
             self.rect.figure.canvas.mpl_disconnect(self.cidpress)
             self.rect.figure.canvas.mpl_disconnect(self.cidrelease)
             self.rect.figure.canvas.mpl_disconnect(self.cidmotion)
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    fig, ax = plt.subplots()
     rects = ax.bar(range(10), 20*np.random.rand(10))
     drs = []
     for rect in rects:
@@ -343,7 +328,6 @@ Extra credit solution::
         drs.append(dr)
 
     plt.show()
-
 
 .. _enter-leave-events:
 
@@ -381,20 +365,16 @@ background that the mouse is over::
         event.canvas.figure.patch.set_facecolor('grey')
         event.canvas.draw()
 
-    fig1 = plt.figure()
+    fig1, axs = plt.subplots(2)
     fig1.suptitle('mouse hover over figure or axes to trigger events')
-    ax1 = fig1.add_subplot(211)
-    ax2 = fig1.add_subplot(212)
 
     fig1.canvas.mpl_connect('figure_enter_event', enter_figure)
     fig1.canvas.mpl_connect('figure_leave_event', leave_figure)
     fig1.canvas.mpl_connect('axes_enter_event', enter_axes)
     fig1.canvas.mpl_connect('axes_leave_event', leave_axes)
 
-    fig2 = plt.figure()
+    fig2, axs = plt.subplots(2)
     fig2.suptitle('mouse hover over figure or axes to trigger events')
-    ax1 = fig2.add_subplot(211)
-    ax2 = fig2.add_subplot(212)
 
     fig2.canvas.mpl_connect('figure_enter_event', enter_figure)
     fig2.canvas.mpl_connect('figure_leave_event', leave_figure)
@@ -403,100 +383,77 @@ background that the mouse is over::
 
     plt.show()
 
-
 .. _object-picking:
 
 Object picking
 ==============
 
-You can enable picking by setting the ``picker`` property of an
-:class:`~matplotlib.artist.Artist` (e.g., a matplotlib
-:class:`~matplotlib.lines.Line2D`, :class:`~matplotlib.text.Text`,
-:class:`~matplotlib.patches.Patch`, :class:`~matplotlib.patches.Polygon`,
-:class:`~matplotlib.image.AxesImage`, etc...)
+You can enable picking by setting the ``picker`` property of an `.Artist` (such
+as `.Line2D`, `.Text`, `.Patch`, `.Polygon`, `.AxesImage`, etc.)
 
-There are a variety of meanings of the ``picker`` property:
+The ``picker`` property can be set using various types:
 
     ``None``
-	picking is disabled for this artist (default)
-
+        Picking is disabled for this artist (default).
     ``boolean``
-	if True then picking will be enabled and the artist will fire a
-	pick event if the mouse event is over the artist
+        If True, then picking will be enabled and the artist will fire a
+        pick event if the mouse event is over the artist.
+    ``callable``
+        If picker is a callable, it is a user supplied function which
+        determines whether the artist is hit by the mouse event.  The
+        signature is ``hit, props = picker(artist, mouseevent)`` to
+        determine the hit test.  If the mouse event is over the artist,
+        return ``hit = True``; ``props`` is a dictionary of properties that
+        become additional attributes on the `.PickEvent`.
 
-    ``float``
-	if picker is a number it is interpreted as an epsilon tolerance in
-	points and the artist will fire off an event if its data is
-	within epsilon of the mouse event.  For some artists like lines
-	and patch collections, the artist may provide additional data to
-	the pick event that is generated, e.g., the indices of the data
-	within epsilon of the pick event.
-
-    ``function``
-	if picker is callable, it is a user supplied function which
-	determines whether the artist is hit by the mouse event.  The
-	signature is ``hit, props = picker(artist, mouseevent)`` to
-	determine the hit test.  If the mouse event is over the artist,
-	return ``hit=True`` and props is a dictionary of properties you
-	want added to the :class:`~matplotlib.backend_bases.PickEvent`
-	attributes
-
+The artist's ``pickradius`` property can additionally be set to a tolerance
+value in points (there are 72 points per inch) that determines how far the
+mouse can be and still trigger a mouse event.
 
 After you have enabled an artist for picking by setting the ``picker``
-property, you need to connect to the figure canvas pick_event to get
-pick callbacks on mouse press events.  e.g.::
+property, you need to connect a handler to the figure canvas pick_event to get
+pick callbacks on mouse press events.  The handler typically looks like ::
 
     def pick_handler(event):
         mouseevent = event.mouseevent
         artist = event.artist
         # now do something with this...
 
+The `.PickEvent` passed to your callback always has the following attributes:
 
-The :class:`~matplotlib.backend_bases.PickEvent` which is passed to
-your callback is always fired with two attributes:
-
-    ``mouseevent`` the mouse event that generate the pick event.  The
-	mouse event in turn has attributes like ``x`` and ``y`` (the
-	coords in display space, e.g., pixels from left, bottom) and xdata,
-	ydata (the coords in data space).  Additionally, you can get
-	information about which buttons were pressed, which keys were
-	pressed, which :class:`~matplotlib.axes.Axes` the mouse is over,
-	etc.  See :class:`matplotlib.backend_bases.MouseEvent` for
-	details.
-
+    ``mouseevent``
+        The `.MouseEvent` that generate the pick event.  See event-attributes_
+        for a list of useful attributes on the mouse event.
     ``artist``
-	the :class:`~matplotlib.artist.Artist` that generated the pick
-	event.
+        The `.Artist` that generated the pick event.
 
-Additionally, certain artists like :class:`~matplotlib.lines.Line2D`
-and :class:`~matplotlib.collections.PatchCollection` may attach
-additional meta data like the indices into the data that meet the
+Additionally, certain artists like `.Line2D` and `.PatchCollection` may attach
+additional metadata, like the indices of the data that meet the
 picker criteria (e.g., all the points in the line that are within the
-specified epsilon tolerance)
+specified ``pickradius`` tolerance).
 
 Simple picking example
 ----------------------
 
-In the example below, we set the line picker property to a scalar, so
-it represents a tolerance in points (72 points per inch).  The onpick
+In the example below, we enable picking on the line and set a pick radius
+tolerance in points.  The ``onpick``
 callback function will be called when the pick event it within the
 tolerance distance from the line, and has the indices of the data
-vertices that are within the pick distance tolerance.  Our onpick
+vertices that are within the pick distance tolerance.  Our ``onpick``
 callback function simply prints the data that are under the pick
-location.  Different matplotlib Artists can attach different data to
+location.  Different Matplotlib Artists can attach different data to
 the PickEvent.  For example, ``Line2D`` attaches the ind property,
 which are the indices into the line data under the pick point.  See
-:meth:`~matplotlib.lines.Line2D.pick` for details on the ``PickEvent``
-properties of the line.  Here is the code::
+`.Line2D.pick` for details on the ``PickEvent`` properties of the line.  ::
 
     import numpy as np
     import matplotlib.pyplot as plt
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    fig, ax = plt.subplots()
     ax.set_title('click on points')
 
-    line, = ax.plot(np.random.rand(100), 'o', picker=5)  # 5 points tolerance
+    line, = ax.plot(np.random.rand(100), 'o',
+                    picker=True, pickradius=5)  # 5 points tolerance
 
     def onpick(event):
         thisline = event.artist
@@ -509,7 +466,6 @@ properties of the line.  Here is the code::
     fig.canvas.mpl_connect('pick_event', onpick)
 
     plt.show()
-
 
 Picking exercise
 ----------------
@@ -526,10 +482,11 @@ can use multiple subplots to plot the multiple time series.
 Exercise solution::
 
     """
-    compute the mean and stddev of 100 data sets and plot mean vs. stddev.
-    When you click on one of the mu, sigma points, plot the raw data from
-    the dataset that generated the mean and stddev
+    Compute the mean and stddev of 100 data sets and plot mean vs. stddev.
+    When you click on one of the (mean, stddev) points, plot the raw dataset
+    that generated that point.
     """
+
     import numpy as np
     import matplotlib.pyplot as plt
 
@@ -537,30 +494,27 @@ Exercise solution::
     xs = np.mean(X, axis=1)
     ys = np.std(X, axis=1)
 
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
+    fig, ax = plt.subplots()
     ax.set_title('click on point to plot time series')
-    line, = ax.plot(xs, ys, 'o', picker=5)  # 5 points tolerance
+    line, = ax.plot(xs, ys, 'o', picker=True, pickradius=5)  # 5 points tolerance
 
 
     def onpick(event):
-
-        if event.artist!=line: return True
-
-        N = len(event.ind)
-        if not N: return True
-
-
-        figi = plt.figure()
-        for subplotnum, dataind in enumerate(event.ind):
-            ax = figi.add_subplot(N,1,subplotnum+1)
+        if event.artist != line:
+            return
+        n = len(event.ind)
+        if not n:
+            return
+        fig, axs = plt.subplots(n, squeeze=False)
+        for dataind, ax in zip(event.ind, axs.flat):
             ax.plot(X[dataind])
-            ax.text(0.05, 0.9, 'mu=%1.3f\nsigma=%1.3f'%(xs[dataind], ys[dataind]),
-                    transform=ax.transAxes, va='top')
+            ax.text(0.05, 0.9,
+                    f"$\\mu$={xs[dataind]:1.3f}\n$\\sigma$={ys[dataind]:1.3f}",
+                    transform=ax.transAxes, verticalalignment='top')
             ax.set_ylim(-0.5, 1.5)
-        figi.show()
+        fig.show()
         return True
 
-    fig.canvas.mpl_connect('pick_event', onpick)
 
+    fig.canvas.mpl_connect('pick_event', onpick)
     plt.show()


### PR DESCRIPTION
Much reformatting.

Remove documentation for `picker=<float>` which is deprecated in favor
of `pickradius`.

Add reference to default keymaps (closes https://github.com/matplotlib/matplotlib/issues/11472).

Modernize examples: use `pickradius`, use `subplots()` instead of
`add_subplot(111)`, etc.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
