### PR TITLE
Deprecate setting a Collection/Patch's pickradius via set_picker.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19026-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19026-AL.rst
@@ -1,0 +1,5 @@
+Setting pickradius on Collections and Patches via ``set_picker``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting the pickradius (i.e. the tolerance for pick events and containment
+checks)of a `.Collection` or a `.Patch` via `.Artist.set_picker` is deprecated;
+use ``set_pickradius`` instead.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -558,10 +558,10 @@ class Artist:
               artist, return *hit=True* and props is a dictionary of
               properties you want added to the PickEvent attributes.
 
-            - *deprecated*: For `.Line2D` only, *picker* can also be a float
-              that sets the tolerance for checking whether an event occurred
-              "on" the line; this is deprecated.  Use `.Line2D.set_pickradius`
-              instead.
+            - *deprecated*: For `.Line2D` and `.Collection`, *picker* can also
+              be a float that sets the tolerance for checking whether an event
+              occurred "on" the artist; this is deprecated.  Use
+              `.Line2D.set_pickradius`/`.Collection.set_pickradius` instead.
         """
         self._picker = picker
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -415,6 +415,17 @@ class Collection(artist.Artist, cm.ScalarMappable):
         renderer.close_group(self.__class__.__name__)
         self.stale = False
 
+    def set_picker(self, p):
+        # docstring inherited
+        # After deprecation, the whole method can be deleted and inherited.
+        if isinstance(p, Number) and not isinstance(p, bool):
+            cbook.warn_deprecated(
+                "3.4", message="Setting the collections's pick radius via "
+                "set_picker is deprecated since %(since)s and will be removed "
+                "%(removal)s; use set_pickradius instead.")
+            self.set_pickradius(p)
+        self._picker = p
+
     def set_pickradius(self, pr):
         """
         Set the pick radius used for containment tests.
@@ -439,32 +450,21 @@ class Collection(artist.Artist, cm.ScalarMappable):
         inside, info = self._default_contains(mouseevent)
         if inside is not None:
             return inside, info
-
         if not self.get_visible():
             return False, {}
-
-        pickradius = (
-            float(self._picker)
-            if isinstance(self._picker, Number) and
-               self._picker is not True  # the bool, not just nonzero or 1
-            else self._pickradius)
-
         if self.axes:
             self.axes._unstale_viewLim()
-
         transform, transOffset, offsets, paths = self._prepare_points()
-
         # Tests if the point is contained on one of the polygons formed
         # by the control points of each of the paths. A point is considered
         # "on" a path if it would lie within a stroke of width 2*pickradius
         # following the path. If pickradius <= 0, then we instead simply check
         # if the point is *inside* of the path instead.
         ind = _path.point_in_path_collection(
-            mouseevent.x, mouseevent.y, pickradius,
+            mouseevent.x, mouseevent.y, self._pickradius,
             transform.frozen(), paths, self.get_transforms(),
-            offsets, transOffset, pickradius <= 0,
+            offsets, transOffset, self._pickradius <= 0,
             self._offset_position)
-
         return len(ind) > 0, dict(ind=ind)
 
     def set_urls(self, urls):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -757,7 +757,7 @@ def test_hexbin_pickable():
     fig, ax = plt.subplots()
     data = (np.arange(200) / 200).reshape((2, 100))
     x, y = data
-    hb = ax.hexbin(x, y, extent=[.1, .3, .6, .7], picker=-1)
+    hb = ax.hexbin(x, y, extent=[.1, .3, .6, .7], picker=True, pickradius=-1)
     mouse_event = SimpleNamespace(x=400, y=300)
     assert hb.contains(mouse_event)[0]
 

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -3,7 +3,7 @@ import platform
 
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib import cbook
+from matplotlib import _api, cbook
 from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib.backend_bases import MouseEvent
 from matplotlib.colors import LogNorm
@@ -409,8 +409,9 @@ def test_picking_callbacks_overlap(big_on_axes, small_on_axes, click_on):
     # In each case we expect that both rectangles are picked if we click on the
     # small one and only the big one is picked if we click on the big one.
     # Also tests picking on normal axes ("gca") as a control.
-    big = plt.Rectangle((0.25, 0.25), 0.5, 0.5, picker=5)
-    small = plt.Rectangle((0.4, 0.4), 0.2, 0.2, facecolor="r", picker=5)
+    big = plt.Rectangle((0.25, 0.25), 0.5, 0.5, picker=True, pickradius=5)
+    with _api.suppress_matplotlib_deprecation_warning():
+        small = plt.Rectangle((0.4, 0.4), 0.2, 0.2, facecolor="r", picker=5)
     # Machinery for "receiving" events
     received_events = []
     def on_pick(event):


### PR DESCRIPTION
This is the same deprecation as the one introduced for Line2D in 3.3.

(The exact deprecation strategy used here may already break convoluted
call sequences on Collections: calling
`coll.set_pickradius(3); coll.set_picker(5); coll.set_picker(False); coll.set_picker(True)`
will leave the pickradius at 5 instead of 3 as was the case before, but
I'm not too worried about that (if anything the new behavior is more
sensical...).)

On Patches, note that the old implementation of `_process_radius` was
likely wrong: after calling `set_picker(True)`, `_picker` would be a
bool and therefore a `Number`, so the fallback cases to the patch
linewidth did not occur.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
