### PR TITLE
Inline MovieWriter._frame_sink.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -344,12 +344,8 @@ class MovieWriter(AbstractMovieWriter):
         # All frames must have the same size to save the movie correctly.
         self.fig.set_size_inches(self._w, self._h)
         # Save the figure data to the sink, using the frame format and dpi.
-        self.fig.savefig(self._frame_sink(), format=self.frame_format,
+        self.fig.savefig(self._proc.stdin, format=self.frame_format,
                          dpi=self.dpi, **savefig_kwargs)
-
-    def _frame_sink(self):
-        """Return the place to which frames should be written."""
-        return self._proc.stdin
 
     def _args(self):
         """Assemble list of encoder-specific command-line arguments."""
@@ -358,7 +354,6 @@ class MovieWriter(AbstractMovieWriter):
     def cleanup(self):
         """Clean-up and collect the process used to write the movie file."""
         out, err = self._proc.communicate()
-        self._frame_sink().close()
         # Use the encoding/errors that universal_newlines would use.
         out = TextIOWrapper(BytesIO(out)).read()
         err = TextIOWrapper(BytesIO(err)).read()
@@ -474,30 +469,18 @@ class FileMovieWriter(MovieWriter):
         # for extension and the prefix.
         return self.fname_format_str % (self.temp_prefix, self.frame_format)
 
-    def _frame_sink(self):
-        # Creates a filename for saving using the basename and the current
-        # counter.
-        path = Path(self._base_temp_name() % self._frame_counter)
-
-        # Save the filename so we can delete it later if necessary
-        self._temp_paths.append(path)
-        _log.debug('FileMovieWriter.frame_sink: saving frame %d to path=%s',
-                   self._frame_counter, path)
-        self._frame_counter += 1  # Ensures each created name is 'unique'
-
-        # This file returned here will be closed once it's used by savefig()
-        # because it will no longer be referenced and will be gc-ed.
-        return open(path, 'wb')
-
     def grab_frame(self, **savefig_kwargs):
         # docstring inherited
         # Overloaded to explicitly close temp file.
-        _log.debug('MovieWriter.grab_frame: Grabbing frame.')
-        # Tell the figure to save its data to the sink, using the
-        # frame format and dpi.
-        with self._frame_sink() as myframesink:
-            self.fig.savefig(myframesink, format=self.frame_format,
-                             dpi=self.dpi, **savefig_kwargs)
+        # Creates a filename for saving using basename and counter.
+        path = Path(self._base_temp_name() % self._frame_counter)
+        self._temp_paths.append(path)  # Record the filename for later cleanup.
+        self._frame_counter += 1  # Ensures each created name is unique.
+        _log.debug('FileMovieWriter.grab_frame: Grabbing frame %d to path=%s',
+                   self._frame_counter, path)
+        with open(path, 'wb') as sink:  # Save figure to the sink.
+            self.fig.savefig(sink, format=self.frame_format, dpi=self.dpi,
+                             **savefig_kwargs)
 
     def finish(self):
         # Call run here now that all frame grabbing is done. All temp files


### PR DESCRIPTION
It plays two fairly different roles in MovieWriter (it's the stdin of
the long-standing ffmpeg-like subprocess) and FileMovieWriter (it's the
ever-changing handle of the frame currently being saved), with different
life-cycles and no reuse between the subclasses, so it's easier to just
inline it at the call site (and skip a comment about how
FileMovieWriter._frame_sink gets closed in grab_frame, hinting at the
tight-coupling between the two of them).

Also, no need to close the process stdin after calling communicate() --
communicate() does it for us.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
