### PR TITLE
Prepare inlining MovieWriter.cleanup() into MovieWriter.finish().

### DIFF
--- a/doc/api/next_api_changes/deprecations/19046-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19046-AL.rst
@@ -1,0 +1,5 @@
+``MovieWriter.cleanup`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Cleanup logic is now fully implemented in `.MovieWriter.finish`.  Third-party
+movie writers should likewise move the relevant cleanup logic there, as
+overridden ``cleanup``\s will no longer be called in the future.

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -251,7 +251,7 @@
     ],
     "matplotlib.axes._axes.Axes": [
       "doc/api/artist_api.rst:189",
-      "doc/api/axes_api.rst:617",
+      "doc/api/axes_api.rst:609",
       "lib/matplotlib/projections/polar.py:docstring of matplotlib.projections.polar.PolarAxes:1",
       "lib/mpl_toolkits/axes_grid1/mpl_axes.py:docstring of mpl_toolkits.axes_grid1.mpl_axes.Axes:1",
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.Axes:1",
@@ -259,7 +259,7 @@
     ],
     "matplotlib.axes._base._AxesBase": [
       "doc/api/artist_api.rst:189",
-      "doc/api/axes_api.rst:617",
+      "doc/api/axes_api.rst:609",
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes:1"
     ],
     "matplotlib.backend_bases.FigureCanvas": [
@@ -831,6 +831,7 @@
       "lib/matplotlib/image.py:docstring of matplotlib.image.composite_images:9"
     ],
     "cleanup": [
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.setup:18",
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.HTMLWriter.setup:18"
     ],
     "colorbar.ColorbarBase.outline": [
@@ -895,7 +896,7 @@
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.get_ylim3d:24"
     ],
     "ipykernel.pylab.backend_inline": [
-      "doc/users/interactive.rst:256"
+      "doc/users/interactive.rst:257"
     ],
     "kde.covariance_factor": [
       "lib/matplotlib/mlab.py:docstring of matplotlib.mlab.GaussianKDE:41"
@@ -1102,16 +1103,19 @@
       "doc/api/_as_gen/matplotlib.animation.FFMpegWriter.rst:28:<autosummary>:1"
     ],
     "matplotlib.animation.FileMovieWriter.args_key": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.cleanup:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.clear_temp:1:<autosummary>:1"
     ],
     "matplotlib.animation.FileMovieWriter.bin_path": [
       "doc/api/_as_gen/matplotlib.animation.FileMovieWriter.rst:28:<autosummary>:1"
     ],
+    "matplotlib.animation.FileMovieWriter.cleanup": [
+      "doc/api/_as_gen/matplotlib.animation.FileMovieWriter.rst:28:<autosummary>:1"
+    ],
     "matplotlib.animation.FileMovieWriter.exec_key": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.cleanup:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.clear_temp:1:<autosummary>:1"
     ],
     "matplotlib.animation.FileMovieWriter.frame_size": [
-      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.cleanup:1:<autosummary>:1"
+      "lib/matplotlib/animation.py:docstring of matplotlib.animation.FileMovieWriter.clear_temp:1:<autosummary>:1"
     ],
     "matplotlib.animation.FileMovieWriter.isAvailable": [
       "doc/api/_as_gen/matplotlib.animation.FileMovieWriter.rst:28:<autosummary>:1"


### PR DESCRIPTION
The docs only mention `finish()`; but the implementations of `finish()`
simply forwards themselves to `cleanup()` (and do a bit more).  One can
instead just put all the relevant logic in `finish()` and not expose a
separate (basically internal) API.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
