### PR TITLE
Remove _draw_{ticks2,label2}; skip extents computation in _update_ticks.

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -911,76 +911,23 @@ class AxisArtist(martist.Artist):
 
         tick_loc_angle, ticklabel_loc_angle_label = \
             self._get_tick_info(majortick_iter)
-
         self.major_ticks.set_locs_angles(tick_loc_angle)
         self.major_ticklabels.set_locs_angles_labels(ticklabel_loc_angle_label)
 
-        # minor ticks
         tick_loc_angle, ticklabel_loc_angle_label = \
             self._get_tick_info(minortick_iter)
-
         self.minor_ticks.set_locs_angles(tick_loc_angle)
         self.minor_ticklabels.set_locs_angles_labels(ticklabel_loc_angle_label)
-
-        return self.major_ticklabels.get_window_extents(renderer)
 
     def _draw_ticks(self, renderer):
-
-        extents = self._update_ticks(renderer)
-
+        self._update_ticks(renderer)
         self.major_ticks.draw(renderer)
         self.major_ticklabels.draw(renderer)
-
         self.minor_ticks.draw(renderer)
         self.minor_ticklabels.draw(renderer)
-
         if (self.major_ticklabels.get_visible()
                 or self.minor_ticklabels.get_visible()):
             self._draw_offsetText(renderer)
-
-        return extents
-
-    def _draw_ticks2(self, renderer):
-        # set extra pad for major and minor ticklabels: use ticksize of
-        # majorticks even for minor ticks. not clear what is best.
-
-        dpi_cor = renderer.points_to_pixels(1.)
-        if self.major_ticks.get_visible() and self.major_ticks.get_tick_out():
-            self.major_ticklabels._set_external_pad(
-                self.major_ticks._ticksize * dpi_cor)
-            self.minor_ticklabels._set_external_pad(
-                self.major_ticks._ticksize * dpi_cor)
-        else:
-            self.major_ticklabels._set_external_pad(0)
-            self.minor_ticklabels._set_external_pad(0)
-
-        majortick_iter, minortick_iter = \
-            self._axis_artist_helper.get_tick_iterators(self.axes)
-
-        tick_loc_angle, ticklabel_loc_angle_label = \
-            self._get_tick_info(majortick_iter)
-
-        self.major_ticks.set_locs_angles(tick_loc_angle)
-        self.major_ticklabels.set_locs_angles_labels(ticklabel_loc_angle_label)
-
-        self.major_ticks.draw(renderer)
-        self.major_ticklabels.draw(renderer)
-
-        # minor ticks
-        tick_loc_angle, ticklabel_loc_angle_label = \
-            self._get_tick_info(minortick_iter)
-
-        self.minor_ticks.set_locs_angles(tick_loc_angle)
-        self.minor_ticklabels.set_locs_angles_labels(ticklabel_loc_angle_label)
-
-        self.minor_ticks.draw(renderer)
-        self.minor_ticklabels.draw(renderer)
-
-        if (self.major_ticklabels.get_visible()
-                or self.minor_ticklabels.get_visible()):
-            self._draw_offsetText(renderer)
-
-        return self.major_ticklabels.get_window_extents(renderer)
 
     _offsetText_pos = dict(left=(0, 1, "bottom", "right"),
                            right=(1, 1, "bottom", "left"),
@@ -1058,36 +1005,6 @@ class AxisArtist(martist.Artist):
 
     def _draw_label(self, renderer):
         self._update_label(renderer)
-        self.label.draw(renderer)
-
-    def _draw_label2(self, renderer):
-        if not self.label.get_visible():
-            return
-
-        if self._ticklabel_add_angle != self._axislabel_add_angle:
-            if ((self.major_ticks.get_visible()
-                 and not self.major_ticks.get_tick_out())
-                or (self.minor_ticks.get_visible()
-                    and not self.major_ticks.get_tick_out())):
-                axislabel_pad = self.major_ticks._ticksize
-            else:
-                axislabel_pad = 0
-        else:
-            axislabel_pad = max(self.major_ticklabels._axislabel_pad,
-                                self.minor_ticklabels._axislabel_pad)
-
-        self.label._set_external_pad(axislabel_pad)
-
-        xy, angle_tangent = \
-            self._axis_artist_helper.get_axislabel_pos_angle(self.axes)
-        if xy is None:
-            return
-
-        angle_label = angle_tangent - 90
-
-        x, y = xy
-        self.label._set_ref_angle(angle_label+self._axislabel_add_angle)
-        self.label.set(x=x, y=y)
         self.label.draw(renderer)
 
     def set_label(self, s):


### PR DESCRIPTION
- As far as I can see, AxisArtist._draw_{ticks2,labels2} have never been
  used, and are exactly identical to `_draw_{ticks,labels}` with the
  exception that the call to `_update_{ticks,labels}` has additionally
  been inlined.
- We don't need to compute the window extents in `_update_ticks` and
  forward it in `_draw_ticks`: it's never used at the call sites, and
  `get_tightbbox` (which is the sole consumer of this info) calls again
  `major_ticklabels.get_window_extent` (as well as
  `minor_ticklabels.get_window_extent`) itself.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
