### PR TITLE
Support raw/rgba frame format in FFMpegFileWriter

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -634,9 +634,15 @@ class FFMpegFileWriter(FFMpegBase, FileMovieWriter):
     def _args(self):
         # Returns the command line parameters for subprocess to use
         # ffmpeg to create a movie using a collection of temp images
-        return [self.bin_path(), '-r', str(self.fps),
+        args = [self.bin_path(), '-r', str(self.fps),
                 '-i', self._base_temp_name(),
-                '-vframes', str(self._frame_counter)] + self.output_args
+                '-vframes', str(self._frame_counter)]
+        # Logging is quieted because subprocess.PIPE has limited buffer size.
+        # If you have a lot of frames in your animation and set logging to
+        # DEBUG, you will have a buffer overrun.
+        if _log.getEffectiveLevel() > logging.DEBUG:
+            args += ['-loglevel', 'error']
+        return [*args, *self.output_args]
 
 
 # Base class of avconv information.  AVConv has identical arguments to FFMpeg.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -628,8 +628,7 @@ class FFMpegFileWriter(FFMpegBase, FileMovieWriter):
     Frames are written to temporary files on disk and then stitched
     together at the end.
     """
-    supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',
-                         'pbm', 'raw', 'rgba']
+    supported_formats = ['png', 'jpeg', 'tiff', 'raw', 'rgba']
 
     def _args(self):
         # Returns the command line parameters for subprocess to use
@@ -759,8 +758,7 @@ class ImageMagickFileWriter(ImageMagickBase, FileMovieWriter):
     together at the end.
     """
 
-    supported_formats = ['png', 'jpeg', 'ppm', 'tiff', 'sgi', 'bmp',
-                         'pbm', 'raw', 'rgba']
+    supported_formats = ['png', 'jpeg', 'tiff', 'raw', 'rgba']
 
     def _args(self):
         # Force format: ImageMagick does not recognize 'raw'.


### PR DESCRIPTION
## PR Summary

This could maybe be tested, but I think maybe after the cleanup from #19044.

Additionally, copy the logging setting that is done in `FFMpegWriter._args`.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).