### PR TITLE
Support blitting in webagg backend

### DIFF
--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from imp import reload"
@@ -23,9 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib\n",
@@ -49,9 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.backends.backend_webagg_core\n",
@@ -78,9 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.plot([3, 2, 1])\n",
@@ -99,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
@@ -119,12 +109,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "plt.close(fig1)"
+    "plt.close(fig1)\n",
+    "plt.close('all')"
    ]
   },
   {
@@ -140,9 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.plot(range(10))"
@@ -160,9 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
@@ -180,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.show()\n",
@@ -203,9 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.interactive(True)\n",
@@ -223,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.plot(range(3))"
@@ -241,9 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
@@ -259,9 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.interactive(False)"
@@ -279,9 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "plt.gcf().canvas.manager.reshow()"
@@ -310,9 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
@@ -335,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from matplotlib.backends.backend_nbagg import new_figure_manager,show\n",
@@ -361,9 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.animation as animation\n",
@@ -384,7 +351,7 @@
     "    return line,\n",
     "\n",
     "ani = animation.FuncAnimation(fig, animate, np.arange(1, 200), init_func=init,\n",
-    "                              interval=32., blit=True)\n",
+    "                              interval=100., blit=True)\n",
     "plt.show()"
    ]
   },
@@ -404,9 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib\n",
@@ -430,9 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import itertools\n",
@@ -477,9 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import time\n",
@@ -506,9 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -531,9 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -549,9 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -569,7 +524,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### UAT17 - stopping figure when removed from DOM\n",
+    "### UAT 18 - stopping figure when removed from DOM\n",
     "\n",
     "When the div that contains from the figure is removed from the DOM the figure should shut down it's comm, and if the python-side figure has no more active comms, it should destroy the figure. Repeatedly running the cell below should always have the same figure number"
    ]
@@ -577,9 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
@@ -597,20 +550,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fig.canvas.manager.reshow()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": true
    },
+   "source": [
+    "### UAT 19 - Blitting\n",
+    "\n",
+    "Clicking on the figure should plot a green horizontal line moving up the axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "cnt = itertools.count()\n",
+    "bg = None\n",
+    "\n",
+    "def onclick_handle(event):\n",
+    "    \"\"\"Should draw elevating green line on each mouse click\"\"\"\n",
+    "    global bg\n",
+    "    if bg is None:\n",
+    "        bg = ax.figure.canvas.copy_from_bbox(ax.bbox) \n",
+    "    ax.figure.canvas.restore_region(bg)\n",
+    "\n",
+    "    cur_y = (next(cnt) % 10) * 0.1\n",
+    "    ln.set_ydata([cur_y, cur_y])\n",
+    "    ax.draw_artist(ln)\n",
+    "    ax.figure.canvas.blit(ax.bbox)\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot([0, 1], [0, 1], 'r')\n",
+    "ln, = ax.plot([0, 1], [0, 0], 'g', animated=True)\n",
+    "plt.show()\n",
+    "ax.figure.canvas.draw()\n",
+    "\n",
+    "ax.figure.canvas.mpl_connect('button_press_event', onclick_handle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -631,9 +623,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
## PR Summary
Closes: https://github.com/matplotlib/matplotlib/issues/4288
Closes: https://github.com/matplotlib/ipympl/issues/228
Supersedes: https://github.com/matplotlib/matplotlib/pull/9240

I replaced the second Agg renderer by storing the previous buffer in a private attribute. Removing the second renderer as suggested by @tacaswell eliminates the the flickering issues noted in https://github.com/matplotlib/matplotlib/pull/9240#issuecomment-528170704

I also tried out a modified version of the test case by @mbewley in https://github.com/matplotlib/matplotlib/pull/9240#issuecomment-332677090 and found that performance was improved considerably when blitting was enabled.

```python
from imp import reload

import matplotlib
reload(matplotlib)

matplotlib.use('nbagg')

import matplotlib.backends.backend_nbagg
reload(matplotlib.backends.backend_nbagg)
import matplotlib.backends.backend_webagg_core
reload(matplotlib.backends.backend_webagg_core)


import numpy as np
import matplotlib.pyplot as plt
import matplotlib.patches as mpatches
IMSIZE = 7000
RED = (1,0,0,1)
GREEN = (0,1,0,1)

plt.ion()
class ExampleToggle:
    
    def __init__(self):
        self.fig = plt.figure()
        self.ax = self.fig.add_subplot(111)
        self.canvas = self.ax.figure.canvas

        self.im = np.random.randint(0, 255, [IMSIZE,IMSIZE, 3]).astype('uint8')
        self.tmp_colour = RED
        self.rect = mpatches.Rectangle([0, 0], 200, 200, edgecolor='yellow', facecolor=self.tmp_colour, linewidth=0.5, animated=True)
        self.ax.add_patch(self.rect)
        
        self.canvas.mpl_connect('button_press_event', self.clicked)
        self.ax.imshow(self.im)
        self.canvas.draw()
        self._been_clicked = False

    def clicked(self, event):
        if not self._been_clicked:
            self.background = self.canvas.copy_from_bbox(self.ax.bbox)    
            self._been_clicked = True

        if self.tmp_colour == RED:
            self.tmp_colour = GREEN
        elif self.tmp_colour == GREEN:
            self.tmp_colour = RED
        self.rect.set_facecolor(self.tmp_colour)
        self.canvas.restore_region(self.background)
        self.ax.draw_artist(self.rect)
        self.canvas.blit(self.ax.bbox)
et = ExampleToggle()
```

(the modification was to use the `self._been_clicked` as I was finding that otherwise the figure was resizing and the bbox was incorrect)

![blit](https://user-images.githubusercontent.com/10111092/100962117-bb5b0800-34f1-11eb-8d38-c0ae9d113acb.gif)



Unlike the previous PR this does not need to implement `copy_from_bbox` as that is inherited from `backend_agg.FigureCanvasAgg`.

I didn't add any new tests but I did try the UAT notebook and found that the flickering mentioned is is resolved by this approach. Should we consider adding the above blit test for perforamance to the UAT notebook?

One issue is that at times the animation can get tripped up and fail to properly blit. Though I believe that this is an issue that was revealed by, rather than caused by, this PR. My theory is that maybe new messages reach the frontend before it finishes a redraw and then the frontend trips over itself? This is something I've noticed on occasion with ipympl as well, even without blitting. The result looks like this, though if I increase the interval of the animation then this pathology goes away:

**with interval=32**
![borked-blit](https://user-images.githubusercontent.com/10111092/100961625-bea1c400-34f0-11eb-80a7-fd4ac25f5667.gif)
**with interval=100**
![slow-interval](https://user-images.githubusercontent.com/10111092/100961712-ec870880-34f0-11eb-86ff-41919b46a9b4.gif)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [UAT] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A (i think?)] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

would this get an API note or a new feature? or neither?
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
