### PR TITLE
Fix broken link in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@
 .. _PyPi: https://badge.fury.io/py/matplotlib
 
 .. |Downloads| image:: https://pepy.tech/badge/matplotlib/month
-.. _Downloads: https://pepy.tech/project/matplotlib/month
+.. _Downloads: https://pepy.tech/project/matplotlib
 
 .. |NUMFocus| image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
 .. _NUMFocus: https://numfocus.org


### PR DESCRIPTION
## PR Summary
Currently the link to pepy https://pepy.tech/project/matplotlib/month results in this:
![image](https://user-images.githubusercontent.com/44469195/100987253-8df07780-354e-11eb-9645-96b843e7fd5b.png)

The right link should be
https://pepy.tech/project/matplotlib/