### PR TITLE
Backport PR #19036 on branch v3.3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,226 @@
+name: Tests
+
+on:
+  push:
+    branches-ignore:
+      - auto-backport-of-pr-[0-9]+
+      - v[0-9]+.[0-9]+.[0-9x]+-doc
+  pull_request:
+
+env:
+  NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.
+  OPENBLAS_NUM_THREADS: 1
+  PYTHONFAULTHANDLER: 1
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.name-suffix }}"
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - name-suffix: "(Minimum Versions)"
+            os: ubuntu-16.04
+            python-version: 3.6
+            extra-requirements: '-c requirements/testing/minver.txt'
+            delete-font-cache: true
+            XVFB_RUN: xvfb-run -a
+          - os: ubuntu-16.04
+            python-version: 3.7
+            extra-requirements: '-r requirements/testing/travis_extra.txt'
+            XVFB_RUN: xvfb-run -a
+          - os: ubuntu-16.04
+            python-version: 3.8
+            extra-requirements: '-r requirements/testing/travis_extra.txt'
+            XVFB_RUN: xvfb-run -a
+          - os: macos-latest
+            python-version: 3.8
+            XVFB_RUN: ""
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install OS dependencies
+        run: |
+          case "${{ runner.os }}" in
+          Linux)
+            sudo apt-get update -yy
+            sudo apt-get install -yy \
+              ccache \
+              cm-super \
+              dvipng \
+              ffmpeg \
+              gdb \
+              gir1.2-gtk-3.0 \
+              graphviz \
+              inkscape \
+              lcov \
+              libcairo2 \
+              libcairo2-dev \
+              libffi-dev \
+              libgeos-dev \
+              libgirepository1.0-dev \
+              libsdl2-2.0-0 \
+              libxkbcommon-x11-0 \
+              libxcb-icccm4 \
+              libxcb-image0 \
+              libxcb-keysyms1 \
+              libxcb-randr0 \
+              libxcb-render-util0 \
+              libxcb-xinerama0 \
+              lmodern \
+              fonts-freefont-otf \
+              texlive-pictures \
+              pkg-config \
+              qtbase5-dev \
+              texlive-fonts-recommended \
+              texlive-latex-base \
+              texlive-latex-extra \
+              texlive-latex-recommended \
+              texlive-luatex \
+              texlive-xetex \
+              ttf-wqy-zenhei
+            ;;
+          macOS)
+            brew update
+            brew install ccache
+            ;;
+          esac
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements/*/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+      - name: Cache pip
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements/*/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-pip-
+      - name: Cache ccache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ccache
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-ccache-${{ hashFiles('src/*') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-ccache-
+      - name: Cache Matplotlib
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/matplotlib
+            !~/.cache/matplotlib/tex.cache
+            !~/.cache/matplotlib/test_cache
+          key: ${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-
+            ${{ runner.os }}-py${{ matrix.python-version }}-mpl-
+
+      - name: Install Python dependencies
+        run: |
+          # Upgrade pip and setuptools and wheel to get as clean an install as
+          # possible.
+          python -mpip install --upgrade pip setuptools wheel
+
+          # Install dependencies from PyPI.
+          python -mpip install --upgrade $PRE \
+            cycler kiwisolver numpy pillow pyparsing python-dateutil \
+            -r requirements/testing/travis_all.txt \
+            ${{ matrix.extra-requirements }}
+
+          # Install optional dependencies from PyPI.
+          # Sphinx is needed to run sphinxext tests
+          python -mpip install --upgrade sphinx
+
+          # GUI toolkits are pip-installable only for some versions of Python
+          # so don't fail if we can't install them.  Make it easier to check
+          # whether the install was successful by trying to import the toolkit
+          # (sometimes, the install appears to be successful but shared
+          # libraries cannot be loaded at runtime, so an actual import is a
+          # better check).
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+            # PyGObject, pycairo, and cariocffi do not install on OSX 10.12;
+            # pycairo 1.20+ requires a new version of Cairo, unavailable on
+            # Ubuntu 16.04, so PyGObject must be installed without build
+            # isolation in order to pick up the lower pre-installed version.
+             python -mpip install --upgrade 'pycairo<1.20.0' 'cairocffi>=0.8' &&
+             python -mpip install --upgrade --no-build-isolation PyGObject &&
+               python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&
+               echo 'PyGObject is available' ||
+               echo 'PyGObject is not available'
+
+            # There are no functioning wheels available for OSX 10.12 (as of
+            # Sept 2020) for either pyqt5 (there are only wheels for 10.13+) or
+            # pyside2 (the latest version (5.13.2) with 10.12 wheels has a
+            # fatal to us bug, it was fixed in 5.14.0 which has 10.13 wheels)
+             python -mpip install --upgrade pyqt5 &&
+               python -c 'import PyQt5.QtCore' &&
+               echo 'PyQt5 is available' ||
+               echo 'PyQt5 is not available'
+             python -mpip install --upgrade pyside2 &&
+               python -c 'import PySide2.QtCore' &&
+               echo 'PySide2 is available' ||
+               echo 'PySide2 is not available'
+          fi
+          python -mpip install --upgrade \
+            -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04 \
+            wxPython &&
+            python -c 'import wx' &&
+            echo 'wxPython is available' ||
+            echo 'wxPython is not available'
+
+      - name: Install Matplotlib
+        run: |
+          ccache -s
+          git describe
+
+          # Set flag in a delayed manner to avoid issues with installing other
+          # packages
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+            export CPPFLAGS=--coverage
+          fi
+
+          # All dependencies must have been pre-installed, so that the minver
+          # constraints are held.
+          python -mpip install --no-deps -e .
+
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+            unset CPPFLAGS
+          fi
+
+      - name: Clear font cache
+        run: |
+          rm -rf ~/.cache/matplotlib
+        if: matrix.delete-font-cache
+
+      - name: Run pytest
+        run: |
+          ${{ matrix.XVFB_RUN }} python -mpytest -raR -n auto \
+            --maxfail=50 --timeout=300 --durations=25 \
+            --cov-report= --cov=lib --log-level=DEBUG
+
+      - name: Filter C coverage
+        run: |
+          lcov --capture --directory . --output-file coverage.info
+          lcov --output-file coverage.info \
+            --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
+          lcov --list coverage.info
+          find . -name '*.gc*' -delete
+        if: ${{ runner.os != 'macOS' }}
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
   include:
     - python: 3.6
       env:
-        - PINNEDVERS='-c requirements/testing/travis36minver.txt'
+        - PINNEDVERS='-c requirements/testing/minver.txt'
         - DELETE_FONT_CACHE=1
     - python: 3.7
       env:

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -1,0 +1,8 @@
+# Extra pip requirements for the minimum-version CI run
+
+cycler==0.10
+kiwisolver==1.0.1
+numpy==1.15.0
+pillow==6.2.0
+pyparsing==2.0.3
+python-dateutil==2.1

--- a/requirements/testing/travis36minver.txt
+++ b/requirements/testing/travis36minver.txt
@@ -1,6 +1,0 @@
-# Extra pip requirements for the first travis python 3.6 build
-
-cycler==0.10
-python-dateutil==2.1
-numpy==1.15.0
-pyparsing==2.0.3


### PR DESCRIPTION
## PR Summary

Note, at some point on `master`, the requirements file was renamed from `travis36minver.txt` to `minver.txt`, so I did that in this PR as well to reduce differences between the branches.

It also runs slightly different Python versions, since older Python is still supported for this branch.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).