### PR TITLE
Give plot_directive output a `max-width: 100%`

### DIFF
--- a/lib/matplotlib/sphinxext/__init__.py
+++ b/lib/matplotlib/sphinxext/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+_static_path = Path(__file__).resolve().parent / Path('static')

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -156,7 +156,7 @@ import jinja2  # Sphinx dependency.
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
 import matplotlib.pyplot as plt
-from matplotlib import _api, _pylab_helpers, cbook
+from matplotlib import _api, _pylab_helpers, cbook, sphinxext
 
 matplotlib.use("agg")
 align = _api.deprecated(
@@ -254,6 +254,13 @@ class PlotDirective(Directive):
             raise self.error(str(e))
 
 
+def _copy_css_file(app, exc):
+    if exc is None and app.builder.format == 'html':
+        src = sphinxext._static_path / Path('plot_directive.css')
+        dst = app.outdir / Path('_static')
+        shutil.copy(src, dst)
+
+
 def setup(app):
     setup.app = app
     setup.config = app.config
@@ -269,9 +276,9 @@ def setup(app):
     app.add_config_value('plot_apply_rcparams', False, True)
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
-
     app.connect('doctree-read', mark_plot_labels)
-
+    app.add_css_file('plot_directive.css')
+    app.connect('build-finished', _copy_css_file)
     metadata = {'parallel_read_safe': True, 'parallel_write_safe': True,
                 'version': matplotlib.__version__}
     return metadata
@@ -337,7 +344,6 @@ def split_code_at_show(text):
 # Template
 # -----------------------------------------------------------------------------
 
-
 TEMPLATE = """
 {{ source_code }}
 
@@ -374,7 +380,7 @@ TEMPLATE = """
         )
       {%- endif -%}
 
-      {{ caption }}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
    {% endfor %}
 
 .. only:: not html
@@ -383,9 +389,9 @@ TEMPLATE = """
    .. figure:: {{ build_dir }}/{{ img.basename }}.*
       {% for option in options -%}
       {{ option }}
-      {% endfor %}
+      {% endfor -%}
 
-      {{ caption }}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
    {% endfor %}
 
 """
@@ -521,7 +527,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
     """
     formats = get_plot_formats(config)
 
-    # -- Try to determine if all images already exist
+    # Try to determine if all images already exist
 
     code_pieces = split_code_at_show(code)
 
@@ -624,6 +630,13 @@ def run(arguments, content, options, state_machine, state, lineno):
     default_fmt = formats[0][0]
 
     options.setdefault('include-source', config.plot_include_source)
+    if 'class' in options:
+        # classes are parsed into a list of string, and output by simply
+        # printing the list, abusing the fact that RST guarantees to strip
+        # non-conforming characters
+        options['class'] = ['plot-directive'] + options['class']
+    else:
+        options.setdefault('class', ['plot-directive'])
     keep_context = 'context' in options
     context_opt = None if not keep_context else options['context']
 
@@ -743,8 +756,8 @@ def run(arguments, content, options, state_machine, state, lineno):
         errors = [sm]
 
     # Properly indent the caption
-    caption = '\n'.join('      ' + line.strip()
-                        for line in caption.split('\n'))
+    caption = '\n' + '\n'.join('      ' + line.strip()
+                               for line in caption.split('\n'))
 
     # generate output restructuredtext
     total_lines = []

--- a/lib/matplotlib/sphinxext/static/plot_directive.css
+++ b/lib/matplotlib/sphinxext/static/plot_directive.css
@@ -1,0 +1,16 @@
+/*
+ * plot_directive.css
+ * ~~~~~~~~~~~~
+ *
+ * Stylesheet controlling images created using the `plot` directive within
+ * Sphinx.
+ *
+ * :copyright: Copyright 2020-* by the Matplotlib development team.
+ * :license: Matplotlib, see LICENSE for details.
+ *
+ */
+
+img.plot-directive {
+    border: 0;
+    max-width: 100%;
+}

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -58,3 +58,7 @@ def test_tinypages(tmpdir):
     assert b'Plot 17 uses the caption option.' in html_contents
     # check if figure caption made it into html file
     assert b'This is the caption for plot 18.' in html_contents
+    # check if the custom classes made it into the html file
+    assert b'plot-directive my-class my-other-class' in html_contents
+    # check that the multi-image caption is applied twice
+    assert html_contents.count(b'This caption applies to both plots.') == 2

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -141,3 +141,23 @@ using the :caption: option:
 
 .. plot:: range4.py
    :caption: This is the caption for plot 18.
+
+Plot 19 uses shows that the "plot-directive" class is still appended, even if
+we request other custom classes:
+
+.. plot:: range4.py
+   :class: my-class my-other-class
+
+    Should also have a caption.
+
+Plot 20 shows that the default template correctly prints the multi-image
+scenario:
+
+.. plot::
+   :caption: This caption applies to both plots.
+
+   plt.figure()
+   plt.plot(range(6))
+
+   plt.figure()
+   plt.plot(range(4))


### PR DESCRIPTION
## PR Summary

Currently, non-sphinx-gallery plots in the documentation (for example, from a `.. plot::` directive in a docstring) produce plots that do not scale with screen size. This means that on e.g. phones, the plots get chopped off, as seen here:

![overfull-example](https://user-images.githubusercontent.com/1475390/101184089-26493380-3605-11eb-8068-c6ee92a0afdb.png)

Other Sphinx extensions (gallery, the inheritance diagram extension, etc) add their own custom CSS to make the images fit in the page. I copied the approach taken by `sphinx.ext.graphviz` to get the following result:

![fixed-overfull-example](https://user-images.githubusercontent.com/1475390/101184097-28ab8d80-3605-11eb-84ad-b32779827de1.png)

This became increasingly important for my GSOD work (e.g. #18544, where the API docs center around the inclusion of a "demo" figure showing the various options).

Edit: additionally, I had to fix an existing bug in `plot_directive.TEMPLATE` that caused Sphinx to warn (failing our tests) whenever there is both a caption and a custom class assigned to a figure.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
