### PR TITLE
Mention in a few more places that artists default to not-pickable.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1471,7 +1471,8 @@ class MouseEvent(LocationEvent):
 class PickEvent(Event):
     """
     A pick event, fired when the user picks a location on the canvas
-    sufficiently close to an artist.
+    sufficiently close to an artist that has been made pickable with
+    `.Artist.set_picker`.
 
     Attrs: all the `Event` attributes plus
 
@@ -1480,7 +1481,8 @@ class PickEvent(Event):
     mouseevent : `MouseEvent`
         The mouse event that generated the pick.
     artist : `matplotlib.artist.Artist`
-        The picked artist.
+        The picked artist.  Note that artists are not pickable by default
+        (see `.Artist.set_picker`).
     other
         Additional attributes may be present depending on the type of the
         picked object; e.g., a `~.Line2D` pick may define different extra
@@ -1831,6 +1833,9 @@ class FigureCanvasBase:
 
         This method will be called by artists who are picked and will
         fire off `PickEvent` callbacks registered listeners.
+
+        Note that artists are not pickable by default (see
+        `.Artist.set_picker`).
         """
         s = 'pick_event'
         event = PickEvent(s, self, mouseevent, artist,


### PR DESCRIPTION
## PR Summary

Closes #7238 (I can't think of other places where we could mention this...).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
