### PR TITLE
correct reference to 68-95-99.7% rule

### DIFF
--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -34,9 +34,9 @@ import matplotlib.transforms as transforms
 #
 # The radiuses of the ellipse can be controlled by n_std which is the number
 # of standard deviations. The default value is 3 which makes the ellipse
-# enclose 99.4% of the points - given the data is normally distributed
-# like in these examples. Why not 99.7%? See :ref:`No 68-95-99.7 Rule<no_rule>`
-# below for a brief explanation.
+# enclose 99.4% of the points it the data is normally distributed
+# like in these examples (3 standard deviations in 1-D contain 99.7% of the data, 
+# which is 99.4% of the data in 2-D).
 
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):
@@ -231,4 +231,3 @@ plt.show()
 # of 0.68, 0.95 and 99.7 to 0.462, 0.903 and 0.994, respectively.
 # If you wish, you can think of it as a new "46-90-99 Rule" for
 # two-dimensional data.
-

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -34,8 +34,8 @@ import matplotlib.transforms as transforms
 #
 # The radiuses of the ellipse can be controlled by n_std which is the number
 # of standard deviations. The default value is 3 which makes the ellipse
-# enclose 99.4% of the points it the data is normally distributed
-# like in these examples (3 standard deviations in 1-D contain 99.7% of the data, 
+# enclose 99.4% of the points if the data is normally distributed
+# like in these examples (3 standard deviations in 1-D contain 99.7% of the data,
 # which is 99.4% of the data in 2-D).
 
 
@@ -214,20 +214,3 @@ ax_kwargs.set_title('Using kwargs')
 
 fig.subplots_adjust(hspace=0.25)
 plt.show()
-
-#############################################################################
-#
-# No 68-95-99.7 Rule
-# """"""""""""""""""
-#
-# .. no_rule:
-# The well-known 68-95-99.7 rule states that in a normal distribution 68%
-# of the observations lie within +/- 1 standard deviation from the mean, 95%
-# within 2 standard deviations and 99.7% within 3 standard deviations.
-#
-# However this rule only holds for one-dimensional data.
-# To adjust this rule to two-dimensional data,
-# it suffices to square the probabilities
-# of 0.68, 0.95 and 99.7 to 0.462, 0.903 and 0.994, respectively.
-# If you wish, you can think of it as a new "46-90-99 Rule" for
-# two-dimensional data.

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -35,7 +35,8 @@ import matplotlib.transforms as transforms
 # The radiuses of the ellipse can be controlled by n_std which is the number
 # of standard deviations. The default value is 3 which makes the ellipse
 # enclose 99.4% of the points - given the data is normally distributed
-# like in these examples. Why not 99.7%? See :ref:`No 68-95-99.7 Rule<no_rule>` below for a brief explanation.
+# like in these examples. Why not 99.7%? See :ref:`No 68-95-99.7 Rule<no_rule>`
+# below for a brief explanation.
 
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):
@@ -218,14 +219,15 @@ plt.show()
 #
 # No 68-95-99.7 Rule
 # """"""""""""""""""
-# 
+#
 # .. no_rule:
 # The well-known 68-95-99.7 rule states that in a normal distribution 68%
 # of the observations lie within +/- 1 standard deviation from the mean, 95%
 # within 2 standard deviations and 99.7% within 3 standard deviations.
 #
 # However this rule only holds for one-dimensional data.
-# To adjust this rule to two-dimensional data, it suffices to square the probabilities
+# To adjust this rule to two-dimensional data,
+# it suffices to square the probabilities
 # of 0.68, 0.95 and 99.7 to 0.462, 0.903 and 0.994, respectively.
 # If you wish, you can think of it as a new "46-90-99 Rule" for
 # two-dimensional data.

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -231,3 +231,4 @@ plt.show()
 # of 0.68, 0.95 and 99.7 to 0.462, 0.903 and 0.994, respectively.
 # If you wish, you can think of it as a new "46-90-99 Rule" for
 # two-dimensional data.
+

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -35,8 +35,8 @@ import matplotlib.transforms as transforms
 # The radiuses of the ellipse can be controlled by n_std which is the number
 # of standard deviations. The default value is 3 which makes the ellipse
 # enclose 99.4% of the points if the data is normally distributed
-# like in these examples (3 standard deviations in 1-D contain 99.7% of the data,
-# which is 99.4% of the data in 2-D).
+# like in these examples (3 standard deviations in 1-D contain 99.7%
+# of the data, which is 99.4% of the data in 2-D).
 
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -34,8 +34,8 @@ import matplotlib.transforms as transforms
 #
 # The radiuses of the ellipse can be controlled by n_std which is the number
 # of standard deviations. The default value is 3 which makes the ellipse
-# enclose 99.7% of the points (given the data is normally distributed
-# like in these examples).
+# enclose 99.4% of the points - given the data is normally distributed
+# like in these examples. Why not 99.7%? See :ref:`No 68-95-99.7 Rule<no_rule>` below for a brief explanation.
 
 
 def confidence_ellipse(x, y, ax, n_std=3.0, facecolor='none', **kwargs):
@@ -213,3 +213,19 @@ ax_kwargs.set_title('Using kwargs')
 
 fig.subplots_adjust(hspace=0.25)
 plt.show()
+
+#############################################################################
+#
+# No 68-95-99.7 Rule
+# """"""""""""""""""
+# 
+# .. no_rule:
+# The well-known 68-95-99.7 rule states that in a normal distribution 68%
+# of the observations lie within +/- 1 standard deviation from the mean, 95%
+# within 2 standard deviations and 99.7% within 3 standard deviations.
+#
+# However this rule only holds for one-dimensional data.
+# To adjust this rule to two-dimensional data, it suffices to square the probabilities
+# of 0.68, 0.95 and 99.7 to 0.462, 0.903 and 0.994, respectively.
+# If you wish, you can think of it as a new "46-90-99 Rule" for
+# two-dimensional data.


### PR DESCRIPTION
## PR Summary
When I first created this example I stated that a plotted ellipse of e.g. 3 standarddeviations would contain 99.7% of the total observations, if the data was normally distributed.
However, this reference to the 68-95-99.7 rule does not hold with more than one dimension. I have corrected this statement and added a very brief explanation.
If you want to read more on this, please look at the comments on my [gitHub-Gist](https://gist.github.com/CarstenSchelp/b992645537660bda692f218b562d0712) on the same subject. The comments there pointed me to the issue, in the first place.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
