### PR TITLE
Fix headless tests on Wayland.

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -12,6 +12,7 @@ import urllib.request
 import pytest
 
 import matplotlib as mpl
+from matplotlib import _c_internal_utils
 
 
 # Minimal smoke-testing of the backends for which the dependencies are
@@ -40,8 +41,9 @@ def _get_testable_interactive_backends():
     ]:
         reason = None
         missing = [dep for dep in deps if not importlib.util.find_spec(dep)]
-        if sys.platform == "linux" and not os.environ.get("DISPLAY"):
-            reason = "$DISPLAY is unset"
+        if (sys.platform == "linux" and
+                not _c_internal_utils.display_is_valid()):
+            reason = "$DISPLAY and $WAYLAND_DISPLAY are unset"
         elif missing:
             reason = "{} cannot be imported".format(", ".join(missing))
         elif backend == 'macosx' and os.environ.get('TF_BUILD'):
@@ -276,7 +278,8 @@ import os
 import sys
 
 # make it look headless
-del os.environ['DISPLAY']
+os.environ.pop('DISPLAY', None)
+os.environ.pop('WAYLAND_DISPLAY', None)
 
 # we should fast-track to Agg
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -10,7 +10,7 @@ from cycler import cycler, Cycler
 import pytest
 
 import matplotlib as mpl
-from matplotlib import _api
+from matplotlib import _api, _c_internal_utils
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np
@@ -476,7 +476,8 @@ def test_rcparams_reset_after_fail():
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
 def test_backend_fallback_headless(tmpdir):
     env = {**os.environ,
-           "DISPLAY": "", "MPLBACKEND": "", "MPLCONFIGDIR": str(tmpdir)}
+           "DISPLAY": "", "WAYLAND_DISPLAY": "",
+           "MPLBACKEND": "", "MPLCONFIGDIR": str(tmpdir)}
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             [sys.executable, "-c",
@@ -487,8 +488,9 @@ def test_backend_fallback_headless(tmpdir):
             env=env, check=True)
 
 
-@pytest.mark.skipif(sys.platform == "linux" and not os.environ.get("DISPLAY"),
-                    reason="headless")
+@pytest.mark.skipif(
+    sys.platform == "linux" and not _c_internal_utils.display_is_valid(),
+    reason="headless")
 def test_backend_fallback_headful(tmpdir):
     pytest.importorskip("tkinter")
     env = {**os.environ, "MPLBACKEND": "", "MPLCONFIGDIR": str(tmpdir)}


### PR DESCRIPTION
## PR Summary

Since #17396, backends now check for Wayland settings as part of headless detection. However, the headless tests do not override those settings. When running on Wayland, they thus think the display exists when they are not supposed to.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).