### PR TITLE
FIX/TST: recursively remove ticks

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -112,6 +112,7 @@ def remove_ticks_and_titles(figure):
     figure.suptitle("")
     null_formatter = ticker.NullFormatter()
     def remove_ticks(ax):
+        """Remove ticks in *ax* and all its child Axes."""
         ax.set_title("")
         ax.xaxis.set_major_formatter(null_formatter)
         ax.xaxis.set_minor_formatter(null_formatter)

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -111,7 +111,7 @@ def _checked_on_freetype_version(required_freetype_version):
 def remove_ticks_and_titles(figure):
     figure.suptitle("")
     null_formatter = ticker.NullFormatter()
-    for ax in figure.get_axes():
+    def remove_ticks(ax):
         ax.set_title("")
         ax.xaxis.set_major_formatter(null_formatter)
         ax.xaxis.set_minor_formatter(null_formatter)
@@ -122,6 +122,10 @@ def remove_ticks_and_titles(figure):
             ax.zaxis.set_minor_formatter(null_formatter)
         except AttributeError:
             pass
+        for child in ax.child_axes:
+            remove_ticks(child)
+    for ax in figure.get_axes():
+        remove_ticks(ax)
 
 
 def _raise_on_image_difference(expected, actual, tol):


### PR DESCRIPTION
## PR Summary

If we are removing ticks from all the axes in a figure, we should remove them from child axes as well.  Needed for #18900.  


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
