### PR TITLE
Ignore CLOSEPOLY vertices when computing dataLim from patches

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -25,6 +25,7 @@ import matplotlib.spines as mspines
 import matplotlib.font_manager as font_manager
 import matplotlib.text as mtext
 import matplotlib.image as mimage
+import matplotlib.path as mpath
 from matplotlib.rcsetup import cycler, validate_axisbelow
 
 _log = logging.getLogger(__name__)
@@ -2094,7 +2095,9 @@ class _AxesBase(martist.Artist):
         if (isinstance(patch, mpatches.Rectangle) and
                 ((not patch.get_width()) and (not patch.get_height()))):
             return
-        vertices = patch.get_path().vertices
+        vertices = np.array([v for s in patch.get_path().iter_segments()
+                             if s[1] != mpath.Path.CLOSEPOLY
+                             for v in s[0]]).reshape([-1,2])
         if vertices.size > 0:
             xys = patch.get_patch_transform().transform(vertices)
             if patch.get_data_transform() != self.transData:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2097,7 +2097,7 @@ class _AxesBase(martist.Artist):
             return
         vertices = np.array([v for s in patch.get_path().iter_segments()
                              if s[1] != mpath.Path.CLOSEPOLY
-                             for v in s[0]]).reshape([-1,2])
+                             for v in s[0]]).reshape([-1, 2])
         if vertices.size > 0:
             xys = patch.get_patch_transform().transform(vertices)
             if patch.get_data_transform() != self.transData:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2097,6 +2097,7 @@ class _AxesBase(martist.Artist):
             return
         vertices = np.array([v for s in patch.get_path().iter_segments()
                              if s[1] != mpath.Path.CLOSEPOLY
+                             and s[1] != mpath.Path.STOP
                              for v in s[0]]).reshape([-1, 2])
         if vertices.size > 0:
             xys = patch.get_patch_transform().transform(vertices)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2095,10 +2095,9 @@ class _AxesBase(martist.Artist):
         if (isinstance(patch, mpatches.Rectangle) and
                 ((not patch.get_width()) and (not patch.get_height()))):
             return
-        vertices = np.array([v for s in patch.get_path().iter_segments()
-                             if s[1] != mpath.Path.CLOSEPOLY
-                             and s[1] != mpath.Path.STOP
-                             for v in s[0]]).reshape([-1, 2])
+        p = patch.get_path()
+        vertices = p.vertices if p.codes is None else p.vertices[np.isin(
+            p.codes, (mpath.Path.CLOSEPOLY, mpath.Path.STOP), invert=True)]
         if vertices.size > 0:
             xys = patch.get_patch_transform().transform(vertices)
             if patch.get_data_transform() != self.transData:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -34,6 +34,8 @@ from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib import rc_context
 from matplotlib.cbook import MatplotlibDeprecationWarning
+import sys
+import math
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
@@ -6924,3 +6926,15 @@ def test_bar_label_labels():
     labels = ax.bar_label(rects, labels=['A', 'B'])
     assert labels[0].get_text() == 'A'
     assert labels[1].get_text() == 'B'
+
+
+def test_patch_bounds():  # PR 19078
+    fig, ax = plt.subplots()
+    tol = 16*sys.float_info.epsilon
+    ax.add_patch(mpatches.Wedge((0, -1), 1.05, 60, 120, 0.1))
+    bounds = ax.dataLim.bounds
+    bot = 1.9*math.sin(15*math.pi/180)**2
+    assert abs(bounds[0]+0.525) < tol and \
+           abs(bounds[1]+(bot+0.05)) < tol and \
+           abs(bounds[2]-1.05) < tol and \
+           abs(bounds[3]-(bot+0.1)) < tol

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -34,8 +34,6 @@ from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib import rc_context
 from matplotlib.cbook import MatplotlibDeprecationWarning
-import sys
-import math
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
@@ -6930,11 +6928,7 @@ def test_bar_label_labels():
 
 def test_patch_bounds():  # PR 19078
     fig, ax = plt.subplots()
-    tol = 16*sys.float_info.epsilon
     ax.add_patch(mpatches.Wedge((0, -1), 1.05, 60, 120, 0.1))
-    bounds = ax.dataLim.bounds
-    bot = 1.9*math.sin(15*math.pi/180)**2
-    assert abs(bounds[0]+0.525) < tol and \
-           abs(bounds[1]+(bot+0.05)) < tol and \
-           abs(bounds[2]-1.05) < tol and \
-           abs(bounds[3]-(bot+0.1)) < tol
+    bot = 1.9*np.sin(15*np.pi/180)**2
+    np.testing.assert_array_almost_equal_nulp(
+        np.array((-0.525, -(bot+0.05), 1.05, bot+0.1)), ax.dataLim.bounds, 16)


### PR DESCRIPTION
## PR Summary
CLOSEPOLY verticies are not actual points in a path, but _update_patch_limits uses them anyhow when computing dataLim. This patch removes the CLOSEPOLY vertices from the list of vertices used in the computation. Fixes #19078. 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
