### PR TITLE
Corrects cursor's Z coordinate display for NonUniformImage

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1008,7 +1008,6 @@ class AxesImage(_ImageBase):
 
 
 class NonUniformImage(AxesImage):
-    mouseover = False  # This class still needs its own get_cursor_data impl.
 
     def __init__(self, ax, *, interpolation='nearest', **kwargs):
         """
@@ -1131,6 +1130,19 @@ class NonUniformImage(AxesImage):
         if self._A is not None:
             raise RuntimeError('Cannot change colors after loading data')
         super().set_cmap(cmap)
+
+    def get_cursor_data(self, event):
+        # docstring inherited
+        x, y = event.xdata, event.ydata
+        if (x < self._Ax[0] or x > self._Ax[-1] or
+                y < self._Ay[0] or y > self._Ay[-1]):
+            return None
+        j = np.searchsorted(self._Ax, x) - 1
+        i = np.searchsorted(self._Ay, y) - 1
+        try:
+            return self._A[i, j]
+        except IndexError:
+            return None
 
 
 class PcolorImage(AxesImage):


### PR DESCRIPTION
## PR Summary
Bugfix for issue #[18652](https://github.com/matplotlib/matplotlib/issues/18652) where Z coordinate information is incorrect, it seemed it inverted the values on the y axis. This fix implements format_cursor_data() for nonuniform images.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A ] New features are documented, with examples if plot related.
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
