### PR TITLE
Support setting rcParams["image.cmap"] to Colormap instances.

### DIFF
--- a/doc/users/next_whats_new/2019-06-28-AL.rst
+++ b/doc/users/next_whats_new/2019-06-28-AL.rst
@@ -11,3 +11,7 @@ first copy the colormap and set the extreme colors on that copy.
 The new `.Colormap.set_extremes` method is provided for API symmetry with
 `.Colormap.with_extremes`, but note that it suffers from the same issue as the
 earlier individual setters.
+
+Additionally, it is now possible to set :rc:`image.cmap` to a `.Colormap`
+instance, such as a new colormap created with `~.Colormap.set_extremes`.  (This
+can only be done from Python code, not from the :file:`matplotlibrc` file.)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -25,7 +25,7 @@ import numpy as np
 from matplotlib import _api, animation, cbook
 from matplotlib.cbook import ls_mapper
 from matplotlib.fontconfig_pattern import parse_fontconfig_pattern
-from matplotlib.colors import is_color_like
+from matplotlib.colors import Colormap, is_color_like
 
 # Don't let the original cycler collide with our validating cycler
 from cycler import Cycler, cycler as ccycler
@@ -393,6 +393,13 @@ def validate_color(s):
 
 validate_colorlist = _listify_validator(
     validate_color, allow_stringlist=True, doc='return a list of colorspecs')
+
+
+def _validate_cmap(s):
+    cbook._check_isinstance((str, Colormap), cmap=s)
+    return s
+
+
 validate_orientation = ValidateInStrings(
     'orientation', ['landscape', 'portrait'], _deprecated_since="3.3")
 
@@ -1141,7 +1148,7 @@ _validators = {
 
     "image.aspect":          validate_aspect,  # equal, auto, a number
     "image.interpolation":   validate_string,
-    "image.cmap":            validate_string,  # gray, jet, etc.
+    "image.cmap":            _validate_cmap,  # gray, jet, etc.
     "image.lut":             validate_int,  # lookup table
     "image.origin":          ["upper", "lower"],
     "image.resample":        validate_bool,


### PR DESCRIPTION
This makes it possible to set the rcParam to a non-registered colormap
(which cannot be referred to by name).  A use-case is to set it to e.g.
`viridis.with_extremes(bad="k")`.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
