### PR TITLE
Backport PR #19108 on branch v3.3.x

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -891,6 +891,22 @@ class HTMLWriter(FileMovieWriter):
                                              interval=interval,
                                              **mode_dict))
 
+        # duplicate the temporary file clean up logic from
+        # FileMovieWriter.cleanup.  We can not call the inherited
+        # versions of finished or cleanup because both assume that
+        # there is a subprocess that we either need to call to merge
+        # many frames together or that there is a subprocess call that
+        # we need to clean up.
+        if self._tmpdir:
+            _log.debug('MovieWriter: clearing temporary path=%s', self._tmpdir)
+            self._tmpdir.cleanup()
+        else:
+            if self._clear_temp:
+                _log.debug('MovieWriter: clearing temporary paths=%s',
+                           self._temp_paths)
+                for path in self._temp_paths:
+                    path.unlink()
+
 
 class Animation:
     """

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -763,20 +763,16 @@ class GraphicsContextPgf(GraphicsContextBase):
 
 
 class TmpDirCleaner:
-    _remaining_tmpdirs = set()
-
-    @cbook._classproperty
-    def remaining_tmpdirs(cls):
-        return cls._remaining_tmpdirs
+    remaining_tmpdirs = set()
 
     @staticmethod
     def add(tmpdir):
-        TmpDirCleaner._remaining_tmpdirs.add(tmpdir)
+        TmpDirCleaner.remaining_tmpdirs.add(tmpdir)
 
     @staticmethod
     @atexit.register
     def cleanup_remaining_tmpdirs():
-        for tmpdir in TmpDirCleaner._remaining_tmpdirs:
+        for tmpdir in TmpDirCleaner.remaining_tmpdirs:
             error_message = "error deleting tmp directory {}".format(tmpdir)
             shutil.rmtree(
                 tmpdir,

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from tempfile import TemporaryDirectory
 import weakref
 
 from PIL import Image
@@ -208,7 +209,6 @@ class LatexManager:
     determining the metrics of text elements. The LaTeX environment can be
     modified by setting fonts and/or a custom preamble in `.rcParams`.
     """
-    _unclean_instances = weakref.WeakSet()
 
     @staticmethod
     def _build_latex_header():
@@ -245,12 +245,6 @@ class LatexManager:
     def _get_cached_or_new_impl(cls, header):  # Helper for _get_cached_or_new.
         return cls()
 
-    @staticmethod
-    def _cleanup_remaining_instances():
-        unclean_instances = list(LatexManager._unclean_instances)
-        for latex_manager in unclean_instances:
-            latex_manager._cleanup()
-
     def _stdin_writeln(self, s):
         if self.latex is None:
             self._setup_latex_process()
@@ -276,13 +270,10 @@ class LatexManager:
         return self._expect("\n*")
 
     def __init__(self):
-        # store references for __del__
-        self._os_path = os.path
-        self._shutil = shutil
-
-        # create a tmp directory for running latex, remember to cleanup
-        self.tmpdir = tempfile.mkdtemp(prefix="mpl_pgf_lm_")
-        LatexManager._unclean_instances.add(self)
+        # create a tmp directory for running latex, register it for deletion
+        self._tmpdir = TemporaryDirectory()
+        self.tmpdir = self._tmpdir.name
+        self._finalize_tmpdir = weakref.finalize(self, self._tmpdir.cleanup)
 
         # test the LaTeX setup to ensure a clean startup of the subprocess
         self.texcommand = mpl.rcParams["pgf.texsystem"]
@@ -311,11 +302,21 @@ class LatexManager:
         self.str_cache = {}  # cache for strings already processed
 
     def _setup_latex_process(self):
-        # open LaTeX process for real work
+        # Open LaTeX process for real work; register it for deletion.  On
+        # Windows, we must ensure that the subprocess has quit before being
+        # able to delete the tmpdir in which it runs; in order to do so, we
+        # must first `kill()` it, and then `communicate()` with it.
         self.latex = subprocess.Popen(
             [self.texcommand, "-halt-on-error"],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             encoding="utf-8", cwd=self.tmpdir)
+
+        def finalize_latex(latex):
+            latex.kill()
+            latex.communicate()
+
+        self._finalize_latex = weakref.finalize(
+            self, finalize_latex, self.latex)
         # write header with 'pgf_backend_query_start' token
         self._stdin_writeln(self._build_latex_header())
         # read all lines until our 'pgf_backend_query_start' token appears
@@ -325,23 +326,6 @@ class LatexManager:
     @cbook.deprecated("3.3")
     def latex_stdin_utf8(self):
         return self.latex.stdin
-
-    def _cleanup(self):
-        if not self._os_path.isdir(self.tmpdir):
-            return
-        try:
-            self.latex.communicate()
-        except Exception:
-            pass
-        try:
-            self._shutil.rmtree(self.tmpdir)
-            LatexManager._unclean_instances.discard(self)
-        except Exception:
-            sys.stderr.write("error deleting tmp directory %s\n" % self.tmpdir)
-
-    def __del__(self):
-        _log.debug("deleting LatexManager")
-        self._cleanup()
 
     def get_width_height_descent(self, text, prop):
         """
@@ -779,15 +763,20 @@ class GraphicsContextPgf(GraphicsContextBase):
 
 
 class TmpDirCleaner:
-    remaining_tmpdirs = set()
+    _remaining_tmpdirs = set()
+
+    @cbook._classproperty
+    def remaining_tmpdirs(cls):
+        return cls._remaining_tmpdirs
 
     @staticmethod
     def add(tmpdir):
-        TmpDirCleaner.remaining_tmpdirs.add(tmpdir)
+        TmpDirCleaner._remaining_tmpdirs.add(tmpdir)
 
     @staticmethod
+    @atexit.register
     def cleanup_remaining_tmpdirs():
-        for tmpdir in TmpDirCleaner.remaining_tmpdirs:
+        for tmpdir in TmpDirCleaner._remaining_tmpdirs:
             error_message = "error deleting tmp directory {}".format(tmpdir)
             shutil.rmtree(
                 tmpdir,
@@ -977,14 +966,6 @@ FigureManagerPgf = FigureManagerBase
 @_Backend.export
 class _BackendPgf(_Backend):
     FigureCanvas = FigureCanvasPgf
-
-
-def _cleanup_all():
-    LatexManager._cleanup_remaining_instances()
-    TmpDirCleaner.cleanup_remaining_tmpdirs()
-
-
-atexit.register(_cleanup_all)
 
 
 class PdfPages:

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -718,7 +718,8 @@ def test_load_from_url():
            + ('///' if sys.platform == 'win32' else '')
            + path.resolve().as_posix())
     plt.imread(url)
-    plt.imread(urllib.request.urlopen(url))
+    with urllib.request.urlopen(url) as file:
+        plt.imread(file)
 
 
 @image_comparison(['log_scale_image'], remove_text=True)


### PR DESCRIPTION
Backport PR #19108 on branch v3.3.x

In contrast to the original PR, no changes in tests are needed because we did not have tests that would trigger the warning back in 3.3.x.