### PR TITLE
Rename a confusing variable.

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -196,14 +196,15 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 diff = buff != self._last_buff
                 output = np.where(diff, buff, 0)
 
-            buf = BytesIO()
-            data = output.view(dtype=np.uint8).reshape((*output.shape, 4))
-            Image.fromarray(data).save(buf, format="png")
-            # store the current buffer so we can compute the next diff
+            # Store the current buffer so we can compute the next diff.
             np.copyto(self._last_buff, buff)
             self._force_full = False
             self._png_is_old = False
-            return buf.getvalue()
+
+            data = output.view(dtype=np.uint8).reshape((*output.shape, 4))
+            with BytesIO() as png:
+                Image.fromarray(data).save(png, format="png")
+                return png.getvalue()
 
     def get_renderer(self, cleared=None):
         # Mirrors super.get_renderer, but caches the old one so that we can do


### PR DESCRIPTION
## PR Summary

As noted in #19059, there is both a `buff` and `buf` in this function. The latter is a PNG file, so rename it to `png`.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).