### PR TITLE
FIX/DOC - make Text doscstring interp more easily searchable

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -608,7 +608,7 @@ class Axes(_AxesBase):
         **kwargs : `~matplotlib.text.Text` properties.
             Other miscellaneous text parameters.
 
-            %(Text)s
+            %(Text_kwdoc)s
 
         Examples
         --------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1215,7 +1215,7 @@ default: {va}
         **kwargs : `~matplotlib.text.Text` properties
             Other miscellaneous text parameters.
 
-            %(Text)s
+            %(Text_kwdoc)s
 
         See Also
         --------

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -177,7 +177,7 @@ class Cell(Rectangle):
 
         Valid keyword arguments are:
 
-        %(Text)s
+        %(Text_kwdoc)s
         """
         self._text.update(kwargs)
         self.stale = True

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -146,7 +146,7 @@ class Text(Artist):
 
         Valid keyword arguments are:
 
-        %(Text)s
+        %(Text_kwdoc)s
         """
         super().__init__()
         self._x, self._y = x, y
@@ -1276,7 +1276,7 @@ class Text(Artist):
         return self.set_family(fontname)
 
 
-docstring.interpd.update(Text=artist.kwdoc(Text))
+docstring.interpd.update(Text_kwdoc=artist.kwdoc(Text))
 docstring.dedent_interpd(Text.__init__)
 
 


### PR DESCRIPTION
## PR Summary

We use docstring interpolation for `Text` in quite a few places, but that is extremely hard to trace through the code.  Changed to `_Text_docst`.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
