### PR TITLE
Use Qt events to refresh pixel ratio.

### DIFF
--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -27,9 +27,6 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         In Qt, all drawing should be done inside of here when a widget is
         shown onscreen.
         """
-        if self._update_dpi():
-            # The dpi update triggered its own paintEvent.
-            return
         self._draw_idle()  # Only does something if a draw is pending.
 
         # If the canvas does not have a renderer, then give up and wait for

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -17,7 +17,6 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         super().draw()
 
     def paintEvent(self, event):
-        self._update_dpi()
         dpi_ratio = self._dpi_ratio
         width = int(dpi_ratio * self.width())
         height = int(dpi_ratio * self.height())


### PR DESCRIPTION
## PR Summary

With this, we don't need to check things on every draw, but can instead rely on Qt telling us to update DPI.

This also fixes the pixel ratio test, which has never really worked for me. Hopefully it is not broken elsewhere.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).