### PR TITLE
DOC: contributor incubator

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -11,6 +11,22 @@ is expected to abide by our `code of conduct <../../CODE_OF_CONDUCT.md>`_.
 The project is hosted on
 https://github.com/matplotlib/matplotlib
 
+Contributor Incubator
+=====================
+
+Contributing to a major open source project can be intimidating! There
+may be technical (git / github), process (code review!), or impostor
+syndrome (your changes will be downloaded over 10M times a month)
+related barriers to YOU feeling like you can contribute to Matplotilb.
+If you are interested in becoming a regular contributor to Matplotlib,
+but are not sure where to start, please go to `gitter
+<https://gitter.im/matplotlib/matplotlib>`_ and asked to be added to
+``'#incubator'``.  This is a private gitter room moderated by core
+Matplotlib developers where you can get guidance and support for your
+first few PRs.  This is a place you can ask questions about anything:
+how to use git, github, how our PR review process works, technical questions
+about the code, or get "pre-review" on your PR.
+
 
 .. _submitting-a-bug-report:
 


### PR DESCRIPTION
## PR Summary

Adds prose to docs about the "incubator" (nee `#tidepool`) discussed on the call.

The purpose of this channel is that, operating on the theory than the hardest PR to a project is the first, is to provide some mentoring / support to people who want to become regular contributors but do not know where to start.

The other issue I think we have in the user -> first PR -> multiple PR -> reviewer pipeline as that we can not tell who of our first time contributors wants to become a regular contributor and who is doing a drive-by PR to scratch their itch.   This is a path where we are asking people to self-identify as wanting to be come regular contributors. 