### PR TITLE
Cleanups to webagg & friends.

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -142,7 +142,7 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
 
 
 class FigureCanvasNbAgg(FigureCanvasWebAggCore):
-    _timer_cls = TimerTornado
+    pass
 
 
 class CommSocket:

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -48,12 +48,7 @@ webagg_server_thread = ServerThread()
 
 
 class FigureCanvasWebAgg(core.FigureCanvasWebAggCore):
-    _timer_cls = TimerTornado
-
-    def show(self):
-        # show the figure window
-        global show  # placates pyflakes: created by @_Backend.export below
-        show()
+    pass
 
 
 class WebAggApplication(tornado.web.Application):


### PR DESCRIPTION
FigureCanvasWebAgg and FigureCanvasNbAgg empty subclasses of
FigureCanvasWebAggCore.  They only differed in that WebAggCore did not
define the (common) timer class, which is easily fixed (but the
TimerTornado definition needs to be moved above the
FigureCanvasWegAggCore definition), and that WebAgg explicitly redefined
`show` to use the module's `show`, whereas WebAggCore's `show` uses
`pyplot.show`... but `pyplot.show` is defined as calling the backend
module's `show`, so it comes down to the same.

Still it's useful for them to be subclasses rather than straight
aliases, to keep the possibility of a canvas->manager mapping (#18854).

No need to explicitly mark WebAggCore as `supports_blit`, as that's
autodetected now (one can easily check that
`FigureCanvasWebAggCore.supports_blit` is still True).

Saving `pgf` to a BytesIO actually works fine nowadays, and can indeed
by manually tested on WebAgg.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
