### PR TITLE
DOC: remove reference to 2.2.x branches from list of active branches

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -265,13 +265,6 @@ The current active branches are
   Documentation for the current release.  On a patch release, this will be
   replaced by a properly named branch for the new release.
 
-*v2.2.x*
-  Maintenance branch for Matplotlib 2.2 LTS.  Supports Python 2.7, 3.4+.
-
-*v2.2.N-doc*
-  Documentation for the current release.  On a patch release, this will be
-  replaced by a properly named branch for the new release.
-
 
 .. _pr-branch-selection:
 


### PR DESCRIPTION
## PR Summary

While responding to a question on the mailing list I discovered we had never removed the 2.2.x branches from the docs, this does so.

We also still have the 2.2.x and 2.2.5-doc branches on the repo, I'm inclined to drop those now as well.