### PR TITLE
Fix WebAgg initialization

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -157,9 +157,6 @@ mpl.figure.prototype._init_canvas = function () {
         1;
 
     this.ratio = (window.devicePixelRatio || 1) / backingStore;
-    if (this.ratio !== 1) {
-        fig.send_message('set_dpi_ratio', { dpi_ratio: this.ratio });
-    }
 
     var rubberband_canvas = (this.rubberband_canvas = document.createElement(
         'canvas'

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -224,7 +224,7 @@ mpl.figure.prototype._init_canvas = function () {
             // And update the size in Python. We ignore the initial 0/0 size
             // that occurs as the element is placed into the DOM, which should
             // otherwise not happen due to the minimum size styling.
-            if (width != 0 && height != 0) {
+            if (fig.ws.readyState == 1 && width != 0 && height != 0) {
                 fig.request_resize(width, height);
             }
         }


### PR DESCRIPTION
## PR Summary

Sending the pixel ratio in initialization fails because the WebSocket is not open yet; this is already sent in the `onopen` handler, so just remove it from initialization.

Also, fix a similar bug in sending resizes too early. This one is non-fatal because it is in an async handler.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).