### PR TITLE
Backport latexpdf fixes to v3.3.3-doc

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -320,7 +320,19 @@ latex_documents = [
 # the title page.
 latex_logo = None
 
+# Use Unicode aware LaTeX engine
+latex_engine = 'xelatex'  # or 'lualatex'
+
 latex_elements = {}
+
+# Keep babel usage also with xelatex (Sphinx default is polyglossia)
+# If this key is removed or changed, latex build directory must be cleaned
+latex_elements['babel'] = r'\usepackage{babel}'
+
+# Font configuration
+# Sphinx default since 2.x is GNU FreeFont
+latex_elements['fontpkg'] = r'\setmainfont{DejaVu Serif}'
+
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r"""
    % One line per author on title page
@@ -332,11 +344,6 @@ latex_elements['preamble'] = r"""
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
-
-   \usepackage{amsmath}
-   \usepackage{amsfonts}
-   \usepackage{amssymb}
-   \usepackage{txfonts}
 
    % The enumitem package provides unlimited nesting of lists and
    % enums.  Sphinx may use this in the future, in which case this can
@@ -370,13 +377,6 @@ texinfo_documents = [
 # numpydoc config
 
 numpydoc_show_class_members = False
-
-latex_engine = 'xelatex'  # or 'lualatex'
-
-latex_elements = {
-    'babel': r'\usepackage{babel}',
-    'fontpkg': r'\setmainfont{DejaVu Serif}',
-}
 
 html4_writer = True
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -338,20 +338,31 @@ latex_elements['preamble'] = r"""
    % One line per author on title page
    \DeclareRobustCommand{\and}%
      {\end{tabular}\kern-\tabcolsep\\\begin{tabular}[t]{c}}%
-   % In the parameters section, place a newline after the Parameters
-   % header.  (This is stolen directly from Numpy's conf.py, since it
-   % affects Numpy-style docstrings).
    \usepackage{expdlist}
    \let\latexdescription=\description
    \def\description{\latexdescription{}{} \breaklabel}
-
-   % The enumitem package provides unlimited nesting of lists and
-   % enums.  Sphinx may use this in the future, in which case this can
-   % be removed.  See
-   % https://bitbucket.org/birkenfeld/sphinx/issue/777/latex-output-too-deeply-nested
-   \usepackage{enumitem}
-   \setlistdepth{2048}
+   % But expdlist old LaTeX package requires fixes:
+   % 1) remove extra space
+   \usepackage{etoolbox}
+   \makeatletter
+   \patchcmd\@item{{\@breaklabel} }{{\@breaklabel}}{}{}
+   \makeatother
+   % 2) fix bug in expdlist's way of breaking the line after long item label
+   \makeatletter
+   \def\breaklabel{%
+       \def\@breaklabel{%
+           \leavevmode\par
+           % now a hack because Sphinx inserts \leavevmode after term node
+           \def\leavevmode{\def\leavevmode{\unhbox\voidb@x}}%
+      }%
+   }
+   \makeatother
 """
+# Sphinx 1.5 provides this to avoid "too deeply nested" LaTeX error
+# and usage of "enumitem" LaTeX package is unneeded.
+# Value can be increased but do not set it to something such as 2048
+# which needlessly would trigger creation of thousands of TeX macros
+latex_elements['maxlistdepth'] = '10'
 latex_elements['pointsize'] = '11pt'
 
 # Documents to append as an appendix to all manuals.

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -97,7 +97,7 @@ produces
 
 .. math::
 
-    \frac{3}{4} \binom{3}{4} \genfrac{}{}{0}{}{3}{4}
+    \frac{3}{4} \binom{3}{4} \genfrac{}{}{0pt}{}{3}{4}
 
 Fractions can be arbitrarily nested::
 


### PR DESCRIPTION
## PR Summary

These are the minimum changes necessary to get the PDF building again.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).