### PR TITLE
Fix the docstring of suptitle/subxlabel/supylabel.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -373,30 +373,24 @@ class FigureBase(Artist):
 
     def _suplabels(self, t, info, **kwargs):
         """
-        Add a centered {name} to the figure.
+        Add a centered %(name)s to the figure.
 
         Parameters
         ----------
         t : str
-            The {name} text.
-
-        x : float, default: {x0}
+            The %(name)s text.
+        x : float, default: %(x0)s
             The x location of the text in figure coordinates.
-
-        y : float, default: {y0}
+        y : float, default: %(y0)s
             The y location of the text in figure coordinates.
-
-        horizontalalignment, ha : {{'center', 'left', 'right'}}, default: {ha}
+        horizontalalignment, ha : {'center', 'left', 'right'}, default: %(ha)s
             The horizontal alignment of the text relative to (*x*, *y*).
-
-        verticalalignment, va : {{'top', 'center', 'bottom', 'baseline'}}, \
-default: {va}
+        verticalalignment, va : {'top', 'center', 'bottom', 'baseline'}, \
+default: %(va)s
             The vertical alignment of the text relative to (*x*, *y*).
-
         fontsize, size : default: :rc:`figure.titlesize`
             The font size of the text. See `.Text.set_size` for possible
             values.
-
         fontweight, weight : default: :rc:`figure.titleweight`
             The font weight of the text. See `.Text.set_weight` for possible
             values.
@@ -404,7 +398,7 @@ default: {va}
         Returns
         -------
         text
-            The `.Text` instance of the {name}.
+            The `.Text` instance of the %(name)s.
 
         Other Parameters
         ----------------
@@ -416,7 +410,6 @@ default: {va}
 
         **kwargs
             Additional kwargs are `matplotlib.text.Text` properties.
-
         """
 
         manual_position = ('x' in kwargs or 'y' in kwargs)


### PR DESCRIPTION
Docstring substitution uses %-formatting, not {}-formatting.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
