### PR TITLE
Move from cbook._deprecate_*() to _api.deprecate_*()

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -18,7 +18,7 @@ import warnings
 from .deprecation import (
     deprecated, warn_deprecated,
     rename_parameter, delete_parameter, make_keyword_only,
-    _deprecate_method_override, _deprecate_privatize_attribute,
+    deprecate_method_override, deprecate_privatize_attribute,
     suppress_matplotlib_deprecation_warning,
     MatplotlibDeprecationWarning)
 

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -271,7 +271,7 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
     return deprecate
 
 
-class _deprecate_privatize_attribute:
+class deprecate_privatize_attribute:
     """
     Helper to deprecate public access to an attribute.
 
@@ -473,7 +473,7 @@ def make_keyword_only(since, name, func=None):
     return wrapper
 
 
-def _deprecate_method_override(method, obj, *, allow_empty=False, **kwargs):
+def deprecate_method_override(method, obj, *, allow_empty=False, **kwargs):
     """
     Return ``obj.method`` with a deprecation if it was overridden, else None.
 

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -203,7 +203,7 @@ class Fonts:
         result = self.mathtext_backend.get_results(
             box, self.get_used_characters())
         if self.destroy != TruetypeFonts.destroy.__get__(self):
-            destroy = cbook._deprecate_method_override(
+            destroy = _api.deprecate_method_override(
                 __class__.destroy, self, since="3.4")
             if destroy:
                 destroy()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -261,8 +261,8 @@ class MovieWriter(AbstractMovieWriter):
     # stored.  Third-party writers cannot meaningfully set these as they cannot
     # extend rcParams with new keys.
 
-    exec_key = cbook._deprecate_privatize_attribute("3.3")
-    args_key = cbook._deprecate_privatize_attribute("3.3")
+    exec_key = _api.deprecate_privatize_attribute("3.3")
+    args_key = _api.deprecate_privatize_attribute("3.3")
 
     # Pipe-based writers only support RGBA, but file-based ones support more
     # formats.
@@ -339,7 +339,7 @@ class MovieWriter(AbstractMovieWriter):
 
     def finish(self):
         """Finish any processing for writing the movie."""
-        overridden_cleanup = cbook._deprecate_method_override(
+        overridden_cleanup = _api.deprecate_method_override(
             __class__.cleanup, self, since="3.4", alternative="finish()")
         if overridden_cleanup is not None:
             overridden_cleanup()

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -179,7 +179,7 @@ class Tick(martist.Artist):
                            ("_get_gridline", "gridline"),
                            ("_get_text1", "label1"),
                            ("_get_text2", "label2")]:
-            overridden_method = cbook._deprecate_method_override(
+            overridden_method = _api.deprecate_method_override(
                 getattr(__class__, meth), self, since="3.3", message="Relying "
                 f"on {meth} to initialize Tick.{attr} is deprecated since "
                 f"%(since)s and will not work %(removal)s; please directly "

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2876,7 +2876,7 @@ class NavigationToolbar2:
         # This cursor will be set after the initial draw.
         self._lastCursor = cursors.POINTER
 
-        init = cbook._deprecate_method_override(
+        init = _api.deprecate_method_override(
             __class__._init_toolbar, self, allow_empty=True, since="3.3",
             addendum="Please fully initialize the toolbar in your subclass' "
             "__init__; a fully empty _init_toolbar implementation may be kept "
@@ -3093,7 +3093,7 @@ class NavigationToolbar2:
         id_drag = self.canvas.mpl_connect("motion_notify_event", self.drag_pan)
         self._pan_info = self._PanInfo(
             button=event.button, axes=axes, cid=id_drag)
-        press = cbook._deprecate_method_override(
+        press = _api.deprecate_method_override(
             __class__.press, self, since="3.3", message="Calling an "
             "overridden press() at pan start is deprecated since %(since)s "
             "and will be removed %(removal)s; override press_pan() instead.")
@@ -3117,7 +3117,7 @@ class NavigationToolbar2:
             'motion_notify_event', self.mouse_move)
         for ax in self._pan_info.axes:
             ax.end_pan()
-        release = cbook._deprecate_method_override(
+        release = _api.deprecate_method_override(
             __class__.press, self, since="3.3", message="Calling an "
             "overridden release() at pan stop is deprecated since %(since)s "
             "and will be removed %(removal)s; override release_pan() instead.")
@@ -3157,7 +3157,7 @@ class NavigationToolbar2:
         self._zoom_info = self._ZoomInfo(
             direction="in" if event.button == 1 else "out",
             start_xy=(event.x, event.y), axes=axes, cid=id_zoom)
-        press = cbook._deprecate_method_override(
+        press = _api.deprecate_method_override(
             __class__.press, self, since="3.3", message="Calling an "
             "overridden press() at zoom start is deprecated since %(since)s "
             "and will be removed %(removal)s; override press_zoom() instead.")
@@ -3193,7 +3193,7 @@ class NavigationToolbar2:
                 or (abs(event.y - start_y) < 5 and event.key != "x")):
             self._draw()
             self._zoom_info = None
-            release = cbook._deprecate_method_override(
+            release = _api.deprecate_method_override(
                 __class__.press, self, since="3.3", message="Calling an "
                 "overridden release() at zoom stop is deprecated since "
                 "%(since)s and will be removed %(removal)s; override "
@@ -3217,7 +3217,7 @@ class NavigationToolbar2:
         self._zoom_info = None
         self.push_current()
 
-        release = cbook._deprecate_method_override(
+        release = _api.deprecate_method_override(
             __class__.release, self, since="3.3", message="Calling an "
             "overridden release() at zoom stop is deprecated since %(since)s "
             "and will be removed %(removal)s; override release_zoom() "

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -127,7 +127,7 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         self.set_double_buffered(True)
         self.set_can_focus(True)
 
-        renderer_init = cbook._deprecate_method_override(
+        renderer_init = _api.deprecate_method_override(
             __class__._renderer_init, self, allow_empty=True, since="3.3",
             addendum="Please initialize the renderer, if needed, in the "
             "subclass' __init__; a fully empty _renderer_init implementation "

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1129,13 +1129,13 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         # and/or dc.GetContentScaleFactor()
         self._retinaFix = 'wxMac' in wx.PlatformInfo
 
-    prevZoomRect = cbook._deprecate_privatize_attribute("3.3")
-    retinaFix = cbook._deprecate_privatize_attribute("3.3")
-    savedRetinaImage = cbook._deprecate_privatize_attribute("3.3")
-    wxoverlay = cbook._deprecate_privatize_attribute("3.3")
-    zoomAxes = cbook._deprecate_privatize_attribute("3.3")
-    zoomStartX = cbook._deprecate_privatize_attribute("3.3")
-    zoomStartY = cbook._deprecate_privatize_attribute("3.3")
+    prevZoomRect = _api.deprecate_privatize_attribute("3.3")
+    retinaFix = _api.deprecate_privatize_attribute("3.3")
+    savedRetinaImage = _api.deprecate_privatize_attribute("3.3")
+    wxoverlay = _api.deprecate_privatize_attribute("3.3")
+    zoomAxes = _api.deprecate_privatize_attribute("3.3")
+    zoomStartX = _api.deprecate_privatize_attribute("3.3")
+    zoomStartY = _api.deprecate_privatize_attribute("3.3")
 
     @staticmethod
     def _icon(name):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -32,9 +32,7 @@ from matplotlib import _api, _c_internal_utils
 from matplotlib._api import (
     warn_external as _warn_external, classproperty as _classproperty)
 from matplotlib._api.deprecation import (
-    deprecated, warn_deprecated,
-    _deprecate_method_override, _deprecate_privatize_attribute,
-    MatplotlibDeprecationWarning, mplDeprecation)
+    deprecated, warn_deprecated, MatplotlibDeprecationWarning, mplDeprecation)
 
 
 def _get_running_interactive_framework():

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -500,7 +500,7 @@ class ScalarMappable:
             self._update_dict[key] = True
         self.stale = True
 
-    update_dict = cbook._deprecate_privatize_attribute("3.3")
+    update_dict = _api.deprecate_privatize_attribute("3.3")
 
     @_api.deprecated("3.3")
     def add_checker(self, checker):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1026,7 +1026,7 @@ class NonUniformImage(AxesImage):
         """Return False. Do not use unsampled image."""
         return False
 
-    is_grayscale = cbook._deprecate_privatize_attribute("3.3")
+    is_grayscale = _api.deprecate_privatize_attribute("3.3")
 
     def make_image(self, renderer, magnification=1.0, unsampled=False):
         # docstring inherited
@@ -1177,7 +1177,7 @@ class PcolorImage(AxesImage):
         if A is not None:
             self.set_data(x, y, A)
 
-    is_grayscale = cbook._deprecate_privatize_attribute("3.3")
+    is_grayscale = _api.deprecate_privatize_attribute("3.3")
 
     def make_image(self, renderer, magnification=1.0, unsampled=False):
         # docstring inherited

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -24,7 +24,7 @@ Container classes for `.Artist`\s.
 
 import numpy as np
 
-from matplotlib import _api, cbook, docstring, rcParams
+from matplotlib import _api, docstring, rcParams
 import matplotlib.artist as martist
 import matplotlib.path as mpath
 import matplotlib.text as mtext
@@ -1630,7 +1630,7 @@ class DraggableBase:
 
         if not ref_artist.pickable():
             ref_artist.set_picker(True)
-        overridden_picker = cbook._deprecate_method_override(
+        overridden_picker = _api.deprecate_method_override(
             __class__.artist_picker, self, since="3.3",
             addendum="Directly set the artist's picker if desired.")
         if overridden_picker is not None:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -677,7 +677,7 @@ class Shadow(Patch):
         self._shadow_transform = transforms.Affine2D()
         self._update()
 
-    props = cbook._deprecate_privatize_attribute("3.3")
+    props = _api.deprecate_privatize_attribute("3.3")
 
     def _update(self):
         self.update_from(self.patch)
@@ -2006,7 +2006,7 @@ class BoxStyle(_Style):
         # This can go away once the deprecation period elapses, leaving _Base
         # as a fully abstract base class just providing docstrings, no logic.
         def __init_subclass__(cls):
-            transmute = cbook._deprecate_method_override(
+            transmute = _api.deprecate_method_override(
                 __class__.transmute, cls, since="3.4")
             if transmute:
                 cls.__call__ = transmute

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -4,7 +4,7 @@ import functools
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _api, cbook
+from matplotlib import _api
 from matplotlib.gridspec import SubplotSpec
 
 from .axes_divider import Size, SubplotDivider, Divider
@@ -40,9 +40,9 @@ class CbarAxesBase:
         self._config_axes()
         return cb
 
-    cbid = cbook._deprecate_privatize_attribute(
+    cbid = _api.deprecate_privatize_attribute(
         "3.3", alternative="mappable.colorbar_cid")
-    locator = cbook._deprecate_privatize_attribute(
+    locator = _api.deprecate_privatize_attribute(
         "3.3", alternative=".colorbar().locator")
 
     def _config_axes(self):


### PR DESCRIPTION
## PR Summary

Followup of moving all API helpers to `matplotlib._api` (#18657). 

This changes internal usages:

- `cbook._deprecate_method_override` -> `_api.deprecate_method_override`
- `cbook._deprecate_privatize_attribute` -> `_api.deprecate_privatize_attribute`

