### PR TITLE
Move from @cbook._classproperty to @_api.classproperty

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1700,7 +1700,7 @@ class FigureCanvasBase:
 
     filetypes = _default_filetypes
 
-    @cbook._classproperty
+    @_api.classproperty
     def supports_blit(cls):
         """If this Canvas sub-class supports blitting."""
         return (hasattr(cls, "copy_from_bbox")

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -752,7 +752,7 @@ class GraphicsContextPgf(GraphicsContextBase):
 class TmpDirCleaner:
     _remaining_tmpdirs = set()
 
-    @cbook._classproperty
+    @_api.classproperty
     @_api.deprecated("3.4")
     def remaining_tmpdirs(cls):
         return cls._remaining_tmpdirs

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -29,7 +29,6 @@ import numpy as np
 
 import matplotlib
 from matplotlib import _api, _c_internal_utils
-from matplotlib._api import classproperty as _classproperty
 from matplotlib._api.deprecation import (
     deprecated, warn_deprecated, MatplotlibDeprecationWarning, mplDeprecation)
 


### PR DESCRIPTION
## PR Summary

Followup of moving all API helpers to matplotlib._api (#18657).