### PR TITLE
Deprecate @cbook.deprecated and move internal calls to @_api.deprecated

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -795,7 +795,7 @@ class StandardPsFonts(Fonts):
         self.fonts['default'] = default_font
         self.fonts['regular'] = default_font
 
-    pswriter = cbook.deprecated("3.4")(property(lambda self: StringIO()))
+    pswriter = _api.deprecated("3.4")(property(lambda self: StringIO()))
 
     def _get_font(self, font):
         if font in self.fontmap:
@@ -1549,7 +1549,7 @@ class Glue(Node):
     it's easier to stick to what TeX does.)
     """
 
-    glue_subtype = cbook.deprecated("3.3")(property(lambda self: "normal"))
+    glue_subtype = _api.deprecated("3.3")(property(lambda self: "normal"))
 
     @_api.delete_parameter("3.3", "copy")
     def __init__(self, glue_type, copy=False):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -795,7 +795,7 @@ class HTMLWriter(FileMovieWriter):
     """Writer for JavaScript-based HTML movies."""
 
     supported_formats = ['png', 'jpeg', 'tiff', 'svg']
-    args_key = cbook.deprecated("3.3")(property(
+    args_key = _api.deprecated("3.3")(property(
         lambda self: 'animation.html_args'))
 
     @classmethod

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2710,7 +2710,7 @@ class FigureManagerBase:
                 figure.canvas.manager.button_press_handler_id)
     """
 
-    statusbar = cbook.deprecated("3.3")(property(lambda self: None))
+    statusbar = _api.deprecated("3.3")(property(lambda self: None))
 
     def __init__(self, canvas, num):
         self.canvas = canvas

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -5,6 +5,7 @@ Common functionality between the PDF and PS backends.
 import functools
 
 import matplotlib as mpl
+from matplotlib import _api
 from .. import font_manager, ft2font
 from ..afm import AFM
 from ..backend_bases import RendererBase
@@ -27,7 +28,7 @@ class CharacterTracker:
     def __init__(self):
         self.used = {}
 
-    @mpl.cbook.deprecated("3.3")
+    @_api.deprecated("3.3")
     @property
     def used_characters(self):
         d = {}

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -121,9 +121,9 @@ _f_angles = {
 
 
 class RendererCairo(RendererBase):
-    fontweights = cbook.deprecated("3.3")(property(lambda self: {*_f_weights}))
-    fontangles = cbook.deprecated("3.3")(property(lambda self: {*_f_angles}))
-    mathtext_parser = cbook.deprecated("3.4")(
+    fontweights = _api.deprecated("3.3")(property(lambda self: {*_f_weights}))
+    fontangles = _api.deprecated("3.3")(property(lambda self: {*_f_angles}))
+    mathtext_parser = _api.deprecated("3.4")(
         property(lambda self: MathTextParser('Cairo')))
 
     def __init__(self, dpi):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -432,7 +432,7 @@ class FigureManagerGTK3(FigureManagerBase):
 
 
 class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
-    ctx = cbook.deprecated("3.3")(property(
+    ctx = _api.deprecated("3.3")(property(
         lambda self: self.canvas.get_property("window").cairo_create()))
 
     def __init__(self, canvas, window):

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -932,7 +932,7 @@ class PdfPages:
         '_info_dict',
         '_metadata',
     )
-    metadata = cbook.deprecated('3.3')(property(lambda self: self._metadata))
+    metadata = _api.deprecated('3.3')(property(lambda self: self._metadata))
 
     def __init__(self, filename, *, keep_empty=True, metadata=None):
         """

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -223,9 +223,9 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
     _afm_font_dir = cbook._get_data_path("fonts/afm")
     _use_afm_rc_name = "ps.useafm"
 
-    mathtext_parser = cbook.deprecated("3.4")(property(
+    mathtext_parser = _api.deprecated("3.4")(property(
         lambda self: MathTextParser("PS")))
-    used_characters = cbook.deprecated("3.3")(property(
+    used_characters = _api.deprecated("3.3")(property(
         lambda self: self._character_tracker.used_characters))
 
     def __init__(self, width, height, pswriter, imagedpi=72):

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 import matplotlib as mpl
+from matplotlib import _api
 
 
 QT_API_PYQT5 = "PyQt5"
@@ -87,7 +88,7 @@ def _setup_pyqt5():
         raise ValueError("Unexpected value for the 'backend.qt5' rcparam")
     _getSaveFileName = QtWidgets.QFileDialog.getSaveFileName
 
-    @mpl.cbook.deprecated("3.3", alternative="QtCore.qVersion()")
+    @_api.deprecated("3.3", alternative="QtCore.qVersion()")
     def is_pyqt5():
         return True
 
@@ -143,7 +144,7 @@ def _setup_pyqt4():
         raise ValueError("Unexpected value for the 'backend.qt4' rcparam")
     QtWidgets = QtGui
 
-    @mpl.cbook.deprecated("3.3", alternative="QtCore.qVersion()")
+    @_api.deprecated("3.3", alternative="QtCore.qVersion()")
     def is_pyqt5():
         return False
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -30,7 +30,12 @@ import numpy as np
 import matplotlib
 from matplotlib import _api, _c_internal_utils
 from matplotlib._api.deprecation import (
-    deprecated, warn_deprecated, MatplotlibDeprecationWarning, mplDeprecation)
+    warn_deprecated, MatplotlibDeprecationWarning, mplDeprecation)
+
+
+@_api.deprecated("3.4")
+def deprecated(*args, **kwargs):
+    return _api.deprecated(*args, **kwargs)
 
 
 def _get_running_interactive_framework():
@@ -287,7 +292,7 @@ class silent_list(list):
             return "<an empty list>"
 
 
-@deprecated("3.3")
+@_api.deprecated("3.3")
 class IgnoredKeywordWarning(UserWarning):
     """
     A class for issuing warnings about keyword arguments that will be ignored
@@ -296,7 +301,7 @@ class IgnoredKeywordWarning(UserWarning):
     pass
 
 
-@deprecated("3.3", alternative="normalize_kwargs")
+@_api.deprecated("3.3", alternative="normalize_kwargs")
 def local_over_kwdict(local_var, kwargs, *keys):
     """
     Enforces the priority of a local variable over potentially conflicting
@@ -532,7 +537,7 @@ def flatten(seq, scalarp=is_scalar_or_string):
             yield from flatten(item, scalarp)
 
 
-@deprecated("3.3", alternative="os.path.realpath and os.stat")
+@_api.deprecated("3.3", alternative="os.path.realpath and os.stat")
 @functools.lru_cache()
 def get_realpath_and_stat(path):
     realpath = os.path.realpath(path)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -682,7 +682,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
     %(contour_set_attributes)s
     """
 
-    ax = cbook.deprecated("3.3")(property(lambda self: self.axes))
+    ax = _api.deprecated("3.3")(property(lambda self: self.axes))
 
     def __init__(self, ax, *args,
                  levels=None, filled=False, linewidths=None, linestyles=None,

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -351,7 +351,7 @@ for _cls_name in [
         *[c.__name__ for c in _mathtext.Node.__subclasses__()],
         "Ship", "Parser",
 ]:
-    globals()[_cls_name] = cbook.deprecated("3.4")(
+    globals()[_cls_name] = _api.deprecated("3.4")(
         type(_cls_name, (getattr(_mathtext, _cls_name),), {}))
 
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -156,10 +156,10 @@ import jinja2  # Sphinx dependency.
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
 import matplotlib.pyplot as plt
-from matplotlib import _pylab_helpers, cbook
+from matplotlib import _api, _pylab_helpers, cbook
 
 matplotlib.use("agg")
-align = cbook.deprecated(
+align = _api.deprecated(
     "3.4", alternative="docutils.parsers.rst.directives.images.Image.align")(
         Image.align)
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -73,19 +73,19 @@ class TexManager:
         'computer modern sans serif': ('cmss', r'\usepackage{type1ec}'),
         'computer modern typewriter': ('cmtt', r'\usepackage{type1ec}')}
 
-    cachedir = cbook.deprecated(
+    cachedir = _api.deprecated(
         "3.3", alternative="matplotlib.get_cachedir()")(
             property(lambda self: mpl.get_cachedir()))
-    rgba_arrayd = cbook.deprecated("3.3")(property(lambda self: {}))
+    rgba_arrayd = _api.deprecated("3.3")(property(lambda self: {}))
     _fonts = {}  # Only for deprecation period.
-    serif = cbook.deprecated("3.3")(property(
+    serif = _api.deprecated("3.3")(property(
         lambda self: self._fonts.get("serif", ('cmr', ''))))
-    sans_serif = cbook.deprecated("3.3")(property(
+    sans_serif = _api.deprecated("3.3")(property(
         lambda self: self._fonts.get("sans-serif", ('cmss', ''))))
-    cursive = cbook.deprecated("3.3")(property(
+    cursive = _api.deprecated("3.3")(property(
         lambda self:
         self._fonts.get("cursive", ('pzc', r'\usepackage{chancery}'))))
-    monospace = cbook.deprecated("3.3")(property(
+    monospace = _api.deprecated("3.3")(property(
         lambda self: self._fonts.get("monospace", ('cmtt', ''))))
 
     @functools.lru_cache()  # Always return the same instance.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2118,11 +2118,11 @@ class MaxNLocator(Locator):
         """
         if args:
             if 'nbins' in kwargs:
-                cbook.deprecated("3.1",
-                                 message='Calling MaxNLocator with positional '
-                                         'and keyword parameter *nbins* is '
-                                         'considered an error and will fail '
-                                         'in future versions of matplotlib.')
+                _api.deprecated("3.1",
+                                message='Calling MaxNLocator with positional '
+                                        'and keyword parameter *nbins* is '
+                                        'considered an error and will fail '
+                                        'in future versions of matplotlib.')
             kwargs['nbins'] = args[0]
             if len(args) > 1:
                 raise ValueError(

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -109,7 +109,7 @@ class AxesWidget(Widget):
         If False, the widget does not respond to events.
     """
 
-    cids = cbook.deprecated("3.4")(property(lambda self: self._cids))
+    cids = _api.deprecated("3.4")(property(lambda self: self._cids))
 
     def __init__(self, ax):
         self.ax = ax
@@ -151,9 +151,9 @@ class Button(AxesWidget):
         The color of the button when hovering.
     """
 
-    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+    cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: len(self._observers.callbacks['clicked'])))
-    observers = cbook.deprecated("3.4")(property(
+    observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['clicked']))
 
     def __init__(self, ax, label, image=None,
@@ -243,9 +243,9 @@ class Slider(AxesWidget):
         Slider value.
     """
 
-    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+    cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: len(self._observers.callbacks['changed'])))
-    observers = cbook.deprecated("3.4")(property(
+    observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['changed']))
 
     def __init__(self, ax, label, valmin, valmax, valinit=0.5, valfmt=None,
@@ -536,9 +536,9 @@ class CheckButtons(AxesWidget):
         each box, but have ``set_visible(False)`` when its box is not checked.
     """
 
-    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+    cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: len(self._observers.callbacks['clicked'])))
-    observers = cbook.deprecated("3.4")(property(
+    observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['clicked']))
 
     def __init__(self, ax, labels, actives=None):
@@ -688,13 +688,13 @@ class TextBox(AxesWidget):
         The color of the text box when hovering.
     """
 
-    params_to_disable = cbook.deprecated("3.3")(property(
+    params_to_disable = _api.deprecated("3.3")(property(
         lambda self: [key for key in mpl.rcParams if 'keymap' in key]))
-    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+    cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: sum(len(d) for d in self._observers.callbacks.values())))
-    change_observers = cbook.deprecated("3.4")(property(
+    change_observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['change']))
-    submit_observers = cbook.deprecated("3.4")(property(
+    submit_observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['submit']))
 
     def __init__(self, ax, label, initial='',
@@ -1005,9 +1005,9 @@ class RadioButtons(AxesWidget):
 
         self._observers = cbook.CallbackRegistry()
 
-    cnt = cbook.deprecated("3.4")(property(  # Not real, but close enough.
+    cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: len(self._observers.callbacks['clicked'])))
-    observers = cbook.deprecated("3.4")(property(
+    observers = _api.deprecated("3.4")(property(
         lambda self: self._observers.callbacks['clicked']))
 
     def _clicked(self, event):
@@ -1133,17 +1133,17 @@ class SubplotTool(Widget):
             event.canvas.draw()
             self.targetfig.canvas.draw()
 
-    axleft = cbook.deprecated("3.3")(
+    axleft = _api.deprecated("3.3")(
         property(lambda self: self.sliderleft.ax))
-    axright = cbook.deprecated("3.3")(
+    axright = _api.deprecated("3.3")(
         property(lambda self: self.sliderright.ax))
-    axbottom = cbook.deprecated("3.3")(
+    axbottom = _api.deprecated("3.3")(
         property(lambda self: self.sliderbottom.ax))
-    axtop = cbook.deprecated("3.3")(
+    axtop = _api.deprecated("3.3")(
         property(lambda self: self.slidertop.ax))
-    axwspace = cbook.deprecated("3.3")(
+    axwspace = _api.deprecated("3.3")(
         property(lambda self: self.sliderwspace.ax))
-    axhspace = cbook.deprecated("3.3")(
+    axhspace = _api.deprecated("3.3")(
         property(lambda self: self.sliderhspace.ax))
 
     @_api.deprecated("3.3")

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -181,11 +181,11 @@ class Axes3D(Axes):
     get_zgridlines = _axis_method_wrapper("zaxis", "get_gridlines")
     get_zticklines = _axis_method_wrapper("zaxis", "get_ticklines")
 
-    w_xaxis = cbook.deprecated("3.1", alternative="xaxis", pending=True)(
+    w_xaxis = _api.deprecated("3.1", alternative="xaxis", pending=True)(
         property(lambda self: self.xaxis))
-    w_yaxis = cbook.deprecated("3.1", alternative="yaxis", pending=True)(
+    w_yaxis = _api.deprecated("3.1", alternative="yaxis", pending=True)(
         property(lambda self: self.yaxis))
-    w_zaxis = cbook.deprecated("3.1", alternative="zaxis", pending=True)(
+    w_zaxis = _api.deprecated("3.1", alternative="zaxis", pending=True)(
         property(lambda self: self.zaxis))
 
     def _get_axis_list(self):
@@ -406,8 +406,8 @@ class Axes3D(Axes):
             # the attributes listed below, and they are temporarily attached to
             # the _class_ in the `_setattr_cm` call. These can both be removed
             # once the deprecation expires
-            name: cbook.deprecated('3.4', name=name,
-                                   alternative=f'self.axes.{name}')(
+            name: _api.deprecated('3.4', name=name,
+                                  alternative=f'self.axes.{name}')(
                 property(lambda self, _value=getattr(self, name): _value))
             for name in ['M', 'vvec', 'eye', 'get_axis_position']
         }


### PR DESCRIPTION
## PR Summary

Followup of moving all API helpers to matplotlib._api (#18657).
