### PR TITLE
MNT: Remove deprecated axes kwargs collision detection (version 2)

### DIFF
--- a/doc/api/next_api_changes/deprecations/19153-LPS.rst
+++ b/doc/api/next_api_changes/deprecations/19153-LPS.rst
@@ -1,0 +1,5 @@
+``pyplot.gca()``, ``Figure.gca``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Passing keyword arguments to `.pyplot.gca` or `.figure.Figure.gca` will not be
+supported in a future release.

--- a/doc/users/next_whats_new/axes_kwargs_collision.rst
+++ b/doc/users/next_whats_new/axes_kwargs_collision.rst
@@ -1,0 +1,21 @@
+Changes to behavior of Axes creation methods (``gca()``, ``add_axes()``, ``add_subplot()``)
+-------------------------------------------------------------------------------------------
+
+The behavior of the functions to create new axes (`.pyplot.axes`,
+`.pyplot.subplot`, `.figure.Figure.add_axes`,
+`.figure.Figure.add_subplot`) has changed. In the past, these functions would
+detect if you were attempting to create Axes with the same keyword arguments as
+already-existing axes in the current figure, and if so, they would return the
+existing Axes. Now, these functions will always create new Axes. A special
+exception is `.pyplot.subplot`, which will reuse any existing subplot with a
+matching subplot spec. However, if there is a subplot with a matching subplot
+spec, then that subplot will be returned, even if the keyword arguments with
+which it was created differ.
+
+Correspondingly, the behavior of the functions to get the current Axes
+(`.pyplot.gca`, `.figure.Figure.gca`) has changed. In the past, these functions
+accepted keyword arguments. If the keyword arguments matched an
+already-existing Axes, then that Axes would be returned, otherwise new Axes
+would be created with those keyword arguments. Now, the keyword arguments are
+only considered if there are no axes at all in the current figure. In a future
+release, these functions will not accept keyword arguments at all.

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,5 +1,4 @@
 import functools
-import uuid
 
 from matplotlib import _api, docstring
 import matplotlib.artist as martist
@@ -142,16 +141,7 @@ class SubplotBase:
             # which currently uses this internal API.
             if kwargs["sharex"] is not self and kwargs["sharey"] is not self:
                 raise ValueError("Twinned Axes may share only one axis")
-        # The dance here with label is to force add_subplot() to create a new
-        # Axes (by passing in a label never seen before).  Note that this does
-        # not affect plot reactivation by subplot() as twin axes can never be
-        # reactivated by subplot().
-        sentinel = str(uuid.uuid4())
-        real_label = kwargs.pop("label", sentinel)
-        twin = self.figure.add_subplot(
-            self.get_subplotspec(), *args, label=sentinel, **kwargs)
-        if real_label is not sentinel:
-            twin.set_label(real_label)
+        twin = self.figure.add_subplot(self.get_subplotspec(), *args, **kwargs)
         self.set_adjustable('datalim')
         twin.set_adjustable('datalim')
         self._twinned_axes.join(self, twin)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -606,6 +606,9 @@ class Stack:
     def __getitem__(self, ind):
         return self._elements[ind]
 
+    def as_list(self):
+        return list(self._elements)
+
     def forward(self):
         """Move the position forward and return the current element."""
         self._pos = min(self._pos + 1, len(self._elements) - 1)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2398,28 +2398,36 @@ def test_as_mpl_axes_api():
     # testing axes creation with plt.axes
     ax = plt.axes([0, 0, 1, 1], projection=prj)
     assert type(ax) == PolarAxes
-    ax_via_gca = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
+        ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     plt.close()
 
     # testing axes creation with gca
-    ax = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
+        ax = plt.gca(projection=prj)
     assert type(ax) == mpl.axes._subplots.subplot_class_factory(PolarAxes)
-    ax_via_gca = plt.gca(projection=prj)
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
+        ax_via_gca = plt.gca(projection=prj)
     assert ax_via_gca is ax
     # try getting the axes given a different polar projection
-    with pytest.warns(UserWarning) as rec:
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
         ax_via_gca = plt.gca(projection=prj2)
-        assert len(rec) == 1
-        assert 'Requested projection is different' in str(rec[0].message)
-    assert ax_via_gca is not ax
+    assert ax_via_gca is ax
     assert ax.get_theta_offset() == 0
-    assert ax_via_gca.get_theta_offset() == np.pi
     # try getting the axes given an == (not is) polar projection
-    with pytest.warns(UserWarning):
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
         ax_via_gca = plt.gca(projection=prj3)
-        assert len(rec) == 1
-        assert 'Requested projection is different' in str(rec[0].message)
     assert ax_via_gca is ax
     plt.close()
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -899,7 +899,7 @@ def test_autoscale():
 @pytest.mark.parametrize('auto', (True, False, None))
 def test_unautoscale(axis, auto):
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
 
     x = np.arange(100)
     y = np.linspace(-0.1, 0.1, 100)


### PR DESCRIPTION
This replaces #18978, and addresses the comments from @tacaswell and @jklymak to preserve the behavior of repeated calls to `plt.subplot` with the same subplot spec.

## PR Summary

In Matplotlib 2.1, the behavior of reusing existing axes when created with the same arguments was deprecated (see #9037). This behavior is now removed.

The behavior of the functions to create new axes (`pyplot.axes`, `pyplot.subplot`, `figure.Figure.add_axes`, `figure.Figure.add_subplot`) has changed. In the past, these functions would detect if you were attempting to create Axes with the same keyword arguments as already-existing axes in the current figure, and if so, they would return the existing Axes. Now, these functions will always create new Axes. A special exception is `pyplot.subplot`, which will reuse any existing subplot with a matching subplot spec. However, if there is a subplot with a matching subplot spec, then that subplot will be returned, even if the keyword arguments with which it was created differ.

Correspondingly, the behavior of the functions to get the current Axes (`pyplot.gca`, `figure.Figure.gca`) has changed. In the past, these functions accepted keyword arguments. If the keyword arguments matched an already-existing Axes, then that Axes would be returned, otherwise new Axes would be created with those keyword arguments. Now, the keyword arguments are only considered if there are no axes at all in the current figure. In a future release, these functions will not accept keyword arguments at all.

Fixes #18832.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).