### PR TITLE
Simplify test_backend_pdf::test_multipage_properfinalize.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -3,7 +3,6 @@ import decimal
 import io
 import os
 from pathlib import Path
-import sys
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -66,9 +65,9 @@ def test_multipage_properfinalize():
             fig, ax = plt.subplots()
             ax.set_title('This is a long title')
             fig.savefig(pdf, format="pdf")
-    pdfio.seek(0)
-    assert sum(b'startxref' in line for line in pdfio) == 1
-    assert sys.getsizeof(pdfio) < 40000
+    s = pdfio.getvalue()
+    assert s.count(b'startxref') == 1
+    assert len(s) < 40000
 
 
 def test_multipage_keep_empty():


### PR DESCRIPTION
Apparently sys.getsizeof(io.BytesIO(...)) doesn't work on PyPy, and
anyways it's a rather strange way to compute the length of a buffer.

See https://github.com/matplotlib/matplotlib/issues/19160.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
