### PR TITLE
Deprecate cbook.warn_deprecated and move internal calls to _api.warn_deprecated

### DIFF
--- a/doc/api/next_api_changes/deprecations/18657-TH.rst
+++ b/doc/api/next_api_changes/deprecations/18657-TH.rst
@@ -1,3 +1,12 @@
-``matplotlib.cbook.deprecation`` is deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The module is considered internal and will be removed from the public API.
+Deprecation-related functionality is considered internal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The module ``matplotlib.cbook.deprecation`` is considered internal and will be
+removed from the public API. This also holds for deprecation-related re-imports
+in ``matplotlib.cbook``, i.e. ``matplotlib.cbook.deprecated()``,
+``matplotlib.cbook.warn_deprecated()``,
+``matplotlib.cbook.MatplotlibDeprecationWarning`` and
+``matplotlib.cbook.mplDeprecation``.
+
+If needed, external users may import ``MatplotlibDeprecationWarning`` directly
+from the ``matplotlib`` namespace. ``mplDeprecation`` is only an alias of
+``MatplotlibDeprecationWarning`` and should not be used anymore.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -472,7 +472,7 @@ def get_cachedir():
 def get_data_path(*, _from_rc=None):
     """Return the path to Matplotlib data."""
     if _from_rc is not None:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.2",
             message=("Setting the datapath via matplotlibrc is deprecated "
                      "%(since)s and will be removed %(removal)s."),
@@ -495,7 +495,7 @@ def _get_data_path():
     if path.is_dir():
         return str(path)
 
-    cbook.warn_deprecated(
+    _api.warn_deprecated(
         "3.2", message="Matplotlib installs where the data is not in the "
         "mpl-data subdirectory of the package are deprecated since %(since)s "
         "and support for them will be removed %(removal)s.")
@@ -617,17 +617,16 @@ class RcParams(MutableMapping, dict):
         try:
             if key in _deprecated_map:
                 version, alt_key, alt_val, inverse_alt = _deprecated_map[key]
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     version, name=key, obj_type="rcparam", alternative=alt_key)
                 key = alt_key
                 val = alt_val(val)
             elif key in _deprecated_remain_as_none and val is not None:
                 version, = _deprecated_remain_as_none[key]
-                cbook.warn_deprecated(
-                    version, name=key, obj_type="rcparam")
+                _api.warn_deprecated(version, name=key, obj_type="rcparam")
             elif key in _deprecated_ignore_map:
                 version, alt_key = _deprecated_ignore_map[key]
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     version, name=key, obj_type="rcparam", alternative=alt_key)
                 return
             elif key == 'backend':
@@ -647,13 +646,13 @@ class RcParams(MutableMapping, dict):
     def __getitem__(self, key):
         if key in _deprecated_map:
             version, alt_key, alt_val, inverse_alt = _deprecated_map[key]
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 version, name=key, obj_type="rcparam", alternative=alt_key)
             return inverse_alt(dict.__getitem__(self, alt_key))
 
         elif key in _deprecated_ignore_map:
             version, alt_key = _deprecated_ignore_map[key]
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 version, name=key, obj_type="rcparam", alternative=alt_key)
             return dict.__getitem__(self, alt_key) if alt_key else None
 
@@ -811,7 +810,7 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
                                  fname, line_no, line.rstrip('\n'), msg)
         elif key in _deprecated_ignore_map:
             version, alt_key = _deprecated_ignore_map[key]
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 version, name=key, alternative=alt_key, obj_type='rcparam',
                 addendum="Please update your matplotlibrc.")
         else:

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1719,7 +1719,7 @@ class FuncAnimation(TimedAnimation):
                     except StopIteration:
                         pass
                     else:
-                        cbook.warn_deprecated(
+                        _api.warn_deprecated(
                             "2.2", message="FuncAnimation.save has truncated "
                             "your animation to 100 frames.  In the future, no "
                             "such truncation will occur; please pass "

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1036,7 +1036,7 @@ class Artist:
         with cbook._setattr_cm(self, eventson=False):
             for k, v in props.items():
                 if k != k.lower():
-                    cbook.warn_deprecated(
+                    _api.warn_deprecated(
                         "3.3", message="Case-insensitive properties were "
                         "deprecated in %(since)s and support will be removed "
                         "%(removal)s")
@@ -1156,7 +1156,7 @@ class Artist:
                 i_other = keys.index(other)
                 if i_other < i_color:
                     move_color_to_start = True
-                    cbook.warn_deprecated(
+                    _api.warn_deprecated(
                         "3.3", message=f"You have passed the {other!r} kwarg "
                         "before the 'color' kwarg.  Artist.set() currently "
                         "reorders the properties to apply 'color' first, but "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3032,7 +3032,7 @@ class Axes(_AxesBase):
 
         if normalize is None:
             if sx < 1:
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="normalize=None does not normalize "
                     "if the sum is less than 1 but this behavior "
                     "is deprecated since %(since)s until %(removal)s. "
@@ -3062,7 +3062,7 @@ class Axes(_AxesBase):
                 return next(color_cycle)
 
         if radius is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for passing a radius of None to mean "
                 "1 is deprecated since %(since)s and will be removed "
                 "%(removal)s.")
@@ -3070,7 +3070,7 @@ class Axes(_AxesBase):
 
         # Starting theta1 is the start fraction of the circle
         if startangle is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for passing a startangle of None to "
                 "mean 0 is deprecated since %(since)s and will be removed "
                 "%(removal)s.")
@@ -5634,7 +5634,7 @@ default: :rc:`scatter.edgecolors`
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
             if (ncols == Nx or nrows == Ny):
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="shading='flat' when X and Y have the same "
                     "dimensions as C is deprecated since %(since)s.  Either "
                     "specify the corners of the quadrilaterals with X and Y, "

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2772,7 +2772,7 @@ class _AxesBase(martist.Artist):
     def draw(self, renderer=None, inframe=False):
         # docstring inherited
         if renderer is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for not passing the 'renderer' "
                 "parameter to Axes.draw() is deprecated since %(since)s and "
                 "will be removed %(removal)s.  Use axes.draw_artist(axes) "

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,7 +1,7 @@
 import functools
 import uuid
 
-from matplotlib import _api, cbook, docstring
+from matplotlib import _api, docstring
 import matplotlib.artist as martist
 from matplotlib.axes._axes import Axes
 from matplotlib.gridspec import GridSpec, SubplotSpec
@@ -180,7 +180,7 @@ def subplot_class_factory(axes_class=None):
     not have to be created for every type of Axes.
     """
     if axes_class is None:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for passing None to subplot_class_factory "
             "is deprecated since %(since)s; explicitly pass the default Axes "
             "class instead. This will become an error %(removal)s.")

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -416,7 +416,7 @@ class RendererBase:
         Nurls = len(urls)
 
         if offset_position == "data":
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for offset_position='data' is "
                 "deprecated since %(since)s and will be removed %(removal)s.")
 
@@ -1191,7 +1191,7 @@ class TimerBase:
         pass it to `add_callback` as a `functools.partial` object.
         """
         if args or kwargs:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.1", message="In a future version, Timer.remove_callback "
                 "will not take *args, **kwargs anymore, but remove all "
                 "callbacks where the callable matches; to keep a specific "
@@ -1652,7 +1652,7 @@ def _check_savefig_extra_args(func=None, extra_kwargs=()):
         for arg in list(kwargs):
             if arg in accepted_kwargs:
                 continue
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 '3.3', name=name,
                 message='%(name)s() got unexpected keyword argument "'
                         + arg + '" which is no longer supported as of '
@@ -1967,7 +1967,7 @@ class FigureCanvasBase:
         else:
             x = None
             y = None
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 '3.0', removal='3.5', name='enter_notify_event',
                 message='Since %(since)s, %(name)s expects a location but '
                 'your backend did not pass one. This will become an error '
@@ -2607,7 +2607,7 @@ def key_press_handler(event, canvas=None, toolbar=None):
         for a in canvas.figure.get_axes():
             if (event.x is not None and event.y is not None
                     and a.in_axes(event)):  # FIXME: Why only these?
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="Toggling axes navigation from the "
                     "keyboard is deprecated since %(since)s and will be "
                     "removed %(removal)s.")
@@ -2620,7 +2620,7 @@ def key_press_handler(event, canvas=None, toolbar=None):
             for i, a in enumerate(canvas.figure.get_axes()):
                 if (event.x is not None and event.y is not None
                         and a.in_axes(event)):  # FIXME: Why only these?
-                    cbook.warn_deprecated(
+                    _api.warn_deprecated(
                         "3.3", message="Toggling axes navigation from the "
                         "keyboard is deprecated since %(since)s and will be "
                         "removed %(removal)s.")

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -199,7 +199,7 @@ class ToolManager:
         self._remove_keys(name)
         for key in [key, *args]:
             if isinstance(key, str) and validate_stringlist(key) != [key]:
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="Passing a list of keys as a single "
                     "comma-separated string is deprecated since %(since)s and "
                     "support will be removed %(removal)s; pass keys as a list "

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -168,7 +168,7 @@ class RendererAgg(RendererBase):
                              linewidths, linestyles, antialiaseds, urls,
                              offset_position):
         if offset_position == "data":
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for offset_position='data' is "
                 "deprecated since %(since)s and will be removed %(removal)s.")
         return self._renderer.draw_path_collection(
@@ -219,7 +219,7 @@ class RendererAgg(RendererBase):
 
         if ismath in ["TeX", "TeX!"]:
             if ismath == "TeX!":
-                cbook._warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="Support for ismath='TeX!' is deprecated "
                     "since %(since)s and will be removed %(removal)s; use "
                     "ismath='TeX' instead.")
@@ -573,7 +573,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             quality = pil_kwargs["quality"] = \
                 dict.__getitem__(mpl.rcParams, "savefig.jpeg_quality")
             if quality not in [0, 75, 95]:  # default qualities.
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", name="savefig.jpeg_quality", obj_type="rcParam",
                     addendum="Set the quality using "
                     "`pil_kwargs={'quality': ...}`; the future default "

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -969,7 +969,7 @@ class PdfPages:
                     'moddate': 'ModDate',
                 }.get(key.lower(), key.lower().title())
                 if canonical != key:
-                    cbook.warn_deprecated(
+                    _api.warn_deprecated(
                         '3.3', message='Support for setting PDF metadata keys '
                         'case-insensitively is deprecated since %(since)s and '
                         'will be removed %(removal)s; '

--- a/lib/matplotlib/backends/backend_qt4.py
+++ b/lib/matplotlib/backends/backend_qt4.py
@@ -1,4 +1,4 @@
-from .. import cbook
+from .. import _api
 from .backend_qt5 import (
     backend_version, SPECIAL_KEYS,
     SUPER, ALT, CTRL, SHIFT, MODIFIER_KEYS,  # These are deprecated.
@@ -6,7 +6,7 @@ from .backend_qt5 import (
     FigureManagerQT, NavigationToolbar2QT, SubplotToolQt, exception_handler)
 
 
-cbook.warn_deprecated("3.3", name=__name__, obj_type="backend")
+_api.warn_deprecated("3.3", name=__name__, obj_type="backend")
 
 
 @_BackendQT5.export

--- a/lib/matplotlib/backends/backend_qt4agg.py
+++ b/lib/matplotlib/backends/backend_qt4agg.py
@@ -2,12 +2,12 @@
 Render to qt from agg
 """
 
-from .. import cbook
+from .. import _api
 from .backend_qt5agg import (
     _BackendQT5Agg, FigureCanvasQTAgg, FigureManagerQT, NavigationToolbar2QT)
 
 
-cbook.warn_deprecated("3.3", name=__name__, obj_type="backend")
+_api.warn_deprecated("3.3", name=__name__, obj_type="backend")
 
 
 @_BackendQT5Agg.export

--- a/lib/matplotlib/backends/backend_qt4cairo.py
+++ b/lib/matplotlib/backends/backend_qt4cairo.py
@@ -1,8 +1,8 @@
-from .. import cbook
+from .. import _api
 from .backend_qt5cairo import _BackendQT5Cairo, FigureCanvasQTCairo
 
 
-cbook.warn_deprecated("3.3", name=__name__, obj_type="backend")
+_api.warn_deprecated("3.3", name=__name__, obj_type="backend")
 
 
 @_BackendQT5Cairo.export

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -142,7 +142,7 @@ class RendererWx(RendererBase):
 
     def __init__(self, bitmap, dpi):
         """Initialise a wxWindows renderer instance."""
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "2.0", name="wx", obj_type="backend", removal="the future",
             alternative="wxagg", addendum="See the Matplotlib usage FAQ for "
             "more info on backends.")

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -185,7 +185,7 @@ ETS = dict(pyqt=(QT_API_PYQTv2, 4), pyside=(QT_API_PYSIDE, 4),
 QT_RC_MAJOR_VERSION = int(QtCore.qVersion().split(".")[0])
 
 if QT_RC_MAJOR_VERSION == 4:
-    mpl.cbook.warn_deprecated("3.3", name="support for Qt4")
+    _api.warn_deprecated("3.3", name="support for Qt4")
 
 
 def _devicePixelRatioF(obj):

--- a/lib/matplotlib/backends/qt_editor/formsubplottool.py
+++ b/lib/matplotlib/backends/qt_editor/formsubplottool.py
@@ -1,8 +1,8 @@
-from matplotlib import cbook
+from matplotlib import _api
 from ._formsubplottool import UiSubplotTool
 
 
-cbook.warn_deprecated(
+_api.warn_deprecated(
     "3.3", obj_type="module", name=__name__,
     alternative="matplotlib.backends.backend_qt5.SubplotToolQt")
 __all__ = ["UiSubplotTool"]

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -30,12 +30,17 @@ import numpy as np
 import matplotlib
 from matplotlib import _api, _c_internal_utils
 from matplotlib._api.deprecation import (
-    warn_deprecated, MatplotlibDeprecationWarning, mplDeprecation)
+    MatplotlibDeprecationWarning, mplDeprecation)
 
 
 @_api.deprecated("3.4")
 def deprecated(*args, **kwargs):
     return _api.deprecated(*args, **kwargs)
+
+
+@_api.deprecated("3.4")
+def warn_deprecated(*args, **kwargs):
+    _api.warn_deprecated(*args, **kwargs)
 
 
 def _get_running_interactive_framework():
@@ -427,9 +432,9 @@ def to_filehandle(fname, flag='r', return_opened=False, encoding=None):
     if isinstance(fname, os.PathLike):
         fname = os.fspath(fname)
     if "U" in flag:
-        warn_deprecated("3.3", message="Passing a flag containing 'U' to "
-                        "to_filehandle() is deprecated since %(since)s and "
-                        "will be removed %(removal)s.")
+        _api.warn_deprecated(
+            "3.3", message="Passing a flag containing 'U' to to_filehandle() "
+            "is deprecated since %(since)s and will be removed %(removal)s.")
         flag = flag.replace("U", "")
     if isinstance(fname, str):
         if fname.endswith('.gz'):
@@ -491,7 +496,7 @@ def get_sample_data(fname, asfileobj=True, *, np_load=False):
             if np_load:
                 return np.load(path)
             else:
-                warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message="In a future release, get_sample_data "
                     "will automatically load numpy arrays.  Set np_load to "
                     "True to get the array and suppress this warning.  Set "

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -82,7 +82,7 @@ class _DeprecatedCmapDictWrapper(MutableMapping):
         return self._cmap_registry.get(key, default)
 
     def _warn_deprecated(self):
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3",
             message="The global colormaps dictionary is no longer "
                     "considered public API.",
@@ -279,7 +279,7 @@ class ScalarMappable:
         if vmin is not None or vmax is not None:
             self.set_clim(vmin, vmax)
             if norm is not None:
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3",
                     message="Passing parameters norm and vmin/vmax "
                             "simultaneously is deprecated since %(since)s and "

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1630,7 +1630,7 @@ class EventCollection(LineCollection):
             else:
                 raise
             normalized = "horizontal" if is_horizontal else "vertical"
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for setting the orientation of "
                 f"EventCollection to {orientation!r} is deprecated since "
                 f"%(since)s and will be removed %(removal)s; please set it to "

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1148,7 +1148,7 @@ def _add_disjoint_kwargs(d, **kwargs):
     """
     for k, v in kwargs.items():
         if k in d:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message=f"The {k!r} parameter to Colorbar has no "
                 "effect because it is overridden by the mappable; it is "
                 "deprecated since %(since)s and will be removed %(removal)s.")

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -516,7 +516,7 @@ def _create_lookup_table(N, data, gamma=1.0):
 
 def _warn_if_global_cmap_modified(cmap):
     if getattr(cmap, '_global', False):
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3",
             message="You are modifying the state of a globally registered "
                     "colormap. In future versions, you will not be able to "

--- a/lib/matplotlib/compat/__init__.py
+++ b/lib/matplotlib/compat/__init__.py
@@ -1,4 +1,4 @@
-from matplotlib import cbook
+from matplotlib import _api
 
 
-cbook.warn_deprecated("3.3", name=__name__, obj_type="module")
+_api.warn_deprecated("3.3", name=__name__, obj_type="module")

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -86,7 +86,7 @@ class _AxesStack(cbook.Stack):
         item = dict(self._elements).get(key)
         if item is None:
             return None
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "2.1",
             message="Adding an axes using the same arguments as a previous "
             "axes currently reuses the earlier instance.  In a future "
@@ -314,7 +314,7 @@ class FigureBase(Artist):
             Selects which ticklabels to rotate.
         """
         if which is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for passing which=None to mean "
                 "which='major' is deprecated since %(since)s and will be "
                 "removed %(removal)s.")
@@ -671,7 +671,7 @@ default: %(va)s
         """
 
         if not len(args) and 'rect' not in kwargs:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3",
                 message="Calling add_axes() without argument is "
                 "deprecated since %(since)s and will be removed %(removal)s. "
@@ -1162,7 +1162,7 @@ default: %(va)s
                 **kwargs)
         # check for third arg
         if len(extra_args):
-            # cbook.warn_deprecated(
+            # _api.warn_deprecated(
             #     "2.1",
             #     message="Figure.legend will accept no more than two "
             #     "positional arguments in the future.  Use "
@@ -1237,7 +1237,7 @@ default: %(va)s
             ax = self.gca()
             if (hasattr(mappable, "axes") and ax is not mappable.axes
                     and cax is None):
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.4", message="Starting from Matplotlib 3.6, colorbar() "
                     "will steal space from the mappable's axes, rather than "
                     "from the current axes, to place the colorbar.  To "

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1037,7 +1037,7 @@ class FontManager:
                     paths.extend(ttfpath.split(':'))
                 else:
                     paths.append(ttfpath)
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", name=pathname, obj_type="environment variable",
                     alternative="FontManager.addfont()")
         _log.debug('font search path %s', str(paths))

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -16,7 +16,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _api, _pylab_helpers, cbook, tight_layout, rcParams
+from matplotlib import _api, _pylab_helpers, tight_layout, rcParams
 from matplotlib.transforms import Bbox
 import matplotlib._layoutgrid as layoutgrid
 
@@ -618,7 +618,7 @@ class SubplotSpec:
                 return arg
             else:
                 if not isinstance(arg, Integral):
-                    cbook.warn_deprecated("3.3", message=message)
+                    _api.warn_deprecated("3.3", message=message)
                     arg = str(arg)
                 try:
                     rows, cols, num = map(int, str(arg))
@@ -630,18 +630,18 @@ class SubplotSpec:
         elif len(args) == 3:
             rows, cols, num = args
             if not (isinstance(rows, Integral) and isinstance(cols, Integral)):
-                cbook.warn_deprecated("3.3", message=message)
+                _api.warn_deprecated("3.3", message=message)
                 rows, cols = map(int, [rows, cols])
             gs = GridSpec(rows, cols, figure=figure)
             if isinstance(num, tuple) and len(num) == 2:
                 if not all(isinstance(n, Integral) for n in num):
-                    cbook.warn_deprecated("3.3", message=message)
+                    _api.warn_deprecated("3.3", message=message)
                     i, j = map(int, num)
                 else:
                     i, j = num
             else:
                 if not isinstance(num, Integral):
-                    cbook.warn_deprecated("3.3", message=message)
+                    _api.warn_deprecated("3.3", message=message)
                     num = int(num)
                 if num < 1 or num > rows*cols:
                     raise ValueError(

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from matplotlib import cbook
+from matplotlib import _api
 from matplotlib.path import Path
 
 
@@ -193,7 +193,7 @@ def _validate_hatch_pattern(hatch):
         if invalids:
             valid = ''.join(sorted(valid_hatch_patterns))
             invalids = ''.join(sorted(invalids))
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 '3.4',
                 message=f'hatch must consist of a string of "{valid}" or '
                         'None, but found the following invalid values '

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -46,7 +46,7 @@ def _get_dash_pattern(style):
     elif isinstance(style, tuple):
         offset, dashes = style
         if offset is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Passing the dash offset as None is deprecated "
                 "since %(since)s and support for it will be removed "
                 "%(removal)s; pass it as zero instead.")
@@ -604,7 +604,7 @@ class Line2D(Artist):
         # docstring inherited
         if isinstance(p, Number) and not isinstance(p, bool):
             # After deprecation, the whole method can be deleted and inherited.
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Setting the line's pick radius via set_picker "
                 "is deprecated since %(since)s and will be removed "
                 "%(removal)s; use set_pickradius instead.")

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -24,7 +24,7 @@ import types
 import numpy as np
 from PIL import Image
 
-from matplotlib import _api, cbook, colors as mcolors, rcParams, _mathtext
+from matplotlib import _api, colors as mcolors, rcParams, _mathtext
 from matplotlib.ft2font import FT2Image, LOAD_NO_HINTING
 from matplotlib.font_manager import FontProperties
 # Backcompat imports, all are deprecated as of 3.4.
@@ -434,7 +434,7 @@ class MathTextParser:
         with the same expression should be fast.
         """
         if _force_standard_ps_fonts:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.4",
                 removal="3.5",
                 message=(

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3655,7 +3655,7 @@ class FancyBboxPatch(Patch):
         self._height = height
 
         if boxstyle == "custom":
-            cbook._warn_deprecated(
+            _api.warn_deprecated(
                 "3.4", message="Support for boxstyle='custom' is deprecated "
                 "since %(since)s and will be removed %(removal)s; directly "
                 "pass a boxstyle instance as the boxstyle parameter instead.")
@@ -3770,7 +3770,7 @@ class FancyBboxPatch(Patch):
         except TypeError:
             # Don't apply aspect twice.
             path = boxstyle(x, y, width, height, m_scale, 1)
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.4", message="boxstyles must be callable without the "
                 "'mutation_aspect' parameter since %(since)s; support for the "
                 "old call signature will be removed %(removal)s.")

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -64,7 +64,7 @@ class ValidateInStrings:
     def __call__(self, s):
         if self._deprecated_since:
             name, = (k for k, v in globals().items() if v is self)
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 self._deprecated_since, name=name, obj_type="function")
         if self.ignorecase:
             s = s.lower()
@@ -184,7 +184,7 @@ def _validate_date_int_mult(s):
 
 def _validate_tex_preamble(s):
     if s is None or s == 'None':
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for setting the 'text.latex.preamble' or "
             "'pgf.preamble' rcParam to None is deprecated since %(since)s and "
             "will be removed %(removal)s; set it to an empty string instead.")
@@ -193,7 +193,7 @@ def _validate_tex_preamble(s):
         if isinstance(s, str):
             return s
         elif np.iterable(s):
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Support for setting the 'text.latex.preamble' "
                 "or 'pgf.preamble' rcParam to a list of strings is deprecated "
                 "since %(since)s and will be removed %(removal)s; set it to a "
@@ -213,7 +213,7 @@ def validate_axisbelow(s):
             if s == 'line':
                 return 'line'
             if s.lower().startswith('line'):
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.3", message=f"Support for setting axes.axisbelow to "
                     f"{s!r} to mean 'line' is deprecated since %(since)s and "
                     f"will be removed %(removal)s; set it to 'line' instead.")
@@ -464,7 +464,7 @@ def _validate_mathtext_fallback_to_cm(b):
     if b is None or b == 'none':
         return None
     else:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for setting the 'mathtext.fallback_to_cm' "
             "rcParam is deprecated since %(since)s and will be removed "
             "%(removal)s; use 'mathtext.fallback : 'cm' instead.")
@@ -563,7 +563,7 @@ def _validate_linestyle(ls):
             and len(ls[1]) % 2 == 0
             and all(isinstance(elem, Number) for elem in ls[1])):
         if ls[0] is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Passing the dash offset as None is deprecated "
                 "since %(since)s and support for it will be removed "
                 "%(removal)s; pass it as zero instead.")
@@ -581,12 +581,12 @@ def _deprecate_case_insensitive_join_cap(s):
     s_low = s.lower()
     if s != s_low:
         if s_low in ['miter', 'round', 'bevel']:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Case-insensitive capstyles are deprecated "
                 "since %(since)s and support for them will be removed "
                 "%(removal)s; please pass them in lowercase.")
         elif s_low in ['butt', 'round', 'projecting']:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3", message="Case-insensitive joinstyles are deprecated "
                 "since %(since)s and support for them will be removed "
                 "%(removal)s; please pass them in lowercase.")

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -6,7 +6,7 @@ Streamline plotting for 2D vector fields.
 import numpy as np
 
 import matplotlib
-from matplotlib import _api, cbook, cm
+from matplotlib import _api, cm
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
@@ -233,7 +233,7 @@ class StreamplotSet:
 
     def __init__(self, lines, arrows, **kwargs):
         if kwargs:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.3",
                 message="Passing arbitrary keyword arguments to StreamplotSet "
                         "is deprecated since %(since) and will become an "

--- a/lib/matplotlib/ttconv.py
+++ b/lib/matplotlib/ttconv.py
@@ -2,8 +2,8 @@
 Converting and subsetting TrueType fonts to PS types 3 and 42, and PDF type 3.
 """
 
-from . import cbook
+from . import _api
 from ._ttconv import convert_ttf_to_ps, get_pdf_charprocs  # noqa
 
 
-cbook.warn_deprecated('3.3', name=__name__, obj_type='module')
+_api.warn_deprecated('3.3', name=__name__, obj_type='module')

--- a/lib/mpl_toolkits/axes_grid/__init__.py
+++ b/lib/mpl_toolkits/axes_grid/__init__.py
@@ -2,10 +2,10 @@ from . import axes_size as Size
 from .axes_divider import Divider, SubplotDivider, make_axes_locatable
 from .axes_grid import Grid, ImageGrid, AxesGrid
 #from axes_divider import make_axes_locatable
-from matplotlib.cbook import warn_deprecated
-warn_deprecated(since='2.1',
-                name='mpl_toolkits.axes_grid',
-                alternative='mpl_toolkits.axes_grid1 and'
-                            ' mpl_toolkits.axisartist, which provide'
-                            ' the same functionality',
-                obj_type='module')
+from matplotlib import _api
+_api.warn_deprecated(since='2.1',
+                     name='mpl_toolkits.axes_grid',
+                     alternative='mpl_toolkits.axes_grid1 and'
+                                 ' mpl_toolkits.axisartist, which provide'
+                                 ' the same functionality',
+                     obj_type='module')

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -4,7 +4,7 @@ Helper classes to adjust the positions of multiple axes at drawing time.
 
 import numpy as np
 
-from matplotlib import _api, cbook
+from matplotlib import _api
 from matplotlib.axes import SubplotBase
 from matplotlib.gridspec import SubplotSpec, GridSpec
 import matplotlib.transforms as mtransforms
@@ -450,7 +450,7 @@ class AxesDivider(Divider):
             main axes will be used.
         """
         if pad is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.2", message="In a future version, 'pad' will default to "
                 "rcParams['figure.subplot.wspace'].  Set pad=0 to keep the "
                 "old behavior.")
@@ -499,7 +499,7 @@ class AxesDivider(Divider):
             main axes will be used.
         """
         if pad is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.2", message="In a future version, 'pad' will default to "
                 "rcParams['figure.subplot.hspace'].  Set pad=0 to keep the "
                 "old behavior.")

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -1,6 +1,6 @@
 import functools
 
-from matplotlib import _api, cbook
+from matplotlib import _api
 import matplotlib.artist as martist
 import matplotlib.transforms as mtransforms
 from matplotlib.axes import subplot_class_factory
@@ -87,7 +87,7 @@ class ParasiteAxesBase:
 @functools.lru_cache(None)
 def parasite_axes_class_factory(axes_class=None):
     if axes_class is None:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for passing None to "
             "parasite_axes_class_factory is deprecated since %(since)s and "
             "will be removed %(removal)s; explicitly pass the default Axes "
@@ -150,7 +150,7 @@ class ParasiteAxesAuxTransBase:
 @functools.lru_cache(None)
 def parasite_axes_auxtrans_class_factory(axes_class=None):
     if axes_class is None:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for passing None to "
             "parasite_axes_auxtrans_class_factory is deprecated since "
             "%(since)s and will be removed %(removal)s; explicitly pass the "
@@ -320,7 +320,7 @@ class HostAxesBase:
 @functools.lru_cache(None)
 def host_axes_class_factory(axes_class=None):
     if axes_class is None:
-        cbook.warn_deprecated(
+        _api.warn_deprecated(
             "3.3", message="Support for passing None to host_axes_class is "
             "deprecated since %(since)s and will be removed %(removed)s; "
             "explicitly pass the default Axes class instead.")

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -450,7 +450,7 @@ class Axes3D(Axes):
                     # deprecation has expired.
                     return artist.do_3d_projection()
 
-                cbook.warn_deprecated(
+                _api.warn_deprecated(
                     "3.4",
                     message="The 'renderer' parameter of "
                     "do_3d_projection() was deprecated in Matplotlib "
@@ -1678,7 +1678,7 @@ class Axes3D(Axes):
         cmap = kwargs.get('cmap', None)
         shade = kwargs.pop('shade', cmap is None)
         if shade is None:
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.1",
                 message="Passing shade=None to Axes3D.plot_surface() is "
                         "deprecated since matplotlib 3.1 and will change its "


### PR DESCRIPTION
## PR Summary

Followup of moving all API helpers to matplotlib._api (#18657).

Builds on top of #19151.

- [x] still needs the actual deprecation.

