### PR TITLE
Ignore missing _FancyAxislineStyle doc targets.

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -480,6 +480,12 @@
     "mpl_toolkits.axisartist.axisline_style.AxislineStyle._Base": [
       "lib/mpl_toolkits/axisartist/axisline_style.py:docstring of mpl_toolkits.axisartist.axisline_style.AxislineStyle.SimpleArrow:1"
     ],
+    "mpl_toolkits.axisartist.axisline_style._FancyAxislineStyle.FilledArrow": [
+      "<unknown>:1"
+    ],
+    "mpl_toolkits.axisartist.axisline_style._FancyAxislineStyle.SimpleArrow": [
+      "<unknown>:1"
+    ],
     "mpl_toolkits.axisartist.axislines.AxisArtistHelper._Base": [
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelper.Fixed:1",
       "lib/mpl_toolkits/axisartist/axislines.py:docstring of mpl_toolkits.axisartist.axislines.AxisArtistHelper.Floating:1"


### PR DESCRIPTION
## PR Summary

These are already ignored using a shorter path, so just ignore them when using the full import path as well.

I can't reproduce locally, but adding these doesn't break anything for me, and hopefully fixes CI.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).