### PR TITLE
docs: fix simple typo, backslahes -> backslashes

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,7 +35,7 @@ sys.path.append('.')
 # usage in the gallery.
 warnings.filterwarnings('error', append=True)
 
-# Strip backslahes in function's signature
+# Strip backslashes in function's signature
 # To be removed when numpydoc > 0.9.x
 strip_signature_backslash = True
 

--- a/doc/users/prev_whats_new/github_stats_3.3.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.3.0.rst
@@ -203,7 +203,7 @@ Pull Requests (1066):
 * :ghpull:`17795`: Backport PR #17781 on branch v3.3.x (Fix limit setting after plotting empty data)
 * :ghpull:`17764`: FIX: be more careful about not importing pyplot early
 * :ghpull:`17781`: Fix limit setting after plotting empty data
-* :ghpull:`17787`: Backport PR #17784 on branch v3.3.x (Allow passing emtpy list of ticks to FixedLocator)
+* :ghpull:`17787`: Backport PR #17784 on branch v3.3.x (Allow passing empty list of ticks to FixedLocator)
 * :ghpull:`17784`: Allow passing empty list of ticks to FixedLocator
 * :ghpull:`17766`: Backport PR #17752 on branch v3.3.x (Numpydoc-ify various functions)
 * :ghpull:`17752`: Numpydoc-ify various functions


### PR DESCRIPTION
There is a small typo in doc/conf.py.

Should read `backslashes` rather than `backslahes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md