### PR TITLE
CI: add github action to post to first-time PRs openers

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,0 +1,31 @@
+name: PR Greetings
+
+on: [pull_request]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/first-interaction@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        pr-message: >+
+          Thank you for opening your first PR into Matplotlib!
+
+          If you have not heard from us in a while please feel free to
+          ping `@matplotlib/developers` or anyone who has commented on the
+          PR.  Most of our reviewers are volunteers and it is easy for
+          things to fall through the cracks.
+
+          You can also join us [on
+          gitter](https://gitter.im/matplotlib/matplotlib) if real-time
+          discussion would be useful.
+
+          For details on testing, writing docs, and our review process
+          please see [the developer
+          guide](https://matplotlib.org/devdocs/devel/index.html)
+
+          We strive to be a welcoming and open project, please follow our
+          [Code of
+          Conduct](https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md).

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -15,12 +15,12 @@ jobs:
 
           If you have not heard from us in a while please feel free to
           ping `@matplotlib/developers` or anyone who has commented on the
-          PR.  Most of our reviewers are volunteers and it is easy for
+          PR.  Most of our reviewers are volunteers and sometimes
           things to fall through the cracks.
 
           You can also join us [on
-          gitter](https://gitter.im/matplotlib/matplotlib) if real-time
-          discussion would be useful.
+          gitter](https://gitter.im/matplotlib/matplotlib) for real-time
+          discussion.
 
           For details on testing, writing docs, and our review process
           please see [the developer


### PR DESCRIPTION
## PR Summary

Not sure how to test this?  


Below the line is how I think this should render:

--------


Thank you for opening your first PR into Matplotlib!

If you have not heard from us in a while please feel free to ping `@matplotlib/developers` or anyone who has commented on the PR.  Most of our reviewers are volunteers and it is easy for things to fall through the cracks.

You can also join us [on gitter](https://gitter.im/matplotlib/matplotlib) if real-time discussion would be useful.

For details on testing, write docs, and our review process please see [the developer guide](https://matplotlib.org/devdocs/devel/index.html)

We strive to be a welcoming and open project, please follow our [Code of Conduct](https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md).