### PR TITLE
Add support for HiDPI in TkAgg on Windows

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2107,7 +2107,7 @@ class FigureCanvasBase:
         self._device_pixel_ratio = ratio
         return True
 
-    def get_width_height(self):
+    def get_width_height(self, *, physical=False):
         """
         Return the figure width and height in integral points or pixels.
 
@@ -2115,13 +2115,20 @@ class FigureCanvasBase:
         it), the truncation to integers occurs after scaling by the device
         pixel ratio.
 
+        Parameters
+        ----------
+        physical : bool, default: False
+            Whether to return true physical pixels or logical pixels. Physical
+            pixels may be used by backends that support HiDPI, but still
+            configure the canvas using its actual size.
+
         Returns
         -------
         width, height : int
             The size of the figure, in points or pixels, depending on the
             backend.
         """
-        return tuple(int(size / self.device_pixel_ratio)
+        return tuple(int(size / (1 if physical else self.device_pixel_ratio))
                      for size in self.figure.bbox.max)
 
     @classmethod

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -5,9 +5,10 @@ import math
 import os.path
 import sys
 import tkinter as tk
-from tkinter.simpledialog import SimpleDialog
 import tkinter.filedialog
+import tkinter.font
 import tkinter.messagebox
+from tkinter.simpledialog import SimpleDialog
 
 import numpy as np
 from PIL import Image, ImageTk
@@ -525,16 +526,19 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
                 if tooltip_text is not None:
                     ToolTip.createToolTip(button, tooltip_text)
 
+        self._label_font = tkinter.font.Font(size=10)
+
         # This filler item ensures the toolbar is always at least two text
         # lines high. Otherwise the canvas gets redrawn as the mouse hovers
         # over images because those use two-line messages which resize the
         # toolbar.
-        label = tk.Label(master=self,
+        label = tk.Label(master=self, font=self._label_font,
                          text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
         label.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)
-        self._message_label = tk.Label(master=self, textvariable=self.message)
+        self._message_label = tk.Label(master=self, font=self._label_font,
+                                       textvariable=self.message)
         self._message_label.pack(side=tk.RIGHT)
 
         NavigationToolbar2.__init__(self, canvas)
@@ -602,8 +606,10 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
                             if size > 24 else image_file) as im:
                 image = ImageTk.PhotoImage(im.resize((size, size)),
                                            master=self)
-            b.config(image=image, height='18p', width='18p')
+            b.configure(image=image, height='18p', width='18p')
             b._ntimage = image  # Prevent garbage collection.
+        else:
+            b.configure(font=self._label_font)
         b.pack(side=tk.LEFT)
         return b
 
@@ -745,8 +751,10 @@ class ToolbarTk(ToolContainerBase, tk.Frame):
         tk.Frame.__init__(self, master=window,
                           width=int(width), height=int(height),
                           borderwidth=2)
+        self._label_font = tkinter.font.Font(size=10)
         self._message = tk.StringVar(master=self)
-        self._message_label = tk.Label(master=self, textvariable=self._message)
+        self._message_label = tk.Label(master=self, font=self._label_font,
+                                       textvariable=self._message)
         self._message_label.pack(side=tk.RIGHT)
         self._toolitems = {}
         self.pack(side=tk.TOP, fill=tk.X)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -866,7 +866,7 @@ class _BackendTk(_Backend):
         with _restore_foreground_window_at_end():
             if cbook._get_running_interactive_framework() is None:
                 cbook._setup_new_guiapp()
-                _c_internal_utils.Win32_SetDpiAwareness()
+                _c_internal_utils.Win32_SetProcessDpiAwareness_max()
             window = tk.Tk(className="matplotlib")
             window.withdraw()
 

--- a/setupext.py
+++ b/setupext.py
@@ -444,8 +444,8 @@ class Matplotlib(SetupPackage):
             ],
             include_dirs=["src"],
             # psapi library needed for finding Tcl/Tk at run time.
-            libraries=({"linux": ["dl"], "win32": ["psapi"],
-                        "cygwin": ["psapi"]}.get(sys.platform, [])),
+            libraries={"linux": ["dl"], "win32": ["comctl32", "psapi"],
+                       "cygwin": ["comctl32", "psapi"]}.get(sys.platform, []),
             extra_link_args={"win32": ["-mwindows"]}.get(sys.platform, []))
         add_numpy_flags(ext)
         add_libagg_flags(ext)

--- a/src/_c_internal_utils.c
+++ b/src/_c_internal_utils.c
@@ -125,10 +125,42 @@ mpl_SetForegroundWindow(PyObject* module, PyObject *arg)
 }
 
 static PyObject*
-mpl_SetDpiAwareness(PyObject* module)
+mpl_SetProcessDpiAwareness_max(PyObject* module)
 {
 #ifdef _WIN32
+#ifdef _DPI_AWARENESS_CONTEXTS_
+    // These functions and options were added in later Windows 10 updates, so
+    // must be loaded dynamically.
+    typedef BOOL (WINAPI *IsValidDpiAwarenessContext_t)(DPI_AWARENESS_CONTEXT);
+    typedef BOOL (WINAPI *SetProcessDpiAwarenessContext_t)(DPI_AWARENESS_CONTEXT);
+
+    HMODULE user32 = LoadLibrary("user32.dll");
+    IsValidDpiAwarenessContext_t IsValidDpiAwarenessContextPtr =
+        (IsValidDpiAwarenessContext_t)GetProcAddress(
+            user32, "IsValidDpiAwarenessContext");
+    SetProcessDpiAwarenessContext_t SetProcessDpiAwarenessContextPtr =
+        (SetProcessDpiAwarenessContext_t)GetProcAddress(
+            user32, "SetProcessDpiAwarenessContext");
+    if (IsValidDpiAwarenessContextPtr != NULL && SetProcessDpiAwarenessContextPtr != NULL) {
+        if (IsValidDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)) {
+            // Added in Creators Update of Windows 10.
+            SetProcessDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+        } else if (IsValidDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE)) {
+            // Added in Windows 10.
+            SetProcessDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
+        } else if (IsValidDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE)) {
+            // Added in Windows 10.
+            SetProcessDpiAwarenessContextPtr(DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+        }
+    } else {
+        // Added in Windows Vista.
+        SetProcessDPIAware();
+    }
+    FreeLibrary(user32);
+#else
+    // Added in Windows Vista.
     SetProcessDPIAware();
+#endif
 #endif
     Py_RETURN_NONE;
 }
@@ -160,11 +192,11 @@ static PyMethodDef functions[] = {
      "Win32_SetForegroundWindow(hwnd, /)\n--\n\n"
      "Wrapper for Windows' SetForegroundWindow.  On non-Windows platforms, \n"
      "a no-op."},
-    {"Win32_SetDpiAwareness",
-     (PyCFunction)mpl_SetDpiAwareness, METH_NOARGS,
-     "Win32_SetDpiAwareness()\n--\n\n"
-     "Set Windows' process DPI awareness to be enabled. On non-Windows\n"
-     "platforms, does nothing."},
+    {"Win32_SetProcessDpiAwareness_max",
+     (PyCFunction)mpl_SetProcessDpiAwareness_max, METH_NOARGS,
+     "Win32_SetProcessDpiAwareness_max()\n--\n\n"
+     "Set Windows' process DPI awareness to best option available.\n"
+     "On non-Windows platforms, does nothing."},
     {NULL, NULL}};  // sentinel.
 static PyModuleDef util_module = {
     PyModuleDef_HEAD_INIT, "_c_internal_utils", "", 0, functions, NULL, NULL, NULL, NULL};

--- a/src/_c_internal_utils.c
+++ b/src/_c_internal_utils.c
@@ -124,6 +124,15 @@ mpl_SetForegroundWindow(PyObject* module, PyObject *arg)
 #endif
 }
 
+static PyObject*
+mpl_SetDpiAwareness(PyObject* module)
+{
+#ifdef _WIN32
+    SetProcessDPIAware();
+#endif
+    Py_RETURN_NONE;
+}
+
 static PyMethodDef functions[] = {
     {"display_is_valid", (PyCFunction)mpl_display_is_valid, METH_NOARGS,
      "display_is_valid()\n--\n\n"
@@ -151,6 +160,11 @@ static PyMethodDef functions[] = {
      "Win32_SetForegroundWindow(hwnd, /)\n--\n\n"
      "Wrapper for Windows' SetForegroundWindow.  On non-Windows platforms, \n"
      "a no-op."},
+    {"Win32_SetDpiAwareness",
+     (PyCFunction)mpl_SetDpiAwareness, METH_NOARGS,
+     "Win32_SetDpiAwareness()\n--\n\n"
+     "Set Windows' process DPI awareness to be enabled. On non-Windows\n"
+     "platforms, does nothing."},
     {NULL, NULL}};  // sentinel.
 static PyModuleDef util_module = {
     PyModuleDef_HEAD_INIT, "_c_internal_utils", "", 0, functions, NULL, NULL, NULL, NULL};

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -95,6 +95,12 @@ typedef void (*Tk_PhotoPutBlock_NoComposite_t) (Tk_PhotoHandle handle,
         Tk_PhotoImageBlock *blockPtr, int x, int y,
         int width, int height);
 
+#ifdef WIN32_DLL
+/* Typedefs derived from function signatures in Tcl header */
+typedef const char *(*Tcl_SetVar_t)(Tcl_Interp *interp, const char *varName,
+                                    const char *newValue, int flags);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## PR Summary

At the moment, Tk does not support updating the 'scaling' value when the monitor pixel ratio changes, or the window is moved to a different one. Thus this needs a patch in the C extension to catch that window message and propagate it to Python. Due to thread locking issues, this needs to be done via a polled queue.

~~This is waiting for the pixel ratio refactor, #19126.~~

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).