### PR TITLE
Ensure backend tests are skipped if unavailable

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -34,8 +34,12 @@ def qt_core(request):
 
 @pytest.mark.parametrize('backend', [
     # Note: the value is irrelevant; the important part is the marker.
-    pytest.param('Qt4Agg', marks=pytest.mark.backend('Qt4Agg')),
-    pytest.param('Qt5Agg', marks=pytest.mark.backend('Qt5Agg')),
+    pytest.param(
+        'Qt4Agg',
+        marks=pytest.mark.backend('Qt4Agg', skip_on_importerror=True)),
+    pytest.param(
+        'Qt5Agg',
+        marks=pytest.mark.backend('Qt5Agg', skip_on_importerror=True)),
 ])
 def test_fig_close(backend):
     # save the state of Gcf.figs
@@ -53,7 +57,7 @@ def test_fig_close(backend):
     assert init_figs == Gcf.figs
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_fig_signals(qt_core):
     # Create a figure
     plt.figure()
@@ -130,8 +134,12 @@ def test_fig_signals(qt_core):
 )
 @pytest.mark.parametrize('backend', [
     # Note: the value is irrelevant; the important part is the marker.
-    pytest.param('Qt4Agg', marks=pytest.mark.backend('Qt4Agg')),
-    pytest.param('Qt5Agg', marks=pytest.mark.backend('Qt5Agg')),
+    pytest.param(
+        'Qt4Agg',
+        marks=pytest.mark.backend('Qt4Agg', skip_on_importerror=True)),
+    pytest.param(
+        'Qt5Agg',
+        marks=pytest.mark.backend('Qt5Agg', skip_on_importerror=True)),
 ])
 def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
     """
@@ -157,7 +165,7 @@ def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
     qt_canvas.keyPressEvent(_Event())
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_pixel_ratio_change():
     """
     Make sure that if the pixel ratio changes, the figure dpi changes but the
@@ -229,7 +237,7 @@ def test_pixel_ratio_change():
         assert (fig.get_size_inches() == (5, 2)).all()
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_subplottool():
     fig, ax = plt.subplots()
     with mock.patch(
@@ -238,7 +246,7 @@ def test_subplottool():
         fig.canvas.manager.toolbar.configure_subplots()
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_figureoptions():
     fig, ax = plt.subplots()
     ax.plot([1, 2])
@@ -250,7 +258,7 @@ def test_figureoptions():
         fig.canvas.manager.toolbar.edit_parameters()
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_double_resize():
     # Check that resizing a figure twice keeps the same window size
     fig, ax = plt.subplots()
@@ -270,7 +278,7 @@ def test_double_resize():
     assert window.height() == old_height
 
 
-@pytest.mark.backend("Qt5Agg")
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_canvas_reinit():
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -100,7 +100,8 @@ def test_determinism_check(objects, fmt, usetex):
             [sys.executable, "-R", "-c",
              f"from matplotlib.tests.test_determinism import _save_figure;"
              f"_save_figure({objects!r}, {fmt!r}, {usetex})"],
-            env={**os.environ, "SOURCE_DATE_EPOCH": "946684800"})
+            env={**os.environ, "SOURCE_DATE_EPOCH": "946684800",
+                 "MPLBACKEND": "Agg"})
         for _ in range(3)
     ]
     for p in plots[1:]:
@@ -139,5 +140,6 @@ def test_determinism_source_date_epoch(fmt, string):
         [sys.executable, "-R", "-c",
          f"from matplotlib.tests.test_determinism import _save_figure; "
          f"_save_figure('', {fmt!r})"],
-        env={**os.environ, "SOURCE_DATE_EPOCH": "946684800"})
+        env={**os.environ, "SOURCE_DATE_EPOCH": "946684800",
+             "MPLBACKEND": "Agg"})
     assert string in buf

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -56,4 +56,4 @@ def test_importable_with__OO():
         "import matplotlib.patches as mpatches"
     )
     cmd = [sys.executable, "-OO", "-c", program]
-    assert subprocess.call(cmd) == 0
+    assert subprocess.call(cmd, env={**os.environ, "MPLBACKEND": ""}) == 0

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -1,6 +1,7 @@
 """Tests for tinypages build using sphinx extensions."""
 
 import filecmp
+import os
 from pathlib import Path
 from subprocess import Popen, PIPE
 import sys
@@ -19,14 +20,14 @@ def test_tinypages(tmpdir):
     cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
            '-d', str(doctree_dir),
            str(Path(__file__).parent / 'tinypages'), str(html_dir)]
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True,
+                 env={**os.environ, "MPLBACKEND": ""})
     out, err = proc.communicate()
 
     assert proc.returncode == 0, \
-        "sphinx build failed with stdout:\n{}\nstderr:\n{}\n".format(out, err)
+        f"sphinx build failed with stdout:\n{out}\nstderr:\n{err}\n"
     if err:
-        pytest.fail("sphinx build emitted the following warnings:\n{}"
-                    .format(err))
+        pytest.fail(f"sphinx build emitted the following warnings:\n{err}")
 
     assert html_dir.is_dir()
 


### PR DESCRIPTION
## PR Summary

When running headless or with an unavailable backend set in `matplotlibrc`, some tests fail when they shouldn't. These tests should either use Agg, or be skipped.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).