### PR TITLE
Check that no new figures are created in image comparison tests

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -109,10 +109,10 @@ def test_acorr(fig_test, fig_ref):
     x = np.random.normal(0, 1, Nx).cumsum()
     maxlags = Nx-1
 
-    fig_test, ax_test = plt.subplots()
+    ax_test = fig_test.subplots()
     ax_test.acorr(x, maxlags=maxlags)
 
-    fig_ref, ax_ref = plt.subplots()
+    ax_ref = fig_ref.subplots()
     # Normalized autocorrelation
     norm_auto_corr = np.correlate(x, x, mode="full")/np.dot(x, x)
     lags = np.arange(-maxlags, maxlags+1)

--- a/lib/matplotlib/tests/test_testing.py
+++ b/lib/matplotlib/tests/test_testing.py
@@ -1,5 +1,8 @@
 import warnings
+
 import pytest
+
+import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal
 
 
@@ -22,3 +25,17 @@ def test_wrap_failure():
         @check_figures_equal()
         def should_fail(test, ref):
             pass
+
+
+@pytest.mark.xfail(raises=RuntimeError, strict=True,
+                   reason='Test for check_figures_equal test creating '
+                          'new figures')
+@check_figures_equal()
+def test_check_figures_equal_extra_fig(fig_test, fig_ref):
+    plt.figure()
+
+
+@check_figures_equal()
+def test_check_figures_equal_closed_fig(fig_test, fig_ref):
+    fig = plt.figure()
+    plt.close(fig)


### PR DESCRIPTION
## PR Summary
xref https://github.com/matplotlib/matplotlib/issues/18581. Perhaps this should be a warning instead to start with in case anyone else is using this function outside of MPL?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
