### PR TITLE
Document Triangulation.triangles

### DIFF
--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -22,7 +22,8 @@ class Triangulation:
     ----------
     triangles : int array-like of shape (ntri, 3)
         For each triangle, the indices of the three points that make
-        up the triangle, ordered in an anticlockwise manner.
+        up the triangle, ordered in an anticlockwise manner. If you want to
+        take the *mask* into account, use `get_masked_triangles` instead.
     mask : bool array of shape (ntri, 3)
         Masked out triangles.
     is_delaunay : bool

--- a/lib/matplotlib/tri/triangulation.py
+++ b/lib/matplotlib/tri/triangulation.py
@@ -20,10 +20,9 @@ class Triangulation:
 
     Attributes
     ----------
-    edges : int array of shape (nedges, 2)
-        See `~.Triangulation.edges`
-    neighbors : int array of shape (ntri, 3)
-        See `~.Triangulation.neighbors`
+    triangles : int array-like of shape (ntri, 3)
+        For each triangle, the indices of the three points that make
+        up the triangle, ordered in an anticlockwise manner.
     mask : bool array of shape (ntri, 3)
         Masked out triangles.
     is_delaunay : bool


### PR DESCRIPTION
xref https://github.com/matplotlib/matplotlib/issues/18946. I'm not sure this fixes the issue, but it:

- Documents the triangles parameter
- Removes duplicated documentation for two attributes that are really properties, and therefore have their own property docstrings.