### PR TITLE
Create tiny mathtext baseline images using svg with non-embedded fonts.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2158,7 +2158,8 @@ class Parser:
 
         p.sqrt <<= Group(
             Suppress(Literal(r"\sqrt"))
-            - ((Optional(p.lbracket + p.int_literal + p.rbracket, default=None)
+            - ((Group(Optional(
+                p.lbracket + OneOrMore(~p.rbracket + p.token) + p.rbracket))
                 + p.required_group)
                | Error("Expected \\sqrt{value}"))
         )
@@ -2864,10 +2865,10 @@ class Parser:
 
         # Add the root and shift it upward so it is above the tick.
         # The value of 0.6 is a hard-coded hack ;)
-        if root is None:
+        if not root:
             root = Box(check.width * 0.5, 0., 0.)
         else:
-            root = Hlist([Char(x, state) for x in root])
+            root = Hlist(root)
             root.shrink()
             root.shrink()
 

--- a/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext1_all_00.svg
+++ b/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext1_all_00.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg height="378pt" version="1.1" viewBox="0 0 378 378" width="378pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <style type="text/css">*{stroke-linecap:butt;stroke-linejoin:round;}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="text_1">
+   <!-- $\sqrt[ab]{123}$ -->
+   <g transform="translate(173.16 344.124375)">
+    <text>
+     <tspan style="font: 5.88px 'cmmi10'" x="0 3.103652" y="-7.579999999999998">ab</tspan>
+     <tspan style="font: 10.008677px 'cmex10'" x="0.627344" y="-11.87375">p</tspan>
+     <tspan style="font: 12px 'cmr10'" x="12.127344 18.127344 24.127344" y="-0.25">123</tspan>
+    </text>
+    <rect height="0.75" width="21" x="10.627344" y="-12.5"/>
+   </g>
+  </g>
+  <g id="text_2">
+   <!-- $\sqrt[ab]{123}$ -->
+   <g transform="translate(172.74 269.28)">
+    <text>
+     <tspan style="font: italic 5.88px 'STIXGeneral'" x="0 2.945877" y="-7.61125">ab</tspan>
+     <tspan style="font: 12px 'STIXGeneral'" x="0.317876 12.953862 18.953847 24.953832" y="-0.6081249999999994 -0.140625 -0.140625 -0.140625">√123</tspan>
+    </text>
+    <rect height="0.75" width="20.999954" x="11.453862" y="-12.5"/>
+   </g>
+  </g>
+  <g id="text_3">
+   <!-- $\sqrt[ab]{123}$ -->
+   <g transform="translate(172.92 193.68)">
+    <text>
+     <tspan style="font: italic 5.88px 'STIXGeneral'" x="0 2.634236" y="-7.61125">𝘢𝘣</tspan>
+     <tspan style="font: 12px 'STIXGeneral'" x="-0.017279 12.618707 18.618692 24.618677" y="-0.6081249999999994 -0.125 -0.125 -0.125">√𝟣𝟤𝟥</tspan>
+    </text>
+    <rect height="0.75" width="20.999954" x="11.118707" y="-12.5"/>
+   </g>
+  </g>
+  <g id="text_4">
+   <!-- $\sqrt[ab]{123}$ -->
+   <g transform="translate(170.52 117.744375)">
+    <text>
+     <tspan style="font: oblique 5.88px 'DejaVu Sans'" x="0 3.603223" y="-8.18">ab</tspan>
+     <tspan style="font: 6.942918px 'STIXSizeOneSym'" x="3.636151" y="-2.4206249999999994">√</tspan>
+     <tspan style="font: 12px 'DejaVu Sans'" x="12.535138 20.169904 27.804669" y="-0.34375">123</tspan>
+    </text>
+    <rect height="0.75" width="25.904297" x="11.035138" y="-13.5"/>
+   </g>
+  </g>
+  <g id="text_5">
+   <!-- $\sqrt[ab]{123}$ -->
+   <g transform="translate(170.52 42.144375)">
+    <text>
+     <tspan style="font: italic 5.88px 'DejaVu Serif'" x="0 3.505605" y="-8.18">ab</tspan>
+     <tspan style="font: 6.942918px 'STIXSizeOneSym'" x="3.570116" y="-2.4206249999999994">√</tspan>
+     <tspan style="font: 12px 'DejaVu Serif'" x="12.469103 20.103868 27.738634" y="-0.34375">123</tspan>
+    </text>
+    <rect height="0.75" width="25.904297" x="10.969103" y="-13.5"/>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -1,6 +1,8 @@
 import io
-import os
+from pathlib import Path
 import re
+import shlex
+from xml.etree import ElementTree as ET
 
 import numpy as np
 import pytest
@@ -328,7 +330,7 @@ def test_mathtext_fallback_to_cm_invalid():
      ("stix", ['DejaVu Sans', 'mpltest', 'STIXGeneral'])])
 def test_mathtext_fallback(fallback, fontlist):
     mpl.font_manager.fontManager.addfont(
-        os.path.join((os.path.dirname(os.path.realpath(__file__))), 'mpltest.ttf'))
+        str(Path(__file__).resolve().parent / 'mpltest.ttf'))
     mpl.rcParams["svg.fonttype"] = 'none'
     mpl.rcParams['mathtext.fontset'] = 'custom'
     mpl.rcParams['mathtext.rm'] = 'mpltest'
@@ -342,12 +344,13 @@ def test_mathtext_fallback(fallback, fontlist):
     fig, ax = plt.subplots()
     fig.text(.5, .5, test_str, fontsize=40, ha='center')
     fig.savefig(buff, format="svg")
-    char_fonts = [
-        line.split("font-family:")[-1].split(";")[0]
-        for line in str(buff.getvalue()).split(r"\n") if "tspan" in line
-    ]
+    tspans = (ET.fromstring(buff.getvalue())
+              .findall(".//{http://www.w3.org/2000/svg}tspan[@style]"))
+    # Getting the last element of the style attrib is a close enough
+    # approximation for parsing the font property.
+    char_fonts = [shlex.split(tspan.attrib["style"])[-1] for tspan in tspans]
     assert char_fonts == fontlist
-    mpl.font_manager.fontManager.ttflist = mpl.font_manager.fontManager.ttflist[:-1]
+    mpl.font_manager.fontManager.ttflist.pop()
 
 
 def test_math_to_image(tmpdir):

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -113,6 +113,7 @@ math_tests = [
     r'$\dfrac{\$100.00}{y}$',  # github issue #1888
 ]
 svg_only_math_tests = [
+    r'$\sqrt[ab]{123}$',  # github issue #8665
 ]
 
 digits = "0123456789"

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -112,6 +112,8 @@ math_tests = [
     r'$\left(X\right)_{a}^{b}$',  # github issue 7615
     r'$\dfrac{\$100.00}{y}$',  # github issue #1888
 ]
+svg_only_math_tests = [
+]
 
 digits = "0123456789"
 uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -167,8 +169,6 @@ for fonts, chars in font_test_specs:
         for set in chars:
             font_tests.append(wrapper % set)
 
-font_tests = list(filter(lambda x: x[1] is not None, enumerate(font_tests)))
-
 
 @pytest.fixture
 def baseline_images(request, fontset, index):
@@ -190,6 +190,32 @@ def test_mathtext_rendering(baseline_images, fontset, index, test):
     fig = plt.figure(figsize=(5.25, 0.75))
     fig.text(0.5, 0.5, test,
              horizontalalignment='center', verticalalignment='center')
+
+
+cur_svg_only_math_tests = list(
+    filter(lambda x: x[1] is not None, enumerate(svg_only_math_tests)))
+
+
+@pytest.mark.parametrize('index, test', cur_svg_only_math_tests,
+                         ids=[str(idx) for idx, _ in cur_svg_only_math_tests])
+@pytest.mark.parametrize('fontset', ['all'])
+@pytest.mark.parametrize('baseline_images', ['mathtext1'], indirect=True)
+@image_comparison(
+    baseline_images=None, extensions=['svg'],
+    savefig_kwarg={
+        'metadata': {  # Minimize svg size.
+            'Creator': None, 'Date': None, 'Format': None, 'Type': None}})
+def test_mathtext_rendering_svg_only(baseline_images, fontset, index, test):
+    mpl.rcParams['svg.fonttype'] = 'none'
+    fig = plt.figure(figsize=(5.25, 5.25))
+    fig.patch.set_visible(False)  # Minimize svg size.
+    fontsets = ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif']
+    for i, fontset in enumerate(fontsets):
+        fig.text(0.5, (i + .5) / len(fontsets), test, math_fontfamily=fontset,
+                 horizontalalignment='center', verticalalignment='center')
+
+
+font_tests = list(filter(lambda x: x[1] is not None, enumerate(font_tests)))
 
 
 @pytest.mark.parametrize('index, test', font_tests,


### PR DESCRIPTION
... and using non-integer bases sqrt as example use case.

See https://github.com/matplotlib/matplotlib/pull/19186#issuecomment-752266330.

While I was at it I also fixed/shortened the font attribute used to specify the font (first commit).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
