### PR TITLE
Fix creation of AGG images bigger than 1024**3 pixels

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -29,7 +29,7 @@ RendererAgg::RendererAgg(unsigned int width, unsigned int height, double dpi)
     : width(width),
       height(height),
       dpi(dpi),
-      NUMBYTES(width * height * 4),
+      NUMBYTES((size_t) width * (size_t) height * 4),
       pixBuffer(NULL),
       renderingBuffer(),
       alphaBuffer(NULL),

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -95,7 +95,7 @@ int PyBufferRegion_get_buffer(PyBufferRegion *self, Py_buffer *buf, int flags)
     Py_INCREF(self);
     buf->obj = (PyObject *)self;
     buf->buf = self->x->get_data();
-    buf->len = self->x->get_width() * self->x->get_height() * 4;
+    buf->len = (long) self->x->get_width() * (long) self->x->get_height() * 4;
     buf->readonly = 0;
     buf->format = (char *)"B";
     buf->ndim = 3;
@@ -531,7 +531,7 @@ int PyRendererAgg_get_buffer(PyRendererAgg *self, Py_buffer *buf, int flags)
     Py_INCREF(self);
     buf->obj = (PyObject *)self;
     buf->buf = self->x->pixBuffer;
-    buf->len = self->x->get_width() * self->x->get_height() * 4;
+    buf->len = (long) self->x->get_width() * (long) self->x->get_height() * 4;
     buf->readonly = 0;
     buf->format = (char *)"B";
     buf->ndim = 3;


### PR DESCRIPTION
## PR Summary

Various buffer size calculations were overflowing, because C is awesome. Simple reproduction case:

```python
import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt
fig, ax = plt.subplots(figsize=(463, 232), dpi=100)
fig.savefig('big.png')
```

(A size of 462x232 is just *under* the gigapixel threshold.)

Closes #19209.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
