### PR TITLE
MNT: try to put more whitespace in welcome message

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -13,18 +13,22 @@ jobs:
         pr-message: >+
           Thank you for opening your first PR into Matplotlib!
 
+
           If you have not heard from us in a while, please feel free to
           ping `@matplotlib/developers` or anyone who has commented on the
           PR.  Most of our reviewers are volunteers and sometimes
           things fall through the cracks.
 
+
           You can also join us [on
           gitter](https://gitter.im/matplotlib/matplotlib) for real-time
           discussion.
 
+
           For details on testing, writing docs, and our review process,
           please see [the developer
           guide](https://matplotlib.org/devdocs/devel/index.html)
+
 
           We strive to be a welcoming and open project. Please follow our
           [Code of


### PR DESCRIPTION
The welcome message seems to be working now (see https://github.com/matplotlib/matplotlib/pull/19210#pullrequestreview-560512912) but it is very compressed.  Try to add more white space in the workflow to see if that will render nicer. 
