### PR TITLE
Ignore non-draw codes when calculating path extent

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -621,7 +621,12 @@ class Path:
         if self.codes is None:
             xys = self.vertices
         elif len(np.intersect1d(self.codes, [Path.CURVE3, Path.CURVE4])) == 0:
-            xys = self.vertices[self.codes != Path.CLOSEPOLY]
+            # Optimization for the straight line case.
+            # Instead of iterating through each curve, consider
+            # each line segment's end-points
+            # (recall that STOP and CLOSEPOLY vertices are ignored)
+            xys = self.vertices[np.isin(self.codes,
+                                        [Path.MOVETO, Path.LINETO])]
         else:
             xys = []
             for curve, code in self.iter_bezier(**kwargs):

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -102,6 +102,16 @@ def test_exact_extents(path, extents):
     assert np.all(path.get_extents().extents == extents)
 
 
+@pytest.mark.parametrize('ignored_code', [Path.CLOSEPOLY, Path.STOP])
+def test_extents_with_ignored_codes(ignored_code):
+    # Check that STOP and CLOSEPOLY points are ignored when calculating extents
+    # of a path with only straight lines
+    path = Path([[0, 0],
+                 [1, 1],
+                 [2, 2]], [Path.MOVETO, Path.MOVETO, ignored_code])
+    assert np.all(path.get_extents().extents == (0., 0., 1., 1.))
+
+
 def test_point_in_path_nan():
     box = np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
     p = Path(box)


### PR DESCRIPTION
When calculating the extents of a path, any ~MOVETO,~ CLOESPOLY, or STOP codes shouldn't be taken into account.  This is a follow up to https://github.com/matplotlib/matplotlib/pull/16832. 