### PR TITLE
Request an autoscale at the end of ax.pie()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3146,7 +3146,9 @@ class Axes(_AxesBase):
 
             theta1 = theta2
 
-        if not frame:
+        if frame:
+            self._request_autoscale_view()
+        else:
             self.set(frame_on=False, xticks=[], yticks=[],
                      xlim=(-1.25 + center[0], 1.25 + center[0]),
                      ylim=(-1.25 + center[1], 1.25 + center[1]))


### PR DESCRIPTION
I noticed in https://github.com/matplotlib/matplotlib/pull/19214 that `pie()` doesn't currently request an autoscale at the end, but it probably should to fall in line with the rest of the `Axes` plotting methods. This is needed in https://github.com/matplotlib/matplotlib/pull/19214 to make some of the pie chart limits more sensible, but I thought it was orthogonal enough to warrant a separate PR.