### PR TITLE
Validate text rotation in setter

### DIFF
--- a/examples/text_labels_and_annotations/watermark_text.py
+++ b/examples/text_labels_and_annotations/watermark_text.py
@@ -18,7 +18,7 @@ ax.grid()
 
 ax.text(0.5, 0.5, 'created with matplotlib', transform=ax.transAxes,
         fontsize=40, color='gray', alpha=0.5,
-        ha='center', va='center', rotation='30')
+        ha='center', va='center', rotation=30)
 
 plt.show()
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -303,7 +303,7 @@ def test_add_subplot_invalid():
 def test_suptitle():
     fig, _ = plt.subplots()
     fig.suptitle('hello', color='r')
-    fig.suptitle('title', color='g', rotation='30')
+    fig.suptitle('title', color='g', rotation=30)
 
 
 def test_suptitle_fontproperties():

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -711,6 +711,14 @@ def test_update_mutate_input():
     assert inp['bbox'] == cache['bbox']
 
 
+@pytest.mark.parametrize('rotation', ['invalid string', [90]])
+def test_invalid_rotation_values(rotation):
+    with pytest.raises(
+            ValueError,
+            match=("rotation must be 'vertical', 'horizontal' or a number")):
+        Text(0, 0, 'foo', rotation=rotation)
+
+
 def test_invalid_color():
     with pytest.raises(ValueError):
         plt.figtext(.5, .5, "foo", c="foobar")

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -4,6 +4,7 @@ Classes for including text in a figure.
 
 import logging
 import math
+import numbers
 import weakref
 
 import numpy as np
@@ -149,7 +150,7 @@ class Text(Artist):
         self.set_verticalalignment(verticalalignment)
         self.set_horizontalalignment(horizontalalignment)
         self._multialignment = multialignment
-        self._rotation = rotation
+        self.set_rotation(rotation)
         self._transform_rotates_text = transform_rotates_text
         self._bbox_patch = None  # a FancyBboxPatch instance
         self._renderer = None
@@ -1177,6 +1178,11 @@ class Text(Artist):
             The rotation angle in degrees in mathematically positive direction
             (counterclockwise). 'horizontal' equals 0, 'vertical' equals 90.
         """
+        if (s is not None and
+                not isinstance(s, numbers.Real) and
+                s not in ['vertical', 'horizontal']):
+            raise ValueError("rotation must be 'vertical', 'horizontal' or "
+                             f"a number, not {s}")
         self._rotation = s
         self.stale = True
 


### PR DESCRIPTION
xref https://github.com/matplotlib/matplotlib/issues/19223. I think checking for `numbers.Real` is the right thing to do here?