### PR TITLE
Add support for handling timedelta

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -167,16 +167,20 @@ import matplotlib as mpl
 from matplotlib import _api, cbook, ticker, units
 
 __all__ = ('datestr2num', 'date2num', 'num2date', 'num2timedelta', 'drange',
+           'timedelta2num', 'pd_timedelta2np',
            'epoch2num', 'num2epoch', 'set_epoch', 'get_epoch', 'DateFormatter',
            'ConciseDateFormatter', 'IndexDateFormatter', 'AutoDateFormatter',
+           'TimedeltaFormatter', 'ConciseTimedeltaFormatter',
+           'AutoTimedeltaFormatter',
            'DateLocator', 'RRuleLocator', 'AutoDateLocator', 'YearLocator',
            'MonthLocator', 'WeekdayLocator',
            'DayLocator', 'HourLocator', 'MinuteLocator',
            'SecondLocator', 'MicrosecondLocator',
+           'TimedeltaLocator', 'AutoTimedeltaLocator', 'FixedTimedeltaLocator',
            'rrule', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU',
            'YEARLY', 'MONTHLY', 'WEEKLY', 'DAILY',
            'HOURLY', 'MINUTELY', 'SECONDLY', 'MICROSECONDLY', 'relativedelta',
-           'DateConverter', 'ConciseDateConverter')
+           'DateConverter', 'ConciseDateConverter', 'TimedeltaConverter')
 
 
 _log = logging.getLogger(__name__)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -992,6 +992,38 @@ def test_num2timedelta(x, tdelta):
     assert dt == tdelta
 
 
+def test_pd_timedelta2np(pd):
+    pd_td = [pd.Timedelta(seconds=1), pd.NaT]
+    td = np.array([np.timedelta64(1, 's'),
+                   np.timedelta64('nat')])
+    converted = mdates.pd_timedelta2np(pd_td)
+    np.testing.assert_array_equal(td, converted)
+
+
+@pytest.mark.parametrize("x, tdelta",
+                         [(1, datetime.timedelta(days=1)),
+                          (0.25, datetime.timedelta(hours=6)),
+                          (3/86400/1000, datetime.timedelta(milliseconds=3)),
+                          (np.nan, np.timedelta64('nat')),
+                          ([1, 1.5], [datetime.timedelta(days=1),
+                                      datetime.timedelta(days=1.5)])])
+def test_timedelta2num(x, tdelta):
+    np.testing.assert_equal(x, mdates.timedelta2num(tdelta))
+
+
+@pytest.mark.parametrize("x, td_kwargs",
+                         [(2, {'days': 2}),
+                          (0.25, {'hours': 6}),
+                          (3/86400/1000, {'milliseconds': 3})])
+def test_timedelta2num_pandas(pd, x, td_kwargs):
+    pd_td = pd.Timedelta(**td_kwargs)
+    np.testing.assert_equal(x, mdates.timedelta2num(pd_td))
+
+
+def test_timedelta2num_pandas_nat(pd):
+    assert np.isnan(mdates.timedelta2num(pd.NaT))
+
+
 def test_datetime64_in_list():
     dt = [np.datetime64('2000-01-01'), np.datetime64('2001-01-01')]
     dn = mdates.date2num(dt)

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -47,6 +47,7 @@ from numbers import Number
 
 import numpy as np
 from numpy import ma
+import datetime
 
 from matplotlib import cbook
 
@@ -60,15 +61,18 @@ def _is_natively_supported(x):
     Return whether *x* is of a type that Matplotlib natively supports or an
     array of objects of such types.
     """
-    # Matplotlib natively supports all number types except Decimal.
+    # Matplotlib natively supports all number types except Decimal,
+    # datetime.timedelta and numpy.timedelta64. (Timedeltas are only not
+    # supported natively because of 'nat' values.)
+    unsupported = (Decimal, np.timedelta64, datetime.timedelta)
     if np.iterable(x):
         # Assume lists are homogeneous as other functions in unit system.
         for thisx in x:
             if thisx is ma.masked:
                 continue
-            return isinstance(thisx, Number) and not isinstance(thisx, Decimal)
+            return isinstance(thisx, Number) and not isinstance(thisx, unsupported)
     else:
-        return isinstance(x, Number) and not isinstance(x, Decimal)
+        return isinstance(x, Number) and not isinstance(x, unsupported)
 
 
 class AxisInfo:


### PR DESCRIPTION
## PR Summary

This pull request adds full support for plotting timedelta values similar to the support that is available for plotting datetime values.
It includes converters, conversion functions, formatters and locators.

This allows for plotting `datetime.timedelta`, `numpy.timedelta64` and 'pandas.Timedelta' as well as the corresponding `nat` data types / values. Previously `nat` would be plotted as very high negative number. Now it is skipped like `nan` (or like `nat` when plotting datetime).

Locators and formatters provide nice ticks as multiples of default units of time (days, hours, ...)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

## More detail

### Conversion of values

- timedelta values are converted to days as floating point values (same as internal date handling)
- `nat` values are replaced with `nan` so that they are skipped when plotting
- a fallback conversion which can handle conversion of for `pandas.Timedelta`  if it also contains `pandas.NaT` without depending on pandas

### Locators
 
Fixed/AutoTimedeltaLocator similar to locators for datetime. 
- Fixed: ticks in fixed intervals
- Auto: automatic intervals as multiples of days, hours, ...

### Formatting

- Function for timedelta string formatting with a template string. This is not natively available (contrary to formatting datetime). Therefore I created my own implementation of this. Not fully documented yet.
Quick overview:
  - `%d, %h, %m, %s, %ms, %us`: will "overflow" into the next larger unit; i.e. range 0...24, 0...59, ... 
  - `%H, %M, %S`: total hours, minutes, seconds; i.e. allows to format 2 days as 48 hours and similar
  - `%day`: special, the string 'day' or 'days' with correct plural
  
  Example: "%d %day, %h:%m" --> '12 days, 14:34'
 
 - Fixed/Auto/ConciseFormatter similar to datetime formatters
   - Fixed: User defined format, optionally allows to apply an axis offset on days, hours, ... and to specify a format for the offset
   - Auto: Selects tick format based on locator tick level; creates tick label with a full-length timedelta string
   - Concise: Selects tick format, axis offset and offset format based on locator tick level


### General
Whenever possible, I have shamelessly copied code and documentation from similar date-related functionality so as to not reinvent the wheel.
General documentation does exist but certainly needs improvements, more examples and some thing are still missing. The documentation builds without errors except for references to `numpy.timedelta64`.
I have tried to create basic tests for all of the new functionality but I assume some additional tests may be necessary.


### Reasons why I think this is an improvement
- consistent handling of `nat`/`nan`
- also supports `pandas.NaT`
- can easily provide tick locations on days, hours, minutes, ... 
- timedelta is very common, therefore default functionality is nice to have
- relationship with datetime: provide similar support for both