### PR TITLE
Remove redundant Python2 numeric relics

### DIFF
--- a/examples/animation/unchained.py
+++ b/examples/animation/unchained.py
@@ -32,9 +32,9 @@ G = 1.5 * np.exp(-4 * X ** 2)
 lines = []
 for i in range(len(data)):
     # Small reduction of the X extents to get a cheap perspective effect
-    xscale = 1 - i / 200.
+    xscale = 1 - i / 200
     # Same for linewidth (thicker strokes on bottom)
-    lw = 1.5 - i / 100.0
+    lw = 1.5 - i / 100
     line, = ax.plot(xscale * X, i + G * data[i], color="w", lw=lw)
     lines.append(line)
 

--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -14,6 +14,8 @@ For more information on colors in matplotlib see
 * the :doc:`/gallery/color/color_demo`.
 """
 
+import math
+
 from matplotlib.patches import Rectangle
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
@@ -38,7 +40,7 @@ def plot_colortable(colors, title, sort_colors=True, emptycols=0):
 
     n = len(names)
     ncols = 4 - emptycols
-    nrows = n // ncols + int(n % ncols > 0)
+    nrows = math.ceil(n / ncols)
 
     width = cell_width * 4 + 2 * margin
     height = cell_height * nrows + margin + topmargin

--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -96,7 +96,7 @@ class Puck:
         if self.y < -1 + fudge or self.y > 1 - fudge:
             self.vy *= -1.0
             # add some randomness, just to make it interesting
-            self.vy -= (randn()/300.0 + 1/300.0) * np.sign(self.vy)
+            self.vy -= (randn() / 300 + 1 / 300) * np.sign(self.vy)
         self._speedlimit()
         return False
 

--- a/examples/lines_bars_and_markers/timeline.py
+++ b/examples/lines_bars_and_markers/timeline.py
@@ -10,10 +10,12 @@ we show how to create a simple timeline using the dates for recent releases
 of Matplotlib. First, we'll pull the data from GitHub.
 """
 
+import math
+from datetime import datetime
+
 import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.dates as mdates
-from datetime import datetime
 
 try:
     # Try to fetch a list of Matplotlib releases and their dates
@@ -64,8 +66,7 @@ except Exception:
 
 
 # Choose some nice levels
-levels = np.tile([-5, 5, -3, 3, -1, 1],
-                 int(np.ceil(len(dates)/6)))[:len(dates)]
+levels = np.tile([-5, 5, -3, 3, -1, 1], math.ceil(len(dates) / 6))[:len(dates)]
 
 # Create figure and plot a stem plot with the date
 fig, ax = plt.subplots(figsize=(8.8, 4), constrained_layout=True)

--- a/examples/misc/custom_projection.py
+++ b/examples/misc/custom_projection.py
@@ -69,7 +69,7 @@ class GeoAxes(Axes):
         self.grid(rcParams['axes.grid'])
 
         Axes.set_xlim(self, -np.pi, np.pi)
-        Axes.set_ylim(self, -np.pi / 2.0, np.pi / 2.0)
+        Axes.set_ylim(self, -np.pi / 2, np.pi / 2)
 
     def _set_lim_and_transforms(self):
         # A (possibly non-linear) projection on the (already scaled) data
@@ -427,7 +427,7 @@ class HammerAxes(GeoAxes):
             return HammerAxes.HammerTransform(self._resolution)
 
     def __init__(self, *args, **kwargs):
-        self._longitude_cap = np.pi / 2.0
+        self._longitude_cap = np.pi / 2
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
         self.cla()

--- a/examples/misc/fill_spiral.py
+++ b/examples/misc/fill_spiral.py
@@ -11,7 +11,7 @@ theta = np.arange(0, 8*np.pi, 0.1)
 a = 1
 b = .2
 
-for dt in np.arange(0, 2*np.pi, np.pi/2.0):
+for dt in np.arange(0, 2*np.pi, np.pi/2):
 
     x = a*np.cos(theta + dt)*np.exp(b*theta)
     y = a*np.sin(theta + dt)*np.exp(b*theta)

--- a/examples/misc/table_demo.py
+++ b/examples/misc/table_demo.py
@@ -36,7 +36,7 @@ cell_text = []
 for row in range(n_rows):
     plt.bar(index, data[row], bar_width, bottom=y_offset, color=colors[row])
     y_offset = y_offset + data[row]
-    cell_text.append(['%1.1f' % (x / 1000.0) for x in y_offset])
+    cell_text.append(['%1.1f' % (x / 1000) for x in y_offset])
 # Reverse colors and text labels to display the last value at the top.
 colors = colors[::-1]
 cell_text.reverse()

--- a/examples/mplot3d/quiver3d.py
+++ b/examples/mplot3d/quiver3d.py
@@ -19,7 +19,7 @@ x, y, z = np.meshgrid(np.arange(-0.8, 1, 0.2),
 # Make the direction data for the arrows
 u = np.sin(np.pi * x) * np.cos(np.pi * y) * np.cos(np.pi * z)
 v = -np.cos(np.pi * x) * np.sin(np.pi * y) * np.cos(np.pi * z)
-w = (np.sqrt(2.0 / 3.0) * np.cos(np.pi * x) * np.cos(np.pi * y) *
+w = (np.sqrt(2 / 3) * np.cos(np.pi * x) * np.cos(np.pi * y) *
      np.sin(np.pi * z))
 
 ax.quiver(x, y, z, u, v, w, length=0.1, normalize=True)

--- a/examples/mplot3d/trisurf3d_2.py
+++ b/examples/mplot3d/trisurf3d_2.py
@@ -29,9 +29,9 @@ u, v = u.flatten(), v.flatten()
 
 # This is the Mobius mapping, taking a u, v pair and returning an x, y, z
 # triple
-x = (1 + 0.5 * v * np.cos(u / 2.0)) * np.cos(u)
-y = (1 + 0.5 * v * np.cos(u / 2.0)) * np.sin(u)
-z = 0.5 * v * np.sin(u / 2.0)
+x = (1 + 0.5 * v * np.cos(u / 2)) * np.cos(u)
+y = (1 + 0.5 * v * np.cos(u / 2)) * np.sin(u)
+z = 0.5 * v * np.sin(u / 2)
 
 # Triangulate parameter space to determine the triangles
 tri = mtri.Triangulation(u, v)

--- a/examples/mplot3d/voxels_rgb.py
+++ b/examples/mplot3d/voxels_rgb.py
@@ -13,12 +13,12 @@ import numpy as np
 def midpoints(x):
     sl = ()
     for i in range(x.ndim):
-        x = (x[sl + np.index_exp[:-1]] + x[sl + np.index_exp[1:]]) / 2.0
+        x = (x[sl + np.index_exp[:-1]] + x[sl + np.index_exp[1:]]) / 2
         sl += np.index_exp[:]
     return x
 
 # prepare some coordinates, and attach rgb values to each
-r, g, b = np.indices((17, 17, 17)) / 16.0
+r, g, b = np.indices((17, 17, 17)) / 16
 rc = midpoints(r)
 gc = midpoints(g)
 bc = midpoints(b)

--- a/examples/mplot3d/voxels_torus.py
+++ b/examples/mplot3d/voxels_torus.py
@@ -14,7 +14,7 @@ import numpy as np
 def midpoints(x):
     sl = ()
     for i in range(x.ndim):
-        x = (x[sl + np.index_exp[:-1]] + x[sl + np.index_exp[1:]]) / 2.0
+        x = (x[sl + np.index_exp[:-1]] + x[sl + np.index_exp[1:]]) / 2
         sl += np.index_exp[:]
     return x
 

--- a/examples/pie_and_polar_charts/pie_and_donut_labels.py
+++ b/examples/pie_and_polar_charts/pie_and_donut_labels.py
@@ -43,7 +43,7 @@ ingredients = [x.split()[-1] for x in recipe]
 
 
 def func(pct, allvals):
-    absolute = int(round(pct/100.*np.sum(allvals)))
+    absolute = round(pct/100.*np.sum(allvals))
     return "{:.1f}%\n({:d} g)".format(pct, absolute)
 
 
@@ -107,7 +107,7 @@ for i, p in enumerate(wedges):
     ang = (p.theta2 - p.theta1)/2. + p.theta1
     y = np.sin(np.deg2rad(ang))
     x = np.cos(np.deg2rad(ang))
-    horizontalalignment = {-1: "right", 1: "left"}[int(np.sign(x))]
+    horizontalalignment = "right" if x < 0 else "left"
     connectionstyle = "angle,angleA=0,angleB={}".format(ang)
     kw["arrowprops"].update({"connectionstyle": connectionstyle})
     ax.annotate(recipe[i], xy=(x, y), xytext=(1.35*np.sign(x), 1.4*y),

--- a/examples/scales/log_demo.py
+++ b/examples/scales/log_demo.py
@@ -16,7 +16,7 @@ t = np.arange(0.01, 20.0, 0.01)
 fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
 
 # log y axis
-ax1.semilogy(t, np.exp(-t / 5.0))
+ax1.semilogy(t, np.exp(-t / 5))
 ax1.set(title='semilogy')
 ax1.grid()
 
@@ -26,7 +26,7 @@ ax2.set(title='semilogx')
 ax2.grid()
 
 # log x and y axis
-ax3.loglog(t, 20 * np.exp(-t / 10.0))
+ax3.loglog(t, 20 * np.exp(-t / 10))
 ax3.set_xscale('log', base=2)
 ax3.set(title='loglog base 2 on x')
 ax3.grid()

--- a/examples/scales/log_test.py
+++ b/examples/scales/log_test.py
@@ -15,7 +15,7 @@ fig, ax = plt.subplots()
 dt = 0.01
 t = np.arange(dt, 20.0, dt)
 
-ax.semilogx(t, np.exp(-t / 5.0))
+ax.semilogx(t, np.exp(-t / 5))
 ax.grid()
 
 plt.show()

--- a/examples/scales/symlog_demo.py
+++ b/examples/scales/symlog_demo.py
@@ -25,7 +25,7 @@ plt.yscale('symlog')
 plt.ylabel('symlogy')
 
 plt.subplot(313)
-plt.plot(x, np.sin(x / 3.0))
+plt.plot(x, np.sin(x / 3))
 plt.xscale('symlog')
 plt.yscale('symlog', linthresh=0.015)
 plt.grid(True)

--- a/examples/shapes_and_collections/collections.py
+++ b/examples/shapes_and_collections/collections.py
@@ -49,7 +49,7 @@ fig.subplots_adjust(top=0.92, left=0.07, right=0.97,
 
 col = collections.LineCollection([spiral], offsets=xyo,
                                  transOffset=ax1.transData)
-trans = fig.dpi_scale_trans + transforms.Affine2D().scale(1.0/72.0)
+trans = fig.dpi_scale_trans + transforms.Affine2D().scale(1 / 72)
 col.set_transform(trans)  # the points to pixels transform
 # Note: the first argument to the collection initializer
 # must be a list of sequences of (x, y) tuples; we have only
@@ -74,7 +74,7 @@ ax1.set_title('LineCollection using offsets')
 # The same data as above, but fill the curves.
 col = collections.PolyCollection([spiral], offsets=xyo,
                                  transOffset=ax2.transData)
-trans = transforms.Affine2D().scale(fig.dpi/72.0)
+trans = transforms.Affine2D().scale(fig.dpi / 72)
 col.set_transform(trans)  # the points to pixels transform
 ax2.add_collection(col, autolim=True)
 col.set_color(colors)
@@ -87,7 +87,7 @@ ax2.set_title('PolyCollection using offsets')
 
 col = collections.RegularPolyCollection(
     7, sizes=np.abs(xx) * 10.0, offsets=xyo, transOffset=ax3.transData)
-trans = transforms.Affine2D().scale(fig.dpi / 72.0)
+trans = transforms.Affine2D().scale(fig.dpi / 72)
 col.set_transform(trans)  # the points to pixels transform
 ax3.add_collection(col, autolim=True)
 col.set_color(colors)

--- a/examples/shapes_and_collections/ellipse_collection.py
+++ b/examples/shapes_and_collections/ellipse_collection.py
@@ -17,8 +17,8 @@ X, Y = np.meshgrid(x, y)
 
 XY = np.column_stack((X.ravel(), Y.ravel()))
 
-ww = X / 10.0
-hh = Y / 15.0
+ww = X / 10
+hh = Y / 15
 aa = X * 9
 
 

--- a/examples/statistics/time_series_histogram.py
+++ b/examples/statistics/time_series_histogram.py
@@ -41,7 +41,7 @@ x = np.linspace(0, 4 * np.pi, num_points)
 # Generate unbiased Gaussian random walks
 Y = np.cumsum(np.random.randn(num_series, num_points), axis=-1)
 # Generate sinusoidal signals
-num_signal = int(round(SNR * num_series))
+num_signal = round(SNR * num_series)
 phi = (np.pi / 8) * np.random.randn(num_signal, 1)  # small random offset
 Y[-num_signal:] = (
     np.sqrt(np.arange(num_points))[None, :]  # random walk RMS scaling factor

--- a/examples/text_labels_and_annotations/arrow_demo.py
+++ b/examples/text_labels_and_annotations/arrow_demo.py
@@ -192,13 +192,13 @@ def make_arrow_plot(data, size=4, display='length', shape='right',
         if where == 'left':
             orig_position = 3 * np.array([[max_arrow_width, max_arrow_width]])
         elif where == 'absolute':
-            orig_position = np.array([[max_arrow_length / 2.0,
+            orig_position = np.array([[max_arrow_length / 2,
                                        3 * max_arrow_width]])
         elif where == 'right':
             orig_position = np.array([[length - 3 * max_arrow_width,
                                        3 * max_arrow_width]])
         elif where == 'center':
-            orig_position = np.array([[length / 2.0, 3 * max_arrow_width]])
+            orig_position = np.array([[length / 2, 3 * max_arrow_width]])
         else:
             raise ValueError("Got unknown position parameter %s" % where)
 

--- a/examples/ticks_and_spines/date_index_formatter2.py
+++ b/examples/ticks_and_spines/date_index_formatter2.py
@@ -32,7 +32,7 @@ class MyFormatter(Formatter):
 
     def __call__(self, x, pos=0):
         """Return the label for time x at position pos."""
-        ind = int(round(x))
+        ind = round(x)
         if ind >= len(self.dates) or ind < 0:
             return ''
         return dates.num2date(self.dates[ind]).strftime(self.fmt)

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -278,15 +278,15 @@ cm.add_conversion_factor(inch, 1/2.54)
 
 radians = BasicUnit('rad', 'radians')
 degrees = BasicUnit('deg', 'degrees')
-radians.add_conversion_factor(degrees, 180.0/np.pi)
-degrees.add_conversion_factor(radians, np.pi/180.0)
+radians.add_conversion_factor(degrees, 180 / np.pi)
+degrees.add_conversion_factor(radians, np.pi / 180)
 
 secs = BasicUnit('s', 'seconds')
 hertz = BasicUnit('Hz', 'Hertz')
 minutes = BasicUnit('min', 'minutes')
 
-secs.add_conversion_fn(hertz, lambda x: 1./x)
-secs.add_conversion_factor(minutes, 1/60.0)
+secs.add_conversion_fn(hertz, lambda x: 1 / x)
+secs.add_conversion_factor(minutes, 1 / 60)
 
 
 # radians formatting

--- a/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -56,8 +56,8 @@ class PlotPanel(wx.Panel):
     def init_plot_data(self):
         ax = self.fig.add_subplot()
 
-        x = np.arange(120.0) * 2 * np.pi / 60.0
-        y = np.arange(100.0) * 2 * np.pi / 50.0
+        x = np.arange(120.0) * 2 * np.pi / 60
+        y = np.arange(100.0) * 2 * np.pi / 50
         self.x, self.y = np.meshgrid(x, y)
         z = np.sin(self.x) + np.cos(self.y)
         self.im = ax.imshow(z, cmap=cm.RdBu, origin='lower')

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -271,18 +271,18 @@ class TruetypeFonts(Fonts):
             num,
             flags=self.mathtext_backend.get_hinting_type())
 
-        xmin, ymin, xmax, ymax = [val/64.0 for val in glyph.bbox]
+        xmin, ymin, xmax, ymax = [val / 64 for val in glyph.bbox]
         offset = self._get_offset(font, glyph, fontsize, dpi)
         metrics = types.SimpleNamespace(
-            advance = glyph.linearHoriAdvance/65536.0,
-            height  = glyph.height/64.0,
-            width   = glyph.width/64.0,
+            advance = glyph.linearHoriAdvance / 65536,
+            height  = glyph.height / 64,
+            width   = glyph.width / 64,
             xmin    = xmin,
             xmax    = xmax,
             ymin    = ymin+offset,
             ymax    = ymax+offset,
             # iceberg is the equivalent of TeX's "height"
-            iceberg = glyph.horiBearingY/64.0 + offset,
+            iceberg = glyph.horiBearingY / 64 + offset,
             slanted = slanted
             )
 
@@ -307,14 +307,14 @@ class TruetypeFonts(Fonts):
             metrics = self.get_metrics(
                 fontname, mpl.rcParams['mathtext.default'], 'x', fontsize, dpi)
             return metrics.iceberg
-        xHeight = (pclt['xHeight'] / 64.0) * (fontsize / 12.0) * (dpi / 100.0)
+        xHeight = (pclt['xHeight'] / 64) * (fontsize / 12) * (dpi / 100)
         return xHeight
 
     def get_underline_thickness(self, font, fontsize, dpi):
         # This function used to grab underline thickness from the font
         # metrics, but that information is just too un-reliable, so it
         # is now hardcoded.
-        return ((0.75 / 12.0) * fontsize * dpi) / 72.0
+        return ((0.75 / 12) * fontsize * dpi) / 72
 
     def get_kern(self, font1, fontclass1, sym1, fontsize1,
                  font2, fontclass2, sym2, fontsize2, dpi):
@@ -2503,7 +2503,7 @@ class Parser:
         if accent == 'mathring':
             accent_box.shrink()
             accent_box.shrink()
-        centered = HCentered([Hbox(sym.width / 4.0), accent_box])
+        centered = HCentered([Hbox(sym.width / 4), accent_box])
         centered.hpack(sym.width, 'exactly')
         return Vlist([
                 centered,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1733,13 +1733,13 @@ class _AxesBase(martist.Artist):
 
         if adjust_y:
             yc = 0.5 * (ymin + ymax)
-            y0 = yc - Ysize / 2.0
-            y1 = yc + Ysize / 2.0
+            y0 = yc - Ysize / 2
+            y1 = yc + Ysize / 2
             self.set_ybound(y_trf.inverted().transform([y0, y1]))
         else:
             xc = 0.5 * (xmin + xmax)
-            x0 = xc - Xsize / 2.0
-            x1 = xc + Xsize / 2.0
+            x0 = xc - Xsize / 2
+            x1 = xc + Xsize / 2
             self.set_xbound(x_trf.inverted().transform([x0, x1]))
 
     def axis(self, *args, emit=True, **kwargs):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -5,6 +5,7 @@ Classes for the ticks and x and y axis.
 import datetime
 import functools
 import logging
+import math
 
 import numpy as np
 
@@ -2258,7 +2259,7 @@ class XAxis(Axis):
         # is no more than 3:1
         size = self._get_tick_label_size('x') * 3
         if size > 0:
-            return int(np.floor(length / size))
+            return math.floor(length / size)
         else:
             return 2**31 - 1
 
@@ -2541,6 +2542,6 @@ class YAxis(Axis):
         # Having a spacing of at least 2 just looks good.
         size = self._get_tick_label_size('y') * 2
         if size > 0:
-            return int(np.floor(length / size))
+            return math.floor(length / size)
         else:
             return 2**31 - 1

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -23,6 +23,7 @@ try:
     import threading
 except ImportError:
     import dummy_threading as threading
+import math
 from contextlib import nullcontext
 from math import radians, cos, sin
 
@@ -138,7 +139,7 @@ class RendererAgg(RendererBase):
         if (npts > nmax > 100 and path.should_simplify and
                 rgbFace is None and gc.get_hatch() is None):
             nch = np.ceil(npts / nmax)
-            chsize = int(np.ceil(npts / nch))
+            chsize = math.ceil(npts / nch)
             i0 = np.arange(0, npts, chsize)
             i1 = np.zeros_like(i0)
             i1[:-1] = i0[1:] - 1

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -204,7 +204,7 @@ class RendererAgg(RendererBase):
         font.set_text(s, 0, flags=flags)
         font.draw_glyphs_to_bitmap(
             antialiased=mpl.rcParams['text.antialiased'])
-        d = font.get_descent() / 64.0
+        d = font.get_descent() / 64
         # The descent needs to be adjusted for the angle.
         xo, yo = font.get_bitmap_offset()
         xo /= 64.0

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1889,7 +1889,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         self.file._character_tracker.merge(*args, **kwargs)
 
     def get_image_magnification(self):
-        return self.image_dpi/72.0
+        return self.image_dpi / 72
 
     def draw_image(self, gc, x, y, im, transform=None):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -930,7 +930,7 @@ class RendererSVG(RendererBase):
         return True
 
     def get_image_magnification(self):
-        return self.image_dpi / 72.0
+        return self.image_dpi / 72
 
     def draw_image(self, gc, x, y, im, transform=None):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -308,7 +308,7 @@ class RendererWx(RendererBase):
 
     def points_to_pixels(self, points):
         # docstring inherited
-        return points * (PIXELS_PER_INCH / 72.0 * self.dpi / 72.0)
+        return points * (PIXELS_PER_INCH / 72 * self.dpi / 72)
 
 
 class GraphicsContextWx(GraphicsContextBase):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -944,7 +944,7 @@ class _CollectionWithSizes(Collection):
         else:
             self._sizes = np.asarray(sizes)
             self._transforms = np.zeros((len(self._sizes), 3, 3))
-            scale = np.sqrt(self._sizes) * dpi / 72.0 * self._factor
+            scale = np.sqrt(self._sizes) * dpi / 72 * self._factor
             self._transforms[:, 0, 0] = scale
             self._transforms[:, 1, 1] = scale
             self._transforms[:, 2, 2] = 1.0
@@ -1757,7 +1757,7 @@ class EllipseCollection(Collection):
         elif self._units == 'inches':
             sc = fig.dpi
         elif self._units == 'points':
-            sc = fig.dpi / 72.0
+            sc = fig.dpi / 72
         elif self._units == 'width':
             sc = ax.bbox.width
         elif self._units == 'height':
@@ -2003,7 +2003,7 @@ class QuadMesh(Collection):
         p_b = p[:-1, 1:]
         p_c = p[1:, 1:]
         p_d = p[1:, :-1]
-        p_center = (p_a + p_b + p_c + p_d) / 4.0
+        p_center = (p_a + p_b + p_c + p_d) / 4
 
         triangles = np.concatenate((
                 p_a, p_b, p_center,
@@ -2018,7 +2018,7 @@ class QuadMesh(Collection):
         c_b = c[:-1, 1:]
         c_c = c[1:, 1:]
         c_d = c[1:, :-1]
-        c_center = (c_a + c_b + c_c + c_d) / 4.0
+        c_center = (c_a + c_b + c_c + c_d) / 4
 
         colors = np.concatenate((
                         c_a, c_b, c_center,

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -581,7 +581,7 @@ class ColorbarBase:
             if self.boundaries is None:
                 if isinstance(self.norm, colors.NoNorm):
                     nv = len(self._values)
-                    base = 1 + int(nv / 10)
+                    base = 1 + nv // 10
                     locator = ticker.IndexLocator(base=base, offset=0)
                 elif isinstance(self.norm, colors.BoundaryNorm):
                     b = self.norm.boundaries

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1751,7 +1751,7 @@ def rgb_to_hsv(arr):
     idx = (arr[..., 2] == arr_max) & ipos
     out[idx, 0] = 4. + (arr[idx, 0] - arr[idx, 1]) / delta[idx]
 
-    out[..., 0] = (out[..., 0] / 6.0) % 1.0
+    out[..., 0] = (out[..., 0] / 6) % 1.0
     out[..., 1] = s
     out[..., 2] = arr_max
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -383,7 +383,7 @@ def to_hex(c, keep_alpha=False):
     c = to_rgba(c)
     if not keep_alpha:
         c = c[:3]
-    return "#" + "".join(format(int(round(val * 255)), "02x") for val in c)
+    return "#" + "".join(format(round(val * 255), "02x") for val in c)
 
 
 ### Backwards-compatible color-conversion API

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -2,6 +2,7 @@
 Classes to support contour plotting and labelling for the Axes class.
 """
 
+import math
 from numbers import Integral
 
 import numpy as np
@@ -280,7 +281,7 @@ class ContourLabeler:
         Find good place to draw a label (relatively flat part of the contour).
         """
         ctr_size = len(linecontour)
-        n_blocks = int(np.ceil(ctr_size / labelwidth)) if labelwidth > 1 else 1
+        n_blocks = math.ceil(ctr_size / labelwidth) if labelwidth > 1 else 1
         block_size = ctr_size if n_blocks == 1 else int(labelwidth)
         # Split contour into blocks of length ``block_size``, filling the last
         # block by cycling the contour start (per `np.resize` semantics).  (Due
@@ -1217,7 +1218,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             else:
                 linewidths = list(linewidths)
                 if len(linewidths) < Nlev:
-                    nreps = int(np.ceil(Nlev / len(linewidths)))
+                    nreps = math.ceil(Nlev / len(linewidths))
                     linewidths = linewidths * nreps
                 if len(linewidths) > Nlev:
                     linewidths = linewidths[:Nlev]
@@ -1241,7 +1242,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             elif np.iterable(linestyles):
                 tlinestyles = list(linestyles)
                 if len(tlinestyles) < Nlev:
-                    nreps = int(np.ceil(Nlev / len(linestyles)))
+                    nreps = math.ceil(Nlev / len(linestyles))
                     tlinestyles = tlinestyles * nreps
                 if len(tlinestyles) > Nlev:
                     tlinestyles = tlinestyles[:Nlev]

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -333,7 +333,7 @@ class ContourLabeler:
         if lc is None:
             lc = []
         # Half the label width
-        hlw = lw / 2.0
+        hlw = lw / 2
 
         # Check if closed and, if so, rotate contour so label is at edge
         closed = _is_closed_polygon(slc)

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -325,7 +325,7 @@ def _from_ordinalf(x, tz=None):
         tz = _get_rc_timezone()
 
     dt = (np.datetime64(get_epoch()) +
-          np.timedelta64(int(np.round(x * MUSECONDS_PER_DAY)), 'us'))
+          np.timedelta64(round(x * MUSECONDS_PER_DAY), 'us'))
     if dt < np.datetime64('0001-01-01') or dt >= np.datetime64('10000-01-01'):
         raise ValueError(f'Date ordinal {x} converts to {dt} (using '
                          f'epoch {get_epoch()}), but Matplotlib dates must be '
@@ -556,7 +556,7 @@ def drange(dstart, dend, delta):
     step = delta.total_seconds() / SEC_PER_DAY
 
     # calculate the difference between dend and dstart in times of delta
-    num = int(np.ceil((f2 - f1) / step))
+    num = math.ceil((f2 - f1) / step)
 
     # calculate end of the interval which will be generated
     dinterval_end = dstart + num * delta
@@ -638,7 +638,7 @@ class IndexDateFormatter(ticker.Formatter):
 
     def __call__(self, x, pos=0):
         """Return the label for time *x* at position *pos*."""
-        ind = int(round(x))
+        ind = round(x)
         if ind >= len(self.t) or ind <= 0:
             return ''
         return num2date(self.t[ind], self.tz).strftime(self.fmt)

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -297,7 +297,7 @@ def _dt64_to_ordinalf(d):
     extra = (d - dseconds).astype('timedelta64[ns]')
     t0 = np.datetime64(get_epoch(), 's')
     dt = (dseconds - t0).astype(np.float64)
-    dt += extra.astype(np.float64) / 1.0e9
+    dt += extra.astype(np.float64) / 1e9
     dt = dt / SEC_PER_DAY
 
     NaT_int = np.datetime64('NaT').astype(np.int64)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1195,7 +1195,7 @@ class FontManager:
             stretchval2 = int(stretch2)
         except ValueError:
             stretchval2 = stretch_dict.get(stretch2, 500)
-        return abs(stretchval1 - stretchval2) / 1000.0
+        return abs(stretchval1 - stretchval2) / 1000
 
     def score_weight(self, weight1, weight2):
         """

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -162,7 +162,7 @@ class SmallFilledCircles(SmallCircles):
 
 
 class Stars(Shapes):
-    size = 1.0 / 3.0
+    size = 1 / 3
     filled = True
 
     def __init__(self, hatch, density):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1190,8 +1190,8 @@ class PcolorImage(AxesImage):
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
         height = (round(t) + 0.5) - (round(b) - 0.5)
-        width = int(round(width * magnification))
-        height = int(round(height * magnification))
+        width = round(width * magnification)
+        height = round(height * magnification)
         if self._rgbacache is None:
             A = self.to_rgba(self._A, bytes=True)
             self._rgbacache = A

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -618,7 +618,7 @@ class Line2D(Artist):
                                  ignore=True)
         # correct for marker size, if any
         if self._marker:
-            ms = (self._markersize / 72.0 * self.figure.dpi) * 0.5
+            ms = (self._markersize / 72 * self.figure.dpi) * 0.5
             bbox = bbox.padded(ms)
         return bbox
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -137,8 +137,8 @@ class MathtextBackendAgg(MathtextBackend):
         else:
             height = max(int(y2 - y1) - 1, 0)
             if height == 0:
-                center = (y2 + y1) / 2.0
-                y = int(center - (height + 1) / 2.0)
+                center = (y2 + y1) / 2
+                y = int(center - (height + 1) / 2)
             else:
                 y = int(y1)
             self.image.draw_rect_filled(int(x1), y, np.ceil(x2), y + height)
@@ -614,7 +614,7 @@ def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
     parser = MathTextParser('path')
     width, height, depth, _, _ = parser.parse(s, dpi=72, prop=prop)
 
-    fig = figure.Figure(figsize=(width / 72.0, height / 72.0))
+    fig = figure.Figure(figsize=(width / 72, height / 72))
     fig.text(0, depth/height, s, fontproperties=prop)
     backend_agg.FigureCanvasAgg(fig)
     fig.savefig(filename_or_obj, dpi=dpi, format=format)

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -930,7 +930,7 @@ class GaussianKDE:
 
     def silverman_factor(self):
         return np.power(
-            self.num_dp * (self.dim + 2.0) / 4.0, -1. / (self.dim + 4))
+            self.num_dp * (self.dim + 2) / 4, -1. / (self.dim + 4))
 
     #  Default method to calculate bandwidth, can be overwritten by subclass
     covariance_factor = scotts_factor
@@ -970,14 +970,14 @@ class GaussianKDE:
             for i in range(self.num_dp):
                 diff = self.dataset[:, i, np.newaxis] - points
                 tdiff = np.dot(self.inv_cov, diff)
-                energy = np.sum(diff * tdiff, axis=0) / 2.0
+                energy = np.sum(diff * tdiff, axis=0) / 2
                 result = result + np.exp(-energy)
         else:
             # loop over points
             for i in range(num_m):
                 diff = self.dataset - points[:, i, np.newaxis]
                 tdiff = np.dot(self.inv_cov, diff)
-                energy = np.sum(diff * tdiff, axis=0) / 2.0
+                energy = np.sum(diff * tdiff, axis=0) / 2
                 result[i] = np.sum(np.exp(-energy), axis=0)
 
         result = result / self.norm_factor

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2318,9 +2318,9 @@ class BoxStyle(_Style):
 
             # the sizes of the vertical and horizontal sawtooth are
             # separately adjusted to fit the given box size.
-            dsx_n = int(round((width - tooth_size) / (tooth_size * 2))) * 2
+            dsx_n = round((width - tooth_size) / (tooth_size * 2)) * 2
             dsx = (width - tooth_size) / dsx_n
-            dsy_n = int(round((height - tooth_size) / (tooth_size * 2))) * 2
+            dsy_n = round((height - tooth_size) / (tooth_size * 2)) * 2
             dsy = (height - tooth_size) / dsy_n
 
             x0, y0 = x0 - pad + tooth_size2, y0 - pad + tooth_size2

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -9,6 +9,7 @@ such as `.PathPatch` and `.PathCollection`, can be used for convenient `Path`
 visualisation.
 """
 
+import math
 from functools import lru_cache
 from weakref import WeakValueDictionary
 
@@ -945,7 +946,7 @@ class Path:
 
         # number of curve segments to make
         if n is None:
-            n = int(2 ** np.ceil((eta2 - eta1) / halfpi))
+            n = 2 ** math.ceil((eta2 - eta1) / halfpi)
         if n < 1:
             raise ValueError("n must be >= 1 or None")
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -773,7 +773,7 @@ class Path:
             theta = (2*np.pi/ns2 * np.arange(ns2 + 1))
             # This initial rotation is to make sure the polygon always
             # "points-up"
-            theta += np.pi / 2.0
+            theta += np.pi / 2
             r = np.ones(ns2 + 1)
             r[1::2] = innerCircle
             verts = (r * np.vstack((np.cos(theta), np.sin(theta)))).T
@@ -952,7 +952,7 @@ class Path:
 
         deta = (eta2 - eta1) / n
         t = np.tan(0.5 * deta)
-        alpha = np.sin(deta) * (np.sqrt(4.0 + 3.0 * t * t) - 1) / 3.0
+        alpha = np.sin(deta) * (np.sqrt(4 + 3 * t * t) - 1) / 3
 
         steps = np.linspace(eta1, eta2, n + 1, True)
         cos_eta = np.cos(steps)

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -6,6 +6,8 @@ Defines classes for path effects. The path effects are supported in `~.Text`,
    :doc:`/tutorials/advanced/patheffects_guide`
 """
 
+import math
+
 from matplotlib.backend_bases import RendererBase
 from matplotlib import colors as mcolors
 from matplotlib import patches as mpatches
@@ -468,7 +470,7 @@ class TickedStroke(AbstractPathEffect):
             s = np.concatenate(([0.0], np.cumsum(ds)))
             s_total = s[-1]
 
-            num = int(np.ceil(s_total / spacing_px)) - 1
+            num = math.ceil(s_total / spacing_px) - 1
             # Pick parameter values for ticks.
             s_tick = np.linspace(spacing_px/2, s_total - spacing_px/2, num)
 

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -53,7 +53,7 @@ class GeoAxes(Axes):
         self.grid(rcParams['axes.grid'])
 
         Axes.set_xlim(self, -np.pi, np.pi)
-        Axes.set_ylim(self, -np.pi / 2.0, np.pi / 2.0)
+        Axes.set_ylim(self, -np.pi / 2, np.pi / 2)
 
     def _set_lim_and_transforms(self):
         # A (possibly non-linear) projection on the (already scaled) data
@@ -260,7 +260,7 @@ class AitoffAxes(GeoAxes):
             longitude, latitude = ll.T
 
             # Pre-compute some values
-            half_long = longitude / 2.0
+            half_long = longitude / 2
             cos_latitude = np.cos(latitude)
 
             alpha = np.arccos(cos_latitude * np.cos(half_long))
@@ -286,7 +286,7 @@ class AitoffAxes(GeoAxes):
             return AitoffAxes.AitoffTransform(self._resolution)
 
     def __init__(self, *args, **kwargs):
-        self._longitude_cap = np.pi / 2.0
+        self._longitude_cap = np.pi / 2
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
         self.cla()
@@ -304,7 +304,7 @@ class HammerAxes(GeoAxes):
         def transform_non_affine(self, ll):
             # docstring inherited
             longitude, latitude = ll.T
-            half_long = longitude / 2.0
+            half_long = longitude / 2
             cos_latitude = np.cos(latitude)
             sqrt2 = np.sqrt(2.0)
             alpha = np.sqrt(1.0 + cos_latitude * np.cos(half_long))
@@ -331,7 +331,7 @@ class HammerAxes(GeoAxes):
             return HammerAxes.HammerTransform(self._resolution)
 
     def __init__(self, *args, **kwargs):
-        self._longitude_cap = np.pi / 2.0
+        self._longitude_cap = np.pi / 2
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
         self.cla()
@@ -401,7 +401,7 @@ class MollweideAxes(GeoAxes):
             return MollweideAxes.MollweideTransform(self._resolution)
 
     def __init__(self, *args, **kwargs):
-        self._longitude_cap = np.pi / 2.0
+        self._longitude_cap = np.pi / 2
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
         self.cla()

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1448,7 +1448,7 @@ class PolarAxes(Axes):
         angle = np.deg2rad(self.get_rlabel_position())
         mode = ''
         if button == 1:
-            epsilon = np.pi / 45.0
+            epsilon = np.pi / 45
             t, r = self.transData.inverted().transform((x, y))
             if angle - epsilon <= t <= angle + epsilon:
                 mode = 'drag_r_labels'

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -744,7 +744,7 @@ class Quiver(mcollections.PolyCollection):
         tooshort = length < self.minlength
         if tooshort.any():
             # Use a heptagonal dot:
-            th = np.arange(0, 8, 1, np.float64) * (np.pi / 3.0)
+            th = np.arange(0, 8, 1, np.float64) * (np.pi / 3)
             x1 = np.cos(th) * self.minlength * 0.5
             y1 = np.sin(th) * self.minlength * 0.5
             X1 = np.repeat(x1[np.newaxis, :], N, axis=0)

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -156,7 +156,7 @@ class Sankey:
         self.shoulder = shoulder
         self.offset = offset
         self.margin = margin
-        self.pitch = np.tan(np.pi * (1 - head_angle / 180.0) / 2.0)
+        self.pitch = np.tan(np.pi * (1 - head_angle / 180) / 2)
         self.tolerance = tolerance
 
         # Initialize the vertices of tight box around the diagram(s).
@@ -234,7 +234,7 @@ class Sankey:
             dipdepth = (flow / 2) * self.pitch
             if angle == RIGHT:
                 x -= length
-                dip = [x + dipdepth, y + flow / 2.0]
+                dip = [x + dipdepth, y + flow / 2]
                 path.extend([(Path.LINETO, [x, y]),
                              (Path.LINETO, dip),
                              (Path.LINETO, [x, y + flow]),
@@ -288,7 +288,7 @@ class Sankey:
             tipheight = (self.shoulder - flow / 2) * self.pitch
             if angle == RIGHT:
                 x += length
-                tip = [x + tipheight, y + flow / 2.0]
+                tip = [x + tipheight, y + flow / 2]
                 path.extend([(Path.LINETO, [x, y]),
                              (Path.LINETO, [x, y + self.shoulder]),
                              (Path.LINETO, tip),
@@ -303,7 +303,7 @@ class Sankey:
                 else:
                     sign = -1
 
-                tip = [x - flow / 2.0, y + sign * (length + tipheight)]
+                tip = [x - flow / 2, y + sign * (length + tipheight)]
                 if angle == UP:
                     quadrant = 3
                 else:
@@ -599,34 +599,24 @@ class Sankey:
 
         # Begin the subpaths, and smooth the transition if the sum of the flows
         # is nonzero.
-        urpath = [(Path.MOVETO, [(self.gap - trunklength / 2.0),  # Upper right
-                                 gain / 2.0]),
-                  (Path.LINETO, [(self.gap - trunklength / 2.0) / 2.0,
-                                 gain / 2.0]),
-                  (Path.CURVE4, [(self.gap - trunklength / 2.0) / 8.0,
-                                 gain / 2.0]),
-                  (Path.CURVE4, [(trunklength / 2.0 - self.gap) / 8.0,
-                                 -loss / 2.0]),
-                  (Path.LINETO, [(trunklength / 2.0 - self.gap) / 2.0,
-                                 -loss / 2.0]),
-                  (Path.LINETO, [(trunklength / 2.0 - self.gap),
-                                 -loss / 2.0])]
-        llpath = [(Path.LINETO, [(trunklength / 2.0 - self.gap),  # Lower left
-                                 loss / 2.0]),
-                  (Path.LINETO, [(trunklength / 2.0 - self.gap) / 2.0,
-                                 loss / 2.0]),
-                  (Path.CURVE4, [(trunklength / 2.0 - self.gap) / 8.0,
-                                 loss / 2.0]),
-                  (Path.CURVE4, [(self.gap - trunklength / 2.0) / 8.0,
-                                 -gain / 2.0]),
-                  (Path.LINETO, [(self.gap - trunklength / 2.0) / 2.0,
-                                 -gain / 2.0]),
-                  (Path.LINETO, [(self.gap - trunklength / 2.0),
-                                 -gain / 2.0])]
-        lrpath = [(Path.LINETO, [(trunklength / 2.0 - self.gap),  # Lower right
-                                 loss / 2.0])]
-        ulpath = [(Path.LINETO, [self.gap - trunklength / 2.0,  # Upper left
-                                 gain / 2.0])]
+        # upper right
+        urpath = [(Path.MOVETO, [(self.gap - trunklength / 2), gain / 2]),
+                  (Path.LINETO, [(self.gap - trunklength / 2) / 2, gain / 2]),
+                  (Path.CURVE4, [(self.gap - trunklength / 2) / 8, gain / 2]),
+                  (Path.CURVE4, [(trunklength / 2 - self.gap) / 8, -loss / 2]),
+                  (Path.LINETO, [(trunklength / 2 - self.gap) / 2, -loss / 2]),
+                  (Path.LINETO, [(trunklength / 2 - self.gap), -loss / 2])]
+        # lower left
+        llpath = [(Path.LINETO, [(trunklength / 2 - self.gap), loss / 2]),
+                  (Path.LINETO, [(trunklength / 2 - self.gap) / 2, loss / 2]),
+                  (Path.CURVE4, [(trunklength / 2 - self.gap) / 8, loss / 2]),
+                  (Path.CURVE4, [(self.gap - trunklength / 2) / 8, -gain / 2]),
+                  (Path.LINETO, [(self.gap - trunklength / 2) / 2, -gain / 2]),
+                  (Path.LINETO, [(self.gap - trunklength / 2), -gain / 2])]
+        # lower right
+        lrpath = [(Path.LINETO, [(trunklength / 2 - self.gap), loss / 2])]
+        # Upper left
+        ulpath = [(Path.LINETO, [self.gap - trunklength / 2, gain / 2])]
 
         # Add the subpaths and assign the locations of the tips and labels.
         tips = np.zeros((n, 2))

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -383,7 +383,7 @@ class Table(Artist):
         self.stale = True
 
     def _approx_text_height(self):
-        return (self.FONTSIZE / 72.0 * self.figure.dpi /
+        return (self.FONTSIZE / 72 * self.figure.dpi /
                 self._axes.bbox.height * 1.2)
 
     @allow_rasterization

--- a/lib/matplotlib/testing/jpl_units/Epoch.py
+++ b/lib/matplotlib/testing/jpl_units/Epoch.py
@@ -96,7 +96,7 @@ class Epoch:
         if frame != self._frame:
             t = self.convert(frame)
 
-        return t._jd + t._seconds / 86400.0
+        return t._jd + t._seconds / 86400
 
     def secondsPast(self, frame, jd):
         t = self

--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -70,7 +70,7 @@ class EpochConverter(units.ConversionInterface):
         = RETURN VALUE
         - Returns the value parameter converted to floats.
         """
-        return value.seconds() / 86400.0
+        return value.seconds() / 86400
 
     @staticmethod
     def convert(value, unit, axis):

--- a/lib/matplotlib/testing/jpl_units/UnitDbl.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDbl.py
@@ -21,7 +21,7 @@ class UnitDbl:
         "deg": (1.745329251994330e-02, "rad"),
 
         "sec": (1, "sec"),
-        "min": (60.0, "sec"),
+        "min": (60, "sec"),
         "hour": (3600, "sec"),
         }
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3,6 +3,7 @@ import datetime
 from decimal import Decimal
 import io
 from itertools import product
+import math
 import platform
 from types import SimpleNamespace
 try:
@@ -4346,7 +4347,7 @@ def test_specgram():
     all_sides = ["default", "onesided", "twosided"]
     for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
         noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        pad_to = 2 ** math.ceil(np.log2(NFFT))
         for ax, sides in zip(plt.figure().subplots(3), all_sides):
             ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
                         pad_to=pad_to, sides=sides)
@@ -4383,7 +4384,7 @@ def test_specgram_magnitude():
     all_sides = ["default", "onesided", "twosided"]
     for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
         noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        pad_to = 2 ** math.ceil(np.log2(NFFT))
         for ax, sides in zip(plt.figure().subplots(3), all_sides):
             ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
                         pad_to=pad_to, sides=sides, mode="magnitude")
@@ -4420,7 +4421,7 @@ def test_specgram_angle():
     all_sides = ["default", "onesided", "twosided"]
     for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
         noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        pad_to = 2 ** math.ceil(np.log2(NFFT))
         for mode in ["angle", "phase"]:
             for ax, sides in zip(plt.figure().subplots(3), all_sides):
                 ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
@@ -4486,7 +4487,7 @@ def test_psd_csd():
                   {"sides": "twosided", "return_line": True}]
     for ys, NFFT in [(ys_freqs, NFFT_freqs), (ys_noise, NFFT_noise)]:
         noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        pad_to = 2 ** math.ceil(np.log2(NFFT))
         for ax, kwargs in zip(plt.figure().subplots(3), all_kwargs):
             ret = ax.psd(np.concatenate(ys), NFFT=NFFT, Fs=Fs,
                          noverlap=noverlap, pad_to=pad_to, **kwargs)
@@ -4515,7 +4516,7 @@ def test_spectrum():
 
     fstims1 = [Fs/4, Fs/5, Fs/11]
     NFFT = int(1000 * Fs / min(fstims1))
-    pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+    pad_to = 2 ** math.ceil(np.log2(NFFT))
 
     x = np.arange(0, n, 1/Fs)
     y_freqs = ((np.sin(2 * np.pi * np.outer(x, fstims1)) * 10**np.arange(3))

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -262,7 +262,7 @@ def test_strmethodformatter_auto_formatter():
 @image_comparison(["twin_axis_locators_formatters"])
 def test_twin_axis_locators_formatters():
     vals = np.linspace(0, 1, num=5, endpoint=True)
-    locs = np.sin(np.pi * vals / 2.0)
+    locs = np.sin(np.pi * vals / 2)
 
     majl = plt.FixedLocator(locs)
     minl = plt.FixedLocator([0.1, 0.2, 0.3])
@@ -599,7 +599,7 @@ def test_fill_units():
     # generate some data
     t = units.Epoch("ET", dt=datetime.datetime(2009, 4, 27))
     value = 10.0 * units.deg
-    day = units.Duration("ET", 24.0 * 60.0 * 60.0)
+    day = units.Duration("ET", 24 * 60 * 60)
     dt = np.arange('2009-04-27', '2009-04-29', dtype='datetime64[D]')
     dtn = mdates.date2num(dt)
 
@@ -3805,7 +3805,7 @@ def test_mollweide_forward_inverse_closure():
 
     # set up 1-degree grid in longitude, latitude
     lon = np.linspace(-np.pi, np.pi, 360)
-    lat = np.linspace(-np.pi / 2.0, np.pi / 2.0, 180)
+    lat = np.linspace(-np.pi / 2, np.pi / 2, 180)
     lon, lat = np.meshgrid(lon, lat)
     ll = np.vstack((lon.flatten(), lat.flatten())).T
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -78,7 +78,7 @@ def test_interp_nearest_vs_none():
 def test_figimage(suppressComposite):
     fig = plt.figure(figsize=(2, 2), dpi=100)
     fig.suppressComposite = suppressComposite
-    x, y = np.ix_(np.arange(100) / 100.0, np.arange(100) / 100)
+    x, y = np.ix_(np.arange(100) / 100, np.arange(100) / 100)
     z = np.sin(x**2 + y**2 - x*y)
     c = np.sin(20*x**2 + 50*y**2)
     img = z + c/5

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -1,3 +1,5 @@
+import math
+
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_equal, assert_array_almost_equal_nulp)
 import numpy as np
@@ -308,7 +310,7 @@ class TestSpectral:
         if pad_to_density is None:
             pad_to_density_real = NFFT_density_real
         elif pad_to_density < 0:
-            pad_to_density = int(2**np.ceil(np.log2(NFFT_density_real)))
+            pad_to_density = 2 ** math.ceil(np.log2(NFFT_density_real))
             pad_to_density_real = pad_to_density
         else:
             pad_to_density_real = pad_to_density

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -65,7 +65,7 @@ def test_rotate_rect():
     rect2 = Rectangle(loc, width, height)
 
     # Set up an explicit rotation matrix (in radians)
-    angle_rad = np.pi * angle / 180.0
+    angle_rad = np.pi * angle / 180
     rotation_matrix = np.array([[np.cos(angle_rad), -np.sin(angle_rad)],
                                 [np.sin(angle_rad),  np.cos(angle_rad)]])
 

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -24,7 +24,7 @@ def test_zorder():
     yoff = np.zeros(len(colLabels))
     for row in reversed(data):
         yoff += row
-        cellText.append(['%1.1f' % (x/1000.0) for x in yoff])
+        cellText.append(['%1.1f' % (x / 1000) for x in yoff])
 
     t = np.linspace(0, 2*np.pi, 100)
     plt.plot(t, np.cos(t), lw=4, zorder=2)

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -127,7 +127,7 @@ def test_jpl_bar_units():
     import matplotlib.testing.jpl_units as units
     units.register()
 
-    day = units.Duration("ET", 24.0 * 60.0 * 60.0)
+    day = units.Duration("ET", 24 * 60 * 60)
     x = [0 * units.km, 1 * units.km, 2 * units.km]
     w = [1 * day, 2 * day, 3 * day]
     b = units.Epoch("ET", dt=datetime(2009, 4, 25))
@@ -142,7 +142,7 @@ def test_jpl_barh_units():
     import matplotlib.testing.jpl_units as units
     units.register()
 
-    day = units.Duration("ET", 24.0 * 60.0 * 60.0)
+    day = units.Duration("ET", 24 * 60 * 60)
     x = [0 * units.km, 1 * units.km, 2 * units.km]
     w = [1 * day, 2 * day, 3 * day]
     b = units.Epoch("ET", dt=datetime(2009, 4, 25))

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -402,7 +402,7 @@ class Text(Artist):
             elif valign == 'baseline':
                 offsety = ymin + descent
             elif valign == 'center_baseline':
-                offsety = ymin + height - baseline / 2.0
+                offsety = ymin + height - baseline / 2
             else:
                 offsety = ymin
         else:
@@ -410,20 +410,20 @@ class Text(Artist):
             xmax1, ymax1 = corners_horiz[2]
 
             if halign == 'center':
-                offsetx = (xmin1 + xmax1) / 2.0
+                offsetx = (xmin1 + xmax1) / 2
             elif halign == 'right':
                 offsetx = xmax1
             else:
                 offsetx = xmin1
 
             if valign == 'center':
-                offsety = (ymin1 + ymax1) / 2.0
+                offsety = (ymin1 + ymax1) / 2
             elif valign == 'top':
                 offsety = ymax1
             elif valign == 'baseline':
                 offsety = ymax1 - baseline
             elif valign == 'center_baseline':
-                offsety = ymax1 - baseline / 2.0
+                offsety = ymax1 - baseline / 2
             else:
                 offsety = ymin1
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -895,7 +895,7 @@ class ScalarFormatter(Formatter):
         if len(self.locs) < 2:
             # We needed the end points only for the loc_range calculation.
             locs = locs[:-2]
-        loc_range_oom = int(math.floor(math.log10(loc_range)))
+        loc_range_oom = math.floor(math.log10(loc_range))
         # first estimate:
         sigfigs = max(0, 3 - loc_range_oom)
         # refined estimate:
@@ -1306,7 +1306,7 @@ class LogitFormatter(Formatter):
         if all(
             is_decade(x, rtol=1e-7)
             or is_decade(1 - x, rtol=1e-7)
-            or (is_close_to_int(2 * x) and int(np.round(2 * x)) == 1)
+            or (is_close_to_int(2 * x) and round(2 * x) == 1)
             for x in locs
         ):
             # minor ticks are subsample from ideal, so no label
@@ -1352,7 +1352,7 @@ class LogitFormatter(Formatter):
             diff = np.sort(np.abs(locs - x))[1]
             precision = -np.log10(diff) + exponent
             precision = (
-                int(np.round(precision))
+                round(precision)
                 if is_close_to_int(precision)
                 else math.ceil(precision)
             )
@@ -1522,7 +1522,7 @@ class EngFormatter(Formatter):
             num = -num
 
         if num != 0:
-            pow10 = int(math.floor(math.log10(num) / 3) * 3)
+            pow10 = math.floor(math.log10(num) / 3) * 3
         else:
             pow10 = 0
             # Force num to zero, to avoid inconsistencies like
@@ -1863,7 +1863,7 @@ class FixedLocator(Locator):
         """
         if self.nbins is None:
             return self.locs
-        step = max(int(np.ceil(len(self.locs) / self.nbins)), 1)
+        step = max(math.ceil(len(self.locs) / self.nbins), 1)
         ticks = self.locs[::step]
         for i in range(1, step):
             ticks1 = self.locs[i::step]

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -3007,9 +3007,9 @@ class OldAutoLocator(Locator):
             if d >= 5 * base:
                 ticksize = base
             elif d >= 2 * base:
-                ticksize = base / 2.0
+                ticksize = base / 2
             else:
-                ticksize = base / 5.0
+                ticksize = base / 5
             locator = MultipleLocator(ticksize)
 
         return locator

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -615,8 +615,8 @@ class BboxBase(TransformNode):
         """
         width = self.width
         height = self.height
-        deltaw = (sw * width - width) / 2.0
-        deltah = (sh * height - height) / 2.0
+        deltaw = (sw * width - width) / 2
+        deltah = (sh * height - height) / 2
         a = np.array([[-deltaw, -deltah], [deltaw, deltah]])
         return Bbox(self._points + a)
 

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -15,10 +15,10 @@ def select_step_degree(dv):
     minsec_steps_  = [1,   2,   3,   5, 10, 15, 20, 30]
 
     minute_limits_ = np.array(minsec_limits_) / 60
-    minute_factors = [60.] * len(minute_limits_)
+    minute_factors = [60] * len(minute_limits_)
 
     second_limits_ = np.array(minsec_limits_) / 3600
-    second_factors = [3600.] * len(second_limits_)
+    second_factors = [3600] * len(second_limits_)
 
     degree_limits = [*second_limits_, *minute_limits_, *degree_limits_]
     degree_steps = [*minsec_steps_, *minsec_steps_, *degree_steps_]
@@ -41,10 +41,10 @@ def select_step_hour(dv):
     minsec_steps_  = [1,   2,   3,   4,   5,   6, 10, 12, 15, 20, 30]
 
     minute_limits_ = np.array(minsec_limits_) / 60
-    minute_factors = [60.] * len(minute_limits_)
+    minute_factors = [60] * len(minute_limits_)
 
     second_limits_ = np.array(minsec_limits_) / 3600
-    second_factors = [3600.] * len(second_limits_)
+    second_factors = [3600] * len(second_limits_)
 
     hour_limits = [*second_limits_, *minute_limits_, *hour_limits_]
     hour_steps = [*minsec_steps_, *minsec_steps_, *hour_steps_]
@@ -78,7 +78,7 @@ def select_step_sub(dv):
 
 
 def select_step(v1, v2, nv, hour=False, include_last=True,
-                threshold_factor=3600.):
+                threshold_factor=3600):
 
     if v1 > v2:
         v1, v2 = v2, v1
@@ -87,10 +87,10 @@ def select_step(v1, v2, nv, hour=False, include_last=True,
 
     if hour:
         _select_step = select_step_hour
-        cycle = 24.
+        cycle = 24
     else:
         _select_step = select_step_degree
-        cycle = 360.
+        cycle = 360
 
     # for degree
     if dv > 1 / threshold_factor:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1658,8 +1658,8 @@ class Axes3D(Axes):
             compute_strides = not has_stride
 
         if compute_strides:
-            rstride = int(max(np.ceil(rows / rcount), 1))
-            cstride = int(max(np.ceil(cols / ccount), 1))
+            rstride = max(math.ceil(rows / rcount), 1)
+            cstride = max(math.ceil(cols / ccount), 1)
 
         if 'facecolors' in kwargs:
             fcolors = kwargs.pop('facecolors')
@@ -1885,14 +1885,14 @@ class Axes3D(Axes):
             # So, only compute strides from counts
             # if counts were explicitly given
             if has_count:
-                rstride = int(max(np.ceil(rows / rcount), 1)) if rcount else 0
-                cstride = int(max(np.ceil(cols / ccount), 1)) if ccount else 0
+                rstride = max(math.ceil(rows / rcount), 1) if rcount else 0
+                cstride = max(math.ceil(cols / ccount), 1) if ccount else 0
         else:
             # If the strides are provided then it has priority.
             # Otherwise, compute the strides from the counts.
             if not has_stride:
-                rstride = int(max(np.ceil(rows / rcount), 1)) if rcount else 0
-                cstride = int(max(np.ceil(cols / ccount), 1)) if ccount else 0
+                rstride = max(math.ceil(rows / rcount), 1) if rcount else 0
+                cstride = max(math.ceil(cols / ccount), 1) if ccount else 0
 
         # We want two sets of lines, one running along the "rows" of
         # Z and another set of lines running along the "columns" of Z.
@@ -2073,9 +2073,9 @@ class Axes3D(Axes):
                     continue
 
             stepsize = (len(topverts[0]) - 1) / (nsteps - 1)
-            for i in range(int(round(nsteps)) - 1):
-                i1 = int(round(i * stepsize))
-                i2 = int(round((i + 1) * stepsize))
+            for i in range(round(nsteps) - 1):
+                i1 = round(i * stepsize)
+                i2 = round((i + 1) * stepsize)
                 polyverts.append([topverts[0][i1],
                                   topverts[0][i2],
                                   botverts[0][i2],

--- a/lib/mpl_toolkits/tests/test_axisartist_angle_helper.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_angle_helper.py
@@ -42,7 +42,7 @@ HMS_RE = re.compile(_MS_RE.format(degree=re.escape(FormatterHMS.deg_mark),
 
 
 def dms2float(degrees, minutes=0, seconds=0):
-    return degrees + minutes / 60.0 + seconds / 3600.0
+    return degrees + minutes / 60 + seconds / 3600
 
 
 @pytest.mark.parametrize('args, kwargs, expected_levels, expected_factor', [

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1013,12 +1013,12 @@ class TestVoxels:
             sl = ()
             for i in range(x.ndim):
                 x = (x[sl + np.index_exp[:-1]] +
-                     x[sl + np.index_exp[1:]]) / 2.0
+                     x[sl + np.index_exp[1:]]) / 2
                 sl += np.index_exp[:]
             return x
 
         # prepare some coordinates, and attach rgb values to each
-        r, g, b = np.indices((17, 17, 17)) / 16.0
+        r, g, b = np.indices((17, 17, 17)) / 16
         rc = midpoints(r)
         gc = midpoints(g)
         bc = midpoints(b)

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -73,6 +73,8 @@ Colormaps are often split into several categories based on their function (see,
 
 # sphinx_gallery_thumbnail_number = 2
 
+import math
+
 import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -255,7 +257,7 @@ for cmap_category, cmap_list in cmaps.items():
     # Do subplots so that colormaps have enough space.
     # Default is 6 colormaps per subplot.
     dsub = _DSUBS.get(cmap_category, 6)
-    nsubplots = int(np.ceil(len(cmap_list) / dsub))
+    nsubplots = math.ceil(len(cmap_list) / dsub)
 
     # squeeze=False to handle similarly the case of a single subplot
     fig, axs = plt.subplots(nrows=nsubplots, squeeze=False,


### PR DESCRIPTION
## PR Summary


Remove redundant `int` and `float` conversions where not necessary in Python3. Also use integer literals where possible. These were converted to floats in Python2 to guarantee correct division, but are not necessary in Python3. As an example is the number of seconds in a minute. It is `60` and not `60.0`. But if you divide `30 / 60`, you will get the expected float `0.5`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
