### PR TITLE
Fix build with LTO disabled in environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
             python-version: 3.7
             extra-requirements: '-r requirements/testing/travis_extra.txt'
             XVFB_RUN: xvfb-run -a
+            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
           - os: ubuntu-16.04
             python-version: 3.8
             extra-requirements: '-r requirements/testing/travis_extra.txt'

--- a/setupext.py
+++ b/setupext.py
@@ -447,7 +447,6 @@ class Matplotlib(SetupPackage):
         ext = Extension(
             "matplotlib.backends._tkagg", [
                 "src/_tkagg.cpp",
-                "src/py_converters.cpp",
             ],
             include_dirs=["src"],
             # psapi library needed for finding Tcl/Tk at run time.

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -33,14 +33,17 @@
 #define dlsym GetProcAddress
 #else
 #include <dlfcn.h>
-// Suppress -Wunused-function on POSIX, but not on Windows where that would
-// lead to PY_ARRAY_UNIQUE_SYMBOL being an unresolved external.
-#define NO_IMPORT_ARRAY
 #endif
 
 // Include our own excerpts from the Tcl / Tk headers
 #include "_tkmini.h"
-#include "py_converters.h"
+
+static int convert_voidptr(PyObject *obj, void *p)
+{
+    void **val = (void **)p;
+    *val = PyLong_AsVoidPtr(obj);
+    return *val != NULL ? 1 : !PyErr_Occurred();
+}
 
 // Global vars for Tk functions.  We load these symbols from the tkinter
 // extension module or loaded Tk libraries at run-time.

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -94,13 +94,6 @@ int convert_from_attr(PyObject *obj, const char *name, converter func, void *p)
     return 1;
 }
 
-int convert_voidptr(PyObject *obj, void *p)
-{
-    void **val = (void **)p;
-    *val = PyLong_AsVoidPtr(obj);
-    return *val != NULL ? 1 : !PyErr_Occurred();
-}
-
 int convert_double(PyObject *obj, void *p)
 {
     double *val = (double *)p;

--- a/src/py_converters.h
+++ b/src/py_converters.h
@@ -22,7 +22,6 @@ typedef int (*converter)(PyObject *, void *);
 int convert_from_attr(PyObject *obj, const char *name, converter func, void *p);
 int convert_from_method(PyObject *obj, const char *name, converter func, void *p);
 
-int convert_voidptr(PyObject *obj, void *p);
 int convert_double(PyObject *obj, void *p);
 int convert_bool(PyObject *obj, void *p);
 int convert_cap(PyObject *capobj, void *capp);


### PR DESCRIPTION
## PR Summary

Fixes #19227.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).