### PR TITLE
Fix markup for mplot3d example.

### DIFF
--- a/examples/mplot3d/pathpatch3d.py
+++ b/examples/mplot3d/pathpatch3d.py
@@ -3,7 +3,7 @@
 Draw flat objects in 3D plot
 ============================
 
-Demonstrate using pathpatch_2d_to_3d to 'draw' shapes and text on a 3D plot.
+Demonstrate using `.pathpatch_2d_to_3d` to 'draw' shapes and text on a 3D plot.
 """
 
 import numpy as np
@@ -16,11 +16,11 @@ import mpl_toolkits.mplot3d.art3d as art3d
 
 def text3d(ax, xyz, s, zdir="z", size=None, angle=0, usetex=False, **kwargs):
     """
-    Plots the string 's' on the axes 'ax', with position 'xyz', size 'size',
-    and rotation angle 'angle'.  'zdir' gives the axis which is to be treated
-    as the third dimension.  usetex is a boolean indicating whether the string
-    should be interpreted as latex or not.  Any additional keyword arguments
-    are passed on to transform_path.
+    Plots the string *s* on the axes *ax*, with position *xyz*, size *size*,
+    and rotation angle *angle*. *zdir* gives the axis which is to be treated as
+    the third dimension. *usetex* is a boolean indicating whether the string
+    should be run through a LaTeX subprocess or not.  Any additional keyword
+    arguments are forwarded to `.transform_path`.
 
     Note: zdir affects the interpretation of xyz.
     """


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
