### PR TITLE
more robust check for enter key in TextBox

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1111,7 +1111,7 @@ class TextBox(AxesWidget):
             self._rendercursor()
             if self.eventson:
                 self._observers.process('change', self.text)
-                if key == "enter":
+                if key in ["enter", "return"]:
                     self._observers.process('submit', self.text)
 
     def set_val(self, val):


### PR DESCRIPTION
## PR Summary
TextBox now checks for both `return` and `enter` to check for submission. On my system:
```
Thinkpad T490
PopOs 20.04 
5.8.0-7630-generic #32~1605108853~20.04~8bcf10e-Ubuntu SMP Wed Nov 11 22:42:16 UTC  x86_64 x86_64 x86_64 GNU/Linux
```

Hitting the key silkscreend as labelled `Enter` produces a KeyEvent with `event.key` of `return`

You can check this on your system with:
```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
def _keypress(event):
    print(event)
    print(event.key)
fig.canvas.mpl_connect('key_press_event', _keypress)
plt.show()
```
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [NA ] New features are documented, with examples if plot related.
- [NA ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [NA ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [NA ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
