### PR TITLE
Expand on slider_demo example

### DIFF
--- a/examples/widgets/range_slider.py
+++ b/examples/widgets/range_slider.py
@@ -8,6 +8,12 @@ Using the RangeSlider widget to control the thresholding of an image.
 The RangeSlider widget can be used similarly to the `.widgets.Slider`
 widget. The major difference is that RangeSlider's ``val`` attribute
 is a tuple of floats ``(lower val, upper val)`` rather than a single float.
+
+See :doc:`/gallery/widgets/slider_demo` for an example of using
+``Slider``s to control a single float.
+
+See :doc:`/gallery/widgets/slider_snap_demo` for an example of having
+the ``Slider``s snap to discrete values.
 """
 
 import numpy as np

--- a/examples/widgets/range_slider.py
+++ b/examples/widgets/range_slider.py
@@ -10,10 +10,10 @@ widget. The major difference is that RangeSlider's ``val`` attribute
 is a tuple of floats ``(lower val, upper val)`` rather than a single float.
 
 See :doc:`/gallery/widgets/slider_demo` for an example of using
-``Slider``s to control a single float.
+a ``Slider`` to control a single float.
 
 See :doc:`/gallery/widgets/slider_snap_demo` for an example of having
-the ``Slider``s snap to discrete values.
+the ``Slider`` snap to discrete values.
 """
 
 import numpy as np

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -21,7 +21,7 @@ from matplotlib.widgets import Slider, Button
 def f(t, amplitude, frequency):
     return amplitude * np.sin(2 * np.pi * frequency * t)
 
-t = np.arange(0.0, 1.0, 0.001)
+t = np.linspace(0, 1, 1000)
 
 # Define initial parameters
 init_amplitude = 5
@@ -30,6 +30,7 @@ init_frequency = 3
 # Create the figure and the line that we will manipulate
 fig, ax = plt.subplots()
 line, = plt.plot(t, f(t, init_amplitude, init_frequency), lw=2)
+ax.set_xlabel('Time [s]')
 
 axcolor = 'lightgoldenrodyellow'
 ax.margins(x=0)
@@ -41,10 +42,10 @@ plt.subplots_adjust(left=0.25, bottom=0.25)
 axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
 freq_slider = Slider(
     ax=axfreq,
-    label='Frequency',
+    label='Frequency [Hz]',
     valmin=0.1,
-    valmax=30.0,
-    valinit=init_amplitude,
+    valmax=30,
+    valinit=init_frequency,
 )
 
 # Make a vertically oriented slider to control the amplitude
@@ -52,8 +53,8 @@ axamp = plt.axes([0.1, 0.25, 0.0225, 0.63], facecolor=axcolor)
 amp_slider = Slider(
     ax=axamp,
     label="Amplitude",
-    valmin=0.1,
-    valmax=10.0,
+    valmin=0,
+    valmax=10,
     valinit=init_amplitude,
     orientation="vertical"
 )

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -6,11 +6,11 @@ Slider
 In this example, sliders are used to control the frequency and amplitude of
 a sine wave.
 
-For an example of having the slider snap to discrete values see
-:doc:`/gallery/widgets/slider_snap_demo`.
+See :doc:`/gallery/widgets/slider_snap_demo` for an example of having
+the ``Slider``s snap to discrete values.
 
-For an example of using a `matplotlib.widgets.RangeSlider` to define a range
-of values see :doc:`/gallery/widgets/range_slider`.
+See :doc:`/gallery/widgets/range_slider` for an example of using
+``RangeSlider``s to define a range of values.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -53,7 +53,7 @@ freq_slider = Slider(
 )
 
 # Make a vertically oriented slider to control the amplitude
-axamp = plt.axes([0.1, 0.15, 0.03, 0.65], facecolor=axcolor)
+axamp = plt.axes([0.1, 0.25, 0.0225, 0.63], facecolor=axcolor)
 amp_slider = Slider(
     ax=axamp,
     label="Amplitude",

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -5,62 +5,69 @@ Slider
 
 Using the slider widget to control visual properties of your plot.
 
-In this example, a slider is used to choose the frequency of a sine
-wave. You can control many continuously-varying properties of your plot in
-this way.
+In this example, sliders are used to control the frequency and amplitude of
+a sine wave. You can control many continuously-varying properties of your plot
+in this way.
+
+For a more detailed example of value snapping see
+:doc:`/gallery/widgets/slider_snap_demo`.
+
+For an example of using a `matplotlib.widgets.RangeSlider` to define a range
+of values see :doc:`/gallery/widgets/range_slider`.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider, Button, RadioButtons
+from matplotlib.widgets import Slider, Button
 
-fig, ax = plt.subplots()
-plt.subplots_adjust(left=0.25, bottom=0.25)
+
+def fxn(t, amp, freq):
+    return amp * np.sin(2 * np.pi * freq * t)
+
 t = np.arange(0.0, 1.0, 0.001)
+
+# Define initial parameters
 a0 = 5
 f0 = 3
-delta_f = 5.0
-s = a0 * np.sin(2 * np.pi * f0 * t)
-l, = plt.plot(t, s, lw=2)
-ax.margins(x=0)
+
+# Create the figure and the `~.Line2D` that we will manipulate
+fig, ax = plt.subplots()
+line, = plt.plot(t, fxn(t, a0, f0), lw=2)
 
 axcolor = 'lightgoldenrodyellow'
-axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
-axamp = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=axcolor)
+ax.margins(x=0)
 
-sfreq = Slider(axfreq, 'Freq', 0.1, 30.0, valinit=f0, valstep=delta_f)
-samp = Slider(axamp, 'Amp', 0.1, 10.0, valinit=a0)
+# adjust the main plot to make room for the sliders
+plt.subplots_adjust(left=0.25, bottom=0.25)
+
+# Make a horizontal slider to control the frequency.
+# This slider will snap to discrete values as defind by ``valstep``.
+axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
+freq_slider = Slider(axfreq, 'Freq', 0.1, 30.0, valinit=f0, valstep=5.0)
+
+# Make a vertically oriented slider to control the amplitude
+axamp = plt.axes([0.1, 0.15, 0.03, 0.65], facecolor=axcolor)
+amp_slider = Slider(
+    axamp, "Amp", 0.1, 10.0, valinit=a0, orientation="vertical"
+)
 
 
 def update(val):
-    amp = samp.val
-    freq = sfreq.val
-    l.set_ydata(amp*np.sin(2*np.pi*freq*t))
+    line.set_ydata(fxn(t, amp_slider.val, freq_slider.val))
     fig.canvas.draw_idle()
 
 
-sfreq.on_changed(update)
-samp.on_changed(update)
+freq_slider.on_changed(update)
+amp_slider.on_changed(update)
 
+# Create a `matplotlib.widgets.Button` to reset the sliders to initial values.
 resetax = plt.axes([0.8, 0.025, 0.1, 0.04])
 button = Button(resetax, 'Reset', color=axcolor, hovercolor='0.975')
 
 
 def reset(event):
-    sfreq.reset()
-    samp.reset()
+    freq_slider.reset()
+    amp_slider.reset()
 button.on_clicked(reset)
-
-rax = plt.axes([0.025, 0.5, 0.15, 0.15], facecolor=axcolor)
-radio = RadioButtons(rax, ('red', 'blue', 'green'), active=0)
-
-
-def colorfunc(label):
-    l.set_color(label)
-    fig.canvas.draw_idle()
-radio.on_clicked(colorfunc)
-
-# Initialize plot with correct initial active value
-colorfunc(radio.value_selected)
 
 plt.show()
 
@@ -76,5 +83,4 @@ plt.show()
 
 import matplotlib
 matplotlib.widgets.Button
-matplotlib.widgets.RadioButtons
 matplotlib.widgets.Slider

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -3,13 +3,10 @@
 Slider
 ======
 
-Using the slider widget to control visual properties of your plot.
-
 In this example, sliders are used to control the frequency and amplitude of
-a sine wave. You can control many continuously-varying properties of your plot
-in this way.
+a sine wave.
 
-For a more detailed example of value snapping see
+For an example of having the slider snap to discrete values see
 :doc:`/gallery/widgets/slider_snap_demo`.
 
 For an example of using a `matplotlib.widgets.RangeSlider` to define a range
@@ -30,7 +27,7 @@ t = np.arange(0.0, 1.0, 0.001)
 init_amplitude = 5
 init_frequency = 3
 
-# Create the figure and the `~.Line2D` that we will manipulate
+# Create the figure and the line that we will manipulate
 fig, ax = plt.subplots()
 line, = plt.plot(t, f(t, init_amplitude, init_frequency), lw=2)
 
@@ -41,7 +38,6 @@ ax.margins(x=0)
 plt.subplots_adjust(left=0.25, bottom=0.25)
 
 # Make a horizontal slider to control the frequency.
-# This slider will snap to discrete values as defind by ``valstep``.
 axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
 freq_slider = Slider(
     ax=axfreq,
@@ -49,7 +45,6 @@ freq_slider = Slider(
     valmin=0.1,
     valmax=30.0,
     valinit=init_amplitude,
-    valstep=5.0
 )
 
 # Make a vertically oriented slider to control the amplitude
@@ -64,11 +59,13 @@ amp_slider = Slider(
 )
 
 
+# The function to be called anytime a slider's value changes
 def update(val):
     line.set_ydata(f(t, amp_slider.val, freq_slider.val))
     fig.canvas.draw_idle()
 
 
+# register the update function with each slider
 freq_slider.on_changed(update)
 amp_slider.on_changed(update)
 

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -20,18 +20,19 @@ import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider, Button
 
 
-def fxn(t, amp, freq):
-    return amp * np.sin(2 * np.pi * freq * t)
+# The parametrized function to be plotted
+def f(t, amplitude, frequency):
+    return amplitude * np.sin(2 * np.pi * frequency * t)
 
 t = np.arange(0.0, 1.0, 0.001)
 
 # Define initial parameters
-a0 = 5
-f0 = 3
+init_amplitude = 5
+init_frequency = 3
 
 # Create the figure and the `~.Line2D` that we will manipulate
 fig, ax = plt.subplots()
-line, = plt.plot(t, fxn(t, a0, f0), lw=2)
+line, = plt.plot(t, f(t, init_amplitude, init_frequency), lw=2)
 
 axcolor = 'lightgoldenrodyellow'
 ax.margins(x=0)
@@ -42,17 +43,29 @@ plt.subplots_adjust(left=0.25, bottom=0.25)
 # Make a horizontal slider to control the frequency.
 # This slider will snap to discrete values as defind by ``valstep``.
 axfreq = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=axcolor)
-freq_slider = Slider(axfreq, 'Freq', 0.1, 30.0, valinit=f0, valstep=5.0)
+freq_slider = Slider(
+    ax=axfreq,
+    label='Frequency',
+    valmin=0.1,
+    valmax=30.0,
+    valinit=init_amplitude,
+    valstep=5.0
+)
 
 # Make a vertically oriented slider to control the amplitude
 axamp = plt.axes([0.1, 0.15, 0.03, 0.65], facecolor=axcolor)
 amp_slider = Slider(
-    axamp, "Amp", 0.1, 10.0, valinit=a0, orientation="vertical"
+    ax=axamp,
+    label="Amplitude",
+    valmin=0.1,
+    valmax=10.0,
+    valinit=init_amplitude,
+    orientation="vertical"
 )
 
 
 def update(val):
-    line.set_ydata(fxn(t, amp_slider.val, freq_slider.val))
+    line.set_ydata(f(t, amp_slider.val, freq_slider.val))
     fig.canvas.draw_idle()
 
 

--- a/examples/widgets/slider_demo.py
+++ b/examples/widgets/slider_demo.py
@@ -7,10 +7,10 @@ In this example, sliders are used to control the frequency and amplitude of
 a sine wave.
 
 See :doc:`/gallery/widgets/slider_snap_demo` for an example of having
-the ``Slider``s snap to discrete values.
+the ``Slider`` snap to discrete values.
 
 See :doc:`/gallery/widgets/range_slider` for an example of using
-``RangeSlider``s to define a range of values.
+a ``RangeSlider`` to define a range of values.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/widgets/slider_snap_demo.py
+++ b/examples/widgets/slider_snap_demo.py
@@ -8,6 +8,12 @@ You can snap slider values to discrete values using the ``valstep`` argument.
 In this example the Freq slider is constrained to be multiples of pi, and the
 Amp slider uses an array as the ``valstep`` argument to more densely sample
 the first part of its range.
+
+See :doc:`/gallery/widgets/slider_demo` for an example of using
+``Slider``s to control a single float.
+
+See :doc:`/gallery/widgets/range_slider` for an example of using
+``RangeSlider``s to define a range of values.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/widgets/slider_snap_demo.py
+++ b/examples/widgets/slider_snap_demo.py
@@ -10,10 +10,10 @@ Amp slider uses an array as the ``valstep`` argument to more densely sample
 the first part of its range.
 
 See :doc:`/gallery/widgets/slider_demo` for an example of using
-``Slider``s to control a single float.
+a ``Slider`` to control a single float.
 
 See :doc:`/gallery/widgets/range_slider` for an example of using
-``RangeSlider``s to define a range of values.
+a ``RangeSlider`` to define a range of values.
 """
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## PR Summary
I tried to address all the things I remember finding frustrating when I first figuring out widgets

1. Removed the `RadioButtons`
   - The have their own example and distract from the main thrust of this example
2. Added an example of a vertical slider (in the space formerly occupied by the radio buttons
3. longer more explicit names (e.g. `sfreq` -> `freq_slider`)
   - I think this helps in the context of an example when you are scanning through and trying to decipher.
4. Made a function that gets plotted rather than rewriting the equation in multiple places.
5. Added a reference to the other slider examples.
   - xref https://github.com/matplotlib/matplotlib/issues/19230
 6. More explanatory comments everywhere
 7. Added links to the other slider examples
    - I never found this frustrating as those other examples didn't used to exist, but I'll bet I would have found it frustrating if they weren't linked to.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [NA ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [NA] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [NA] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [NA] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).


