### PR TITLE
WIP: Add support to edit subplot configurations via textbox

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1384,13 +1384,12 @@ class SubplotTool(Widget):
 
         self._sliders = []
         self._textboxes = []
+        gs_kw = {'width_ratios': [6, 1]}
         names = ["left", "bottom", "right", "top", "wspace", "hspace"]
         # The last subplot, removed below, keeps space for the "Reset" button.
         for name, axes in zip(names, toolfig.subplots(len(names) + 1, 2,
                                                       sharey=True,
-                                                      gridspec_kw={
-                                                                   'width_ratios': [6, 1]
-                                                                  })):
+                                                      gridspec_kw=gs_kw)):
             for ax in axes:
                 ax.set_navigate(False)
 


### PR DESCRIPTION
## PR Summary
This PR adds support to manually edit the slider values in the subplot configuration tool via a TextBox.
(potentially a `NumericTextBox`)
This is a WIP, to mockup the desired behavior mentioned at https://github.com/matplotlib/matplotlib/issues/19257#issuecomment-757525072.

Behaviour:
<img src="https://user-images.githubusercontent.com/43996118/104157053-61166680-5410-11eb-838e-bf7ab71f464a.gif" width="75%"/>


To test it out, you can use any snippet:
```python
import matplotlib.pyplot as plt


def example_plot(ax, fontsize=12):
    ax.plot([1, 2])
    ax.set_xlabel('x-label', fontsize=fontsize)
    ax.set_ylabel('y-label', fontsize=fontsize)
    ax.set_title('Title', fontsize=fontsize)

fig, axis = plt.subplots()
example_plot(axis, fontsize=24)
plt.show()
```

A partial fix to https://github.com/matplotlib/matplotlib/issues/19257

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
