### PR TITLE
Warn on redundant definition of plot properties

### DIFF
--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -20,7 +20,7 @@ ax = fig1.add_axes([0.1, 0.1, 0.8, 0.8])
 l1, = ax.plot([0.1, 0.5, 0.9], [0.1, 0.9, 0.5], "bo-",
               mec="b", lw=5, ms=10, label="Line 1")
 l2, = ax.plot([0.1, 0.5, 0.9], [0.5, 0.2, 0.7], "rs-",
-              mec="r", lw=5, ms=10, color="r", label="Line 2")
+              mec="r", lw=5, ms=10, label="Line 2")
 
 
 for l in [l1, l2]:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -624,6 +624,17 @@ def test_fill_units():
     fig.autofmt_xdate()
 
 
+def test_plot_format_kwarg_redundant():
+    with pytest.warns(UserWarning, match="marker .* redundantly defined"):
+        plt.plot([0], [0], 'o', marker='x')
+    with pytest.warns(UserWarning, match="linestyle .* redundantly defined"):
+        plt.plot([0], [0], '-', linestyle='--')
+    with pytest.warns(UserWarning, match="color .* redundantly defined"):
+        plt.plot([0], [0], 'r', color='blue')
+    # smoke-test: should not warn
+    plt.errorbar([0], [0], fmt='none', color='blue')
+
+
 @image_comparison(['single_point', 'single_point'])
 def test_single_point():
     # Issue #1796: don't let lines.marker affect the grid


### PR DESCRIPTION
`plt.plot(x, y, fmt)` allows to specify marker, linestyle and color via
`fmt`. Warn if there are additionally keyword arguments that specify the
same properties.

Closes #19275.

Builds on top of #19278, which cleans up _plot_args(). This separation
is done for easier review of the cleanup.
