### PR TITLE
Fix sphinx search

### DIFF
--- a/doc/_templates/search.html
+++ b/doc/_templates/search.html
@@ -3,6 +3,7 @@
 {%- block scripts %}
     {{ super() }}
     <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block body %}
   <h1 id="search-documentation">{{ _('Search') }}</h1>


### PR DESCRIPTION
## PR Summary

Search does not work on our current devdocs, which are built with Sphinx 3.4.x.

### Reason / Solution

Sphinx stopped loading language_data.js globally in 3.4.
This file now has to be loaded explicitly on the search page.

See

- https://github.com/sphinx-doc/sphinx/pull/8445
- https://github.com/readthedocs/sphinx_rtd_theme/pull/1021

