### PR TITLE
Change the filler label to member variable for navigation toolbar's background

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -515,9 +515,9 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # lines high. Otherwise the canvas gets redrawn as the mouse hovers
         # over images because those use two-line messages which resize the
         # toolbar.
-        label = tk.Label(master=self,
+        self._label_filler = tk.Label(master=self,
                          text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
-        label.pack(side=tk.RIGHT)
+        self._label_filler.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, textvariable=self.message)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -516,7 +516,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # over images because those use two-line messages which resize the
         # toolbar.
         self._label_filler = tk.Label(master=self,
-                         text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+                                      text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
         self._label_filler.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -515,8 +515,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # lines high. Otherwise the canvas gets redrawn as the mouse hovers
         # over images because those use two-line messages which resize the
         # toolbar.
-        self._label_filler = tk.Label(master=self,
-                        text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+        self._label_filler = tk.Label(master=self, text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
         self._label_filler.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -518,7 +518,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         self._label_filler = tk.Label(master=self)
         self._label_filler['text'] = '\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}'
         self._label_filler.pack(side=tk.RIGHT)
-        
+
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, textvariable=self.message)
         self._message_label.pack(side=tk.RIGHT)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -516,7 +516,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # over images because those use two-line messages which resize the
         # toolbar.
         self._label_filler = tk.Label(master=self,
-                         text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+                        text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
         self._label_filler.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -515,7 +515,8 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # lines high. Otherwise the canvas gets redrawn as the mouse hovers
         # over images because those use two-line messages which resize the
         # toolbar.
-        self._label_filler = tk.Label(master=self, text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+        self._label_filler = tk.Label(master=self,
+                         text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
         self._label_filler.pack(side=tk.RIGHT)
 
         self.message = tk.StringVar(master=self)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -515,10 +515,10 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # lines high. Otherwise the canvas gets redrawn as the mouse hovers
         # over images because those use two-line messages which resize the
         # toolbar.
-        self._label_filler = tk.Label(master=self,
-                                      text='\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}')
+        self._label_filler = tk.Label(master=self)
+        self._label_filler['text'] = '\N{NO-BREAK SPACE}\n\N{NO-BREAK SPACE}'
         self._label_filler.pack(side=tk.RIGHT)
-
+        
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, textvariable=self.message)
         self._message_label.pack(side=tk.RIGHT)


### PR DESCRIPTION
## PR Summary

I tried navigation toolbar's background by inheritance of NavigationToolbar2Tk, and noticed the background of the label filler could never be changed. 
That's why the scope of label filler is limited to the backend initializer, so I need to promote the label filler to member variable.

There are unpainted area at right-bottom area of window.

**_Before_**
![image](https://user-images.githubusercontent.com/15176995/104406698-3d375a00-55a3-11eb-9599-074ea6407052.png)


**_After_**
![image](https://user-images.githubusercontent.com/15176995/104406087-d49bad80-55a1-11eb-9811-284a7660a0c4.png)

## An example of Navigation Toolbar Implements

```
import matplotlib
import matplotlib.pyplot as plt
import numpy as np
from collections import namedtuple

import tkinter as tk
from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk

class NavigationToolbarExt(NavigationToolbar2Tk):
	toolitems = [t for t in NavigationToolbar2Tk.toolitems if t[0] in ('Pan', 'Save')]

	def __init__(self, canvas=None, master=None):
 		super().__init__(canvas, master)
 		self.canvas = canvas
 		self.master = master

 		self['bg'] = 'white'
 		self._message_label['bg'] = 'white'
 		### [notes] The following code is omitted on the previous code and inserted on the new code ###
 		# self._label_filler['bg'] = 'white'


if __name__ == '__main__':
 	root = tk.Tk()
 	fig = plt.figure(figsize=(8, 5))

	graph_bar = tk.Frame(root)

	canvas = FigureCanvasTkAgg(fig, master=graph_bar)
	canvas.draw()
	canvas.get_tk_widget().pack(side=tk.TOP, fill=tk.BOTH)

	toolbar = NavigationToolbarExt(canvas, graph_bar)
	toolbar.pack(side=tk.BOTTOM, fill=tk.BOTH)

	graph_bar.pack(side=tk.BOTTOM, fill=tk.BOTH)

	x = np.linspace(0, 1, 101)
	y1 = x
	y2 = x ** 2

	subp1 = plt.subplot(1, 2, 1)
	subp1.plot(x, y1)

	subp2 = plt.subplot(1, 2, 2)
	subp2.plot(x, y2)


	root.protocol("WM_DELETE_WINDOW", toolbar.quit)
	root.mainloop()
```



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
