### PR TITLE
Escape octothorpe characters in matplotlibrc

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -751,6 +751,24 @@ def _open_file_or_url(fname):
             yield f
 
 
+def strip_comment(line):
+    """Strips comments at the end of the line.
+    Comments start with '#' but can be escaped ('\#').
+    """
+    splitline = line.split('#')
+    escaped_line = []
+    for i, segment in enumerate(splitline):
+        escape_at_end = segment.endswith('\\')
+        if escape_at_end and len(splitline) > i:
+            # this segment ended with \#
+            segment = segment[:-1]+'#'
+        escaped_line.append(segment)
+        if not escape_at_end:
+            break
+    parsed = ''.join(escaped_line).strip()
+    return parsed
+
+
 def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
     """
     Construct a `RcParams` instance from file *fname*.
@@ -773,7 +791,7 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
         try:
             for line_no, line in enumerate(fd, 1):
                 line = transform(line)
-                strippedline = line.split('#', 1)[0].strip()
+                strippedline = strip_comment(line).strip()
                 if not strippedline:
                     continue
                 tup = strippedline.split(':', 1)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -751,7 +751,7 @@ def _open_file_or_url(fname):
             yield f
 
 
-def strip_comment(line):
+def _strip_comment(line):
     """Strip line and remove comment line
     Only removes comments at the start of a line (may have leading whitespace)
     """
@@ -761,7 +761,7 @@ def strip_comment(line):
     return line
 
 
-def parse_keyval(key, val):
+def _parse_keyval(key, val):
     """Parse a key-value pair.
     We are only passing key in case we want to
     conditionally allow quoted strings"""
@@ -812,7 +812,7 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
         try:
             for line_no, line in enumerate(fd, 1):
                 line = transform(line)
-                strippedline = strip_comment(line).strip()
+                strippedline = _strip_comment(line).strip()
                 if not strippedline:
                     continue
                 tup = strippedline.split(':', 1)
@@ -823,7 +823,7 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
                 key, val = tup
                 key = key.strip()
                 val = val.strip()
-                val = parse_keyval(key, val)
+                val = _parse_keyval(key, val)
                 if val is None:
                     _log.warning('Cannot parse key value in file %r, line %d (%r)',
                                 fname, line_no, line.rstrip('\n'))

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -752,7 +752,8 @@ def _open_file_or_url(fname):
 
 
 def _strip_comment(line):
-    """Strip line and remove comment line
+    """
+    Strip line and remove comment line.
     Only removes comments at the start of a line (may have leading whitespace)
     """
     line = line.strip()
@@ -762,9 +763,10 @@ def _strip_comment(line):
 
 
 def _parse_keyval(key, val):
-    """Parse a key-value pair.
-    We are only passing key in case we want to
-    conditionally allow quoted strings"""
+    """
+    Parse a key-value pair.
+    We are only passing key in case we want to conditionally allow quoted strings
+    """
     # remove whitespace
     val = val.strip()
     # regex


### PR DESCRIPTION
## PR Summary

Fixes #19288 

When parsing matplotlibrc files, the octothorpe (`#`) indicates a comment. Escaping with `\#` now allows the parameter value itself to contain `#`. For example,

```
text.latex.preamble: \newcommand{\foo}[1]{\bar{\#1}} # add foo as shorthand for bar
```

results in `rcParams["text.latex.preamble"] == "\\newcommand{\\foo}[1]{\\bar{#1}}"` as desired.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
