### PR TITLE
Fix some docstring interpolations

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -673,7 +673,7 @@ this example from `matplotlib.lines`:
 .. code-block:: python
 
   # in lines.py
-  docstring.interpd.update(Line2D=artist.kwdoc(Line2D))
+  docstring.interpd.update(Line2D_kwdoc=artist.kwdoc(Line2D))
 
 Then in any function accepting `~.Line2D` pass-through ``kwargs``, e.g.,
 `matplotlib.axes.Axes.plot`:
@@ -686,13 +686,28 @@ Then in any function accepting `~.Line2D` pass-through ``kwargs``, e.g.,
       """
       Some stuff omitted
 
-      The kwargs are Line2D properties:
-      %(_Line2D_docstr)s
+      Other Parameters
+      ----------------
+      scalex, scaley : bool, default: True
+          These parameters determine if the view limits are adapted to the
+          data limits. The values are passed on to `autoscale_view`.
 
-      kwargs scalex and scaley, if defined, are passed on
-      to autoscale_view to determine whether the x and y axes are
-      autoscaled; default True.  See Axes.autoscale_view for more
-      information
+      **kwargs : `.Line2D` properties, optional
+          *kwargs* are used to specify properties like a line label (for
+          auto legends), linewidth, antialiasing, marker face color.
+          Example::
+
+          >>> plot([1, 2, 3], [1, 2, 3], 'go-', label='line 1', linewidth=2)
+          >>> plot([1, 2, 3], [1, 4, 9], 'rs', label='line 2')
+
+          If you specify multiple lines with one plot call, the kwargs apply
+          to all those lines. In case the label object is iterable, each
+          element is used as labels for each set of data.
+
+          Here is a list of available `.Line2D` properties:
+
+          %(Line2D_kwdoc)s
+
       """
 
 Note there is a problem for `~matplotlib.artist.Artist` ``__init__`` methods,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1497,10 +1497,9 @@ class Axes(_AxesBase):
             >>> plot([1, 2, 3], [1, 2, 3], 'go-', label='line 1', linewidth=2)
             >>> plot([1, 2, 3], [1, 4, 9], 'rs', label='line 2')
 
-            If you make multiple lines with one plot call, the kwargs
-            apply to all those lines.
-            In case if label object is iterable, each its element is
-            used as label for a separate line.
+            If you specify multiple lines with one plot call, the kwargs apply
+            to all those lines. In case the label object is iterable, each
+            element is used as labels for each set of data.
 
             Here is a list of available `.Line2D` properties:
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -352,6 +352,7 @@ class Axes(_AxesBase):
 
         return inset_ax
 
+    @docstring.dedent_interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,
                        facecolor='none', edgecolor='0.5', alpha=0.5,
                        zorder=4.99, **kwargs):
@@ -921,6 +922,7 @@ class Axes(_AxesBase):
         self._request_autoscale_view(scalex=False)
         return p
 
+    @docstring.dedent_interpd
     def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
         """
         Add a vertical span (rectangle) across the Axes.


### PR DESCRIPTION
## PR Summary

Fixes #19292.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).