### PR TITLE
Deprecate project argument to Line3DCollection.draw.

### DIFF
--- a/doc/api/next_api_changes/deprecations/18302-ES.rst
+++ b/doc/api/next_api_changes/deprecations/18302-ES.rst
@@ -12,9 +12,15 @@ now deprecated:
 These attributes are all available via `.Axes3D`, which can be accessed via
 ``self.axes`` on all `.Artist`\s.
 
-``renderer`` argument of ``do_3d_projection`` method for ``Collection3D``/``Patch3D``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*renderer* argument of ``do_3d_projection`` method for ``Collection3D``/``Patch3D``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``renderer`` argument for the ``do_3d_projection`` method on
-``Collection3D`` and ``Patch3D`` is no longer necessary, and passing it during
-draw is deprecated.
+The *renderer* argument for the ``do_3d_projection`` method on ``Collection3D``
+and ``Patch3D`` is no longer necessary, and passing it during draw is
+deprecated.
+
+*project* argument of ``draw`` method for ``Line3DCollection``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *project* argument for the ``draw`` method on ``Line3DCollection`` is
+deprecated. Call `.Line3DCollection.do_3d_projection` explicitly instead.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -316,6 +316,8 @@ class Line3DCollection(LineCollection):
         return minz
 
     @artist.allow_rasterization
+    @_api.delete_parameter('3.4', 'project',
+                           alternative='Line3DCollection.do_3d_projection')
     def draw(self, renderer, project=False):
         if project:
             self.do_3d_projection()

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -357,7 +357,8 @@ class Axis(maxis.XAxis):
             self.gridlines.set_color(info['grid']['color'])
             self.gridlines.set_linewidth(info['grid']['linewidth'])
             self.gridlines.set_linestyle(info['grid']['linestyle'])
-            self.gridlines.draw(renderer, project=True)
+            self.gridlines.do_3d_projection()
+            self.gridlines.draw(renderer)
 
         # Draw ticks
         tickdir = info['tickdir']


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).