### PR TITLE
Fix several CI issues

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ environment:
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
                  --cov-report= --cov=lib --log-level=DEBUG
+    PINNEDVERS: "pyzmq!=21.0.0"
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ steps:
         texlive-xetex texlive-luatex
       ;;
     darwin)
-      brew cask install xquartz
+      brew install --cask xquartz
       brew install pkg-config ffmpeg imagemagick mplayer ccache
       ;;
     win32)


### PR DESCRIPTION
## PR Summary

* Fix brew installation on Azure pipelines.
* Don't allow pyzmq 21.0.0 on AppVeyor.
  This version is broken on Windows: zeromq/pyzmq#1470.
* TST: Mark Cairo backends as not threadsafe.
    Cairo backends save the `cairo_t` object on the graphics context (as
    `self.gc.ctx`), but this object is not threadsafe.
  This should fix sporadic failures in `test_interactive_thread_safety`.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).