### PR TITLE
Fix some packaging issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,4 @@ recursive-include tutorials *
 include versioneer.py
 include lib/matplotlib/_version.py
 include tests.py
+recursive-exclude lib/matplotlib/backends/web_backend/node_modules *

--- a/ci/check_wheel_licenses.py
+++ b/ci/check_wheel_licenses.py
@@ -21,14 +21,15 @@ project_dir = Path(__file__).parent.resolve().parent
 dist_dir = project_dir / 'dist'
 license_dir = project_dir / 'LICENSE'
 
-license_file_names = [path.name for path in sorted(license_dir.glob('*'))]
+license_file_names = {path.name for path in sorted(license_dir.glob('*'))}
 for wheel in dist_dir.glob('*.whl'):
     print(f'Checking LICENSE files in: {wheel}')
     with zipfile.ZipFile(wheel) as f:
-        wheel_license_file_names = [Path(path).name
+        wheel_license_file_names = {Path(path).name
                                     for path in sorted(f.namelist())
-                                    if '.dist-info/LICENSE' in path]
-        if wheel_license_file_names != license_file_names:
+                                    if '.dist-info/LICENSE' in path}
+        if not (len(wheel_license_file_names) and
+                wheel_license_file_names.issuperset(license_file_names)):
             print(f'LICENSE file(s) missing:\n'
                   f'{wheel_license_file_names} !=\n'
                   f'{license_file_names}')


### PR DESCRIPTION
## PR Summary

Fix the license check for the added Qhull license and avoid adding a huge `node_modules` directory to the sdist.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).