### PR TITLE
Add missing possible return value to docs of get_verticalalignment()

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -849,7 +849,7 @@ class Text(Artist):
     def get_verticalalignment(self):
         """
         Return the vertical alignment as a string.  Will be one of
-        'top', 'center', 'bottom' or 'baseline'.
+        'top', 'center', 'bottom', 'baseline' or 'center_baseline'.
         """
         return self._verticalalignment
 


### PR DESCRIPTION
See also `set_verticalaligment()` where the value "center_baseline" is documented and processed.