### PR TITLE
Update the markers part of matplotlib.pyplot.plot document (fix issue #19274)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1528,61 +1528,35 @@ class Axes(_AxesBase):
 
         **Markers**
 
-        ============================== ========================================
-        character                      description
-        ============================== ========================================
-        ``'.'``                        point marker
-        ``','``                        pixel marker
-        ``'o'``                        circle marker
-        ``'v'``                        triangle_down marker
-        ``'^'``                        triangle_up marker
-        ``'<'``                        triangle_left marker
-        ``'>'``                        triangle_right marker
-        ``'1'``                        tri_down marker
-        ``'2'``                        tri_up marker
-        ``'3'``                        tri_left marker
-        ``'4'``                        tri_right marker
-        ``'8'``                        octagon marker
-        ``'s'``                        square marker
-        ``'p'``                        pentagon marker
-        ``'P'``                        plus (filled) marker
-        ``'*'``                        star marker
-        ``'h'``                        hexagon1 marker
-        ``'H'``                        hexagon2 marker
-        ``'+'``                        plus marker
-        ``'x'``                        x marker
-        ``'X'``                        x (filled) marker
-        ``'D'``                        diamond marker
-        ``'d'``                        thin_diamond marker
-        ``'|'``                        vline marker
-        ``'_'``                        hline marker
-        ``0`` (``TICKLEFT``)           tickleft marker
-        ``1`` (``TICKRIGHT``)          tickright marker
-        ``2`` (``TICKUP``)             tickup marker
-        ``3`` (``TICKDOWN``)           tickdown marker
-        ``4`` (``CARETLEFT``)          caretleft marker
-        ``5`` (``CARETRIGHT``)         caretright marker
-        ``6`` (``CARETUP``)            caretup marker
-        ``7`` (``CARETDOWN``)          caretdown marker
-        ``8`` (``CARETLEFTBASE``)      caretleft (centered at base)
-        ``9`` (``CARETRIGHTBASE``)     caretright (centered at base)
-        ``10`` (``CARETUPBASE``)       caretup (centered at base)
-        ``11`` (``CARETDOWNBASE``)     caretdown (centered at base)
-        ``"None"``, ``" "`` or  ``""`` nothing
-        ``'$...$'``                    Render the string using mathtext.
-        ``verts``                      A list of (x, y) pairs used for Path
-                                       vertices. The center of the marker is
-                                       located at (0, 0) and the size is
-                                       normalized, such that the created path
-                                       is encapsulated inside the unit cell.
-        path                           A `~matplotlib.path.Path` instance.
-        ``(numsides, 0, angle)``       A regular polygon with ``numsides``
-                                       sides, rotated by ``angle``.
-        ``(numsides, 1, angle)``       A star-like symbol with ``numsides``
-                                       sides, rotated by ``angle``.
-        ``(numsides, 2, angle)``       An asterisk with ``numsides`` sides,
-                                       rotated by ``angle``.
-        ============================== ========================================
+        =============   ===============================
+        character       description
+        =============   ===============================
+        ``'.'``         point marker
+        ``','``         pixel marker
+        ``'o'``         circle marker
+        ``'v'``         triangle_down marker
+        ``'^'``         triangle_up marker
+        ``'<'``         triangle_left marker
+        ``'>'``         triangle_right marker
+        ``'1'``         tri_down marker
+        ``'2'``         tri_up marker
+        ``'3'``         tri_left marker
+        ``'4'``         tri_right marker
+        ``'8'``         octagon marker
+        ``'s'``         square marker
+        ``'p'``         pentagon marker
+        ``'P'``         plus (filled) marker
+        ``'*'``         star marker
+        ``'h'``         hexagon1 marker
+        ``'H'``         hexagon2 marker
+        ``'+'``         plus marker
+        ``'x'``         x marker
+        ``'X'``         x (filled) marker
+        ``'D'``         diamond marker
+        ``'d'``         thin_diamond marker
+        ``'|'``         vline marker
+        ``'_'``         hline marker
+        =============   ===============================
 
         **Line Styles**
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1528,32 +1528,61 @@ class Axes(_AxesBase):
 
         **Markers**
 
-        =============    ===============================
-        character        description
-        =============    ===============================
-        ``'.'``          point marker
-        ``','``          pixel marker
-        ``'o'``          circle marker
-        ``'v'``          triangle_down marker
-        ``'^'``          triangle_up marker
-        ``'<'``          triangle_left marker
-        ``'>'``          triangle_right marker
-        ``'1'``          tri_down marker
-        ``'2'``          tri_up marker
-        ``'3'``          tri_left marker
-        ``'4'``          tri_right marker
-        ``'s'``          square marker
-        ``'p'``          pentagon marker
-        ``'*'``          star marker
-        ``'h'``          hexagon1 marker
-        ``'H'``          hexagon2 marker
-        ``'+'``          plus marker
-        ``'x'``          x marker
-        ``'D'``          diamond marker
-        ``'d'``          thin_diamond marker
-        ``'|'``          vline marker
-        ``'_'``          hline marker
-        =============    ===============================
+        ============================== ========================================
+        character                      description
+        ============================== ========================================
+        ``'.'``                        point marker
+        ``','``                        pixel marker
+        ``'o'``                        circle marker
+        ``'v'``                        triangle_down marker
+        ``'^'``                        triangle_up marker
+        ``'<'``                        triangle_left marker
+        ``'>'``                        triangle_right marker
+        ``'1'``                        tri_down marker
+        ``'2'``                        tri_up marker
+        ``'3'``                        tri_left marker
+        ``'4'``                        tri_right marker
+        ``'8'``                        octagon marker
+        ``'s'``                        square marker
+        ``'p'``                        pentagon marker
+        ``'P'``                        plus (filled) marker
+        ``'*'``                        star marker
+        ``'h'``                        hexagon1 marker
+        ``'H'``                        hexagon2 marker
+        ``'+'``                        plus marker
+        ``'x'``                        x marker
+        ``'X'``                        x (filled) marker
+        ``'D'``                        diamond marker
+        ``'d'``                        thin_diamond marker
+        ``'|'``                        vline marker
+        ``'_'``                        hline marker
+        ``0`` (``TICKLEFT``)           tickleft marker
+        ``1`` (``TICKRIGHT``)          tickright marker
+        ``2`` (``TICKUP``)             tickup marker
+        ``3`` (``TICKDOWN``)           tickdown marker
+        ``4`` (``CARETLEFT``)          caretleft marker
+        ``5`` (``CARETRIGHT``)         caretright marker
+        ``6`` (``CARETUP``)            caretup marker
+        ``7`` (``CARETDOWN``)          caretdown marker
+        ``8`` (``CARETLEFTBASE``)      caretleft (centered at base)
+        ``9`` (``CARETRIGHTBASE``)     caretright (centered at base)
+        ``10`` (``CARETUPBASE``)       caretup (centered at base)
+        ``11`` (``CARETDOWNBASE``)     caretdown (centered at base)
+        ``"None"``, ``" "`` or  ``""`` nothing
+        ``'$...$'``                    Render the string using mathtext.
+        ``verts``                      A list of (x, y) pairs used for Path
+                                       vertices. The center of the marker is
+                                       located at (0, 0) and the size is
+                                       normalized, such that the created path
+                                       is encapsulated inside the unit cell.
+        path                           A `~matplotlib.path.Path` instance.
+        ``(numsides, 0, angle)``       A regular polygon with ``numsides``
+                                       sides, rotated by ``angle``.
+        ``(numsides, 1, angle)``       A star-like symbol with ``numsides``
+                                       sides, rotated by ``angle``.
+        ``(numsides, 2, angle)``       An asterisk with ``numsides`` sides,
+                                       rotated by ``angle``.
+        ============================== ========================================
 
         **Line Styles**
 


### PR DESCRIPTION
## PR Summary
This updates the doc of matplotlib.pyplot.plot and closes #19274. The Markers part of matplotlib.pyplot.plot is not up to date with matplotlib.markers. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
