### PR TITLE
Pin to oldest supported PyQt on minver CI instance.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
             os: ubuntu-16.04
             python-version: 3.7
             extra-requirements: '-c requirements/testing/minver.txt'
+            pyqt5-ver: '==5.8 sip==4.19.7'  # oldest versions with a Py3.7 wheel.
             delete-font-cache: true
             XVFB_RUN: xvfb-run -a
           - os: ubuntu-16.04
@@ -168,7 +169,7 @@ jobs:
             # Sept 2020) for either pyqt5 (there are only wheels for 10.13+) or
             # pyside2 (the latest version (5.13.2) with 10.12 wheels has a
             # fatal to us bug, it was fixed in 5.14.0 which has 10.13 wheels)
-             python -mpip install --upgrade pyqt5 &&
+             python -mpip install --upgrade pyqt5${{ matrix.pyqt5-ver }} &&
                python -c 'import PyQt5.QtCore' &&
                echo 'PyQt5 is available' ||
                echo 'PyQt5 is not available'


### PR DESCRIPTION
This will be relevant once we also include PyQt6 support, as details of
enum access have changed in PyQt 5.11 (#19255).

PyQt is not actually a dependency so I don't think we can use the
constraints file (minver.txt) for that.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
