### PR TITLE
DOC: make canonical version stable

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -15,7 +15,7 @@
 {%- if '+' in release %}
     <link rel="canonical" href="https://matplotlib.org/devdocs/{{pagename}}.html" />
 {%- else %}
-    <link rel="canonical" href="https://matplotlib.org/{{version}}/{{pagename}}.html" />
+    <link rel="canonical" href="https://matplotlib.org/stable/{{pagename}}.html" />
 {%- endif %}
 {%- endblock %}
 

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -342,13 +342,16 @@ matplotlib ::
   rsync -a ../matplotlib/doc/build/html/* 2.0.0
   cp ../matplotlib/doc/build/latex/Matplotlib.pdf 2.0.0
 
-which will copy the built docs over.  If this is a final release, also
-replace the top-level docs ::
+which will copy the built docs over.  If this is a final release, link the
+``stable`` subdirectory to the newest version::
 
   rsync -a 2.0.0/* ./
+  rm stable
+  ln -s 2.0.0/ stable
 
 You will need to manually edit :file:`versions.html` to show the last
-3 tagged versions.  Now commit and push everything to GitHub ::
+3 tagged versions.  You will also need to edit :file:`sitemap.xml` to include
+the newly released version.  Now commit and push everything to GitHub ::
 
   git add *
   git commit -a -m 'Updating docs for v2.0.0'


### PR DESCRIPTION
## PR Summary


Depends on https://github.com/matplotlib/matplotlib.github.com/pull/47

Makes `matplotlib.org/stable` the canonical root.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
