### PR TITLE
Improve FT2Font docstrings.

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -63,9 +63,8 @@ static void PyFT2Image_dealloc(PyFT2Image *self)
 
 const char *PyFT2Image_draw_rect__doc__ =
     "draw_rect(x0, y0, x1, y1)\n"
-    "\n"
-    "Draw a rect to the image.\n"
-    "\n";
+    "--\n\n"
+    "Draw an empty rectangle to the image.\n";
 
 static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
@@ -82,9 +81,8 @@ static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args, PyObject
 
 const char *PyFT2Image_draw_rect_filled__doc__ =
     "draw_rect_filled(x0, y0, x1, y1)\n"
-    "\n"
-    "Draw a filled rect to the image.\n"
-    "\n";
+    "--\n\n"
+    "Draw a filled rectangle to the image.\n";
 
 static PyObject *PyFT2Image_draw_rect_filled(PyFT2Image *self, PyObject *args, PyObject *kwds)
 {
@@ -327,30 +325,39 @@ static PyObject *PyFT2Font_new(PyTypeObject *type, PyObject *args, PyObject *kwd
 
 const char *PyFT2Font_init__doc__ =
     "FT2Font(ttffile)\n"
+    "--\n\n"
+    "Create a new FT2Font object.\n"
     "\n"
-    "Create a new FT2Font object\n"
-    "The following global font attributes are defined:\n"
-    "  num_faces              number of faces in file\n"
-    "  face_flags             face flags  (int type); see the ft2font constants\n"
-    "  style_flags            style flags  (int type); see the ft2font constants\n"
-    "  num_glyphs             number of glyphs in the face\n"
-    "  family_name            face family name\n"
-    "  style_name             face style name\n"
-    "  num_fixed_sizes        number of bitmap in the face\n"
-    "  scalable               face is scalable\n"
-    "\n"
-    "The following are available, if scalable is true:\n"
-    "  bbox                   face global bounding box (xmin, ymin, xmax, ymax)\n"
-    "  units_per_EM           number of font units covered by the EM\n"
-    "  ascender               ascender in 26.6 units\n"
-    "  descender              descender in 26.6 units\n"
-    "  height                 height in 26.6 units; used to compute a default\n"
-    "                         line spacing (baseline-to-baseline distance)\n"
-    "  max_advance_width      maximum horizontal cursor advance for all glyphs\n"
-    "  max_advance_height     same for vertical layout\n"
-    "  underline_position     vertical position of the underline bar\n"
-    "  underline_thickness    vertical thickness of the underline\n"
-    "  postscript_name        PostScript name of the font\n";
+    "Attributes\n"
+    "----------\n"
+    "num_faces\n"
+    "    Number of faces in file.\n"
+    "face_flags, style_flags : int\n"
+    "    Face and style flags; see the ft2font constants.\n"
+    "num_glyphs\n"
+    "    Number of glyphs in the face.\n"
+    "family_name, style_name\n"
+    "    Face family and style name.\n"
+    "num_fixed_sizes\n"
+    "    Number of bitmap in the face.\n"
+    "scalable\n"
+    "    Whether face is scalable; attributes after this one are only\n"
+    "    defined for scalable faces.\n"
+    "bbox\n"
+    "    Face global bounding box (xmin, ymin, xmax, ymax).\n"
+    "units_per_EM\n"
+    "    Number of font units covered by the EM.\n"
+    "ascender, descender\n"
+    "    Ascender and descender in 26.6 units.\n"
+    "height\n"
+    "    Height in 26.6 units; used to compute a default line spacing\n"
+    "    (baseline-to-baseline distance).\n"
+    "max_advance_width, max_advance_height\n"
+    "    Maximum horizontal and vertical cursor advance for all glyphs.\n"
+    "underline_position, underline_thickness\n"
+    "    Vertical position and thickness of the underline bar.\n"
+    "postscript_name\n"
+    "    PostScript name of the font.\n";
 
 static int PyFT2Font_init(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -418,8 +425,8 @@ static void PyFT2Font_dealloc(PyFT2Font *self)
 
 const char *PyFT2Font_clear__doc__ =
     "clear()\n"
-    "\n"
-    "Clear all the glyphs, reset for a new set_text";
+    "--\n\n"
+    "Clear all the glyphs, reset for a new call to `.set_text`.\n";
 
 static PyObject *PyFT2Font_clear(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -430,7 +437,7 @@ static PyObject *PyFT2Font_clear(PyFT2Font *self, PyObject *args, PyObject *kwds
 
 const char *PyFT2Font_set_size__doc__ =
     "set_size(ptsize, dpi)\n"
-    "\n"
+    "--\n\n"
     "Set the point size and dpi of the text.\n";
 
 static PyObject *PyFT2Font_set_size(PyFT2Font *self, PyObject *args, PyObject *kwds)
@@ -449,8 +456,8 @@ static PyObject *PyFT2Font_set_size(PyFT2Font *self, PyObject *args, PyObject *k
 
 const char *PyFT2Font_set_charmap__doc__ =
     "set_charmap(i)\n"
-    "\n"
-    "Make the i-th charmap current\n";
+    "--\n\n"
+    "Make the i-th charmap current.\n";
 
 static PyObject *PyFT2Font_set_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -467,8 +474,8 @@ static PyObject *PyFT2Font_set_charmap(PyFT2Font *self, PyObject *args, PyObject
 
 const char *PyFT2Font_select_charmap__doc__ =
     "select_charmap(i)\n"
-    "\n"
-    "select charmap i where i is one of the FT_Encoding number\n";
+    "--\n\n"
+    "Select a charmap by its FT_Encoding number.\n";
 
 static PyObject *PyFT2Font_select_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -484,10 +491,10 @@ static PyObject *PyFT2Font_select_charmap(PyFT2Font *self, PyObject *args, PyObj
 }
 
 const char *PyFT2Font_get_kerning__doc__ =
-    "dx = get_kerning(left, right, mode)\n"
-    "\n"
-    "Get the kerning between left char and right glyph indices\n"
-    "mode is a kerning mode constant\n"
+    "get_kerning(left, right, mode)\n"
+    "--\n\n"
+    "Get the kerning between *left* and *right* glyph indices.\n"
+    "*mode* is a kerning mode constant:\n"
     "  KERNING_DEFAULT  - Return scaled and grid-fitted kerning distances\n"
     "  KERNING_UNFITTED - Return scaled but un-grid-fitted kerning distances\n"
     "  KERNING_UNSCALED - Return the kerning vector in original font units\n";
@@ -507,11 +514,13 @@ static PyObject *PyFT2Font_get_kerning(PyFT2Font *self, PyObject *args, PyObject
 }
 
 const char *PyFT2Font_set_text__doc__ =
-    "set_text(s, angle)\n"
-    "\n"
-    "Set the text string and angle.\n"
-    "You must call this before draw_glyphs_to_bitmap\n"
-    "A sequence of x,y positions is returned";
+    "set_text(string, angle, flags=32)\n"
+    "--\n\n"
+    "Set the text *string* and *angle*.\n"
+    "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
+    "the default value is LOAD_FORCE_AUTOHINT.\n"
+    "You must call this before `.draw_glyphs_to_bitmap`.\n"
+    "A sequence of x,y positions is returned.\n";
 
 static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -575,8 +584,8 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
 
 const char *PyFT2Font_get_num_glyphs__doc__ =
     "get_num_glyphs()\n"
-    "\n"
-    "Return the number of loaded glyphs\n";
+    "--\n\n"
+    "Return the number of loaded glyphs.\n";
 
 static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -584,10 +593,11 @@ static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args, PyObj
 }
 
 const char *PyFT2Font_load_char__doc__ =
-    "load_char(charcode, flags=LOAD_FORCE_AUTOHINT)\n"
-    "\n"
-    "Load character with charcode in current fontfile and set glyph.\n"
-    "The flags argument can be a bitwise-or of the LOAD_XXX constants.\n"
+    "load_char(charcode, flags=32)\n"
+    "--\n\n"
+    "Load character with *charcode* in current fontfile and set glyph.\n"
+    "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
+    "the default value is LOAD_FORCE_AUTOHINT.\n"
     "Return value is a Glyph object, with attributes\n"
     "  width          # glyph width\n"
     "  height         # glyph height\n"
@@ -622,10 +632,11 @@ static PyObject *PyFT2Font_load_char(PyFT2Font *self, PyObject *args, PyObject *
 }
 
 const char *PyFT2Font_load_glyph__doc__ =
-    "load_glyph(glyphindex, flags=LOAD_FORCE_AUTOHINT)\n"
-    "\n"
-    "Load character with glyphindex in current fontfile and set glyph.\n"
-    "The flags argument can be a bitwise-or of the LOAD_XXX constants.\n"
+    "load_glyph(glyphindex, flags=32)\n"
+    "--\n\n"
+    "Load character with *glyphindex* in current fontfile and set glyph.\n"
+    "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
+    "the default value is LOAD_FORCE_AUTOHINT.\n"
     "Return value is a Glyph object, with attributes\n"
     "  width          # glyph width\n"
     "  height         # glyph height\n"
@@ -660,11 +671,11 @@ static PyObject *PyFT2Font_load_glyph(PyFT2Font *self, PyObject *args, PyObject 
 }
 
 const char *PyFT2Font_get_width_height__doc__ =
-    "w, h = get_width_height()\n"
-    "\n"
-    "Get the width and height in 26.6 subpixels of the current string set by set_text\n"
+    "get_width_height()\n"
+    "--\n\n"
+    "Get the width and height in 26.6 subpixels of the current string set by `.set_text`.\n"
     "The rotation of the string is accounted for.  To get width and height\n"
-    "in pixels, divide these values by 64\n";
+    "in pixels, divide these values by 64.\n";
 
 static PyObject *PyFT2Font_get_width_height(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -676,10 +687,10 @@ static PyObject *PyFT2Font_get_width_height(PyFT2Font *self, PyObject *args, PyO
 }
 
 const char *PyFT2Font_get_bitmap_offset__doc__ =
-    "x, y = get_bitmap_offset()\n"
-    "\n"
-    "Get the offset in 26.6 subpixels for the bitmap if ink hangs left or below (0, 0).\n"
-    "Since matplotlib only supports left-to-right text, y is always 0.\n";
+    "get_bitmap_offset()\n"
+    "--\n\n"
+    "Get the (x, y) offset in 26.6 subpixels for the bitmap if ink hangs left or below (0, 0).\n"
+    "Since Matplotlib only supports left-to-right text, y is always 0.\n";
 
 static PyObject *PyFT2Font_get_bitmap_offset(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -691,9 +702,9 @@ static PyObject *PyFT2Font_get_bitmap_offset(PyFT2Font *self, PyObject *args, Py
 }
 
 const char *PyFT2Font_get_descent__doc__ =
-    "d = get_descent()\n"
-    "\n"
-    "Get the descent of the current string set by set_text in 26.6 subpixels.\n"
+    "get_descent()\n"
+    "--\n\n"
+    "Get the descent in 26.6 subpixels of the current string set by `.set_text`.\n"
     "The rotation of the string is accounted for.  To get the descent\n"
     "in pixels, divide this value by 64.\n";
 
@@ -708,9 +719,9 @@ static PyObject *PyFT2Font_get_descent(PyFT2Font *self, PyObject *args, PyObject
 
 const char *PyFT2Font_draw_glyphs_to_bitmap__doc__ =
     "draw_glyphs_to_bitmap()\n"
-    "\n"
-    "Draw the glyphs that were loaded by set_text to the bitmap\n"
-    "The bitmap size will be automatically set to include the glyphs\n";
+    "--\n\n"
+    "Draw the glyphs that were loaded by `.set_text` to the bitmap.\n"
+    "The bitmap size will be automatically set to include the glyphs.\n";
 
 static PyObject *PyFT2Font_draw_glyphs_to_bitmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -729,8 +740,8 @@ static PyObject *PyFT2Font_draw_glyphs_to_bitmap(PyFT2Font *self, PyObject *args
 
 const char *PyFT2Font_get_xys__doc__ =
     "get_xys()\n"
-    "\n"
-    "Get the xy locations of the current glyphs\n";
+    "--\n\n"
+    "Get the xy locations of the current glyphs.\n";
 
 static PyObject *PyFT2Font_get_xys(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -750,15 +761,15 @@ static PyObject *PyFT2Font_get_xys(PyFT2Font *self, PyObject *args, PyObject *kw
 
 const char *PyFT2Font_draw_glyph_to_bitmap__doc__ =
     "draw_glyph_to_bitmap(bitmap, x, y, glyph)\n"
-    "\n"
-    "Draw a single glyph to the bitmap at pixel locations x,y\n"
+    "--\n\n"
+    "Draw a single glyph to the bitmap at pixel locations x, y\n"
     "Note it is your responsibility to set up the bitmap manually\n"
-    "with set_bitmap_size(w,h) before this call is made.\n"
+    "with ``set_bitmap_size(w, h)`` before this call is made.\n"
     "\n"
-    "If you want automatic layout, use set_text in combinations with\n"
-    "draw_glyphs_to_bitmap.  This function is intended for people who\n"
-    "want to render individual glyphs at precise locations, eg, a\n"
-    "a glyph returned by load_char\n";
+    "If you want automatic layout, use `.set_text` in combinations with\n"
+    "`.draw_glyphs_to_bitmap`.  This function is instead intended for people\n"
+    "who want to render individual glyphs (e.g., returned by `.load_char`)\n"
+    "at precise locations.\n";
 
 static PyObject *PyFT2Font_draw_glyph_to_bitmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -791,11 +802,11 @@ static PyObject *PyFT2Font_draw_glyph_to_bitmap(PyFT2Font *self, PyObject *args,
 
 const char *PyFT2Font_get_glyph_name__doc__ =
     "get_glyph_name(index)\n"
+    "--\n\n"
+    "Retrieve the ASCII name of a given glyph *index* in a face.\n"
     "\n"
-    "Retrieves the ASCII name of a given glyph in a face.\n"
-    "\n"
-    "Due to Matplotlib's internal design, for fonts that do not contain glyph \n"
-    "names (per FT_FACE_FLAG_GLYPH_NAMES), this returns a made-up name which \n"
+    "Due to Matplotlib's internal design, for fonts that do not contain glyph\n"
+    "names (per FT_FACE_FLAG_GLYPH_NAMES), this returns a made-up name which\n"
     "does *not* roundtrip through `.get_name_index`.\n";
 
 static PyObject *PyFT2Font_get_glyph_name(PyFT2Font *self, PyObject *args, PyObject *kwds)
@@ -811,8 +822,8 @@ static PyObject *PyFT2Font_get_glyph_name(PyFT2Font *self, PyObject *args, PyObj
 
 const char *PyFT2Font_get_charmap__doc__ =
     "get_charmap()\n"
-    "\n"
-    "Returns a dictionary that maps the character codes of the selected charmap\n"
+    "--\n\n"
+    "Return a dict that maps the character codes of the selected charmap\n"
     "(Unicode by default) to their corresponding glyph indices.\n";
 
 static PyObject *PyFT2Font_get_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
@@ -841,9 +852,9 @@ static PyObject *PyFT2Font_get_charmap(PyFT2Font *self, PyObject *args, PyObject
 
 
 const char *PyFT2Font_get_char_index__doc__ =
-    "get_char_index()\n"
-    "\n"
-    "Given a character code, returns a glyph index.\n";
+    "get_char_index(codepoint)\n"
+    "--\n\n"
+    "Return the glyph index corresponding to a character *codepoint*.\n";
 
 static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -861,11 +872,11 @@ static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args, PyObj
 
 
 const char *PyFT2Font_get_sfnt__doc__ =
-    "get_sfnt(name)\n"
-    "\n"
-    "Get all values from the SFNT names table.  Result is a dictionary whose "
-    "key is the platform-ID, ISO-encoding-scheme, language-code, and "
-    "description.\n";
+    "get_sfnt()\n"
+    "--\n\n"
+    "Load the entire SFNT names table, as a dict whose keys are\n"
+    "(platform-ID, ISO-encoding-scheme, language-code, and description)\n"
+    "tuples.\n";
 
 static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -923,9 +934,9 @@ static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args, PyObject *k
 
 const char *PyFT2Font_get_name_index__doc__ =
     "get_name_index(name)\n"
-    "\n"
-    "Returns the glyph index of a given glyph name.\n"
-    "The glyph index 0 means `undefined character code'.\n";
+    "--\n\n"
+    "Return the glyph index of a given glyph *name*.\n"
+    "The glyph index 0 means 'undefined character code'.\n";
 
 static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -940,7 +951,7 @@ static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args, PyObj
 
 const char *PyFT2Font_get_ps_font_info__doc__ =
     "get_ps_font_info()\n"
-    "\n"
+    "--\n\n"
     "Return the information in the PS Font Info structure.\n";
 
 static PyObject *PyFT2Font_get_ps_font_info(PyFT2Font *self, PyObject *args, PyObject *kwds)
@@ -967,7 +978,7 @@ static PyObject *PyFT2Font_get_ps_font_info(PyFT2Font *self, PyObject *args, PyO
 
 const char *PyFT2Font_get_sfnt_table__doc__ =
     "get_sfnt_table(name)\n"
-    "\n"
+    "--\n\n"
     "Return one of the following SFNT tables: head, maxp, OS/2, hhea, "
     "vhea, post, or pclt.\n";
 
@@ -1269,7 +1280,7 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObj
 
 const char *PyFT2Font_get_path__doc__ =
     "get_path()\n"
-    "\n"
+    "--\n\n"
     "Get the path data from the currently loaded glyph as a tuple of vertices, "
     "codes.\n";
 
@@ -1280,8 +1291,8 @@ static PyObject *PyFT2Font_get_path(PyFT2Font *self, PyObject *args, PyObject *k
 
 const char *PyFT2Font_get_image__doc__ =
     "get_image()\n"
-    "\n"
-    "Returns the underlying image buffer for this font object.\n";
+    "--\n\n"
+    "Return the underlying image buffer for this font object.\n";
 
 static PyObject *PyFT2Font_get_image(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
@@ -1488,7 +1499,7 @@ static PyTypeObject *PyFT2Font_init_type(PyObject *m, PyTypeObject *type)
         {"get_ps_font_info", (PyCFunction)PyFT2Font_get_ps_font_info, METH_NOARGS, PyFT2Font_get_ps_font_info__doc__},
         {"get_sfnt_table", (PyCFunction)PyFT2Font_get_sfnt_table, METH_VARARGS, PyFT2Font_get_sfnt_table__doc__},
         {"get_path", (PyCFunction)PyFT2Font_get_path, METH_NOARGS, PyFT2Font_get_path__doc__},
-        {"get_image", (PyCFunction)PyFT2Font_get_image, METH_NOARGS, PyFT2Font_get_path__doc__},
+        {"get_image", (PyCFunction)PyFT2Font_get_image, METH_NOARGS, PyFT2Font_get_image__doc__},
         {NULL}
     };
 


### PR DESCRIPTION
## PR Summary

(See https://github.com/matplotlib/matplotlib/pull/15009 for the format.)

I know it's still not perfect, but let's do things incrementally...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
