### PR TITLE
Whitespace in Choosing Colormaps tutorial plots

### DIFF
--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -199,13 +199,13 @@ cmaps['Miscellaneous'] = [
 # First, we'll show the range of each colormap. Note that some seem
 # to change more "quickly" than others.
 
-nrows = max(len(cmap_list) for cmap_category, cmap_list in cmaps.items())
+nrows = [len(cmap_list) for cmap_category, cmap_list in cmaps.items()]
 gradient = np.linspace(0, 1, 256)
 gradient = np.vstack((gradient, gradient))
 
 
 def plot_color_gradients(cmap_category, cmap_list, nrows):
-    fig, axs = plt.subplots(nrows=nrows)
+    fig, axs = plt.subplots(nrows=nrows, figsize=(6, 0.24 * nrows))
     fig.subplots_adjust(top=0.95, bottom=0.01, left=0.2, right=0.99)
     axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
 
@@ -221,8 +221,8 @@ def plot_color_gradients(cmap_category, cmap_list, nrows):
         ax.set_axis_off()
 
 
-for cmap_category, cmap_list in cmaps.items():
-    plot_color_gradients(cmap_category, cmap_list, nrows)
+for i, (cmap_category, cmap_list) in enumerate(cmaps.items()):
+    plot_color_gradients(cmap_category, cmap_list, nrows[i])
 
 plt.show()
 

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -199,12 +199,12 @@ cmaps['Miscellaneous'] = [
 # First, we'll show the range of each colormap. Note that some seem
 # to change more "quickly" than others.
 
-nrows = [len(cmap_list) for cmap_category, cmap_list in cmaps.items()]
 gradient = np.linspace(0, 1, 256)
 gradient = np.vstack((gradient, gradient))
 
 
-def plot_color_gradients(cmap_category, cmap_list, nrows):
+def plot_color_gradients(cmap_category, cmap_list):
+    nrows = len(cmap_list)
     fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6, 0.29 * nrows))
     fig.subplots_adjust(top=1, bottom=0, left=0.2, right=0.99)
     axs[0].text(0.5, 0.5, cmap_category + " colormaps", fontsize=14,
@@ -223,8 +223,8 @@ def plot_color_gradients(cmap_category, cmap_list, nrows):
         ax.set_axis_off()
 
 
-for rows, (cmap_category, cmap_list) in zip(nrows, cmaps.items()):
-    plot_color_gradients(cmap_category, cmap_list, rows)
+for cmap_category, cmap_list in cmaps.items():
+    plot_color_gradients(cmap_category, cmap_list)
 
 plt.show()
 

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -204,19 +204,18 @@ gradient = np.vstack((gradient, gradient))
 
 
 def plot_color_gradients(cmap_category, cmap_list):
+    # Create figure and adjust figure height to number of colormaps
     nrows = len(cmap_list)
-    fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6, 0.29 * nrows))
-    fig.subplots_adjust(top=1, bottom=0, left=0.2, right=0.99)
-    axs[0].text(0.5, 0.5, cmap_category + " colormaps", fontsize=14,
-                transform=axs[0].transAxes, horizontalalignment="center",
-                verticalalignment="center")
+    figh = 0.35 + 0.15 + (nrows + (nrows - 1) * 0.1) * 0.22
+    fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6.4, figh))
+    fig.subplots_adjust(top=1 - 0.35 / figh, bottom=0.15 / figh,
+                        left=0.2, right=0.99)
+    axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
 
-    for ax, name in zip(axs[1:], cmap_list):
+    for ax, name in zip(axs, cmap_list):
         ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
-        pos = list(ax.get_position().bounds)
-        x_text = pos[0] - 0.01
-        y_text = pos[1] + pos[3]/2.
-        fig.text(x_text, y_text, name, va='center', ha='right', fontsize=10)
+        ax.text(-0.01, 0.5, name, va='center', ha='right', fontsize=10,
+                transform=ax.transAxes)
 
     # Turn off *all* ticks & spines, not just the ones with colormaps.
     for ax in axs:

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -205,11 +205,13 @@ gradient = np.vstack((gradient, gradient))
 
 
 def plot_color_gradients(cmap_category, cmap_list, nrows):
-    fig, axs = plt.subplots(nrows=nrows, figsize=(6, 0.24 * nrows))
-    fig.subplots_adjust(top=0.95, bottom=0.01, left=0.2, right=0.99)
-    axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
+    fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6, 0.29 * nrows))
+    fig.subplots_adjust(top=1, bottom=0, left=0.2, right=0.99)
+    axs[0].text(0.5, 0.5, cmap_category + " colormaps", fontsize=14,
+                transform=axs[0].transAxes, horizontalalignment="center",
+                verticalalignment="center")
 
-    for ax, name in zip(axs, cmap_list):
+    for ax, name in zip(axs[1:], cmap_list):
         ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
         pos = list(ax.get_position().bounds)
         x_text = pos[0] - 0.01

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -223,8 +223,8 @@ def plot_color_gradients(cmap_category, cmap_list, nrows):
         ax.set_axis_off()
 
 
-for i, (cmap_category, cmap_list) in enumerate(cmaps.items()):
-    plot_color_gradients(cmap_category, cmap_list, nrows[i])
+for rows, (cmap_category, cmap_list) in zip(nrows, cmaps.items()):
+    plot_color_gradients(cmap_category, cmap_list, rows)
 
 plt.show()
 


### PR DESCRIPTION
## PR Summary
This should solve #19308. However, I'm not sure if setting figsize explicitly is the way to go.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
