### PR TITLE
Deprecate angleA/B parameters of bracket arrowstyles.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19327-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19327-AL.rst
@@ -1,0 +1,4 @@
+*angleA*, *angleB* parameters of bracket arrowstyles
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Then *angleA* and *angleB* parameters of the ``]-``, ``-[``, ``]-[``, and ``|-|``
+arrowstyles have no effect and are deprecated.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3188,6 +3188,9 @@ class ArrowStyle(_Style):
 
     class _Bracket(_Base):
 
+        # angleA and angleB are deprecated as of 3.4, but delete_parameter is
+        # only applied on the public subclasses (to avoid triggering a spurious
+        # warning when None is forwarded by super-calls).
         def __init__(self, bracketA=None, bracketB=None,
                      widthA=1., widthB=1.,
                      lengthA=0.2, lengthB=0.2,
@@ -3267,6 +3270,8 @@ class ArrowStyle(_Style):
     class BracketAB(_Bracket):
         """An arrow with outward square brackets at both ends."""
 
+        @_api.delete_parameter("3.4", "angleA")
+        @_api.delete_parameter("3.4", "angleB")
         def __init__(self,
                      widthA=1., lengthA=0.2, angleA=None,
                      widthB=1., lengthB=0.2, angleB=None):
@@ -3299,6 +3304,7 @@ class ArrowStyle(_Style):
     class BracketA(_Bracket):
         """An arrow with an outward square bracket at its start."""
 
+        @_api.delete_parameter("3.4", "angleA")
         def __init__(self, widthA=1., lengthA=0.2, angleA=None):
             """
             Parameters
@@ -3319,6 +3325,7 @@ class ArrowStyle(_Style):
     class BracketB(_Bracket):
         """An arrow with an outward square bracket at its end."""
 
+        @_api.delete_parameter("3.4", "angleB")
         def __init__(self, widthB=1., lengthB=0.2, angleB=None):
             """
             Parameters
@@ -3339,6 +3346,8 @@ class ArrowStyle(_Style):
     class BarAB(_Bracket):
         """An arrow with vertical bars ``|`` at both ends."""
 
+        @_api.delete_parameter("3.4", "angleA")
+        @_api.delete_parameter("3.4", "angleB")
         def __init__(self,
                      widthA=1., angleA=None,
                      widthB=1., angleB=None):


### PR DESCRIPTION
They actually have no accompanying implementation and have no effect (as
can be checked e.g. with
```
annotate("", (.4, .5), (.6, .5),
         arrowprops=dict(arrowstyle=mpl.patches.ArrowStyle("]-[", angleA=45, lengthB=5)))
```

Perhaps the feature (rotating the brackets) makes sense, but we can
always restore it when someone puts in an implementation).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
