### PR TITLE
Explain annotation behavior when used in conjunction with arrows

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1675,7 +1675,9 @@ class Annotation(Text, _AnnotationBase):
 
         arrowprops : dict, optional
             The properties used to draw a `.FancyArrowPatch` arrow between the
-            positions *xy* and *xytext*.
+            positions *xy* and *xytext*. Note that the edge of the arrow pointing
+            to *xytext* will be centered on the text itself and may not point
+            directly to the coordinates given in *xytext*.
 
             If *arrowprops* does not contain the key 'arrowstyle' the
             allowed keys are:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1675,9 +1675,9 @@ class Annotation(Text, _AnnotationBase):
 
         arrowprops : dict, optional
             The properties used to draw a `.FancyArrowPatch` arrow between the
-            positions *xy* and *xytext*. Note that the edge of the arrow pointing
-            to *xytext* will be centered on the text itself and may not point
-            directly to the coordinates given in *xytext*.
+            positions *xy* and *xytext*. Note that the edge of the arrow
+            pointing to *xytext* will be centered on the text itself and may
+            not point directly to the coordinates given in *xytext*.
 
             If *arrowprops* does not contain the key 'arrowstyle' the
             allowed keys are:


### PR DESCRIPTION
## PR Summary
Closes #19084. Added a note in the documentation to describe the behavior of annotations when used with arrows.

## PR Checklist
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
