### PR TITLE
Fix building against system qhull

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ from distutils.errors import CompileError
 from distutils.dist import Distribution
 
 import setupext
-from setupext import (
-    get_and_extract_tarball, print_raw, print_status, LOCAL_QHULL_VERSION)
+from setupext import print_raw, print_status
 
 # Get the version from versioneer
 import versioneer
@@ -61,6 +60,7 @@ mpl_packages = [
     setupext.Python(),
     setupext.Platform(),
     setupext.FreeType(),
+    setupext.Qhull(),
     setupext.SampleData(),
     setupext.Tests(),
     setupext.BackendMacOSX(),
@@ -86,18 +86,8 @@ class NoopTestCommand(TestCommand):
               "'python setup.py test'. Please run 'pytest'.")
 
 
-def _download_qhull():
-    toplevel = get_and_extract_tarball(
-        urls=["http://www.qhull.org/download/qhull-2020-src-8.0.2.tgz"],
-        sha="b5c2d7eb833278881b952c8a52d20179eab87766b00b865000469a45c1838b7e",
-        dirname=f"qhull-{LOCAL_QHULL_VERSION}",
-    )
-    shutil.copyfile(toplevel / "COPYING.txt", "LICENSE/LICENSE_QHULL")
-
-
 class BuildExtraLibraries(BuildExtCommand):
     def finalize_options(self):
-        _download_qhull()
         self.distribution.ext_modules[:] = [
             ext
             for package in good_packages

--- a/setupext.py
+++ b/setupext.py
@@ -384,7 +384,7 @@ class Matplotlib(SetupPackage):
             ])
         add_numpy_flags(ext)
         add_libagg_flags_and_sources(ext)
-        FreeType().add_flags(ext)
+        FreeType.add_flags(ext)
         yield ext
         # c_internal_utils
         ext = Extension(
@@ -412,7 +412,7 @@ class Matplotlib(SetupPackage):
                 "src/mplutils.cpp",
                 "src/py_converters.cpp",
             ])
-        FreeType().add_flags(ext)
+        FreeType.add_flags(ext)
         add_numpy_flags(ext)
         add_libagg_flags(ext)
         yield ext
@@ -569,7 +569,8 @@ def add_qhull_flags(ext):
 class FreeType(SetupPackage):
     name = "freetype"
 
-    def add_flags(self, ext):
+    @classmethod
+    def add_flags(cls, ext):
         ext.sources.insert(0, 'src/checkdep_freetype2.c')
         if options.get('system_freetype'):
             pkg_config_setup_extension(


### PR DESCRIPTION
## PR Summary

It always tries to download it, even with the option set. It also links against `qhull`, but should use `qhull_r` now.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).