### PR TITLE
Remove register storage class from Agg files.

### DIFF
--- a/extern/agg24-svn/include/agg_basics.h
+++ b/extern/agg24-svn/include/agg_basics.h
@@ -228,7 +228,7 @@ namespace agg
     {
         AGG_INLINE static unsigned mul(unsigned a, unsigned b)
         {
-            register unsigned q = a * b + (1 << (Shift-1));
+            unsigned q = a * b + (1 << (Shift-1));
             return (q + (q >> Shift)) >> Shift;
         }
     };

--- a/extern/agg24-svn/include/agg_image_accessors.h
+++ b/extern/agg24-svn/include/agg_image_accessors.h
@@ -174,8 +174,8 @@ namespace agg
     private:
         AGG_INLINE const int8u* pixel() const
         {
-            register int x = m_x;
-            register int y = m_y;
+            int x = m_x;
+            int y = m_y;
             if(x < 0) x = 0;
             if(y < 0) y = 0;
             if(x >= (int)m_pixf->width())  x = m_pixf->width() - 1;

--- a/extern/agg24-svn/include/agg_trans_affine.h
+++ b/extern/agg24-svn/include/agg_trans_affine.h
@@ -292,7 +292,7 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::transform(double* x, double* y) const
     {
-        register double tmp = *x;
+        double tmp = *x;
         *x = tmp * sx  + *y * shx + tx;
         *y = tmp * shy + *y * sy  + ty;
     }
@@ -300,7 +300,7 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::transform_2x2(double* x, double* y) const
     {
-        register double tmp = *x;
+        double tmp = *x;
         *x = tmp * sx  + *y * shx;
         *y = tmp * shy + *y * sy;
     }
@@ -308,9 +308,9 @@ namespace agg
     //------------------------------------------------------------------------
     inline void trans_affine::inverse_transform(double* x, double* y) const
     {
-        register double d = determinant_reciprocal();
-        register double a = (*x - tx) * d;
-        register double b = (*y - ty) * d;
+        double d = determinant_reciprocal();
+        double a = (*x - tx) * d;
+        double b = (*y - ty) * d;
         *x = a * sy - b * shx;
         *y = b * sx - a * shy;
     }

--- a/extern/agg24-svn/src/platform/win32/agg_platform_support.cpp
+++ b/extern/agg24-svn/src/platform/win32/agg_platform_support.cpp
@@ -1480,7 +1480,7 @@ namespace agg
         tok.len = 0;
         if(m_src_string == 0 || m_start == -1) return tok;
 
-        register const char *pstr = m_src_string + m_start;
+        const char *pstr = m_src_string + m_start;
 
         if(*pstr == 0) 
         {


### PR DESCRIPTION
## PR Summary

This storage class has been removed from C++17, and causes a warning when compiling with latest gcc:

```
warning: ISO C++17 does not allow ‘register’ storage class specifier
```

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).