### PR TITLE
Skip an ImageMagick test if ffmpeg is unavailable.

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -201,6 +201,10 @@ def test_save_animation_smoketest(tmpdir, writer, frame_format, output, anim):
 ])
 @pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_animation_repr_html(writer, html, want, anim):
+    if (writer == 'imagemagick' and html == 'html5'
+            # ImageMagick delegates to ffmpeg for this format.
+            and not animation.FFMpegWriter.isAvailable()):
+        pytest.skip('Requires FFMpeg')
     # create here rather than in the fixture otherwise we get __del__ warnings
     # about producing no output
     anim = animation.FuncAnimation(**anim)


### PR DESCRIPTION
## PR Summary

For certain formats, ImageMagick delegates to ffmpeg.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).