### PR TITLE
Prefer concatenate to h/vstack in simple cases.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4810,8 +4810,8 @@ default: :rc:`scatter.edgecolors`
                     else:
                         lattice2[i, j] = np.nan
 
-            accum = np.hstack((lattice1.astype(float).ravel(),
-                               lattice2.astype(float).ravel()))
+            accum = np.concatenate([lattice1.astype(float).ravel(),
+                                    lattice2.astype(float).ravel()])
             good_idxs = ~np.isnan(accum)
 
         offsets = np.zeros((n, 2), float)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1252,7 +1252,7 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
             stats['whislo'] = np.min(wisklo)
 
         # compute a single array of outliers
-        stats['fliers'] = np.hstack([
+        stats['fliers'] = np.concatenate([
             x[x < stats['whislo']],
             x[x > stats['whishi']],
         ])

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -608,10 +608,10 @@ class MarkerStyle:
         else:
             verts = polypath.vertices
 
-            top = Path(np.vstack((verts[0:4, :], verts[7:10, :], verts[0])))
-            bottom = Path(np.vstack((verts[3:8, :], verts[3])))
-            left = Path(np.vstack((verts[0:6, :], verts[0])))
-            right = Path(np.vstack((verts[0], verts[5:10, :], verts[0])))
+            top = Path(np.concatenate([verts[0:4], verts[7:10], verts[0:1]]))
+            bottom = Path(np.concatenate([verts[3:8], verts[3:4]]))
+            left = Path(np.concatenate([verts[0:6], verts[0:1]]))
+            right = Path(np.concatenate([verts[0:1], verts[5:10], verts[0:1]]))
 
             if fs == 'top':
                 mpath, mpath_alt = top, bottom
@@ -641,10 +641,10 @@ class MarkerStyle:
 
             # not drawing inside lines
             x = np.abs(np.cos(5 * np.pi / 6.))
-            top = Path(np.vstack(([-x, 0], verts[(1, 0, 5), :], [x, 0])))
-            bottom = Path(np.vstack(([-x, 0], verts[2:5, :], [x, 0])))
-            left = Path(verts[(0, 1, 2, 3), :])
-            right = Path(verts[(0, 5, 4, 3), :])
+            top = Path(np.concatenate([[(-x, 0)], verts[[1, 0, 5]], [(x, 0)]]))
+            bottom = Path(np.concatenate([[(-x, 0)], verts[2:5], [(x, 0)]]))
+            left = Path(verts[0:4])
+            right = Path(verts[[0, 5, 4, 3]])
 
             if fs == 'top':
                 mpath, mpath_alt = top, bottom
@@ -675,11 +675,12 @@ class MarkerStyle:
 
             # not drawing inside lines
             x, y = np.sqrt(3) / 4, 3 / 4.
-            top = Path(verts[(1, 0, 5, 4, 1), :])
-            bottom = Path(verts[(1, 2, 3, 4), :])
-            left = Path(np.vstack(([x, y], verts[(0, 1, 2), :],
-                                   [-x, -y], [x, y])))
-            right = Path(np.vstack(([x, y], verts[(5, 4, 3), :], [-x, -y])))
+            top = Path(verts[[1, 0, 5, 4, 1]])
+            bottom = Path(verts[1:5])
+            left = Path(np.concatenate([
+                [(x, y)], verts[:3], [(-x, -y), (x, y)]]))
+            right = Path(np.concatenate([
+                [(x, y)], verts[5:2:-1], [(-x, -y)]]))
 
             if fs == 'top':
                 mpath, mpath_alt = top, bottom

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -994,14 +994,14 @@ class StepPatch(PathPatch):
             x = np.repeat(self._edges[idx0:idx1+1], 2)
             y = np.repeat(self._values[idx0:idx1], 2)
             if self._baseline is None:
-                y = np.hstack((y[0], y, y[-1]))
+                y = np.concatenate([y[:1], y, y[-1:]])
             elif self._baseline.ndim == 0:  # single baseline value
-                y = np.hstack((self._baseline, y, self._baseline))
+                y = np.concatenate([[self._baseline], y, [self._baseline]])
             elif self._baseline.ndim == 1:  # baseline array
                 base = np.repeat(self._baseline[idx0:idx1], 2)[::-1]
                 x = np.concatenate([x, x[::-1]])
-                y = np.concatenate([np.hstack((base[-1], y, base[0],
-                                               base[0], base, base[-1]))])
+                y = np.concatenate([base[-1:], y, base[:1],
+                                    base[:1], base, base[-1:]])
             else:  # no baseline
                 raise ValueError('Invalid `baseline` specified')
             if self.orientation == 'vertical':
@@ -1179,13 +1179,16 @@ class Wedge(Patch):
             # followed by a reversed and scaled inner ring
             v1 = arc.vertices
             v2 = arc.vertices[::-1] * (self.r - self.width) / self.r
-            v = np.vstack([v1, v2, v1[0, :], (0, 0)])
-            c = np.hstack([arc.codes, arc.codes, connector, Path.CLOSEPOLY])
+            v = np.concatenate([v1, v2, [v1[0, :], (0, 0)]])
+            c = np.concatenate([
+                arc.codes, arc.codes, [connector, Path.CLOSEPOLY]])
             c[len(arc.codes)] = connector
         else:
             # Wedge doesn't need an inner ring
-            v = np.vstack([arc.vertices, [(0, 0), arc.vertices[0, :], (0, 0)]])
-            c = np.hstack([arc.codes, [connector, connector, Path.CLOSEPOLY]])
+            v = np.concatenate([
+                arc.vertices, [(0, 0), arc.vertices[0, :], (0, 0)]])
+            c = np.concatenate([
+                arc.codes, [connector, connector, Path.CLOSEPOLY]])
 
         # Shift and scale the wedge to the final location.
         v *= self.r

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2139,18 +2139,16 @@ class MaxNLocator(Locator):
             raise ValueError('steps argument must be an increasing sequence '
                              'of numbers between 1 and 10 inclusive')
         if steps[0] != 1:
-            steps = np.hstack((1, steps))
+            steps = np.concatenate([[1], steps])
         if steps[-1] != 10:
-            steps = np.hstack((steps, 10))
+            steps = np.concatenate([steps, [10]])
         return steps
 
     @staticmethod
     def _staircase(steps):
-        # Make an extended staircase within which the needed
-        # step will be found.  This is probably much larger
-        # than necessary.
-        flights = (0.1 * steps[:-1], steps, 10 * steps[1])
-        return np.hstack(flights)
+        # Make an extended staircase within which the needed step will be
+        # found.  This is probably much larger than necessary.
+        return np.concatenate([0.1 * steps[:-1], steps, [10 * steps[1]]])
 
     def set_params(self, **kwargs):
         """


### PR DESCRIPTION
concatenate is (much) faster than hstack, while being essentially
equivalent in the 1D case; when working on 2D arrays it can replace
vstack too.

Timings:
```
In [1]: u = np.arange(5)

In [2]: %timeit np.concatenate([u, u])
842 ns ± 8.16 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [3]: %timeit np.hstack([u, u])
2.43 µs ± 7.43 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [4]: u = np.arange(1000)

In [5]: %timeit np.concatenate([u, u])
1.2 µs ± 2.67 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [6]: %timeit np.hstack([u, u])
2.9 µs ± 10.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [7]: u = np.arange(10).reshape((5, 2))

In [8]: %timeit np.concatenate([u, u])
934 ns ± 19.9 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [9]: %timeit np.vstack([u, u])
2.54 µs ± 7.55 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [10]: u = np.arange(2000).reshape((1000, 2))

In [11]: %timeit np.concatenate([u, u])
1.61 µs ± 2.64 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [12]: %timeit np.vstack([u, u])
3.37 µs ± 17.1 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
