### PR TITLE
Fix qt backend on mac big sur

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -183,7 +183,7 @@ else:  # We should not get there.
 # Fixes issues with Big Sur
 # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
 if (sys.platform == 'darwin' and
-    LooseVersion(QtCore.qVersion()) < LooseVersion('5.15.2')):
+        LooseVersion(QtCore.qVersion()) < LooseVersion('5.15.2')):
     os.environ['QT_MAC_WANTS_LAYER'] = '1'
 
 

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -180,6 +180,13 @@ else:  # We should not get there.
     raise AssertionError("Unexpected QT_API: {}".format(QT_API))
 
 
+# Fixes issues with Big Sur
+# https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
+if (sys.platform == 'darwin' and
+    LooseVersion(QtCore.qVersion()) < LooseVersion('5.15.2')):
+    os.environ['QT_MAC_WANTS_LAYER'] = '1'
+
+
 # These globals are only defined for backcompatibility purposes.
 ETS = dict(pyqt=(QT_API_PYQTv2, 4), pyside=(QT_API_PYSIDE, 4),
            pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -15,6 +15,7 @@ Support for PyQt4 is deprecated.
 
 from distutils.version import LooseVersion
 import os
+import platform
 import sys
 
 import matplotlib as mpl
@@ -183,8 +184,10 @@ else:  # We should not get there.
 # Fixes issues with Big Sur
 # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
 if (sys.platform == 'darwin' and
-        LooseVersion(QtCore.qVersion()) < LooseVersion('5.15.2')):
-    os.environ['QT_MAC_WANTS_LAYER'] = '1'
+        LooseVersion(platform.mac_ver()[0]) >= LooseVersion("10.16") and
+        LooseVersion(QtCore.qVersion()) < LooseVersion("5.15.2") and
+        "QT_MAC_WANTS_LAYER" not in os.environ):
+    os.environ["QT_MAC_WANTS_LAYER"] = "1"
 
 
 # These globals are only defined for backcompatibility purposes.


### PR DESCRIPTION
## PR Summary

The qt backend is not working on mac big sur as reported in #18954.
It is fixed in qt 5.15.2 (https://codereview.qt-project.org/c/qt/qtbase/+/322228) and in the coming 5.12.11 (https://codereview.qt-project.org/c/qt/qtbase/+/322507) but setting this environment variable is necessary for qt <5.15.2.

Even if in a ideal word `matplotlib` shouldn't be setting this variable environment, this is pragmatic and very convenient fix!

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
