### PR TITLE
Revert "Deprecate setting Line2D's pickradius via set_picker."

### DIFF
--- a/doc/api/next_api_changes/deprecations/19336-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19336-AL.rst
@@ -1,0 +1,3 @@
+Setting a Line2D's pickradius via ``set_picker`` is undeprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This cancels the deprecation introduced in Matplotlib 3.3.0.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -539,7 +539,7 @@ class Artist:
 
         Parameters
         ----------
-        picker : None or bool or callable
+        picker : None or bool or float or callable
             This can be one of the following:
 
             - *None*: Picking is disabled for this artist (default).
@@ -547,6 +547,14 @@ class Artist:
             - A boolean: If *True* then picking will be enabled and the
               artist will fire a pick event if the mouse event is over
               the artist.
+
+            - A float: If picker is a number it is interpreted as an
+              epsilon tolerance in points and the artist will fire
+              off an event if its data is within epsilon of the mouse
+              event.  For some artists like lines and patch collections,
+              the artist may provide additional data to the pick event
+              that is generated, e.g., the indices of the data within
+              epsilon of the pick event
 
             - A function: If picker is callable, it is a user supplied
               function which determines whether the artist is hit by the
@@ -557,11 +565,6 @@ class Artist:
               to determine the hit test.  if the mouse event is over the
               artist, return *hit=True* and props is a dictionary of
               properties you want added to the PickEvent attributes.
-
-            - *deprecated*: For `.Line2D` only, *picker* can also be a float
-              that sets the tolerance for checking whether an event occurred
-              "on" the line; this is deprecated.  Use `.Line2D.set_pickradius`
-              instead.
         """
         self._picker = picker
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -397,6 +397,8 @@ class Line2D(Artist):
         self.update(kwargs)
         self.pickradius = pickradius
         self.ind_offset = 0
+        if isinstance(self._picker, Number):
+            self.pickradius = self._picker
 
         self._xorig = np.asarray([])
         self._yorig = np.asarray([])
@@ -601,13 +603,17 @@ class Line2D(Artist):
         return self._markevery
 
     def set_picker(self, p):
-        # docstring inherited
-        if isinstance(p, Number) and not isinstance(p, bool):
-            # After deprecation, the whole method can be deleted and inherited.
-            _api.warn_deprecated(
-                "3.3", message="Setting the line's pick radius via set_picker "
-                "is deprecated since %(since)s and will be removed "
-                "%(removal)s; use set_pickradius instead.")
+        """
+        Sets the event picker details for the line.
+
+        Parameters
+        ----------
+        p : float or callable[[Artist, Event], Tuple[bool, dict]]
+            If a float, it is used as the pick radius in points.
+        """
+        if callable(p):
+            self._contains = p
+        else:
             self.pickradius = p
         self._picker = p
 


### PR DESCRIPTION
This partially reverts commit a2de5bbe3437e19c2886cf481b8a53e714a1ae51 (#16154).
(The cleanup to legend_picking.py is kept; using `set_picker` here there
fine.)

See discussion at https://github.com/matplotlib/matplotlib/issues/19039#issuecomment-764915803.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
