### PR TITLE
Make YearLocator a subclass of RRuleLocator

### DIFF
--- a/doc/api/next_api_changes/removals/19348-OE.rst
+++ b/doc/api/next_api_changes/removals/19348-OE.rst
@@ -1,6 +1,6 @@
 Removed ``dates.YearLocator.replaced`` attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`.YearLocator` is now a subclass of `RRuleLocator`, and the attribute
+`.YearLocator` is now a subclass of `.RRuleLocator`, and the attribute
 ``YearLocator.replaced`` has been removed. For tick locations that
-required modifying this, a custom rrule and ``RRuleLocator`` can be used instead.
+required modifying this, a custom rrule and `.RRuleLocator` can be used instead.

--- a/doc/api/next_api_changes/removals/19348-OE.rst
+++ b/doc/api/next_api_changes/removals/19348-OE.rst
@@ -1,5 +1,6 @@
-``dates.YearLocator`` attribute
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Removed ``dates.YearLocator.replaced`` attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The attribute ``YearLocator.replaced`` has been removed. For tick locations which
+`.YearLocator` is now a subclass of `RRuleLocator`, and the attribute
+``YearLocator.replaced`` has been removed. For tick locations that
 required modifying this, a custom rrule and ``RRuleLocator`` can be used instead.

--- a/doc/api/next_api_changes/removals/19348-OE.rst
+++ b/doc/api/next_api_changes/removals/19348-OE.rst
@@ -1,0 +1,5 @@
+``dates.YearLocator`` attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The attribute ``YearLocator.replaced`` has been removed. For tick locations which
+required modifying this, a custom rrule and ``RRuleLocator`` can be used instead.

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -197,6 +197,18 @@ def test_RRuleLocator_dayrange():
     # On success, no overflow error shall be thrown
 
 
+def test_RRuleLocator_close_minmax():
+    # if d1 and d2 are very close together, rrule cannot create
+    # reasonable tick intervals; ensure that this is handled properly
+    rrule = mdates.rrulewrapper(dateutil.rrule.SECONDLY, interval=5)
+    loc = mdates.RRuleLocator(rrule)
+    d1 = datetime.datetime(year=2020, month=1, day=1)
+    d2 = datetime.datetime(year=2020, month=1, day=1, microsecond=1)
+    expected = ['2020-01-01 00:00:00+00:00',
+                '2020-01-01 00:00:00.000001+00:00']
+    assert list(map(str, mdates.num2date(loc.tick_values(d1, d2)))) == expected
+
+
 @image_comparison(['DateFormatter_fractionalSeconds.png'])
 def test_DateFormatter():
     import matplotlib.testing.jpl_units as units
@@ -990,6 +1002,10 @@ def test_YearLocator():
                  '2100-05-16 00:00:00+00:00', '2120-05-16 00:00:00+00:00',
                  '2140-05-16 00:00:00+00:00', '2160-05-16 00:00:00+00:00',
                  '2180-05-16 00:00:00+00:00', '2200-05-16 00:00:00+00:00']
+                ],
+               [datetime.timedelta(weeks=52 * 5),
+                {'base': 20, 'month': 9, 'day': 25},
+                ['1980-09-25 00:00:00+00:00', '2000-09-25 00:00:00+00:00']
                 ],
                )
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -980,8 +980,8 @@ def test_YearLocator():
     def _create_year_locator(date1, date2, **kwargs):
         locator = mdates.YearLocator(**kwargs)
         locator.create_dummy_axis()
-        locator.set_view_interval(mdates.date2num(date1),
-                                  mdates.date2num(date2))
+        locator.axis.set_view_interval(mdates.date2num(date1),
+                                       mdates.date2num(date2))
         return locator
 
     d1 = datetime.datetime(1990, 1, 1)

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -964,6 +964,41 @@ def test_yearlocator_pytz():
     assert st == expected
 
 
+def test_YearLocator():
+    def _create_year_locator(date1, date2, **kwargs):
+        locator = mdates.YearLocator(**kwargs)
+        locator.create_dummy_axis()
+        locator.set_view_interval(mdates.date2num(date1),
+                                  mdates.date2num(date2))
+        return locator
+
+    d1 = datetime.datetime(1990, 1, 1)
+    results = ([datetime.timedelta(weeks=52 * 200),
+                {'base': 20, 'month': 1, 'day': 1},
+                ['1980-01-01 00:00:00+00:00', '2000-01-01 00:00:00+00:00',
+                 '2020-01-01 00:00:00+00:00', '2040-01-01 00:00:00+00:00',
+                 '2060-01-01 00:00:00+00:00', '2080-01-01 00:00:00+00:00',
+                 '2100-01-01 00:00:00+00:00', '2120-01-01 00:00:00+00:00',
+                 '2140-01-01 00:00:00+00:00', '2160-01-01 00:00:00+00:00',
+                 '2180-01-01 00:00:00+00:00', '2200-01-01 00:00:00+00:00']
+                ],
+               [datetime.timedelta(weeks=52 * 200),
+                {'base': 20, 'month': 5, 'day': 16},
+                ['1980-05-16 00:00:00+00:00', '2000-05-16 00:00:00+00:00',
+                 '2020-05-16 00:00:00+00:00', '2040-05-16 00:00:00+00:00',
+                 '2060-05-16 00:00:00+00:00', '2080-05-16 00:00:00+00:00',
+                 '2100-05-16 00:00:00+00:00', '2120-05-16 00:00:00+00:00',
+                 '2140-05-16 00:00:00+00:00', '2160-05-16 00:00:00+00:00',
+                 '2180-05-16 00:00:00+00:00', '2200-05-16 00:00:00+00:00']
+                ],
+               )
+
+    for delta, arguments, expected in results:
+        d2 = d1 + delta
+        locator = _create_year_locator(d1, d2, **arguments)
+        assert list(map(str, mdates.num2date(locator()))) == expected
+
+
 def test_DayLocator():
     with pytest.raises(ValueError):
         mdates.DayLocator(interval=-1)


### PR DESCRIPTION
## PR Summary

This makes  the YearLocator a subclass of RRuleLocator instead of DateLocator.

Advantanges:
  - less custom code, tick positions are now determined through rrule, pytz is now handled through the rrulewrapper
  - easier implementation of locators for potential timedelta support (#19236)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
