### PR TITLE
Install matplotlib before test dependencies on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,15 +84,15 @@ steps:
   displayName: 'Install dependencies'
 
 - bash: |
+    python -m pip install -ve . ||
+      [[ "$PYTHON_VERSION" = 'Pre' ]]
+  displayName: "Install self"
+
+- bash: |
     python -m pip install --upgrade pip
     python -m pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis_extra.txt ||
       [[ "$PYTHON_VERSION" = 'Pre' ]]
   displayName: 'Install dependencies with pip'
-
-- bash: |
-    python -m pip install -ve . ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
-  displayName: "Install self"
 
 - script: env
   displayName: 'print env'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,14 +84,12 @@ steps:
   displayName: 'Install dependencies'
 
 - bash: |
-    python -m pip install -ve . ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
+    python -m pip install -ve .
   displayName: "Install self"
 
 - bash: |
     python -m pip install --upgrade pip
-    python -m pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis_extra.txt ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
+    python -m pip install -r requirements/testing/travis_all.txt -r requirements/testing/travis_extra.txt
   displayName: 'Install dependencies with pip'
 
 - script: env


### PR DESCRIPTION
Possibly fixes https://github.com/matplotlib/matplotlib/issues/19352. I think it might be better to try installing matplotlib first anyway, so if that fails there hasn't been a load of wasted time installing the test dependencies. Maybe I've missed something though.