### PR TITLE
Fix half-filled markers protrusion

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -519,15 +519,13 @@ class MarkerStyle:
         if not self._half_fill():
             self._path = Path.unit_rectangle()
         else:
-            # Build a bottom filled square out of two rectangles, one filled.
-            self._path = Path([[0.0, 0.0], [1.0, 0.0], [1.0, 0.5],
-                               [0.0, 0.5], [0.0, 0.0]])
-            self._alt_path = Path([[0.0, 0.5], [1.0, 0.5], [1.0, 1.0],
-                                   [0.0, 1.0], [0.0, 0.5]])
+            self._path = self._alt_path = Path(  # Half-square.
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 0.5], [0.0, 0.5], [0.0, 0.0]],
+                closed=True)
             fs = self.get_fillstyle()
             rotate = {'bottom': 0, 'right': 90, 'top': 180, 'left': 270}[fs]
             self._transform.rotate_deg(rotate)
-            self._alt_transform = self._transform
+            self._alt_transform = self._transform.frozen().rotate_deg(180)
 
         self._joinstyle = JoinStyle.miter
 
@@ -537,17 +535,21 @@ class MarkerStyle:
         if not self._half_fill():
             self._path = Path.unit_rectangle()
         else:
-            self._path = Path([[0, 0], [1, 0], [1, 1], [0, 0]])
-            self._alt_path = Path([[0, 0], [0, 1], [1, 1], [0, 0]])
+            eps = 1e-3  # Don't let the miter joins protrude.
+            self._path = self._alt_path = Path(
+                [[eps, eps], [eps, 0], [1, 0], [1, 1-eps], [1-eps, 1-eps],
+                 [eps, eps]], closed=True)
             fs = self.get_fillstyle()
-            rotate = {'right': 0, 'top': 90, 'left': 180, 'bottom': 270}[fs]
+            rotate = {'bottom': 0, 'right': 90, 'top': 180, 'left': 270}[fs]
             self._transform.rotate_deg(rotate)
-            self._alt_transform = self._transform
-        self._joinstyle = JoinStyle.miter
+            self._alt_transform = self._transform.frozen().rotate_deg(180)
+        self._joinstyle = 'miter'
 
     def _set_thin_diamond(self):
         self._set_diamond()
         self._transform.scale(0.6, 1.0)
+        if self._alt_transform:
+            self._alt_transform.scale(0.6, 1.0)
 
     def _set_pentagon(self):
         self._transform = Affine2D().scale(0.5)


### PR DESCRIPTION
Don't let the miter joins protrude by manually cropping them (#14357).  This is
currently only implemented for diamond, but others should work
"similarly".  However, this reveals a bug(?) in Agg's handling of
miter with close corners, which does not handle that case correctly.
(pdf, ps, svg, and cairo all handle it fine).

Also don't forget a closepoly on half-filled squares.

Goes on top of https://github.com/matplotlib/matplotlib/pull/19357.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
