### PR TITLE
FIX: aggressively downsample very large images

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -167,6 +167,22 @@ def _resample(
     Image object *image_obj*.
     """
 
+    # pre-decimate if data is ridiculously large compared to out_shape:
+    raty = int(data.shape[0] / out_shape[0])
+    if raty > 5e2:
+        raty = int(raty / 1000)
+        data = data[::raty, :]
+    else:
+        raty = 1
+    ratx = int(data.shape[1] / out_shape[1])
+    if ratx > 5e2:
+        ratx = int(ratx / 1000)
+        data = data[:, ::ratx]
+    else:
+        ratx = 1
+    if (ratx > 1) or (raty > 1):
+        transform = transform + Affine2D().scale(sx=ratx, sy=raty)
+
     # decide if we need to apply anti-aliasing if the data is upsampled:
     # compare the number of displayed pixels to the number of
     # the data pixels.


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/19276

Agg doesn't like to downsample really large images.   This PR just downsamples (with no filtering) the incoming image if the resample is more than a factor of 500.  

Needs a test, but now 
```python
import numpy as np
import matplotlib.pyplot as plt

# Very large
array = np.zeros(150_000_000, dtype=np.uint8)
array[len(array) // 2:] = 1
fig, ax = plt.subplots(figsize=(10, 3))
im = ax.imshow(array.reshape(1, -1), vmin=0, vmax=1, aspect='auto')
fig.colorbar(im, ax=ax)

# 10x smaller
array = np.zeros(15_000_000, dtype=np.uint8)
array[len(array) // 2:] = 1
print('array', array[0], array[-1])
fig, ax = plt.subplots(figsize=(10, 3))
im = ax.imshow(array.reshape(1, -1), vmin=0, vmax=1, aspect='auto') #, interpolation='nearest', interp_postrgba=True)
fig.colorbar(im, ax=ax)

plt.show()
```

works fine.

