### PR TITLE
Deprecate imread() reading from URLs

### DIFF
--- a/doc/api/next_api_changes/deprecations/18649-TH.rst
+++ b/doc/api/next_api_changes/deprecations/18649-TH.rst
@@ -1,5 +1,7 @@
 ``imread()`` reading from URLs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Passing a URL to `~.pyplot.imread()` is deprecated. Please open the URL before
-reading using ``urllib.request.urlopen()``.
+Passing a URL to `~.pyplot.imread()` is deprecated. Please open the URL for
+reading and directly use the Pillow API
+(``PIL.Image.open(urllib.request.urlopen(url))``, or
+``PIL.Image.open(io.BytesIO(requests.get(url).content))``) instead.

--- a/doc/api/next_api_changes/deprecations/18649-TH.rst
+++ b/doc/api/next_api_changes/deprecations/18649-TH.rst
@@ -1,0 +1,5 @@
+``imread()`` reading from URLs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Passing a URL to `~.pyplot.imread()` is deprecated. Please open the URL before
+reading using ``urllib.request.urlopen()``.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1430,6 +1430,9 @@ def imread(fname, format=None):
     fname : str or file-like
         The image file to read: a filename, a URL or a file-like object opened
         in read-binary mode.
+
+        Passing a URL is deprecated. Please open the URL before reading using
+        ``urllib.request.urlopen()``.
     format : str, optional
         The image file format assumed for reading the data. If not
         given, the format is deduced from the filename.  If nothing can
@@ -1472,9 +1475,12 @@ def imread(fname, format=None):
     img_open = (
         PIL.PngImagePlugin.PngImageFile if ext == 'png' else PIL.Image.open)
     if isinstance(fname, str):
-
         parsed = parse.urlparse(fname)
         if len(parsed.scheme) > 1:  # Pillow doesn't handle URLs directly.
+            cbook.warn_deprecated(
+                "3.4", message="Directly reading images from URLs is "
+                               "deprecated. Please open the URL before "
+                               "reading using urllib.request.urlopen().")
             # hide imports to speed initial import on systems with slow linkers
             from urllib import request
             ssl_ctx = mpl._get_ssl_context()

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1431,8 +1431,9 @@ def imread(fname, format=None):
         The image file to read: a filename, a URL or a file-like object opened
         in read-binary mode.
 
-        Passing a URL is deprecated. Please open the URL before reading using
-        ``urllib.request.urlopen()``.
+        Passing a URL is deprecated.  Please open the URL
+        for reading and pass the result to Pillow, e.g. with
+        ``PIL.Image.open(urllib.request.urlopen(url))``.
     format : str, optional
         The image file format assumed for reading the data. If not
         given, the format is deduced from the filename.  If nothing can
@@ -1479,8 +1480,9 @@ def imread(fname, format=None):
         if len(parsed.scheme) > 1:  # Pillow doesn't handle URLs directly.
             cbook.warn_deprecated(
                 "3.4", message="Directly reading images from URLs is "
-                               "deprecated. Please open the URL before "
-                               "reading using urllib.request.urlopen().")
+                "deprecated. Please open the URL for reading and pass the "
+                "result to Pillow, e.g. with "
+                "``PIL.Image.open(urllib.request.urlopen(url))``.")
             # hide imports to speed initial import on systems with slow linkers
             from urllib import request
             ssl_ctx = mpl._get_ssl_context()

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -12,7 +12,7 @@ from numpy.testing import assert_array_equal
 from PIL import Image
 
 from matplotlib import (
-    colors, image as mimage, patches, pyplot as plt, style, rcParams)
+    _api, colors, image as mimage, patches, pyplot as plt, style, rcParams)
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
@@ -714,7 +714,8 @@ def test_load_from_url():
     url = ('file:'
            + ('///' if sys.platform == 'win32' else '')
            + path.resolve().as_posix())
-    plt.imread(url)
+    with _api.suppress_matplotlib_deprecation_warning():
+        plt.imread(url)
     with urllib.request.urlopen(url) as file:
         plt.imread(file)
 
@@ -1128,7 +1129,8 @@ def test_exact_vmin():
 @pytest.mark.network
 @pytest.mark.flaky
 def test_https_imread_smoketest():
-    v = mimage.imread('https://matplotlib.org/1.5.0/_static/logo2.png')
+    with _api.suppress_matplotlib_deprecation_warning():
+        v = mimage.imread('https://matplotlib.org/1.5.0/_static/logo2.png')
 
 
 # A basic ndarray subclass that implements a quantity


### PR DESCRIPTION
## PR Summary

Replaces https://github.com/matplotlib/matplotlib/pull/18649, with the suggestion to directly using the Pillow API (https://github.com/matplotlib/matplotlib/pull/18649#pullrequestreview-503145250).  Closes #18648.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
