### PR TITLE
test for align_ylabel bug with constrained_layout

### DIFF
--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -521,3 +521,36 @@ def test_bboxtight():
 def test_bbox():
     fig, ax = plt.subplots(constrained_layout=True)
     ax.set_aspect(1.)
+
+def test_align_labels():
+    """
+    Tests for a bug in which constrained layout and align_ylabels on three
+    unevenly sized subplots, one of whose y tick labels include negative
+    numbers, drives the non-negative subplots' y labels off the edge of the plot
+
+    """
+
+    data = [0,1]
+
+    fig, (ax3, ax1, ax2) = plt.subplots(3, 1, constrained_layout=True,
+                                        figsize=(6.4,8),
+                                        gridspec_kw={"height_ratios":(1, 1, 0.7)})
+
+    ax1.plot(data, data)
+    ax1.set_ylabel("Label")
+
+    ax2.plot(data, data)
+    ax2.set_ylim(-1.5, 1.5)
+    ax2.set_ylabel("Label")
+
+    ax3.plot(data, data)
+    ax3.set_ylabel("Label")
+
+    fig.align_ylabels(axs=(ax3, ax1, ax2))
+
+    fig.canvas.draw()
+    after_align = (ax1.yaxis.label.get_window_extent(),
+                   ax2.yaxis.label.get_window_extent(),
+                   ax3.yaxis.label.get_window_extent())
+
+    assert round(after_align[0].x0, 5) == round(after_align[1].x0, 5) == round(after_align[2].x0, 5) > 1

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -522,19 +522,22 @@ def test_bbox():
     fig, ax = plt.subplots(constrained_layout=True)
     ax.set_aspect(1.)
 
+
 def test_align_labels():
     """
-    Tests for a bug in which constrained layout and align_ylabels on three
-    unevenly sized subplots, one of whose y tick labels include negative
-    numbers, drives the non-negative subplots' y labels off the edge of the plot
+    Tests for a bug in which constrained layout and align_ylabels on
+    three unevenly sized subplots, one of whose y tick labels include
+    negative numbers, drives the non-negative subplots' y labels off
+    the edge of the plot
 
     """
 
-    data = [0,1]
+    data = [0, 1]
 
     fig, (ax3, ax1, ax2) = plt.subplots(3, 1, constrained_layout=True,
-                                        figsize=(6.4,8),
-                                        gridspec_kw={"height_ratios":(1, 1, 0.7)})
+                                        figsize=(6.4, 8),
+                                        gridspec_kw={"height_ratios": (1, 1,
+                                                                       0.7)})
 
     ax1.plot(data, data)
     ax1.set_ylabel("Label")
@@ -552,5 +555,8 @@ def test_align_labels():
     after_align = (ax1.yaxis.label.get_window_extent(),
                    ax2.yaxis.label.get_window_extent(),
                    ax3.yaxis.label.get_window_extent())
-
-    assert round(after_align[0].x0, 5) == round(after_align[1].x0, 5) == round(after_align[2].x0, 5) > 1
+    #ensure labels are approximately aligned
+    np.testing.assert_allclose([after_align[0].x0, after_align[2].x0],
+                               after_align[1].x0, rtol=0, atol=1e-05)
+    #ensure labels do not go off the edge
+    assert after_align[0].x0 >= 1

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -529,34 +529,29 @@ def test_align_labels():
     three unevenly sized subplots, one of whose y tick labels include
     negative numbers, drives the non-negative subplots' y labels off
     the edge of the plot
-
     """
-
-    data = [0, 1]
-
     fig, (ax3, ax1, ax2) = plt.subplots(3, 1, constrained_layout=True,
                                         figsize=(6.4, 8),
                                         gridspec_kw={"height_ratios": (1, 1,
                                                                        0.7)})
 
-    ax1.plot(data, data)
+    ax1.set_ylim(0, 1)
     ax1.set_ylabel("Label")
 
-    ax2.plot(data, data)
     ax2.set_ylim(-1.5, 1.5)
     ax2.set_ylabel("Label")
 
-    ax3.plot(data, data)
+    ax3.set_ylim(0, 1)
     ax3.set_ylabel("Label")
 
     fig.align_ylabels(axs=(ax3, ax1, ax2))
 
     fig.canvas.draw()
-    after_align = (ax1.yaxis.label.get_window_extent(),
+    after_align = [ax1.yaxis.label.get_window_extent(),
                    ax2.yaxis.label.get_window_extent(),
-                   ax3.yaxis.label.get_window_extent())
-    #ensure labels are approximately aligned
+                   ax3.yaxis.label.get_window_extent()]
+    # ensure labels are approximately aligned
     np.testing.assert_allclose([after_align[0].x0, after_align[2].x0],
                                after_align[1].x0, rtol=0, atol=1e-05)
-    #ensure labels do not go off the edge
+    # ensure labels do not go off the edge
     assert after_align[0].x0 >= 1


### PR DESCRIPTION
## PR Summary
Checks for bug in which align_ylabel drives y labels of some subplots off the edge of the plot when using constrained layout under the circumstances laid out here: https://github.com/matplotlib/matplotlib/issues/19152 . This is my first contribution to open-source, so any feedback is helpful! On the first checklist item, I'm not sure what "pytest style unit tests" are in particular, and I'm having trouble getting the test suite to run at all, though I managed the first time I cloned the repository and my added test performed as it should have. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
