### PR TITLE
Always include sample_data in installs.

### DIFF
--- a/setup.cfg.template
+++ b/setup.cfg.template
@@ -21,7 +21,6 @@ license_files = LICENSE/*
 # considered optional. All except 'tests' data (meaning the baseline
 # image files) are installed by default, but that can be changed here.
 #tests = False
-#sample_data = True
 
 [gui_support]
 # Matplotlib supports multiple GUI toolkits, known as backends.

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ mpl_packages = [
     setupext.Platform(),
     setupext.FreeType(),
     setupext.Qhull(),
-    setupext.SampleData(),
     setupext.Tests(),
     setupext.BackendMacOSX(),
     ]

--- a/setupext.py
+++ b/setupext.py
@@ -365,9 +365,7 @@ class Matplotlib(SetupPackage):
         return {
             'matplotlib': [
                 'mpl-data/matplotlibrc',
-                *_pkg_data_helper('matplotlib', 'mpl-data/fonts'),
-                *_pkg_data_helper('matplotlib', 'mpl-data/images'),
-                *_pkg_data_helper('matplotlib', 'mpl-data/stylelib'),
+                *_pkg_data_helper('matplotlib', 'mpl-data'),
                 *_pkg_data_helper('matplotlib', 'backends/web_backend'),
                 '*.dll',  # Only actually matters on Windows.
             ],
@@ -477,21 +475,6 @@ class Matplotlib(SetupPackage):
             include_dirs=["extern"])
         add_numpy_flags(ext)
         yield ext
-
-
-class SampleData(OptionalPackage):
-    """
-    This handles the sample data that ships with matplotlib.  It is
-    technically optional, though most often will be desired.
-    """
-    name = "sample_data"
-
-    def get_package_data(self):
-        return {
-            'matplotlib': [
-                *_pkg_data_helper('matplotlib', 'mpl-data/sample_data'),
-            ],
-        }
 
 
 class Tests(OptionalPackage):


### PR DESCRIPTION
The whole sample data folder is ~500K now, which is much less than many
compiled extension modules (backend_agg, ft2font, _image, _path, _qhull
shared objects all weight ~2-3M).  Always installing sample_data is a
step towards making Matplotlib installs more homogeneous (i.e., fewer
variants).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
