### PR TITLE
New event examples showing z-value at cursor position.

### DIFF
--- a/examples/event_handling/mouse_z_contour.py
+++ b/examples/event_handling/mouse_z_contour.py
@@ -1,0 +1,41 @@
+"""
+=========================================
+Z-value at mouse position of contour plot
+=========================================
+
+This example shows how a motion_notify_event can be used to display the z-value
+corresponding to the mouse cursor position.  The z-value is interpolated from
+the (x, y, z) data used to generate a contourf plot.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.interpolate import interp2d
+
+
+def on_mouse_move(event):
+    title = ''
+    if event.inaxes == ax:
+        z = interp(event.xdata, event.ydata)[0]
+        if not np.ma.is_masked(z):
+            title = f'z = {z:.3f}'
+    ax.set_title(title)
+    event.canvas.draw()
+
+
+n = 10
+x, y = np.meshgrid(np.linspace(0.0, 1.0, n), np.linspace(0.0, 1.0, n))
+np.random.seed(42)
+x += np.random.normal(scale=0.15/n, size=(n, n))
+y += np.random.normal(scale=0.15/n, size=(n, n))
+z = np.sin(10*x)*np.cos(10*y)
+
+# Function used to interpolate z-values.
+interp = interp2d(x, y, z)
+
+fig, ax = plt.subplots()
+cs = ax.contourf(x, y, z)
+fig.colorbar(cs)
+ax.plot(x, y, x.T, y.T, c='C1', alpha=0.5)
+fig.canvas.mpl_connect('motion_notify_event', on_mouse_move)
+fig.suptitle('Move mouse to show z-value at cursor position')
+plt.show()

--- a/examples/event_handling/mouse_z_contour.py
+++ b/examples/event_handling/mouse_z_contour.py
@@ -6,6 +6,10 @@ Z-value at mouse position of contour plot
 This example shows how a motion_notify_event can be used to display the z-value
 corresponding to the mouse cursor position.  The z-value is interpolated from
 the (x, y, z) data used to generate a contourf plot.
+
+Note that the contour plot is not used to determine the z-value, rather it is
+intended to help guide the user's mouse movements.  A pcolor plot could be
+used instead.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/event_handling/mouse_z_tricontour.py
+++ b/examples/event_handling/mouse_z_tricontour.py
@@ -1,0 +1,41 @@
+"""
+============================================
+Z-value at mouse position of tricontour plot
+============================================
+
+This example shows how a motion_notify_event can be used to display the z-value
+corresponding to the mouse cursor position.  The z-value is interpolated from
+the (x, y, z) data used to generate a tricontourf plot.
+"""
+import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
+import numpy as np
+
+
+def on_mouse_move(event):
+    title = ''
+    if event.inaxes == ax:
+        z = interp(event.xdata, event.ydata)
+        if not np.ma.is_masked(z):
+            title = f'z = {z:.3f}'
+    ax.set_title(title)
+    event.canvas.draw()
+
+
+n = 40
+np.random.seed(23)
+x = np.random.uniform(size=(n,))
+y = np.random.uniform(size=(n,))
+z = np.sin(10*x)*np.cos(10*y)
+triang = mtri.Triangulation(x, y)
+
+# Function used to interpolate z-values.
+interp = mtri.LinearTriInterpolator(triang, z)
+
+fig, ax = plt.subplots()
+cs = ax.tricontourf(triang, z)
+fig.colorbar(cs)
+ax.triplot(triang, c='C1', alpha=0.5)
+fig.canvas.mpl_connect('motion_notify_event', on_mouse_move)
+fig.suptitle('Move mouse to show z-value at cursor position')
+plt.show()

--- a/examples/event_handling/mouse_z_tricontour.py
+++ b/examples/event_handling/mouse_z_tricontour.py
@@ -6,6 +6,10 @@ Z-value at mouse position of tricontour plot
 This example shows how a motion_notify_event can be used to display the z-value
 corresponding to the mouse cursor position.  The z-value is interpolated from
 the (x, y, z) data used to generate a tricontourf plot.
+
+Note that the tricontour plot is not used to determine the z-value, rather it
+is intended to help guide the user's mouse movements.  A tripcolor plot could
+be used instead.
 """
 import matplotlib.pyplot as plt
 import matplotlib.tri as mtri


### PR DESCRIPTION
New examples using `motion_notify_event` to show the z-value at the mouse cursor position.  Two examples, one of quadrilateral grids using `contourf` and the other of triangle grids using `tricontourf`.

The intention is to demonstrate how to solve problems like issue #14804 without adding such functionality for all contour/tricontour/pcolor like functions, which will detrimentally affect performance for many users.