### PR TITLE
Don't allow pyzmq 22.0.0 on AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ environment:
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
                  --cov-report= --cov=lib --log-level=DEBUG
-    PINNEDVERS: "pyzmq!=21.0.0"
+    PINNEDVERS: "pyzmq!=21.0.0 pyzmq!=22.0.0"
 
   matrix:
     # In theory we could use a single CONDA_INSTALL_LOCN because we construct


### PR DESCRIPTION
## PR Summary

This version is broken on Windows:
https://github.com/zeromq/pyzmq/issues/1496.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).