### PR TITLE
Fix tk event coordinates in the presence of scrollbars.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -251,68 +251,53 @@ class FigureCanvasTk(FigureCanvasBase):
         """
         return self._tkcanvas
 
+    def _event_mpl_coords(self, event):
+        # calling canvasx/canvasy allows taking scrollbars into account (i.e.
+        # the top of the widget may have been scrolled out of view).
+        return (self._tkcanvas.canvasx(event.x),
+                # flipy so y=0 is bottom of canvas
+                self.figure.bbox.height - self._tkcanvas.canvasy(event.y))
+
     def motion_notify_event(self, event):
-        x = event.x
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y
-        super().motion_notify_event(x, y, guiEvent=event)
+        super().motion_notify_event(
+            *self._event_mpl_coords(event), guiEvent=event)
 
     def enter_notify_event(self, event):
-        x = event.x
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y
-        super().enter_notify_event(guiEvent=event, xy=(x, y))
+        super().enter_notify_event(
+            guiEvent=event, xy=self._event_mpl_coords(event))
 
     def button_press_event(self, event, dblclick=False):
-        x = event.x
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y
         num = getattr(event, 'num', None)
-
-        if sys.platform == 'darwin':
-            # 2 and 3 were reversed on the OSX platform I tested under tkagg.
-            if num == 2:
-                num = 3
-            elif num == 3:
-                num = 2
-
-        super().button_press_event(x, y, num,
-                                   dblclick=dblclick, guiEvent=event)
+        if sys.platform == 'darwin':  # 2 and 3 are reversed.
+            num = {2: 3, 3: 2}.get(num, num)
+        super().button_press_event(
+            *self._event_mpl_coords(event), num, dblclick=dblclick,
+            guiEvent=event)
 
     def button_dblclick_event(self, event):
         self.button_press_event(event, dblclick=True)
 
     def button_release_event(self, event):
-        x = event.x
-        # flipy so y=0 is bottom of canvas
-        y = self.figure.bbox.height - event.y
-
         num = getattr(event, 'num', None)
-
-        if sys.platform == 'darwin':
-            # 2 and 3 were reversed on the OSX platform I tested under tkagg.
-            if num == 2:
-                num = 3
-            elif num == 3:
-                num = 2
-
-        super().button_release_event(x, y, num, guiEvent=event)
+        if sys.platform == 'darwin':  # 2 and 3 are reversed.
+            num = {2: 3, 3: 2}.get(num, num)
+        super().button_release_event(
+            *self._event_mpl_coords(event), num, guiEvent=event)
 
     def scroll_event(self, event):
-        x = event.x
-        y = self.figure.bbox.height - event.y
         num = getattr(event, 'num', None)
         step = 1 if num == 4 else -1 if num == 5 else 0
-        super().scroll_event(x, y, step, guiEvent=event)
+        super().scroll_event(
+            *self._event_mpl_coords(event), step, guiEvent=event)
 
     def scroll_event_windows(self, event):
         """MouseWheel event processor"""
         # need to find the window that contains the mouse
         w = event.widget.winfo_containing(event.x_root, event.y_root)
         if w == self._tkcanvas:
-            x = event.x_root - w.winfo_rootx()
-            y = event.y_root - w.winfo_rooty()
-            y = self.figure.bbox.height - y
+            x = self._tkcanvas.canvasx(event.x_root - w.winfo_rootx())
+            y = (self.figure.bbox.height
+                 - self._tkcanvas.canvasy(event.y_root - w.winfo_rooty()))
             step = event.delta/120.
             FigureCanvasBase.scroll_event(self, x, y, step, guiEvent=event)
 


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/17584 (well, perhaps not https://github.com/matplotlib/matplotlib/issues/17584#issuecomment-640607651 but that seems to be a separate point which I didn't fully get...)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
