### PR TITLE
DOC: fix incorrect parameter names

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1065,7 +1065,7 @@ class GraphicsContextBase:
             pixels.  If scale is `None`, or not provided, no sketch filter will
             be provided.
         length : float, default: 128
-             The length of the wiggle along the line, in pixels.
+            The length of the wiggle along the line, in pixels.
         randomness : float, default: 16
             The scale factor by which the length is shrunken or expanded.
         """
@@ -3420,7 +3420,7 @@ class ToolContainerBase:
             Name of the group that this tool belongs to.
         position : int
             Position of the tool within its group, if -1 it goes at the end.
-        image_file : str
+        image : str
             Filename of the image for the button or `None`.
         description : str
             Description of the tool, used for the tooltips.

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -191,7 +191,7 @@ class ToolManager:
         ----------
         name : str
             Name of the Tool.
-        keys : str or list of str
+        key : str or list of str
             Keys to associate with the tool.
         """
         if name not in self._tools:

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -421,7 +421,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         Parameters
         ----------
-        d : float
+        pr : float
             Pick radius, in points.
         """
         self._pickradius = pr
@@ -705,7 +705,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         Returns
         -------
         linewidths, dashes : list
-             Will be the same length, dashes are scaled by paired linewidth
+            Will be the same length, dashes are scaled by paired linewidth
         """
         if mpl.rcParams['_internal.classic_mode']:
             return linewidths, dashes
@@ -1384,15 +1384,17 @@ class LineCollection(Collection):
         antialiaseds : bool or list of bool, default: :rc:`lines.antialiased`
             Whether to use antialiasing for each line.
         zorder : int, default: 2
-           zorder of the lines once drawn.
+            zorder of the lines once drawn.
+
         facecolors : color or list of color, default: 'none'
-           When setting *facecolors*, each line is interpreted as a boundary
-           for an area, implicitly closing the path from the last point to the
-           first point. The enclosed area is filled with *facecolor*.
-           In order to manually specify what should count as the "interior" of
-           each line, please use `.PathCollection` instead, where the
-           "interior" can be specified by appropriate usage of
-           `~.path.Path.CLOSEPOLY`.
+            When setting *facecolors*, each line is interpreted as a boundary
+            for an area, implicitly closing the path from the last point to the
+            first point. The enclosed area is filled with *facecolor*.
+            In order to manually specify what should count as the "interior" of
+            each line, please use `.PathCollection` instead, where the
+            "interior" can be specified by appropriate usage of
+            `~.path.Path.CLOSEPOLY`.
+
         **kwargs
             Forwareded to `.Collection`.
         """

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -213,7 +213,7 @@ class TriInterpolator:
 
         Parameters
         ----------
-        return_index : {'z', 'dzdx', 'dzdy'}
+        return_key : {'z', 'dzdx', 'dzdy'}
             Identifies the requested values (z or its derivatives)
         tri_index : 1D int array
             Valid triangle index (-1 prohibited)
@@ -461,8 +461,8 @@ class CubicTriInterpolator(TriInterpolator):
         Returns
         -------
         array-like, shape (npts, 2)
-              Estimation of the gradient at triangulation nodes (stored as
-              degree of freedoms of reduced-HCT triangle elements).
+            Estimation of the gradient at triangulation nodes (stored as
+            degree of freedoms of reduced-HCT triangle elements).
         """
         if kind == 'user':
             if dz is None:

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -759,7 +759,7 @@ class AxisArtist(martist.Artist):
 
         Parameters
         ----------
-        tick_direction : {"+", "-"}
+        label_direction : {"+", "-"}
         """
         self._axislabel_add_angle = _api.check_getitem(
             {"+": 0, "-": 180}, label_direction=label_direction)


### PR DESCRIPTION
Also uniformise indent of one section to match the rest of the file
