### PR TITLE
FIX: allow add option for Axes3D(fig)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -645,6 +645,8 @@ class _AxesBase(martist.Artist):
         if yscale:
             self.set_yscale(yscale)
 
+        # remove when Axis3d deprecation expires and this kwarg is removed:
+        kwargs.pop('add', None)
         self.update(kwargs)
 
         for name, axis in self._get_axis_map().items():

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -579,6 +579,8 @@ default: %(va)s
             projection_class, kwargs = self._process_projection_requirements(
                 *args, **kwargs)
 
+            # remove this when deprecation for Axes3d(add=True) ends:
+            kwargs['add'] = False
             # create the new axes using the axes class given
             a = projection_class(self, rect, **kwargs)
         return self._add_axes_internal(a)
@@ -708,6 +710,10 @@ default: %(va)s
                 args = tuple(map(int, str(args[0])))
             projection_class, kwargs = self._process_projection_requirements(
                 *args, **kwargs)
+
+            # remove this when deprecation for Axes3d(add=True) ends:
+            kwargs['add'] = False
+
             ax = subplot_class_factory(projection_class)(self, *args, **kwargs)
         return self._add_axes_internal(ax)
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -382,7 +382,6 @@ def test_EllipseCollection():
 
 @image_comparison(['polycollection_close.png'], remove_text=True)
 def test_polycollection_close():
-    from mpl_toolkits.mplot3d import Axes3D
 
     vertsQuad = [
         [[0., 0.], [0., 1.], [1., 1.], [1., 0.]],
@@ -391,7 +390,7 @@ def test_polycollection_close():
         [[3., 0.], [3., 1.], [4., 1.], [4., 0.]]]
 
     fig = plt.figure()
-    ax = fig.add_axes(Axes3D(fig))
+    ax = fig.add_subplot(projection='3d')
 
     colors = ['r', 'g', 'b', 'y', 'k']
     zpos = list(range(5))

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -382,6 +382,7 @@ def test_EllipseCollection():
 
 @image_comparison(['polycollection_close.png'], remove_text=True)
 def test_polycollection_close():
+    from mpl_toolkits.mplot3d import Axes3D
 
     vertsQuad = [
         [[0., 0.], [0., 1.], [1., 1.], [1., 0.]],
@@ -390,7 +391,7 @@ def test_polycollection_close():
         [[3., 0.], [3., 1.], [4., 1.], [4., 0.]]]
 
     fig = plt.figure()
-    ax = fig.add_subplot(projection='3d')
+    ax = fig.add_axes(Axes3D(fig, add=False))
 
     colors = ['r', 'g', 'b', 'y', 'k']
     zpos = list(range(5))

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -97,6 +97,8 @@ class Axes3D(Axes):
             self._shared_z_axes.join(self, sharez)
             self._adjustable = 'datalim'
 
+        add = kwargs.pop("add", True)
+
         super().__init__(
             fig, rect, frameon=True, box_aspect=box_aspect, *args, **kwargs
         )
@@ -124,6 +126,14 @@ class Axes3D(Axes):
         # Calculate the pseudo-data width and height
         pseudo_bbox = self.transLimits.inverted().transform([(0, 0), (1, 1)])
         self._pseudo_w, self._pseudo_h = pseudo_bbox[1] - pseudo_bbox[0]
+
+        if add:
+            _api.warn_deprecated(
+                "3.4", message="Axes3D(fig) adding itself "
+                "to the figure is deprecated since %(since)s and will "
+                "no longer work %(removal)s; this is consistent with "
+                "other axes classes.  Use fig.add_subplot(projection='3d')")
+            self.figure.add_axes(self)
 
         # mplot3d currently manages its own spines and needs these turned off
         # for bounding box calculations

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -3,7 +3,7 @@ import itertools
 
 import pytest
 
-from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
+from mpl_toolkits.mplot3d import axes3d, proj3d, art3d
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseButton
 from matplotlib import cm
@@ -725,7 +725,7 @@ def test_add_collection3d_zs_scalar():
 @mpl3d_image_comparison(['axes3d_labelpad.png'], remove_text=False)
 def test_axes3d_labelpad():
     fig = plt.figure()
-    ax = fig.add_axes(Axes3D(fig))
+    ax = fig.add_subplot(projection='3d')
     # labelpad respects rcParams
     assert ax.xaxis.labelpad == mpl.rcParams['axes.labelpad']
     # labelpad can be set in set_label
@@ -1132,7 +1132,7 @@ def test_inverted_cla():
 
 def test_ax3d_tickcolour():
     fig = plt.figure()
-    ax = Axes3D(fig)
+    ax = fig.add_subplot(projection="3d")
 
     ax.tick_params(axis='x', colors='red')
     ax.tick_params(axis='y', colors='red')

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -3,7 +3,7 @@ import itertools
 
 import pytest
 
-from mpl_toolkits.mplot3d import axes3d, proj3d, art3d
+from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseButton
 from matplotlib import cm
@@ -725,7 +725,8 @@ def test_add_collection3d_zs_scalar():
 @mpl3d_image_comparison(['axes3d_labelpad.png'], remove_text=False)
 def test_axes3d_labelpad():
     fig = plt.figure()
-    ax = fig.add_subplot(projection='3d')
+    ax = Axes3D(fig, add=False)
+    fig.add_axes(ax)
     # labelpad respects rcParams
     assert ax.xaxis.labelpad == mpl.rcParams['axes.labelpad']
     # labelpad can be set in set_label


### PR DESCRIPTION
## PR Summary

Closes #18939

We changed the logic to deal with `Axes3d(fig)`  to not add the new axes to `fig` in #18564, but of course that broke some people who were working off older examples.  

This PR pops up a DeprecationWarning if folks use the old call, however, if they do the somewhat awkward:

```
ax = Axes3d(fig)
fig.add_axes(ax)
```

they will *also* get a Deprecation Warning, which they can suppress with 

```
ax = Axes3d(fig, add=False)
fig.add_axes(ax)
```

However, the deprecation warning just suggests that they add the subplot the idiomatic way:

```
ax = fig.add_subplot(projection='3d')
```

I'm not a super fan of this proposal - it pops up a warning for a valid if rare use case, but its better than mysteriously not adding the Axes3d object.   and we can rip it all out in a cycle or two.  






## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
