### PR TITLE
Make TaggedValue in basic_units a sequence

### DIFF
--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -154,6 +154,9 @@ class TaggedValue(metaclass=TaggedValueMeta):
     def __len__(self):
         return len(self.value)
 
+    def __getitem__(self, key):
+        return TaggedValue(self.value[key], self.unit)
+
     def __iter__(self):
         # Return a generator expression rather than use `yield`, so that
         # TypeError is raised by iter(self) if appropriate when checking for


### PR DESCRIPTION
This is needed to avoid a deprecation warning with numpy 1.20, and fixes the doc build.

See https://numpy.org/doc/stable/release/1.20.0-notes.html#arraylike-objects-which-do-not-define-len-and-getitem for more information. Essentially, `__len__` and `__getitem__` needed to be implemented for numpy to recognise the class as a sequence.