### PR TITLE
Style fixes to triintepolate docs.

### DIFF
--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -114,14 +114,14 @@ class TriInterpolator:
         The purpose of :meth:`_interpolate_multikeys` is to implement the
         following common tasks needed in all subclasses implementations:
 
-            - calculation of containing triangles
-            - dealing with more than one interpolation request at the same
-              location (e.g., if the 2 derivatives are requested, it is
-              unnecessary to compute the containing triangles twice)
-            - scaling according to self._unit_x, self._unit_y
-            - dealing with points outside of the grid (with fill value np.nan)
-            - dealing with multi-dimensional *x*, *y* arrays: flattening for
-              :meth:`_interpolate_params` call and final reshaping.
+        - calculation of containing triangles
+        - dealing with more than one interpolation request at the same
+          location (e.g., if the 2 derivatives are requested, it is
+          unnecessary to compute the containing triangles twice)
+        - scaling according to self._unit_x, self._unit_y
+        - dealing with points outside of the grid (with fill value np.nan)
+        - dealing with multi-dimensional *x*, *y* arrays: flattening for
+          :meth:`_interpolate_params` call and final reshaping.
 
         (Note that np.vectorize could do most of those things very well for
         you, but it does it by function evaluations over successive tuples of
@@ -214,9 +214,9 @@ class TriInterpolator:
         Parameters
         ----------
         return_key : {'z', 'dzdx', 'dzdy'}
-            Identifies the requested values (z or its derivatives)
+            The requested values (z or its derivatives).
         tri_index : 1D int array
-            Valid triangle index (-1 prohibited)
+            Valid triangle index (cannot be -1).
         x, y : 1D arrays, same shape as `tri_index`
             Valid locations where interpolation is requested.
 
@@ -245,8 +245,8 @@ class LinearTriInterpolator(TriInterpolator):
     z : array-like of shape (npoints,)
         Array of values, defined at grid points, to interpolate between.
     trifinder : `~matplotlib.tri.TriFinder`, optional
-          If this is not specified, the Triangulation's default TriFinder will
-          be used by calling `.Triangulation.get_trifinder`.
+        If this is not specified, the Triangulation's default TriFinder will
+        be used by calling `.Triangulation.get_trifinder`.
 
     Methods
     -------


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
