### PR TITLE
Use a standard white background for GTK backends.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -23,10 +23,8 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         w, h = allocation.width, allocation.height
 
         if not len(self._bbox_queue):
-            Gtk.render_background(
-                self.get_style_context(), ctx,
-                allocation.x, allocation.y,
-                allocation.width, allocation.height)
+            ctx.set_source_rgb(1.0, 1.0, 1.0)
+            ctx.paint()
             bbox_queue = [transforms.Bbox([[0, 0], [w, h]])]
         else:
             bbox_queue = self._bbox_queue

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -22,10 +22,8 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
               else nullcontext()):
             self._renderer.set_context(ctx)
             allocation = self.get_allocation()
-            Gtk.render_background(
-                self.get_style_context(), ctx,
-                allocation.x, allocation.y,
-                allocation.width, allocation.height)
+            ctx.set_source_rgb(1.0, 1.0, 1.0)
+            ctx.paint()
             self._renderer.set_width_height(
                 allocation.width, allocation.height)
             self.figure.draw(self._renderer)


### PR DESCRIPTION
## PR Summary

See explanation in #19410, but using non-deprecated API.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).