### PR TITLE
Add units to bar_label padding documentation.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2541,11 +2541,11 @@ class Axes(_AxesBase):
               value displayed will be the position of that end-point.
             - 'center': label placed in the center of the bar segment, and the
               value displayed will be the length of that segment.
-              (useful for stacked bars, i.e.
+              (useful for stacked bars, i.e.,
               :doc:`/gallery/lines_bars_and_markers/bar_label_demo`)
 
         padding : float, default: 0
-            Distance of label from the end of the bar.
+            Distance of label from the end of the bar, in points.
 
         **kwargs
             Any remaining keyword arguments are passed through to


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [b/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).