### PR TITLE
Always create a new subplot in plt.subplot()

### DIFF
--- a/doc/users/next_whats_new/axes_kwargs_collision.rst
+++ b/doc/users/next_whats_new/axes_kwargs_collision.rst
@@ -6,11 +6,7 @@ The behavior of the functions to create new axes (`.pyplot.axes`,
 `.figure.Figure.add_subplot`) has changed. In the past, these functions would
 detect if you were attempting to create Axes with the same keyword arguments as
 already-existing axes in the current figure, and if so, they would return the
-existing Axes. Now, these functions will always create new Axes. A special
-exception is `.pyplot.subplot`, which will reuse any existing subplot with a
-matching subplot spec. However, if there is a subplot with a matching subplot
-spec, then that subplot will be returned, even if the keyword arguments with
-which it was created differ.
+existing Axes. Now, these functions will always create new Axes.
 
 Correspondingly, the behavior of the functions to get the current Axes
 (`.pyplot.gca`, `.figure.Figure.gca`) has changed. In the past, these functions

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1156,15 +1156,6 @@ def subplot(*args, **kwargs):
     If you do not want this behavior, use the `.Figure.add_subplot` method
     or the `.pyplot.axes` function instead.
 
-    If the figure already has a subplot with key (*args*,
-    *kwargs*) then it will simply make that subplot current and
-    return it.  This behavior is deprecated. Meanwhile, if you do
-    not want this behavior (i.e., you want to force the creation of a
-    new subplot), you must use a unique set of args and kwargs.  The axes
-    *label* attribute has been exposed for this purpose: if you want
-    two subplots that are otherwise identical to be added to the figure,
-    make sure you give them unique labels.
-
     In rare circumstances, `.Figure.add_subplot` may be called with a single
     argument, a subplot axes instance already created in the
     present figure but not in the figure's list of axes.
@@ -1221,17 +1212,7 @@ def subplot(*args, **kwargs):
                         "and/or 'nrows'.  Did you intend to call subplots()?")
 
     fig = gcf()
-
-    # First, search for an existing subplot with a matching spec.
-    key = SubplotSpec._from_subplot_args(fig, args)
-    ax = next(
-        (ax for ax in fig.axes
-         if hasattr(ax, 'get_subplotspec') and ax.get_subplotspec() == key),
-        None)
-
-    # If no existing axes match, then create a new one.
-    if ax is None:
-        ax = fig.add_subplot(*args, **kwargs)
+    ax = fig.add_subplot(*args, **kwargs)
 
     bbox = ax.bbox
     axes_to_delete = []


### PR DESCRIPTION
Fixes https://github.com/matplotlib/matplotlib/issues/19432.

The behaviour before this patch was to return an existing `Axes` if it had the same subplot-spec, regardless of `**kwargs`. This changes that to always create a new `Axes`, which is what is documented and expected from the deprecation.