### PR TITLE
Replace gtk3 deprecated APIs that have simple replacements.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -124,7 +124,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
 
         self.set_events(self.__class__.event_mask)
 
-        self.set_double_buffered(True)
         self.set_can_focus(True)
 
         renderer_init = _api.deprecate_method_override(
@@ -180,7 +179,7 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
 
     def motion_notify_event(self, widget, event):
         if event.is_hint:
-            t, x, y, state = event.window.get_pointer()
+            t, x, y, state = event.window.get_device_position(event.device)
         else:
             x, y = event.x, event.y
 
@@ -338,12 +337,6 @@ class FigureManagerGTK3(FigureManagerBase):
 
         self.toolbar = self._get_toolbar()
 
-        def add_widget(child):
-            child.show()
-            self.vbox.pack_end(child, False, False, 0)
-            size_request = child.size_request()
-            return size_request.height
-
         if self.toolmanager:
             backend_tools.add_tools_to_manager(self.toolmanager)
             if self.toolbar:
@@ -351,7 +344,9 @@ class FigureManagerGTK3(FigureManagerBase):
 
         if self.toolbar is not None:
             self.toolbar.show()
-            h += add_widget(self.toolbar)
+            self.vbox.pack_end(self.toolbar, False, False, 0)
+            min_size, nat_size = self.toolbar.get_preferred_size()
+            h += nat_size.height
 
         self.window.set_default_size(w, h)
 


### PR DESCRIPTION
- set_double_buffered (deprecated since gtk3.14) is unnecessary, gtk
  (even gtk2) defaults to being double-buffered (this line of code comes
  from the old gtk2 backend which used to disable double buffering).
  https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-set-double-buffered

- gtk_window_get_pointer is deprecated since gtk3.0.
  https://developer.gnome.org/gdk3/stable/gdk3-Windows.html#gdk-window-get-pointer

- get_window_size_request is deprecated since gtk3.0.  Also inline
  add_widget, which is used exactly once.
  https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-size-request

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
