### PR TITLE
FIX: restore creating new axes via plt.subplot with different kwargs

### DIFF
--- a/doc/api/next_api_changes/behavior/19438-TAC.rst
+++ b/doc/api/next_api_changes/behavior/19438-TAC.rst
@@ -1,0 +1,65 @@
+``plt.subplot`` re-selection without keyword arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The purpose of `.pyplot.subplot` is to facilitate creating and re-selecting
+Axes in a Figure when working strictly in the implicit pyplot API.  When
+creating new Axes it is possible to select the projection (e.g. polar, 3D, or
+various cartographic projections) as well as to pass additional keyword
+arguments through to the Axes-subclass that is created.
+
+The first time `.pyplot.subplot` is called for a given position in the Axes
+grid it always creates and return a new Axes with the passed arguments and
+projection (defaulting to a rectilinear).  On subsequent calls to
+`.pyplot.subplot` we have to determine if an existing Axes has equivalent
+parameters, in which case in should be selected as the current Axes and
+returned, or different parameters, in which case a new Axes is created and the
+existing Axes is removed.  This leaves the question of what is "equivalent
+parameters".
+
+Previously it was the case that an existing Axes subclass, except for Axes3D,
+would be considered equivalent to a 2D rectilinear Axes, despite having
+different projections, if the kwargs (other than *projection*) matched.  Thus
+::
+
+  ax1 = plt.subplot(1, 1, 1, projection='polar')
+  ax2 =  plt.subplots(1, 1, 1)
+  ax1 is ax2
+
+We are embracing this long standing behavior to ensure that in the case when no
+keyword arguments (of any sort) are passed to `.pyplot.subplot` any existing
+Axes is returned, without consideration for keywords or projection used to
+initially create it.  This will cause a change in behavior when additional
+keywords were passed to the original axes ::
+
+  ax1 = plt.subplot(111, projection='polar', theta_offset=.75)
+  ax2 = plt.subplots(1, 1, 1)
+  ax1 is ax2         # new behavior
+  # ax1 is not ax2   # old behavior, made a new axes
+
+  ax1 = plt.subplot(111, label='test')
+  ax2 = plt.subplots(1, 1, 1)
+  ax1 is ax2         # new behavior
+  # ax1 is not ax2   # old behavior, made a new axes
+
+
+For the same reason, if there was an existing Axes that was not rectilinear,
+passing ``projection='rectilinear'`` would reuse the existing Axes ::
+
+  ax1 = plt.subplot(projection='polar')
+  ax2 = plt.subplot(projection='rectilinear')
+  ax1 is not ax2     # new behavior, makes new axes
+  # ax1 is ax2       # old behavior
+
+
+contrary to the users request.
+
+Previously Axes3D could not be re-selected with `.pyplot.subplot` due to an
+unrelated bug (also fixed in mpl3.4).  While Axes3D are now consistent with all
+other projections there is a change in behavior for ::
+
+  plt.subplot(projection='3d')  # create a 3D Axes
+
+  plt.subplot()                 # now returns existing 3D Axes, but
+                                # previously created new 2D Axes
+
+  plt.subplot(projection='rectilinear')  # to get a new 2D Axes

--- a/doc/users/next_whats_new/axes_kwargs_collision.rst
+++ b/doc/users/next_whats_new/axes_kwargs_collision.rst
@@ -3,19 +3,19 @@ Changes to behavior of Axes creation methods (``gca()``, ``add_axes()``, ``add_s
 
 The behavior of the functions to create new axes (`.pyplot.axes`,
 `.pyplot.subplot`, `.figure.Figure.add_axes`,
-`.figure.Figure.add_subplot`) has changed. In the past, these functions would
-detect if you were attempting to create Axes with the same keyword arguments as
-already-existing axes in the current figure, and if so, they would return the
-existing Axes. Now, these functions will always create new Axes. A special
-exception is `.pyplot.subplot`, which will reuse any existing subplot with a
-matching subplot spec. However, if there is a subplot with a matching subplot
-spec, then that subplot will be returned, even if the keyword arguments with
-which it was created differ.
+`.figure.Figure.add_subplot`) has changed.  In the past, these
+functions would detect if you were attempting to create Axes with the
+same keyword arguments as already-existing axes in the current figure,
+and if so, they would return the existing Axes.  Now, `.pyplot.axes`,
+`.figure.Figure.add_axes`, and `.figure.Figure.add_subplot` will
+always create new Axes.  `.pyplot.subplot` will continue to reuse an
+existing Axes with a matching subplot spec and equal *kwargs*.
 
 Correspondingly, the behavior of the functions to get the current Axes
-(`.pyplot.gca`, `.figure.Figure.gca`) has changed. In the past, these functions
-accepted keyword arguments. If the keyword arguments matched an
-already-existing Axes, then that Axes would be returned, otherwise new Axes
-would be created with those keyword arguments. Now, the keyword arguments are
-only considered if there are no axes at all in the current figure. In a future
-release, these functions will not accept keyword arguments at all.
+(`.pyplot.gca`, `.figure.Figure.gca`) has changed.  In the past, these
+functions accepted keyword arguments.  If the keyword arguments
+matched an already-existing Axes, then that Axes would be returned,
+otherwise new Axes would be created with those keyword arguments.
+Now, the keyword arguments are only considered if there are no axes at
+all in the current figure. In a future release, these functions will
+not accept keyword arguments at all.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1237,6 +1237,7 @@ class _AxesBase(martist.Artist):
         self._mouseover_set = _OrderedSet()
         self.child_axes = []
         self._current_image = None  # strictly for pyplot via _sci, _gci
+        self._projection_init = None  # strictly for pyplot.subplot
         self.legend_ = None
         self.collections = []  # collection.Collection instances
         self.containers = []

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1508,9 +1508,9 @@ default: %(va)s
             if polar:
                 if projection is not None and projection != 'polar':
                     raise ValueError(
-                        "polar=True, yet projection=%r. "
-                        "Only one of these arguments should be supplied." %
-                        projection)
+                        f"polar={polar}, yet projection={projection!r}. "
+                        "Only one of these arguments should be supplied."
+                    )
                 projection = 'polar'
 
             if isinstance(projection, str) or projection is None:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1232,6 +1232,7 @@ def subplot(*args, **kwargs):
     # If no existing axes match, then create a new one.
     if ax is None:
         ax = fig.add_subplot(*args, **kwargs)
+    fig.sca(ax)
 
     bbox = ax.bbox
     axes_to_delete = []

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -939,53 +939,7 @@ def test_subfigure_double():
     axsRight = subfigs[1].subplots(2, 2)
 
 
-def test_axes_kwargs():
-    # plt.axes() always creates new axes, even if axes kwargs differ.
-    plt.figure()
-    ax = plt.axes()
-    ax1 = plt.axes()
-    assert ax is not None
-    assert ax1 is not ax
-    plt.close()
-
-    plt.figure()
-    ax = plt.axes(projection='polar')
-    ax1 = plt.axes(projection='polar')
-    assert ax is not None
-    assert ax1 is not ax
-    plt.close()
-
-    plt.figure()
-    ax = plt.axes(projection='polar')
-    ax1 = plt.axes()
-    assert ax is not None
-    assert ax1.name == 'rectilinear'
-    assert ax1 is not ax
-    plt.close()
-
-    # fig.add_axes() always creates new axes, even if axes kwargs differ.
-    fig = plt.figure()
-    ax = fig.add_axes([0, 0, 1, 1])
-    ax1 = fig.add_axes([0, 0, 1, 1])
-    assert ax is not None
-    assert ax1 is not ax
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.add_axes([0, 0, 1, 1], projection='polar')
-    ax1 = fig.add_axes([0, 0, 1, 1], projection='polar')
-    assert ax is not None
-    assert ax1 is not ax
-    plt.close()
-
-    fig = plt.figure()
-    ax = fig.add_axes([0, 0, 1, 1], projection='polar')
-    ax1 = fig.add_axes([0, 0, 1, 1])
-    assert ax is not None
-    assert ax1.name == 'rectilinear'
-    assert ax1 is not ax
-    plt.close()
-
+def test_add_subplot_kwargs():
     # fig.add_subplot() always creates new axes, even if axes kwargs differ.
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1)
@@ -1009,49 +963,27 @@ def test_axes_kwargs():
     assert ax1 is not ax
     plt.close()
 
-    # plt.subplot() searches for axes with the same subplot spec, and if one
-    # exists, returns it, regardless of whether the axes kwargs were the same.
+
+def test_add_axes_kwargs():
+    # fig.add_axes() always creates new axes, even if axes kwargs differ.
     fig = plt.figure()
-    ax = plt.subplot(1, 2, 1)
-    ax1 = plt.subplot(1, 2, 1)
-    ax2 = plt.subplot(1, 2, 2)
-    ax3 = plt.subplot(1, 2, 1, projection='polar')
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax1 = fig.add_axes([0, 0, 1, 1])
     assert ax is not None
-    assert ax1 is ax
-    assert ax2 is not ax
-    assert ax3 is ax
-    assert ax.name == 'rectilinear'
-    assert ax3.name == 'rectilinear'
+    assert ax1 is not ax
     plt.close()
 
-    # plt.gca() returns an existing axes, unless there were no axes.
-    plt.figure()
-    ax = plt.gca()
-    ax1 = plt.gca()
+    fig = plt.figure()
+    ax = fig.add_axes([0, 0, 1, 1], projection='polar')
+    ax1 = fig.add_axes([0, 0, 1, 1], projection='polar')
     assert ax is not None
-    assert ax1 is ax
+    assert ax1 is not ax
     plt.close()
 
-    # plt.gca() raises a DeprecationWarning if called with kwargs.
-    plt.figure()
-    with pytest.warns(
-            MatplotlibDeprecationWarning,
-            match=r'Calling gca\(\) with keyword arguments was deprecated'):
-        ax = plt.gca(projection='polar')
-    ax1 = plt.gca()
+    fig = plt.figure()
+    ax = fig.add_axes([0, 0, 1, 1], projection='polar')
+    ax1 = fig.add_axes([0, 0, 1, 1])
     assert ax is not None
-    assert ax1 is ax
-    assert ax1.name == 'polar'
-    plt.close()
-
-    # plt.gca() ignores keyword arguments if an axes already exists.
-    plt.figure()
-    ax = plt.gca()
-    with pytest.warns(
-            MatplotlibDeprecationWarning,
-            match=r'Calling gca\(\) with keyword arguments was deprecated'):
-        ax1 = plt.gca(projection='polar')
-    assert ax is not None
-    assert ax1 is ax
     assert ax1.name == 'rectilinear'
+    assert ax1 is not ax
     plt.close()

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -168,5 +168,145 @@ def test_subplot_reuse():
     assert ax1 is plt.gca()
     ax2 = plt.subplot(122)
     assert ax2 is plt.gca()
-    ax1 = plt.subplot(121)
+    ax3 = plt.subplot(121)
     assert ax1 is plt.gca()
+    assert ax1 is ax3
+
+
+def test_axes_kwargs():
+    # plt.axes() always creates new axes, even if axes kwargs differ.
+    plt.figure()
+    ax = plt.axes()
+    ax1 = plt.axes()
+    assert ax is not None
+    assert ax1 is not ax
+    plt.close()
+
+    plt.figure()
+    ax = plt.axes(projection='polar')
+    ax1 = plt.axes(projection='polar')
+    assert ax is not None
+    assert ax1 is not ax
+    plt.close()
+
+    plt.figure()
+    ax = plt.axes(projection='polar')
+    ax1 = plt.axes()
+    assert ax is not None
+    assert ax1.name == 'rectilinear'
+    assert ax1 is not ax
+    plt.close()
+
+
+def test_subplot_replace_projection():
+    # plt.subplot() searches for axes with the same subplot spec, and if one
+    # exists, and the kwargs match returns it, create a new one if they do not
+    fig = plt.figure()
+    ax = plt.subplot(1, 2, 1)
+    ax1 = plt.subplot(1, 2, 1)
+    ax2 = plt.subplot(1, 2, 2)
+    # This will delete ax / ax1 as they fully overlap
+    ax3 = plt.subplot(1, 2, 1, projection='polar')
+    ax4 = plt.subplot(1, 2, 1, projection='polar')
+    assert ax is not None
+    assert ax1 is ax
+    assert ax2 is not ax
+    assert ax3 is not ax
+    assert ax3 is ax4
+
+    assert ax not in fig.axes
+    assert ax2 in fig.axes
+    assert ax3 in fig.axes
+
+    assert ax.name == 'rectilinear'
+    assert ax2.name == 'rectilinear'
+    assert ax3.name == 'polar'
+
+
+def test_subplot_kwarg_collision():
+    ax1 = plt.subplot(projection='polar', theta_offset=0)
+    ax2 = plt.subplot(projection='polar', theta_offset=0)
+    assert ax1 is ax2
+    ax3 = plt.subplot(projection='polar', theta_offset=1)
+    assert ax1 is not ax3
+    assert ax1 not in plt.gcf().axes
+
+
+def test_gca_kwargs():
+    # plt.gca() returns an existing axes, unless there were no axes.
+    plt.figure()
+    ax = plt.gca()
+    ax1 = plt.gca()
+    assert ax is not None
+    assert ax1 is ax
+    plt.close()
+
+    # plt.gca() raises a DeprecationWarning if called with kwargs.
+    plt.figure()
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
+        ax = plt.gca(projection='polar')
+    ax1 = plt.gca()
+    assert ax is not None
+    assert ax1 is ax
+    assert ax1.name == 'polar'
+    plt.close()
+
+    # plt.gca() ignores keyword arguments if an axes already exists.
+    plt.figure()
+    ax = plt.gca()
+    with pytest.warns(
+            MatplotlibDeprecationWarning,
+            match=r'Calling gca\(\) with keyword arguments was deprecated'):
+        ax1 = plt.gca(projection='polar')
+    assert ax is not None
+    assert ax1 is ax
+    assert ax1.name == 'rectilinear'
+    plt.close()
+
+
+def test_subplot_projection_reuse():
+    # create an axes
+    ax1 = plt.subplot(111)
+    # check that it is current
+    assert ax1 is plt.gca()
+    # make sure we get it back if we ask again
+    assert ax1 is plt.subplot(111)
+    # create a polar plot
+    ax2 = plt.subplot(111, projection='polar')
+    assert ax2 is plt.gca()
+    # this should have deleted the first axes
+    assert ax1 not in plt.gcf().axes
+    # assert we get it back if no extra parameters passed
+    assert ax2 is plt.subplot(111)
+    # now check explicitly setting the projection to rectilinear
+    # makes a new axes
+    ax3 = plt.subplot(111, projection='rectilinear')
+    assert ax3 is plt.gca()
+    assert ax3 is not ax2
+    assert ax2 not in plt.gcf().axes
+
+
+def test_subplot_polar_normalization():
+    ax1 = plt.subplot(111, projection='polar')
+    ax2 = plt.subplot(111, polar=True)
+    ax3 = plt.subplot(111, polar=True, projection='polar')
+    assert ax1 is ax2
+    assert ax1 is ax3
+
+    with pytest.raises(ValueError,
+                       match="polar=True, yet projection='3d'"):
+        ax2 = plt.subplot(111, polar=True, projection='3d')
+
+
+def test_subplot_change_projection():
+    ax = plt.subplot()
+    projections = ('aitoff', 'hammer', 'lambert', 'mollweide',
+                   'polar', 'rectilinear', '3d')
+    for proj in projections:
+        ax_next = plt.subplot(projection=proj)
+        assert ax_next is plt.subplot()
+        assert ax_next.name == proj
+        assert ax is not ax_next
+        ax = ax_next

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -161,3 +161,12 @@ def test_close():
     except TypeError as e:
         assert str(e) == "close() argument must be a Figure, an int, " \
                          "a string, or None, not <class 'float'>"
+
+
+def test_subplot_reuse():
+    ax1 = plt.subplot(121)
+    assert ax1 is plt.gca()
+    ax2 = plt.subplot(122)
+    assert ax2 is plt.gca()
+    ax1 = plt.subplot(121)
+    assert ax1 is plt.gca()


### PR DESCRIPTION
This adds a small amount of additional state to the Axes created via
Figure.add_axes and Figure.add_subplot (which the other Axes creation
methods eventually funnel through) to track the kwargs passed
through.

We then use that state in `pyplot.subplot` to determine if we should
re-use an Axes found at a given position or create a new one (and
implicitly destroy the existing one).

closes #19432
closes #10700

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
