### PR TITLE
Make backend_gtk3foo importable on headless environments.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19441-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19441-AL.rst
@@ -1,0 +1,4 @@
+``backend_gtk3.cursord``
+~~~~~~~~~~~~~~~~~~~~~~~~
+This dict is deprecated, in order to make the module importable on headless
+environments.

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -37,7 +37,7 @@ backend_version = "%s.%s.%s" % (
 
 try:
     _display = Gdk.Display.get_default()
-    cursord = {
+    cursord = {  # deprecated in Matplotlib 3.5.
         cursors.MOVE:          Gdk.Cursor.new_from_name(_display, "move"),
         cursors.HAND:          Gdk.Cursor.new_from_name(_display, "pointer"),
         cursors.POINTER:       Gdk.Cursor.new_from_name(_display, "default"),
@@ -45,9 +45,7 @@ try:
         cursors.WAIT:          Gdk.Cursor.new_from_name(_display, "wait"),
     }
 except TypeError as exc:
-    # Happens when running headless.  Convert to ImportError to cooperate with
-    # backend switching.
-    raise ImportError(exc) from exc
+    cursord = {}  # deprecated in Matplotlib 3.5.
 
 
 class TimerGTK3(TimerBase):
@@ -486,10 +484,22 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         escaped = GLib.markup_escape_text(s)
         self.message.set_markup(f'<small>{escaped}</small>')
 
+    @staticmethod
+    @functools.lru_cache()
+    def _mpl_to_gtk_cursor(mpl_cursor):
+        name = {
+            cursors.MOVE: "move",
+            cursors.HAND: "pointer",
+            cursors.POINTER: "default",
+            cursors.SELECT_REGION: "crosshair",
+            cursors.WAIT: "wait",
+        }[mpl_cursor]
+        return Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
+
     def set_cursor(self, cursor):
         window = self.canvas.get_property("window")
         if window is not None:
-            window.set_cursor(cursord[cursor])
+            window.set_cursor(self._mpl_to_gtk_cursor(cursor))
             Gtk.main_iteration()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):


### PR DESCRIPTION
This should ultimately make it easier to generate apidocs on CI.

The change in value of `cursord` only happens on headless envs, where
the module was not importable at all before, so that's not an API break.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
