### PR TITLE
Remove unnecessary facecolor cache in Patch3D.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -344,13 +344,9 @@ class Patch3D(Patch):
         zs = np.broadcast_to(zs, len(verts))
         self._segment3d = [juggle_axes(x, y, z, zdir)
                            for ((x, y), z) in zip(verts, zs)]
-        self._facecolor3d = Patch.get_facecolor(self)
 
     def get_path(self):
         return self._path2d
-
-    def get_facecolor(self):
-        return self._facecolor2d
 
     @_api.delete_parameter('3.4', 'renderer')
     def do_3d_projection(self, renderer=None):
@@ -359,8 +355,6 @@ class Patch3D(Patch):
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
                                                         self.axes.M)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]))
-        # FIXME: coloring
-        self._facecolor2d = self._facecolor3d
         return min(vzs)
 
 
@@ -385,8 +379,6 @@ class PathPatch3D(Patch3D):
         vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
                                                         self.axes.M)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]), self._code3d)
-        # FIXME: coloring
-        self._facecolor2d = self._facecolor3d
         return min(vzs)
 
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -582,6 +582,19 @@ def test_quiver3d_masked():
     ax.quiver(x, y, z, u, v, w, length=0.1, pivot='tip', normalize=True)
 
 
+def test_patch_modification():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="3d")
+    circle = Circle((0, 0))
+    ax.add_patch(circle)
+    art3d.patch_2d_to_3d(circle)
+    circle.set_facecolor((1.0, 0.0, 0.0, 1))
+
+    assert mcolors.same_color(circle.get_facecolor(), (1, 0, 0, 1))
+    fig.canvas.draw()
+    assert mcolors.same_color(circle.get_facecolor(), (1, 0, 0, 1))
+
+
 @check_figures_equal(extensions=['png'])
 def test_patch_collection_modification(fig_test, fig_ref):
     # Test that modifying Patch3DCollection properties after creation works.


### PR DESCRIPTION
## PR Summary

It simply copies the value from the 2D version to `self._facecolor3d`, and then later to `self._facecolor2d`, but never does anything to require these additional copies.

Fixes #18815.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).