### PR TITLE
Use absolute link for discourse

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -17,7 +17,7 @@ require writing code at all. For example:
 If you have any questions on the
 process or how to fix something feel free to ask on `gitter
 <https://gitter.im/matplotlib/matplotlib>`_ for short questions and on
-`discourse <discourse.matplotlib.org>`_ for longer questions.
+`discourse <https://discourse.matplotlib.org>`_ for longer questions.
 
 .. raw:: html
 


### PR DESCRIPTION

## PR Summary
Fix the link to discourse. Otherwise it ends up linking to https://matplotlib.org/devdocs/devel/discourse.matplotlib.org

See: https://matplotlib.org/devdocs/devel/index.html#

Follow up to https://github.com/matplotlib/matplotlib/pull/19344 so attn @timhoffm 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->


- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).


