### PR TITLE
Fix default label visibility for top-or-left-labeled shared subplots().

### DIFF
--- a/doc/users/next_whats_new/top-left-shared-subplots.rst
+++ b/doc/users/next_whats_new/top-left-shared-subplots.rst
@@ -1,0 +1,10 @@
+Shared-axes ``subplots`` tick label visibility is now correct for top or left labels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When calling ``subplots(..., sharex=True, sharey=True)``, Matplotlib
+automatically hides x tick labels for axes not in the first column and y tick
+labels for axes not in the last row.  This behavior is incorrect if rcParams
+specify that axes should be labeled on the top (``rcParams["xtick.labeltop"] =
+True``) or on the right (``rcParams["ytick.labelright"] = True``).
+
+Such cases are now handled correctly (adjusting visibility as needed on the
+first row and last column of axes).

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -309,17 +309,23 @@ class GridSpecBase:
 
         # turn off redundant tick labeling
         if sharex in ["col", "all"]:
-            # turn off all but the bottom row
-            for ax in axarr[:-1, :].flat:
-                ax.xaxis.set_tick_params(which='both',
-                                         labelbottom=False, labeltop=False)
-                ax.xaxis.offsetText.set_visible(False)
+            for ax in axarr[:-1, :].flat:  # Remove bottom labels/offsettexts.
+                ax.xaxis.set_tick_params(which="both", labelbottom=False)
+                if ax.xaxis.offsetText.get_position()[1] == 0:
+                    ax.xaxis.offsetText.set_visible(False)
+            for ax in axarr[1:, :].flat:  # Remove top labels/offsettexts.
+                ax.xaxis.set_tick_params(which="both", labeltop=False)
+                if ax.xaxis.offsetText.get_position()[1] == 1:
+                    ax.xaxis.offsetText.set_visible(False)
         if sharey in ["row", "all"]:
-            # turn off all but the first column
-            for ax in axarr[:, 1:].flat:
-                ax.yaxis.set_tick_params(which='both',
-                                         labelleft=False, labelright=False)
-                ax.yaxis.offsetText.set_visible(False)
+            for ax in axarr[:, 1:].flat:  # Remove left labels/offsettexts.
+                ax.yaxis.set_tick_params(which="both", labelleft=False)
+                if ax.yaxis.offsetText.get_position()[0] == 0:
+                    ax.yaxis.offsetText.set_visible(False)
+            for ax in axarr[:, :-1].flat:  # Remove right labels/offsettexts.
+                ax.yaxis.set_tick_params(which="both", labelright=False)
+                if ax.yaxis.offsetText.get_position()[0] == 1:
+                    ax.yaxis.offsetText.set_visible(False)
 
         if squeeze:
             # Discarding unneeded dimensions that equal 1.  If we only have one

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -160,6 +160,28 @@ def test_subplots_offsettext():
     axs[1, 1].plot(y, x)
 
 
+@pytest.mark.parametrize("top", [True, False])
+@pytest.mark.parametrize("bottom", [True, False])
+@pytest.mark.parametrize("left", [True, False])
+@pytest.mark.parametrize("right", [True, False])
+def test_subplots_hide_labels(top, bottom, left, right):
+    # Ideally, we would also test offset-text visibility (and remove
+    # test_subplots_offsettext), but currently, setting rcParams fails to move
+    # the offset texts as well.
+    with plt.rc_context({"xtick.labeltop": top, "xtick.labelbottom": bottom,
+                         "ytick.labelleft": left, "ytick.labelright": right}):
+        axs = plt.figure().subplots(3, 3, sharex=True, sharey=True)
+    for (i, j), ax in np.ndenumerate(axs):
+        xtop = ax.xaxis._major_tick_kw["label2On"]
+        xbottom = ax.xaxis._major_tick_kw["label1On"]
+        yleft = ax.yaxis._major_tick_kw["label1On"]
+        yright = ax.yaxis._major_tick_kw["label2On"]
+        assert xtop == (top and i == 0)
+        assert xbottom == (bottom and i == 2)
+        assert yleft == (left and j == 0)
+        assert yright == (right and j == 2)
+
+
 def test_get_gridspec():
     # ahem, pretty trivial, but...
     fig, ax = plt.subplots()


### PR DESCRIPTION
On the following example
```python
from pylab import *
rcParams.update({"xtick.labeltop": 1, "xtick.labelbottom": 0,
                 "ytick.labelright": 1, "ytick.labelleft": 0})
subplots(3, 3, sharex=True, sharey=True)
```
subplots() now correctly leaves the xlabels on the first row and the
ylabels on the last column, rather than the other way round.

old:
![old1](https://user-images.githubusercontent.com/1322974/107149528-5a203c80-6959-11eb-9bb1-8c724f75295f.png)
new:
![new1](https://user-images.githubusercontent.com/1322974/107149519-542a5b80-6959-11eb-9085-81b661d2321d.png)

On the following example
```python
from pylab import *
rcParams.update({"xtick.labeltop": 1, "xtick.labelbottom": 1,
                 "ytick.labelright": 1, "ytick.labelleft": 1})
subplots(3, 3, sharex=True, sharey=True)
show()
```
subplots() now correctly leaves the xlabels on the first and last row
and the ylabels on the first and last column.

old:
![old2](https://user-images.githubusercontent.com/1322974/107149535-60aeb400-6959-11eb-9acb-c4c529e8f5ff.png)
new:
![new2](https://user-images.githubusercontent.com/1322974/107149530-5d1b2d00-6959-11eb-9b64-9ffc343b1a30.png)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
