### PR TITLE
Fix CallbackRegistry memory leak

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -197,7 +197,7 @@ class CallbackRegistry:
             s: {proxy: cid for cid, proxy in d.items()}
             for s, d in self.callbacks.items()}
 
-    @_api.rename_parameter("3.3.4", "s", "signal")
+    @_api.rename_parameter("3.4", "s", "signal")
     def connect(self, signal, func):
         """Register *func* to be called when signal *s* is generated."""
         self._func_cid_map.setdefault(signal, {})

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -216,12 +216,11 @@ class CallbackRegistry:
         if _is_finalizing():
             # Weakrefs can't be properly torn down at that point anymore.
             return
-        for signal, proxies in list(self._func_cid_map.items()):
-            try:
-                del self.callbacks[signal][proxies[proxy]]
+        for signal, proxy_to_cid in list(self._func_cid_map.items()):
+            cid = proxy_to_cid.pop(proxy, None)
+            if cid is not None:
+                del self.callbacks[signal][cid]
                 break
-            except KeyError:
-                pass
         else:
             # Not found
             return

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -197,16 +197,17 @@ class CallbackRegistry:
             s: {proxy: cid for cid, proxy in d.items()}
             for s, d in self.callbacks.items()}
 
-    def connect(self, s, func):
+    @_api.rename_parameter("3.3.4", "s", "signal")
+    def connect(self, signal, func):
         """Register *func* to be called when signal *s* is generated."""
-        self._func_cid_map.setdefault(s, {})
+        self._func_cid_map.setdefault(signal, {})
         proxy = _weak_or_strong_ref(func, self._remove_proxy)
-        if proxy in self._func_cid_map[s]:
-            return self._func_cid_map[s][proxy]
+        if proxy in self._func_cid_map[signal]:
+            return self._func_cid_map[signal][proxy]
         cid = next(self._cid_gen)
-        self._func_cid_map[s][proxy] = cid
-        self.callbacks.setdefault(s, {})
-        self.callbacks[s][cid] = proxy
+        self._func_cid_map[signal][proxy] = cid
+        self.callbacks.setdefault(signal, {})
+        self.callbacks[signal][cid] = proxy
         return cid
 
     # Keep a reference to sys.is_finalizing, as sys may have been cleared out

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -199,7 +199,7 @@ class CallbackRegistry:
 
     @_api.rename_parameter("3.4", "s", "signal")
     def connect(self, signal, func):
-        """Register *func* to be called when signal *s* is generated."""
+        """Register *func* to be called when signal *signal* is generated."""
         self._func_cid_map.setdefault(signal, {})
         proxy = _weak_or_strong_ref(func, self._remove_proxy)
         if proxy in self._func_cid_map[signal]:

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -219,11 +219,15 @@ class CallbackRegistry:
         for signal, proxies in list(self._func_cid_map.items()):
             try:
                 del self.callbacks[signal][proxies[proxy]]
+                break
             except KeyError:
                 pass
-            if len(self.callbacks[signal]) == 0:
-                del self.callbacks[signal]
-                del self._func_cid_map[signal]
+        else:
+            # Not found
+            return
+        if len(self.callbacks[signal]) == 0:
+            del self.callbacks[signal]
+            del self._func_cid_map[signal]
 
     def disconnect(self, cid):
         """

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -220,6 +220,7 @@ class CallbackRegistry:
             cid = proxy_to_cid.pop(proxy, None)
             if cid is not None:
                 del self.callbacks[signal][cid]
+                self._pickled_cids.discard(cid)
                 break
         else:
             # Not found
@@ -235,6 +236,7 @@ class CallbackRegistry:
 
         No error is raised if such a callback does not exist.
         """
+        self._pickled_cids.discard(cid)
         # Clean up callbacks
         for signal, cid_to_proxy in list(self.callbacks.items()):
             proxy = cid_to_proxy.pop(cid, None)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -230,17 +230,20 @@ class CallbackRegistry:
 
         No error is raised if such a callback does not exist.
         """
-        for eventname, callbackd in list(self.callbacks.items()):
-            try:
-                del callbackd[cid]
-            except KeyError:
-                continue
-            else:
-                for signal, functions in list(self._func_cid_map.items()):
-                    for function, value in list(functions.items()):
-                        if value == cid:
-                            del functions[function]
-                return
+        # Clean up callbacks
+        for signal, cid_to_proxy in list(self.callbacks.items()):
+            proxy = cid_to_proxy.pop(cid, None)
+            if proxy is not None:
+                break
+        else:
+            # Not found
+            return
+
+        proxy_to_cid = self._func_cid_map[signal]
+        for current_proxy, current_cid in list(proxy_to_cid.items()):
+            if current_cid == cid:
+                assert proxy is current_proxy
+                del proxy_to_cid[current_proxy]
 
     def process(self, s, *args, **kwargs):
         """

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -224,6 +224,7 @@ class CallbackRegistry:
         else:
             # Not found
             return
+        # Clean up empty dicts
         if len(self.callbacks[signal]) == 0:
             del self.callbacks[signal]
             del self._func_cid_map[signal]
@@ -248,6 +249,10 @@ class CallbackRegistry:
             if current_cid == cid:
                 assert proxy is current_proxy
                 del proxy_to_cid[current_proxy]
+        # Clean up empty dicts
+        if len(self.callbacks[signal]) == 0:
+            del self.callbacks[signal]
+            del self._func_cid_map[signal]
 
     def process(self, s, *args, **kwargs):
         """

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -226,7 +226,6 @@ class Test_callback_registry:
         # check we now have no callbacks registered
         self.is_empty()
 
-    @pytest.mark.xfail(reason="must be fixed")
     def test_callback_disconnect(self):
         # ensure we start with an empty registry
         self.is_empty()

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -261,6 +261,32 @@ class Test_callback_registry:
         # check we still have callbacks registered
         self.is_not_empty()
 
+    @pytest.mark.xfail(reason="must be fixed")
+    def test_registration_on_non_empty_registry(self):
+        # ensure we start with an empty registry
+        self.is_empty()
+
+        # setup the registry with a callback
+        mini_me = Test_callback_registry()
+        self.connect(self.signal, mini_me.dummy)
+
+        # Add another callback
+        mini_me2 = Test_callback_registry()
+        self.connect(self.signal, mini_me2.dummy)
+
+        # Remove and add the second callback
+        mini_me2 = Test_callback_registry()
+        self.connect(self.signal, mini_me2.dummy)
+
+        # We still have 2 references
+        self.is_not_empty()
+        assert self.count() == 2
+
+        # Removing the last 2 references
+        mini_me = None
+        mini_me2 = None
+        self.is_empty()
+
     def dummy(self):
         pass
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -261,7 +261,6 @@ class Test_callback_registry:
         # check we still have callbacks registered
         self.is_not_empty()
 
-    @pytest.mark.xfail(reason="must be fixed")
     def test_registration_on_non_empty_registry(self):
         # ensure we start with an empty registry
         self.is_empty()

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -185,6 +185,15 @@ class Test_callback_registry:
     def connect(self, s, func):
         return self.callbacks.connect(s, func)
 
+    def disconnect(self, cid):
+        return self.callbacks.disconnect(cid)
+
+    def count(self):
+        count1 = len(self.callbacks._func_cid_map.get(self.signal, []))
+        count2 = len(self.callbacks.callbacks.get(self.signal))
+        assert count1 == count2
+        return count1
+
     def is_empty(self):
         assert self.callbacks._func_cid_map == {}
         assert self.callbacks.callbacks == {}
@@ -216,6 +225,41 @@ class Test_callback_registry:
 
         # check we now have no callbacks registered
         self.is_empty()
+
+    @pytest.mark.xfail(reason="must be fixed")
+    def test_callback_disconnect(self):
+        # ensure we start with an empty registry
+        self.is_empty()
+
+        # create a class for testing
+        mini_me = Test_callback_registry()
+
+        # test that we can add a callback
+        cid1 = self.connect(self.signal, mini_me.dummy)
+        assert type(cid1) == int
+        self.is_not_empty()
+
+        self.disconnect(cid1)
+
+        # check we now have no callbacks registered
+        self.is_empty()
+
+    def test_callback_wrong_disconnect(self):
+        # ensure we start with an empty registry
+        self.is_empty()
+
+        # create a class for testing
+        mini_me = Test_callback_registry()
+
+        # test that we can add a callback
+        cid1 = self.connect(self.signal, mini_me.dummy)
+        assert type(cid1) == int
+        self.is_not_empty()
+
+        self.disconnect("foo")
+
+        # check we still have callbacks registered
+        self.is_not_empty()
 
     def dummy(self):
         pass


### PR DESCRIPTION
## PR Summary

This PR fixes the issue #19474, and probably the issue #19345

- Plus rewrite some code for readability (like full name instead of letter, intricate loop, try-catch potentially caching many things)
- Plus coverage for the method `disconnect`

A much shorter change count be done to only fix the issue, if you like.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
