### PR TITLE
Proof of concept images with units

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1174,6 +1174,17 @@ class Colorbar(ColorbarBase):
         self.mappable = mappable
         _add_disjoint_kwargs(kwargs, cmap=mappable.cmap, norm=mappable.norm)
 
+        # Set the formatter if
+        # - It isn't explicity specified
+        # - The mappable has a converter and units that provide a formatter
+        if 'format' not in kwargs:
+            if hasattr(mappable, 'converter') and hasattr(mappable, 'units'):
+                info = mappable.converter.axisinfo(mappable.units, self)
+                if info is None:
+                    pass
+                if info.majfmt is not None:
+                    kwargs['format'] = info.majfmt
+
         if isinstance(mappable, contour.ContourSet):
             cs = mappable
             _add_disjoint_kwargs(


### PR DESCRIPTION
xref https://github.com/matplotlib/matplotlib/issues/19476

There is likely lots to iron out, and many tests and documentation that would need adding, but I thought I would open this as a proof of concept for images (or more generally mappables) with units. Things that come to mind are:

- Unit converters expect an `axis` argument, I'm not sure what to do about this when we have a mappable and not an axis
- `munits.registry.get_converter` expects a 1D sequence as input, not 2D, there's probably a way to modify this though

This allows things like this image, where the correct formatter is automatically set on the colorbar:

![imshow-dates](https://user-images.githubusercontent.com/6197628/107235153-48ec3400-6a1c-11eb-82ba-d2f675dca0b9.png)

```python
from datetime import datetime, timedelta
import matplotlib.colors as mcolor
import matplotlib.pyplot as plt

data = [[datetime.now(), datetime.now() - timedelta(seconds=1)],
        [datetime.now(), datetime.now()]]

fig, ax = plt.subplots()
im = ax.imshow(data)
fig.colorbar(im)

plt.show()
```
