### PR TITLE
fix regression of axline behavior with non-linear scales

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1432,7 +1432,8 @@ class _AxLine(Line2D):
 
     def get_transform(self):
         ax = self.axes
-        points_transform = self._transform + ax.transData.inverted()
+        points_transform = self._transform + ax.transData.inverted()\
+                           + ax.transScale
 
         if self._xy2 is not None:
             # two points were given

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1432,8 +1432,8 @@ class _AxLine(Line2D):
 
     def get_transform(self):
         ax = self.axes
-        points_transform = self._transform + ax.transData.inverted()\
-                           + ax.transScale
+        points_transform = (self._transform + ax.transData.inverted() +
+                            ax.transScale)
 
         if self._xy2 is not None:
             # two points were given

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4104,6 +4104,19 @@ def test_eb_line_zorder():
 
 
 @check_figures_equal()
+def test_axline_loglog(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
+    ax.loglog([.3, .6], [.3, .6], ".-")
+    ax.axline((1, 1e-3), (10, 1e-2), c="k")
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
+    ax.loglog([.3, .6], [.3, .6], ".-")
+    ax.loglog([1, 10], [1e-3, 1e-2], c="k")
+
+
+@check_figures_equal()
 def test_axline(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))


### PR DESCRIPTION
## PR Summary

#18647 broke loglog scale axlines (see #19445). This PR fixes it by adding `transScale` to the transformations applied to the points of the line and adds a test to verify the result (based on the example given by @anntzer in #19445).

This should have no effect on results with linear scales, and the remaining tests are still passing, so it looks like it works correctly.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related. [N/A]
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error). [N/A]
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`). [N/A]
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there). [N/A]
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there). [N/A]

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
