### PR TITLE
Deprecate unused \*args to print_<foo>.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19487-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19487-AL.rst
@@ -1,0 +1,6 @@
+Unused positional parameters to ``print_<fmt>`` methods are deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+None of the ``print_<fmt>`` methods implemented by canvas subclasses used
+positional arguments other that the first (the output filename or file-like),
+so these extra parameters are deprecated.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -448,6 +448,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         return self.renderer.buffer_rgba()
 
     @_check_savefig_extra_args
+    @_api.delete_parameter("3.5", "args")
     def print_raw(self, filename_or_obj, *args):
         FigureCanvasAgg.draw(self)
         renderer = self.get_renderer()
@@ -457,6 +458,7 @@ class FigureCanvasAgg(FigureCanvasBase):
     print_rgba = print_raw
 
     @_check_savefig_extra_args
+    @_api.delete_parameter("3.5", "args")
     def print_png(self, filename_or_obj, *args,
                   metadata=None, pil_kwargs=None):
         """
@@ -528,6 +530,7 @@ class FigureCanvasAgg(FigureCanvasBase):
                            alternative="pil_kwargs={'optimize': ...}")
     @_api.delete_parameter("3.3", "progressive",
                            alternative="pil_kwargs={'progressive': ...}")
+    @_api.delete_parameter("3.5", "args")
     def print_jpg(self, filename_or_obj, *args, pil_kwargs=None, **kwargs):
         """
         Write the figure to a JPEG file.

--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -70,11 +70,6 @@ class FigureCanvasGTK3Agg(backend_gtk3.FigureCanvasGTK3,
         backend_agg.FigureCanvasAgg.draw(self)
         super().draw()
 
-    def print_png(self, filename, *args, **kwargs):
-        # Do this so we can save the resolution of figure in the PNG file
-        agg = self.switch_backends(backend_agg.FigureCanvasAgg)
-        return agg.print_png(filename, *args, **kwargs)
-
 
 class FigureManagerGTK3Agg(backend_gtk3.FigureManagerGTK3):
     pass

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -843,7 +843,7 @@ class FigureCanvasPgf(FigureCanvasBase):
         writeln(fh, r"\makeatother")
         writeln(fh, r"\endgroup")
 
-    def print_pgf(self, fname_or_fh, *args, **kwargs):
+    def print_pgf(self, fname_or_fh, **kwargs):
         """
         Output pgf macros for drawing the figure so it can be included and
         rendered in latex documents.
@@ -851,9 +851,9 @@ class FigureCanvasPgf(FigureCanvasBase):
         with cbook.open_file_cm(fname_or_fh, "w", encoding="utf-8") as file:
             if not cbook.file_requires_unicode(file):
                 file = codecs.getwriter("utf-8")(file)
-            self._print_pgf_to_fh(file, *args, **kwargs)
+            self._print_pgf_to_fh(file, **kwargs)
 
-    def print_pdf(self, fname_or_fh, *args, metadata=None, **kwargs):
+    def print_pdf(self, fname_or_fh, *, metadata=None, **kwargs):
         """Use LaTeX to compile a pgf generated figure to pdf."""
         w, h = self.figure.get_figwidth(), self.figure.get_figheight()
 
@@ -865,7 +865,7 @@ class FigureCanvasPgf(FigureCanvasBase):
             tmppath = pathlib.Path(tmpdir)
 
             # print figure to pgf and compile it with latex
-            self.print_pgf(tmppath / "figure.pgf", *args, **kwargs)
+            self.print_pgf(tmppath / "figure.pgf", **kwargs)
 
             latexcode = """
 \\PassOptionsToPackage{pdfinfo={%s}}{hyperref}
@@ -891,14 +891,14 @@ class FigureCanvasPgf(FigureCanvasBase):
                  cbook.open_file_cm(fname_or_fh, "wb") as dest:
                 shutil.copyfileobj(orig, dest)  # copy file contents to target
 
-    def print_png(self, fname_or_fh, *args, **kwargs):
+    def print_png(self, fname_or_fh, **kwargs):
         """Use LaTeX to compile a pgf figure to pdf and convert it to png."""
         converter = make_pdf_to_png_converter()
         with TemporaryDirectory() as tmpdir:
             tmppath = pathlib.Path(tmpdir)
             pdf_path = tmppath / "figure.pdf"
             png_path = tmppath / "figure.png"
-            self.print_pdf(pdf_path, *args, **kwargs)
+            self.print_pdf(pdf_path, **kwargs)
             converter(pdf_path, png_path, dpi=self.figure.dpi)
             with png_path.open("rb") as orig, \
                  cbook.open_file_cm(fname_or_fh, "wb") as dest:

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -823,15 +823,17 @@ class FigureCanvasPS(FigureCanvasBase):
     def get_default_filetype(self):
         return 'ps'
 
+    @_api.delete_parameter("3.5", "args")
     def print_ps(self, outfile, *args, **kwargs):
-        return self._print_ps(outfile, 'ps', *args, **kwargs)
+        return self._print_ps(outfile, 'ps', **kwargs)
 
+    @_api.delete_parameter("3.5", "args")
     def print_eps(self, outfile, *args, **kwargs):
-        return self._print_ps(outfile, 'eps', *args, **kwargs)
+        return self._print_ps(outfile, 'eps', **kwargs)
 
     @_api.delete_parameter("3.4", "dpi")
     def _print_ps(
-            self, outfile, format, *args,
+            self, outfile, format, *,
             dpi=None, metadata=None, papertype=None, orientation='portrait',
             **kwargs):
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1286,6 +1286,7 @@ class FigureCanvasSVG(FigureCanvasBase):
 
     fixed_dpi = 72
 
+    @_api.delete_parameter("3.5", "args")
     def print_svg(self, filename, *args, **kwargs):
         """
         Parameters
@@ -1337,6 +1338,7 @@ class FigureCanvasSVG(FigureCanvasBase):
             if detach:
                 fh.detach()
 
+    @_api.delete_parameter("3.5", "args")
     def print_svgz(self, filename, *args, **kwargs):
         with cbook.open_file_cm(filename, "wb") as fh, \
                 gzip.GzipFile(mode='w', fileobj=fh) as gzipwriter:

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -29,6 +29,7 @@ method), you can register it as the default handler for a given file type::
     plt.savefig("figure.xyz")
 """
 
+from matplotlib import _api
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
      FigureCanvasBase, FigureManagerBase, GraphicsContextBase, RendererBase)
@@ -209,6 +210,7 @@ class FigureCanvasTemplate(FigureCanvasBase):
     # you should add it to the class-scope filetypes dictionary as follows:
     filetypes = {**FigureCanvasBase.filetypes, 'foo': 'My magic Foo format'}
 
+    @_api.delete_parameter("3.5", "args")
     def print_foo(self, filename, *args, **kwargs):
         """
         Write out format foo.


### PR DESCRIPTION
These `*args` are never used.

gtk3agg's print_png can just be directly inherited from agg (likely, it
is a remnant of a time when gtk3 would rely on cairo's png output by
default).

For the pgf backend, `*args` can be directly deleted because it would
previously have caused exceptions when forwarded to _print_pgf_to_fh.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
