### PR TITLE
Fix error message in plt.close().

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -908,7 +908,7 @@ def close(fig=None):
         _pylab_helpers.Gcf.destroy_fig(fig)
     else:
         raise TypeError("close() argument must be a Figure, an int, a string, "
-                        "or None, not '%s'")
+                        "or None, not %s" % type(fig))
 
 
 def clf():

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -153,3 +153,11 @@ def test_nested_ion_ioff():
     with plt.ioff():
         plt.ion()
     assert not mpl.is_interactive()
+
+
+def test_close():
+    try:
+        plt.close(1.1)
+    except TypeError as e:
+        assert str(e) == "close() argument must be a Figure, an int, " \
+                         "a string, or None, not <class 'float'>"


### PR DESCRIPTION
## PR Summary

Currently, the `TypeError` thrown when an inappropriate type is passed to `pyplot.close()` has the following message:

> TypeError: close() argument must be a Figure, an int, a string, or None, not '%s'

This is clearly a typo (introduced in f6bdcb5fe60fabe8fa2093981383b5e23a109fce) as it says `'%s'` instead of telling the user the type that was passed in.

We update the `raise` statement to include the type so that `pyplot.close(1.1)` gives

> TypeError: close() argument must be a Figure, an int, a string, or None, not <class 'float'>

instead of 

> TypeError: close() argument must be a Figure, an int, a string, or None, not '%s'

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
