### PR TITLE
Move svg basename detection down to RendererSVG.

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -280,8 +280,13 @@ class RendererSVG(RendererBase):
         self.writer = XMLWriter(svgwriter)
         self.image_dpi = image_dpi  # actual dpi at which we rasterize stuff
 
-        self._groupd = {}
+        if basename is None:
+            basename = getattr(svgwriter, "name", "")
+            if not isinstance(basename, str):
+                basename = ""
         self.basename = basename
+
+        self._groupd = {}
         self._image_counter = itertools.count()
         self._clipd = {}
         self._markers = {}
@@ -1311,9 +1316,6 @@ class FigureCanvasSVG(FigureCanvasBase):
             __ DC_
         """
         with cbook.open_file_cm(filename, "w", encoding="utf-8") as fh:
-            filename = getattr(fh, 'name', '')
-            if not isinstance(filename, str):
-                filename = ''
             if not cbook.file_requires_unicode(fh):
                 fh = codecs.getwriter('utf-8')(fh)
             self._print_svg(filename, fh, **kwargs)
@@ -1336,7 +1338,7 @@ class FigureCanvasSVG(FigureCanvasBase):
 
         renderer = MixedModeRenderer(
             self.figure, width, height, dpi,
-            RendererSVG(w, h, fh, filename, dpi, metadata=metadata),
+            RendererSVG(w, h, fh, image_dpi=dpi, metadata=metadata),
             bbox_inches_restore=bbox_inches_restore)
 
         self.figure.draw(renderer)


### PR DESCRIPTION
This means one fewer argument to track down the call stack (avoiding
passing it from print_svg to RendererSVG).  Wrapping the file object
in a TextIOWrapper (as done in print_svg) forwards the `.name` to the
wrapper, so we're fine there.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
