### PR TITLE
Add overset/underset whatsnew entry

### DIFF
--- a/doc/users/next_whats_new/mathtext.rst
+++ b/doc/users/next_whats_new/mathtext.rst
@@ -2,7 +2,7 @@
 ---------------------------------------------------------------------------
 
 `.mathtext` now supports *overset* and *underset*, called as 
-``\overset{body}{annotation}`` or ``\underset{body}{annotation}``, where 
+``\overset{annotation}{body}`` or ``\underset{annotation}{body}``, where 
 *annotation* is the text "above" or "below" the *body*.
 
 .. plot::

--- a/doc/users/next_whats_new/mathtext.rst
+++ b/doc/users/next_whats_new/mathtext.rst
@@ -1,12 +1,9 @@
 ``matplotlib.mathtext`` now supports *overset* and *underset* LaTeX symbols
 ---------------------------------------------------------------------------
 
-`.mathtext`, the default TeX layout engine which is shipped along with
-Matplotlib now supports symbols like *overset* and *underset*.
-
-The structure which should be followed: "\overset{body}{annotation}" or
-"\underset{body}{annotation}", where *body* would be the text "above" or
-"below" the *annotation* - the baseline character.
+`.mathtext` now supports *overset* and *underset*, called as 
+``\overset{body}{annotation}`` or ``\underset{body}{annotation}``, where 
+*annotation* is the text "above" or "below" the *body*.
 
 .. plot::
 

--- a/doc/users/next_whats_new/mathtext.rst
+++ b/doc/users/next_whats_new/mathtext.rst
@@ -1,0 +1,14 @@
+``matplotlib.mathtext`` now supports *overset* and *underset* LaTeX symbols
+---------------------------------------------------------------------------
+
+`.mathtext`, the default TeX layout engine which is shipped along with
+Matplotlib now supports symbols like *overset* and *underset*.
+
+The structure which should be followed: "\overset{body}{annotation}" or
+"\underset{body}{annotation}", where *body* would be the text "above" or
+"below" the *annotation* - the baseline character.
+
+.. plot::
+
+    math_expr = r"$ x \overset{f}{\rightarrow} y \underset{f}{\leftarrow} z $"
+    plt.text(0.4, 0.5, math_expr, usetex=False)

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2859,32 +2859,32 @@ class Parser:
         return self._genfrac('(', ')', 0.0, self._MathStyle.TEXTSTYLE,
                              num, den)
 
-    def _genset(self, state, body, annotation, overunder):
+    def _genset(self, state, annotation, body, overunder):
         thickness = state.font_output.get_underline_thickness(
             state.font, state.fontsize, state.dpi)
 
-        body.shrink()
+        annotation.shrink()
 
-        cbody = HCentered([body])
         cannotation = HCentered([annotation])
-        width = max(cbody.width, cannotation.width)
-        cbody.hpack(width, 'exactly')
+        cbody = HCentered([body])
+        width = max(cannotation.width, cbody.width)
         cannotation.hpack(width, 'exactly')
+        cbody.hpack(width, 'exactly')
 
         vgap = thickness * 3
         if overunder == "under":
-            vlist = Vlist([cannotation,                # annotation
-                           Vbox(0, vgap),              # space
-                           cbody                       # body
+            vlist = Vlist([cbody,                       # body
+                           Vbox(0, vgap),               # space
+                           cannotation                  # annotation
                            ])
-            # Shift so the annotation sits in the same vertical position
-            shift_amount = cannotation.depth + cbody.height + vgap
+            # Shift so the body sits in the same vertical position
+            shift_amount = cbody.depth + cannotation.height + vgap
 
             vlist.shift_amount = shift_amount
         else:
-            vlist = Vlist([cbody,                      # body
-                           Vbox(0, vgap),              # space
-                           cannotation                 # annotation
+            vlist = Vlist([cannotation,                 # annotation
+                           Vbox(0, vgap),               # space
+                           cbody                        # body
                            ])
 
         # To add horizontal gap between symbols: wrap the Vlist into
@@ -2956,18 +2956,18 @@ class Parser:
         assert len(toks[0]) == 2
 
         state = self.get_state()
-        body, annotation = toks[0]
+        annotation, body = toks[0]
 
-        return self._genset(state, body, annotation, overunder="over")
+        return self._genset(state, annotation, body, overunder="over")
 
     def underset(self, s, loc, toks):
         assert len(toks) == 1
         assert len(toks[0]) == 2
 
         state = self.get_state()
-        body, annotation = toks[0]
+        annotation, body = toks[0]
 
-        return self._genset(state, body, annotation, overunder="under")
+        return self._genset(state, annotation, body, overunder="under")
 
     def _auto_sized_delimiter(self, front, middle, back):
         state = self.get_state()


### PR DESCRIPTION
## PR Summary
This is a continuation of the previous PR https://github.com/matplotlib/matplotlib/pull/18916,
w.r.t. this comment: https://github.com/matplotlib/matplotlib/pull/18916#issuecomment-776654901

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
