### PR TITLE
Dedupe implementations of {XAxis,YAxis}._get_tick_boxes_siblings.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -136,8 +136,7 @@ class FigureBase(Artist):
         # groupers to keep track of x and y labels we want to align.
         # see self.align_xlabels and self.align_ylabels and
         # axis._get_tick_boxes_siblings
-        self._align_xlabel_grp = cbook.Grouper()
-        self._align_ylabel_grp = cbook.Grouper()
+        self._align_label_groups = {"x": cbook.Grouper(), "y": cbook.Grouper()}
 
         self.figure = self
         # list of child gridspecs for this figure
@@ -1203,7 +1202,7 @@ default: %(va)s
                     if (pos == 'top' and rowspan.start == rowspanc.start or
                             pos == 'bottom' and rowspan.stop == rowspanc.stop):
                         # grouper for groups of xlabels to align
-                        self._align_xlabel_grp.join(ax, axc)
+                        self._align_label_groups['x'].join(ax, axc)
 
     def align_ylabels(self, axs=None):
         """
@@ -1263,7 +1262,7 @@ default: %(va)s
                     if (pos == 'left' and colspan.start == colspanc.start or
                             pos == 'right' and colspan.stop == colspanc.stop):
                         # grouper for groups of ylabels to align
-                        self._align_ylabel_grp.join(ax, axc)
+                        self._align_label_groups['y'].join(ax, axc)
 
     def align_labels(self, axs=None):
         """
@@ -2154,12 +2153,6 @@ class Figure(FigureBase):
         self._cachedRenderer = None
 
         self.set_constrained_layout(constrained_layout)
-
-        # groupers to keep track of x and y labels we want to align.
-        # see self.align_xlabels and self.align_ylabels and
-        # axis._get_tick_boxes_siblings
-        self._align_xlabel_grp = cbook.Grouper()
-        self._align_ylabel_grp = cbook.Grouper()
 
         # list of child gridspecs for this figure
         self._gridspecs = []


### PR DESCRIPTION
A single implementation can be written in the base class.

Also, the alignment groupers only need to be defined in FigureBase;
we don't need to redefine them in the Figure subclass.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
