### PR TITLE
Fully fold overset/underset into _genset.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2859,12 +2859,13 @@ class Parser:
         return self._genfrac('(', ')', 0.0, self._MathStyle.TEXTSTYLE,
                              num, den)
 
-    def _genset(self, state, annotation, body, overunder):
+    def _genset(self, s, loc, toks):
+        (annotation, body), = toks
+        state = self.get_state()
         thickness = state.font_output.get_underline_thickness(
             state.font, state.fontsize, state.dpi)
 
         annotation.shrink()
-
         cannotation = HCentered([annotation])
         cbody = HCentered([body])
         width = max(cannotation.width, cbody.width)
@@ -2872,16 +2873,14 @@ class Parser:
         cbody.hpack(width, 'exactly')
 
         vgap = thickness * 3
-        if overunder == "under":
+        if s[loc + 1] == "u":  # \underset
             vlist = Vlist([cbody,                       # body
                            Vbox(0, vgap),               # space
                            cannotation                  # annotation
                            ])
             # Shift so the body sits in the same vertical position
-            shift_amount = cbody.depth + cannotation.height + vgap
-
-            vlist.shift_amount = shift_amount
-        else:
+            vlist.shift_amount = cbody.depth + cannotation.height + vgap
+        else:  # \overset
             vlist = Vlist([cannotation,                 # annotation
                            Vbox(0, vgap),               # space
                            cbody                        # body
@@ -2890,6 +2889,8 @@ class Parser:
         # To add horizontal gap between symbols: wrap the Vlist into
         # an Hlist and extend it with an Hbox(0, horizontal_gap)
         return vlist
+
+    overset = underset = _genset
 
     def sqrt(self, s, loc, toks):
         (root, body), = toks
@@ -2950,24 +2951,6 @@ class Parser:
 
         hlist = Hlist([rightside])
         return [hlist]
-
-    def overset(self, s, loc, toks):
-        assert len(toks) == 1
-        assert len(toks[0]) == 2
-
-        state = self.get_state()
-        annotation, body = toks[0]
-
-        return self._genset(state, annotation, body, overunder="over")
-
-    def underset(self, s, loc, toks):
-        assert len(toks) == 1
-        assert len(toks[0]) == 2
-
-        state = self.get_state()
-        annotation, body = toks[0]
-
-        return self._genset(state, annotation, body, overunder="under")
 
     def _auto_sized_delimiter(self, front, middle, back):
         state = self.get_state()


### PR DESCRIPTION
No need to repeat the tokens expansion twice, and it seems reasonable
enough to check the string itself instead of inventing a separate
parameter just to pass the information of whether an overset or an
underset is being handled.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
