### PR TITLE
Fix text position with usetex and xcolor

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -313,18 +313,26 @@ class Dvi:
         #   xxx comment
         #   down
         #   push
-        #     down, down
+        #     down
+        #     <push, push, xxx, right, xxx, pop, pop>  # if using xcolor
+        #     down
         #     push
         #       down (possibly multiple)
         #       push  <=  here, v is the baseline position.
         #         etc.
         # (dviasm is useful to explore this structure.)
+        # Thus, we use the vertical position at the first time the stack depth
+        # reaches 3, while at least three "downs" have been executed, as the
+        # baseline (the "down" count is necessary to handle xcolor).
+        downs = 0
         self._baseline_v = None
         while True:
             byte = self.file.read(1)[0]
             self._dtable[byte](self, byte)
+            downs += self._dtable[byte].__name__ == "_down"
             if (self._baseline_v is None
-                    and len(getattr(self, "stack", [])) == 3):
+                    and len(getattr(self, "stack", [])) == 3
+                    and downs >= 4):
                 self._baseline_v = self.v
             if byte == 140:                         # end of page
                 return True

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -75,3 +75,7 @@ def check_for_pgf(texsystem):
         except (OSError, subprocess.CalledProcessError):
             return False
         return True
+
+
+def _has_tex_package(package):
+    return bool(mpl.dviread.find_tex_file(f"{package}.sty"))

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -2,14 +2,13 @@ import datetime
 from io import BytesIO
 import os
 import shutil
-import subprocess
 
 import numpy as np
 import pytest
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from matplotlib.testing import check_for_pgf
+from matplotlib.testing import _has_tex_package, check_for_pgf
 from matplotlib.testing.compare import compare_images, ImageComparisonFailure
 from matplotlib.backends.backend_pgf import PdfPages, common_texification
 from matplotlib.testing.decorators import (_image_directories,
@@ -27,10 +26,6 @@ needs_lualatex = pytest.mark.skipif(not check_for_pgf('lualatex'),
 needs_ghostscript = pytest.mark.skipif(
     "eps" not in mpl.testing.compare.converter,
     reason="This test needs a ghostscript installation")
-
-
-def _has_tex_package(package):
-    return bool(mpl.dviread.find_tex_file(f"{package}.sty"))
 
 
 def compare_figure(fname, savefig_kwargs={}, tol=0):

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import matplotlib as mpl
+from matplotlib.testing import _has_tex_package
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.pyplot as plt
 
@@ -78,6 +79,23 @@ def test_minus_no_descent(fontsize):
         heights[vals] = ((np.array(fig.canvas.buffer_rgba())[..., 0] != 255)
                          .any(axis=1).sum())
     assert len({*heights.values()}) == 1
+
+
+@pytest.mark.skipif(not _has_tex_package('xcolor'),
+                    reason='xcolor is not available')
+def test_usetex_xcolor():
+    mpl.rcParams['text.usetex'] = True
+
+    fig = plt.figure()
+    t = fig.text(0.5, 0.5, "Some text 0123456789")
+    fig.canvas.draw()
+    pos = t.get_window_extent()
+
+    mpl.rcParams['text.latex.preamble'] = r'\usepackage[dvipsnames]{xcolor}'
+    fig = plt.figure()
+    t = fig.text(0.5, 0.5, "Some text 0123456789")
+    fig.canvas.draw()
+    np.testing.assert_array_equal(t.get_window_extent(), pos)
 
 
 def test_textcomp_full():

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -87,15 +87,15 @@ def test_usetex_xcolor():
     mpl.rcParams['text.usetex'] = True
 
     fig = plt.figure()
-    t = fig.text(0.5, 0.5, "Some text 0123456789")
+    text = fig.text(0.5, 0.5, "Some text 0123456789")
     fig.canvas.draw()
-    pos = t.get_window_extent()
 
     mpl.rcParams['text.latex.preamble'] = r'\usepackage[dvipsnames]{xcolor}'
     fig = plt.figure()
-    t = fig.text(0.5, 0.5, "Some text 0123456789")
+    text2 = fig.text(0.5, 0.5, "Some text 0123456789")
     fig.canvas.draw()
-    np.testing.assert_array_equal(t.get_window_extent(), pos)
+    np.testing.assert_array_equal(text2.get_window_extent(),
+                                  text.get_window_extent())
 
 
 def test_textcomp_full():


### PR DESCRIPTION
## PR Summary

Applies the patch from @anntzer and adds a test
Fixes #19234.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).