### PR TITLE
Prefer projection="polar" over polar=True.

### DIFF
--- a/examples/pie_and_polar_charts/nested_pie.py
+++ b/examples/pie_and_polar_charts/nested_pie.py
@@ -52,7 +52,7 @@ plt.show()
 # a circle. The cumulative sum of the values are used as the edges
 # of the bars.
 
-fig, ax = plt.subplots(subplot_kw=dict(polar=True))
+fig, ax = plt.subplots(subplot_kw=dict(projection="polar"))
 
 size = 0.3
 vals = np.array([[60., 32.], [37., 40.], [29., 10.]])

--- a/examples/pie_and_polar_charts/polar_scatter.py
+++ b/examples/pie_and_polar_charts/polar_scatter.py
@@ -33,7 +33,7 @@ c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 # rotate the plot.
 
 fig = plt.figure()
-ax = fig.add_subplot(polar=True)
+ax = fig.add_subplot(projection='polar')
 c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 
 ax.set_rorigin(-2.5)
@@ -47,7 +47,7 @@ ax.set_theta_zero_location('W', offset=10)
 # theta start and end limits, producing a sector instead of a full circle.
 
 fig = plt.figure()
-ax = fig.add_subplot(polar=True)
+ax = fig.add_subplot(projection='polar')
 c = ax.scatter(theta, r, c=colors, s=area, cmap='hsv', alpha=0.75)
 
 ax.set_thetamin(45)

--- a/examples/pyplots/annotation_polar.py
+++ b/examples/pyplots/annotation_polar.py
@@ -12,7 +12,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 fig = plt.figure()
-ax = fig.add_subplot(polar=True)
+ax = fig.add_subplot(projection='polar')
 r = np.arange(0, 1, 0.001)
 theta = 2 * 2*np.pi * r
 line, = ax.plot(theta, r, color='#ee8d18', lw=3)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -813,7 +813,7 @@ default: %(va)s
             ax2.scatter(x, y)
 
             # Create four polar Axes and access them through the returned array
-            axes = fig.subplots(2, 2, subplot_kw=dict(polar=True))
+            axes = fig.subplots(2, 2, subplot_kw=dict(projection='polar'))
             axes[0, 0].plot(x, y)
             axes[1, 1].scatter(x, y)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1360,7 +1360,7 @@ def subplots(nrows=1, ncols=1, sharex=False, sharey=False, squeeze=True,
         ax2.scatter(x, y)
 
         # Create four polar axes and access them through the returned array
-        fig, axs = plt.subplots(2, 2, subplot_kw=dict(polar=True))
+        fig, axs = plt.subplots(2, 2, subplot_kw=dict(projection="polar"))
         axs[0, 0].plot(x, y)
         axs[1, 1].scatter(x, y)
 
@@ -2426,7 +2426,7 @@ def polar(*args, **kwargs):
         else:
             _api.warn_external('Trying to create polar plot on an Axes '
                                'that does not have a polar projection.')
-    ax = axes(polar=True)
+    ax = axes(projection="polar")
     ret = ax.plot(*args, **kwargs)
     return ret
 


### PR DESCRIPTION
... per dev call.

The docstring of add_axes/add_subplot still needs to be changed, but
this should wait until after projection reuse behavior is finalized.

Also, cases of polar=True in the tests have been left as such, to keep
exercising that API.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
