### PR TITLE
Fix tight_layout() on "canvasless" figures.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19503-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19503-AL.rst
@@ -1,0 +1,6 @@
+The *dpi* parameter of ``FigureCanvas.print_foo`` printers is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The `~.Figure.savefig` machinery already took care of setting the figure dpi
+to the desired value, so ``print_foo`` can directly read it from there.  Not
+passing *dpi* to ``print_foo`` allows clearer detection of unused parameters
+passed to `~.Figure.savefig`.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2701,10 +2701,13 @@ class FigureCanvasPdf(FigureCanvasBase):
         return 'pdf'
 
     @_check_savefig_extra_args
+    @_api.delete_parameter("3.4", "dpi")
     def print_pdf(self, filename, *,
-                  dpi=72,  # dpi to use for images
+                  dpi=None,  # dpi to use for images
                   bbox_inches_restore=None, metadata=None):
 
+        if dpi is None:  # always use this branch after deprecation elapses.
+            dpi = self.figure.get_dpi()
         self.figure.set_dpi(72)            # there are 72 pdf points to an inch
         width, height = self.figure.get_size_inches()
         if isinstance(filename, PdfPages):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -829,11 +829,14 @@ class FigureCanvasPS(FigureCanvasBase):
     def print_eps(self, outfile, *args, **kwargs):
         return self._print_ps(outfile, 'eps', *args, **kwargs)
 
+    @_api.delete_parameter("3.4", "dpi")
     def _print_ps(
             self, outfile, format, *args,
-            dpi=72, metadata=None, papertype=None, orientation='portrait',
+            dpi=None, metadata=None, papertype=None, orientation='portrait',
             **kwargs):
 
+        if dpi is None:  # always use this branch after deprecation elapses.
+            dpi = self.figure.get_dpi()
         self.figure.set_dpi(72)  # Override the dpi kwarg
 
         dsc_comments = {}

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1343,9 +1343,12 @@ class FigureCanvasSVG(FigureCanvasBase):
             return self.print_svg(gzipwriter)
 
     @_check_savefig_extra_args
-    def _print_svg(self, filename, fh, *, dpi=72, bbox_inches_restore=None,
+    @_api.delete_parameter("3.4", "dpi")
+    def _print_svg(self, filename, fh, *, dpi=None, bbox_inches_restore=None,
                    metadata=None):
-        self.figure.set_dpi(72.0)
+        if dpi is None:  # always use this branch after deprecation elapses.
+            dpi = self.figure.get_dpi()
+        self.figure.set_dpi(72)
         width, height = self.figure.get_size_inches()
         w, h = width * 72, height * 72
 

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -204,9 +204,13 @@ class FigureCanvasTemplate(FigureCanvasBase):
 
     def print_foo(self, filename, *args, **kwargs):
         """
-        Write out format foo.  The dpi, facecolor and edgecolor are restored
-        to their original values after this call, so you don't need to
-        save and restore them.
+        Write out format foo.
+
+        This method is normally called via `.Figure.savefig` and
+        `.FigureCanvasBase.print_figure`, which take care of setting the figure
+        facecolor, edgecolor, and dpi to the desired output values, and will
+        restore them to the original values.  Therefore, `print_foo` does not
+        need to handle these settings.
         """
         self.draw()
 


### PR DESCRIPTION
This patch avoids a deprecation warning ("unexpected argument 'dpi'")
on `Figure().tight_layout()`.  To do so we stop passing `dpi` to
`print_foo`, which is actually fine because `print_figure` already sets
the figure dpi to whatever value we will want, so `print_foo` can just
read `self.figure.dpi`.

Closes https://github.com/matplotlib/matplotlib/issues/19486.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
