### PR TITLE
FIX: ensure we import when the user cwd does not exist

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -497,7 +497,7 @@ def matplotlib_fname():
 
     def gen_candidates():
         # rely on down-stream code to make absolute.  This protects us
-        # from having to directly get if the current working directory
+        # from having to directly get the current working directory
         # which can fail if the user has ended up with a cwd that is
         # non-existent.
         yield 'matplotlibrc'

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -496,7 +496,11 @@ def matplotlib_fname():
     """
 
     def gen_candidates():
-        yield os.path.join(os.getcwd(), 'matplotlibrc')
+        # rely on down-stream code to make absolute.  This protects us
+        # from having to directly get if the current working directory
+        # which can fail if the user has ended up with a cwd that is
+        # non-existent.
+        yield 'matplotlibrc'
         try:
             matplotlibrc = os.environ['MATPLOTLIBRC']
         except KeyError:


### PR DESCRIPTION
## PR Summary

This is the only place that we directly access the cwd in the main library.

You can drive your self to this state by in one shell cd'ing to a directory and then from a different shell removing that directory.  The first shell will still think it's working directory is the (now non-existent) path and mild chaos ensues.

This has probably been broken forever (at least back to the 2.2.x series), however I do not think that it is worth the trouble to set up this weird state in the tests.   If you are in this state IPyhon will not start and PyQt5 will not import.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
