### PR TITLE
DOC: add fixed-aspect colorbar examples

### DIFF
--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -53,6 +53,47 @@ fig.colorbar(pcm, ax=axs[0, :2], shrink=0.6, location='bottom')
 fig.colorbar(pcm, ax=[axs[0, 2]], location='bottom')
 fig.colorbar(pcm, ax=axs[1:, :], location='right', shrink=0.6)
 fig.colorbar(pcm, ax=[axs[2, 1]], location='left')
+plt.show()
 
+######################################################################
+# Colorbars with fixed-aspect-ratio axes
+# ======================================
+#
+# Placing colorbars for axes with a fixed aspect ratio pose a particular
+# challenge as the parent axes changes size depending on the data view.
 
+fig, axs = plt.subplots(2, 2,  constrained_layout=True)
+cmaps = ['RdBu_r', 'viridis']
+for col in range(2):
+    for row in range(2):
+        ax = axs[row, col]
+        pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
+                            cmap=cmaps[col])
+        if col == 0:
+            ax.set_aspect(2)
+        else:
+            ax.set_aspect(1/2)
+        if row == 1:
+            fig.colorbar(pcm, ax=ax, shrink=0.6)
+plt.show()
+
+######################################################################
+# One way around this issue is to use an `.Axes.inset_axes` to locate the
+# axes in axes co-ordinates.  Note that if you zoom in on the axes, and
+# change the shape of the axes, the colorbar will also change position.
+
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
+cmaps = ['RdBu_r', 'viridis']
+for col in range(2):
+    for row in range(2):
+        ax = axs[row, col]
+        pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
+                            cmap=cmaps[col])
+        if col == 0:
+            ax.set_aspect(2)
+        else:
+            ax.set_aspect(1/2)
+        if row == 1:
+            cax = ax.inset_axes([1.04, 0.2, 0.05, 0.6], transform=ax.transAxes)
+            fig.colorbar(pcm, ax=ax, cax=cax)
 plt.show()


### PR DESCRIPTION
## PR Summary

Update the colorbar placement tutorial to point out the utility of `ax.inset_axes` for placing colorbars when the axes has fixed aspect ratios...



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
