### PR TITLE
Colorbar axis zoom and pan

### DIFF
--- a/doc/api/next_api_changes/behavior/19515-GL.rst
+++ b/doc/api/next_api_changes/behavior/19515-GL.rst
@@ -1,0 +1,6 @@
+Colorbars now have pan and zoom functionality
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Interactive plots with colorbars can now be zoomed and panned on
+the colorbar axis. This adjusts the *vmin* and *vmax* of the
+``ScalarMappable`` associated with the colorbar.

--- a/doc/api/next_api_changes/behavior/19515-GL.rst
+++ b/doc/api/next_api_changes/behavior/19515-GL.rst
@@ -3,4 +3,8 @@ Colorbars now have pan and zoom functionality
 
 Interactive plots with colorbars can now be zoomed and panned on
 the colorbar axis. This adjusts the *vmin* and *vmax* of the
-``ScalarMappable`` associated with the colorbar.
+``ScalarMappable`` associated with the colorbar. This is currently
+only enabled for continuous norms. Norms used with contourf and
+categoricals, such as ``BoundaryNorm`` and ``NoNorm``, have the
+interactive capability disabled by default. ``cb.ax.set_navigate()``
+can be used to set whether a colorbar axes is interactive or not.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4418,7 +4418,7 @@ class _AxesBase(martist.Artist):
         Helper function to return the new points after a pan.
 
         This helper function returns the points on the axis after a pan has
-        occurred. This a convenience method to abstract the pan logic
+        occurred. This is a convenience method to abstract the pan logic
         out of the base setter.
         """
         def format_deltas(key, dx, dy):
@@ -4474,7 +4474,6 @@ class _AxesBase(martist.Artist):
         # Just ignore invalid limits (typically, underflow in log-scale).
         points[~valid] = None
         return points
-
 
     def drag_pan(self, button, key, x, y):
         """

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3166,6 +3166,15 @@ class NavigationToolbar2:
             y1, y2 = ax.bbox.intervaly
         elif event.key == "y":
             x1, x2 = ax.bbox.intervalx
+
+        # A colorbar is one-dimensional, so we extend the zoom rectangle out
+        # to the edge of the axes bbox in the other dimension
+        if hasattr(ax, "_colorbar"):
+            if ax._colorbar.orientation == 'horizontal':
+                y1, y2 = ax.bbox.intervaly
+            else:
+                x1, x2 = ax.bbox.intervalx
+
         self.draw_rubberband(event, x1, y1, x2, y2)
 
     def release_zoom(self, event):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1274,6 +1274,36 @@ class Colorbar:
             return self.ax.xaxis
         return self.ax.yaxis
 
+    def _get_view(self):
+        # docstring inherited
+        # An interactive view for a colorbar is the norm's vmin/vmax
+        return self.norm.vmin, self.norm.vmax
+
+    def _set_view(self, view):
+        # docstring inherited
+        # An interactive view for a colorbar is the norm's vmin/vmax
+        self.norm.vmin, self.norm.vmax = view
+
+    def _set_view_from_bbox(self, bbox, direction='in',
+                            mode=None, twinx=False, twiny=False):
+        # docstring inherited
+        # For colorbars, we use the zoom bbox to scale the norm's vmin/vmax
+        new_xbound, new_ybound = self.ax._prepare_view_from_bbox(
+            bbox, direction=direction, mode=mode, twinx=twinx, twiny=twiny)
+        if self.orientation == 'horizontal':
+            self.norm.vmin, self.norm.vmax = new_xbound
+        elif self.orientation == 'vertical':
+            self.norm.vmin, self.norm.vmax = new_ybound
+
+    def drag_pan(self, button, key, x, y):
+        # docstring inherited
+        points = self.ax._get_pan_points(button, key, x, y)
+        if points is not None:
+            if self.orientation == 'horizontal':
+                self.norm.vmin, self.norm.vmax = points[:, 0]
+            elif self.orientation == 'vertical':
+                self.norm.vmin, self.norm.vmax = points[:, 1]
+
 
 ColorbarBase = Colorbar  # Backcompat API
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -422,7 +422,6 @@ class Colorbar:
 
         self.ax = ax
         self.ax._axes_locator = _ColorbarAxesLocator(self)
-        ax.set(navigate=False)
 
         if extend is None:
             if (not isinstance(mappable, contour.ContourSet)
@@ -495,6 +494,16 @@ class Colorbar:
 
         if isinstance(mappable, contour.ContourSet) and not mappable.filled:
             self.add_lines(mappable)
+
+        # Link the Axes and Colorbar for interactive use
+        self.ax._colorbar = self
+        for x in ["_get_view", "_set_view", "_set_view_from_bbox",
+                  "drag_pan", "start_pan", "end_pan"]:
+            setattr(self.ax, x, getattr(self, x))
+        # Don't navigate on any of these types of mappables
+        if (isinstance(self.norm, (colors.BoundaryNorm, colors.NoNorm)) or
+                isinstance(self.mappable, contour.ContourSet)):
+            self.ax.set_navigate(False)
 
     # Also remove ._patch after deprecation elapses.
     patch = _api.deprecate_privatize_attribute("3.5", alternative="ax")

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -202,10 +202,13 @@ def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
     assert cb.ax.get_navigate()
 
     # Mouse from 4 to 6 (data coordinates, "d").
-    # The y coordinate doesn't matter, just needs to be between 0 and 1
     vmin, vmax = 4, 6
-    d0 = (vmin, 0.1)
-    d1 = (vmax, 0.9)
+    # The y coordinate doesn't matter, it just needs to be between 0 and 1
+    # However, we will set d0/d1 to the same y coordinate to test that small
+    # pixel changes in that coordinate doesn't cancel the zoom like a normal
+    # axes would.
+    d0 = (vmin, 0.5)
+    d1 = (vmax, 0.5)
     # Swap them if the orientation is vertical
     if orientation == "vertical":
         d0 = d0[::-1]

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -181,6 +181,63 @@ def test_interactive_zoom():
     assert not ax.get_autoscalex_on() and not ax.get_autoscaley_on()
 
 
+@pytest.mark.parametrize("plot_func", ["imshow", "contourf"])
+@pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
+@pytest.mark.parametrize("tool,button,expected",
+                         [("zoom", MouseButton.LEFT, (4, 6)),  # zoom in
+                          ("zoom", MouseButton.RIGHT, (-20, 30)),  # zoom out
+                          ("pan", MouseButton.LEFT, (-2, 8))])
+def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
+    fig, ax = plt.subplots()
+    data = np.arange(12).reshape((4, 3))
+    vmin0, vmax0 = 0, 10
+    coll = getattr(ax, plot_func)(data, vmin=vmin0, vmax=vmax0)
+
+    cb = fig.colorbar(coll, ax=ax, orientation=orientation)
+    if plot_func == "contourf":
+        # Just determine we can't navigate and exit out of the test
+        assert not cb.ax.get_navigate()
+        return
+
+    assert cb.ax.get_navigate()
+
+    # Mouse from 4 to 6 (data coordinates, "d").
+    # The y coordinate doesn't matter, just needs to be between 0 and 1
+    vmin, vmax = 4, 6
+    d0 = (vmin, 0.1)
+    d1 = (vmax, 0.9)
+    # Swap them if the orientation is vertical
+    if orientation == "vertical":
+        d0 = d0[::-1]
+        d1 = d1[::-1]
+    # Convert to screen coordinates ("s").  Events are defined only with pixel
+    # precision, so round the pixel values, and below, check against the
+    # corresponding xdata/ydata, which are close but not equal to d0/d1.
+    s0 = cb.ax.transData.transform(d0).astype(int)
+    s1 = cb.ax.transData.transform(d1).astype(int)
+
+    # Set up the mouse movements
+    start_event = MouseEvent(
+        "button_press_event", fig.canvas, *s0, button)
+    stop_event = MouseEvent(
+        "button_release_event", fig.canvas, *s1, button)
+
+    tb = NavigationToolbar2(fig.canvas)
+    if tool == "zoom":
+        tb.zoom()
+        tb.press_zoom(start_event)
+        tb.drag_zoom(stop_event)
+        tb.release_zoom(stop_event)
+    else:
+        tb.pan()
+        tb.press_pan(start_event)
+        tb.drag_pan(stop_event)
+        tb.release_pan(stop_event)
+
+    # Should be close, but won't be exact due to screen integer resolution
+    assert (cb.vmin, cb.vmax) == pytest.approx(expected, abs=0.15)
+
+
 def test_toolbar_zoompan():
     expected_warning_regex = (
         r"Treat the new Tool classes introduced in "


### PR DESCRIPTION
## PR Summary

I've wanted to zoom/pan on values rather than extents of the image before and haven't figured out a clean way to do that without adding widgets. For example, if I set the range poorly the first time with my data and want to zoom in on a specific region of data, or if outliers made the vmin/vmax too large the first time. This adds zoom and pan capabilities to the colorbar. When zooming and panning on the axis, this updates the vmin/vmax of the scalar mappable norm associated with the colorbar. Currently, this changes the xlim/ylim of the axis holding the colorbar, which I don't think is desired behavior.

![ezgif-6-88618ea58e72](https://user-images.githubusercontent.com/12417828/127752218-bfbe7c3c-889d-46fc-a20e-c7f934838541.gif)

For this to work, we need the parent axis for events, and the scalar mappable object. I wasn't sure where the best place to implement these methods is, as we need to override the parent axis event handlers, but that doesn't have access to the scalarmappable... I might be overlooking something obvious here too, so better suggestions welcome
.

Interactive example if you use the zoom/pan on the colorbar axis:
```python
import matplotlib as mpl
import matplotlib.pyplot as plt
import numpy as np


rand_data = np.random.random((10, 10))*100

fig, [ax1, ax2, ax3] = plt.subplots(ncols=3)
cm = mpl.cm.get_cmap('plasma')
norm = mpl.colors.LogNorm(1, 100)
sm = mpl.cm.ScalarMappable(norm=norm, cmap=cm)

mesh1 = ax1.pcolor(rand_data, cmap=cm, norm=norm)
mesh2 = ax2.pcolorfast(rand_data, cmap=cm, norm=norm)
mesh3 = ax3.pcolormesh(rand_data, cmap=cm, norm=norm,)

cb3 = fig.colorbar(sm, ax=[ax1, ax2, ax3],
                   extend='max', orientation='horizontal')

plt.show()
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
