### PR TITLE
Deprecate toplevel is_url, URL_REGEX helpers.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19517-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19517-AL.rst
@@ -1,0 +1,4 @@
+``is_url`` and ``URL_REGEX``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.  (They were previously defined in the toplevel
+:mod:`matplotlib` module.)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -661,9 +661,11 @@ def rc_params(fail_on_error=False):
     return rc_params_from_file(matplotlib_fname(), fail_on_error)
 
 
+# Deprecated in Matplotlib 3.5.
 URL_REGEX = re.compile(r'^http://|^https://|^ftp://|^file:')
 
 
+@_api.deprecated("3.5")
 def is_url(filename):
     """Return whether *filename* is an http, https, ftp, or file URL path."""
     return URL_REGEX.match(filename) is not None
@@ -682,7 +684,8 @@ def _get_ssl_context():
 
 @contextlib.contextmanager
 def _open_file_or_url(fname):
-    if not isinstance(fname, Path) and is_url(fname):
+    if (isinstance(fname, str)
+            and fname.startswith(('http://', 'https://', 'ftp://', 'file:'))):
         import urllib.request
         ssl_ctx = _get_ssl_context()
         if ssl_ctx is None:


### PR DESCRIPTION
They certainly don't warrant being defined at the toplevel.  Also, we
don't actually need regexes here.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
