### PR TITLE
Skip setting up a tmpdir in tests that don't need one.

### DIFF
--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -59,12 +59,8 @@ def test_canvas_ctor():
     assert isinstance(FigureCanvasBase().figure, Figure)
 
 
-def test_get_default_filename(tmpdir):
-    plt.rcParams['savefig.directory'] = str(tmpdir)
-    fig = plt.figure()
-    canvas = FigureCanvasBase(fig)
-    filename = canvas.get_default_filename()
-    assert filename == 'image.png'
+def test_get_default_filename():
+    assert plt.figure().canvas.get_default_filename() == 'image.png'
 
 
 def test_canvas_change():

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -315,16 +315,11 @@ def test_pdf_eps_savefig_when_color_is_none(fig_test, fig_ref):
 
 
 @needs_usetex
-def test_failing_latex(tmpdir):
+def test_failing_latex():
     """Test failing latex subprocess call"""
-    path = str(tmpdir.join("tmpoutput.pdf"))
-
-    rcParams['text.usetex'] = True
-
-    # This fails with "Double subscript"
-    plt.xlabel("$22_2_2$")
+    plt.xlabel("$22_2_2$", usetex=True)  # This fails with "Double subscript"
     with pytest.raises(RuntimeError):
-        plt.savefig(path)
+        plt.savefig(io.BytesIO(), format="pdf")
 
 
 def test_empty_rasterized():

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -312,11 +312,10 @@ def test_tex_restart_after_error():
 
 
 @needs_xelatex
-def test_bbox_inches_tight(tmpdir):
+def test_bbox_inches_tight():
     fig, ax = plt.subplots()
     ax.imshow([[0, 1], [2, 3]])
-    fig.savefig(os.path.join(tmpdir, "test.pdf"), backend="pgf",
-                bbox_inches="tight")
+    fig.savefig(BytesIO(), format="pdf", backend="pgf", bbox_inches="tight")
 
 
 @needs_xelatex


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
