### PR TITLE
Reuse single kpsewhich instance for speed.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
 
           # Install dependencies from PyPI.
           python -mpip install --upgrade $PRE \
-            cycler kiwisolver numpy pillow pyparsing python-dateutil \
+            cycler kiwisolver numpy pillow ptyprocess pyparsing python-dateutil \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}
 

--- a/doc/api/next_api_changes/deprecations/19531-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19531-AL.rst
@@ -1,0 +1,3 @@
+The *format* kwarg to ``dviread.find_tex_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.

--- a/setup.py
+++ b/setup.py
@@ -309,6 +309,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         "pillow>=6.2.0",
         "pyparsing>=2.2.1",
         "python-dateutil>=2.7",
+        "ptyprocess;os_name=='posix'",
     ],
 
     cmdclass=cmdclass,


### PR DESCRIPTION
On MacOS, where spawing kpsewhich instances is rather slow (https://github.com/matplotlib/matplotlib/issues/4880#issuecomment-355492230), this appears
to speed up
```
python -c 'from pylab import *; mpl.use("pdf"); rcParams["text.usetex"] = True; plot(); savefig("/tmp/test.pdf", backend="pdf")'
```
around two-fold (~4s to ~2s).  (There's also a small speedup on Linux,
perhaps ~10%, but the whole thing is already reasonably fast.)

Note that this is assuming that the dvi cache has already been built;
the costly subprocess calls here are due to calls to kpsewhich to
resolve the fonts whose name are listed in the dvi file.

Much of the complexity here comes from the need to force unbuffered
stdin/stdout when interacting with kpsewhich (otherwise, things just
hang); this is also the reason why this is not implemented on Windows
(Windows experts are welcome to look into this...; there, the speedup
should be even more significant).  (On Linux, another solution, which
does not require a third-party dependency, is to call
`stdbuf -oL kpsewhich ...` and pass bufsize=0 to Popen(), but
`ptyprocess` is pure Python so adding a dependency seems reasonable).

The `format` kwarg to `find_tex_file` had never been used before, and
cannot be handled in the single-process case, so just deprecate it.

Edit: See https://github.com/matplotlib/matplotlib/pull/19558 for another approach, which also works on Windows for a large speedup.  I'll keep this PR as separate for now to allow comparing the various approaches.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
