### PR TITLE
Fix example's BasicUnit array conversion.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,9 @@ commands:
       - run:
           name: Install Python dependencies
           command: |
-            python -m pip install --user numpy<< parameters.numpy_version >> codecov coverage
-            python -m pip install --user -r requirements/doc/doc-requirements.txt
+            python -m pip install --user \
+                numpy<< parameters.numpy_version >> codecov coverage \
+                -r requirements/doc/doc-requirements.txt
 
   mpl-install:
     steps:

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -5,6 +5,7 @@ Basic Units
 
 """
 
+from distutils.version import LooseVersion
 import math
 
 import numpy as np
@@ -154,8 +155,9 @@ class TaggedValue(metaclass=TaggedValueMeta):
     def __len__(self):
         return len(self.value)
 
-    def __getitem__(self, key):
-        return TaggedValue(self.value[key], self.unit)
+    if LooseVersion(np.__version__) >= '1.20':
+        def __getitem__(self, key):
+            return TaggedValue(self.value[key], self.unit)
 
     def __iter__(self):
         # Return a generator expression rather than use `yield`, so that

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -218,7 +218,7 @@ class BasicUnit:
         return TaggedValue(array, self)
 
     def __array__(self, t=None, context=None):
-        ret = np.array([1])
+        ret = np.array(1)
         if t is not None:
             return ret.astype(t)
         else:


### PR DESCRIPTION
## PR Summary

The unit examples are broken in NumPy < 1.20. This fixes a bug that was exposed by #19415 ~~, but does not fix the examples fully. `radian_demo` is fixed by this change, but `ellipse_with_units` is still broken. I do not understand the NumPy subclassing methods enough to fix it short of reverting #19415..~~

A unit is a scalar, not a length-1 array. Though `BasicUnit` implements `__rmul__`, if multiplying by an array, the NumPy implementation will call `__array__` instead. If the LHS is an array, everything is fine, but if the LHS is a scalar, the previous code would incorrectly cause it to be upcast to a 1D array. When `__getitem__` was added in #19415, `np.atleast_1d` started iterating each (now 1D, not scalar) `TaggedValue`, seeing it was length 1, and made the x/y arrays into (N, 1) instead of (N,).

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).