### PR TITLE
Speedup pdftex.map parsing.

### DIFF
--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -1,10 +1,10 @@
 % used by test_dviread.py
-TeXfont1 PSfont1 <font1.pfb "<font1.enc"
-TeXfont2 PSfont2 <font2.enc "<font2.pfa"
-"TeXfont3" PSfont3 "1.23 UnknownEffect" <[enc3.foo <font3.pfa
+TeXfont1 PSfont1 <font1.pfb <font1.enc
+TeXfont2 PSfont2 <font2.enc <font2.pfa
+TeXfont3 PSfont3 "1.23 UnknownEffect" <[enc3.foo <font3.pfa
 TeXfont4 PSfont4 "-0.1 SlantFont 2.2 ExtendFont" <font4.enc <font4.pfa
-TeXfont5 "PSfont5" <encoding1.enc <encoding2.enc <font5.pfb
+TeXfont5 PSfont5 <encoding1.enc <encoding2.enc <font5.pfb
 TeXfont6 PSfont6
 TeXfont7 PSfont7 <font7.enc
 TeXfont8 PSfont8 <font8.pfb
-TeXfont9 PSfont9 </absolute/font9.pfb
+TeXfont9 </absolute/font9.pfb

--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -1,10 +1,10 @@
 % used by test_dviread.py
 TeXfont1 PSfont1 <font1.pfb <font1.enc
 TeXfont2 PSfont2 <font2.enc <font2.pfa
-TeXfont3 PSfont3 "1.23 UnknownEffect" <[enc3.foo <font3.pfa
+TeXfont3 PSfont3 "1.23 UnknownEffect" <[enc3.foo < font3.pfa
 TeXfont4 PSfont4 "-0.1 SlantFont 2.2 ExtendFont" <font4.enc <font4.pfa
 TeXfont5 PSfont5 <encoding1.enc <encoding2.enc <font5.pfb
 TeXfont6 PSfont6
-TeXfont7 PSfont7 <font7.enc
-TeXfont8 PSfont8 <font8.pfb
+TeXfont7 PSfont7 < font7.enc
+TeXfont8 PSfont8 <<font8.pfb
 TeXfont9 </absolute/font9.pfb

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -42,10 +42,13 @@ def test_PsfontsMap(monkeypatch):
     assert entry.filename == b'font8.pfb'
     assert entry.encoding is None
     entry = fontmap[b'TeXfont9']
+    assert entry.psname == b'TeXfont9'
     assert entry.filename == b'/absolute/font9.pfb'
     # Missing font
     with pytest.raises(KeyError, match='no-such-font'):
         fontmap[b'no-such-font']
+    with pytest.raises(KeyError, match='%'):
+        fontmap[b'%']
 
 
 @pytest.mark.skipif(shutil.which("kpsewhich") is None,


### PR DESCRIPTION
1st commit:

For reminder, pdftex.map is a file that maps tex font names ("cmr10") to
filesystem font names ("cmr10.pfb"), together with additional metadata
(font encoding, postscript special commands).  When using pdf output
with usetex, we parse usetex-generated dvi files and then need to locate
and load these fonts for embedding into the pdf file, hence then need to
parse pdftex.map.

On some systems (likely with large texlive installs), pdftex.map can be
really large (>10^4 entries), and parsing it is quite slow (>500ms on
the matplotlib macos).

This patch implements a new (simpler?) parser, which is ~25% faster
(so it can cut hundreds of ms on systems with large maps).  The patch
additionally correctly handles entries of the form `foo <bar.pfb`
(i.e., with no postscript font name -- in that case the docs say that
the postscript font name is the same as the tfm name).  On the other
hand, the patch also drops support for quotes around anything but the
postscript specials (in accordance with the psfonts.map docs, and the
actual pdftex implementation in `src/texk/web2c/pdftexdir/mapfile.c`:
`case '"': /* opening quote */` only handles postscript specials).  See
also changes to test.map for the changes in supported syntax.

2nd commit:

See previous commit for description of pdftex.map.  The vast majority
of entries (dozens of thousands) in pdftex.map actually end up being
unused, and their parsing is just wasted.  This patch takes advantage of
the fact that we can quickly recover the tex font name from pdftex.map
entries (it's just the first word), so we can very quickly build a
mapping of tex font names to unparsed pdftex.map entries, and then only
parse the few entries that we'll need on-demand.  This speeds up e.g.
```
python -c 'from pylab import *; rcParams["text.usetex"] = True; plot(); savefig("/tmp/test.pdf")'
```
by ~700ms (~20%) on the matplotlib macos.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
