### PR TITLE
Share subplots() label visibility handling with label_outer().

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -117,22 +117,44 @@ class SubplotBase:
         """
         Only show "outer" labels and tick labels.
 
-        x-labels are only kept for subplots on the last row; y-labels only for
-        subplots on the first column.
+        x-labels are only kept for subplots on the last row (or first row, if
+        labels are on the top side); y-labels only for subplots on the first
+        column (or last column, if labels are on the right side).
         """
+        self._label_outer_xaxis()
+        self._label_outer_yaxis()
+
+    def _label_outer_xaxis(self):
         ss = self.get_subplotspec()
-        lastrow = ss.is_last_row()
-        firstcol = ss.is_first_col()
-        if not lastrow:
-            for label in self.get_xticklabels(which="both"):
-                label.set_visible(False)
-            self.xaxis.get_offset_text().set_visible(False)
-            self.set_xlabel("")
-        if not firstcol:
-            for label in self.get_yticklabels(which="both"):
-                label.set_visible(False)
-            self.yaxis.get_offset_text().set_visible(False)
-            self.set_ylabel("")
+        label_position = self.xaxis.get_label_position()
+        if not ss.is_first_row():  # Remove top label/ticklabels/offsettext.
+            if label_position == "top":
+                self.set_xlabel("")
+            self.xaxis.set_tick_params(which="both", labeltop=False)
+            if self.xaxis.offsetText.get_position()[1] == 1:
+                self.xaxis.offsetText.set_visible(False)
+        if not ss.is_last_row():  # Remove bottom label/ticklabels/offsettext.
+            if label_position == "bottom":
+                self.set_xlabel("")
+            self.xaxis.set_tick_params(which="both", labelbottom=False)
+            if self.xaxis.offsetText.get_position()[1] == 0:
+                self.xaxis.offsetText.set_visible(False)
+
+    def _label_outer_yaxis(self):
+        ss = self.get_subplotspec()
+        label_position = self.yaxis.get_label_position()
+        if not ss.is_first_col():  # Remove left label/ticklabels/offsettext.
+            if label_position == "left":
+                self.set_ylabel("")
+            self.yaxis.set_tick_params(which="both", labelleft=False)
+            if self.yaxis.offsetText.get_position()[0] == 0:
+                self.yaxis.offsetText.set_visible(False)
+        if not ss.is_last_col():  # Remove right label/ticklabels/offsettext.
+            if label_position == "right":
+                self.set_ylabel("")
+            self.yaxis.set_tick_params(which="both", labelright=False)
+            if self.yaxis.offsetText.get_position()[0] == 1:
+                self.yaxis.offsetText.set_visible(False)
 
     def _make_twin_axes(self, *args, **kwargs):
         """Make a twinx axes of self. This is used for twinx and twiny."""

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -309,23 +309,11 @@ class GridSpecBase:
 
         # turn off redundant tick labeling
         if sharex in ["col", "all"]:
-            for ax in axarr[:-1, :].flat:  # Remove bottom labels/offsettexts.
-                ax.xaxis.set_tick_params(which="both", labelbottom=False)
-                if ax.xaxis.offsetText.get_position()[1] == 0:
-                    ax.xaxis.offsetText.set_visible(False)
-            for ax in axarr[1:, :].flat:  # Remove top labels/offsettexts.
-                ax.xaxis.set_tick_params(which="both", labeltop=False)
-                if ax.xaxis.offsetText.get_position()[1] == 1:
-                    ax.xaxis.offsetText.set_visible(False)
+            for ax in axarr.flat:
+                ax._label_outer_xaxis()
         if sharey in ["row", "all"]:
-            for ax in axarr[:, 1:].flat:  # Remove left labels/offsettexts.
-                ax.yaxis.set_tick_params(which="both", labelleft=False)
-                if ax.yaxis.offsetText.get_position()[0] == 0:
-                    ax.yaxis.offsetText.set_visible(False)
-            for ax in axarr[:, :-1].flat:  # Remove right labels/offsettexts.
-                ax.yaxis.set_tick_params(which="both", labelright=False)
-                if ax.yaxis.offsetText.get_position()[0] == 1:
-                    ax.yaxis.offsetText.set_visible(False)
+            for ax in axarr.flat:
+                ax._label_outer_yaxis()
 
         if squeeze:
             # Discarding unneeded dimensions that equal 1.  If we only have one


### PR DESCRIPTION
This allows label_outer() to also benefit from handling of top-or-right
labeled axes (not only for the tick labels, but also for the axis labels
themselves).

followup to #19472.

edit: this should also be useful for https://github.com/matplotlib/matplotlib/issues/18305.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
