### PR TITLE
Increase tolerances for other arches.

### DIFF
--- a/lib/matplotlib/tests/test_arrow_patches.py
+++ b/lib/matplotlib/tests/test_arrow_patches.py
@@ -114,7 +114,8 @@ def test_fancyarrow_dash():
     ax.add_patch(e2)
 
 
-@image_comparison(['arrow_styles.png'], style='mpl20', remove_text=True)
+@image_comparison(['arrow_styles.png'], style='mpl20', remove_text=True,
+                  tol=0 if platform.machine() == 'x86_64' else 0.005)
 def test_arrow_styles():
     styles = mpatches.ArrowStyle.get_styles()
 

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -17,7 +17,7 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
 
 
 @image_comparison(['custom_transform.png'], style='default',
-                  tol=0.03 if platform.machine() == 'x86_64' else 0.034)
+                  tol=0.03 if platform.machine() == 'x86_64' else 0.04)
 def test_custom_transform():
     class MyTransform(Transform):
         input_dims = output_dims = 2

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import platform
 
 import pytest
 
@@ -1267,7 +1268,8 @@ def test_errorbar3d():
     ax.legend()
 
 
-@image_comparison(['stem3d.png'], style='mpl20')
+@image_comparison(['stem3d.png'], style='mpl20',
+                  tol=0.0 if platform.machine() == 'x86_64' else 0.003)
 def test_stem3d():
     fig, axs = plt.subplots(2, 3, figsize=(8, 6),
                             constrained_layout=True,


### PR DESCRIPTION
## PR Summary

See scratch build here:
https://koji.fedoraproject.org/koji/taskinfo?taskID=62275793

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).