### PR TITLE
Use luatex's kpsewhich for speed.

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -406,6 +406,9 @@
     "matplotlib.projections.geo.MollweideAxes": [
       "doc/api/artist_api.rst:189"
     ],
+    "matplotlib.texmanager._InteractiveTex": [
+      "lib/matplotlib/backends/backend_pgf.py:docstring of matplotlib.backends.backend_pgf.LatexManager:1"
+    ],
     "matplotlib.text._AnnotationBase": [
       "doc/api/artist_api.rst:189",
       "lib/matplotlib/offsetbox.py:docstring of matplotlib.offsetbox.AnnotationBbox:1",

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1044,7 +1044,9 @@ class _LuatexKpathsea(texmanager._InteractiveTex):
     @lru_cache()
     def __new__(cls):
         self = super().__new__(cls)
-        super(cls, self).__init__("luatex")
+        # As of MiKTeX 20.7, luatex's interactive console errors ("! Emergency
+        # stop") as soon as a command is given, but lualatex works.  Go figure.
+        super(cls, self).__init__("lualatex")
         return self
 
     def __init__(self):

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -459,8 +459,12 @@ class _InteractiveTex:
         # ensure that the subprocess has quit before being able to delete the
         # tmpdir in which it runs; in order to do so, we must first `kill()`
         # it, and then `communicate()` with it.
+        # Passing "\relax" makes that the first command interpreted by the tex
+        # instance, causing e.g. lualatex (used by dviread) to load (and
+        # report) the latex layers it need; doing so now avoids messing up
+        # later outputs.
         self._tex = subprocess.Popen(
-            [cmd, "-halt-on-error"], cwd=self._tmpdir.name,
+            [cmd, "-halt-on-error", r"\relax"], cwd=self._tmpdir.name,
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             encoding="utf-8", errors="surrogateescape")
 


### PR DESCRIPTION
The machinery for running an interactive tex session mostly already
existed in backend_pgf, so directly reuse that (as a base class).  On
the matplotlib macos, this significantly speeds up
```sh
python -c 'from pylab import *; mpl.use("pdf"); rcParams["text.usetex"] = True; plot(); savefig("/tmp/test.pdf", backend="pdf")'
```
from ~4.5s to ~2.5s.

Note that filesystem encodings may be a bit iffy, we still need to check
how things go through the various layers here; it may end up being best
to make the process streams be binary and perform the encoding/decoding
ourselves.

We also need to figure out how to best advertise this (do we emit a
warning suggesting to install luatex on windows and macos if luatex is
not present?).

---

Edit: See https://github.com/matplotlib/matplotlib/pull/19558 for another approach, which also works on Windows for a large speedup.  I'll keep this PR as separate for now to allow comparing the various approaches.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
