### PR TITLE
Remove scalarmappable private update attributes

### DIFF
--- a/doc/api/next_api_changes/removals/19552-GL.rst
+++ b/doc/api/next_api_changes/removals/19552-GL.rst
@@ -1,0 +1,5 @@
+ScalarMappable update checkers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``ScalarMappable.update_dict``, ``ScalarMappable.add_checker()``, and
+``ScalarMappable.check_update()`` have been removed. A callback can
+be registered in ``ScalarMappable.callbacksSM`` to be notified of updates.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -264,7 +264,6 @@ class ScalarMappable:
         #: The last colorbar associated with this ScalarMappable. May be None.
         self.colorbar = None
         self.callbacksSM = cbook.CallbackRegistry()
-        self._update_dict = {'array': False}
 
     def _scale_norm(self, norm, vmin, vmax):
         """
@@ -369,7 +368,6 @@ class ScalarMappable:
         A : ndarray or None
         """
         self._A = A
-        self._update_dict['array'] = True
 
     def get_array(self):
         """Return the data array."""
@@ -476,30 +474,10 @@ class ScalarMappable:
         self.norm.autoscale_None(self._A)
         self.changed()
 
-    def _add_checker(self, checker):
-        """
-        Add an entry to a dictionary of boolean flags
-        that are set to True when the mappable is changed.
-        """
-        self._update_dict[checker] = False
-
-    def _check_update(self, checker):
-        """Return whether mappable has changed since the last check."""
-        if self._update_dict[checker]:
-            self._update_dict[checker] = False
-            return True
-        return False
-
     def changed(self):
         """
         Call this whenever the mappable is changed to notify all the
         callbackSM listeners to the 'changed' signal.
         """
         self.callbacksSM.process('changed', self)
-        for key in self._update_dict:
-            self._update_dict[key] = True
         self.stale = True
-
-    update_dict = _api.deprecate_privatize_attribute("3.3")
-    add_checker = _api.deprecate_privatize_attribute("3.3")
-    check_update = _api.deprecate_privatize_attribute("3.3")

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -851,7 +851,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
             supported.
         """
         artist.Artist._set_alpha_for_array(self, alpha)
-        self._update_dict['array'] = True
         self._set_facecolor(self._original_facecolor)
         self._set_edgecolor(self._original_edgecolor)
 
@@ -907,7 +906,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if not self._set_mappable_flags():
             return
         # Allow possibility to call 'self.set_array(None)'.
-        if self._check_update("array") and self._A is not None:
+        if self._A is not None:
             # QuadMesh can map 2d arrays (but pcolormesh supplies 1d array)
             if self._A.ndim > 1 and not isinstance(self, QuadMesh):
                 raise ValueError('Collections can only map rank 1 arrays')
@@ -958,7 +957,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._A = other._A
         self.norm = other.norm
         self.cmap = other.cmap
-        # do we need to copy self._update_dict? -JJL
         self.stale = True
 
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -715,6 +715,22 @@ def test_quadmesh_set_array():
     assert np.array_equal(coll.get_array(), np.ones(9))
 
 
+def test_quadmesh_vmin_vmax():
+    # test when vmin/vmax on the norm changes, the quadmesh gets updated
+    fig, ax = plt.subplots()
+    cmap = mpl.cm.get_cmap('plasma')
+    norm = mpl.colors.Normalize(vmin=0, vmax=1)
+    coll = ax.pcolormesh([[1]], cmap=cmap, norm=norm)
+    fig.canvas.draw()
+    assert np.array_equal(coll.get_facecolors()[0, :], cmap(norm(1)))
+
+    # Change the vmin/vmax of the norm so that the color is from
+    # the bottom of the colormap now
+    norm.vmin, norm.vmax = 1, 2
+    fig.canvas.draw()
+    assert np.array_equal(coll.get_facecolors()[0, :], cmap(norm(1)))
+
+
 def test_quadmesh_alpha_array():
     x = np.arange(4)
     y = np.arange(4)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -695,13 +695,11 @@ def _update_scalarmappable(sm):
     """
     if sm._A is None:
         return
-    copy_state = sm._update_dict['array']
-    ret = sm.update_scalarmappable()
-    if copy_state:
-        if sm._face_is_mapped:
-            sm._facecolor3d = sm._facecolors
-        elif sm._edge_is_mapped:  # Should this be plain "if"?
-            sm._edgecolor3d = sm._edgecolors
+    sm.update_scalarmappable()
+    if sm._face_is_mapped:
+        sm._facecolor3d = sm._facecolors
+    elif sm._edge_is_mapped:  # Should this be plain "if"?
+        sm._edgecolor3d = sm._edgecolors
 
 
 def patch_collection_2d_to_3d(col, zs=0, zdir='z', depthshade=True):


### PR DESCRIPTION
## PR Summary

The updates to scalar mappable would only occur if the
array was updated. This meant that updating the vmin/vmax of
the sm's norm would not be propagated to the drawn artists. This
update removes the array update checks from scalar mappable to calculate
the colors regardless of updates to the array.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
