### PR TITLE
ENH: Adding callbacks to Norms for update signals

### DIFF
--- a/doc/users/next_whats_new/callbacks_on_norms.rst
+++ b/doc/users/next_whats_new/callbacks_on_norms.rst
@@ -1,0 +1,8 @@
+A callback registry has been added to Normalize objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`.colors.Normalize` objects now have a callback registry, ``callbacks``,
+that can be connected to by other objects to be notified when the norm is
+updated. The callback emits the key ``changed`` when the norm is modified.
+`.cm.ScalarMappable` is now a listener and will register a change
+when the norm's vmin, vmax or other attributes are changed.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -471,6 +471,7 @@ class Colorbar:
         self.ax.add_collection(self.dividers)
 
         self.locator = None
+        self.minorlocator = None
         self.formatter = None
         self.__scale = None  # linear, log10 for now.  Hopefully more?
 
@@ -1096,7 +1097,7 @@ class Colorbar:
         # vmax of the colorbar, not the norm.  This allows the situation
         # where the colormap has a narrower range than the colorbar, to
         # accommodate extra contours:
-        norm = copy.copy(self.norm)
+        norm = copy.deepcopy(self.norm)
         norm.vmin = self.vmin
         norm.vmax = self.vmax
         x = np.array([0.0, 1.0])

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1090,6 +1090,15 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     in zip(segs, kinds)]
 
     def changed(self):
+        if not hasattr(self, "cvalues"):
+            # Just return after calling the super() changed function
+            cm.ScalarMappable.changed(self)
+            return
+        # Force an autoscale immediately because self.to_rgba() calls
+        # autoscale_None() internally with the data passed to it,
+        # so if vmin/vmax are not set yet, this would override them with
+        # content from *cvalues* rather than levels like we want
+        self.norm.autoscale_None(self.levels)
         tcolors = [(tuple(rgba),)
                    for rgba in self.to_rgba(self.cvalues, alpha=self.alpha)]
         self.tcolors = tcolors

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -537,11 +537,14 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
                 if isinstance(self.norm, mcolors.LogNorm) and s_vmin <= 0:
                     # Don't give 0 or negative values to LogNorm
                     s_vmin = np.finfo(scaled_dtype).eps
-                with cbook._setattr_cm(self.norm,
-                                       vmin=s_vmin,
-                                       vmax=s_vmax,
-                                       ):
-                    output = self.norm(resampled_masked)
+                # Block the norm from sending an update signal during the
+                # temporary vmin/vmax change
+                with self.norm.callbacks.blocked():
+                    with cbook._setattr_cm(self.norm,
+                                           vmin=s_vmin,
+                                           vmax=s_vmax,
+                                           ):
+                        output = self.norm(resampled_masked)
             else:
                 if A.ndim == 2:  # _interpolation_stage == 'rgba'
                     self.norm.autoscale_None(A)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1,5 +1,6 @@
 import copy
 import itertools
+import unittest.mock
 
 from io import BytesIO
 import numpy as np
@@ -17,7 +18,7 @@ import matplotlib.colorbar as mcolorbar
 import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
 import matplotlib.scale as mscale
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
 @pytest.mark.parametrize('N, result', [
@@ -1408,3 +1409,69 @@ def test_norm_deepcopy():
     norm2 = copy.deepcopy(norm)
     assert norm2._scale is None
     assert norm2.vmin == norm.vmin
+
+
+def test_norm_callback():
+    increment = unittest.mock.Mock(return_value=None)
+
+    norm = mcolors.Normalize()
+    norm.callbacks.connect('changed', increment)
+    # Haven't updated anything, so call count should be 0
+    assert increment.call_count == 0
+
+    # Now change vmin and vmax to test callbacks
+    norm.vmin = 1
+    assert increment.call_count == 1
+    norm.vmax = 5
+    assert increment.call_count == 2
+    # callback shouldn't be called if setting to the same value
+    norm.vmin = 1
+    assert increment.call_count == 2
+    norm.vmax = 5
+    assert increment.call_count == 2
+
+
+def test_scalarmappable_norm_update():
+    norm = mcolors.Normalize()
+    sm = matplotlib.cm.ScalarMappable(norm=norm, cmap='plasma')
+    # sm doesn't have a stale attribute at first, set it to False
+    sm.stale = False
+    # The mappable should be stale after updating vmin/vmax
+    norm.vmin = 5
+    assert sm.stale
+    sm.stale = False
+    norm.vmax = 5
+    assert sm.stale
+    sm.stale = False
+    norm.clip = True
+    assert sm.stale
+    # change to the CenteredNorm and TwoSlopeNorm to test those
+    # Also make sure that updating the norm directly and with
+    # set_norm both update the Norm callback
+    norm = mcolors.CenteredNorm()
+    sm.norm = norm
+    sm.stale = False
+    norm.vcenter = 1
+    assert sm.stale
+    norm = mcolors.TwoSlopeNorm(vcenter=0, vmin=-1, vmax=1)
+    sm.set_norm(norm)
+    sm.stale = False
+    norm.vcenter = 1
+    assert sm.stale
+
+
+@check_figures_equal()
+def test_norm_update_figs(fig_test, fig_ref):
+    ax_ref = fig_ref.add_subplot()
+    ax_test = fig_test.add_subplot()
+
+    z = np.arange(100).reshape((10, 10))
+    ax_ref.imshow(z, norm=mcolors.Normalize(10, 90))
+
+    # Create the norm beforehand with different limits and then update
+    # after adding to the plot
+    norm = mcolors.Normalize(0, 1)
+    ax_test.imshow(z, norm=norm)
+    # Force initial draw to make sure it isn't already stale
+    fig_test.canvas.draw()
+    norm.vmin, norm.vmax = 10, 90

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1017,8 +1017,8 @@ def test_imshow_bool():
 def test_full_invalid():
     fig, ax = plt.subplots()
     ax.imshow(np.full((10, 10), np.nan))
-    with pytest.warns(UserWarning):
-        fig.canvas.draw()
+
+    fig.canvas.draw()
 
 
 @pytest.mark.parametrize("fmt,counted",


### PR DESCRIPTION
## PR Summary

This adds a callback registry to Norm instances that can be connected to by other objects to be notified when the Norm is updated. This is particularly relevant for ScalarMappables to be notified when the vmin/vmax are changed on the Norm. With this update, the axis is now immediately registered as stale in the following example.

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
norm = plt.Normalize(-2, 2)
ax.imshow([[0, 1], [2, -1]], norm=norm)

norm.vmax = 0.1
print(ax.stale)
```

Closes #4387
Fixes #17052

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).