### PR TITLE
Use luatex in --luaonly mode to query kpsewhich.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19558-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19558-AL.rst
@@ -1,0 +1,3 @@
+The *format* parameter of ``dviread.find_tex_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated (with no replacement).

--- a/lib/matplotlib/mpl-data/kpsewhich.lua
+++ b/lib/matplotlib/mpl-data/kpsewhich.lua
@@ -1,0 +1,3 @@
+-- see dviread._LuatexKpsewhich
+kpse.set_program_name("tex")
+while true do print(kpse.lookup(io.read():gsub("\r", ""))); io.flush(); end

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -1,23 +1,23 @@
 r"""
-Support for embedded TeX expressions in Matplotlib via dvipng and dvips for the
-raster and PostScript backends.  The tex and dvipng/dvips information is cached
-in ~/.matplotlib/tex.cache for reuse between sessions.
+Support for embedded TeX expressions in Matplotlib.
 
 Requirements:
 
-* LaTeX
-* \*Agg backends: dvipng>=1.6
-* PS backend: psfrag, dvips, and Ghostscript>=9.0
-
-For raster output, you can get RGBA numpy arrays from TeX expressions
-as follows::
-
-  texmanager = TexManager()
-  s = "\TeX\ is Number $\displaystyle\sum_{n=1}^\infty\frac{-e^{i\pi}}{2^n}$!"
-  Z = texmanager.get_rgba(s, fontsize=12, dpi=80, rgb=(1, 0, 0))
+* LaTeX.
+* \*Agg backends: dvipng>=1.6.
+* PS backend: PSfrag, dvips, and Ghostscript>=9.0.
+* PDF and SVG backends: if LuaTeX is present, it will be used to speed up some
+  post-processing steps, but note that it is not used to parse the TeX string
+  itself (only LaTeX is supported).
 
 To enable TeX rendering of all text in your Matplotlib figure, set
 :rc:`text.usetex` to True.
+
+TeX and dvipng/dvips processing results are cached
+in ~/.matplotlib/tex.cache for reuse between sessions.
+
+`TexManager.get_rgba` can also be used to directly obtain raster output as RGBA
+numpy arrays.
 """
 
 import functools
@@ -274,7 +274,15 @@ class TexManager:
         return alpha
 
     def get_rgba(self, tex, fontsize=None, dpi=None, rgb=(0, 0, 0)):
-        """Return latex's rendering of the tex string as an rgba array."""
+        r"""
+        Return latex's rendering of the tex string as an rgba array.
+
+        Examples
+        --------
+        >>> texmanager = TexManager()
+        >>> s = r"\TeX\ is $\displaystyle\sum_n\frac{-e^{i\pi}}{2^n}$!"
+        >>> Z = texmanager.get_rgba(s, fontsize=12, dpi=80, rgb=(1, 0, 0))
+        """
         alpha = self.get_grey(tex, fontsize, dpi)
         rgba = np.empty((*alpha.shape, 4))
         rgba[..., :3] = mpl.colors.to_rgb(rgb)

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -11,10 +11,13 @@ is more flexible, since different LaTeX packages (font packages, math packages,
 etc.) can be used. The results can be striking, especially when you take care
 to use the same fonts in your figures as in the main document.
 
-Matplotlib's LaTeX support requires a working LaTeX_ installation.  For the
-\*Agg backends, dvipng_ is additionally required; for the PS backend, psfrag_,
-dvips_ and Ghostscript_ are additionally required.  The executables for these
-external dependencies must all be located on your :envvar:`PATH`.
+Matplotlib's LaTeX support requires a working LaTeX_ installation.  For
+the \*Agg backends, dvipng_ is additionally required; for the PS backend,
+PSfrag_, dvips_ and Ghostscript_ are additionally required.  For the PDF
+and SVG backends, if LuaTeX is present, it will be used to speed up some
+post-processing steps, but note that it is not used to parse the TeX string
+itself (only LaTeX is supported).  The executables for these external
+dependencies must all be located on your :envvar:`PATH`.
 
 There are a couple of options to mention, which can be changed using
 :doc:`rc settings </tutorials/introductory/customizing>`. Here is an example
@@ -140,6 +143,6 @@ Troubleshooting
 .. _LaTeX: http://www.tug.org
 .. _Poppler: https://poppler.freedesktop.org/
 .. _PSNFSS: http://www.ctan.org/tex-archive/macros/latex/required/psnfss/psnfss2e.pdf
-.. _psfrag: https://ctan.org/pkg/psfrag
+.. _PSfrag: https://ctan.org/pkg/psfrag
 .. _Xpdf: http://www.xpdfreader.com/
 """


### PR DESCRIPTION
`luatex --luaonly` runs a *lua* interpreter with relevant tex libraries
available, which avoids the overhead of repeatedly initializing
kpathsea (the old approach, very slow on macos and windows).  An
alternative approach would be to use `luatex` followed by `\directlua`
calls, but on windows it appears that one needs to use `lualatex` to get
a working interactive prompt, and just loading the latex format takes
seconds(!).

For the simple following benchmark:
```sh
python -c 'from pylab import *; mpl.use("pdf"); rcParams["text.usetex"] = True; plot(); savefig("test.pdf", backend="pdf")'
```
On a macos machine, this patch brings runtime from ~4.5s to ~2.5s.
On a windows machine, this patch brings runtime from ~6.5s to ~1.7s.

We also need to figure out how to best advertise this (do we emit a
warning suggesting to install luatex on windows and macos if luatex is
not present?).

---

See also #19531 and #19551 for other approaches; I opened separate PRs to
simplify comparison of the approaches.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
