### PR TITLE
Micro-optimize type1font loading

### DIFF
--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -135,9 +135,8 @@ class Type1Font:
 
         return data[:len1], binary, data[idx+1:]
 
-    _whitespace_re = re.compile(br'[\0\t\r\014\n ]+')
+    _whitespace_or_comment_re = re.compile(br'[\0\t\r\014\n ]+|%[^\r\n\v]*')
     _token_re = re.compile(br'/{0,2}[^]\0\t\r\v\n ()<>{}/%[]+')
-    _comment_re = re.compile(br'%[^\r\n\v]*')
     _instring_re = re.compile(br'[()\\]')
 
     @classmethod
@@ -148,8 +147,7 @@ class Type1Font:
         """
         pos = 0
         while pos < len(text):
-            match = (cls._comment_re.match(text, pos) or
-                     cls._whitespace_re.match(text, pos))
+            match = cls._whitespace_or_comment_re.match(text, pos)
             if match:
                 yield (_TokenType.whitespace, match.group())
                 pos = match.end()

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -157,7 +157,7 @@ class Type1Font:
             if match:
                 yield (tok_whitespace, match.group())
                 pos = match.end()
-            elif text[pos] == b'(':
+            elif text[pos:pos+1] == b'(':
                 start = pos
                 pos += 1
                 depth = 1
@@ -176,7 +176,7 @@ class Type1Font:
             elif text[pos:pos + 2] in (b'<<', b'>>'):
                 yield (tok_delimiter, text[pos:pos + 2])
                 pos += 2
-            elif text[pos] == b'<':
+            elif text[pos:pos+1] == b'<':
                 start = pos
                 pos = text.index(b'>', pos)
                 yield (tok_string, text[start:pos])

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -148,20 +148,20 @@ class Type1Font:
         """
         pos = 0
         while pos < len(text):
-            match = (cls._comment_re.match(text[pos:]) or
-                     cls._whitespace_re.match(text[pos:]))
+            match = (cls._comment_re.match(text, pos) or
+                     cls._whitespace_re.match(text, pos))
             if match:
                 yield (_TokenType.whitespace, match.group())
-                pos += match.end()
+                pos = match.end()
             elif text[pos] == b'(':
                 start = pos
                 pos += 1
                 depth = 1
                 while depth:
-                    match = cls._instring_re.search(text[pos:])
+                    match = cls._instring_re.search(text, pos)
                     if match is None:
                         return
-                    pos += match.end()
+                    pos = match.end()
                     if match.group() == b'(':
                         depth += 1
                     elif match.group() == b')':
@@ -174,17 +174,17 @@ class Type1Font:
                 pos += 2
             elif text[pos] == b'<':
                 start = pos
-                pos += text[pos:].index(b'>')
+                pos = text.index(b'>', pos)
                 yield (_TokenType.string, text[start:pos])
             else:
-                match = cls._token_re.match(text[pos:])
+                match = cls._token_re.match(text, pos)
                 if match:
                     try:
                         float(match.group())
                         yield (_TokenType.number, match.group())
                     except ValueError:
                         yield (_TokenType.name, match.group())
-                    pos += match.end()
+                    pos = match.end()
                 else:
                     yield (_TokenType.delimiter, text[pos:pos + 1])
                     pos += 1


### PR DESCRIPTION
1st commit: Avoid constructing temporary strings in type1font parsing.

Just avoiding to construct a bunch of temporary strings (by instead
asking regexes to start their search at a given position) speeds up
```
python -c 'from pylab import *; mpl.use("pdf"); rcParams["text.usetex"] = True; plot(); [savefig("/tmp/test.pdf", backend="pdf") for _ in range(100)]'
```
by ~5%.

2nd commit: Combine whitespace and comment regexes.

This shaves off another percent or two of runtime.

3nd commit: Avoid repeatedly accessing enum values in type1font parsing.
    
Enum getattr is surprisingly slow; avoiding repeated attribute accesses
speeds up
```
python -c 'from pylab import *; mpl.use("pdf"); rcParams["text.usetex"] = True; plot(); [savefig("/tmp/test.pdf", backend="pdf") for _ in range(100)]'
```
by ~5%

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
