### PR TITLE
Fail early when setting Text color to a non-colorlike.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -147,6 +147,15 @@ def is_color_like(c):
         return True
 
 
+def _check_color_like(**kwargs):
+    """
+    For each *key, value* pair in *kwargs*, check that *value* is color-like.
+    """
+    for k, v in kwargs.items():
+        if not is_color_like(v):
+            raise ValueError(f"{v!r} is not a valid value for {k}")
+
+
 def same_color(c1, c2):
     """
     Return whether the colors *c1* and *c2* are the same.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -13,7 +13,6 @@ from . import _api, artist, cbook, colors as mcolors, docstring, rcParams
 from .artist import Artist, allow_rasterization
 from .cbook import (
     _to_unmasked_float_array, ls_mapper, ls_mapper_r, STEP_LOOKUP_MAP)
-from .colors import is_color_like, get_named_colors_mapping
 from .markers import MarkerStyle
 from .path import Path
 from .transforms import Bbox, BboxTransformTo, TransformedPath
@@ -1050,9 +1049,8 @@ class Line2D(Artist):
         ----------
         color : color
         """
-        if not is_color_like(color) and color != 'auto':
-            _api.check_in_list(get_named_colors_mapping(),
-                               _print_supported_values=False, color=color)
+        if not cbook._str_equal(color, 'auto'):
+            mcolors._check_color_like(color=color)
         self._color = color
         self.stale = True
 

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -709,3 +709,8 @@ def test_update_mutate_input():
     t.update(inp)
     assert inp['fontproperties'] == cache['fontproperties']
     assert inp['bbox'] == cache['bbox']
+
+
+def test_invalid_color():
+    with pytest.raises(ValueError):
+        plt.figtext(.5, .5, "foo", c="foobar")

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -934,6 +934,10 @@ class Text(Artist):
         ----------
         color : color
         """
+        # "auto" is only supported by axisartist, but we can just let it error
+        # out at draw time for simplicity.
+        if not cbook._str_equal(color, "auto"):
+            mpl.colors._check_color_like(color=color)
         # Make sure it is hashable, or get_prop_tup will fail.
         try:
             hash(color)


### PR DESCRIPTION
Otherwise, the error is only raised when drawing the artist, which is
always confusing.  Also add a general `_check_color_like` mechanism and
use it for Line2D as well, instead of relying on a slightly strange
`if not is_color_like(): check_in_list(get_named_colors_mapping())`
call where the check_in_list *always* fails.

Closes https://github.com/matplotlib/matplotlib/issues/19569 (well, likely the OP was confused about other stuff, but this should at least bring the error message closer to the relevant place).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
