### PR TITLE
Deprecate Text.get_prop_tup.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19575-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19575-AL.rst
@@ -1,0 +1,4 @@
+``Text.get_prop_tup``
+~~~~~~~~~~~~~~~~~~~~~
+... is deprecated with no replacements (because the `.Text` class cannot know
+whether a backend needs to update cache e.g. when the text's color changes).

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -284,13 +284,28 @@ class Text(Artist):
         self._linespacing = other._linespacing
         self.stale = True
 
+    def _get_layout_cache_key(self, renderer=None):
+        """
+        Return a hashable tuple of properties that lets `_get_layout` know
+        whether a previously computed layout can be reused.
+        """
+        x, y = self.get_unitless_position()
+        renderer = renderer or self._renderer
+        return (
+            x, y, self.get_text(), hash(self._fontproperties),
+            self._verticalalignment, self._horizontalalignment,
+            self._linespacing,
+            self._rotation, self._rotation_mode, self._transform_rotates_text,
+            self.figure.dpi, weakref.ref(renderer),
+        )
+
     def _get_layout(self, renderer):
         """
         Return the extent (bbox) of the text together with
         multiple-alignment information. Note that it returns an extent
         of a rotated text when necessary.
         """
-        key = self.get_prop_tup(renderer=renderer)
+        key = self._get_layout_cache_key(renderer=renderer)
         if key in self._cached:
             return self._cached[key]
 
@@ -831,6 +846,8 @@ class Text(Artist):
         # specified with 'set_x' and 'set_y'.
         return self._x, self._y
 
+    # When removing, also remove the hash(color) check in set_color()
+    @_api.deprecated("3.5")
     def get_prop_tup(self, renderer=None):
         """
         Return a hashable tuple of properties.
@@ -938,7 +955,8 @@ class Text(Artist):
         # out at draw time for simplicity.
         if not cbook._str_equal(color, "auto"):
             mpl.colors._check_color_like(color=color)
-        # Make sure it is hashable, or get_prop_tup will fail.
+        # Make sure it is hashable, or get_prop_tup will fail (remove this once
+        # get_prop_tup is removed).
         try:
             hash(color)
         except TypeError:


### PR DESCRIPTION
get_prop_tup was intended as a general caching mechanism for reusing
Text layouts, but it ended up only being used by _get_layout (which
backends have to call anyways to handle multiline text).  Note that in
fact, if we really wanted to make backends use that info for caching,
whether e.g. the text color needs to be taken into account would likely
depend on the backend's own caching mechanism.

Replace it by a private `_get_layout_cache_key`, which does not take
color into account (color doesn't affect layout), which will later allow
removing a color-must-be-hashable check.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
