### PR TITLE
MNT: let bad rcParam keys pass

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -833,9 +833,10 @@ with _api.suppress_matplotlib_deprecation_warning():
     defaultParams = {}
     for key, validator in rcsetup._validators.items():
         if key == 'backend':
-            defaultParams['backend'] = rcsetup._auto_backend_sentinel
+            defaultParams['backend'] = [rcsetup._auto_backend_sentinel,
+                                        validator]
         elif key in rcParamsDefault.keys():
-            defaultParams[key] = validator
+            defaultParams[key] = [rcParamsDefault[key], validator]
         else:
             _api.warn_external(f'rcsetup key "{key}" not in the default'
                                 ' rcParams')

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -830,12 +830,17 @@ with _api.suppress_matplotlib_deprecation_warning():
     rcParamsOrig = RcParams(rcParams.copy())
     # This also checks that all rcParams are indeed listed in the template.
     # Assigning to rcsetup.defaultParams is left only for backcompat.
-    defaultParams = rcsetup.defaultParams = {
-        # We want to resolve deprecated rcParams, but not backend...
-        key: [(rcsetup._auto_backend_sentinel if key == "backend" else
-               rcParamsDefault[key]),
-              validator]
-        for key, validator in rcsetup._validators.items()}
+    defaultParams = {}
+    for key, validator in rcsetup._validators.items():
+        if key == 'backend':
+            defaultParams['backend'] = rcsetup._auto_backend_sentinel
+        elif key in rcParamsDefault.keys():
+            defaultParams[key] = validator
+        else:
+            _api.warn_external(f'rcsetup key "{key}" not in the default'
+                                ' rcParams')
+    rcsetup.defaultParams = defaultParams
+
 if rcParams['axes.formatter.use_locale']:
     locale.setlocale(locale.LC_ALL, '')
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -13,6 +13,7 @@ import matplotlib as mpl
 from matplotlib import _api, _c_internal_utils
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
+import matplotlib.rcsetup as rcsetup
 import numpy as np
 from matplotlib.rcsetup import (
     validate_bool,
@@ -29,6 +30,23 @@ from matplotlib.rcsetup import (
     validate_stringlist,
     _validate_linestyle,
     _listify_validator)
+
+
+def test_rc_validators_in_sync():
+    # make sure that matplotlibrc.template and rcsetup._validators
+    # are in sync.
+    rc = mpl._rc_params_in_file(
+            'matplotlibrc.template',
+            # Strip leading comment.
+            transform=lambda line: line[1:] if line.startswith("#") else line,
+            fail_on_error=True)
+    for key, validator in rcsetup._validators.items():
+        if (key not in mpl._deprecated_remain_as_none and
+                key not in mpl._deprecated_ignore_map and
+                key[0] != '_'):
+            assert key in list(rc.keys())
+    for key in list(rc.keys()):
+        assert key in list(rcsetup._validators.keys())
 
 
 def test_rcparams(tmpdir):


### PR DESCRIPTION
## PR Summary
Close #19578

~I don't see why we would fail to import if the rcdefault and the rcParam dicts don't exactly match.  It definitely is a pain for developers who need to bisect.  But I frankly don't follow why we have all this machinery at all, so no doubt I am missing a subtlety...~

EDIT:  As pointed out by @timhoffm the issue is that `/matplotlibrc.template` can get out of sync with `rcdefaults._validators`.  
This is confusing because we were not checking against `/matplotlibrc.template`, but rather `/lib/matplotlib.mpl-data/matplotlibrc` which gets copied from  `/matplotlibrc.template` when `setup.py` is called.  

This PR moves the check from being done on `import matplotlib` to a test that is run by CI.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
