### PR TITLE
Changes linestyle parameter of flierprops

### DIFF
--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -61,7 +61,7 @@ plt.show()
 
 boxprops = dict(linestyle='--', linewidth=3, color='darkgoldenrod')
 flierprops = dict(marker='o', markerfacecolor='green', markersize=12,
-                  linestyle='none')
+                  markeredgecolor='none')
 medianprops = dict(linestyle='-.', linewidth=2.5, color='firebrick')
 meanpointprops = dict(marker='D', markeredgecolor='black',
                       markerfacecolor='firebrick')


### PR DESCRIPTION
## PR Summary

linestyle='none' [here](https://github.com/matplotlib/matplotlib/blob/a5ea869114fd67ee4db17b22e77a1e495f45336f/examples/statistics/boxplot.py#L63) has no effect in removing the marker edges, thus
it was changed to markeredgecolor='none' to achieve this outcome.

Solves #19427 

| With `linestyle='none'` (no effect)              | With `markeredgecolor='none'` (border removed)                     |
| ------------------------------ | ------------------------------------ |
| <img width="170" alt="previous" src="https://user-images.githubusercontent.com/37598144/109292066-7b769900-7832-11eb-939a-8244e6402c71.png"> | <img width="166" alt="current" src="https://user-images.githubusercontent.com/37598144/109292230-b8db2680-7832-11eb-871d-c39d89ca2311.png"> |



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
