### PR TITLE
Fix for issue 17769: wx interactive figure close cause crash

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -973,10 +973,9 @@ class FigureFrameWx(wx.Frame):
         self.canvas.stop_event_loop()
         # set FigureManagerWx.frame to None to prevent repeated attempts to
         # close this frame from FigureManagerWx.destroy()
-        if self.figmgr is not None:
-            self.figmgr.frame = None
-            # remove figure manager from Gcf.figs
-            Gcf.destroy(self.figmgr)
+        self.figmgr.frame = None
+        # remove figure manager from Gcf.figs
+        Gcf.destroy(self.figmgr)
         #carry on with wx close event propagation, frame & children destruction
         event.Skip()
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -976,7 +976,7 @@ class FigureFrameWx(wx.Frame):
         self.figmgr.frame = None
         # remove figure manager from Gcf.figs
         Gcf.destroy(self.figmgr)
-        #carry on with wx close event propagation, frame & children destruction
+        # Carry on with wx close event propagation, frame & children destruction
         event.Skip()
 
     def GetToolBar(self):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -971,9 +971,7 @@ class FigureFrameWx(wx.Frame):
         _log.debug("%s - onClose()", type(self))
         self.canvas.close_event()
         self.canvas.stop_event_loop()
-        Gcf.destroy(self)
-        if self:
-            self.Destroy()
+        Gcf.destroy(self.figmgr)
 
     def GetToolBar(self):
         """Override wxFrame::GetToolBar as we don't have managed toolbar"""
@@ -992,9 +990,6 @@ class FigureFrameWx(wx.Frame):
             super().Destroy(*args, **kwargs)
             if self.toolbar is not None:
                 self.toolbar.Destroy()
-            wxapp = wx.GetApp()
-            if wxapp:
-                wxapp.Yield()
         return True
 
 
@@ -1043,10 +1038,7 @@ class FigureManagerWx(FigureManagerBase):
         _log.debug("%s - destroy()", type(self))
         frame = self.frame
         if frame:  # Else, may have been already deleted, e.g. when closing.
-            frame.Close()
-        wxapp = wx.GetApp()
-        if wxapp:
-            wxapp.Yield()
+            frame.Destroy()
 
     def full_screen_toggle(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -972,7 +972,7 @@ class FigureFrameWx(wx.Frame):
         self.canvas.close_event()
         self.canvas.stop_event_loop()
         # set FigureManagerWx.frame to None to prevent repeated attempts to
-        # close this frame from with the FigureManagerWx.destroy()
+        # close this frame from FigureManagerWx.destroy()
         if self.figmgr is not None:
             self.figmgr.frame = None
             # remove figure manager from Gcf.figs
@@ -995,10 +995,8 @@ class FigureFrameWx(wx.Frame):
         # MPLBACKEND=wxagg python -c 'from pylab import *; plot()'.
         if self and not self.IsBeingDeleted():
             super().Destroy(*args, **kwargs)
-            # This should not be necessary if the close event is allowed to
-            # propagate.
-            #if self.toolbar is not None:
-            #    self.toolbar.Destroy()
+            # self.toolbar.Destroy() should not be necessary if the close event
+            # is allowed to propagate.
         return True
 
 
@@ -1047,8 +1045,8 @@ class FigureManagerWx(FigureManagerBase):
         _log.debug("%s - destroy()", type(self))
         frame = self.frame
         if frame:  # Else, may have been already deleted, e.g. when closing.
-            # as this can be called from non gui thread from plt.close use
-            # wx.CallAfter to esnure thread safety.
+            # As this can be called from non-GUI thread from plt.close use
+            # wx.CallAfter to ensure thread safety.
             wx.CallAfter(frame.Close)
 
     def full_screen_toggle(self):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -971,10 +971,10 @@ class FigureFrameWx(wx.Frame):
         _log.debug("%s - onClose()", type(self))
         self.canvas.close_event()
         self.canvas.stop_event_loop()
-        # set FigureManagerWx.frame to None to prevent repeated attempts to close
-        # this frame from with the FigureManagerWx.destroy()
+        # set FigureManagerWx.frame to None to prevent repeated attempts to
+        # close this frame from with the FigureManagerWx.destroy()
         if self.figmgr is not None:
-            self.figmgr.frame = None 
+            self.figmgr.frame = None
             # remove figure manager from Gcf.figs
             Gcf.destroy(self.figmgr)
         #carry on with wx close event propagation, frame & children destruction
@@ -995,7 +995,8 @@ class FigureFrameWx(wx.Frame):
         # MPLBACKEND=wxagg python -c 'from pylab import *; plot()'.
         if self and not self.IsBeingDeleted():
             super().Destroy(*args, **kwargs)
-            # This should not be necessary if the close event is allowed to propagate.
+            # This should not be necessary if the close event is allowed to
+            # propagate.
             #if self.toolbar is not None:
             #    self.toolbar.Destroy()
         return True
@@ -1046,9 +1047,9 @@ class FigureManagerWx(FigureManagerBase):
         _log.debug("%s - destroy()", type(self))
         frame = self.frame
         if frame:  # Else, may have been already deleted, e.g. when closing.
-            # as this can be called from non gui thread from plt.close use 
+            # as this can be called from non gui thread from plt.close use
             # wx.CallAfter to esnure thread safety.
-            wx.CallAfter( frame.Close )
+            wx.CallAfter(frame.Close)
 
     def full_screen_toggle(self):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -976,7 +976,7 @@ class FigureFrameWx(wx.Frame):
         self.figmgr.frame = None
         # remove figure manager from Gcf.figs
         Gcf.destroy(self.figmgr)
-        # Carry on with wx close event propagation, frame & children destruction
+        # Carry on with close event propagation, frame & children destruction
         event.Skip()
 
     def GetToolBar(self):


### PR DESCRIPTION
## PR Summary
Fix for issue https://github.com/matplotlib/matplotlib/issues/17769

1) On figure window (FigureFrameWx) close - remove figure manager from from Gcf class
 previously Gcf.destroy was called with FigureFrameWx not FigureManagerWx instance so figure was not removed correctly.

2) Destroy now done from FigureManagerWx.destroy() method to prevent multiple calls to the close event handler.

3) Remove unneeded wx mainloop yield calls that cause crash on windows from both FigureManagerWx.destroy and FigureFrameWx.Destroy.

Tested on windows 10, and mint 20.1. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
