### PR TITLE
Fix IPython import issue

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1743,7 +1743,7 @@ class FigureCanvasBase:
         # `ipython --auto`).  This cannot be done at import time due to
         # ordering issues, so we do it when creating a canvas, and should only
         # be done once per class (hence the `lru_cache(1)`).
-        if sys.modules.get("IPython", None) is None:
+        if sys.modules.get("IPython") is None:
             return
         import IPython
         ip = IPython.get_ipython()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1743,7 +1743,7 @@ class FigureCanvasBase:
         # `ipython --auto`).  This cannot be done at import time due to
         # ordering issues, so we do it when creating a canvas, and should only
         # be done once per class (hence the `lru_cache(1)`).
-        if "IPython" not in sys.modules:
+        if sys.modules.get("IPython", None) is None:
             return
         import IPython
         ip = IPython.get_ipython()


### PR DESCRIPTION
When blocking import of `IPython` by defining `sys.modules["IPython"] = None`, creating plots fails because `backend_bases.FigureCanvasBase._fix_ipython_backend2gui` attempts to check if `IPython` is already imported by looking for an entry in `sys.modules`. It then attempts to import `IPython`, which fails due to the import being blocked.

Code sample to reproduce the issue:

```
import sys
sys.modules['IPython'] = None

from matplotlib import pyplot
plt = pyplot.subplots(1,1)
```

which results in:
```
Traceback (most recent call last):
  File "<module1>", line 5, in <module>
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\cbook\deprecation.py", line 451, in wrapper
    return func(*args, **kwargs)
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\pyplot.py", line 1287, in subplots
    fig = figure(**fig_kw)
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\pyplot.py", line 687, in figure
    figManager = new_figure_manager(num, figsize=figsize,
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\pyplot.py", line 315, in new_figure_manager
    return _backend_mod.new_figure_manager(*args, **kwargs)
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\backend_bases.py", line 3493, in new_figure_manager
    fig = fig_cls(*args, **kwargs)
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\figure.py", line 341, in __init__
    FigureCanvasBase(self)  # Set self.canvas.
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\backend_bases.py", line 1686, in __init__
    self._fix_ipython_backend2gui()
  File "C:\Users\Phil\envs\mp_dev\lib\site-packages\matplotlib\backend_bases.py", line 1713, in _fix_ipython_backend2gui
    import IPython
ModuleNotFoundError: import of IPython halted; None in sys.modules
```

This PR addresses this issue by not only checking if `IPython` is present in `sys.modules`, but also if it is blocked from being imported.