### PR TITLE
Fix double picks.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1726,15 +1726,13 @@ class FigureCanvasBase:
         self._button = None  # the button pressed
         self._key = None  # the key pressed
         self._lastx, self._lasty = None, None
-        self.button_pick_id = self.mpl_connect('button_press_event', self.pick)
-        self.scroll_pick_id = self.mpl_connect('scroll_event', self.pick)
         self.mouse_grabber = None  # the axes currently grabbing mouse
         self.toolbar = None  # NavigationToolbar2 will set me
         self._is_idle_drawing = False
 
-    @property
-    def callbacks(self):
-        return self.figure._canvas_callbacks
+    callbacks = property(lambda self: self.figure._canvas_callbacks)
+    button_pick_id = property(lambda self: self.figure._button_pick_id)
+    scroll_pick_id = property(lambda self: self.figure._scroll_pick_id)
 
     @classmethod
     @functools.lru_cache()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2106,6 +2106,10 @@ class Figure(FigureBase):
         # a proxy property), but that actually need to be on the figure for
         # pickling.
         self._canvas_callbacks = cbook.CallbackRegistry()
+        self._button_pick_id = self._canvas_callbacks.connect(
+            'button_press_event', lambda event: self.canvas.pick(event))
+        self._scroll_pick_id = self._canvas_callbacks.connect(
+            'scroll_event', lambda event: self.canvas.pick(event))
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -120,6 +120,19 @@ def test_location_event_position(x, y):
         assert re.match("x=foo +y=foo", ax.format_coord(x, y))
 
 
+def test_pick():
+    fig = plt.figure()
+    fig.text(.5, .5, "hello", ha="center", va="center", picker=True)
+    fig.canvas.draw()
+    picks = []
+    fig.canvas.mpl_connect("pick_event", lambda event: picks.append(event))
+    start_event = MouseEvent(
+        "button_press_event", fig.canvas, *fig.transFigure.transform((.5, .5)),
+        MouseButton.LEFT)
+    fig.canvas.callbacks.process(start_event.name, start_event)
+    assert len(picks) == 1
+
+
 def test_interactive_zoom():
     fig, ax = plt.subplots()
     ax.set(xscale="logit")


### PR DESCRIPTION
pick_events were previously incorrectly emitted twice due to the
combination of two recent(ish) chnages: Figures now always start with a
FigureCanvasBase attached -- eventually switching to a concrete subclass
of FigureCanvasBase for display or saving --, and callbacks are now
actually stored at the Figure level rather than the Canvas level.
Hence, the button_pick_id callback (in charge of emitting picks) would
previously be both registered both through the FigureCanvasBase and the
concrete subclass.  The fix is to also move that callback to the Figure
level, so that each Figure only has one such callback.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
