### PR TITLE
Correctly check inaxes for multicursor

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -2,7 +2,7 @@ import matplotlib.colors as mcolors
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
-from matplotlib.testing.widgets import do_event, get_ax
+from matplotlib.testing.widgets import do_event, get_ax, mock_event
 
 from numpy.testing import assert_allclose
 
@@ -460,3 +460,43 @@ def test_polygon_selector():
                       + polygon_place_vertex(50, 150)
                       + polygon_place_vertex(50, 50))
     check_polygon_selector(event_sequence, expected_result, 1)
+
+
+@pytest.mark.parametrize(
+    "horizOn, vertOn",
+    [(True, True), (True, False), (False, True)],
+)
+def test_MultiCursor(horizOn, vertOn):
+    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
+
+    # useblit=false to avoid having to draw the figure to cache the renderer
+    multi = widgets.MultiCursor(
+        fig.canvas, (ax1, ax2), useblit=False, horizOn=horizOn, vertOn=vertOn
+    )
+
+    # Only two of the axes should have a line drawn on them.
+    if vertOn:
+        assert len(multi.vlines) == 2
+    if horizOn:
+        assert len(multi.hlines) == 2
+
+    # mock a motion_notify_event
+    # Can't use `do_event` as that helper requires the widget
+    # to have a single .ax attribute.
+    event = mock_event(ax1, xdata=.5, ydata=.25)
+    multi.onmove(event)
+
+    # the lines in the first two ax should both move
+    for l in multi.vlines:
+        assert l.get_xdata() == (.5, .5)
+    for l in multi.hlines:
+        assert l.get_ydata() == (.25, .25)
+
+    # test a move event in an axes not part of the MultiCursor
+    # the lines in ax1 and ax2 should not have moved.
+    event = mock_event(ax3, xdata=.75, ydata=.75)
+    multi.onmove(event)
+    for l in multi.vlines:
+        assert l.get_xdata() == (.5, .5)
+    for l in multi.hlines:
+        assert l.get_ydata() == (.25, .25)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1653,7 +1653,7 @@ class MultiCursor(Widget):
     def onmove(self, event):
         if self.ignore(event):
             return
-        if event.inaxes is None:
+        if event.inaxes not in self.axes:
             return
         if not self.canvas.widgetlock.available(self):
             return


### PR DESCRIPTION
## PR Summary
multicursor now checks if `event.inaxes` is one of the axes it will draw on.

Fixes: https://github.com/matplotlib/matplotlib/issues/19635

Before
![Peek 2021-03-03 18-59](https://user-images.githubusercontent.com/10111092/109891169-9bed8b80-7c56-11eb-8c42-c1b956162a9c.gif)
After:

![Peek 2021-03-03 19-28](https://user-images.githubusercontent.com/10111092/109891158-985a0480-7c56-11eb-90da-39815afebdbd.gif)


## PR Checklist


There aren't any multicursor tests - does this change need a test?

- [ NA? ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [NA] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [NA] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [NA] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
