### PR TITLE
FIX: do not allow single element list of str in subplot_mosaic

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1692,6 +1692,8 @@ default: %(va)s
 
             """
             r0, *rest = inp
+            if isinstance(r0, str):
+                raise ValueError('List layout specification must be 2D')
             for j, r in enumerate(rest, start=1):
                 if isinstance(r, str):
                     raise ValueError('List layout specification must be 2D')

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -760,6 +760,8 @@ class TestSubplotMosaic:
     def test_fail_list_of_str(self):
         with pytest.raises(ValueError, match='must be 2D'):
             plt.subplot_mosaic(['foo', 'bar'])
+        with pytest.raises(ValueError, match='must be 2D'):
+            plt.subplot_mosaic(['foo'])
 
     @check_figures_equal(extensions=["png"])
     @pytest.mark.parametrize("subplot_kw", [{}, {"projection": "polar"}, None])


### PR DESCRIPTION
## PR Summary

Also check that the first element of the a list layout is not a string.

closes #19631 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
