### PR TITLE
Fix comment in RectangleSelector

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2475,7 +2475,7 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def edge_centers(self):
-        """Midpoint of rectangle edges from left, moving clockwise."""
+        """Midpoint of rectangle edges from left, moving anti-clockwise."""
         x0, y0, width, height = self._rect_bbox
         w = width / 2.
         h = height / 2.


### PR DESCRIPTION
I'm doing some widget work, and this comment confused me for a little while. I think the implementation was probably intended to be clockwise, but as currently implemented the edges are actually returned in an anti-clockwise manner.