### PR TITLE
Add angle setter/getter to Rectangle

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -799,6 +799,10 @@ class Rectangle(Patch):
         """Return the height of the rectangle."""
         return self._height
 
+    def get_angle(self):
+        """Get the rotation angle in degrees."""
+        return self.angle
+
     def set_x(self, x):
         """Set the left coordinate of the rectangle."""
         self._x0 = x
@@ -807,6 +811,15 @@ class Rectangle(Patch):
     def set_y(self, y):
         """Set the bottom coordinate of the rectangle."""
         self._y0 = y
+        self.stale = True
+
+    def set_angle(self, angle):
+        """
+        Set the rotation angle in degrees.
+
+        The rotation is performed anti-clockwise around *xy*.
+        """
+        self.angle = angle
         self.stale = True
 
     def set_xy(self, xy):

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -76,6 +76,27 @@ def test_rotate_rect():
     assert_almost_equal(rect1.get_verts(), new_verts)
 
 
+@check_figures_equal(extensions=['png'])
+def test_rotate_rect_draw(fig_test, fig_ref):
+    ax_test = fig_test.add_subplot()
+    ax_ref = fig_ref.add_subplot()
+
+    loc = (0, 0)
+    width, height = (1, 1)
+    angle = 30
+    rect_ref = Rectangle(loc, width, height, angle=angle)
+    ax_ref.add_patch(rect_ref)
+    assert rect_ref.get_angle() == angle
+
+    # Check that when the angle is updated after adding to an axes, that the
+    # patch is marked stale and redrawn in the correct location
+    rect_test = Rectangle(loc, width, height)
+    assert rect_test.get_angle() == 0
+    ax_test.add_patch(rect_test)
+    rect_test.set_angle(angle)
+    assert rect_test.get_angle() == angle
+
+
 def test_negative_rect():
     # These two rectangles have the same vertices, but starting from a
     # different point.  (We also drop the last vertex, which is a duplicate.)


### PR DESCRIPTION
This adds an `angle` property, such that the `Rectangle` is labelled stale when it is updated. All the other properties use `set_` and `get_`, but to maintain backwards compatibility I've used a property here since `Rectangle.angle` already existed.