### PR TITLE
Use globals() instead of locals() for adding colormaps as names to cm module

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -92,7 +92,7 @@ class _DeprecatedCmapDictWrapper(MutableMapping):
 
 
 _cmap_registry = _gen_cmap_registry()
-locals().update(_cmap_registry)
+globals().update(_cmap_registry)
 # This is no longer considered public API
 cmap_d = _DeprecatedCmapDictWrapper(_cmap_registry)
 __builtin_cmaps = tuple(_cmap_registry)


### PR DESCRIPTION
## PR Summary

While this seems to have been working, manipulating `locals()` is not guaranteed to have any effect.
https://docs.python.org/3/library/functions.html#locals