### PR TITLE
deprecate_privatize_attribute also works for privatizing methods.

### DIFF
--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -273,7 +273,7 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
 
 class deprecate_privatize_attribute:
     """
-    Helper to deprecate public access to an attribute.
+    Helper to deprecate public access to an attribute (or method).
 
     This helper should only be used at class scope, as follows::
 
@@ -283,7 +283,8 @@ class deprecate_privatize_attribute:
     where *all* parameters are forwarded to `deprecated`.  This form makes
     ``attr`` a property which forwards access to ``self._attr`` (same name but
     with a leading underscore), with a deprecation warning.  Note that the
-    attribute name is derived from *the name this helper is assigned to*.
+    attribute name is derived from *the name this helper is assigned to*.  This
+    helper also works for deprecating methods.
     """
 
     def __init__(self, *args, **kwargs):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3264,11 +3264,6 @@ class NavigationToolbar2:
                  for ax in self.canvas.figure.axes}))
         self.set_history_buttons()
 
-    @_api.deprecated("3.3", alternative="toolbar.canvas.draw_idle()")
-    def draw(self):
-        """Redraw the canvases, update the locators."""
-        self._draw()
-
     # Can be removed once Locator.refresh() is removed, and replaced by an
     # inline call to self.canvas.draw_idle().
     def _draw(self):
@@ -3286,6 +3281,9 @@ class NavigationToolbar2:
             for loc in locators:
                 mpl.ticker._if_refresh_overridden_call_and_emit_deprec(loc)
         self.canvas.draw_idle()
+
+    draw = _api.deprecate_privatize_attribute(
+        "3.3", alternative="toolbar.canvas.draw_idle()")
 
     def _update_view(self):
         """

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -613,11 +613,6 @@ class ToolViewsPositions(ToolBase):
             if a not in self.home_views[figure]:
                 self.home_views[figure][a] = a._get_view()
 
-    @_api.deprecated("3.3", alternative="self.figure.canvas.draw_idle()")
-    def refresh_locators(self):
-        """Redraw the canvases, update the locators."""
-        self._refresh_locators()
-
     # Can be removed once Locator.refresh() is removed, and replaced by an
     # inline call to self.figure.canvas.draw_idle().
     def _refresh_locators(self):
@@ -639,6 +634,9 @@ class ToolViewsPositions(ToolBase):
             for loc in locators:
                 mpl.ticker._if_refresh_overridden_call_and_emit_deprec(loc)
         self.figure.canvas.draw_idle()
+
+    refresh_locators = _api.deprecate_privatize_attribute(
+        "3.3", alternative="self.figure.canvas.draw_idle()")
 
     def home(self):
         """Recall the first view and position from the stack."""

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -501,11 +501,5 @@ class ScalarMappable:
         self.stale = True
 
     update_dict = _api.deprecate_privatize_attribute("3.3")
-
-    @_api.deprecated("3.3")
-    def add_checker(self, checker):
-        return self._add_checker(checker)
-
-    @_api.deprecated("3.3")
-    def check_update(self, checker):
-        return self._check_update(checker)
+    add_checker = _api.deprecate_privatize_attribute("3.3")
+    check_update = _api.deprecate_privatize_attribute("3.3")

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -546,10 +546,6 @@ class ColorbarBase:
         if self.filled:
             self._add_solids(X, Y, self._values[:, np.newaxis])
 
-    @_api.deprecated("3.3")
-    def config_axis(self):
-        self._config_axis()
-
     def _config_axis(self):
         """Set up long and short axis."""
         ax = self.ax
@@ -566,6 +562,8 @@ class ColorbarBase:
         short_axis.set_ticks([])
         short_axis.set_ticks([], minor=True)
         self.stale = True
+
+    config_axis = _api.deprecate_privatize_attribute("3.3")
 
     def _get_ticker_locator_formatter(self):
         """

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -34,6 +34,19 @@ def test_classproperty_deprecation():
         a.f
 
 
+def test_deprecate_privatize_attribute():
+    class C:
+        def __init__(self): self._attr = 1
+        def _meth(self, arg): pass
+        attr = _api.deprecate_privatize_attribute("0.0")
+        meth = _api.deprecate_privatize_attribute("0.0")
+
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        C().attr
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        C().meth(42)
+
+
 def test_delete_parameter():
     @_api.delete_parameter("3.0", "foo")
     def func1(foo=None):


### PR DESCRIPTION
... with no changes (there's now a test for that).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
