### PR TITLE
Allow Selectors to be dragged from anywhere within their patch

### DIFF
--- a/doc/users/next_whats_new/widget_dragging.rst
+++ b/doc/users/next_whats_new/widget_dragging.rst
@@ -1,0 +1,9 @@
+Dragging selectors
+------------------
+
+The `~matplotlib.widgets.RectangleSelector` and
+`~matplotlib.widgets.EllipseSelector` have a new keyword argument,
+*drag_from_anywhere*, which when set to `True` allows you to click and drag
+from anywhere inside the selector to move it. Previously it was only possible
+to move it by either activating the move modifier button, or clicking on the
+central handle.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -44,6 +44,41 @@ def test_rectangle_selector():
     check_rectangle(rectprops=dict(fill=True))
 
 
+@pytest.mark.parametrize('drag_from_anywhere, new_center',
+                         [[True, (60, 75)],
+                          [False, (30, 20)]])
+def test_rectangle_drag(drag_from_anywhere, new_center):
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True,
+                                     drag_from_anywhere=drag_from_anywhere)
+    # Create rectangle
+    do_event(tool, 'press', xdata=0, ydata=10, button=1)
+    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
+    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+    assert tool.center == (50, 65)
+    # Drag inside rectangle, but away from centre handle
+    #
+    # If drag_from_anywhere == True, this will move the rectangle by (10, 10),
+    # giving it a new center of (60, 75)
+    #
+    # If drag_from_anywhere == False, this will create a new rectangle with
+    # center (30, 20)
+    do_event(tool, 'press', xdata=25, ydata=15, button=1)
+    do_event(tool, 'onmove', xdata=35, ydata=25, button=1)
+    do_event(tool, 'release', xdata=35, ydata=25, button=1)
+    assert tool.center == new_center
+    # Check that in both cases, dragging outside the rectangle draws a new
+    # rectangle
+    do_event(tool, 'press', xdata=175, ydata=185, button=1)
+    do_event(tool, 'onmove', xdata=185, ydata=195, button=1)
+    do_event(tool, 'release', xdata=185, ydata=195, button=1)
+    assert tool.center == (180, 190)
+
+
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2189,7 +2189,8 @@ class RectangleSelector(_SelectorWidget):
                  minspanx=0, minspany=0, useblit=False,
                  lineprops=None, rectprops=None, spancoords='data',
                  button=None, maxdist=10, marker_props=None,
-                 interactive=False, state_modifier_keys=None):
+                 interactive=False, state_modifier_keys=None,
+                 drag_from_anywhere=False):
         r"""
         Parameters
         ----------
@@ -2261,6 +2262,10 @@ class RectangleSelector(_SelectorWidget):
               default: "ctrl".
 
             "square" and "center" can be combined.
+
+        drag_from_anywhere : bool, optional
+            If `True`, the widget can be moved by clicking anywhere within
+            its bounds.
         """
         super().__init__(ax, onselect, useblit=useblit, button=button,
                          state_modifier_keys=state_modifier_keys)
@@ -2268,6 +2273,7 @@ class RectangleSelector(_SelectorWidget):
         self.to_draw = None
         self.visible = True
         self.interactive = interactive
+        self.drag_from_anywhere = drag_from_anywhere
 
         if drawtype == 'none':  # draw a line but make it invisible
             drawtype = 'line'
@@ -2407,8 +2413,9 @@ class RectangleSelector(_SelectorWidget):
                 y1 = event.ydata
 
         # move existing shape
-        elif (('move' in self.state or self.active_handle == 'C')
-              and self._extents_on_press is not None):
+        elif (('move' in self.state or self.active_handle == 'C' or
+               (self.drag_from_anywhere and self._contains(event))) and
+              self._extents_on_press is not None):
             x0, x1, y0, y1 = self._extents_on_press
             dx = event.xdata - self.eventpress.xdata
             dy = event.ydata - self.eventpress.ydata
@@ -2539,16 +2546,24 @@ class RectangleSelector(_SelectorWidget):
         if 'move' in self.state:
             self.active_handle = 'C'
             self._extents_on_press = self.extents
-
         # Set active handle as closest handle, if mouse click is close enough.
         elif m_dist < self.maxdist * 2:
+            # Prioritise center handle over other handles
             self.active_handle = 'C'
         elif c_dist > self.maxdist and e_dist > self.maxdist:
-            self.active_handle = None
-            return
+            # Not close to any handles
+            if self.drag_from_anywhere and self._contains(event):
+                # Check if we've clicked inside the region
+                self.active_handle = 'C'
+                self._extents_on_press = self.extents
+            else:
+                self.active_handle = None
+                return
         elif c_dist < e_dist:
+            # Closest to a corner handle
             self.active_handle = self._corner_order[c_idx]
         else:
+            # Closest to an edge handle
             self.active_handle = self._edge_order[e_idx]
 
         # Save coordinates of rectangle at the start of handle movement.
@@ -2559,6 +2574,10 @@ class RectangleSelector(_SelectorWidget):
         if self.active_handle in ['N', 'NW', 'NE']:
             y0, y1 = y1, event.ydata
         self._extents_on_press = x0, x1, y0, y1
+
+    def _contains(self, event):
+        """Return True if event is within the patch."""
+        return self.to_draw.contains(event, radius=0)[0]
 
     @property
     def geometry(self):


### PR DESCRIPTION
## PR Summary
As it says in the what's new entry:

The `~matplotlib.widgets.RectangleSelector` and `~matplotlib.widgets.EllipseSelector` have a new keyword argument, ``select_whole_region``, which when set to `True` allows you to click and drag from anywhere inside the selector to move it. Previously it was only possible to move it by either activating the move modifier button, or clicking on the central handle.

Questions:
- Any opinions on turning this on by default?
- Does anyone have any better ideas for the keyword argument name? `select_whole_region` is the best I came up with, but it doesn't feel great.

Here's an example:

https://user-images.githubusercontent.com/6197628/110214508-c892e480-7e9c-11eb-8544-fa0dc196bb12.mov


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
