### PR TITLE
Allow PolygonSelector points to be removed

### DIFF
--- a/doc/users/next_whats_new/polygons_selector_remove_points.rst
+++ b/doc/users/next_whats_new/polygons_selector_remove_points.rst
@@ -1,0 +1,4 @@
+Removing points on a PolygonSelector
+------------------------------------
+After fishing drawing a `~matplotlib.widgets.PolygonSelector`, individual
+points can now be removed by right-clicking on them.

--- a/doc/users/next_whats_new/polygons_selector_remove_points.rst
+++ b/doc/users/next_whats_new/polygons_selector_remove_points.rst
@@ -1,4 +1,4 @@
 Removing points on a PolygonSelector
 ------------------------------------
-After fishing drawing a `~matplotlib.widgets.PolygonSelector`, individual
+After completing a `~matplotlib.widgets.PolygonSelector`, individual
 points can now be removed by right-clicking on them.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -598,3 +598,29 @@ def test_polygon_selector_remove_first_point():
                       polygon_place_vertex(*verts[0]) +
                       polygon_remove_vertex(*verts[0]))
     check_polygon_selector(event_sequence, verts[1:], 2)
+
+
+def test_polygon_selector_redraw():
+    verts = [(50, 50), (150, 50), (50, 150)]
+    event_sequence = (polygon_place_vertex(*verts[0]) +
+                      polygon_place_vertex(*verts[1]) +
+                      polygon_place_vertex(*verts[2]) +
+                      polygon_place_vertex(*verts[0]) +
+                      # Polygon completed, now remove first two verts
+                      polygon_remove_vertex(*verts[1]) +
+                      polygon_remove_vertex(*verts[2]) +
+                      # At this point the tool should be reset so we can add
+                      # more vertices
+                      polygon_place_vertex(*verts[1]))
+
+    ax = get_ax()
+
+    def onselect(vertices):
+        pass
+
+    tool = widgets.PolygonSelector(ax, onselect)
+    for (etype, event_args) in event_sequence:
+        do_event(tool, etype, **event_args)
+    # After removing two verts, only one remains, and the
+    # selector should be automatically resete
+    assert tool.verts == verts[0:2]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2759,14 +2759,14 @@ class PolygonSelector(_SelectorWidget):
     Select a polygon region of an axes.
 
     Place vertices with each mouse click, and make the selection by completing
-    the polygon (clicking on the first vertex). Once drawn indiviual vertices
+    the polygon (clicking on the first vertex). Once drawn individual vertices
     can be moved by clicking and dragging with the left mouse button, or
-    deleted by clicking the right mouse button.
+    removed by clicking the right mouse button.
 
     In addition, the following modifier keys can be used:
 
     - Hold *ctrl* and click and drag a vertex to reposition it before the
-      polygon has been copleted.
+      polygon has been completed.
     - Hold the *shift* key and click and drag anywhere in the axes to move
       all vertices.
     - Press the *esc* key to start a new polygon.
@@ -2839,7 +2839,6 @@ class PolygonSelector(_SelectorWidget):
 
     def _remove_vertex(self, i):
         """Remove vertex with index i."""
-        print(self._nverts)
         if (self._nverts > 2 and
                 self._polygon_completed and
                 i in (0, self._nverts - 1)):
@@ -2857,7 +2856,7 @@ class PolygonSelector(_SelectorWidget):
             self._xs.pop(i)
             self._ys.pop(i)
         if self._nverts <= 2:
-            # If only one point left, return to un-complete state to let user
+            # If only one point left, return to incomplete state to let user
             # start drawing again
             self._polygon_completed = False
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2795,6 +2795,12 @@ class PolygonSelector(_SelectorWidget):
     Examples
     --------
     :doc:`/gallery/widgets/polygon_selector_demo`
+
+    Notes
+    -----
+    If only one point remains after removing points, the selector reverts to an
+    incomplete state and you can start drawing a new polygon from the existing
+    point.
     """
 
     def __init__(self, ax, onselect, useblit=False,


### PR DESCRIPTION
## PR Summary
This allows one to remove individual points of a `PolygonSelector` by right-clicking on them (mouse button 3).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
