### PR TITLE
ENH: add a copy method to colormaps

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -846,9 +846,7 @@ class Colormap:
                 '</div>')
 
     def copy(self):
-        """
-        Return a copy of the colormap.
-        """
+        """Return a copy of the colormap."""
         return self.__copy__()
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -561,7 +561,7 @@ def _warn_if_global_cmap_modified(cmap):
                     "colormap. In future versions, you will not be able to "
                     "modify a registered colormap in-place. To remove this "
                     "warning, you can make a copy of the colormap first. "
-                    f'cmap = copy.copy(mpl.cm.get_cmap("{cmap.name}"))'
+                    f'cmap = mpl.cm.get_cmap("{cmap.name}").copy()'
         )
 
 
@@ -844,6 +844,12 @@ class Colormap:
                 '<div style="float: right;">'
                 f'over {color_block(self.get_over())}'
                 '</div>')
+
+    def copy(self):
+        """
+        Return a copy of the colormap.
+        """
+        return self.__copy__()
 
 
 class LinearSegmentedColormap(Colormap):

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -150,6 +150,16 @@ def test_colormap_copy():
     with np.errstate(invalid='ignore'):
         ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     assert_array_equal(ret1, ret2)
+    # again with the .copy method:
+    cmap = plt.cm.Reds
+    copied_cmap = cmap.copy()
+    with np.errstate(invalid='ignore'):
+        ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
+    cmap2 = copy.copy(copied_cmap)
+    cmap2.set_bad('g')
+    with np.errstate(invalid='ignore'):
+        ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
+    assert_array_equal(ret1, ret2)
 
 
 def test_colormap_endian():


### PR DESCRIPTION
## PR Summary

Right now we are deprecating access to the global colormaps, but users can only avoid it by doing `newcmap = copy.copy(cmap)` which is a bit heavy-handed.  Here we provide a simple `copy` method to `Colormap` so we can do `newcmap = cmap.copy()`.  

See discussion in #19609, #16991, #18503


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
