### PR TITLE
Changed FormatStrFormatter documentation to include how to get unicode minus

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -411,6 +411,10 @@ class FormatStrFormatter(Formatter):
 
     The format string should have a single variable format (%) in it.
     It will be applied to the value (not the position) of the tick.
+
+    Negative numeric values will use a dash not a unicode minus,
+    use mathtext to get a unicode minus by wrappping the format specifier
+    with $ (e.g. $%g$).
     """
     def __init__(self, fmt):
         self.fmt = fmt

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -414,7 +414,7 @@ class FormatStrFormatter(Formatter):
 
     Negative numeric values will use a dash not a unicode minus,
     use mathtext to get a unicode minus by wrappping the format specifier
-    with $ (e.g. $%g$).
+    with $ (e.g. "$%g$").
     """
     def __init__(self, fmt):
         self.fmt = fmt


### PR DESCRIPTION
## PR Summary
Amended docstring for FormatStrFormatter so there is documentation for how to get a unicode minus instead of a dash.

Closes #17967.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
