### PR TITLE
Change dictionary to list of tuples to permit duplicate keys

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -60,7 +60,7 @@ def figure_edit(axes, parent=None):
     # Sorting for default labels (_lineXXX, _imageXXX).
     def cmp_key(label):
         """
-        Label should be a tuple consisting of the string label, 
+        Label should be a tuple consisting of the string label,
         and the object being sorted by label.
         """
         match = re.match(r"(_line|_image)(\d+)", label[0])

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -59,13 +59,14 @@ def figure_edit(axes, parent=None):
 
     # Sorting for default labels (_lineXXX, _imageXXX).
     def cmp_key(label):
-        if type(label) == tuple:
-            label = label[0]
-        match = re.match(r"(_line|_image)(\d+)", label)
+        """
+        label should be a tuple consisting of the string label, and the object being sorted by label
+        """
+        match = re.match(r"(_line|_image)(\d+)", label[0])
         if match:
             return match.group(1), int(match.group(2))
         else:
-            return label, 0
+            return label[0], 0
 
     # Get / Curves
     labeled_lines = []

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -59,6 +59,8 @@ def figure_edit(axes, parent=None):
 
     # Sorting for default labels (_lineXXX, _imageXXX).
     def cmp_key(label):
+        if type(label) == tuple:
+            label = label[0]
         match = re.match(r"(_line|_image)(\d+)", label)
         if match:
             return match.group(1), int(match.group(2))
@@ -66,12 +68,12 @@ def figure_edit(axes, parent=None):
             return label, 0
 
     # Get / Curves
-    linedict = {}
+    labeled_lines = []
     for line in axes.get_lines():
         label = line.get_label()
         if label == '_nolegend_':
             continue
-        linedict[label] = line
+        labeled_lines.append((label, line))
     curves = []
 
     def prepare_data(d, init):
@@ -101,9 +103,9 @@ def figure_edit(axes, parent=None):
                 sorted(short2name.items(),
                        key=lambda short_and_name: short_and_name[1]))
 
-    curvelabels = sorted(linedict, key=cmp_key)
-    for label in curvelabels:
-        line = linedict[label]
+    sorted_labels_and_curves = sorted(labeled_lines, key=cmp_key)
+
+    for label, line in sorted_labels_and_curves:
         color = mcolors.to_hex(
             mcolors.to_rgba(line.get_color(), line.get_alpha()),
             keep_alpha=True)
@@ -205,7 +207,7 @@ def figure_edit(axes, parent=None):
 
         # Set / Curves
         for index, curve in enumerate(curves):
-            line = linedict[curvelabels[index]]
+            line = labeled_lines[index][1]
             (label, linestyle, drawstyle, linewidth, color, marker, markersize,
              markerfacecolor, markeredgecolor) = curve
             line.set_label(label)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -133,17 +133,16 @@ def figure_edit(axes, parent=None):
     has_curve = bool(curves)
 
     # Get ScalarMappables.
-    mappabledict = {}
+    mappabledict = []
     for mappable in [*axes.images, *axes.collections]:
         label = mappable.get_label()
         if label == '_nolegend_' or mappable.get_array() is None:
             continue
-        mappabledict[label] = mappable
+        mappabledict.append((label, mappable))
     mappablelabels = sorted(mappabledict, key=cmp_key)
     mappables = []
     cmaps = [(cmap, name) for name, cmap in sorted(cm._cmap_registry.items())]
-    for label in mappablelabels:
-        mappable = mappabledict[label]
+    for label, mappable in mappablelabels:
         cmap = mappable.get_cmap()
         if cmap not in cm._cmap_registry.values():
             cmaps = [(cmap, cmap.name), *cmaps]
@@ -224,7 +223,7 @@ def figure_edit(axes, parent=None):
 
         # Set ScalarMappables.
         for index, mappable_settings in enumerate(mappables):
-            mappable = mappabledict[mappablelabels[index]]
+            mappable = mappabledict[index][1]
             if len(mappable_settings) == 5:
                 label, cmap, low, high, interpolation = mappable_settings
                 mappable.set_interpolation(interpolation)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -104,7 +104,6 @@ def figure_edit(axes, parent=None):
                        key=lambda short_and_name: short_and_name[1]))
 
     sorted_labels_and_curves = sorted(labeled_lines, key=cmp_key)
-
     for label, line in sorted_labels_and_curves:
         color = mcolors.to_hex(
             mcolors.to_rgba(line.get_color(), line.get_alpha()),

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -60,8 +60,8 @@ def figure_edit(axes, parent=None):
     # Sorting for default labels (_lineXXX, _imageXXX).
     def cmp_key(label):
         """
-        label should be a tuple consisting of the string label,
-         and the object being sorted by label
+        Label should be a tuple consisting of the string label, 
+        and the object being sorted by label.
         """
         match = re.match(r"(_line|_image)(\d+)", label[0])
         if match:

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -105,8 +105,7 @@ def figure_edit(axes, parent=None):
                 sorted(short2name.items(),
                        key=lambda short_and_name: short_and_name[1]))
 
-    sorted_labels_and_curves = sorted(labeled_lines, key=cmp_key)
-    for label, line in sorted_labels_and_curves:
+    for label, line in sorted(labeled_lines, key=cmp_key):
         color = mcolors.to_hex(
             mcolors.to_rgba(line.get_color(), line.get_alpha()),
             keep_alpha=True)
@@ -135,16 +134,15 @@ def figure_edit(axes, parent=None):
     has_curve = bool(curves)
 
     # Get ScalarMappables.
-    mappabledict = []
+    labeled_mappables = []
     for mappable in [*axes.images, *axes.collections]:
         label = mappable.get_label()
         if label == '_nolegend_' or mappable.get_array() is None:
             continue
-        mappabledict.append((label, mappable))
-    mappablelabels = sorted(mappabledict, key=cmp_key)
+        labeled_mappables.append((label, mappable))
     mappables = []
     cmaps = [(cmap, name) for name, cmap in sorted(cm._cmap_registry.items())]
-    for label, mappable in mappablelabels:
+    for label, mappable in sorted(labeled_mappables, key=cmp_key):
         cmap = mappable.get_cmap()
         if cmap not in cm._cmap_registry.values():
             cmaps = [(cmap, cmap.name), *cmaps]
@@ -225,7 +223,7 @@ def figure_edit(axes, parent=None):
 
         # Set ScalarMappables.
         for index, mappable_settings in enumerate(mappables):
-            mappable = mappabledict[index][1]
+            mappable = labeled_mappables[index][1]
             if len(mappable_settings) == 5:
                 label, cmap, low, high, interpolation = mappable_settings
                 mappable.set_interpolation(interpolation)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -60,7 +60,8 @@ def figure_edit(axes, parent=None):
     # Sorting for default labels (_lineXXX, _imageXXX).
     def cmp_key(label):
         """
-        label should be a tuple consisting of the string label, and the object being sorted by label
+        label should be a tuple consisting of the string label,
+         and the object being sorted by label
         """
         match = re.match(r"(_line|_image)(\d+)", label[0])
         if match:


### PR DESCRIPTION
## PR Summary
As described in [#19607](https://github.com/matplotlib/matplotlib/issues/19607), when multiple curves are given the same label, only the first one of each redundant label can be edited in the PyQT backend. This is because the curves and their corresponding labels have been saved in a dictionary. It's possible that a user may have a use case for giving multiple curves the same label, so they should be able to edit them separately as well.

To accommodate this, we modified the dictionary which was saving the labeled curves, replacing it with a list of tuples. The list of tuples is sorted in the same way.

I am not sure how to add the tests for this; so far I just tested it manually creating an instance of `NavigationToolbar2QT` and giving it redundantly named curves, and verify that they can be edited independently.
There is a test at `lib/matplotlib/tests/test_backend_qt.py::test_figureoptions`, but all it does is call a mock which will eventually call `figureoptions.figure_edit`, just creating it without checking the number of curves available to edit, seems insufficient.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
