### PR TITLE
Only warn about existing redirects if content differs.

### DIFF
--- a/doc/sphinxext/redirect_from.py
+++ b/doc/sphinxext/redirect_from.py
@@ -76,12 +76,13 @@ def _generate_redirects(app, exception):
         return
     for k, v in RedirectFrom.redirects.items():
         p = Path(app.outdir, k + builder.out_suffix)
+        html = HTML_TEMPLATE.format(v=v)
         if p.is_file():
-            logger.warning(f'A redirect-from directive is trying to create '
-                           f'{p}, but that file already exists (perhaps '
-                           f'you need to run "make clean")')
+            if p.read_text() != html:
+                logger.warning(f'A redirect-from directive is trying to '
+                               f'create {p}, but that file already exists '
+                               f'(perhaps you need to run "make clean")')
         else:
+            logger.info(f'making refresh html file: {k} redirect to {v}')
             p.parent.mkdir(parents=True, exist_ok=True)
-            with p.open("x") as file:
-                logger.info(f'making refresh html file: {k} redirect to {v}')
-                file.write(HTML_TEMPLATE.format(v=v))
+            p.write_text(html)


### PR DESCRIPTION
## PR Summary

This allows you to re-run doc builds without cleaning.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).