### PR TITLE
Cleanup license page in docs

### DIFF
--- a/doc/users/license.rst
+++ b/doc/users/license.rst
@@ -1,9 +1,8 @@
 .. _license:
 
-***********************************************
+*******
 License
-***********************************************
-
+*******
 
 Matplotlib only uses BSD compatible code, and its license is based on
 the `PSF <https://python.org/psf/license>`_ license.  See the Open
@@ -16,21 +15,21 @@ licencing choice, see :ref:`license-discussion`.
 Copyright Policy
 ================
 
-John Hunter began matplotlib around 2003.  Since shortly before his
+John Hunter began Matplotlib around 2003.  Since shortly before his
 passing in 2012, Michael Droettboom has been the lead maintainer of
-matplotlib, but, as has always been the case, matplotlib is the work
+Matplotlib, but, as has always been the case, Matplotlib is the work
 of many.
 
 Prior to July of 2013, and the 1.3.0 release, the copyright of the
 source code was held by John Hunter.  As of July 2013, and the 1.3.0
 release, matplotlib has moved to a shared copyright model.
 
-matplotlib uses a shared copyright model. Each contributor maintains
-copyright over their contributions to matplotlib. But, it is important to
+Matplotlib uses a shared copyright model. Each contributor maintains
+copyright over their contributions to Matplotlib. But, it is important to
 note that these contributions are typically only changes to the
-repositories. Thus, the matplotlib source code, in its entirety, is not
+repositories. Thus, the Matplotlib source code, in its entirety, is not
 the copyright of any single person or institution.  Instead, it is the
-collective copyright of the entire matplotlib Development Team.  If
+collective copyright of the entire Matplotlib Development Team.  If
 individual contributors want to maintain a record of what
 changes/contributions they have specific copyright on, they should
 indicate their copyright in the commit message of the change, when
@@ -40,102 +39,8 @@ The Matplotlib Development Team is the set of all contributors to the
 matplotlib project.  A full list can be obtained from the git version
 control logs.
 
-License agreement for matplotlib |version|
-==============================================
+License agreement
+=================
 
-1. This LICENSE AGREEMENT is between the Matplotlib Development Team
-("MDT"), and the Individual or Organization ("Licensee") accessing and
-otherwise using matplotlib software in source or binary form and its
-associated documentation.
-
-2. Subject to the terms and conditions of this License Agreement, MDT
-hereby grants Licensee a nonexclusive, royalty-free, world-wide license
-to reproduce, analyze, test, perform and/or display publicly, prepare
-derivative works, distribute, and otherwise use matplotlib |version|
-alone or in any derivative version, provided, however, that MDT's
-License Agreement and MDT's notice of copyright, i.e., "Copyright (c)
-2012-2013 Matplotlib Development Team; All Rights Reserved" are retained in
-matplotlib |version| alone or in any derivative version prepared by
-Licensee.
-
-3. In the event Licensee prepares a derivative work that is based on or
-incorporates matplotlib |version| or any part thereof, and wants to
-make the derivative work available to others as provided herein, then
-Licensee hereby agrees to include in any such work a brief summary of
-the changes made to matplotlib |version|.
-
-4. MDT is making matplotlib |version| available to Licensee on an "AS
-IS" basis.  MDT MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
-IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, MDT MAKES NO AND
-DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
-FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF MATPLOTLIB |version|
-WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
-
-5. MDT SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF MATPLOTLIB
-|version| FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
-LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING
-MATPLOTLIB |version|, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF
-THE POSSIBILITY THEREOF.
-
-6. This License Agreement will automatically terminate upon a material
-breach of its terms and conditions.
-
-7. Nothing in this License Agreement shall be deemed to create any
-relationship of agency, partnership, or joint venture between MDT and
-Licensee.  This License Agreement does not grant permission to use MDT
-trademarks or trade name in a trademark sense to endorse or promote
-products or services of Licensee, or any third party.
-
-8. By copying, installing or otherwise using matplotlib |version|,
-Licensee agrees to be bound by the terms and conditions of this License
-Agreement.
-
-License agreement for matplotlib versions prior to 1.3.0
-========================================================
-
-1. This LICENSE AGREEMENT is between John D. Hunter ("JDH"), and the
-Individual or Organization ("Licensee") accessing and otherwise using
-matplotlib software in source or binary form and its associated
-documentation.
-
-2. Subject to the terms and conditions of this License Agreement, JDH
-hereby grants Licensee a nonexclusive, royalty-free, world-wide license
-to reproduce, analyze, test, perform and/or display publicly, prepare
-derivative works, distribute, and otherwise use matplotlib |version|
-alone or in any derivative version, provided, however, that JDH's
-License Agreement and JDH's notice of copyright, i.e., "Copyright (c)
-2002-2009 John D. Hunter; All Rights Reserved" are retained in
-matplotlib |version| alone or in any derivative version prepared by
-Licensee.
-
-3. In the event Licensee prepares a derivative work that is based on or
-incorporates matplotlib |version| or any part thereof, and wants to
-make the derivative work available to others as provided herein, then
-Licensee hereby agrees to include in any such work a brief summary of
-the changes made to matplotlib |version|.
-
-4. JDH is making matplotlib |version| available to Licensee on an "AS
-IS" basis.  JDH MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
-IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, JDH MAKES NO AND
-DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
-FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF MATPLOTLIB |version|
-WILL NOT INFRINGE ANY THIRD PARTY RIGHTS.
-
-5. JDH SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF MATPLOTLIB
-|version| FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR
-LOSS AS A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING
-MATPLOTLIB |version|, OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF
-THE POSSIBILITY THEREOF.
-
-6. This License Agreement will automatically terminate upon a material
-breach of its terms and conditions.
-
-7. Nothing in this License Agreement shall be deemed to create any
-relationship of agency, partnership, or joint venture between JDH and
-Licensee.  This License Agreement does not grant permission to use JDH
-trademarks or trade name in a trademark sense to endorse or promote
-products or services of Licensee, or any third party.
-
-8. By copying, installing or otherwise using matplotlib |version|,
-Licensee agrees to be bound by the terms and conditions of this License
-Agreement.
+.. literalinclude:: ../../LICENSE/LICENSE
+   :language: none


### PR DESCRIPTION
## PR Summary

Partly adresses #19687.

Changes:

- Replaced the license text by a literal include of our license file `LICENSE/LICENSE` in the repo.
  We should not carry two versions of the license. Note that the deleted text used the explicit version `|version|` in many places, which `LICENSE` does not. As far as I understand licenses this is not necessary, and I haven't seen this in other licenses. so this technical change is ok. Anyway we cannot have two different license wordings.
- some capitalization of "Matplotlib"

