### PR TITLE
Updated Random Number Generation in Numpy

### DIFF
--- a/examples/statistics/hist.py
+++ b/examples/statistics/hist.py
@@ -12,7 +12,7 @@ from matplotlib import colors
 from matplotlib.ticker import PercentFormatter
 
 # Fixing random state for reproducibility
-r = np.random.default_rng(seed=19680801)
+rng = np.random.default_rng(seed=19680801)
 
 
 ###############################################################################
@@ -27,8 +27,8 @@ N_points = 100000
 n_bins = 20
 
 # Generate a normal distribution, center at x=0 and y=5
-x = r.standard_normal(N_points)
-y = .4 * x + r.standard_normal(100000) + 5
+x = rng.standard_normal(N_points)
+y = .4 * x + rng.standard_normal(100000) + 5
 
 fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
 

--- a/examples/statistics/hist.py
+++ b/examples/statistics/hist.py
@@ -12,7 +12,7 @@ from matplotlib import colors
 from matplotlib.ticker import PercentFormatter
 
 # Fixing random state for reproducibility
-np.random.seed(19680801)
+r = np.random.default_rng(seed=19680801)
 
 
 ###############################################################################
@@ -27,8 +27,8 @@ N_points = 100000
 n_bins = 20
 
 # Generate a normal distribution, center at x=0 and y=5
-x = np.random.randn(N_points)
-y = .4 * x + np.random.randn(100000) + 5
+x = r.standard_normal(N_points)
+y = .4 * x + r.standard_normal(100000) + 5
 
 fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
 


### PR DESCRIPTION
## PR Summary
closes #19670 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
