### PR TITLE
DOC: fix dx in Arrow guide

### DIFF
--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -48,11 +48,11 @@ dy = y_head - y_tail
 # but the anchor points move.
 
 fig, axs = plt.subplots(nrows=2)
-arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (dx, dy),
+arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (x_head, y_head),
                                  mutation_scale=100)
 axs[0].add_patch(arrow)
 
-arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (dx, dy),
+arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (x_head, y_head),
                                  mutation_scale=100)
 axs[1].add_patch(arrow)
 axs[1].set_xlim(0, 2)
@@ -73,12 +73,12 @@ axs[1].set_ylim(0, 2)
 # stays the same.
 
 fig, axs = plt.subplots(nrows=2)
-arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (dx, dy),
+arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (x_head, y_head),
                                  mutation_scale=100,
                                  transform=axs[0].transAxes)
 axs[0].add_patch(arrow)
 
-arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (dx, dy),
+arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (x_head, y_head),
                                  mutation_scale=100,
                                  transform=axs[1].transAxes)
 axs[1].add_patch(arrow)


### PR DESCRIPTION
## PR Summary

The arrow guide mistakenly made it sound like the arguments for FancyArrowPatch are (x, y) and (dx, dy), whereas they are (x_tail, y_tail) and (x_head, y_head).


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
