### PR TITLE
Fix arrow_guide.py typo

### DIFF
--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -10,7 +10,7 @@ that behave differently when the data limits on a plot are changed. In general,
 points on a plot can either be fixed in "data space" or "display space".
 Something plotted in data space moves when the data limits are altered - an
 example would be the points in a scatter plot. Something plotted in display
-space stays static when data limits are altered - an example would be a 
+space stays static when data limits are altered - an example would be a
 figure title or the axis labels.
 
 Arrows consist of a head (and possibly a tail) and a stem drawn between a

--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -39,8 +39,7 @@ dy = y_head - y_tail
 # -----------------------------------------------------------------------
 #
 # This is useful if you are annotating a plot, and don't want the arrow to
-# to change shape or position if you pan or scale the plot. Note that when
-# the axis limits change
+# to change shape or position if you pan or scale the plot. 
 #
 # In this case we use `.patches.FancyArrowPatch`
 #
@@ -63,14 +62,14 @@ axs[1].set_ylim(0, 2)
 # ---------------------------------------------------
 #
 # This is useful if you are annotating a plot, and don't want the arrow to
-# to change shape or position if you pan or scale the plot.
+# change shape or position if you pan or scale the plot.
 #
 # In this case we use `.patches.FancyArrowPatch`, and pass the keyword argument
 # ``transform=ax.transAxes`` where ``ax`` is the axes we are adding the patch
 # to.
 #
 # Note that when the axis limits are changed, the arrow shape and location
-# stays the same.
+# stay the same.
 
 fig, axs = plt.subplots(nrows=2)
 arrow = mpatches.FancyArrowPatch((x_tail, y_tail), (dx, dy),
@@ -93,7 +92,7 @@ axs[1].set_ylim(0, 2)
 # In this case we use `.patches.Arrow`
 #
 # Note that when the axis limits are changed, the arrow shape and location
-# changes.
+# change.
 
 fig, axs = plt.subplots(nrows=2)
 

--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -9,7 +9,7 @@ Arrows are often used to annotate plots. This tutorial shows how to plot arrows
 that behave differently when the data limits on a plot are changed. In general,
 points on a plot can either be fixed in "data space" or "display space".
 Something plotted in data space moves when the data limits are altered - an
-example would the points in a scatter plot. Something plotted in display space
+example would be the points in a scatter plot. Something plotted in display space
 stays static when data limits are altered - an example would be a figure title
 or the axis labels.
 

--- a/examples/shapes_and_collections/arrow_guide.py
+++ b/examples/shapes_and_collections/arrow_guide.py
@@ -9,9 +9,9 @@ Arrows are often used to annotate plots. This tutorial shows how to plot arrows
 that behave differently when the data limits on a plot are changed. In general,
 points on a plot can either be fixed in "data space" or "display space".
 Something plotted in data space moves when the data limits are altered - an
-example would be the points in a scatter plot. Something plotted in display space
-stays static when data limits are altered - an example would be a figure title
-or the axis labels.
+example would be the points in a scatter plot. Something plotted in display
+space stays static when data limits are altered - an example would be a 
+figure title or the axis labels.
 
 Arrows consist of a head (and possibly a tail) and a stem drawn between a
 start point and end point, called 'anchor points' from now on.
@@ -39,9 +39,9 @@ dy = y_head - y_tail
 # -----------------------------------------------------------------------
 #
 # This is useful if you are annotating a plot, and don't want the arrow to
-# to change shape or position if you pan or scale the plot. 
+# to change shape or position if you pan or scale the plot.
 #
-# In this case we use `.patches.FancyArrowPatch`
+# In this case we use `.patches.FancyArrowPatch`.
 #
 # Note that when the axis limits are changed, the arrow shape stays the same,
 # but the anchor points move.
@@ -89,7 +89,7 @@ axs[1].set_ylim(0, 2)
 # Head shape and anchor points fixed in data space
 # ------------------------------------------------
 #
-# In this case we use `.patches.Arrow`
+# In this case we use `.patches.Arrow`.
 #
 # Note that when the axis limits are changed, the arrow shape and location
 # change.


### PR DESCRIPTION
## PR Summary
Just some corrections to the typos and redundancy in `arrow_guide.py`. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
