### PR TITLE
Don't sort lexicographially entries in SVG output.

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -156,7 +156,7 @@ class XMLWriter:
         self.__tags.append(tag)
         self.__write(self.__indentation[:len(self.__tags) - 1])
         self.__write("<%s" % tag)
-        for k, v in sorted({**attrib, **extra}.items()):
+        for k, v in {**attrib, **extra}.items():
             if v:
                 k = escape_cdata(k)
                 v = escape_attrib(v)
@@ -264,7 +264,7 @@ def generate_transform(transform_list=[]):
 def generate_css(attrib={}):
     if attrib:
         output = StringIO()
-        attrib = sorted(attrib.items())
+        attrib = attrib.items()
         for k, v in attrib:
             k = escape_attrib(k)
             v = escape_attrib(v)


### PR DESCRIPTION
Sorting had been added in cb5893d for reproducible outputs, but dicts
now maintain insertion order so this is not needed anymore; moreover,
not sorting allows keeping attributes in a more semantic meaning --
e.g., attributes of the toplevel `<svg>` are now in the order
`xmlns:xlink width height viewBox xmlns version` rather than
`height version viewBox width xmlns xmlns:xlink`; the `<use>` elements
of ticks now have attributes `xlink:href x y style` rather than
`style x xlink:href y`.

The order is still not perfect due to other issues, but that'll be
addressed another time.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
