### PR TITLE
Reword the axis_artist module docstring.

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -1,39 +1,24 @@
 """
-axis_artist.py module provides axis-related artists. They are
+The :mod:`.axis_artist` module implements custom artists to draw axis elements
+(axis lines and labels, tick lines and labels, grid lines).
 
-* axis line
-* tick lines
-* tick labels
-* axis label
-* grid lines
+Axis lines and labels and tick lines and labels are managed by the `AxisArtist`
+class; grid lines are managed by the `GridlinesCollection` class.
 
-The main artist classes are `AxisArtist` and `GridlinesCollection`. While
-`GridlinesCollection` is responsible for drawing grid lines, `AxisArtist`
-is responsible for all other artists. `AxisArtist` has attributes that are
-associated with each type of artists:
+There is one `AxisArtist` per Axis; it can be accessed through
+the ``axis`` dictionary of the parent Axes (which should be a
+`mpl_toolkits.axislines.Axes`), e.g. ``ax.axis["bottom"]``.
 
-* line: axis line
-* major_ticks: major tick lines
-* major_ticklabels: major tick labels
-* minor_ticks: minor tick lines
-* minor_ticklabels: minor tick labels
-* label: axis label
+Children of the AxisArtist are accessed as attributes: ``.line`` and ``.label``
+for the axis line and label, ``.major_ticks``, ``.major_ticklabels``,
+``.minor_ticks``, ``.minor_ticklabels`` for the tick lines and labels (e.g.
+``ax.axis["bottom"].line``).
 
-Typically, the `AxisArtist` associated with an axes will be accessed with the
-*axis* dictionary of the axes, i.e., the `AxisArtist` for the bottom axis is ::
+Children properties (colors, fonts, line widths, etc.) can be set using
+setters, e.g. ::
 
-  ax.axis["bottom"]
-
-where *ax* is an instance of `mpl_toolkits.axislines.Axes`.  Thus,
-``ax.axis["bottom"].line`` is an artist associated with the axis line, and
-``ax.axis["bottom"].major_ticks`` is an artist associated with the major tick
-lines.
-
-You can change the colors, fonts, line widths, etc. of these artists
-by calling suitable set method. For example, to change the color of the major
-ticks of the bottom axis to red, use ::
-
-  ax.axis["bottom"].major_ticks.set_color("r")
+  # Make the major ticks of the bottom axis red.
+  ax.axis["bottom"].major_ticks.set_color("red")
 
 However, things like the locations of ticks, and their ticklabels need to be
 changed from the side of the grid_helper.


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
