### PR TITLE
Only override pickradius when picker is not a bool.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -397,7 +397,8 @@ class Line2D(Artist):
         self.update(kwargs)
         self.pickradius = pickradius
         self.ind_offset = 0
-        if isinstance(self._picker, Number):
+        if (isinstance(self._picker, Number) and
+                not isinstance(self._picker, bool)):
             self.pickradius = self._picker
 
         self._xorig = np.asarray([])

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -4,6 +4,7 @@ Tests specific to the lines module.
 
 import itertools
 import timeit
+from types import SimpleNamespace
 
 from cycler import cycler
 import numpy as np
@@ -264,3 +265,29 @@ def test_marker_as_markerstyle():
 def test_odd_dashes(fig_test, fig_ref):
     fig_test.add_subplot().plot([1, 2], dashes=[1, 2, 3])
     fig_ref.add_subplot().plot([1, 2], dashes=[1, 2, 3, 1, 2, 3])
+
+
+def test_picking():
+    fig, ax = plt.subplots()
+    mouse_event = SimpleNamespace(x=fig.bbox.width // 2,
+                                  y=fig.bbox.height // 2 + 15)
+
+    # Default pickradius is 5, so event should not pick this line.
+    l0, = ax.plot([0, 1], [0, 1], picker=True)
+    found, indices = l0.contains(mouse_event)
+    assert not found
+
+    # But with a larger pickradius, this should be picked.
+    l1, = ax.plot([0, 1], [0, 1], picker=True, pickradius=20)
+    found, indices = l1.contains(mouse_event)
+    assert found
+    assert_array_equal(indices['ind'], [0])
+
+    # And if we modify the pickradius after creation, it should work as well.
+    l2, = ax.plot([0, 1], [0, 1], picker=True)
+    found, indices = l2.contains(mouse_event)
+    assert not found
+    l2.set_pickradius(20)
+    found, indices = l2.contains(mouse_event)
+    assert found
+    assert_array_equal(indices['ind'], [0])


### PR DESCRIPTION
## PR Summary

This was done when the deprecation was added, but then removed when it was undeprecated. However, people now seem to be relying on this new behaviour, and it seems more correct, so we should add it back.

Fixes #19700.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).