### PR TITLE
Cleanup backend_tools docstrings, and minor refactorings.

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -38,42 +38,31 @@ class ToolBase:
     """
     Base tool class.
 
-    A base tool, only implements `trigger` method or not method at all.
+    A base tool, only implements `trigger` method or no method at all.
     The tool is instantiated by `matplotlib.backend_managers.ToolManager`.
-
-    Attributes
-    ----------
-    toolmanager : `matplotlib.backend_managers.ToolManager`
-        ToolManager that controls this Tool.
-    figure : `FigureCanvas`
-        Figure instance that is affected by this Tool.
-    name : str
-        Used as **Id** of the tool, has to be unique among tools of the same
-        ToolManager.
     """
 
     default_keymap = None
     """
     Keymap to associate with this tool.
 
-    **String**: List of comma separated keys that will be used to call this
-    tool when the keypress event of ``self.figure.canvas`` is emitted.
+    ``list[str]``: List of keys that will trigger this tool when a keypress
+    event is emitted on ``self.figure.canvas``.
     """
 
     description = None
     """
     Description of the Tool.
 
-    **String**: If the Tool is included in the Toolbar this text is used
-    as a Tooltip.
+    `str`: Tooltip used if the Tool is included in a Toolbar.
     """
 
     image = None
     """
     Filename of the image.
 
-    **String**: Filename of the image to use in the toolbar. If None, the
-    *name* is used as a label in the toolbar button.
+    `str`: Filename of the image to use in a Toolbar.  If None, the *name* is
+    used as a label in the toolbar button.
     """
 
     def __init__(self, toolmanager, name):
@@ -81,23 +70,26 @@ class ToolBase:
         self._toolmanager = toolmanager
         self._figure = None
 
+    name = property(
+        lambda self: self._name,
+        doc="The tool id (str, must be unique among tools of a tool manager).")
+    toolmanager = property(
+        lambda self: self._toolmanager,
+        doc="The `.ToolManager` that controls this tool.")
+    canvas = property(
+        lambda self: self._figure.canvas if self._figure is not None else None,
+        doc="The canvas of the figure affected by this tool, or None.")
+
     @property
     def figure(self):
+        """The Figure affected by this tool, or None."""
         return self._figure
 
     @figure.setter
     def figure(self, figure):
-        self.set_figure(figure)
+        self._figure = figure
 
-    @property
-    def canvas(self):
-        if not self._figure:
-            return None
-        return self._figure.canvas
-
-    @property
-    def toolmanager(self):
-        return self._toolmanager
+    set_figure = figure.fset
 
     def _make_classic_style_pseudo_toolbar(self):
         """
@@ -108,22 +100,11 @@ class ToolBase:
         """
         return SimpleNamespace(canvas=self.canvas)
 
-    def set_figure(self, figure):
-        """
-        Assign a figure to the tool.
-
-        Parameters
-        ----------
-        figure : `.Figure`
-        """
-        self._figure = figure
-
     def trigger(self, sender, event, data=None):
         """
         Called when this tool gets used.
 
-        This method is called by
-        `matplotlib.backend_managers.ToolManager.trigger_tool`.
+        This method is called by `.ToolManager.trigger_tool`.
 
         Parameters
         ----------
@@ -136,17 +117,11 @@ class ToolBase:
         """
         pass
 
-    @property
-    def name(self):
-        """Tool Id."""
-        return self._name
-
     def destroy(self):
         """
         Destroy the tool.
 
-        This method is called when the tool is removed by
-        `matplotlib.backend_managers.ToolManager.remove_tool`.
+        This method is called by `.ToolManager.remove_tool`.
         """
         pass
 
@@ -167,10 +142,10 @@ class ToolToggleBase(ToolBase):
     """
 
     radio_group = None
-    """Attribute to group 'radio' like tools (mutually exclusive).
+    """
+    Attribute to group 'radio' like tools (mutually exclusive).
 
-    **String** that identifies the group or **None** if not belonging to a
-    group.
+    `str` that identifies the group or **None** if not belonging to a group.
     """
 
     cursor = None
@@ -217,7 +192,6 @@ class ToolToggleBase(ToolBase):
     @property
     def toggled(self):
         """State of the toggled tool."""
-
         return self._toggled
 
     def set_figure(self, figure):


### PR DESCRIPTION
Properties already show up with their docstrings in the generated docs,
so no need to list them in a separate API section (also note that the
document type of the figure attribute was wrong).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
