### PR TITLE
Speed up _delete_parameter.

### DIFF
--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -13,6 +13,7 @@ This documentation is only relevant for Matplotlib developers, not for users.
 import contextlib
 import functools
 import inspect
+import math
 import warnings
 
 
@@ -390,12 +391,22 @@ def delete_parameter(since, name, func=None, **kwargs):
         is_varargs = kind is inspect.Parameter.VAR_POSITIONAL
         is_varkwargs = kind is inspect.Parameter.VAR_KEYWORD
         if not is_varargs and not is_varkwargs:
+            name_idx = (
+                # Deprecated parameter can't be passed positionally.
+                math.inf if kind is inspect.Parameter.KEYWORD_ONLY
+                # If call site has no more than this number of parameters, the
+                # deprecated parameter can't have been passed positionally.
+                else [*signature.parameters].index(name))
             func.__signature__ = signature = signature.replace(parameters=[
                 param.replace(default=_deprecated_parameter)
                 if param.name == name else param
                 for param in signature.parameters.values()])
+        else:
+            name_idx = -1  # Deprecated parameter can always have been passed.
     else:
         is_varargs = is_varkwargs = False
+        # Deprecated parameter can't be passed positionally.
+        name_idx = math.inf
         assert kwargs_name, (
             f"Matplotlib internal error: {name!r} must be a parameter for "
             f"{func.__name__}()")
@@ -404,6 +415,10 @@ def delete_parameter(since, name, func=None, **kwargs):
 
     @functools.wraps(func)
     def wrapper(*inner_args, **inner_kwargs):
+        if len(inner_args) <= name_idx and name not in inner_kwargs:
+            # Early return in the simple, non-deprecated case (much faster than
+            # calling bind()).
+            return func(*inner_args, **inner_kwargs)
         arguments = signature.bind(*inner_args, **inner_kwargs).arguments
         if is_varargs and arguments.get(name):
             warn_deprecated(


### PR DESCRIPTION
`_delete_parameter` is currently used on `Tick.__init__`, which is
called *very* often when creating many axes.  This patch speeds up
```
MPLBACKEND=agg python -mtimeit -s 'from matplotlib.figure import Figure' -- 'Figure().subplots(10, 10)'
```
by ~20-25% (currently, just generating an 10x10 empty grid of axes takes
~1s).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
