### PR TITLE
Remove visibility changes in draw for *Cursor widgets

### DIFF
--- a/doc/api/next_api_changes/deprecations/19763-ES.rst
+++ b/doc/api/next_api_changes/deprecations/19763-ES.rst
@@ -1,0 +1,5 @@
+``Cursor`` and ``MultiCursor`` event handlers are now private
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Access to the event handlers for the `.Cursor` and `.MultiCursor` widgets is
+now deprecated.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1517,7 +1517,7 @@ def test_MultiCursor(horizOn, vertOn):
     # Can't use `do_event` as that helper requires the widget
     # to have a single .ax attribute.
     event = mock_event(ax1, xdata=.5, ydata=.25)
-    multi.onmove(event)
+    multi._onmove(event)
 
     # the lines in the first two ax should both move
     for l in multi.vlines:
@@ -1528,7 +1528,7 @@ def test_MultiCursor(horizOn, vertOn):
     # test a move event in an Axes not part of the MultiCursor
     # the lines in ax1 and ax2 should not have moved.
     event = mock_event(ax3, xdata=.75, ydata=.75)
-    multi.onmove(event)
+    multi._onmove(event)
     for l in multi.vlines:
         assert l.get_xdata() == (.5, .5)
     for l in multi.hlines:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1600,8 +1600,8 @@ class Cursor(AxesWidget):
                  **lineprops):
         super().__init__(ax)
 
-        self.connect_event('motion_notify_event', self.onmove)
-        self.connect_event('draw_event', self.clear)
+        self.connect_event('motion_notify_event', self._onmove)
+        self.connect_event('draw_event', self._clear)
 
         self.visible = True
         self.horizOn = horizOn
@@ -1616,7 +1616,9 @@ class Cursor(AxesWidget):
         self.background = None
         self.needclear = False
 
-    def clear(self, event):
+    clear = _api.deprecate_privatize_attribute('3.5')
+
+    def _clear(self, event):
         """Internal event handler to clear the cursor."""
         if self.ignore(event):
             return
@@ -1625,7 +1627,9 @@ class Cursor(AxesWidget):
         self.linev.set_visible(False)
         self.lineh.set_visible(False)
 
-    def onmove(self, event):
+    onmove = _api.deprecate_privatize_attribute('3.5')
+
+    def _onmove(self, event):
         """Internal event handler to draw the cursor when the mouse moves."""
         if self.ignore(event):
             return
@@ -1749,8 +1753,8 @@ class MultiCursor(Widget):
         """Connect events."""
         for canvas, info in self._canvas_infos.items():
             info["cids"] = [
-                canvas.mpl_connect('motion_notify_event', self.onmove),
-                canvas.mpl_connect('draw_event', self.clear),
+                canvas.mpl_connect('motion_notify_event', self._onmove),
+                canvas.mpl_connect('draw_event', self._clear),
             ]
 
     def disconnect(self):
@@ -1760,7 +1764,9 @@ class MultiCursor(Widget):
                 canvas.mpl_disconnect(cid)
             info["cids"].clear()
 
-    def clear(self, event):
+    clear = _api.deprecate_privatize_attribute('3.5')
+
+    def _clear(self, event):
         """Clear the cursor."""
         if self.ignore(event):
             return
@@ -1770,7 +1776,9 @@ class MultiCursor(Widget):
         for line in self.vlines + self.hlines:
             line.set_visible(False)
 
-    def onmove(self, event):
+    onmove = _api.deprecate_privatize_attribute('3.5')
+
+    def _onmove(self, event):
         if (self.ignore(event)
                 or event.inaxes not in self.axes
                 or not event.canvas.widgetlock.available(self)):


### PR DESCRIPTION
## PR Summary

This can be all handled in the mouse move event handler instead, and prevents triggering extra draws in nbAgg.

Fixes #19633.

Additionally, mark access to said event handlers as deprecated.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).