### PR TITLE
Set colormap modification removal to 3.6.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -557,10 +557,12 @@ def _warn_if_global_cmap_modified(cmap):
     if getattr(cmap, '_global', False):
         _api.warn_deprecated(
             "3.3",
+            removal="3.6",
             message="You are modifying the state of a globally registered "
-                    "colormap. In future versions, you will not be able to "
-                    "modify a registered colormap in-place. To remove this "
-                    "warning, you can make a copy of the colormap first. "
+                    "colormap. This has been deprecated since %(since)s and "
+                    "%(removal)s, you will not be able to modify a "
+                    "registered colormap in-place. To remove this warning, "
+                    "you can make a copy of the colormap first. "
                     f'cmap = mpl.cm.get_cmap("{cmap.name}").copy()'
         )
 


### PR DESCRIPTION
## PR Summary

The deprecation would normally be removed 2 releases later (i.e., 3.5 for a 3.3 deprecation), but we need to extend it as we didn't fully determine the intermediate changes to make.

See #16991 and #19609.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).