### PR TITLE
Fix deprecation for imread on URLs.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1478,9 +1478,10 @@ def imread(fname, format=None):
     if isinstance(fname, str):
         parsed = parse.urlparse(fname)
         if len(parsed.scheme) > 1:  # Pillow doesn't handle URLs directly.
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.4", message="Directly reading images from URLs is "
-                "deprecated. Please open the URL for reading and pass the "
+                "deprecated since %(since)s and will no longer be supported "
+                "%(removal)s. Please open the URL for reading and pass the "
                 "result to Pillow, e.g. with "
                 "``PIL.Image.open(urllib.request.urlopen(url))``.")
             # hide imports to speed initial import on systems with slow linkers


### PR DESCRIPTION
## PR Summary

This deprecation is missing the addition/removal version, and it triggers an extra warning because it uses the old `cbook.warn_deprecated`.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).