### PR TITLE
Fix code-of-conduct link on doc homepage.

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -78,7 +78,8 @@ Join our community!
 ~~~~~~~~~~~~~~~~~~~
 
 Matplotlib is a welcoming, inclusive project, and everyone within the community
-is expected to abide by our `code of conduct <../CODE_OF_CONDUCT.md>`_.
+is expected to abide by our `code of conduct
+<https://github.com/matplotlib/matplotlib/blob/master/CODE_OF_CONDUCT.md>`_.
 
 
 .. raw:: html


### PR DESCRIPTION
## PR Summary

The link is not modified by Sphinx and  just goes to `../CODE_OF_CONDUCT.md`, which doesn't exist in the Sphinx docs.

I already directly patched this on the docs repo after building 3.4.0 docs.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).