### PR TITLE
Small typo fixes to interactive guide.

### DIFF
--- a/doc/users/interactive_guide.rst
+++ b/doc/users/interactive_guide.rst
@@ -117,7 +117,7 @@ non-responsive) you will be able to use the prompt again.  Re-starting
 the event loop will make any open figure responsive again (and will
 process any queued up user interaction).
 
-To start the event loop until all open figures are closed use
+To start the event loop until all open figures are closed, use
 `.pyplot.show` as ::
 
   pyplot.show(block=True)
@@ -345,7 +345,7 @@ become stale.
 
 .. _draw_idle:
 
-Draw Idle
+Idle draw
 =========
 
 .. autosummary::
@@ -393,19 +393,18 @@ CPython / readline
 ------------------
 
 The Python C API provides a hook, :c:data:`PyOS_InputHook`, to register a
-function to be run "The function will be called when Python's
+function to be run ("The function will be called when Python's
 interpreter prompt is about to become idle and wait for user input
-from the terminal.".  This hook can be used to integrate a second
+from the terminal.").  This hook can be used to integrate a second
 event loop (the GUI event loop) with the python input prompt loop.
 The hook functions typically exhaust all pending events on the GUI
 event queue, run the main loop for a short fixed amount of time, or
 run the event loop until a key is pressed on stdin.
 
-
 Matplotlib does not currently do any management of :c:data:`PyOS_InputHook` due
 to the wide range of ways that Matplotlib is used.  This management is left to
 downstream libraries -- either user code or the shell.  Interactive figures,
-even with matplotlib in 'interactive mode', may not work in the vanilla python
+even with Matplotlib in 'interactive mode', may not work in the vanilla python
 repl if an appropriate :c:data:`PyOS_InputHook` is not registered.
 
 Input hooks, and helpers to install them, are usually included with
@@ -415,15 +414,15 @@ Matplotlib supports which can be installed via ``%matplotlib``.  This
 is the recommended method of integrating Matplotlib and a prompt.
 
 
-IPython / prompt toolkit
+IPython / prompt_toolkit
 ------------------------
 
-With IPython >= 5.0 IPython has changed from using cpython's readline
+With IPython >= 5.0 IPython has changed from using CPython's readline
 based prompt to a ``prompt_toolkit`` based prompt.  ``prompt_toolkit``
 has the same conceptual input hook, which is fed into ``prompt_toolkit`` via the
 :meth:`IPython.terminal.interactiveshell.TerminalInteractiveShell.inputhook`
 method.  The source for the ``prompt_toolkit`` input hooks lives at
-:mod:`IPython.terminal.pt_inputhooks`
+:mod:`IPython.terminal.pt_inputhooks`.
 
 
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
