### PR TITLE
Fix non existent URI s

### DIFF
--- a/doc/sphinxext/redirect_from.py
+++ b/doc/sphinxext/redirect_from.py
@@ -65,11 +65,7 @@ class RedirectFrom(Directive):
             raise ValueError(
                 f"{redirected_reldoc} is already noted as redirecting to "
                 f"{self.redirects[redirected_reldoc]}")
-        try:
-            self.redirects[redirected_reldoc] = builder.get_relative_uri(
-                redirected_reldoc, current_doc)
-        except:
-            pass
+        self.redirects[redirected_reldoc] = current_doc
         return []
 
 
@@ -79,7 +75,7 @@ def _generate_redirects(app, exception):
         return
     for k, v in RedirectFrom.redirects.items():
         p = Path(app.outdir, k + builder.out_suffix)
-        html = HTML_TEMPLATE.format(v=v)
+        html = HTML_TEMPLATE.format(v=builder.get_relative_uri(k, v))
         if p.is_file():
             if p.read_text() != html:
                 logger.warning(f'A redirect-from directive is trying to '

--- a/doc/sphinxext/redirect_from.py
+++ b/doc/sphinxext/redirect_from.py
@@ -65,8 +65,11 @@ class RedirectFrom(Directive):
             raise ValueError(
                 f"{redirected_reldoc} is already noted as redirecting to "
                 f"{self.redirects[redirected_reldoc]}")
-        self.redirects[redirected_reldoc] = builder.get_relative_uri(
-            redirected_reldoc, current_doc)
+        try:
+            self.redirects[redirected_reldoc] = builder.get_relative_uri(
+                redirected_reldoc, current_doc)
+        except:
+            pass
         return []
 
 


### PR DESCRIPTION
## PR Summary

Fixes #19780.  @anntzer actually wrote the code, so perhaps he has a more elegant solution...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
