### PR TITLE
Remove usetex-related APIs deprecated in Matplotlib 3.3.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19795-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19795-AL.rst
@@ -1,0 +1,3 @@
+``Dvi.baseline``
+~~~~~~~~~~~~~~~~
+... is deprecated (with no replacement).

--- a/doc/api/next_api_changes/removals/19795-AL.rst
+++ b/doc/api/next_api_changes/removals/19795-AL.rst
@@ -1,0 +1,11 @@
+usetex-related removals
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``text.latex.preview`` rcParam and associated methods
+(``TexManager.make_tex_preview``, ``TexManager.make_dvi_preview``) have been
+removed.
+
+The ``cachedir``, ``rgba_arrayd``, ``serif``, ``sans_serif``, ``cursive``, and
+``monospace`` attributes of ``TexManager`` have been removed.
+
+``dviread.Encoding`` has been removed.

--- a/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -3,49 +3,17 @@
 Usetex Baseline Test
 ====================
 
-A test for :rc:`text.latex.preview`, a deprecated feature which relied
-on the preview.sty LaTeX package to properly align TeX baselines.  This
-feature has been deprecated as Matplotlib's dvi parser now computes baselines
-just as well as preview.sty; this example will be removed together with
-:rc:`text.latex.preview` after the deprecation elapses.
+Comparison of text baselines computed for mathtext and usetex.
 """
 
 import matplotlib.pyplot as plt
-import matplotlib.axes as maxes
 
 
 plt.rcParams.update({"mathtext.fontset": "cm", "mathtext.rm": "serif"})
-
-
-@maxes.subplot_class_factory
-class LatexPreviewSubplot(maxes.Axes):
-    """
-    A hackish way to simultaneously draw texts with text.latex.preview=True and
-    text.latex.preview=False in the same figure.  It does not work with the ps
-    backend.
-    """
-
-    def __init__(self, *args, preview=False, **kwargs):
-        self.preview = preview
-        super().__init__(*args, **kwargs)
-
-    def draw(self, renderer):
-        from matplotlib import _api  # internal, *do not use*
-        with _api.suppress_matplotlib_deprecation_warning():
-            with plt.rc_context({"text.latex.preview": self.preview}):
-                super().draw(renderer)
-
-
-def test_window_extent(ax, usetex, preview):
-
-    ax.xaxis.set_visible(False)
-    ax.yaxis.set_visible(False)
-
-    test_strings = ["lg", r"$\frac{1}{2}\pi$",
-                    r"$p^{3^A}$", r"$p_{3_2}$"]
-
+axs = plt.figure(figsize=(2 * 3, 6.5)).subplots(1, 2)
+for ax, usetex in zip(axs, [False, True]):
     ax.axvline(0, color="r")
-
+    test_strings = ["lg", r"$\frac{1}{2}\pi$", r"$p^{3^A}$", r"$p_{3_2}$"]
     for i, s in enumerate(test_strings):
         ax.axhline(i, color="r")
         ax.text(0., 3 - i, s,
@@ -53,26 +21,6 @@ def test_window_extent(ax, usetex, preview):
                 verticalalignment="baseline",
                 size=50,
                 bbox=dict(pad=0, ec="k", fc="none"))
-
-    ax.set_xlim(-0.1, 1.1)
-    ax.set_ylim(-.8, 3.9)
-
-    title = f"usetex={usetex}\n"
-    if usetex:
-        title += f"preview={preview}"
-    ax.set_title(title)
-
-
-fig = plt.figure(figsize=(2 * 3, 6.5))
-
-for i, usetex, preview in [[0, False, False],
-                           [1, True, False],
-                           [2, True, True]]:
-    ax = LatexPreviewSubplot(fig, 1, 3, i + 1, preview=preview)
-    fig.add_subplot(ax)
-    fig.subplots_adjust(top=0.85)
-
-    test_window_extent(ax, usetex=usetex, preview=preview)
-
-
+    ax.set(xlim=(-0.1, 1.1), ylim=(-.8, 3.9), xticks=[], yticks=[],
+           title=f"usetex={usetex}\n")
 plt.show()

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -539,7 +539,6 @@ _deprecated_remain_as_none = {
     'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
     'savefig.jpeg_quality': ('3.3',),
-    'text.latex.preview': ('3.3',),
 }
 
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -570,19 +570,11 @@ translate
         s = fontcmd % s
         tex = r'\color[rgb]{%s} %s' % (color, s)
 
-        corr = 0  # w/2*(fontsize-10)/10
-        if dict.__getitem__(mpl.rcParams, 'text.latex.preview'):
-            # use baseline alignment!
-            pos = _nums_to_str(x-corr, y)
-            self.psfrag.append(
-                r'\psfrag{%s}[Bl][Bl][1][%f]{\fontsize{%f}{%f}%s}' % (
-                    thetext, angle, fontsize, fontsize*1.25, tex))
-        else:
-            # Stick to the bottom alignment.
-            pos = _nums_to_str(x-corr, y-bl)
-            self.psfrag.append(
-                r'\psfrag{%s}[bl][bl][1][%f]{\fontsize{%f}{%f}%s}' % (
-                    thetext, angle, fontsize, fontsize*1.25, tex))
+        # Stick to the bottom alignment.
+        pos = _nums_to_str(x, y-bl)
+        self.psfrag.append(
+            r'\psfrag{%s}[bl][bl][1][%f]{\fontsize{%f}{%f}%s}' % (
+                thetext, angle, fontsize, fontsize*1.25, tex))
 
         self._pswriter.write(f"""\
 gsave

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1103,7 +1103,6 @@ _validators = {
     "text.color":          validate_color,
     "text.usetex":         validate_bool,
     "text.latex.preamble": _validate_tex_preamble,
-    "text.latex.preview":  validate_bool,
     "text.hinting":        _validate_hinting,
     "text.hinting_factor": validate_int,
     "text.kerning_factor": validate_int,
@@ -1443,7 +1442,6 @@ _hardcoded_defaults = {  # Defaults not inferred from matplotlibrc.template...
     "mathtext.fallback_to_cm": None,
     "keymap.all_axes": ["a"],
     "savefig.jpeg_quality": 95,
-    "text.latex.preview": False,
 }
 _validators = {k: _convert_validator_spec(k, conv)
                for k, conv in _validators.items()}


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
