### PR TITLE
Expire ``keymap.all_axes``-related deprecations.

### DIFF
--- a/doc/api/next_api_changes/removals/19796-AL.rst
+++ b/doc/api/next_api_changes/removals/19796-AL.rst
@@ -1,0 +1,3 @@
+Keymaps toggling ``Axes.get_navigate`` have been removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This includes numeric key events and the ``keymap.all_axes`` rcParam.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -552,7 +552,6 @@ _deprecated_remain_as_none = {
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
     'animation.html_args': ('3.3',),
-    'keymap.all_axes': ('3.3',),
     'savefig.jpeg_quality': ('3.3',),
     'text.latex.preview': ('3.3',),
 }

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2510,7 +2510,6 @@ def key_press_handler(event, canvas=None, toolbar=None):
     grid_minor_keys = rcParams['keymap.grid_minor']
     toggle_yscale_keys = rcParams['keymap.yscale']
     toggle_xscale_keys = rcParams['keymap.xscale']
-    all_keys = dict.__getitem__(rcParams, 'keymap.all_axes')
 
     # toggle fullscreen mode ('f', 'ctrl + f')
     if event.key in fullscreen_keys:
@@ -2629,29 +2628,6 @@ def key_press_handler(event, canvas=None, toolbar=None):
                 _log.warning(str(exc))
                 ax.set_xscale('linear')
             ax.figure.canvas.draw_idle()
-    # enable navigation for all axes that contain the event (default key 'a')
-    elif event.key in all_keys:
-        for a in canvas.figure.get_axes():
-            if (event.x is not None and event.y is not None
-                    and a.in_axes(event)):  # FIXME: Why only these?
-                _api.warn_deprecated(
-                    "3.3", message="Toggling axes navigation from the "
-                    "keyboard is deprecated since %(since)s and will be "
-                    "removed %(removal)s.")
-                a.set_navigate(True)
-    # enable navigation only for axes with this index (if such an axes exist,
-    # otherwise do nothing)
-    elif event.key.isdigit() and event.key != '0':
-        n = int(event.key) - 1
-        if n < len(canvas.figure.get_axes()):
-            for i, a in enumerate(canvas.figure.get_axes()):
-                if (event.x is not None and event.y is not None
-                        and a.in_axes(event)):  # FIXME: Why only these?
-                    _api.warn_deprecated(
-                        "3.3", message="Toggling axes navigation from the "
-                        "keyboard is deprecated since %(since)s and will be "
-                        "removed %(removal)s.")
-                    a.set_navigate(i == n)
 
 
 def button_press_handler(event, canvas=None, toolbar=None):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -362,36 +362,6 @@ class ToolQuitAll(ToolBase):
         Gcf.destroy_all()
 
 
-class _ToolEnableAllNavigation(ToolBase):
-    """Tool to enable all axes for toolmanager interaction."""
-
-    description = 'Enable all axes toolmanager'
-    default_keymap = mpl.rcParams['keymap.all_axes']
-
-    def trigger(self, sender, event, data=None):
-        mpl.backend_bases.key_press_handler(event, self.figure.canvas, None)
-
-
-@_api.deprecated("3.3")
-class ToolEnableAllNavigation(_ToolEnableAllNavigation):
-    pass
-
-
-class _ToolEnableNavigation(ToolBase):
-    """Tool to enable a specific axes for toolmanager interaction."""
-
-    description = 'Enable one axes toolmanager'
-    default_keymap = ('1', '2', '3', '4', '5', '6', '7', '8', '9')
-
-    def trigger(self, sender, event, data=None):
-        mpl.backend_bases.key_press_handler(event, self.figure.canvas, None)
-
-
-@_api.deprecated("3.3")
-class ToolEnableNavigation(_ToolEnableNavigation):
-    pass
-
-
 class ToolGrid(ToolBase):
     """Tool to toggle the major grids of the figure."""
 
@@ -999,8 +969,6 @@ default_tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
                  'fullscreen': ToolFullScreen,
                  'quit': ToolQuit,
                  'quit_all': ToolQuitAll,
-                 'allnav': _ToolEnableAllNavigation,
-                 'nav': _ToolEnableNavigation,
                  'xscale': ToolXScale,
                  'yscale': ToolYScale,
                  'position': ToolCursorPosition,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1377,7 +1377,6 @@ _validators = {
     "keymap.grid_minor": validate_stringlist,
     "keymap.yscale":     validate_stringlist,
     "keymap.xscale":     validate_stringlist,
-    "keymap.all_axes":   validate_stringlist,
     "keymap.help":       validate_stringlist,
     "keymap.copy":       validate_stringlist,
 
@@ -1422,7 +1421,6 @@ _hardcoded_defaults = {  # Defaults not inferred from matplotlibrc.template...
     "animation.avconv_path": "avconv",
     "animation.avconv_args": [],
     "animation.html_args": [],
-    "keymap.all_axes": ["a"],
     "savefig.jpeg_quality": 95,
     "text.latex.preview": False,
 }


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
