### PR TITLE
Expire deprecation of mathtext.fallback_to_cm.

### DIFF
--- a/doc/api/next_api_changes/removals/19801-AL.rst
+++ b/doc/api/next_api_changes/removals/19801-AL.rst
@@ -1,0 +1,3 @@
+The ``mathtext.fallback_to_cm`` rcParams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... has been removed.  Use :rc:`mathtext.fallback` instead.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -536,7 +536,6 @@ _deprecated_remain_as_none = {
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
     'animation.html_args': ('3.3',),
-    'mathtext.fallback_to_cm': ('3.3',),
     'keymap.all_axes': ('3.3',),
     'savefig.jpeg_quality': ('3.3',),
     'text.latex.preview': ('3.3',),

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -456,9 +456,6 @@ class UnicodeFonts(TruetypeFonts):
     def __init__(self, *args, **kwargs):
         # This must come first so the backend's owner is set correctly
         fallback_rc = mpl.rcParams['mathtext.fallback']
-        if mpl.rcParams['mathtext.fallback_to_cm'] is not None:
-            fallback_rc = ('cm' if mpl.rcParams['mathtext.fallback_to_cm']
-                           else None)
         font_cls = {'stix': StixFonts,
                     'stixsans': StixSansFonts,
                     'cm': BakomaFonts

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -463,23 +463,6 @@ def validate_font_properties(s):
     return s
 
 
-def _validate_mathtext_fallback_to_cm(b):
-    """
-    Temporary validate for fallback_to_cm, while deprecated
-
-    """
-    if isinstance(b, str):
-        b = b.lower()
-    if b is None or b == 'none':
-        return None
-    else:
-        _api.warn_deprecated(
-            "3.3", message="Support for setting the 'mathtext.fallback_to_cm' "
-            "rcParam is deprecated since %(since)s and will be removed "
-            "%(removal)s; use 'mathtext.fallback : 'cm' instead.")
-        return validate_bool_maybe_none(b)
-
-
 def _validate_mathtext_fallback(s):
     _fallback_fonts = ['cm', 'stix', 'stixsans']
     if isinstance(s, str):
@@ -1119,7 +1102,6 @@ _validators = {
                                 "stixsans", "custom"],
     "mathtext.default":        ["rm", "cal", "it", "tt", "sf", "bf", "default",
                                 "bb", "frak", "scr", "regular"],
-    "mathtext.fallback_to_cm": _validate_mathtext_fallback_to_cm,
     "mathtext.fallback":       _validate_mathtext_fallback,
 
     "image.aspect":          validate_aspect,  # equal, auto, a number
@@ -1440,7 +1422,6 @@ _hardcoded_defaults = {  # Defaults not inferred from matplotlibrc.template...
     "animation.avconv_path": "avconv",
     "animation.avconv_args": [],
     "animation.html_args": [],
-    "mathtext.fallback_to_cm": None,
     "keymap.all_axes": ["a"],
     "savefig.jpeg_quality": 95,
     "text.latex.preview": False,

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -337,12 +337,6 @@ def test_mathtext_fallback_invalid():
             mpl.rcParams['mathtext.fallback'] = fallback
 
 
-def test_mathtext_fallback_to_cm_invalid():
-    for fallback in [True, False]:
-        with pytest.warns(_api.MatplotlibDeprecationWarning):
-            mpl.rcParams['mathtext.fallback_to_cm'] = fallback
-
-
 @pytest.mark.parametrize(
     "fallback,fontlist",
     [("cm", ['DejaVu Sans', 'mpltest', 'STIXGeneral', 'cmr10', 'STIXGeneral']),


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
