### PR TITLE
Remove JPEG-specific parameters and rcParams.

### DIFF
--- a/doc/api/next_api_changes/removals/19810-AL.rst
+++ b/doc/api/next_api_changes/removals/19810-AL.rst
@@ -1,0 +1,10 @@
+jpeg-related keywords and rcParams
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Support has been removed for the *quality*, *optimize*, and *progressive*
+parameters of `.Figure.savefig` (which only affected jpeg output), as well as
+:rc:`savefig.jpeg_quality`.  This support has also been removed from the
+corresponding ``print_jpg`` methods.
+
+JPEG output options can be set by directly passing the relevant parameters in
+*pil_kwargs*.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -552,7 +552,6 @@ _deprecated_remain_as_none = {
     'animation.avconv_path': ('3.3',),
     'animation.avconv_args': ('3.3',),
     'animation.html_args': ('3.3',),
-    'savefig.jpeg_quality': ('3.3',),
 }
 
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -522,14 +522,7 @@ class FigureCanvasAgg(FigureCanvasBase):
     # print_figure(), and the latter ensures that `self.figure.dpi` already
     # matches the dpi kwarg (if any).
 
-    @_check_savefig_extra_args(
-        extra_kwargs=["quality", "optimize", "progressive"])
-    @_api.delete_parameter("3.3", "quality",
-                           alternative="pil_kwargs={'quality': ...}")
-    @_api.delete_parameter("3.3", "optimize",
-                           alternative="pil_kwargs={'optimize': ...}")
-    @_api.delete_parameter("3.3", "progressive",
-                           alternative="pil_kwargs={'progressive': ...}")
+    @_check_savefig_extra_args()
     @_api.delete_parameter("3.5", "args")
     def print_jpg(self, filename_or_obj, *args, pil_kwargs=None, **kwargs):
         """
@@ -542,23 +535,9 @@ class FigureCanvasAgg(FigureCanvasBase):
 
         Other Parameters
         ----------------
-        quality : int, default: :rc:`savefig.jpeg_quality`
-            The image quality, on a scale from 1 (worst) to 95 (best).
-            Values above 95 should be avoided; 100 disables portions of
-            the JPEG compression algorithm, and results in large files
-            with hardly any gain in image quality.  This parameter is
-            deprecated.
-        optimize : bool, default: False
-            Whether the encoder should make an extra pass over the image
-            in order to select optimal encoder settings.  This parameter is
-            deprecated.
-        progressive : bool, default: False
-            Whether the image should be stored as a progressive JPEG file.
-            This parameter is deprecated.
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to
-            `PIL.Image.Image.save` when saving the figure.  These take
-            precedence over *quality*, *optimize* and *progressive*.
+            `PIL.Image.Image.save` when saving the figure.
         """
         # Remove transparency by alpha-blending on an assumed white background.
         r, g, b, a = mcolors.to_rgba(self.figure.get_facecolor())
@@ -569,19 +548,6 @@ class FigureCanvasAgg(FigureCanvasBase):
             self.figure.set_facecolor((r, g, b, a))
         if pil_kwargs is None:
             pil_kwargs = {}
-        for k in ["quality", "optimize", "progressive"]:
-            if k in kwargs:
-                pil_kwargs.setdefault(k, kwargs.pop(k))
-        if "quality" not in pil_kwargs:
-            quality = pil_kwargs["quality"] = \
-                dict.__getitem__(mpl.rcParams, "savefig.jpeg_quality")
-            if quality not in [0, 75, 95]:  # default qualities.
-                _api.warn_deprecated(
-                    "3.3", name="savefig.jpeg_quality", obj_type="rcParam",
-                    addendum="Set the quality using "
-                    "`pil_kwargs={'quality': ...}`; the future default "
-                    "quality will be 75, matching the default of Pillow and "
-                    "libjpeg.")
         pil_kwargs.setdefault("dpi", (self.figure.dpi, self.figure.dpi))
         # Drop alpha channel now.
         return (Image.fromarray(np.asarray(self.buffer_rgba())[..., :3])

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -831,7 +831,7 @@ class FigureCanvasWx(_FigureCanvasWxBase):
         self.gui_repaint(drawDC=drawDC)
 
     @_check_savefig_extra_args
-    def _print_image(self, filetype, filename, *, quality=None):
+    def _print_image(self, filetype, filename):
         origBitmap = self.bitmap
 
         self.bitmap = wx.Bitmap(math.ceil(self.figure.bbox.width),
@@ -843,16 +843,6 @@ class FigureCanvasWx(_FigureCanvasWxBase):
 
         # image is the object that we call SaveFile on.
         image = self.bitmap
-        # set the JPEG quality appropriately.  Unfortunately, it is only
-        # possible to set the quality on a wx.Image object.  So if we
-        # are saving a JPEG, convert the wx.Bitmap to a wx.Image,
-        # and set the quality.
-        if filetype == wx.BITMAP_TYPE_JPEG:
-            if quality is None:
-                quality = dict.__getitem__(mpl.rcParams,
-                                           'savefig.jpeg_quality')
-            image = self.bitmap.ConvertToImage()
-            image.SetOption(wx.IMAGE_OPTION_QUALITY, str(quality))
 
         # Now that we have rendered into the bitmap, save it to the appropriate
         # file type and clean up.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2840,31 +2840,6 @@ class Figure(FigureBase):
             The resolution in dots per inch.  If 'figure', use the figure's
             dpi value.
 
-        quality : int, default: :rc:`savefig.jpeg_quality`
-            Applicable only if *format* is 'jpg' or 'jpeg', ignored otherwise.
-
-            The image quality, on a scale from 1 (worst) to 95 (best).
-            Values above 95 should be avoided; 100 disables portions of
-            the JPEG compression algorithm, and results in large files
-            with hardly any gain in image quality.
-
-            This parameter is deprecated.
-
-        optimize : bool, default: False
-            Applicable only if *format* is 'jpg' or 'jpeg', ignored otherwise.
-
-            Whether the encoder should make an extra pass over the image
-            in order to select optimal encoder settings.
-
-            This parameter is deprecated.
-
-        progressive : bool, default: False
-            Applicable only if *format* is 'jpg' or 'jpeg', ignored otherwise.
-
-            Whether the image should be stored as a progressive JPEG file.
-
-            This parameter is deprecated.
-
         facecolor : color or 'auto', default: :rc:`savefig.facecolor`
             The facecolor of the figure.  If 'auto', use the current figure
             facecolor.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1318,7 +1318,6 @@ _validators = {
     'savefig.facecolor':    validate_color_or_auto,
     'savefig.edgecolor':    validate_color_or_auto,
     'savefig.orientation':  ['landscape', 'portrait'],
-    'savefig.jpeg_quality': validate_int,
     "savefig.format":       validate_string,
     "savefig.bbox":         validate_bbox,  # "tight", or "standard" (= None)
     "savefig.pad_inches":   validate_float,
@@ -1420,7 +1419,6 @@ _hardcoded_defaults = {  # Defaults not inferred from matplotlibrc.template...
     "animation.avconv_path": "avconv",
     "animation.avconv_args": [],
     "animation.html_args": [],
-    "savefig.jpeg_quality": 95,
 }
 _validators = {k: _convert_validator_spec(k, conv)
                for k, conv in _validators.items()}

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -636,7 +636,7 @@ def test_jpeg_alpha():
     # If this fails, there will be only one color (all black). If this
     # is working, we should have all 256 shades of grey represented.
     num_colors = len(image.getcolors(256))
-    assert 175 <= num_colors <= 185
+    assert 175 <= num_colors <= 210
     # The fully transparent part should be red.
     corner_pixel = image.getpixel((0, 0))
     assert corner_pixel == (254, 0, 0)


### PR DESCRIPTION
## PR Summary

Looks like the change in default quality means test_jpeg_alpha must be slightly tweaked, but note that even as far back as when it was added, `num_colors` was already not completely deterministic... (https://github.com/matplotlib/matplotlib/pull/5324#issuecomment-151829388)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
