### PR TITLE
Fix antialiasing with old pycairo/cairocffi.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -250,8 +250,8 @@ class RendererCairo(RendererBase):
             ctx.set_font_size(prop.get_size_in_points() * self.dpi / 72)
             opts = cairo.FontOptions()
             opts.set_antialias(
-                cairo.Antialias.DEFAULT if mpl.rcParams["text.antialiased"]
-                else cairo.Antialias.NONE)
+                cairo.ANTIALIAS_DEFAULT if mpl.rcParams["text.antialiased"]
+                else cairo.ANTIALIAS_NONE)
             ctx.set_font_options(opts)
             if angle:
                 ctx.rotate(np.deg2rad(-angle))
@@ -357,7 +357,7 @@ class GraphicsContextCairo(GraphicsContextBase):
 
     def set_antialiased(self, b):
         self.ctx.set_antialias(
-            cairo.Antialias.DEFAULT if b else cairo.Antialias.NONE)
+            cairo.ANTIALIAS_DEFAULT if b else cairo.ANTIALIAS_NONE)
 
     def set_capstyle(self, cs):
         self.ctx.set_line_cap(_api.check_getitem(self._capd, capstyle=cs))


### PR DESCRIPTION
## PR Summary

The `cairo.Antialias` Enum was added in pycairo 1.13, but we support 1.11. It also appears to not exist in cairocffi (https://github.com/Kozea/cairocffi/issues/183/).

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
