### PR TITLE
Access pdf annotations while inside pikepdf.Pdf context manager.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -227,13 +227,15 @@ def test_text_urls():
         with pikepdf.Pdf.open(fd) as pdf:
             annots = pdf.pages[0].Annots
 
-    for y, fragment in [('0.1', 'plain'), ('0.4', 'mathtext')]:
-        annot = next(
-            (a for a in annots if a.A.URI == f'{test_url}{fragment}'),
-            None)
-        assert annot is not None
-        # Positions in points (72 per inch.)
-        assert annot.Rect[1] == decimal.Decimal(y) * 72
+            # Iteration over Annots must occur within the context manager,
+            # otherwise it may fail depending on the pdf structure.
+            for y, fragment in [('0.1', 'plain'), ('0.4', 'mathtext')]:
+                annot = next(
+                    (a for a in annots if a.A.URI == f'{test_url}{fragment}'),
+                    None)
+                assert annot is not None
+                # Positions in points (72 per inch.)
+                assert annot.Rect[1] == decimal.Decimal(y) * 72
 
 
 @needs_usetex
@@ -251,12 +253,14 @@ def test_text_urls_tex():
         with pikepdf.Pdf.open(fd) as pdf:
             annots = pdf.pages[0].Annots
 
-    annot = next(
-        (a for a in annots if a.A.URI == f'{test_url}tex'),
-        None)
-    assert annot is not None
-    # Positions in points (72 per inch.)
-    assert annot.Rect[1] == decimal.Decimal('0.7') * 72
+            # Iteration over Annots must occur within the context manager,
+            # otherwise it may fail depending on the pdf structure.
+            annot = next(
+                (a for a in annots if a.A.URI == f'{test_url}tex'),
+                None)
+            assert annot is not None
+            # Positions in points (72 per inch.)
+            assert annot.Rect[1] == decimal.Decimal('0.7') * 72
 
 
 def test_pdfpages_fspath():


### PR DESCRIPTION
Depending on the exact way the pdf file is written, iterating over
Annots can fail after the file has been closed.  This is not the case
for matplotlib-generated pdfs, but is the case for mplcairo-generated
ones.  As a simple repro of the different behavior between
"in-the-contextmanager" and "out-of-the-contextmanager":
```python
from matplotlib import pyplot as plt
plt.figtext(.5, .5, "hello, world", url="https://www.google.com")
plt.savefig("/tmp/test.pdf", backend="pdf")
import pikepdf
with pikepdf.Pdf.open("/tmp/test.pdf") as pdf:
    page = pdf.pages[0]
    print(repr(page.Annots)) # within contextmanager: ok
with pikepdf.Pdf.open("/tmp/test.pdf") as pdf:
    page = pdf.pages[0]
print(repr(page.Annots))  # after contextmanager: AttributeError
```

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
