### PR TITLE
Reformat references (part 2)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -253,7 +253,7 @@ per-file-ignores =
     examples/subplots_axes_and_figures/axes_zoom_effect.py: E402
     examples/subplots_axes_and_figures/custom_figure_class.py: E402
     examples/subplots_axes_and_figures/demo_constrained_layout.py: E402
-    examples/subplots_axes_and_figures/demo_tight_layout.py: E402
+    examples/subplots_axes_and_figures/demo_tight_layout.py: E402, E501
     examples/subplots_axes_and_figures/figure_size_units.py: E402
     examples/subplots_axes_and_figures/secondary_axis.py: E402
     examples/subplots_axes_and_figures/two_scales.py: E402

--- a/examples/axes_grid1/scatter_hist_locatable_axes.py
+++ b/examples/axes_grid1/scatter_hist_locatable_axes.py
@@ -65,17 +65,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+## .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-import mpl_toolkits
-mpl_toolkits.axes_grid1.axes_divider.make_axes_locatable
-matplotlib.axes.Axes.set_aspect
-matplotlib.axes.Axes.scatter
-matplotlib.axes.Axes.hist
+#    - `mpl_toolkits.axes_grid1.axes_divider.make_axes_locatable`
+#    - `matplotlib.axes.Axes.set_aspect`
+#    - `matplotlib.axes.Axes.scatter`
+#    - `matplotlib.axes.Axes.hist`

--- a/examples/images_contours_and_fields/affine_image.py
+++ b/examples/images_contours_and_fields/affine_image.py
@@ -66,15 +66,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.transforms.Affine2D
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.transforms.Affine2D`

--- a/examples/images_contours_and_fields/barb_demo.py
+++ b/examples/images_contours_and_fields/barb_demo.py
@@ -56,14 +56,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.barbs
-matplotlib.pyplot.barbs
+#    - `matplotlib.axes.Axes.barbs` / `matplotlib.pyplot.barbs`

--- a/examples/images_contours_and_fields/barcode_demo.py
+++ b/examples/images_contours_and_fields/barcode_demo.py
@@ -39,15 +39,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.add_axes
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.add_axes`

--- a/examples/images_contours_and_fields/contour_corner_mask.py
+++ b/examples/images_contours_and_fields/contour_corner_mask.py
@@ -39,16 +39,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`

--- a/examples/images_contours_and_fields/contour_demo.py
+++ b/examples/images_contours_and_fields/contour_demo.py
@@ -10,7 +10,6 @@ See also the :doc:`contour image example
 </gallery/images_contours_and_fields/contour_image>`.
 """
 
-import matplotlib
 import numpy as np
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
@@ -57,7 +56,7 @@ ax.set_title('Single color - negative contours dashed')
 ###############################################################################
 # You can set negative contours to be solid instead of dashed:
 
-matplotlib.rcParams['contour.negative_linestyle'] = 'solid'
+plt.rcParams['contour.negative_linestyle'] = 'solid'
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z, 6, colors='k')  # Negative contours default to dashed.
 ax.clabel(CS, fontsize=9, inline=True)
@@ -111,20 +110,13 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.axes.Axes.clabel
-matplotlib.pyplot.clabel
-matplotlib.axes.Axes.set_position
-matplotlib.axes.Axes.get_position
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.axes.Axes.clabel` / `matplotlib.pyplot.clabel`
+#    - `matplotlib.axes.Axes.get_position`
+#    - `matplotlib.axes.Axes.set_position`

--- a/examples/images_contours_and_fields/contour_image.py
+++ b/examples/images_contours_and_fields/contour_image.py
@@ -97,19 +97,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.Normalize
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.Normalize`

--- a/examples/images_contours_and_fields/contour_label_demo.py
+++ b/examples/images_contours_and_fields/contour_label_demo.py
@@ -10,7 +10,6 @@ See also the :doc:`contour demo example
 </gallery/images_contours_and_fields/contour_demo>`.
 """
 
-import matplotlib
 import numpy as np
 import matplotlib.ticker as ticker
 import matplotlib.pyplot as plt
@@ -76,17 +75,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.clabel
-matplotlib.pyplot.clabel
-matplotlib.ticker.LogFormatterMathtext
-matplotlib.ticker.TickHelper.create_dummy_axis
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.clabel` / `matplotlib.pyplot.clabel`
+#    - `matplotlib.ticker.LogFormatterMathtext`
+#    - `matplotlib.ticker.TickHelper.create_dummy_axis`

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -106,24 +106,16 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
-matplotlib.axes.Axes.clabel
-matplotlib.pyplot.clabel
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.Colormap
-matplotlib.colors.Colormap.set_bad
-matplotlib.colors.Colormap.set_under
-matplotlib.colors.Colormap.set_over
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`
+#    - `matplotlib.axes.Axes.clabel` / `matplotlib.pyplot.clabel`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.Colormap`
+#    - `matplotlib.colors.Colormap.set_bad`
+#    - `matplotlib.colors.Colormap.set_under`
+#    - `matplotlib.colors.Colormap.set_over`

--- a/examples/images_contours_and_fields/contourf_hatching.py
+++ b/examples/images_contours_and_fields/contourf_hatching.py
@@ -42,22 +42,14 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.axes.Axes.legend
-matplotlib.pyplot.legend
-matplotlib.contour.ContourSet
-matplotlib.contour.ContourSet.legend_elements
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.axes.Axes.legend` / `matplotlib.pyplot.legend`
+#    - `matplotlib.contour.ContourSet`
+#    - `matplotlib.contour.ContourSet.legend_elements`

--- a/examples/images_contours_and_fields/contourf_log.py
+++ b/examples/images_contours_and_fields/contourf_log.py
@@ -50,19 +50,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.axes.Axes.legend
-matplotlib.pyplot.legend
-matplotlib.ticker.LogLocator
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.axes.Axes.legend` / `matplotlib.pyplot.legend`
+#    - `matplotlib.ticker.LogLocator`

--- a/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -305,15 +305,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The usage of the following functions and methods is shown in this example:
-
-
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -75,13 +75,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
+#    - `matplotlib.axes.Axes.imshow`

--- a/examples/images_contours_and_fields/image_clip_path.py
+++ b/examples/images_contours_and_fields/image_clip_path.py
@@ -23,15 +23,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.artist.Artist.set_clip_path
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.artist.Artist.set_clip_path`

--- a/examples/images_contours_and_fields/image_demo.py
+++ b/examples/images_contours_and_fields/image_demo.py
@@ -175,16 +175,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.artist.Artist.set_clip_path
-matplotlib.patches.PathPatch
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.artist.Artist.set_clip_path`
+#    - `matplotlib.patches.PathPatch`

--- a/examples/images_contours_and_fields/image_masked.py
+++ b/examples/images_contours_and_fields/image_masked.py
@@ -71,18 +71,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.BoundaryNorm
-matplotlib.colorbar.ColorbarBase.set_label
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.BoundaryNorm`
+#    - `matplotlib.colorbar.ColorbarBase.set_label`

--- a/examples/images_contours_and_fields/image_transparency_blend.py
+++ b/examples/images_contours_and_fields/image_transparency_blend.py
@@ -113,18 +113,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.colors.Normalize
-matplotlib.axes.Axes.set_axis_off
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.colors.Normalize`
+#    - `matplotlib.axes.Axes.set_axis_off`

--- a/examples/images_contours_and_fields/interpolation_methods.py
+++ b/examples/images_contours_and_fields/interpolation_methods.py
@@ -42,14 +42,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`

--- a/examples/images_contours_and_fields/irregulardatagrid.py
+++ b/examples/images_contours_and_fields/irregulardatagrid.py
@@ -83,19 +83,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.contour
-matplotlib.pyplot.contour
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
-matplotlib.axes.Axes.tricontour
-matplotlib.pyplot.tricontour
-matplotlib.axes.Axes.tricontourf
-matplotlib.pyplot.tricontourf
+#    - `matplotlib.axes.Axes.contour` / `matplotlib.pyplot.contour`
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`
+#    - `matplotlib.axes.Axes.tricontour` / `matplotlib.pyplot.tricontour`
+#    - `matplotlib.axes.Axes.tricontourf` / `matplotlib.pyplot.tricontourf`

--- a/examples/images_contours_and_fields/layer_images.py
+++ b/examples/images_contours_and_fields/layer_images.py
@@ -43,14 +43,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`

--- a/examples/images_contours_and_fields/matshow.py
+++ b/examples/images_contours_and_fields/matshow.py
@@ -17,14 +17,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.matshow
-matplotlib.pyplot.matshow
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`

--- a/examples/images_contours_and_fields/multi_image.py
+++ b/examples/images_contours_and_fields/multi_image.py
@@ -53,21 +53,15 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.Normalize
-matplotlib.cm.ScalarMappable.set_cmap
-matplotlib.cm.ScalarMappable.set_norm
-matplotlib.cm.ScalarMappable.set_clim
-matplotlib.cbook.CallbackRegistry.connect
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.Normalize`
+#    - `matplotlib.cm.ScalarMappable.set_cmap`
+#    - `matplotlib.cm.ScalarMappable.set_norm`
+#    - `matplotlib.cm.ScalarMappable.set_clim`
+#    - `matplotlib.cbook.CallbackRegistry.connect`

--- a/examples/images_contours_and_fields/pcolor_demo.py
+++ b/examples/images_contours_and_fields/pcolor_demo.py
@@ -111,22 +111,14 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.pcolor
-matplotlib.pyplot.pcolor
-matplotlib.axes.Axes.pcolormesh
-matplotlib.pyplot.pcolormesh
-matplotlib.axes.Axes.pcolorfast
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.LogNorm
+#    - `matplotlib.axes.Axes.pcolor` / `matplotlib.pyplot.pcolor`
+#    - `matplotlib.axes.Axes.pcolormesh` / `matplotlib.pyplot.pcolormesh`
+#    - `matplotlib.axes.Axes.pcolorfast`
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.LogNorm`

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -15,7 +15,6 @@ the input vectors.
 
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -121,12 +120,9 @@ _annotate(ax, x, y, "shading='gouraud'; X, Y same shape as Z")
 plt.show()
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-matplotlib.axes.Axes.pcolormesh
-matplotlib.pyplot.pcolormesh
+#    - `matplotlib.axes.Axes.pcolormesh` / `matplotlib.pyplot.pcolormesh`

--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -8,7 +8,6 @@ is faster than the similar `~.axes.Axes.pcolor`.
 
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.colors import BoundaryNorm
 from matplotlib.ticker import MaxNLocator
@@ -121,18 +120,13 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-matplotlib.axes.Axes.pcolormesh
-matplotlib.pyplot.pcolormesh
-matplotlib.axes.Axes.contourf
-matplotlib.pyplot.contourf
-matplotlib.figure.Figure.colorbar
-matplotlib.pyplot.colorbar
-matplotlib.colors.BoundaryNorm
-matplotlib.ticker.MaxNLocator
+#    - `matplotlib.axes.Axes.pcolormesh` / `matplotlib.pyplot.pcolormesh`
+#    - `matplotlib.axes.Axes.contourf` / `matplotlib.pyplot.contourf`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.colors.BoundaryNorm`
+#    - `matplotlib.ticker.MaxNLocator`

--- a/examples/images_contours_and_fields/plot_streamplot.py
+++ b/examples/images_contours_and_fields/plot_streamplot.py
@@ -72,15 +72,10 @@ plt.tight_layout()
 plt.show()
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.streamplot
-matplotlib.pyplot.streamplot
-matplotlib.gridspec
-matplotlib.gridspec.GridSpec
+#    - `matplotlib.axes.Axes.streamplot` / `matplotlib.pyplot.streamplot`
+#    - `matplotlib.gridspec.GridSpec`

--- a/examples/images_contours_and_fields/quadmesh_demo.py
+++ b/examples/images_contours_and_fields/quadmesh_demo.py
@@ -42,13 +42,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.pcolormesh
-matplotlib.pyplot.pcolormesh
+#    - `matplotlib.axes.Axes.pcolormesh` / `matplotlib.pyplot.pcolormesh`

--- a/examples/images_contours_and_fields/quiver_demo.py
+++ b/examples/images_contours_and_fields/quiver_demo.py
@@ -54,15 +54,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.quiver
-matplotlib.pyplot.quiver
-matplotlib.axes.Axes.quiverkey
-matplotlib.pyplot.quiverkey
+#    - `matplotlib.axes.Axes.quiver` / `matplotlib.pyplot.quiver`
+#    - `matplotlib.axes.Axes.quiverkey` / `matplotlib.pyplot.quiverkey`

--- a/examples/images_contours_and_fields/quiver_simple_demo.py
+++ b/examples/images_contours_and_fields/quiver_simple_demo.py
@@ -24,15 +24,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.quiver
-matplotlib.pyplot.quiver
-matplotlib.axes.Axes.quiverkey
-matplotlib.pyplot.quiverkey
+#    - `matplotlib.axes.Axes.quiver` / `matplotlib.pyplot.quiver`
+#    - `matplotlib.axes.Axes.quiverkey` / `matplotlib.pyplot.quiverkey`

--- a/examples/images_contours_and_fields/shading_example.py
+++ b/examples/images_contours_and_fields/shading_example.py
@@ -64,15 +64,10 @@ if __name__ == '__main__':
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown in this
-# example:
-
-import matplotlib
-matplotlib.colors.LightSource
-matplotlib.axes.Axes.imshow
-matplotlib.pyplot.imshow
+#    - `matplotlib.colors.LightSource`
+#    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`

--- a/examples/images_contours_and_fields/specgram_demo.py
+++ b/examples/images_contours_and_fields/specgram_demo.py
@@ -38,14 +38,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.specgram
-matplotlib.pyplot.specgram
+#    - `matplotlib.axes.Axes.specgram` / `matplotlib.pyplot.specgram`

--- a/examples/images_contours_and_fields/spy_demos.py
+++ b/examples/images_contours_and_fields/spy_demos.py
@@ -33,14 +33,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.spy
-matplotlib.pyplot.spy
+#    - `matplotlib.axes.Axes.spy` / `matplotlib.pyplot.spy`

--- a/examples/images_contours_and_fields/tricontour_demo.py
+++ b/examples/images_contours_and_fields/tricontour_demo.py
@@ -113,15 +113,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.tricontourf
-matplotlib.pyplot.tricontourf
-matplotlib.tri.Triangulation
+#    - `matplotlib.axes.Axes.tricontourf` / `matplotlib.pyplot.tricontourf`
+#    - `matplotlib.tri.Triangulation`

--- a/examples/lines_bars_and_markers/bar_label_demo.py
+++ b/examples/lines_bars_and_markers/bar_label_demo.py
@@ -14,7 +14,6 @@ See also the :doc:`grouped bar
 </gallery/lines_bars_and_markers/barh>` examples.
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -100,17 +99,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.axes.Axes.bar
-matplotlib.pyplot.bar
-matplotlib.axes.Axes.barh
-matplotlib.pyplot.barh
-matplotlib.axes.Axes.bar_label
-matplotlib.pyplot.bar_label
+#    - `matplotlib.axes.Axes.bar` / `matplotlib.pyplot.bar`
+#    - `matplotlib.axes.Axes.barh` / `matplotlib.pyplot.barh`
+#    - `matplotlib.axes.Axes.bar_label` / `matplotlib.pyplot.bar_label`

--- a/examples/lines_bars_and_markers/barchart.py
+++ b/examples/lines_bars_and_markers/barchart.py
@@ -7,7 +7,6 @@ This example shows a how to create a grouped bar chart and how to annotate
 bars with labels.
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -39,15 +38,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.axes.Axes.bar
-matplotlib.pyplot.bar
-matplotlib.axes.Axes.bar_label
-matplotlib.pyplot.bar_label
+#    - `matplotlib.axes.Axes.bar` / `matplotlib.pyplot.bar`
+#    - `matplotlib.axes.Axes.bar_label` / `matplotlib.pyplot.bar_label`

--- a/examples/lines_bars_and_markers/curve_error_band.py
+++ b/examples/lines_bars_and_markers/curve_error_band.py
@@ -71,14 +71,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.patches.PathPatch
-matplotlib.path.Path
+#    - `matplotlib.patches.PathPatch`
+#    - `matplotlib.path.Path`

--- a/examples/lines_bars_and_markers/fill_between_demo.py
+++ b/examples/lines_bars_and_markers/fill_between_demo.py
@@ -132,15 +132,10 @@ ax.fill_between(x, 0, 1, where=y > threshold,
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.fill_between
-matplotlib.pyplot.fill_between
-matplotlib.axes.Axes.get_xaxis_transform
+#    - `matplotlib.axes.Axes.fill_between` / `matplotlib.pyplot.fill_between`
+#    - `matplotlib.axes.Axes.get_xaxis_transform`

--- a/examples/lines_bars_and_markers/hat_graph.py
+++ b/examples/lines_bars_and_markers/hat_graph.py
@@ -7,7 +7,6 @@ labels.
 
 .. _hat graph: https://doi.org/10.1186/s41235-019-0182-3
 """
-import matplotlib
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -73,14 +72,10 @@ fig.tight_layout()
 plt.show()
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-matplotlib.axes.Axes.bar
-matplotlib.pyplot.bar
-matplotlib.axes.Axes.annotate
-matplotlib.pyplot.annotate
+#    - `matplotlib.axes.Axes.bar` / `matplotlib.pyplot.bar`
+#    - `matplotlib.axes.Axes.annotate` / `matplotlib.pyplot.annotate`

--- a/examples/lines_bars_and_markers/scatter_hist.py
+++ b/examples/lines_bars_and_markers/scatter_hist.py
@@ -113,17 +113,13 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.figure.Figure.add_axes
-matplotlib.figure.Figure.add_subplot
-matplotlib.figure.Figure.add_gridspec
-matplotlib.axes.Axes.scatter
-matplotlib.axes.Axes.hist
+#    - `matplotlib.figure.Figure.add_axes`
+#    - `matplotlib.figure.Figure.add_subplot`
+#    - `matplotlib.figure.Figure.add_gridspec`
+#    - `matplotlib.axes.Axes.scatter`
+#    - `matplotlib.axes.Axes.hist`

--- a/examples/lines_bars_and_markers/scatter_with_legend.py
+++ b/examples/lines_bars_and_markers/scatter_with_legend.py
@@ -100,16 +100,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The usage of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.scatter
-matplotlib.pyplot.scatter
-matplotlib.axes.Axes.legend
-matplotlib.pyplot.legend
-matplotlib.collections.PathCollection.legend_elements
+#    - `matplotlib.axes.Axes.scatter` / `matplotlib.pyplot.scatter`
+#    - `matplotlib.axes.Axes.legend` / `matplotlib.pyplot.legend`
+#    - `matplotlib.collections.PathCollection.legend_elements`

--- a/examples/lines_bars_and_markers/simple_plot.py
+++ b/examples/lines_bars_and_markers/simple_plot.py
@@ -6,7 +6,6 @@ Simple Plot
 Create a simple plot.
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -26,14 +25,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-matplotlib.axes.Axes.plot
-matplotlib.pyplot.plot
-matplotlib.pyplot.subplots
-matplotlib.figure.Figure.savefig
+#    - `matplotlib.axes.Axes.plot` / `matplotlib.pyplot.plot`
+#    - `matplotlib.pyplot.subplots`
+#    - `matplotlib.figure.Figure.savefig`

--- a/examples/lines_bars_and_markers/timeline.py
+++ b/examples/lines_bars_and_markers/timeline.py
@@ -97,18 +97,14 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.annotate
-matplotlib.axes.Axes.vlines
-matplotlib.axis.Axis.set_major_locator
-matplotlib.axis.Axis.set_major_formatter
-matplotlib.dates.MonthLocator
-matplotlib.dates.DateFormatter
+#    - `matplotlib.axes.Axes.annotate`
+#    - `matplotlib.axes.Axes.vlines`
+#    - `matplotlib.axis.Axis.set_major_locator`
+#    - `matplotlib.axis.Axis.set_major_formatter`
+#    - `matplotlib.dates.MonthLocator`
+#    - `matplotlib.dates.DateFormatter`

--- a/examples/shapes_and_collections/scatter.py
+++ b/examples/shapes_and_collections/scatter.py
@@ -23,13 +23,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-import matplotlib
-
-matplotlib.axes.Axes.scatter
-matplotlib.pyplot.scatter
+#    - `matplotlib.axes.Axes.scatter` / `matplotlib.pyplot.scatter`

--- a/examples/statistics/barchart_demo.py
+++ b/examples/statistics/barchart_demo.py
@@ -16,7 +16,6 @@ just make up some data for little Johnny Doe.
 """
 
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator
 from collections import namedtuple
@@ -161,16 +160,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.axes.Axes.bar
-matplotlib.pyplot.bar
-matplotlib.axes.Axes.annotate
-matplotlib.pyplot.annotate
-matplotlib.axes.Axes.twinx
+#    - `matplotlib.axes.Axes.bar` / `matplotlib.pyplot.bar`
+#    - `matplotlib.axes.Axes.annotate` / `matplotlib.pyplot.annotate`
+#    - `matplotlib.axes.Axes.twinx` / `matplotlib.pyplot.twinx`

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -98,13 +98,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.boxplot
-matplotlib.pyplot.boxplot
+#    - `matplotlib.axes.Axes.boxplot` / `matplotlib.pyplot.boxplot`

--- a/examples/statistics/boxplot_color.py
+++ b/examples/statistics/boxplot_color.py
@@ -54,13 +54,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.boxplot
-matplotlib.pyplot.boxplot
+#    - `matplotlib.axes.Axes.boxplot` / `matplotlib.pyplot.boxplot`

--- a/examples/statistics/boxplot_demo.py
+++ b/examples/statistics/boxplot_demo.py
@@ -233,14 +233,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.boxplot
-matplotlib.pyplot.boxplot
-matplotlib.axes.Axes.set
+#    - `matplotlib.axes.Axes.boxplot` / `matplotlib.pyplot.boxplot`
+#    - `matplotlib.artist.Artist.set` / `matplotlib.pyplot.setp`

--- a/examples/statistics/boxplot_vs_violin.py
+++ b/examples/statistics/boxplot_vs_violin.py
@@ -56,15 +56,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.boxplot
-matplotlib.pyplot.boxplot
-matplotlib.axes.Axes.violinplot
-matplotlib.pyplot.violinplot
+#    - `matplotlib.axes.Axes.boxplot` / `matplotlib.pyplot.boxplot`
+#    - `matplotlib.axes.Axes.violinplot` / `matplotlib.pyplot.violinplot`

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -105,13 +105,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.bxp
-matplotlib.cbook.boxplot_stats
+#    - `matplotlib.axes.Axes.bxp`
+#    - `matplotlib.cbook.boxplot_stats`

--- a/examples/statistics/confidence_ellipse.py
+++ b/examples/statistics/confidence_ellipse.py
@@ -217,13 +217,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.transforms.Affine2D
-matplotlib.patches.Ellipse
+#    - `matplotlib.transforms.Affine2D`
+#    - `matplotlib.patches.Ellipse`

--- a/examples/statistics/customized_violin.py
+++ b/examples/statistics/customized_violin.py
@@ -77,15 +77,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.violinplot
-matplotlib.pyplot.violinplot
-matplotlib.axes.Axes.vlines
-matplotlib.pyplot.vlines
+#    - `matplotlib.axes.Axes.violinplot` / `matplotlib.pyplot.violinplot`
+#    - `matplotlib.axes.Axes.vlines` / `matplotlib.pyplot.vlines`

--- a/examples/statistics/errorbar.py
+++ b/examples/statistics/errorbar.py
@@ -21,13 +21,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.errorbar
-matplotlib.pyplot.errorbar
+#    - `matplotlib.axes.Axes.errorbar` / `matplotlib.pyplot.errorbar`

--- a/examples/statistics/errorbar_features.py
+++ b/examples/statistics/errorbar_features.py
@@ -48,13 +48,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.errorbar
-matplotlib.pyplot.errorbar
+#    - `matplotlib.axes.Axes.errorbar` / `matplotlib.pyplot.errorbar`

--- a/examples/statistics/errorbar_limits.py
+++ b/examples/statistics/errorbar_limits.py
@@ -77,13 +77,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.errorbar
-matplotlib.pyplot.errorbar
+#    - `matplotlib.axes.Axes.errorbar` / `matplotlib.pyplot.errorbar`

--- a/examples/statistics/errorbars_and_boxes.py
+++ b/examples/statistics/errorbars_and_boxes.py
@@ -70,15 +70,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.errorbar
-matplotlib.pyplot.errorbar
-matplotlib.axes.Axes.add_collection
-matplotlib.collections.PatchCollection
+#    - `matplotlib.axes.Axes.errorbar` / `matplotlib.pyplot.errorbar`
+#    - `matplotlib.axes.Axes.add_collection`
+#    - `matplotlib.collections.PatchCollection`

--- a/examples/statistics/hexbin_demo.py
+++ b/examples/statistics/hexbin_demo.py
@@ -45,13 +45,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hexbin
-matplotlib.pyplot.hexbin
+#    - `matplotlib.axes.Axes.hexbin` / `matplotlib.pyplot.hexbin`

--- a/examples/statistics/hist.py
+++ b/examples/statistics/hist.py
@@ -103,15 +103,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hist
-matplotlib.pyplot.hist
-matplotlib.pyplot.hist2d
-matplotlib.ticker.PercentFormatter
+#    - `matplotlib.axes.Axes.hist` / `matplotlib.pyplot.hist`
+#    - `matplotlib.pyplot.hist2d`
+#    - `matplotlib.ticker.PercentFormatter`

--- a/examples/statistics/histogram_cumulative.py
+++ b/examples/statistics/histogram_cumulative.py
@@ -73,13 +73,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hist
-matplotlib.pyplot.hist
+#    - `matplotlib.axes.Axes.hist` / `matplotlib.pyplot.hist`

--- a/examples/statistics/histogram_features.py
+++ b/examples/statistics/histogram_features.py
@@ -48,16 +48,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hist
-matplotlib.pyplot.hist
-matplotlib.axes.Axes.set_title
-matplotlib.axes.Axes.set_xlabel
-matplotlib.axes.Axes.set_ylabel
+#    - `matplotlib.axes.Axes.hist` / `matplotlib.pyplot.hist`
+#    - `matplotlib.axes.Axes.set_title`
+#    - `matplotlib.axes.Axes.set_xlabel`
+#    - `matplotlib.axes.Axes.set_ylabel`

--- a/examples/statistics/histogram_histtypes.py
+++ b/examples/statistics/histogram_histtypes.py
@@ -51,13 +51,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hist
-matplotlib.pyplot.hist
+#    - `matplotlib.axes.Axes.hist` / `matplotlib.pyplot.hist`

--- a/examples/statistics/histogram_multihist.py
+++ b/examples/statistics/histogram_multihist.py
@@ -47,13 +47,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.hist
-matplotlib.pyplot.hist
+#    - `matplotlib.axes.Axes.hist` / `matplotlib.pyplot.hist`

--- a/examples/statistics/multiple_histograms_side_by_side.py
+++ b/examples/statistics/multiple_histograms_side_by_side.py
@@ -64,13 +64,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.barh
-matplotlib.pyplot.barh
+#    - `matplotlib.axes.Axes.barh` / `matplotlib.pyplot.barh`

--- a/examples/statistics/time_series_histogram.py
+++ b/examples/statistics/time_series_histogram.py
@@ -97,14 +97,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.pcolormesh
-matplotlib.pyplot.pcolormesh
-matplotlib.figure.Figure.colorbar
+#    - `matplotlib.axes.Axes.pcolormesh` / `matplotlib.pyplot.pcolormesh`
+#    - `matplotlib.figure.Figure.colorbar`

--- a/examples/statistics/violinplot.py
+++ b/examples/statistics/violinplot.py
@@ -88,13 +88,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.violinplot
-matplotlib.pyplot.violinplot
+#    - `matplotlib.axes.Axes.violinplot` / `matplotlib.pyplot.violinplot`

--- a/examples/subplots_axes_and_figures/axes_box_aspect.py
+++ b/examples/subplots_axes_and_figures/axes_box_aspect.py
@@ -19,7 +19,6 @@ The following lists a few use cases for `~.Axes.set_box_aspect`.
 #
 # Produce a square axes, no matter what the data limits are.
 
-import matplotlib
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -148,12 +147,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.axes.Axes.set_box_aspect
+#    - `matplotlib.axes.Axes.set_box_aspect`

--- a/examples/subplots_axes_and_figures/axes_margins.py
+++ b/examples/subplots_axes_and_figures/axes_margins.py
@@ -13,6 +13,7 @@ to effectively work around that.
 
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon
 
 
 def f(t):
@@ -64,7 +65,7 @@ ax2.use_sticky_edges = False
 for ax, status in zip((ax1, ax2), ('Is', 'Is Not')):
     cells = ax.pcolor(x, y, x+y, cmap='inferno', shading='auto')  # sticky
     ax.add_patch(
-        plt.Polygon(poly_coords, color='forestgreen', alpha=0.5)
+        Polygon(poly_coords, color='forestgreen', alpha=0.5)
     )  # not sticky
     ax.margins(x=0.1, y=0.05)
     ax.set_aspect('equal')
@@ -75,18 +76,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods is shown
-# in this example:
-
-import matplotlib
-matplotlib.axes.Axes.margins
-matplotlib.pyplot.margins
-matplotlib.axes.Axes.use_sticky_edges
-matplotlib.axes.Axes.pcolor
-matplotlib.pyplot.pcolor
-matplotlib.pyplot.Polygon
+#    - `matplotlib.axes.Axes.margins` / `matplotlib.pyplot.margins`
+#    - `matplotlib.axes.Axes.use_sticky_edges`
+#    - `matplotlib.axes.Axes.pcolor` / `matplotlib.pyplot.pcolor`
+#    - `matplotlib.patches.Polygon`

--- a/examples/subplots_axes_and_figures/demo_constrained_layout.py
+++ b/examples/subplots_axes_and_figures/demo_constrained_layout.py
@@ -62,13 +62,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.gridspec.GridSpec
-matplotlib.gridspec.GridSpecFromSubplotSpec
+#    - `matplotlib.gridspec.GridSpec`
+#    - `matplotlib.gridspec.GridSpecFromSubplotSpec`

--- a/examples/subplots_axes_and_figures/demo_tight_layout.py
+++ b/examples/subplots_axes_and_figures/demo_tight_layout.py
@@ -135,16 +135,12 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.pyplot.tight_layout
-matplotlib.figure.Figure.tight_layout
-matplotlib.figure.Figure.add_gridspec
-matplotlib.figure.Figure.add_subplot
-matplotlib.pyplot.subplot2grid
+#    - `matplotlib.figure.Figure.tight_layout` / `matplotlib.pyplot.tight_layout`
+#    - `matplotlib.figure.Figure.add_gridspec`
+#    - `matplotlib.figure.Figure.add_subplot`
+#    - `matplotlib.pyplot.subplot2grid`

--- a/examples/subplots_axes_and_figures/figure_size_units.py
+++ b/examples/subplots_axes_and_figures/figure_size_units.py
@@ -71,15 +71,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-
-matplotlib.pyplot.figure
-matplotlib.pyplot.subplots
-matplotlib.pyplot.subplot_mosaic
+#    - `matplotlib.pyplot.figure`
+#    - `matplotlib.pyplot.subplots`
+#    - `matplotlib.pyplot.subplot_mosaic`

--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -183,14 +183,10 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-
-matplotlib.axes.Axes.secondary_xaxis
-matplotlib.axes.Axes.secondary_yaxis
+#    - `matplotlib.axes.Axes.secondary_xaxis`
+#    - `matplotlib.axes.Axes.secondary_yaxis`

--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -42,14 +42,11 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions and methods is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.inset_axes
-matplotlib.axes.Axes.indicate_inset_zoom
-matplotlib.axes.Axes.imshow
+#    - `matplotlib.axes.Axes.inset_axes`
+#    - `matplotlib.axes.Axes.indicate_inset_zoom`
+#    - `matplotlib.axes.Axes.imshow`

--- a/examples/text_labels_and_annotations/angle_annotation.py
+++ b/examples/text_labels_and_annotations/angle_annotation.py
@@ -58,7 +58,6 @@ the :ref:`angle-annotation-usage` section.
 
 
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.patches import Arc
 from matplotlib.transforms import IdentityTransform, TransformedBbox, Bbox
@@ -314,18 +313,14 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.patches.Arc
-matplotlib.axes.Axes.annotate
-matplotlib.pyplot.annotate
-matplotlib.text.Annotation
-matplotlib.transforms.IdentityTransform
-matplotlib.transforms.TransformedBbox
-matplotlib.transforms.Bbox
+#    - `matplotlib.patches.Arc`
+#    - `matplotlib.axes.Axes.annotate` / `matplotlib.pyplot.annotate`
+#    - `matplotlib.text.Annotation`
+#    - `matplotlib.transforms.IdentityTransform`
+#    - `matplotlib.transforms.TransformedBbox`
+#    - `matplotlib.transforms.Bbox`

--- a/examples/text_labels_and_annotations/demo_annotation_box.py
+++ b/examples/text_labels_and_annotations/demo_annotation_box.py
@@ -104,20 +104,16 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following functions, methods and classes is shown in this
-# example:
-
-Circle
-TextArea
-DrawingArea
-OffsetImage
-AnnotationBbox
-get_sample_data
-plt.subplots
-plt.imread
-plt.show
+#    - `matplotlib.patches.Circle`
+#    - `matplotlib.offsetbox.TextArea`
+#    - `matplotlib.offsetbox.DrawingArea`
+#    - `matplotlib.offsetbox.OffsetImage`
+#    - `matplotlib.offsetbox.AnnotationBbox`
+#    - `matplotlib.cbook.get_sample_data`
+#    - `matplotlib.pyplot.subplots`
+#    - `matplotlib.pyplot.imread`

--- a/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -78,12 +78,9 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The use of the following method is shown in this example:
-
-import matplotlib
-matplotlib.axes.Axes.text
+#    - `matplotlib.axes.Axes.text` / `matplotlib.pyplot.text`

--- a/examples/ticks_and_spines/date_precision_and_epochs.py
+++ b/examples/ticks_and_spines/date_precision_and_epochs.py
@@ -20,7 +20,6 @@ microseconds.
 import datetime
 import numpy as np
 
-import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
@@ -147,14 +146,12 @@ plt.show()
 _reset_epoch_for_tutorial()  # Don't do this.  Just for this tutorial.
 
 #############################################################################
-# ------------
 #
-# References
-# """"""""""
+# .. admonition:: References
 #
-# The use of the following functions, methods and classes is shown
-# in this example:
-
-matplotlib.dates.num2date
-matplotlib.dates.date2num
-matplotlib.dates.set_epoch
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.dates.num2date`
+#    - `matplotlib.dates.date2num`
+#    - `matplotlib.dates.set_epoch`

--- a/tutorials/intermediate/gridspec.py
+++ b/tutorials/intermediate/gridspec.py
@@ -28,7 +28,6 @@ How to create grid-shaped combinations of axes.
 
 """
 
-import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 
@@ -256,16 +255,14 @@ plt.show()
 
 #############################################################################
 #
-# ------------
+# .. admonition:: References
 #
-# References
-# """"""""""
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
 #
-# The usage of the following functions and methods is shown in this example:
-
-matplotlib.pyplot.subplots
-matplotlib.figure.Figure.add_gridspec
-matplotlib.figure.Figure.add_subplot
-matplotlib.gridspec.GridSpec
-matplotlib.gridspec.SubplotSpec.subgridspec
-matplotlib.gridspec.GridSpecFromSubplotSpec
+#    - `matplotlib.pyplot.subplots`
+#    - `matplotlib.figure.Figure.add_gridspec`
+#    - `matplotlib.figure.Figure.add_subplot`
+#    - `matplotlib.gridspec.GridSpec`
+#    - `matplotlib.gridspec.SubplotSpec.subgridspec`
+#    - `matplotlib.gridspec.GridSpecFromSubplotSpec`


### PR DESCRIPTION
Follow-up to #19788 / #19774.

My original search pattern did not find all usages of the old references format.