### PR TITLE
FIX DateFormatter for month names when usetex=True

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -592,7 +592,21 @@ def drange(dstart, dend, delta):
 
 def _wrap_in_tex(text):
     # Braces ensure dashes are not spaced like binary operators.
-    return '$\\mathdefault{' + text.replace('-', '{-}') + '}$'
+    p = re.compile("[a-zA-Z]+")
+    m = p.finditer(text)
+    cursor = 0
+    ret_text = ''
+
+    for i in m:
+        start = i.start()
+        end = i.end()
+
+        ret_text += '$\\mathdefault{'+text[cursor:start].replace('-', '{-}')
+        ret_text += '}$'+text[start:end]
+        cursor = end
+
+    ret_text += '$\\mathdefault{'+text[cursor:].replace('-', '{-}')+'}$'
+    return ret_text
 
 
 ## date tickers and formatters ###

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -172,6 +172,7 @@ import datetime
 import functools
 import logging
 import math
+import re
 
 from dateutil.rrule import (rrule, MO, TU, WE, TH, FR, SA, SU, YEARLY,
                             MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY,
@@ -591,21 +592,12 @@ def drange(dstart, dend, delta):
 
 
 def _wrap_in_tex(text):
+    p = r'([a-zA-Z]+)'
+    ret_text = re.sub(p, r'}$\1$\\mathdefault{', text)
+
     # Braces ensure dashes are not spaced like binary operators.
-    p = re.compile("[a-zA-Z]+")
-    m = p.finditer(text)
-    cursor = 0
-    ret_text = ''
-
-    for i in m:
-        start = i.start()
-        end = i.end()
-
-        ret_text += '$\\mathdefault{'+text[cursor:start].replace('-', '{-}')
-        ret_text += '}$'+text[start:end]
-        cursor = end
-
-    ret_text += '$\\mathdefault{'+text[cursor:].replace('-', '{-}')+'}$'
+    ret_text = '$\\mathdefault{'+ret_text.replace('-', '{-}')+'}$'
+    ret_text = ret_text.replace('$\\mathdefault{}$', '')
     return ret_text
 
 

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -271,8 +271,7 @@ def test_date_formatter_callable():
     (datetime.timedelta(weeks=52 * 200),
      [r'$\mathdefault{%d}$' % (year,) for year in range(1990, 2171, 20)]),
     (datetime.timedelta(days=30),
-     [r'$\mathdefault{}$Jan$\mathdefault{ %02d 1990}$' % (day,)
-      for day in range(1, 32, 3)]),
+     [r'Jan$\mathdefault{ %02d 1990}$' % (day,) for day in range(1, 32, 3)]),
     (datetime.timedelta(hours=20),
      [r'$\mathdefault{%02d:00:00}$' % (hour,) for hour in range(0, 21, 2)]),
 ])
@@ -285,7 +284,6 @@ def test_date_formatter_usetex(delta, expected):
     locator.axis.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
 
     formatter = mdates.AutoDateFormatter(locator, usetex=True)
-    print([formatter(loc) for loc in locator()])
     assert [formatter(loc) for loc in locator()] == expected
 
 
@@ -552,16 +550,15 @@ def test_concise_formatter_show_offset(t_delta, expected):
     (datetime.timedelta(weeks=52 * 200),
      ['$\\mathdefault{%d}$' % (t, ) for t in range(1980, 2201, 20)]),
     (datetime.timedelta(days=40),
-     ['$\\mathdefault{}$Jan$\\mathdefault{}$', '$\\mathdefault{05}$',
-      '$\\mathdefault{09}$', '$\\mathdefault{13}$', '$\\mathdefault{17}$',
-      '$\\mathdefault{21}$', '$\\mathdefault{25}$', '$\\mathdefault{29}$',
-      '$\\mathdefault{}$Feb$\\mathdefault{}$', '$\\mathdefault{05}$',
-      '$\\mathdefault{09}$']),
+     ['Jan', '$\\mathdefault{05}$', '$\\mathdefault{09}$',
+      '$\\mathdefault{13}$', '$\\mathdefault{17}$', '$\\mathdefault{21}$',
+      '$\\mathdefault{25}$', '$\\mathdefault{29}$', 'Feb',
+      '$\\mathdefault{05}$', '$\\mathdefault{09}$']),
     (datetime.timedelta(hours=40),
-     ['$\\mathdefault{}$Jan$\\mathdefault{{-}01}$', '$\\mathdefault{04:00}$',
+     ['Jan$\\mathdefault{{-}01}$', '$\\mathdefault{04:00}$',
       '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
       '$\\mathdefault{16:00}$', '$\\mathdefault{20:00}$',
-      '$\\mathdefault{}$Jan$\\mathdefault{{-}02}$', '$\\mathdefault{04:00}$',
+      'Jan$\\mathdefault{{-}02}$', '$\\mathdefault{04:00}$',
       '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
       '$\\mathdefault{16:00}$']),
     (datetime.timedelta(seconds=2),

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -271,7 +271,8 @@ def test_date_formatter_callable():
     (datetime.timedelta(weeks=52 * 200),
      [r'$\mathdefault{%d}$' % (year,) for year in range(1990, 2171, 20)]),
     (datetime.timedelta(days=30),
-     [r'$\mathdefault{Jan %02d 1990}$' % (day,) for day in range(1, 32, 3)]),
+     [r'$\mathdefault{}$Jan$\mathdefault{ %02d 1990}$' % (day,)
+      for day in range(1, 32, 3)]),
     (datetime.timedelta(hours=20),
      [r'$\mathdefault{%02d:00:00}$' % (hour,) for hour in range(0, 21, 2)]),
 ])
@@ -284,6 +285,7 @@ def test_date_formatter_usetex(delta, expected):
     locator.axis.set_view_interval(mdates.date2num(d1), mdates.date2num(d2))
 
     formatter = mdates.AutoDateFormatter(locator, usetex=True)
+    print([formatter(loc) for loc in locator()])
     assert [formatter(loc) for loc in locator()] == expected
 
 
@@ -550,15 +552,16 @@ def test_concise_formatter_show_offset(t_delta, expected):
     (datetime.timedelta(weeks=52 * 200),
      ['$\\mathdefault{%d}$' % (t, ) for t in range(1980, 2201, 20)]),
     (datetime.timedelta(days=40),
-     ['$\\mathdefault{Jan}$', '$\\mathdefault{05}$', '$\\mathdefault{09}$',
-      '$\\mathdefault{13}$', '$\\mathdefault{17}$', '$\\mathdefault{21}$',
-      '$\\mathdefault{25}$', '$\\mathdefault{29}$', '$\\mathdefault{Feb}$',
-      '$\\mathdefault{05}$', '$\\mathdefault{09}$']),
+     ['$\\mathdefault{}$Jan$\\mathdefault{}$', '$\\mathdefault{05}$',
+      '$\\mathdefault{09}$', '$\\mathdefault{13}$', '$\\mathdefault{17}$',
+      '$\\mathdefault{21}$', '$\\mathdefault{25}$', '$\\mathdefault{29}$',
+      '$\\mathdefault{}$Feb$\\mathdefault{}$', '$\\mathdefault{05}$',
+      '$\\mathdefault{09}$']),
     (datetime.timedelta(hours=40),
-     ['$\\mathdefault{Jan{-}01}$', '$\\mathdefault{04:00}$',
+     ['$\\mathdefault{}$Jan$\\mathdefault{{-}01}$', '$\\mathdefault{04:00}$',
       '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
       '$\\mathdefault{16:00}$', '$\\mathdefault{20:00}$',
-      '$\\mathdefault{Jan{-}02}$', '$\\mathdefault{04:00}$',
+      '$\\mathdefault{}$Jan$\\mathdefault{{-}02}$', '$\\mathdefault{04:00}$',
       '$\\mathdefault{08:00}$', '$\\mathdefault{12:00}$',
       '$\\mathdefault{16:00}$']),
     (datetime.timedelta(seconds=2),


### PR DESCRIPTION
## PR Summary
close #19836

Although a little bit clumsy, this PR can serve as the interim solution to the format of month names when usetex=True. At a long term, some alternative way should be considered, as proposed by @anntzer.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
