### PR TITLE
DOC: make all images hi-DPI

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1135,8 +1135,8 @@ p.caption {
 }
 
 .sphx-glr-single-img{
-    width: 70%;
-    height: 70%;
+    width: 50%;
+    height: 50%;
     max-width: 99%;
 }
 

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -1134,6 +1134,12 @@ p.caption {
     font-weight: bold;
 }
 
+.sphx-glr-single-img{
+    width: 70%;
+    height: 70%;
+    max-width: 99%;
+}
+
 .sphx-glr-multi-img{
     max-width: 99% !important;
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -154,6 +154,7 @@ def reset_hi_dpi(gallery_conf, fname):
     matplotlib.pyplot.rcdefaults()
     matplotlib.rcParams['figure.dpi'] = 200
     matplotlib.rcParams['savefig.dpi'] = 200
+    
 
 
 # Sphinx gallery configuration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -148,6 +148,11 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 
+def reset_hi_dpi(gallery_conf, fname):
+    import matplotlib
+    matplotlib.pyplot.rcdefaults()
+    matplotlib.rcParams['figure.dpi'] = 200
+    matplotlib.rcParams['savefig.dpi'] = 200
 
 # Sphinx gallery configuration
 sphinx_gallery_conf = {
@@ -168,7 +173,9 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images'),
     'matplotlib_animations': True,
+    'reset_modules': (reset_hi_dpi),
 }
+
 
 plot_gallery = 'True'
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -148,11 +148,13 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }
 
+
 def reset_hi_dpi(gallery_conf, fname):
     import matplotlib
     matplotlib.pyplot.rcdefaults()
     matplotlib.rcParams['figure.dpi'] = 200
     matplotlib.rcParams['savefig.dpi'] = 200
+
 
 # Sphinx gallery configuration
 sphinx_gallery_conf = {


### PR DESCRIPTION
## PR Summary

Right now all our gallery images are 100 dpi; I know this won't speed up loading the thumbnails, but, 100 dpi looks pretty bad on a 200 dpi screen.    Note there is a css change to account for the larger native size.  I don't understand where 70% comes from...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
