### PR TITLE
Fix default backend

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -769,6 +769,17 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
 
     for key, (val, line, line_no) in rc_temp.items():
         if key in rcsetup._validators:
+            # the backend parameter is special because the default value can
+            # not be expressed in the matplotlibrc file (the default is an
+            # internal sentinel to indicated that we should do backend fallback
+            # which picks the first importable interactive backend we find).
+            #
+            # This allows the backend parameter to be unset (as opposed to
+            # not present) in the matplotlibrc file.  This is important because
+            # the defaults are pulled from a (fully commented out) template
+            # including with the installation.
+            if key == 'backend' and val == '':
+                continue
             if fail_on_error:
                 config[key] = val  # try to convert to proper type or raise
             else:

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -78,7 +78,7 @@
 ##     PS PDF SVG Template
 ## You can also deploy your own backend outside of Matplotlib by referring to
 ## the module name (which must be in the PYTHONPATH) as 'module://my_backend'.
-#backend: Agg
+#backend:
 
 ## The port to use for the web server in the WebAgg backend.
 #webagg.port: 8988


### PR DESCRIPTION
## PR Summary

- makes the source installed and real-install matplotlibrc identical
- be forgiving of empty backend value and treat the same as _no_ backend entry.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).  (this is an import bug)
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
