### PR TITLE
Move Line2D units handling to Axes & deprecate "units finalize" signal.

### DIFF
--- a/doc/api/next_api_changes/deprecations/19858-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19858-AL.rst
@@ -1,0 +1,4 @@
+"units finalize" signal
+~~~~~~~~~~~~~~~~~~~~~~~
+This signal (previously emitted by Axis instances) is deprecated.  Connect to
+"units" instead.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -652,7 +652,7 @@ class _AxesBase(martist.Artist):
         for name, axis in self._get_axis_map().items():
             axis.callbacks._pickled_cids.add(
                 axis.callbacks.connect(
-                    'units finalize', self._unit_change_handler(name)))
+                    'units', self._unit_change_handler(name)))
 
         rcParams = mpl.rcParams
         self.tick_params(
@@ -2402,6 +2402,8 @@ class _AxesBase(martist.Artist):
             return functools.partial(
                 self._unit_change_handler, axis_name, event=object())
         _api.check_in_list(self._get_axis_map(), axis_name=axis_name)
+        for line in self.lines:
+            line.recache_always()
         self.relim()
         self._request_autoscale_view(scalex=(axis_name == "x"),
                                      scaley=(axis_name == "y"))

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -201,6 +201,9 @@ class CallbackRegistry:
     @_api.rename_parameter("3.4", "s", "signal")
     def connect(self, signal, func):
         """Register *func* to be called when signal *signal* is generated."""
+        if signal == "units finalize":
+            _api.warn_deprecated(
+                "3.5", name=signal, obj_type="signal", alternative="units")
         self._func_cid_map.setdefault(signal, {})
         proxy = _weak_or_strong_ref(func, self._remove_proxy)
         if proxy in self._func_cid_map[signal]:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -628,15 +628,6 @@ class Line2D(Artist):
             bbox = bbox.padded(ms)
         return bbox
 
-    @Artist.axes.setter
-    def axes(self, ax):
-        # call the set method from the base-class property
-        Artist.axes.fset(self, ax)
-        if ax is not None:
-            for axis in ax._get_axis_map().values():
-                axis.callbacks._pickled_cids.add(
-                    axis.callbacks.connect('units', self.recache_always))
-
     def set_data(self, *args):
         """
         Set the x and y data.


### PR DESCRIPTION
... rather than having each Line2D instance connect its own
callback.  (If we imagine a future where other artist classes can
also update themselves to use new units, one can imagine simply
having an `update_units` method on all artists (currently named
`recache_always`)).

I believe that the `units` and `units finalize` signals both
existed only to ensure that Line2D.recache_always was called before
`Axes._unit_change_handler`, but that's not necessary anymore (perhaps
we need a generic way of manipulating callback order but that'd be a
separate story).  Deprecating the signal directly on CallbackRegistry is
a bit ugly but that's how it was done for idle_event too...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
