### PR TITLE
Write data parameter docs as regular parameter not as note

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1291,7 +1291,7 @@ def _add_data_doc(docstring, replace_names):
         #   seems the most reliable way as the parameters section may be quite
         #   complex.
         # - Go back to the previous empty line (A section title must be
-        #   preceededby an emtpy line.
+        #   preceeded by an emtpy line.
         param_string = '\nParameters\n----------\n'
         i_params = docstring.find(param_string) + len(param_string)
         i_next_heading = docstring.find('\n----', i_params)

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -278,8 +278,8 @@ def test_docstring_addition():
             Text.
         """
     assert not re.search(r"all parameters also accept a string", funcy.__doc__)
-    assert not re.search(r"the following parameters .*: \*bar\*\.",
-                         funcy.__doc__)
+    assert re.search(r"the following parameters .*:\n    \*bar\*\.",
+                     funcy.__doc__, re.DOTALL)
 
     @_preprocess_data(replace_names=["x", "t"])
     def funcy(ax, x, y, z, t=None):
@@ -292,8 +292,8 @@ def test_docstring_addition():
             Text.
         """
     assert not re.search(r"all parameters also accept a string", funcy.__doc__)
-    assert not re.search(r"the following parameters .*: \*x\*, \*t\*\.",
-                         funcy.__doc__)
+    assert re.search(r"the following parameters .*:\n    \*x\*, \*t\*\.",
+                     funcy.__doc__, re.DOTALL)
 
 
 class TestPlotTypes:


### PR DESCRIPTION
## PR Summary

It's cleaner to document this as a normal parameter rather than using a note "The function can take an additional parameter *data* ...".

The docs is inserted before `**kwargs` docs, or if they do not exist as the last entry in `Parameters` (Which is the case only for a handful of methods.