### PR TITLE
Allow Rectangle and Ellipse selectors to be rotated

### DIFF
--- a/doc/users/next_whats_new/selector_rotate.rst
+++ b/doc/users/next_whats_new/selector_rotate.rst
@@ -1,0 +1,7 @@
+Rotating selectors
+------------------
+
+The `~matplotlib.widgets.RectangleSelector` and
+`~matplotlib.widgets.EllipseSelector` can now be rotated by pressing the 'r' key,
+and dragging one of their control points. The rotation is done about the first
+vertex placed when drawing the selector.

--- a/doc/users/next_whats_new/selector_rotate.rst
+++ b/doc/users/next_whats_new/selector_rotate.rst
@@ -2,6 +2,7 @@ Rotating selectors
 ------------------
 
 The `~matplotlib.widgets.RectangleSelector` and
-`~matplotlib.widgets.EllipseSelector` can now be rotated by pressing the 'r' key,
-and dragging one of their control points. The rotation is done about the first
-vertex placed when drawing the selector.
+`~matplotlib.widgets.EllipseSelector` can now be rotated by pressing the 'r'
+key, and dragging one of their control points. This is currently only
+implemented for equal-aspect axes. The rotation is done about the
+first vertex placed when drawing the selector.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -190,6 +190,43 @@ def test_rectangle_handles():
         tool._corner_handles.artist.get_markeredgecolor(), 'b')
 
 
+@pytest.mark.parametrize('selector_class', [widgets.RectangleSelector,
+                                            widgets.EllipseSelector])
+def test_rectangle_rotate(selector_class):
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = selector_class(ax, onselect=onselect, interactive=True)
+    # Draw rectangle
+    do_event(tool, 'press', xdata=100, ydata=100)
+    do_event(tool, 'onmove', xdata=130, ydata=140)
+    do_event(tool, 'release', xdata=130, ydata=140)
+    assert tool.extents == (100, 130, 100, 140)
+
+    # Rotate anticlockwise using top-right corner
+    do_event(tool, 'on_key_press', key='r')
+    do_event(tool, 'press', xdata=130, ydata=140)
+    do_event(tool, 'onmove', xdata=100, ydata=150)
+    do_event(tool, 'release', xdata=100, ydata=200)
+    do_event(tool, 'on_key_release', key='r')
+    # Extents shouldn't change (as shape of rectangle hasn't changed)
+    assert tool.extents == (100, 130, 100, 140)
+    # Corners should move
+    # The third corner is at (100, 150), as the diagonal of the rectangle has
+    # length 50 (it is a 3,4,5 scaled right angled triangle)
+    assert tool.corners == ((100, 124, 100, 76), (100, 118, 150, 132))
+
+    # Scale using top-right corner
+    do_event(tool, 'press', xdata=100, ydata=150)
+    do_event(tool, 'onmove', xdata=100, ydata=125)
+    do_event(tool, 'release', xdata=100, ydata=125)
+    assert tool.extents == (100, 115, 100, 120)
+    # The bottom-left corner doesn't move, the top-right moves to (100, 125)
+    assert tool.corners == ((100, 112, 100, 88), (100, 109, 125, 116))
+
+
 def check_span(*args, **kwargs):
     ax = get_ax()
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -227,6 +227,38 @@ def test_rectangle_rotate(selector_class):
     assert tool.corners == ((100, 112, 100, 88), (100, 109, 125, 116))
 
 
+@pytest.mark.parametrize('selector_class', [widgets.RectangleSelector,
+                                            widgets.EllipseSelector])
+def test_rotate_warning(selector_class):
+    # Check that a warning is raised when trying to rotate on a
+    # non-equal aspect Axes.
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = selector_class(ax, onselect=onselect, interactive=True)
+    ax.set_aspect(2)
+
+    # Draw rectangle
+    do_event(tool, 'press', xdata=100, ydata=100)
+    do_event(tool, 'onmove', xdata=130, ydata=140)
+    do_event(tool, 'release', xdata=130, ydata=140)
+    old_corners = tool.corners
+
+    # Try to rotate
+    do_event(tool, 'on_key_press', key='r')
+    do_event(tool, 'press', xdata=130, ydata=140)
+    # Check warning is raised
+    with pytest.warns(UserWarning, match='Rotation is only implemented for '
+                                         'equal-aspect Axes.'):
+        do_event(tool, 'onmove', xdata=100, ydata=150)
+    do_event(tool, 'release', xdata=100, ydata=200)
+    do_event(tool, 'on_key_release', key='r')
+    # Check that corners haven't moved
+    assert tool.corners == old_corners
+
+
 def check_span(*args, **kwargs):
     ax = get_ax()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2748,7 +2748,7 @@ class RectangleSelector(_SelectorWidget):
         rect = self._to_draw
         x0, y0, width, height, angle = self._rect_properties
         return (transforms.Affine2D()
-                .rotate_deg_around(x0, y0, -np.rad2deg(angle))
+                .rotate_around(x0, y0, -angle)
                 .translate(-x0, -y0))
 
     to_draw = _api.deprecate_privatize_attribute("3.5")
@@ -2947,11 +2947,10 @@ class RectangleSelector(_SelectorWidget):
     def corners(self):
         """Corners of rectangle from lower left, moving clockwise."""
         x0, y0, width, height, angle = self._rect_properties
-        x = np.array([0, width, width, 0])
-        y = np.array([0, 0, height, height])
-        xc = x0 + (np.cos(angle) * x - np.sin(angle) * y)
-        yc = y0 + (np.sin(angle) * x + np.cos(angle) * y)
-        return tuple(xc), tuple(yc)
+        xy = np.array([[0, width, width, 0],
+                       [0, 0, height, height]])
+        xyc = self._get_translate_rotate_transform().inverted().transform(xy.T)
+        return tuple(xyc[:, 0]), tuple(xyc[:, 1])
 
     @property
     def edge_centers(self):
@@ -2959,20 +2958,18 @@ class RectangleSelector(_SelectorWidget):
         x0, y0, width, height, angle = self._rect_properties
         w = width / 2.
         h = height / 2.
-        x = np.array([0, w, width, w])
-        y = np.array([h, 0, h, height])
-        xe = x0 + (np.cos(angle) * x - np.sin(angle) * y)
-        ye = y0 + (np.sin(angle) * x + np.cos(angle) * y)
-        return tuple(xe), tuple(ye)
+        xy = np.array([[0, w, width, w],
+                       [h, 0, h, height]])
+        xye = self._get_translate_rotate_transform().inverted().transform(xy.T)
+        return tuple(xye[:, 0]), tuple(xye[:, 1])
 
     @property
     def center(self):
         """Center of rectangle."""
         x0, y0, width, height, angle = self._rect_properties
-        hw, hh = width / 2, height / 2
-        dx = np.cos(angle) * hw - np.sin(angle) * hh
-        dy = np.sin(angle) * hw + np.cos(angle) * hh
-        return x0 + dx, y0 + dy
+        xy = np.array([width / 2, height / 2])
+        xyc = self._get_translate_rotate_transform().inverted().transform(xy)
+        return tuple(xyc)
 
     @property
     def extents(self):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1929,9 +1929,9 @@ class _SelectorWidget(AxesWidget):
             key = event.key or ''
             key = key.replace('ctrl', 'control')
             # move/rotate state is locked in on a button press
-            for action_key in ['move', 'rotate']:
-                if key == self.state_modifier_keys[action_key]:
-                    self._state.add(action_key)
+            for action in ['move', 'rotate']:
+                if key == self.state_modifier_keys[action]:
+                    self._state.add(action)
 
             self._press(event)
             return True

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -12,6 +12,7 @@ wide and tall you want your Axes to be to accommodate your widget.
 from contextlib import ExitStack
 import copy
 from numbers import Integral, Number
+import warnings
 
 import numpy as np
 
@@ -2603,7 +2604,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         - "center": Make the initial point the center of the shape,
           default: "ctrl".
         - "rotate": Rotate the shape around its corner,
-          default: "r".
+          default: "r". This currently only works for equal-aspect axes.
 
         "square" and "center" can be combined.
 
@@ -2844,11 +2845,15 @@ class RectangleSelector(_SelectorWidget):
 
         # rotate existing shape
         if 'rotate' in self.state:
-            rotation_new = np.arctan2(ymove - y0,
-                                      xmove - x0)
-            rotation_old = np.arctan2(self._prev_ymove - y0,
-                                      self._prev_xmove - x0)
-            rotation += rotation_new - rotation_old
+            if self.ax.get_aspect() == 1:
+                rotation_new = np.arctan2(ymove - y0,
+                                          xmove - x0)
+                rotation_old = np.arctan2(self._prev_ymove - y0,
+                                          self._prev_xmove - x0)
+                rotation += rotation_new - rotation_old
+            else:
+                warnings.warn('Rotation is only implemented for '
+                              'equal-aspect Axes.')
 
         # move existing shape
         elif ('move' in self.state or

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2786,7 +2786,6 @@ class RectangleSelector(_SelectorWidget):
         else:
             self.set_visible(True)
 
-
         self._prev_xmove = event.xdata
         self._prev_ymove = event.ydata
         self.set_visible(self.visible)
@@ -3060,7 +3059,6 @@ class RectangleSelector(_SelectorWidget):
         else:
             # Closest to an edge handle
             self._active_handle = self._edge_order[e_idx]
-
 
     def _contains(self, event):
         """Return True if event is within the patch."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2844,7 +2844,7 @@ class RectangleSelector(_SelectorWidget):
         ymove = event.ydata
 
         # rotate existing shape
-        if 'rotate' in self.state:
+        if 'rotate' in self._state:
             if self.ax.get_aspect() == 1:
                 rotation_new = np.arctan2(ymove - y0,
                                           xmove - x0)
@@ -2856,7 +2856,7 @@ class RectangleSelector(_SelectorWidget):
                               'equal-aspect Axes.')
 
         # move existing shape
-        elif ('move' in self.state or
+        elif ('move' in self._state or
               self._active_handle == 'C' or
               (self.drag_from_anywhere and self._contains(event))):
             x0 += xmove - self._prev_xmove
@@ -2891,8 +2891,8 @@ class RectangleSelector(_SelectorWidget):
         # new shape
         else:
             rotation = 0
-            center = [self.eventpress.xdata, self.eventpress.ydata]
-            center_pix = [self.eventpress.x, self.eventpress.y]
+            center = [self._eventpress.xdata, self._eventpress.ydata]
+            center_pix = [self._eventpress.x, self._eventpress.y]
             dx = (event.xdata - center[0]) / 2.
             dy = (event.ydata - center[1]) / 2.
 
@@ -3038,7 +3038,7 @@ class RectangleSelector(_SelectorWidget):
         m_idx, m_dist = self._center_handle.closest(event.x, event.y)
 
         # Set the active handle
-        if 'move' in self.state:
+        if 'move' in self._state:
             self._active_handle = 'C'
         # Set active handle as closest handle, if mouse click is close enough.
         elif m_dist < self.grab_range * 2:


### PR DESCRIPTION
## PR Summary
This PR allows `RectangleSelector` and `EllipseSelector` to be rotated about their anchor point. This is enabled by default with the `'r'` modifier key. Example:


https://user-images.githubusercontent.com/6197628/113521328-ad48f100-9590-11eb-9ee5-e7b539b99ff6.mov


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [ x Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
