### PR TITLE
Remove "Install from source" from Installing FAQ

### DIFF
--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -135,10 +135,3 @@ Python.org Python, or check your homebrew or macports setup.  Remember that
 the disk image installer only works for Python.org Python, and will not get
 picked up by other Pythons.  If all these fail, please :ref:`let us know
 <reporting-problems>`.
-
-.. _install-from-git:
-
-Install from source
-===================
-
-See :ref:`install_from_source`.


### PR DESCRIPTION
This is only a link to the installation docs, which should be regarded
as the primary reference. We don't need FAQ entries that just link
there (We also don't have a FAQ entry "How do I install using conda").

Mid-term goal is to get rid of the "installing FAQ" altogether and
move relevant content directly to the installing docs.