### PR TITLE
Added PyPI info to third party page

### DIFF
--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -16,6 +16,7 @@ description of the library and an image demonstrating the functionality.
 To be included in the PyPI listing, please include ``Framework :: Matplotlib`` 
 in the classifier list in the ``setup.py`` file for your package. We are also 
 happy to host third party packages within the `Matplotlib GitHub Organization
+<https://github.com/matplotlib>`_.
 
 
 Mapping toolkits

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -5,13 +5,18 @@ Third party packages
 ********************
 
 Several external packages that extend or build on Matplotlib functionality are
-listed below.  They are maintained and distributed separately from Matplotlib
-and thus need to be installed individually.
+listed below. You can find more packages at `PyPI <https://pypi.org/search/?q=&o=&c=Framework+%3A%3A+Matplotlib>`_. 
+They are maintained and distributed separately from Matplotlib, 
+and thus need to be installed individually. 
 
-Please submit an issue or pull request on GitHub if you have created
-a package that you would like to have included.  We are also happy to
-host third party packages within the `Matplotlib GitHub Organization
-<https://github.com/matplotlib>`_.
+If you have a created a package that extends or builds on Matplotlib 
+and would like to have your package listed on this page, please submit 
+an issue or pull request on GitHub. The pull request should include a short 
+description of the library and an image demonstrating the functionality. 
+To be included in the PyPi listing, please include ``Framework :: Matplotlib`` 
+in the classifier list in the ``setup.py`` file for your package. We are also 
+happy to host third party packages within the `Matplotlib GitHub Organization
+
 
 Mapping toolkits
 ****************

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -13,7 +13,7 @@ If you have a created a package that extends or builds on Matplotlib
 and would like to have your package listed on this page, please submit 
 an issue or pull request on GitHub. The pull request should include a short 
 description of the library and an image demonstrating the functionality. 
-To be included in the PyPi listing, please include ``Framework :: Matplotlib`` 
+To be included in the PyPI listing, please include ``Framework :: Matplotlib`` 
 in the classifier list in the ``setup.py`` file for your package. We are also 
 happy to host third party packages within the `Matplotlib GitHub Organization
 


### PR DESCRIPTION
added information about including Framework :: Matplotlib in setup.py & that it's a searchable classifier on PyPI. And expanded a drop on what needs to be in the PR to get added to the page. 

Partially addresses matplotlib#16592 