### PR TITLE
Remove 3.3 backend deprecations

### DIFF
--- a/doc/api/next_api_changes/removals/19898-ES.rst
+++ b/doc/api/next_api_changes/removals/19898-ES.rst
@@ -33,3 +33,32 @@ Statusbar classes and attributes
 The ``statusbar`` attribute of `.FigureManagerBase`,  as well as
 ``backend_bases.StatusbarBase`` and all its subclasses, and ``StatusBarWx``,
 have been removed, as messages are now displayed in the toolbar instead.
+
+Backend-specific internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following module-level classes/variables have been removed:
+
+* ``MODIFIER_KEYS``, ``SUPER``, ``ALT``, ``CTRL``, and ``SHIFT`` of
+  :mod:`matplotlib.backends.backend_qt5agg` and
+  :mod:`matplotlib.backends.backend_qt5cairo`
+* ``backend_pgf.GraphicsContextPgf``
+* ``backend_wx.DEBUG_MSG``
+
+The following parameters have been removed:
+
+* The *dummy* parameter of `.RendererPgf`
+
+The following class attributes have been removed:
+
+* ``RendererCairo.fontweights``, ``RendererCairo.fontangles``
+* ``backend_pgf.LatexManager.latex_stdin_utf8``
+* ``backend_pgf.PdfPages.metadata``
+* ``used_characters`` of `.RendererPdf`, `.PdfFile`, and `.RendererPS`
+
+The following class methods have been removed:
+
+* ``FigureCanvasGTK3._renderer_init``
+* ``track_characters`` and ``merge_used_characters`` of `.RendererPdf`,
+  `.PdfFile`, and `.RendererPS`
+* ``RendererWx.get_gc``

--- a/doc/api/next_api_changes/removals/19898-ES.rst
+++ b/doc/api/next_api_changes/removals/19898-ES.rst
@@ -1,0 +1,29 @@
+NavigationToolbar2._init_toolbar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Overriding this method to initialize third-party toolbars is no longer
+supported. Instead, the toolbar should be initialized in the ``__init__``
+method of the subclass (which should call the base-class' ``__init__`` as
+appropriate).
+
+NavigationToolbar2.press and .release
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These methods were called when pressing or releasing a mouse button, but *only*
+when an interactive pan or zoom was occurring (contrary to what the docs
+stated). They are no longer called; if you write a backend which needs to
+customize such events, please directly override
+``press_pan``/``press_zoom``/``release_pan``/``release_zoom`` instead.
+
+NavigationToolbar2QT.parent and .basedir
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These attributes have been removed. In order to access the parent window, use
+``toolbar.canvas.parent()`` or ``toolbar.parent()``. The base directory to the
+icons is ``os.path.join(mpl.get_data_path(), "images")``.
+
+NavigationToolbar2QT.ctx
+~~~~~~~~~~~~~~~~~~~~~~~~
+This attribute has been removed.
+
+NavigationToolbar2Wx attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``prevZoomRect``, ``retinaFix``, ``savedRetinaImage``, ``wxoverlay``,
+``zoomAxes``, ``zoomStartX``, and ``zoomStartY`` attributes have been removed.

--- a/doc/api/next_api_changes/removals/19898-ES.rst
+++ b/doc/api/next_api_changes/removals/19898-ES.rst
@@ -27,3 +27,9 @@ NavigationToolbar2Wx attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The ``prevZoomRect``, ``retinaFix``, ``savedRetinaImage``, ``wxoverlay``,
 ``zoomAxes``, ``zoomStartX``, and ``zoomStartY`` attributes have been removed.
+
+Statusbar classes and attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``statusbar`` attribute of `.FigureManagerBase`,  as well as
+``backend_bases.StatusbarBase`` and all its subclasses, and ``StatusBarWx``,
+have been removed, as messages are now displayed in the toolbar instead.

--- a/doc/api/next_api_changes/removals/19898-ES.rst
+++ b/doc/api/next_api_changes/removals/19898-ES.rst
@@ -62,3 +62,9 @@ The following class methods have been removed:
 * ``track_characters`` and ``merge_used_characters`` of `.RendererPdf`,
   `.PdfFile`, and `.RendererPS`
 * ``RendererWx.get_gc``
+
+Stricter PDF metadata keys in PGF
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Saving metadata in PDF with the PGF backend no longer changes keys to
+lowercase. Only the canonically cased keys listed in the PDF specification (and
+the `~.backend_pgf.PdfPages` documentation) are accepted.

--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -575,7 +575,7 @@ This is deprecated; pass keys as a list of strings instead.
 
 Statusbar classes and attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The ``statusbar`` attribute of `.FigureManagerBase`, `.StatusbarBase` and all
+The ``statusbar`` attribute of `.FigureManagerBase`, ``StatusbarBase`` and all
 its subclasses, and ``StatusBarWx``, are deprecated, as messages are now
 displayed in the toolbar instead.
 

--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -351,7 +351,7 @@ PGF backend cleanups
 ~~~~~~~~~~~~~~~~~~~~
 The *dummy* parameter of `.RendererPgf` is deprecated.
 
-`.GraphicsContextPgf` is deprecated (use `.GraphicsContextBase` instead).
+``GraphicsContextPgf`` is deprecated (use `.GraphicsContextBase` instead).
 
 ``set_factor`` method of :mod:`mpl_toolkits.axisartist` locators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2777,8 +2777,6 @@ class FigureManagerBase:
                 figure.canvas.manager.button_press_handler_id)
     """
 
-    statusbar = _api.deprecated("3.3")(property(lambda self: None))
-
     def __init__(self, canvas, num):
         self.canvas = canvas
         canvas.manager = self  # store a pointer to parent
@@ -3452,29 +3450,6 @@ class ToolContainerBase:
             Message text.
         """
         raise NotImplementedError
-
-
-@_api.deprecated("3.3")
-class StatusbarBase:
-    """Base class for the statusbar."""
-    def __init__(self, toolmanager):
-        self.toolmanager = toolmanager
-        self.toolmanager.toolmanager_connect('tool_message_event',
-                                             self._message_cbk)
-
-    def _message_cbk(self, event):
-        """Capture the 'tool_message_event' and set the message."""
-        self.set_message(event.message)
-
-    def set_message(self, s):
-        """
-        Display a message on toolbar or in status bar.
-
-        Parameters
-        ----------
-        s : str
-            Message text.
-        """
 
 
 class _Backend:

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2944,14 +2944,6 @@ class NavigationToolbar2:
         # This cursor will be set after the initial draw.
         self._lastCursor = cursors.POINTER
 
-        init = _api.deprecate_method_override(
-            __class__._init_toolbar, self, allow_empty=True, since="3.3",
-            addendum="Please fully initialize the toolbar in your subclass' "
-            "__init__; a fully empty _init_toolbar implementation may be kept "
-            "for compatibility with earlier versions of Matplotlib.")
-        if init:
-            init()
-
         self._id_press = self.canvas.mpl_connect(
             'button_press_event', self._zoom_pan_handler)
         self._id_release = self.canvas.mpl_connect(
@@ -3012,29 +3004,6 @@ class NavigationToolbar2:
         self._nav_stack.forward()
         self.set_history_buttons()
         self._update_view()
-
-    @_api.deprecated("3.3", alternative="__init__")
-    def _init_toolbar(self):
-        """
-        This is where you actually build the GUI widgets (called by
-        __init__).  The icons ``home.xpm``, ``back.xpm``, ``forward.xpm``,
-        ``hand.xpm``, ``zoom_to_rect.xpm`` and ``filesave.xpm`` are standard
-        across backends (there are ppm versions in CVS also).
-
-        You just need to set the callbacks
-
-        home         : self.home
-        back         : self.back
-        forward      : self.forward
-        hand         : self.pan
-        zoom_to_rect : self.zoom
-        filesave     : self.save_figure
-
-        You only need to define the last one - the others are in the base
-        class implementation.
-
-        """
-        raise NotImplementedError
 
     def _update_cursor(self, event):
         """
@@ -3118,14 +3087,6 @@ class NavigationToolbar2:
             elif event.name == "button_release_event":
                 self.release_zoom(event)
 
-    @_api.deprecated("3.3")
-    def press(self, event):
-        """Called whenever a mouse button is pressed."""
-
-    @_api.deprecated("3.3")
-    def release(self, event):
-        """Callback for mouse button release."""
-
     def pan(self, *args):
         """
         Toggle the pan/zoom tool.
@@ -3161,12 +3122,6 @@ class NavigationToolbar2:
         id_drag = self.canvas.mpl_connect("motion_notify_event", self.drag_pan)
         self._pan_info = self._PanInfo(
             button=event.button, axes=axes, cid=id_drag)
-        press = _api.deprecate_method_override(
-            __class__.press, self, since="3.3", message="Calling an "
-            "overridden press() at pan start is deprecated since %(since)s "
-            "and will be removed %(removal)s; override press_pan() instead.")
-        if press is not None:
-            press(event)
 
     def drag_pan(self, event):
         """Callback for dragging in pan/zoom mode."""
@@ -3185,12 +3140,6 @@ class NavigationToolbar2:
             'motion_notify_event', self.mouse_move)
         for ax in self._pan_info.axes:
             ax.end_pan()
-        release = _api.deprecate_method_override(
-            __class__.press, self, since="3.3", message="Calling an "
-            "overridden release() at pan stop is deprecated since %(since)s "
-            "and will be removed %(removal)s; override release_pan() instead.")
-        if release is not None:
-            release(event)
         self._draw()
         self._pan_info = None
         self.push_current()
@@ -3225,12 +3174,6 @@ class NavigationToolbar2:
         self._zoom_info = self._ZoomInfo(
             direction="in" if event.button == 1 else "out",
             start_xy=(event.x, event.y), axes=axes, cid=id_zoom)
-        press = _api.deprecate_method_override(
-            __class__.press, self, since="3.3", message="Calling an "
-            "overridden press() at zoom start is deprecated since %(since)s "
-            "and will be removed %(removal)s; override press_zoom() instead.")
-        if press is not None:
-            press(event)
 
     def drag_zoom(self, event):
         """Callback for dragging in zoom mode."""
@@ -3261,13 +3204,6 @@ class NavigationToolbar2:
                 or (abs(event.y - start_y) < 5 and event.key != "x")):
             self._draw()
             self._zoom_info = None
-            release = _api.deprecate_method_override(
-                __class__.press, self, since="3.3", message="Calling an "
-                "overridden release() at zoom stop is deprecated since "
-                "%(since)s and will be removed %(removal)s; override "
-                "release_zoom() instead.")
-            if release is not None:
-                release(event)
             return
 
         for i, ax in enumerate(self._zoom_info.axes):
@@ -3284,14 +3220,6 @@ class NavigationToolbar2:
         self._draw()
         self._zoom_info = None
         self.push_current()
-
-        release = _api.deprecate_method_override(
-            __class__.release, self, since="3.3", message="Calling an "
-            "overridden release() at zoom stop is deprecated since %(since)s "
-            "and will be removed %(removal)s; override release_zoom() "
-            "instead.")
-        if release is not None:
-            release(event)
 
     def push_current(self):
         """Push the current view limits and position onto the stack."""

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -5,7 +5,6 @@ Common functionality between the PDF and PS backends.
 import functools
 
 import matplotlib as mpl
-from matplotlib import _api
 from .. import font_manager, ft2font
 from ..afm import AFM
 from ..backend_bases import RendererBase
@@ -27,15 +26,6 @@ class CharacterTracker:
 
     def __init__(self):
         self.used = {}
-
-    @_api.deprecated("3.3")
-    @property
-    def used_characters(self):
-        d = {}
-        for fname, chars in self.used.items():
-            realpath, stat_key = mpl.cbook.get_realpath_and_stat(fname)
-            d[stat_key] = (realpath, chars)
-        return d
 
     def track(self, font, s):
         """Record that string *s* is being typeset using font *font*."""

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -15,7 +15,7 @@ import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook, _c_internal_utils
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    StatusbarBase, TimerBase, ToolContainerBase, cursors, _Mode)
+    TimerBase, ToolContainerBase, cursors, _Mode)
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
@@ -766,24 +766,6 @@ class ToolbarTk(ToolContainerBase, tk.Frame):
         for toolitem in self._toolitems[name]:
             toolitem.pack_forget()
         del self._toolitems[name]
-
-    def set_message(self, s):
-        self._message.set(s)
-
-
-@_api.deprecated("3.3")
-class StatusbarTk(StatusbarBase, tk.Frame):
-    def __init__(self, window, *args, **kwargs):
-        StatusbarBase.__init__(self, *args, **kwargs)
-        xmin, xmax = self.toolmanager.canvas.figure.bbox.intervalx
-        height, width = 50, xmax - xmin
-        tk.Frame.__init__(self, master=window,
-                          width=int(width), height=int(height),
-                          borderwidth=2)
-        self._message = tk.StringVar(master=self)
-        self._message_label = tk.Label(master=self, textvariable=self._message)
-        self._message_label.pack(side=tk.RIGHT)
-        self.pack(side=tk.TOP, fill=tk.X)
 
     def set_message(self, s):
         self._message.set(s)

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -123,8 +123,6 @@ _f_angles = {
 
 
 class RendererCairo(RendererBase):
-    fontweights = _api.deprecated("3.3")(property(lambda self: {*_f_weights}))
-    fontangles = _api.deprecated("3.3")(property(lambda self: {*_f_angles}))
     mathtext_parser = _api.deprecated("3.4")(
         property(lambda self: MathTextParser('Cairo')))
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -9,7 +9,7 @@ from matplotlib import _api, backend_tools, cbook
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    StatusbarBase, TimerBase, ToolContainerBase, cursors)
+    TimerBase, ToolContainerBase, cursors)
 from matplotlib.figure import Figure
 from matplotlib.widgets import SubplotTool
 
@@ -661,18 +661,6 @@ class ToolbarGTK3(ToolContainerBase, Gtk.Box):
 
     def set_message(self, s):
         self._message.set_label(s)
-
-
-@_api.deprecated("3.3")
-class StatusbarGTK3(StatusbarBase, Gtk.Statusbar):
-    def __init__(self, *args, **kwargs):
-        StatusbarBase.__init__(self, *args, **kwargs)
-        Gtk.Statusbar.__init__(self)
-        self._context = self.get_context_id('message')
-
-    def set_message(self, s):
-        self.pop(self._context)
-        self.push(self._context, s)
 
 
 class RubberbandGTK3(backend_tools.RubberbandBase):

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -443,9 +443,6 @@ class FigureManagerGTK3(FigureManagerBase):
 
 
 class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
-    ctx = _api.deprecated("3.3")(property(
-        lambda self: self.canvas.get_property("window").cairo_create()))
-
     def __init__(self, canvas, window):
         self.win = window
         GObject.GObject.__init__(self)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -133,19 +133,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
 
-        renderer_init = _api.deprecate_method_override(
-            __class__._renderer_init, self, allow_empty=True, since="3.3",
-            addendum="Please initialize the renderer, if needed, in the "
-            "subclass' __init__; a fully empty _renderer_init implementation "
-            "may be kept for compatibility with earlier versions of "
-            "Matplotlib.")
-        if renderer_init:
-            renderer_init()
-
-    @_api.deprecated("3.3", alternative="__init__")
-    def _renderer_init(self):
-        pass
-
     def destroy(self):
         #Gtk.DrawingArea.destroy(self)
         self.close_event()

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -717,11 +717,6 @@ class PdfFile:
                      'ProcSet': procsets}
         self.writeObject(self.resourceObject, resources)
 
-    @_api.deprecated("3.3")
-    @property
-    def used_characters(self):
-        return self.file._character_tracker.used_characters
-
     def newPage(self, width, height):
         self.endStream()
 
@@ -1879,15 +1874,6 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         # Restore gc to avoid unwanted side effects
         gc._fillcolor = orig_fill
         gc._effective_alphas = orig_alphas
-
-    @_api.deprecated("3.3")
-    def track_characters(self, *args, **kwargs):
-        """Keep track of which characters are required from each font."""
-        self.file._character_tracker.track(*args, **kwargs)
-
-    @_api.deprecated("3.3")
-    def merge_used_characters(self, *args, **kwargs):
-        self.file._character_tracker.merge(*args, **kwargs)
 
     def get_image_magnification(self):
         return self.image_dpi/72.0

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -953,19 +953,6 @@ class PdfPages:
         self._n_figures = 0
         self.keep_empty = keep_empty
         self._metadata = (metadata or {}).copy()
-        if metadata:
-            for key in metadata:
-                canonical = {
-                    'creationdate': 'CreationDate',
-                    'moddate': 'ModDate',
-                }.get(key.lower(), key.lower().title())
-                if canonical != key:
-                    _api.warn_deprecated(
-                        '3.3', message='Support for setting PDF metadata keys '
-                        'case-insensitively is deprecated since %(since)s and '
-                        'will be removed %(removal)s; '
-                        f'set {canonical} instead of {key}.')
-                    self._metadata[canonical] = self._metadata.pop(key)
         self._info_dict = _create_pdf_info_dict('pgf', self._metadata)
         self._file = BytesIO()
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -320,10 +320,6 @@ class LatexManager:
         self._expect("*pgf_backend_query_start")
         self._expect_prompt()
 
-    @_api.deprecated("3.3")
-    def latex_stdin_utf8(self):
-        return self.latex.stdin
-
     def get_width_height_descent(self, text, prop):
         """
         Get the width, total height and descent for a text typeset by the
@@ -387,8 +383,7 @@ def _get_image_inclusion_command():
 
 class RendererPgf(RendererBase):
 
-    @_api.delete_parameter("3.3", "dummy")
-    def __init__(self, figure, fh, dummy=False):
+    def __init__(self, figure, fh):
         """
         Create a new PGF renderer that translates any drawing instruction
         into text commands to be interpreted in a latex pgfpicture environment.
@@ -406,12 +401,6 @@ class RendererPgf(RendererBase):
         self.fh = fh
         self.figure = figure
         self.image_counter = 0
-
-        if dummy:
-            # dummy==True deactivate all methods
-            for m in RendererPgf.__dict__:
-                if m.startswith("draw_"):
-                    self.__dict__[m] = lambda *args, **kwargs: None
 
     def draw_markers(self, gc, marker_path, marker_trans, path, trans,
                      rgbFace=None):
@@ -750,11 +739,6 @@ class RendererPgf(RendererBase):
         return points * mpl_pt_to_in * self.dpi
 
 
-@_api.deprecated("3.3", alternative="GraphicsContextBase")
-class GraphicsContextPgf(GraphicsContextBase):
-    pass
-
-
 @_api.deprecated("3.4")
 class TmpDirCleaner:
     _remaining_tmpdirs = set()
@@ -940,7 +924,6 @@ class PdfPages:
         '_info_dict',
         '_metadata',
     )
-    metadata = _api.deprecated('3.3')(property(lambda self: self._metadata))
 
     def __init__(self, filename, *, keep_empty=True, metadata=None):
         """

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -225,8 +225,6 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
 
     mathtext_parser = _api.deprecated("3.4")(property(
         lambda self: MathTextParser("PS")))
-    used_characters = _api.deprecated("3.3")(property(
-        lambda self: self._character_tracker.used_characters))
 
     def __init__(self, width, height, pswriter, imagedpi=72):
         # Although postscript itself is dpi independent, we need to inform the
@@ -253,15 +251,6 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
         self._path_collection_id = 0
 
         self._character_tracker = _backend_pdf_ps.CharacterTracker()
-
-    @_api.deprecated("3.3")
-    def track_characters(self, *args, **kwargs):
-        """Keep track of which characters are required from each font."""
-        self._character_tracker.track(*args, **kwargs)
-
-    @_api.deprecated("3.3")
-    def merge_used_characters(self, *args, **kwargs):
-        self._character_tracker.merge(*args, **kwargs)
 
     def set_color(self, r, g, b, store=True):
         if (r, g, b) != self.color:

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -81,12 +81,6 @@ cursord = {
     cursors.SELECT_REGION: QtCore.Qt.CrossCursor,
     cursors.WAIT: QtCore.Qt.WaitCursor,
     }
-SUPER = 0  # Deprecated.
-ALT = 1  # Deprecated.
-CTRL = 2  # Deprecated.
-SHIFT = 3  # Deprecated.
-MODIFIER_KEYS = [  # Deprecated.
-    (SPECIAL_KEYS[key], mod, key) for mod, key in _MODIFIER_KEYS]
 
 
 # make place holder

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -9,7 +9,7 @@ from matplotlib import _api, backend_tools, cbook
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    TimerBase, cursors, ToolContainerBase, StatusbarBase, MouseButton)
+    TimerBase, cursors, ToolContainerBase, MouseButton)
 import matplotlib.backends.qt_editor.figureoptions as figureoptions
 from matplotlib.backends.qt_editor._formsubplottool import UiSubplotTool
 from . import qt_compat
@@ -906,17 +906,6 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
 
     def set_message(self, s):
         self.widgetForAction(self._message_action).setText(s)
-
-
-@_api.deprecated("3.3")
-class StatusbarQt(StatusbarBase, QtWidgets.QLabel):
-    def __init__(self, window, *args, **kwargs):
-        StatusbarBase.__init__(self, *args, **kwargs)
-        QtWidgets.QLabel.__init__(self)
-        window.statusBar().addWidget(self)
-
-    def set_message(self, s):
-        self.setText(s)
 
 
 class ConfigureSubplotsQt(backend_tools.ConfigureSubplotsBase):

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -651,22 +651,6 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
         NavigationToolbar2.__init__(self, canvas)
 
-    @_api.deprecated("3.3", alternative="self.canvas.parent()")
-    @property
-    def parent(self):
-        return self.canvas.parent()
-
-    @_api.deprecated("3.3", alternative="self.canvas.setParent()")
-    @parent.setter
-    def parent(self, value):
-        pass
-
-    @_api.deprecated(
-        "3.3", alternative="os.path.join(mpl.get_data_path(), 'images')")
-    @property
-    def basedir(self):
-        return str(cbook._get_data_path('images'))
-
     def _icon(self, name):
         """
         Construct a `.QIcon` from an image file *name*, including the extension

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1110,21 +1110,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
         NavigationToolbar2.__init__(self, canvas)
 
-        self._prevZoomRect = None
-        # for now, use alternate zoom-rectangle drawing on all
-        # Macs. N.B. In future versions of wx it may be possible to
-        # detect Retina displays with window.GetContentScaleFactor()
-        # and/or dc.GetContentScaleFactor()
-        self._retinaFix = 'wxMac' in wx.PlatformInfo
-
-    prevZoomRect = _api.deprecate_privatize_attribute("3.3")
-    retinaFix = _api.deprecate_privatize_attribute("3.3")
-    savedRetinaImage = _api.deprecate_privatize_attribute("3.3")
-    wxoverlay = _api.deprecate_privatize_attribute("3.3")
-    zoomAxes = _api.deprecate_privatize_attribute("3.3")
-    zoomStartX = _api.deprecate_privatize_attribute("3.3")
-    zoomStartY = _api.deprecate_privatize_attribute("3.3")
-
     @staticmethod
     def _icon(name):
         """
@@ -1197,35 +1182,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         cursor = wx.Cursor(cursord[cursor])
         self.canvas.SetCursor(cursor)
         self.canvas.Update()
-
-    def press_zoom(self, event):
-        super().press_zoom(event)
-        if self.mode.name == 'ZOOM':
-            if not self._retinaFix:
-                self._wxoverlay = wx.Overlay()
-            else:
-                if event.inaxes is not None:
-                    self._savedRetinaImage = self.canvas.copy_from_bbox(
-                        event.inaxes.bbox)
-                    self._zoomStartX = event.xdata
-                    self._zoomStartY = event.ydata
-                    self._zoomAxes = event.inaxes
-
-    def release_zoom(self, event):
-        super().release_zoom(event)
-        if self.mode.name == 'ZOOM':
-            # When the mouse is released we reset the overlay and it
-            # restores the former content to the window.
-            if not self._retinaFix:
-                self._wxoverlay.Reset()
-                del self._wxoverlay
-            else:
-                del self._savedRetinaImage
-                if self._prevZoomRect:
-                    self._prevZoomRect.pop(0).remove()
-                    self._prevZoomRect = None
-                if self._zoomAxes:
-                    self._zoomAxes = None
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -35,21 +35,6 @@ import wx
 
 _log = logging.getLogger(__name__)
 
-# Debugging settings here...
-# Debug level set here. If the debug level is less than 5, information
-# messages (progressively more info for lower value) are printed. In addition,
-# traceback is performed, and pdb activated, for all uncaught exceptions in
-# this case
-_DEBUG = 5
-_DEBUG_lvls = {1: 'Low ', 2: 'Med ', 3: 'High', 4: 'Error'}
-
-
-@_api.deprecated("3.3")
-def DEBUG_MSG(string, lvl=3, o=None):
-    if lvl >= _DEBUG:
-        print(f"{_DEBUG_lvls[lvl]}- {string} in {type(o)}")
-
-
 # the True dots per inch on the screen; should be display dependent; see
 # http://groups.google.com/groups?q=screen+dpi+x11&hl=en&lr=&ie=UTF-8&oe=UTF-8&safe=off&selm=7077.26e81ad5%40swift.cs.tcd.ie&rnum=5
 # for some info about screen dpi
@@ -279,16 +264,6 @@ class RendererWx(RendererBase):
         self.gc = GraphicsContextWx(self.bitmap, self)
         self.gc.select()
         self.gc.unselect()
-        return self.gc
-
-    @_api.deprecated("3.3", alternative=".gc")
-    def get_gc(self):
-        """
-        Fetch the locally cached gc.
-        """
-        # This is a dirty hack to allow anything with access to a renderer to
-        # access the current graphics context
-        assert self.gc is not None, "gc must be defined"
         return self.gc
 
     def get_wx_font(self, s, prop):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -21,7 +21,7 @@ import matplotlib as mpl
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
     GraphicsContextBase, MouseButton, NavigationToolbar2, RendererBase,
-    StatusbarBase, TimerBase, ToolContainerBase, cursors)
+    TimerBase, ToolContainerBase, cursors)
 
 from matplotlib import _api, cbook, backend_tools
 from matplotlib._pylab_helpers import Gcf
@@ -1205,21 +1205,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             self.EnableTool(self.wx_ids['Forward'], can_forward)
 
 
-@_api.deprecated("3.3")
-class StatusBarWx(wx.StatusBar):
-    """
-    A status bar is added to _FigureFrame to allow measurements and the
-    previously selected scroll function to be displayed as a user convenience.
-    """
-
-    def __init__(self, parent, *args, **kwargs):
-        super().__init__(parent, -1)
-        self.SetFieldsCount(2)
-
-    def set_function(self, string):
-        self.SetStatusText("%s" % string, 1)
-
-
 # tools for matplotlib.backend_managers.ToolManager:
 
 class ToolbarWx(ToolContainerBase, wx.ToolBar):
@@ -1305,19 +1290,6 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
 
     def set_message(self, s):
         self._label_text.SetLabel(s)
-
-
-@_api.deprecated("3.3")
-class StatusbarWx(StatusbarBase, wx.StatusBar):
-    """For use with ToolManager."""
-    def __init__(self, parent, *args, **kwargs):
-        StatusbarBase.__init__(self, *args, **kwargs)
-        wx.StatusBar.__init__(self, parent, -1)
-        self.SetFieldsCount(1)
-        self.SetStatusText("")
-
-    def set_message(self, s):
-        self.SetStatusText(s)
 
 
 class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).