### PR TITLE
Remove 3.3 text deprecations

### DIFF
--- a/doc/api/next_api_changes/removals/19900-ES.rst
+++ b/doc/api/next_api_changes/removals/19900-ES.rst
@@ -1,3 +1,13 @@
+mathtext ``Glue`` classes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+The following have been removed from `matplotlib.mathtext`:
+
+* *copy* parameter of ``mathtext.Glue``
+* ``mathtext.Glue.glue_subtype``
+* ``mathtext.GlueSpec``
+* ``Fil``, ``Fill``, ``Filll``, ``NegFil``, ``NegFill``, ``NegFilll``, and
+  ``SsGlue``; directly construct glue instances with ``Glue("fil")``, etc.
+
 *ismath* parameter of ``draw_tex``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The *ismath* parameter of the ``draw_tex`` method of all renderer classes has

--- a/doc/api/next_api_changes/removals/19900-ES.rst
+++ b/doc/api/next_api_changes/removals/19900-ES.rst
@@ -1,0 +1,11 @@
+*ismath* parameter of ``draw_tex``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *ismath* parameter of the ``draw_tex`` method of all renderer classes has
+been removed (as a call to ``draw_tex`` -- not to be confused with
+``draw_text``! -- means that the entire string should be passed to the
+``usetex`` machinery anyways). Likewise, the text machinery will no longer pass
+the *ismath* parameter when calling ``draw_tex`` (this should only matter for
+backend implementers).
+
+Passing ``ismath="TeX!"`` to `.RendererAgg.get_text_width_height_descent` is no
+longer supported; pass ``ismath="TeX"`` instead,

--- a/doc/api/next_api_changes/removals/19900-ES.rst
+++ b/doc/api/next_api_changes/removals/19900-ES.rst
@@ -1,3 +1,9 @@
+The ``TTFPATH`` and ``AFMPATH`` environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for the (undocumented) ``TTFPATH`` and ``AFMPATH`` environment
+variables has been removed. Register additional fonts using
+``matplotlib.font_manager.fontManager.addfont()``.
+
 mathtext ``Glue`` classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 The following have been removed from `matplotlib.mathtext`:

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1546,10 +1546,7 @@ class Glue(Node):
     it's easier to stick to what TeX does.)
     """
 
-    glue_subtype = _api.deprecated("3.3")(property(lambda self: "normal"))
-
-    @_api.delete_parameter("3.3", "copy")
-    def __init__(self, glue_type, copy=False):
+    def __init__(self, glue_type):
         super().__init__()
         if isinstance(glue_type, str):
             glue_spec = _GlueSpec._named[glue_type]
@@ -1569,51 +1566,6 @@ class Glue(Node):
         super().grow()
         g = self.glue_spec
         self.glue_spec = g._replace(width=g.width * GROW_FACTOR)
-
-
-# Some convenient ways to get common kinds of glue
-
-
-@_api.deprecated("3.3", alternative="Glue('fil')")
-class Fil(Glue):
-    def __init__(self):
-        super().__init__('fil')
-
-
-@_api.deprecated("3.3", alternative="Glue('fill')")
-class Fill(Glue):
-    def __init__(self):
-        super().__init__('fill')
-
-
-@_api.deprecated("3.3", alternative="Glue('filll')")
-class Filll(Glue):
-    def __init__(self):
-        super().__init__('filll')
-
-
-@_api.deprecated("3.3", alternative="Glue('neg_fil')")
-class NegFil(Glue):
-    def __init__(self):
-        super().__init__('neg_fil')
-
-
-@_api.deprecated("3.3", alternative="Glue('neg_fill')")
-class NegFill(Glue):
-    def __init__(self):
-        super().__init__('neg_fill')
-
-
-@_api.deprecated("3.3", alternative="Glue('neg_filll')")
-class NegFilll(Glue):
-    def __init__(self):
-        super().__init__('neg_filll')
-
-
-@_api.deprecated("3.3", alternative="Glue('ss')")
-class SsGlue(Glue):
-    def __init__(self):
-        super().__init__('ss')
 
 
 class HCentered(Hlist):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -522,8 +522,7 @@ class RendererBase:
         """
         return False
 
-    @_api.delete_parameter("3.3", "ismath")
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         """
         """
         self._draw_text_as_path(gc, x, y, s, prop, angle, ismath="TeX")

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -217,12 +217,8 @@ class RendererAgg(RendererBase):
     def get_text_width_height_descent(self, s, prop, ismath):
         # docstring inherited
 
-        if ismath in ["TeX", "TeX!"]:
-            if ismath == "TeX!":
-                _api.warn_deprecated(
-                    "3.3", message="Support for ismath='TeX!' is deprecated "
-                    "since %(since)s and will be removed %(removal)s; use "
-                    "ismath='TeX' instead.")
+        _api.check_in_list(["TeX", True, False], ismath=ismath)
+        if ismath == "TeX":
             # todo: handle props
             texmanager = self.get_texmanager()
             fontsize = prop.get_size_in_points()

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2156,8 +2156,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         # Pop off the global transformation
         self.file.output(Op.grestore)
 
-    @_api.delete_parameter("3.3", "ismath")
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         # docstring inherited
         texmanager = self.get_texmanager()
         fontsize = prop.get_size_in_points()

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -668,7 +668,7 @@ class RendererPgf(RendererBase):
                  interp, w, h, fname_img))
         writeln(self.fh, r"\end{pgfscope}")
 
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath="TeX!", mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, ismath="TeX", mtext=None):
         # docstring inherited
         self.draw_text(gc, x, y, s, prop, angle, ismath, mtext)
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -548,8 +548,7 @@ translate
 
         self._path_collection_id += 1
 
-    @_api.delete_parameter("3.3", "ismath")
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         # docstring inherited
         if not hasattr(self, "psfrag"):
             _log.warning(

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1217,8 +1217,7 @@ class RendererSVG(RendererBase):
 
             writer.end('g')
 
-    @_api.delete_parameter("3.3", "ismath")
-    def draw_tex(self, gc, x, y, s, prop, angle, ismath='TeX!', mtext=None):
+    def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         # docstring inherited
         self._draw_text_as_path(gc, x, y, s, prop, angle, ismath="TeX")
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1027,23 +1027,10 @@ class FontManager:
         self.__default_weight = weight
         self.default_size = size
 
+        # Create list of font paths.
         paths = [cbook._get_data_path('fonts', subdir)
                  for subdir in ['ttf', 'afm', 'pdfcorefonts']]
-        #  Create list of font paths
-        for pathname in ['TTFPATH', 'AFMPATH']:
-            if pathname in os.environ:
-                ttfpath = os.environ[pathname]
-                if ttfpath.find(';') >= 0:  # win32 style
-                    paths.extend(ttfpath.split(';'))
-                elif ttfpath.find(':') >= 0:  # unix style
-                    paths.extend(ttfpath.split(':'))
-                else:
-                    paths.append(ttfpath)
-                _api.warn_deprecated(
-                    "3.3", name=pathname, obj_type="environment variable",
-                    alternative="FontManager.addfont()")
         _log.debug('font search path %s', str(paths))
-        #  Load TrueType fonts and create font dictionary.
 
         self.defaultFamily = {
             'ttf': 'DejaVu Sans',

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -359,36 +359,6 @@ class MathTextWarning(Warning):
     pass
 
 
-@_api.deprecated("3.3")
-class GlueSpec:
-    """See `Glue`."""
-
-    def __init__(self, width=0., stretch=0., stretch_order=0,
-                 shrink=0., shrink_order=0):
-        self.width         = width
-        self.stretch       = stretch
-        self.stretch_order = stretch_order
-        self.shrink        = shrink
-        self.shrink_order  = shrink_order
-
-    def copy(self):
-        return GlueSpec(
-            self.width,
-            self.stretch,
-            self.stretch_order,
-            self.shrink,
-            self.shrink_order)
-
-    @classmethod
-    def factory(cls, glue_type):
-        return cls._types[glue_type]
-
-
-with _api.suppress_matplotlib_deprecation_warning():
-    GlueSpec._types = {k: GlueSpec(**v._asdict())
-                       for k, v in _mathtext._GlueSpec._named.items()}
-
-
 @_api.deprecated("3.4")
 def ship(ox, oy, box):
     _mathtext.ship(ox, oy, box)


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).