### PR TITLE
Don't set zoom/pan cursor for non-navigatable axes.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2976,7 +2976,7 @@ class NavigationToolbar2:
         """
         Update the cursor after a mouse move event or a tool (de)activation.
         """
-        if self.mode and event.inaxes:
+        if self.mode and event.inaxes and event.inaxes.get_navigate():
             if (self.mode == _Mode.ZOOM
                     and self._lastCursor != cursors.SELECT_REGION):
                 self.set_cursor(cursors.SELECT_REGION)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2976,11 +2976,7 @@ class NavigationToolbar2:
         """
         Update the cursor after a mouse move event or a tool (de)activation.
         """
-        if not event.inaxes or not self.mode:
-            if self._lastCursor != cursors.POINTER:
-                self.set_cursor(cursors.POINTER)
-                self._lastCursor = cursors.POINTER
-        else:
+        if self.mode and event.inaxes:
             if (self.mode == _Mode.ZOOM
                     and self._lastCursor != cursors.SELECT_REGION):
                 self.set_cursor(cursors.SELECT_REGION)
@@ -2989,6 +2985,9 @@ class NavigationToolbar2:
                   and self._lastCursor != cursors.MOVE):
                 self.set_cursor(cursors.MOVE)
                 self._lastCursor = cursors.MOVE
+        elif self._lastCursor != cursors.POINTER:
+            self.set_cursor(cursors.POINTER)
+            self._lastCursor = cursors.POINTER
 
     @contextmanager
     def _wait_cursor_for_draw_cm(self):

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -262,7 +262,8 @@ class SetCursorBase(ToolBase):
     def _set_cursor_cbk(self, event):
         if not event:
             return
-        if self._current_tool and getattr(event, "inaxes", None):
+        if (self._current_tool and getattr(event, "inaxes", None)
+                and event.inaxes.get_navigate()):
             if self._last_cursor != self._current_tool.cursor:
                 self.set_cursor(self._current_tool.cursor)
                 self._last_cursor = self._current_tool.cursor

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -223,12 +223,11 @@ class SetCursorBase(ToolBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._id_drag = None
-        self._cursor = None
+        self._current_tool = None
         self._default_cursor = cursors.POINTER
         self._last_cursor = self._default_cursor
         self.toolmanager.toolmanager_connect('tool_added_event',
                                              self._add_tool_cbk)
-
         # process current tools
         for tool in self.toolmanager.tools.values():
             self._add_tool(tool)
@@ -243,10 +242,9 @@ class SetCursorBase(ToolBase):
 
     def _tool_trigger_cbk(self, event):
         if event.tool.toggled:
-            self._cursor = event.tool.cursor
+            self._current_tool = event.tool
         else:
-            self._cursor = None
-
+            self._current_tool = None
         self._set_cursor_cbk(event.canvasevent)
 
     def _add_tool(self, tool):
@@ -264,16 +262,13 @@ class SetCursorBase(ToolBase):
     def _set_cursor_cbk(self, event):
         if not event:
             return
-
-        if not getattr(event, 'inaxes', False) or not self._cursor:
-            if self._last_cursor != self._default_cursor:
-                self.set_cursor(self._default_cursor)
-                self._last_cursor = self._default_cursor
-        elif self._cursor:
-            cursor = self._cursor
-            if cursor and self._last_cursor != cursor:
-                self.set_cursor(cursor)
-                self._last_cursor = cursor
+        if self._current_tool and getattr(event, "inaxes", None):
+            if self._last_cursor != self._current_tool.cursor:
+                self.set_cursor(self._current_tool.cursor)
+                self._last_cursor = self._current_tool.cursor
+        elif self._last_cursor != self._default_cursor:
+            self.set_cursor(self._default_cursor)
+            self._last_cursor = self._default_cursor
 
     def set_cursor(self, cursor):
         """


### PR DESCRIPTION
## PR Summary

first commit:

Putting the case where a tool is active first avoids negated conditions
(e.g. re: event.inaxes), making things easier to follow.

Also, let SetCursorBase keep a reference to the currently active tool,
rather than its cursor, to avoid having the slightly confusing
`._cursor` next to `._default_cursor` and `._last_cursor`.

second commit:

Zoom/pan cannot be used e.g. on colorbars, which are "non-navigatable".
So don't set the zoom/pan cursor when the mouse is over them, either.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
Putting the case where a tool is active first avoids negated conditions
(e.g. re: event.inaxes), making things easier to follow.

Also, let SetCursorBase keep a reference to the currently active tool,
rather than its cursor, to avoid having the slightly confusing
`._cursor` next to `._default_cursor` and `._last_cursor`.