### PR TITLE
Implement get_cursor_data for QuadMesh.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1251,19 +1251,33 @@ class Artist:
             method yourself.
 
         The default implementation converts ints and floats and arrays of ints
-        and floats into a comma-separated string enclosed in square brackets.
+        and floats into a comma-separated string enclosed in square brackets,
+        unless the artist has an associated colorbar, in which case scalar
+        values are formatted using the colorbar's formatter.
 
         See Also
         --------
         get_cursor_data
         """
-        try:
-            data[0]
-        except (TypeError, IndexError):
-            data = [data]
-        data_str = ', '.join('{:0.3g}'.format(item) for item in data
-                             if isinstance(item, Number))
-        return "[" + data_str + "]"
+        if np.ndim(data) == 0 and getattr(self, "colorbar", None):
+            # This block logically belongs to ScalarMappable, but can't be
+            # implemented in it because most ScalarMappable subclasses inherit
+            # from Artist first and from ScalarMappable second, so
+            # Artist.format_cursor_data would always have precedence over
+            # ScalarMappable.format_cursor_data.
+            return (
+                "["
+                + cbook.strip_math(
+                    self.colorbar.formatter.format_data_short(data)).strip()
+                + "]")
+        else:
+            try:
+                data[0]
+            except (TypeError, IndexError):
+                data = [data]
+            data_str = ', '.join('{:0.3g}'.format(item) for item in data
+                                 if isinstance(item, Number))
+            return "[" + data_str + "]"
 
     @property
     def mouseover(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1930,7 +1930,7 @@ class TriMesh(Collection):
 
 
 class QuadMesh(Collection):
-    """
+    r"""
     Class for the efficient drawing of a quadrilateral mesh.
 
     A quadrilateral mesh is a grid of M by N adjacent qudrilaterals that are
@@ -1957,6 +1957,10 @@ class QuadMesh(Collection):
 
     Notes
     -----
+    Unlike other `.Collection`\s, the default *pickradius* of `.QuadMesh` is 0,
+    i.e. `~.Artist.contains` checks whether the test point is within any of the
+    mesh quadrilaterals.
+
     There exists a deprecated API version ``QuadMesh(M, N, coords)``, where
     the dimensions are given explicitly and ``coords`` is a (M*N, 2)
     array-like. This has been deprecated in Matplotlib 3.5. The following
@@ -1984,8 +1988,8 @@ class QuadMesh(Collection):
     For example, the first entry in *coordinates* is the coordinates of the
     vertex at mesh coordinates (0, 0), then the one at (0, 1), then at (0, 2)
     .. (0, meshWidth), (1, 0), (1, 1), and so on.
-
     """
+
     def __init__(self, *args, **kwargs):
         # signature deprecation since="3.5": Change to new signature after the
         # deprecation has expired. Also remove setting __init__.__signature__,
@@ -2017,6 +2021,7 @@ class QuadMesh(Collection):
                         "coordinates must be 2D; all parameters except "
                         "coordinates will be keyword-only.")
             coords = np.asarray(coords, np.float64).reshape((h + 1, w + 1, 2))
+        kwargs.setdefault("pickradius", 0)
         # end of signature deprecation code
 
         super().__init__(**kwargs)
@@ -2031,7 +2036,7 @@ class QuadMesh(Collection):
     # Only needed during signature deprecation
     __init__.__signature__ = inspect.signature(
         lambda self, coordinates, *,
-               antialiased=True, shading='flat', **kwargs: None)
+               antialiased=True, shading='flat', pickradius=0, **kwargs: None)
 
     def get_paths(self):
         if self._paths is None:
@@ -2162,3 +2167,11 @@ class QuadMesh(Collection):
         gc.restore()
         renderer.close_group(self.__class__.__name__)
         self.stale = False
+
+    def get_cursor_data(self, event):
+        contained, info = self.contains(event)
+        if len(info["ind"]) == 1:
+            ind, = info["ind"]
+            return self.get_array()[ind]
+        else:
+            return None

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -995,16 +995,6 @@ class AxesImage(_ImageBase):
         else:
             return arr[i, j]
 
-    def format_cursor_data(self, data):
-        if np.ndim(data) == 0 and self.colorbar:
-            return (
-                "["
-                + cbook.strip_math(
-                    self.colorbar.formatter.format_data_short(data)).strip()
-                + "]")
-        else:
-            return super().format_cursor_data(data)
-
 
 class NonUniformImage(AxesImage):
     mouseover = False  # This class still needs its own get_cursor_data impl.

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -7,6 +7,7 @@ import pytest
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from matplotlib.backend_bases import MouseEvent
 import matplotlib.collections as mcollections
 import matplotlib.colors as mcolors
 import matplotlib.transforms as mtransforms
@@ -972,3 +973,16 @@ def test_array_wrong_dimensions():
     pc = plt.pcolormesh(z)
     pc.set_array(z)  # 2D is OK for Quadmesh
     pc.update_scalarmappable()
+
+
+def test_quadmesh_cursor_data():
+    fig, ax = plt.subplots()
+    *_, qm = ax.hist2d(
+        np.arange(11)**2, 100 + np.arange(11)**2)  # width-10 bins
+    x, y = ax.transData.transform([1, 101])
+    event = MouseEvent('motion_notify_event', fig.canvas, x, y)
+    assert qm.get_cursor_data(event) == 4  # (0**2, 1**2, 2**2, 3**2)
+    for out_xydata in []:
+        x, y = ax.transData.transform([-1, 101])
+        event = MouseEvent('motion_notify_event', fig.canvas, x, y)
+        assert qm.get_cursor_data(event) is None


### PR DESCRIPTION
The motivation is actually to provide get_cursor_data for hist2d, which
uses a QuadMesh to draw itself (see the test).

As it turns out, Collection.contains already contains the relevant code
to find which path contains the mouse event, so just reuse that.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
