### PR TITLE
Cleanup some consistency in contour extensions

### DIFF
--- a/src/_contour.cpp
+++ b/src/_contour.cpp
@@ -11,11 +11,6 @@
 #include <algorithm>
 
 
-// 'kind' codes.
-#define MOVETO 1
-#define LINETO 2
-#define CLOSEPOLY 79
-
 // Point indices from current quad index.
 #define POINT_SW (quad)
 #define POINT_SE (quad+1)

--- a/src/_path.h
+++ b/src/_path.h
@@ -1138,15 +1138,14 @@ bool __convert_to_string(PathIterator &path,
     double last_x = 0.0;
     double last_y = 0.0;
 
-    const int sizes[] = { 1, 1, 2, 3 };
     int size = 0;
     unsigned code;
 
     while ((code = path.vertex(&x[0], &y[0])) != agg::path_cmd_stop) {
-        if (code == 0x4f) {
+        if (code == CLOSEPOLY) {
             buffer += codes[4];
         } else if (code < 5) {
-            size = sizes[code - 1];
+            size = NUM_VERTICES[code];
 
             for (int i = 1; i < size; ++i) {
                 unsigned subcode = path.vertex(&x[i], &y[i]);

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -203,10 +203,10 @@ ft_outline_move_to(FT_Vector const* to, void* user)
     ft_outline_decomposer* d = reinterpret_cast<ft_outline_decomposer*>(user);
     if (d->codes) {
         if (d->index) {
-            // Appending ENDPOLY is important to make patheffects work.
+            // Appending CLOSEPOLY is important to make patheffects work.
             *(d->vertices++) = 0;
             *(d->vertices++) = 0;
-            *(d->codes++) = ENDPOLY;
+            *(d->codes++) = CLOSEPOLY;
         }
         *(d->vertices++) = to->x / 64.;
         *(d->vertices++) = to->y / 64.;
@@ -286,7 +286,7 @@ FT2Font::get_path()
                      "FT_Outline_Decompose failed with error 0x%x", error);
         return NULL;
     }
-    if (!decomposer.index) {  // Don't append ENDPOLY to null glyphs.
+    if (!decomposer.index) {  // Don't append CLOSEPOLY to null glyphs.
       npy_intp vertices_dims[2] = { 0, 2 };
       numpy::array_view<double, 2> vertices(vertices_dims);
       npy_intp codes_dims[1] = { 0 };
@@ -309,7 +309,7 @@ FT2Font::get_path()
     }
     *(decomposer.vertices++) = 0;
     *(decomposer.vertices++) = 0;
-    *(decomposer.codes++) = ENDPOLY;
+    *(decomposer.codes++) = CLOSEPOLY;
     return Py_BuildValue("NN", vertices.pyobj(), codes.pyobj());
 }
 

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -40,13 +40,14 @@ inline double mpl_round(double v)
     return (double)(int)(v + ((v >= 0.0) ? 0.5 : -0.5));
 }
 
+// 'kind' codes for paths.
 enum {
     STOP = 0,
     MOVETO = 1,
     LINETO = 2,
     CURVE3 = 3,
     CURVE4 = 4,
-    ENDPOLY = 0x4f
+    CLOSEPOLY = 0x4f
 };
 
 const size_t NUM_VERTICES[] = { 1, 1, 1, 2, 3, 1 };

--- a/src/tri/_tri.cpp
+++ b/src/tri/_tri.cpp
@@ -7,14 +7,11 @@
  */
 #define NO_IMPORT_ARRAY
 
+#include "../mplutils.h"
 #include "_tri.h"
 
 #include <algorithm>
 #include <set>
-
-#define MOVETO 1
-#define LINETO 2
-#define CLOSEPOLY 79
 
 
 TriEdge::TriEdge()

--- a/src/tri/_tri.cpp
+++ b/src/tri/_tri.cpp
@@ -651,20 +651,22 @@ PyObject* TriContourGenerator::contour_line_to_segs_and_kinds(const Contour& con
             PyList_SetItem(codes_list, i, (PyObject*)codes)) {
             Py_XDECREF(segs);
             Py_XDECREF(codes);
-            PyErr_SetString(PyExc_RuntimeError,
-                            "Unable to set contour segments and kind codes");
-            return NULL;
+            throw std::runtime_error(
+                "Unable to set contour segments and kind codes");
         }
     }
 
     PyObject* result = PyTuple_New(2);
-    if (PyTuple_SetItem(result, 0, (PyObject*)vertices_list) ||
-        PyTuple_SetItem(result, 1, (PyObject*)codes_list)) {
-        Py_XDECREF(result);
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Unable to set contour segments and kind codes");
-        return NULL;
+    if (result == 0) {
+        Py_XDECREF(vertices_list);
+        Py_XDECREF(codes_list);
+        throw std::runtime_error("Failed to create Python tuple");
     }
+
+    // No error checking here as filling in a brand new pre-allocated result.
+    PyTuple_SET_ITEM(result, 0, vertices_list);
+    PyTuple_SET_ITEM(result, 1, codes_list);
+
     return result;
 }
 
@@ -730,13 +732,16 @@ PyObject* TriContourGenerator::contour_to_segs_and_kinds(const Contour& contour)
     }
 
     PyObject* result = PyTuple_New(2);
-    if (PyTuple_SetItem(result, 0, (PyObject*)vertices_list) ||
-        PyTuple_SetItem(result, 1, (PyObject*)codes_list)) {
-        Py_XDECREF(result);
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Unable to set contour segments and kinds");
-        return NULL;
+    if (result == 0) {
+        Py_XDECREF(vertices_list);
+        Py_XDECREF(codes_list);
+        throw std::runtime_error("Failed to create Python tuple");
     }
+
+    // No error checking here as filling in a brand new pre-allocated tuple.
+    PyTuple_SET_ITEM(result, 0, vertices_list);
+    PyTuple_SET_ITEM(result, 1, codes_list);
+
     return result;
 }
 


### PR DESCRIPTION
## PR Summary

This makes `TriContour` match `QuadContour` a little closer, by using `array_view`, and creating the final `tuple` in the same way.

It also removes redundant definitions of Path codes.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).