### PR TITLE
Remove 3.3 deprecated modules

### DIFF
--- a/doc/api/next_api_changes/removals/19922-ES.rst
+++ b/doc/api/next_api_changes/removals/19922-ES.rst
@@ -4,3 +4,4 @@ Removed modules
 The following deprecated modules have been removed:
 
 * ``matplotlib.compat``
+* ``matplotlib.ttconv``

--- a/doc/api/next_api_changes/removals/19922-ES.rst
+++ b/doc/api/next_api_changes/removals/19922-ES.rst
@@ -1,0 +1,6 @@
+Removed modules
+~~~~~~~~~~~~~~~
+
+The following deprecated modules have been removed:
+
+* ``matplotlib.compat``

--- a/lib/matplotlib/compat/__init__.py
+++ b/lib/matplotlib/compat/__init__.py
@@ -1,4 +1,0 @@
-from matplotlib import _api
-
-
-_api.warn_deprecated("3.3", name=__name__, obj_type="module")

--- a/lib/matplotlib/ttconv.py
+++ b/lib/matplotlib/ttconv.py
@@ -1,9 +1,0 @@
-"""
-Converting and subsetting TrueType fonts to PS types 3 and 42, and PDF type 3.
-"""
-
-from . import _api
-from ._ttconv import convert_ttf_to_ps, get_pdf_charprocs  # noqa
-
-
-_api.warn_deprecated('3.3', name=__name__, obj_type='module')

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -150,81 +150,6 @@ static PyObject *convert_ttf_to_ps(PyObject *self, PyObject *args, PyObject *kwd
     return Py_None;
 }
 
-class PythonDictionaryCallback : public TTDictionaryCallback
-{
-    PyObject *_dict;
-
-  public:
-    PythonDictionaryCallback(PyObject *dict)
-    {
-        _dict = dict;
-    }
-
-    virtual void add_pair(const char *a, const char *b)
-    {
-        assert(a != NULL);
-        assert(b != NULL);
-        PyObject *value = PyBytes_FromString(b);
-        if (!value) {
-            throw py::exception();
-        }
-        if (PyDict_SetItemString(_dict, a, value)) {
-            Py_DECREF(value);
-            throw py::exception();
-        }
-        Py_DECREF(value);
-    }
-};
-
-static PyObject *py_get_pdf_charprocs(PyObject *self, PyObject *args, PyObject *kwds)
-{
-    const char *filename;
-    std::vector<int> glyph_ids;
-    PyObject *result;
-
-    static const char *kwlist[] = { "filename", "glyph_ids", NULL };
-    if (!PyArg_ParseTupleAndKeywords(args,
-                                     kwds,
-                                     "y|O&:get_pdf_charprocs",
-                                     (char **)kwlist,
-                                     &filename,
-                                     pyiterable_to_vector_int,
-                                     &glyph_ids)) {
-        return NULL;
-    }
-
-    result = PyDict_New();
-    if (!result) {
-        return NULL;
-    }
-
-    PythonDictionaryCallback dict(result);
-
-    try
-    {
-        ::get_pdf_charprocs(filename, glyph_ids, dict);
-    }
-    catch (TTException &e)
-    {
-        Py_DECREF(result);
-        PyErr_SetString(PyExc_RuntimeError, e.getMessage());
-        return NULL;
-    }
-    catch (const py::exception &)
-    {
-        Py_DECREF(result);
-        return NULL;
-    }
-    catch (...)
-    {
-        Py_DECREF(result);
-        PyErr_SetString(PyExc_RuntimeError, "Unknown C++ exception");
-        return NULL;
-    }
-
-    return result;
-}
-
 static PyMethodDef ttconv_methods[] =
 {
     {
@@ -244,20 +169,6 @@ static PyMethodDef ttconv_methods[] =
         "subsetting to a Type 3 font.  If glyph_ids is not provided or is None, "
         "then all glyphs will be included.  If any of the glyphs specified are "
         "composite glyphs, then the component glyphs will also be included."
-    },
-    {
-        "get_pdf_charprocs", (PyCFunction)py_get_pdf_charprocs, METH_VARARGS | METH_KEYWORDS,
-        "get_pdf_charprocs(filename, glyph_ids)\n"
-        "\n"
-        "Given a Truetype font file, returns a dictionary containing the PDF Type 3\n"
-        "representation of its paths.  Useful for subsetting a Truetype font inside\n"
-        "of a PDF file.\n"
-        "\n"
-        "filename is the path to a TTF font file.\n"
-        "glyph_ids is a list of the numeric glyph ids to include.\n"
-        "The return value is a dictionary where the keys are glyph names and\n"
-        "the values are the stream content needed to render that glyph.  This\n"
-        "is useful to generate the CharProcs dictionary in a PDF Type 3 font.\n"
     },
     {0, 0, 0, 0}  /* Sentinel */
 };


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).