### PR TITLE
FIX: subfigure indexing error

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1992,11 +1992,11 @@ class SubFigure(FigureBase):
 
         x0 = 0
         if not self._subplotspec.is_first_col():
-            x0 += np.sum(wr[self._subplotspec.colspan.start - 1]) / np.sum(wr)
+            x0 += np.sum(wr[:self._subplotspec.colspan.start]) / np.sum(wr)
 
         y0 = 0
         if not self._subplotspec.is_last_row():
-            y0 += 1 - (np.sum(hr[self._subplotspec.rowspan.stop - 1]) /
+            y0 += 1 - (np.sum(hr[:self._subplotspec.rowspan.stop]) /
                        np.sum(hr))
 
         if self.bbox_relative is None:

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -967,6 +967,28 @@ def test_subfigure_double():
     axsRight = subfigs[1].subplots(2, 2)
 
 
+def test_subfigure_spanning():
+    # test that subfigures get laid out properly...
+    fig = plt.figure(constrained_layout=True)
+    gs = fig.add_gridspec(3, 3)
+    sub_figs = [
+        fig.add_subfigure(gs[0, 0]),
+        fig.add_subfigure(gs[0:2, 1]),
+        fig.add_subfigure(gs[2, 1:3]),
+    ]
+
+    w = 640
+    h = 480
+    np.testing.assert_allclose(sub_figs[0].bbox.min, [0., h * 2/3])
+    np.testing.assert_allclose(sub_figs[0].bbox.max, [w / 3, h])
+
+    np.testing.assert_allclose(sub_figs[1].bbox.min, [w / 3, h / 3])
+    np.testing.assert_allclose(sub_figs[1].bbox.max, [w * 2/3, h])
+
+    np.testing.assert_allclose(sub_figs[2].bbox.min, [w / 3, 0])
+    np.testing.assert_allclose(sub_figs[2].bbox.max, [w, h / 3])
+
+
 def test_add_subplot_kwargs():
     # fig.add_subplot() always creates new axes, even if axes kwargs differ.
     fig = plt.figure()


### PR DESCRIPTION
## PR Summary

Closes #19947.  

The indexing to locate subfigures was wildly off.  Worked fine for 2x2 but was incorrect for anything larger.  

This PR fixes that and adds a test.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
