### PR TITLE
Convert Qhull wrapper to C++ and array_view

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -432,7 +432,7 @@ class Matplotlib(SetupPackage):
         yield ext
         # qhull
         ext = Extension(
-            "matplotlib._qhull", ["src/qhull_wrap.c"],
+            "matplotlib._qhull", ["src/qhull_wrap.cpp"],
             define_macros=[("MPL_DEVNULL", os.devnull)])
         add_numpy_flags(ext)
         Qhull.add_flags(ext)

--- a/src/qhull_wrap.c
+++ b/src/qhull_wrap.c
@@ -82,14 +82,14 @@ at_least_3_unique_points(int npoints, const double* x, const double* y)
     return 0;
 }
 
-/* Delaunay implementation methyod.  If hide_qhull_errors is 1 then qhull error
+/* Delaunay implementation method.  If hide_qhull_errors is 1 then qhull error
  * messages are discarded; if it is 0 then they are written to stderr. */
 static PyObject*
 delaunay_impl(int npoints, const double* x, const double* y,
               int hide_qhull_errors)
 {
-	qhT qh_qh;                  /* qh variable type and name must be like */
-	qhT* qh = &qh_qh;           /* this for Qhull macros to work correctly. */
+    qhT qh_qh;                  /* qh variable type and name must be like */
+    qhT* qh = &qh_qh;           /* this for Qhull macros to work correctly. */
     coordT* points = NULL;
     facetT* facet;
     int i, ntri, max_facet_id;
@@ -182,7 +182,7 @@ delaunay_impl(int npoints, const double* x, const double* y,
         goto error;
     }
 
-    /* Allocate python arrays to return. */
+    /* Allocate Python arrays to return. */
     dims[0] = ntri;
     dims[1] = 3;
     triangles = (PyArrayObject*)PyArray_SimpleNew(ndim, dims, NPY_INT);
@@ -259,7 +259,7 @@ error_before_qhull:
     return NULL;
 }
 
-/* Process python arguments and call Delaunay implementation method. */
+/* Process Python arguments and call Delaunay implementation method. */
 static PyObject*
 delaunay(PyObject *self, PyObject *args)
 {

--- a/src/qhull_wrap.cpp
+++ b/src/qhull_wrap.cpp
@@ -43,8 +43,9 @@ static void
 get_facet_vertices(qhT* qh, const facetT* facet, int indices[3])
 {
     vertexT *vertex, **vertexp;
-    FOREACHvertex_(facet->vertices)
+    FOREACHvertex_(facet->vertices) {
         *indices++ = qh_pointid(qh, vertex->point);
+    }
 }
 
 /* Return the indices of the 3 triangles that are neighbors of the specified
@@ -54,8 +55,9 @@ get_facet_neighbours(const facetT* facet, const int* tri_indices,
                      int indices[3])
 {
     facetT *neighbor, **neighborp;
-    FOREACHneighbor_(facet)
+    FOREACHneighbor_(facet) {
         *indices++ = (neighbor->upperdelaunay ? -1 : tri_indices[neighbor->id]);
+    }
 }
 
 /* Return true if the specified points arrays contain at least 3 unique points,
@@ -74,8 +76,9 @@ at_least_3_unique_points(int npoints, const double* x, const double* y)
     for (i = 1; i < npoints; ++i) {
         if (unique2 == 0) {
             /* Looking for second unique point. */
-            if (x[i] != x[unique1] || y[i] != y[unique1])
+            if (x[i] != x[unique1] || y[i] != y[unique1]) {
                 unique2 = i;
+            }
         }
         else {
             /* Looking for third unique point. */
@@ -178,8 +181,9 @@ delaunay_impl(int npoints, const double* x, const double* y,
        Note that libqhull uses macros to iterate through collections. */
     ntri = 0;
     FORALLfacets {
-        if (!facet->upperdelaunay)
+        if (!facet->upperdelaunay) {
             ++ntri;
+        }
     }
 
     max_facet_id = qh->facet_id - 1;
@@ -222,8 +226,9 @@ delaunay_impl(int npoints, const double* x, const double* y,
             *triangles_ptr++ = indices[1];
             *triangles_ptr++ = (facet->toporient ? indices[2] : indices[0]);
         }
-        else
+        else {
             tri_indices[facet->id] = -1;
+        }
     }
 
     /* Determine neighbors array. */
@@ -239,11 +244,13 @@ delaunay_impl(int npoints, const double* x, const double* y,
     /* Clean up. */
     qh_freeqhull(qh, !qh_ALL);
     qh_memfreeshort(qh, &curlong, &totlong);
-    if (curlong || totlong)
+    if (curlong || totlong) {
         PyErr_WarnEx(PyExc_RuntimeWarning,
                      "Qhull could not free all allocated memory", 1);
-    if (hide_qhull_errors)
+    }
+    if (hide_qhull_errors) {
         fclose(error_file);
+    }
     free(tri_indices);
     free(points);
 
@@ -259,8 +266,9 @@ error:
     qh_freeqhull(qh, !qh_ALL);
     qh_memfreeshort(qh, &curlong, &totlong);
     /* Don't bother checking curlong and totlong as raising error anyway. */
-    if (hide_qhull_errors)
+    if (hide_qhull_errors) {
         fclose(error_file);
+    }
     free(tri_indices);
 
 error_before_qhull:


### PR DESCRIPTION
## PR Summary

Converting the Qhull wrapper to use `array_view` means converting it to C++, but also means doing some rework to avoid `goto` and use destructors for cleanup instead. This works better with any exception flow.

Fixes #19627 with #19918.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).