### PR TITLE
Support escaped characters in matplotlibrc via double-quoted strings

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -81,6 +81,7 @@ Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
 """
 
+import ast
 import atexit
 from collections import namedtuple
 from collections.abc import MutableMapping
@@ -753,6 +754,8 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
                 key, val = tup
                 key = key.strip()
                 val = val.strip()
+                if len(val) >= 2 and val[0] == val[-1] == '"':
+                    val = ast.literal_eval(val)
                 if key in rc_temp:
                     _log.warning('Duplicate key in file %r, line %d (%r)',
                                  fname, line_no, line.rstrip('\n'))

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -30,6 +30,13 @@
 ## All lines start with an additional '#', so that removing all leading '#'s
 ## yields a valid style file.
 ##
+## Strings can be specified without qoutes, in which case they are interpreted
+## literally, e.g.
+##     text.latex.preamble: \newcommand{\foo}{bar}
+##
+## If enclosed in double quotes, the string content is unescaped, e.g.
+##     date.autoformatter.hour: "%b %d\n%H:%M"  # includes a newline
+##
 ## Colors: for the color values below, you can either use
 ##     - a Matplotlib color string, such as r, k, or b
 ##     - an RGB tuple, such as (1.0, 0.5, 0.0)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -38,7 +38,12 @@ def test_rcparams(tmpdir):
     linewidth = mpl.rcParams['lines.linewidth']
 
     rcpath = Path(tmpdir) / 'test_rcparams.rc'
-    rcpath.write_text('lines.linewidth: 33')
+    rcpath.write_text(r"""
+lines.linewidth: 33
+text.latex.preamble: \newcommand{\foo}{\bar}  # unquoted: no unescaping
+date.autoformatter.hour: "%b %d\n%H:%M"  # quoted: unescape to newline
+date.autoformatter.year: "## %Y ##"  # '#' in string
+""")
 
     # test context given dictionary
     with mpl.rc_context(rc={'text.usetex': not usetex}):
@@ -66,6 +71,9 @@ def test_rcparams(tmpdir):
     # test rc_file
     mpl.rc_file(rcpath)
     assert mpl.rcParams['lines.linewidth'] == 33
+    assert mpl.rcParams['text.latex.preamble'] == r"\newcommand{\foo}{\bar}"
+    assert mpl.rcParams['date.autoformatter.hour'] == "%b %d\n%H:%M"
+    assert mpl.rcParams['date.autoformatter.year'] == "## %Y ##"
 
 
 def test_RcParams_class():


### PR DESCRIPTION
## PR Summary

As proposed in https://github.com/matplotlib/matplotlib/issues/15813#issuecomment-560567466.

Closes #19288.

Alternative to #19289.


On a side note: This (as the current matplotlibrc format) is a subset of YAML.