### PR TITLE
Bugfix Tk start_event_loop

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -359,11 +359,12 @@ class FigureCanvasTk(FigureCanvasBase):
 
     def start_event_loop(self, timeout=0):
         # docstring inherited
-        milliseconds = int(1000 * timeout)
-        if milliseconds > 0:
-            self._event_loop_id = self._tkcanvas.after(milliseconds, self.stop_event_loop)
-        else:
-            self._event_loop_id = self._tkcanvas.after_idle(self.stop_event_loop)
+        if timeout > 0:
+            milliseconds = int(1000 * timeout)
+            if milliseconds > 0:
+                self._event_loop_id = self._tkcanvas.after(milliseconds, self.stop_event_loop)
+            else:
+                self._event_loop_id = self._tkcanvas.after_idle(self.stop_event_loop)
         self._master.mainloop()
 
     def stop_event_loop(self):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -358,8 +358,11 @@ class FigureCanvasTk(FigureCanvasBase):
 
     def start_event_loop(self, timeout=0):
         # docstring inherited
-        if timeout > 0:
-            self._master.after(int(1000*timeout), self.stop_event_loop)
+        milliseconds = int(1000 * timeout)
+        if milliseconds > 0:
+            self._master.after(milliseconds, self.stop_event_loop)
+        elif milliseconds == 0:
+            self._master.after_idle(self.stop_event_loop)
         self._master.mainloop()
 
     def stop_event_loop(self):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -362,9 +362,11 @@ class FigureCanvasTk(FigureCanvasBase):
         if timeout > 0:
             milliseconds = int(1000 * timeout)
             if milliseconds > 0:
-                self._event_loop_id = self._tkcanvas.after(milliseconds, self.stop_event_loop)
+                self._event_loop_id = self._tkcanvas.after(
+                    milliseconds, self.stop_event_loop)
             else:
-                self._event_loop_id = self._tkcanvas.after_idle(self.stop_event_loop)
+                self._event_loop_id = self._tkcanvas.after_idle(
+                    self.stop_event_loop)
         self._master.mainloop()
 
     def stop_event_loop(self):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -461,7 +461,8 @@ class FigureManagerTk(FigureManagerBase):
             if self._owns_mainloop and not Gcf.get_num_fig_managers():
                 self.window.quit()
 
-        self.window.after_idle(delayed_destroy)
+        # "after idle after 0" avoids Tcl error/race (GH #19940)
+        self.window.after_idle(self.window.after, 0, delayed_destroy)
 
     def get_window_title(self):
         return self.window.wm_title()


### PR DESCRIPTION
## PR Summary
Closes #19940. With these changes, the example script in that issue no longer has the `after` related stderr spam. No automated tests because the bug arises in a nested interactive event loop which is not a generally supported situation I think.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
