### PR TITLE
FIX: subfigure tightbbox

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1650,7 +1650,11 @@ default: %(va)s
                   and (b.width != 0 or b.height != 0))]
 
         if len(bb) == 0:
-            return self.bbox_inches
+            if hasattr(self, 'bbox_inches'):
+                return self.bbox_inches
+            else:
+                # subfigures do not have bbox_inches, but do have a bbox
+                bb = [self.bbox]
 
         _bbox = Bbox.union(bb)
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -900,6 +900,15 @@ def test_subfigure():
     fig.suptitle('Figure suptitle', fontsize='xx-large')
 
 
+def test_subfigure_tightbbox():
+    # test that we can get the tightbbox with a subfigure...
+    fig = plt.figure(constrained_layout=True)
+    sub = fig.subfigures(1, 2)
+
+    np.testing.assert_allclose(
+            fig.get_tightbbox(fig.canvas.get_renderer()).width, 0.1)
+
+
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'},
                   remove_text=False)


### PR DESCRIPTION
## PR Summary

Closes #19958

subfigure.get_tightbbox failed if there was nothing in the subfigure.  This adds a fallback to the bbox of the subfigure (and a small smoketest)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
