### PR TITLE
test_StrCategoryLocator using parameterized plotter

### DIFF
--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -140,7 +140,7 @@ class TestStrCategoryLocator:
 
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)
     def test_StrCategoryLocatorPlot(self, ax, plotter):
-        ax.plot(["a", "b", "c"])
+        plotter(ax, [1,2,3], ["a", "b", "c"])
         np.testing.assert_array_equal(ax.yaxis.major.locator(), range(3))
 
 

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -140,7 +140,7 @@ class TestStrCategoryLocator:
 
     @pytest.mark.parametrize("plotter", PLOT_LIST, ids=PLOT_IDS)
     def test_StrCategoryLocatorPlot(self, ax, plotter):
-        plotter(ax, [1,2,3], ["a", "b", "c"])
+        plotter(ax, [1, 2, 3], ["a", "b", "c"])
         np.testing.assert_array_equal(ax.yaxis.major.locator(), range(3))
 
 


### PR DESCRIPTION
The plot function in `test_StrCategoryLocator1` in `test_category` is parametrized, but the test was using `ax.plot` so this PR has it use the parameter instead. 