### PR TITLE
FIX: add subplot_mosaic axes in the order the user gave them to us

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -861,6 +861,23 @@ class TestSubplotMosaic:
         fig_test.subplot_mosaic([[object(), object()]])
         fig_ref.subplot_mosaic([["A", "B"]])
 
+    @pytest.mark.parametrize('str_pattern',
+                             ['abc', 'cab', 'bca', 'cba', 'acb', 'bac'])
+    def test_user_order(self, str_pattern):
+        fig = plt.figure()
+        ax_dict = fig.subplot_mosaic(str_pattern)
+        assert list(str_pattern) == list(ax_dict)
+        assert list(fig.axes) == list(ax_dict.values())
+
+    def test_nested_user_order(self):
+        layout = [["A", [["B", "C"], ["D", "E"]]],
+                  ["F", "G"]]
+
+        fig = plt.figure()
+        ax_dict = fig.subplot_mosaic(layout)
+        assert list(ax_dict) == list("ABCDEFG")
+        assert list(fig.axes) == list(ax_dict.values())
+
 
 def test_reused_gridspec():
     """Test that these all use the same gridspec"""

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -870,12 +870,17 @@ class TestSubplotMosaic:
         assert list(fig.axes) == list(ax_dict.values())
 
     def test_nested_user_order(self):
-        layout = [["A", [["B", "C"], ["D", "E"]]],
-                  ["F", "G"]]
+        layout = [
+            ["A", [["B", "C"],
+                   ["D", "E"]]],
+            ["F", "G"],
+            [".", [["H", [["I"],
+                          ["."]]]]]
+        ]
 
         fig = plt.figure()
         ax_dict = fig.subplot_mosaic(layout)
-        assert list(ax_dict) == list("ABCDEFG")
+        assert list(ax_dict) == list("ABCDEFGHI")
         assert list(fig.axes) == list(ax_dict.values())
 
 


### PR DESCRIPTION
## PR Summary

The order the Axes are added to the Figure (and hence the order they are in
the returned dictionary and fig.axes) is now based on the first time we see the
key if the layout were recursively unraveled as a c-style array.

Closes #19736

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

I don't think this needs an API change note as the order was previously unreliable.