### PR TITLE
ENH: draw no output

### DIFF
--- a/doc/users/next_whats_new/fig_draw_no_output.rst
+++ b/doc/users/next_whats_new/fig_draw_no_output.rst
@@ -1,0 +1,8 @@
+Figure now has draw_no_output method
+------------------------------------
+
+Rarely, the user will want to trigger a draw without making output to 
+either the screen or a file.  This is useful for determining the final 
+position of artists on the figure that require a draw like text.
+This could be accomplished via ``fig.canvas.draw()`` but that is 
+not user-facing, so a new method on `.Figure.draw_no_output` is provided.  

--- a/doc/users/next_whats_new/fig_draw_no_output.rst
+++ b/doc/users/next_whats_new/fig_draw_no_output.rst
@@ -3,6 +3,8 @@ Figure now has draw_no_output method
 
 Rarely, the user will want to trigger a draw without making output to 
 either the screen or a file.  This is useful for determining the final 
-position of artists on the figure that require a draw like text.
-This could be accomplished via ``fig.canvas.draw()`` but that is 
-not user-facing, so a new method on `.Figure.draw_no_output` is provided.  
+position of artists on the figure that require a draw, like text artists.
+This could be accomplished via ``fig.canvas.draw()`` but has side effects,
+sometimes requires an open file, and is documented on an object most users 
+do not need to access.  The `.Figure.draw_no_output` is provided to trigger 
+a draw without pushing to the final output, and with fewer side effects.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1584,9 +1584,9 @@ def _get_renderer(figure, print_method=None):
 
 
 def _no_output_draw(figure):
-    renderer = _get_renderer(figure)
-    with renderer._draw_disabled():
-        figure.draw(renderer)
+    # _no_output_draw was promoted to the figure level, but
+    # keep this here in case someone was calling it...
+    figure.draw_no_output()
 
 
 def _is_non_interactive_terminal_ipython(ip):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -29,7 +29,7 @@ from matplotlib import _api, _text_layout, cbook
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
-    GraphicsContextBase, RendererBase, _no_output_draw)
+    GraphicsContextBase, RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.figure import Figure
 from matplotlib.font_manager import findfont, get_font
@@ -2718,7 +2718,7 @@ class FigureCanvasPdf(FigureCanvasBase):
                 file.close()
 
     def draw(self):
-        _no_output_draw(self.figure)
+        self.figure.draw_no_output()
         return super().draw()
 
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -19,7 +19,7 @@ import matplotlib as mpl
 from matplotlib import _api, cbook, font_manager as fm
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
-    GraphicsContextBase, RendererBase, _no_output_draw
+    GraphicsContextBase, RendererBase
 )
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.backends.backend_pdf import (
@@ -889,7 +889,7 @@ class FigureCanvasPgf(FigureCanvasBase):
         return RendererPgf(self.figure, None)
 
     def draw(self):
-        _no_output_draw(self.figure)
+        self.figure.draw_no_output()
         return super().draw()
 
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -23,7 +23,7 @@ from matplotlib import _text_layout
 from matplotlib.afm import AFM
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
-    GraphicsContextBase, RendererBase, _no_output_draw)
+    GraphicsContextBase, RendererBase)
 from matplotlib.cbook import is_writable_file_like, file_requires_unicode
 from matplotlib.font_manager import get_font
 from matplotlib.ft2font import LOAD_NO_HINTING, LOAD_NO_SCALE
@@ -1112,7 +1112,7 @@ showpage
             _move_path_to_path_or_stream(tmpfile, outfile)
 
     def draw(self):
-        _no_output_draw(self.figure)
+        self.figure.draw_no_output()
         return super().draw()
 
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -17,7 +17,7 @@ import matplotlib as mpl
 from matplotlib import _api, cbook
 from matplotlib.backend_bases import (
      _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
-     RendererBase, _no_output_draw)
+     RendererBase)
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.colors import rgb2hex
 from matplotlib.dates import UTC
@@ -1343,7 +1343,7 @@ class FigureCanvasSVG(FigureCanvasBase):
         return 'svg'
 
     def draw(self):
-        _no_output_draw(self.figure)
+        self.figure.draw_no_output()
         return super().draw()
 
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -26,7 +26,7 @@ import matplotlib.artist as martist
 from matplotlib.artist import (
     Artist, allow_rasterization, _finalize_rasterization)
 from matplotlib.backend_bases import (
-    FigureCanvasBase, NonGuiException, MouseButton, _no_output_draw)
+    FigureCanvasBase, NonGuiException, MouseButton, _get_renderer)
 import matplotlib._api as _api
 import matplotlib.cbook as cbook
 import matplotlib.colorbar as cbar
@@ -2744,7 +2744,9 @@ class Figure(FigureBase):
         Draw the figure with no output.  Useful to get the final size of
         artists that require a draw before their size is known (e.g. text).
         """
-        _no_output_draw(self)
+        renderer = _get_renderer(self)
+        with renderer._draw_disabled():
+            self.draw(renderer)
 
     def draw_artist(self, a):
         """
@@ -3022,7 +3024,6 @@ class Figure(FigureBase):
         """
 
         from matplotlib._constrained_layout import do_constrained_layout
-        from matplotlib.tight_layout import get_renderer
 
         _log.debug('Executing constrainedlayout')
         if self._layoutgrid is None:
@@ -3040,7 +3041,7 @@ class Figure(FigureBase):
         w_pad = w_pad / width
         h_pad = h_pad / height
         if renderer is None:
-            renderer = get_renderer(fig)
+            renderer = _get_renderer(fig)
         do_constrained_layout(fig, renderer, h_pad, w_pad, hspace, wspace)
 
     def tight_layout(self, *, pad=1.08, h_pad=None, w_pad=None, rect=None):
@@ -3070,7 +3071,7 @@ class Figure(FigureBase):
         """
 
         from .tight_layout import (
-            get_renderer, get_subplotspec_list, get_tight_layout_figure)
+            get_subplotspec_list, get_tight_layout_figure)
         from contextlib import suppress
         subplotspec_list = get_subplotspec_list(self.axes)
         if None in subplotspec_list:
@@ -3078,7 +3079,7 @@ class Figure(FigureBase):
                                "compatible with tight_layout, so results "
                                "might be incorrect.")
 
-        renderer = get_renderer(self)
+        renderer = _get_renderer(self)
         ctx = (renderer._draw_disabled()
                if hasattr(renderer, '_draw_disabled')
                else suppress())

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -26,7 +26,7 @@ import matplotlib.artist as martist
 from matplotlib.artist import (
     Artist, allow_rasterization, _finalize_rasterization)
 from matplotlib.backend_bases import (
-    FigureCanvasBase, NonGuiException, MouseButton)
+    FigureCanvasBase, NonGuiException, MouseButton, _no_output_draw)
 import matplotlib._api as _api
 import matplotlib.cbook as cbook
 import matplotlib.colorbar as cbar
@@ -2738,6 +2738,13 @@ class Figure(FigureBase):
             self.stale = False
 
         self.canvas.draw_event(renderer)
+
+    def draw_no_output(self):
+        """
+        Draw the figure with no output.  Useful to get the final size of
+        artists that require a draw before their size is known (e.g. text).
+        """
+        _no_output_draw(self)
 
     def draw_artist(self, a):
         """

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -134,7 +134,7 @@ def test_constrained_layout7():
         for gs in gsl:
             fig.add_subplot(gs)
         # need to trigger a draw to get warning
-        fig.draw(fig.canvas.get_renderer())
+        fig.draw_no_output()
 
 
 @image_comparison(['constrained_layout8.png'])
@@ -327,7 +327,7 @@ def test_constrained_layout18():
     ax2 = ax.twinx()
     example_plot(ax)
     example_plot(ax2, fontsize=24)
-    fig.canvas.draw()
+    fig.draw_no_output()
     assert all(ax.get_position().extents == ax2.get_position().extents)
 
 
@@ -339,7 +339,7 @@ def test_constrained_layout19():
     example_plot(ax2, fontsize=24)
     ax2.set_title('')
     ax.set_title('')
-    fig.canvas.draw()
+    fig.draw_no_output()
     assert all(ax.get_position().extents == ax2.get_position().extents)
 
 
@@ -359,11 +359,11 @@ def test_constrained_layout21():
     fig, ax = plt.subplots(constrained_layout=True)
 
     fig.suptitle("Suptitle0")
-    fig.canvas.draw()
+    fig.draw_no_output()
     extents0 = np.copy(ax.get_position().extents)
 
     fig.suptitle("Suptitle1")
-    fig.canvas.draw()
+    fig.draw_no_output()
     extents1 = np.copy(ax.get_position().extents)
 
     np.testing.assert_allclose(extents0, extents1)
@@ -373,11 +373,11 @@ def test_constrained_layout22():
     """#11035: suptitle should not be include in CL if manually positioned"""
     fig, ax = plt.subplots(constrained_layout=True)
 
-    fig.canvas.draw()
+    fig.draw_no_output()
     extents0 = np.copy(ax.get_position().extents)
 
     fig.suptitle("Suptitle", y=0.5)
-    fig.canvas.draw()
+    fig.draw_no_output()
     extents1 = np.copy(ax.get_position().extents)
 
     np.testing.assert_allclose(extents0, extents1)
@@ -425,7 +425,7 @@ def test_hidden_axes():
     # (as does a gridspec slot that is empty)
     fig, axs = plt.subplots(2, 2, constrained_layout=True)
     axs[0, 1].set_visible(False)
-    fig.canvas.draw()
+    fig.draw_no_output()
     extents1 = np.copy(axs[0, 0].get_position().extents)
 
     np.testing.assert_allclose(
@@ -451,7 +451,7 @@ def test_colorbar_align():
         fig.set_constrained_layout_pads(w_pad=4 / 72, h_pad=4 / 72, hspace=0.1,
                                         wspace=0.1)
 
-        fig.canvas.draw()
+        fig.draw_no_output()
         if location in ['left', 'right']:
             np.testing.assert_allclose(cbs[0].ax.get_position().x0,
                                        cbs[2].ax.get_position().x0)
@@ -493,7 +493,7 @@ def test_colorbars_no_overlapH():
 def test_manually_set_position():
     fig, axs = plt.subplots(1, 2, constrained_layout=True)
     axs[0].set_position([0.2, 0.2, 0.3, 0.3])
-    fig.canvas.draw()
+    fig.draw_no_output()
     pp = axs[0].get_position()
     np.testing.assert_allclose(pp, [[0.2, 0.2], [0.5, 0.5]])
 
@@ -501,7 +501,7 @@ def test_manually_set_position():
     axs[0].set_position([0.2, 0.2, 0.3, 0.3])
     pc = axs[0].pcolormesh(np.random.rand(20, 20))
     fig.colorbar(pc, ax=axs[0])
-    fig.canvas.draw()
+    fig.draw_no_output()
     pp = axs[0].get_position()
     np.testing.assert_allclose(pp, [[0.2, 0.2], [0.44, 0.5]])
 
@@ -546,7 +546,7 @@ def test_align_labels():
 
     fig.align_ylabels(axs=(ax3, ax1, ax2))
 
-    fig.canvas.draw()
+    fig.draw_no_output()
     after_align = [ax1.yaxis.label.get_window_extent(),
                    ax2.yaxis.label.get_window_extent(),
                    ax3.yaxis.label.get_window_extent()]

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -415,11 +415,11 @@ def test_autofmt_xdate(which):
 @pytest.mark.style('default')
 def test_change_dpi():
     fig = plt.figure(figsize=(4, 4))
-    fig.canvas.draw()
+    fig.draw_no_output()
     assert fig.canvas.renderer.height == 400
     assert fig.canvas.renderer.width == 400
     fig.dpi = 50
-    fig.canvas.draw()
+    fig.draw_no_output()
     assert fig.canvas.renderer.height == 200
     assert fig.canvas.renderer.width == 200
 


### PR DESCRIPTION
## PR Summary

Make user-facing `draw_no_output` to do the same thing as `fig.canvas.draw`

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
