### PR TITLE
Fix handling of "d" glyph in backend_ps.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -180,12 +180,12 @@ end readonly def
  2 copy known not {pop /.notdef} if
  true 3 1 roll get exec
  end
-} d
+} _d
 
 /BuildChar {
  1 index /Encoding get exch get
  1 index /BuildGlyph get exec
-} d
+} _d
 
 FontName currentdict end definefont pop
 """
@@ -208,7 +208,7 @@ FontName currentdict end definefont pop
                 # decomposer always explicitly moving to the closing point
                 # first).
                 [b"m", b"l", b"", b"c", b""], True).decode("ascii")
-            + "ce} d"
+            + "ce} _d"
         )
 
     return preamble + "\n".join(entries) + postamble
@@ -1338,20 +1338,23 @@ FigureManagerPS = FigureManagerBase
 # The usage comments use the notation of the operator summary
 # in the PostScript Language reference manual.
 psDefs = [
-    # name proc  *d*  -
-    "/d { bind def } bind def",
+    # name proc  *_d*  -
+    # Note that this cannot be bound to /d, because when embedding a Type3 font
+    # we may want to define a "d" glyph using "/d{...} d" which would locally
+    # overwrite the definition.
+    "/_d { bind def } bind def",
     # x y  *m*  -
-    "/m { moveto } d",
+    "/m { moveto } _d",
     # x y  *l*  -
-    "/l { lineto } d",
+    "/l { lineto } _d",
     # x y  *r*  -
-    "/r { rlineto } d",
+    "/r { rlineto } _d",
     # x1 y1 x2 y2 x y *c*  -
-    "/c { curveto } d",
+    "/c { curveto } _d",
     # *cl*  -
-    "/cl { closepath } d",
+    "/cl { closepath } _d",
     # *ce*  -
-    "/ce { closepath eofill } d",
+    "/ce { closepath eofill } _d",
     # w h x y  *box*  -
     """/box {
       m
@@ -1359,15 +1362,15 @@ psDefs = [
       0 exch r
       neg 0 r
       cl
-    } d""",
+    } _d""",
     # w h x y  *clipbox*  -
     """/clipbox {
       box
       clip
       newpath
-    } d""",
+    } _d""",
     # wx wy llx lly urx ury  *setcachedevice*  -
-    "/sc { setcachedevice } d",
+    "/sc { setcachedevice } _d",
 ]
 
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -173,3 +173,14 @@ def test_text_clip(fig_test, fig_ref):
     # Fully clipped-out text should not appear.
     ax.text(0, 0, "hello", transform=fig_test.transFigure, clip_on=True)
     fig_ref.add_subplot()
+
+
+@needs_ghostscript
+def test_d_glyph(tmp_path):
+    # Ensure that we don't have a procedure defined as /d, which would be
+    # overwritten by the glyph definition for "d".
+    fig = plt.figure()
+    fig.text(.5, .5, "def")
+    out = tmp_path / "test.eps"
+    fig.savefig(out)
+    mpl.testing.compare.convert(out, cache=False)  # Should not raise.


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/19979.
A rather "interesting" bug :p

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
