### PR TITLE
Bump minimum NumPy to 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
       - pip-install
 
       - deps-install:
-          numpy_version: "==1.16.0"
+          numpy_version: "==1.17.3"
       - mpl-install
 
       - doc-build

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -13,8 +13,8 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      min-numpy-version: "1.16.0"
-      min-numpy-hash: "04/b6/d7faa70a3e3eac39f943cc6a6a64ce378259677de516bd899dd9eb8f9b32"
+      min-numpy-version: "1.17.0"
+      min-numpy-hash: "da/32/1b8f2bb5fb50e4db68543eb85ce37b9fa6660cd05b58bddfafafa7ed62da"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]

--- a/doc/api/next_api_changes/development/20003-ES.rst
+++ b/doc/api/next_api_changes/development/20003-ES.rst
@@ -1,0 +1,15 @@
+Increase to minimum supported versions of dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For Maptlotlib 3.5, the :ref:`minimum supported versions <dependencies>` are
+being bumped:
+
++------------+-----------------+---------------+
+| Dependency |  min in mpl3.4  | min in mpl3.5 |
++============+=================+===============+
+|   NumPy    |      1.16       |     1.17      |
++------------+-----------------+---------------+
+
+This is consistent with our :ref:`min_deps_policy` and `NEP29
+<https://numpy.org/neps/nep-0029-deprecation_policy.html>`__
+

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -12,7 +12,7 @@ mandatory dependencies are automatically installed. This list is mainly for
 reference.
 
 * `Python <https://www.python.org/downloads/>`_ (>= 3.7)
-* `NumPy <https://numpy.org>`_ (>= 1.16)
+* `NumPy <https://numpy.org>`_ (>= 1.17)
 * `setuptools <https://setuptools.readthedocs.io/en/latest/>`_
 * `cycler <https://matplotlib.org/cycler/>`_ (>= 0.10.0)
 * `dateutil <https://pypi.org/project/python-dateutil>`_ (>= 2.7)

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -83,7 +83,8 @@ specification of the dependencies.
 ==========  ========  ======
 Matplotlib  Python    NumPy
 ==========  ========  ======
-3.4         3.7       1.16.0
+3.5         3.7       1.17.0
+`3.4`_      3.7       1.16.0
 `3.3`_      3.6       1.15.0
 `3.2`_      3.6       1.11.0
 `3.1`_      3.6       1.11.0
@@ -99,6 +100,7 @@ Matplotlib  Python    NumPy
 1.0         2.4       1.1
 ==========  ========  ======
 
+.. _`3.4`: https://matplotlib.org/3.4.0/users/installing.html#dependencies
 .. _`3.3`: https://matplotlib.org/3.3.0/users/installing.html#dependencies
 .. _`3.2`: https://matplotlib.org/3.2.0/users/installing.html#dependencies
 .. _`3.1`: https://matplotlib.org/3.1.0/users/installing.html#dependencies

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -161,7 +161,7 @@ def _check_versions():
             ("cycler", "0.10"),
             ("dateutil", "2.7"),
             ("kiwisolver", "1.0.1"),
-            ("numpy", "1.16"),
+            ("numpy", "1.17"),
             ("pyparsing", "2.2.1"),
     ]:
         module = importlib.import_module(modname)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1009,7 +1009,7 @@ def test_fill_between_interpolate_nan():
     y1 = np.asarray([8, 18, np.nan, 18, 8, 18, 24, 18, 8, 18])
     y2 = np.asarray([18, 11, 8, 11, 18, 26, 32, 30, np.nan, np.nan])
 
-    # numpy 1.16 issues warning 'invalid value encountered in greater_equal'
+    # NumPy <1.19 issues warning 'invalid value encountered in greater_equal'
     # for comparisons that include nan.
     with np.errstate(invalid='ignore'):
         greater2 = y2 >= y1

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -2,7 +2,7 @@
 
 cycler==0.10
 kiwisolver==1.0.1
-numpy==1.16.0
+numpy==1.17.0
 pillow==6.2.0
 pyparsing==2.2.1
 python-dateutil==2.7

--- a/setup.py
+++ b/setup.py
@@ -305,14 +305,14 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
     setup_requires=[
         "certifi>=2020.06.20",
-        "numpy>=1.16",
+        "numpy>=1.17",
         "setuptools_scm>=4",
         "setuptools_scm_git_archive",
     ],
     install_requires=[
         "cycler>=0.10",
         "kiwisolver>=1.0.1",
-        "numpy>=1.16",
+        "numpy>=1.17",
         "pillow>=6.2.0",
         "pyparsing>=2.2.1",
         "python-dateutil>=2.7",


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).