### PR TITLE
DOC: Fix numpydoc syntax, and parameters names.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6077,7 +6077,7 @@ default: :rc:`scatter.edgecolors`
         snap : bool, default: False
             Whether to snap the mesh to pixel boundaries.
 
-        rasterized: bool, optional
+        rasterized : bool, optional
             Rasterize the pcolormesh when drawing vector graphics.  This can
             speed up rendering and produce smaller files for large data sets.
             See also :doc:`/gallery/misc/rasterization_demo`.

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -124,7 +124,7 @@ class StrCategoryLocator(ticker.Locator):
     def __init__(self, units_mapping):
         """
         Parameters
-        -----------
+        ----------
         units_mapping : dict
             Mapping of category names (str) to indices (int).
         """

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -345,7 +345,7 @@ def local_over_kwdict(local_var, kwargs, *keys):
     kwargs : dict
         Dictionary of keyword arguments; modified in place.
 
-    keys : str(s)
+    *keys : str(s)
         Name(s) of keyword arguments to process, in descending order of
         priority.
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1291,7 +1291,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
 
         Parameters
         ----------
-        x, y: float
+        x, y : float
             The reference point.
         indices : list of int or None, default: None
             Indices of contour levels to consider.  If None (the default), all

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -187,10 +187,6 @@ def detrend_linear(y):
     y : 0-D or 1-D array or sequence
         Array or sequence containing the data
 
-    axis : int
-        The axis along which to take the mean.  See numpy.mean for a
-        description of this argument.
-
     See Also
     --------
     detrend_mean : Another detrend algorithm.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -320,7 +320,7 @@ class Patch(artist.Artist):
 
         Parameters
         ----------
-        b : bool or None
+        aa : bool or None
         """
         if aa is None:
             aa = mpl.rcParams['patch.antialiased']


### PR DESCRIPTION
Misc fixes for proper numpydoc parsing, misnamed and non-existing parameters.
