### PR TITLE
Correct minor typos in legend.py and autoscale.py

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -735,7 +735,7 @@ class Legend(Artist):
         # legend items. Each legend item is HPacker packed with
         # legend handleBox and labelBox. handleBox is an instance of
         # offsetbox.DrawingArea which contains legend handle. labelBox
-        # is an instance of offsetbox. TextArea which contains legend
+        # is an instance of offsetbox.TextArea which contains legend
         # text.
 
         text_list = []  # the list of text instances

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -71,7 +71,7 @@ ax[1].set_title("margins(0.2)")
 # `~matplotlib.axes.Axes.use_sticky_edges`.
 # Artists have a property `.Artist.sticky_edges`, and the values of
 # sticky edges can be changed by writing to ``Artist.sticky_edges.x`` or
-# ``.Artist.sticky_edges.y``.
+# ``Artist.sticky_edges.y``.
 #
 # The following example shows how overriding works and when it is needed.
 


### PR DESCRIPTION
## PR Summary
Minor typo correction in doc.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
