### PR TITLE
Fix removal of shared polar axes.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -552,6 +552,8 @@ class Ticker:
     def __init__(self):
         self._locator = None
         self._formatter = None
+        self._locator_is_default = True
+        self._formatter_is_default = True
 
     @property
     def locator(self):
@@ -688,6 +690,38 @@ class Axis(martist.Artist):
 
         self.clear()
         self._set_scale('linear')
+
+    @property
+    def isDefault_majloc(self):
+        return self.major._locator_is_default
+
+    @isDefault_majloc.setter
+    def isDefault_majloc(self, value):
+        self.major._locator_is_default = value
+
+    @property
+    def isDefault_majfmt(self):
+        return self.major._formatter_is_default
+
+    @isDefault_majfmt.setter
+    def isDefault_majfmt(self, value):
+        self.major._formatter_is_default = value
+
+    @property
+    def isDefault_minloc(self):
+        return self.minor._locator_is_default
+
+    @isDefault_minloc.setter
+    def isDefault_minloc(self, value):
+        self.minor._locator_is_default = value
+
+    @property
+    def isDefault_minfmt(self):
+        return self.minor._formatter_is_default
+
+    @isDefault_minfmt.setter
+    def isDefault_minfmt(self, value):
+        self.minor._formatter_is_default = value
 
     # During initialization, Axis objects often create ticks that are later
     # unused; this turns out to be a very slow step.  Instead, use a custom

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -916,33 +916,10 @@ default: %(va)s
             # Set the formatters and locators to be associated with axis
             # (where previously they may have been associated with another
             # Axis instance)
-            #
-            # Because set_major_formatter() etc. force isDefault_* to be False,
-            # we have to manually check if the original formatter was a
-            # default and manually set isDefault_* if that was the case.
-            majfmt = axis.get_major_formatter()
-            isDefault = majfmt.axis.isDefault_majfmt
-            axis.set_major_formatter(majfmt)
-            if isDefault:
-                majfmt.axis.isDefault_majfmt = True
-
-            majloc = axis.get_major_locator()
-            isDefault = majloc.axis.isDefault_majloc
-            axis.set_major_locator(majloc)
-            if isDefault:
-                majloc.axis.isDefault_majloc = True
-
-            minfmt = axis.get_minor_formatter()
-            isDefault = majloc.axis.isDefault_minfmt
-            axis.set_minor_formatter(minfmt)
-            if isDefault:
-                minfmt.axis.isDefault_minfmt = True
-
-            minloc = axis.get_minor_locator()
-            isDefault = majloc.axis.isDefault_minloc
-            axis.set_minor_locator(minloc)
-            if isDefault:
-                minloc.axis.isDefault_minloc = True
+            axis.get_major_formatter().set_axis(axis)
+            axis.get_major_locator().set_axis(axis)
+            axis.get_minor_formatter().set_axis(axis)
+            axis.get_minor_locator().set_axis(axis)
 
         def _break_share_link(ax, grouper):
             siblings = grouper.get_siblings(ax)

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -425,6 +425,9 @@ class RadialLocator(mticker.Locator):
         self.base = base
         self._axes = axes
 
+    def set_axis(self, axis):
+        self.base.set_axis(axis)
+
     def __call__(self):
         # Ensure previous behaviour with full circle non-annular views.
         if self._axes:

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -379,3 +379,18 @@ def test_axvspan():
     ax = plt.subplot(projection="polar")
     span = plt.axvspan(0, np.pi/4)
     assert span.get_path()._interpolation_steps > 1
+
+
+@check_figures_equal(extensions=["png"])
+def test_remove_shared_polar(fig_ref, fig_test):
+    # Removing shared polar axes used to crash.  Test removing them, keeping in
+    # both cases just the lower left axes of a grid to avoid running into a
+    # separate issue (now being fixed) of ticklabel visibility for shared axes.
+    axs = fig_ref.subplots(
+        2, 2, sharex=True, subplot_kw={"projection": "polar"})
+    for i in [0, 1, 3]:
+        axs.flat[i].remove()
+    axs = fig_test.subplots(
+        2, 2, sharey=True, subplot_kw={"projection": "polar"})
+    for i in [0, 1, 3]:
+        axs.flat[i].remove()


### PR DESCRIPTION
There's really two separate fixes here:

- Move isDefault_{maj,min}{loc,fmt} tracking to the Ticker instances,
  where they logically belong (note the previous need to additionally
  track them manually on axes removal, when that info was tracked on
  the Axis).  This has the side effect of fixing removal of sharex'd
  polar axes, as ThetaLocators rely on _AxisWrappers which don't have
  that isDefault attribute.  (Note that the patch would have resulted
  in a net decrease of lines of code if it didn't need to maintain
  backcompat on isDefault_foos).  Closes #19988.  Split out of #13482.

- Ensure that RadialLocator correctly propagates Axis information to
  the linear locator it wraps (consistently with ThetaLocator), so that
  when an axes is removed the wrapped linear locator doesn't stay
  pointing at an obsolete axes.  This, together with the first patch,
  fixes removal of sharey'd polar axes.  Closes #19989.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
