### PR TITLE
Fix default theta tick locations for non-full-circle polar plots.

### DIFF
--- a/doc/api/next_api_changes/behavior/20012-AL.rst
+++ b/doc/api/next_api_changes/behavior/20012-AL.rst
@@ -1,0 +1,5 @@
+Default theta tick locations for non-full-circle polar plots have changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For polar plots that don't cover a full circle, the default theta tick
+locations are now at multiples of 10°, 15°, 30°, 45°, 90°, rather than using
+values that mostly make sense for linear plots (20°, 25°, etc.).

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -393,6 +393,10 @@ class ThetaAxis(maxis.XAxis):
             raise NotImplementedError(
                 "The xscale cannot be set on a polar plot")
         super()._set_scale(value, **kwargs)
+        # LinearScale.set_default_locators_and_formatters just set the major
+        # locator to be an AutoLocator, so we customize it here to have ticks
+        # at sensible degree multiples.
+        self.get_major_locator().set_params(steps=[1, 1.5, 3, 4.5, 9, 10])
         self._wrap_locator_formatter()
 
     def _copy_tick_props(self, src, dest):

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -249,6 +249,8 @@ def test_polar_theta_limits():
                            direction=DIRECTIONS[i % len(DIRECTIONS)],
                            rotation='auto')
             ax.yaxis.set_tick_params(label2On=True, rotation='auto')
+            ax.xaxis.get_major_locator().base.set_params(  # backcompat
+                steps=[1, 2, 2.5, 5, 10])
 
 
 @check_figures_equal(extensions=["png"])
@@ -357,3 +359,17 @@ def test_thetalim_args():
     assert tuple(np.radians((ax.get_thetamin(), ax.get_thetamax()))) == (0, 1)
     ax.set_thetalim((2, 3))
     assert tuple(np.radians((ax.get_thetamin(), ax.get_thetamax()))) == (2, 3)
+
+
+def test_default_thetalocator():
+    # Ideally we would check AAAABBC, but the smallest axes currently puts a
+    # single tick at 150° because MaxNLocator doesn't have a way to accept 15°
+    # while rejecting 150°.
+    fig, axs = plt.subplot_mosaic(
+        "AAAABB.", subplot_kw={"projection": "polar"})
+    for ax in axs.values():
+        ax.set_thetalim(0, np.pi)
+    for ax in axs.values():
+        ticklocs = np.degrees(ax.xaxis.get_majorticklocs()).tolist()
+        assert pytest.approx(90) in ticklocs
+        assert pytest.approx(100) not in ticklocs


### PR DESCRIPTION
Currently, non-full-circle polar plots may (depending on the axes size)
put theta ticks at positions that make sense for linear plots, but are a
bit weird for polar plots (e.g. 50° or 25°).  Instead, prefer "standard"
angles (90°, 45°, 30°, 15°, 10°).  For really small axes, there's still
a problem because a single tick may end up at 150°, but fixing the
machinery to allow 15° while rejecting 150° would be trickier.
(Likewise, really thin slivers likely want ticks at 0.5° steps rather
than 0.45° :/)

```python
from pylab import *
for ax in gcf().subplot_mosaic("AAAABBC", subplot_kw={"projection": "polar"}).values(): ax.set_thetalim(0, np.pi)
```
before:
![old](https://user-images.githubusercontent.com/1322974/115142817-124a1f80-a044-11eb-8774-97474fa08c34.png)
after:
![new](https://user-images.githubusercontent.com/1322974/115142814-10805c00-a044-11eb-8d8b-fb183db25cb3.png)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
