### PR TITLE
Move restriction of polar theta scales to ThetaAxis._set_scale.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -389,6 +389,9 @@ class ThetaAxis(maxis.XAxis):
         self.clear()
 
     def _set_scale(self, value, **kwargs):
+        if value != 'linear':
+            raise NotImplementedError(
+                "The xscale cannot be set on a polar plot")
         super()._set_scale(value, **kwargs)
         self._wrap_locator_formatter()
 
@@ -1390,11 +1393,6 @@ class PolarAxes(Axes):
         for t in self.yaxis.get_ticklabels():
             t.update(kwargs)
         return self.yaxis.get_gridlines(), self.yaxis.get_ticklabels()
-
-    def set_xscale(self, scale, *args, **kwargs):
-        if scale != 'linear':
-            raise NotImplementedError(
-                "You can not set the xscale on a polar plot.")
 
     def format_coord(self, theta, r):
         # docstring inherited


### PR DESCRIPTION
This ensures that there's a single place handling the restriction of
theta scales, which makes it simpler to follow (otherwise, in
ThetaAxis._set_scale, it's not clear what values can be taken by
`value`).

(see e.g. https://github.com/matplotlib/matplotlib/pull/20012/files#diff-f883675cd20e3f5e0f3c82d72bee7fc65253dea7cf2397e662551fdade5cd157R393)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
