### PR TITLE
ENH: constrained_layout simple compress axes

### DIFF
--- a/lib/matplotlib/_layoutgrid.py
+++ b/lib/matplotlib/_layoutgrid.py
@@ -120,7 +120,9 @@ class LayoutGrid:
                        f'innerW{self.inner_widths[j].value():1.3f}, ' \
                        f'innerH{self.inner_heights[i].value():1.3f}, ' \
                        f'ML{self.margins["left"][j].value():1.3f}, ' \
-                       f'MR{self.margins["right"][j].value():1.3f}, \n'
+                       f'MR{self.margins["right"][j].value():1.3f}, ' \
+                       f'MB{self.margins["bottom"][j].value():1.3f}, ' \
+                       f'MT{self.margins["top"][j].value():1.3f}, \n'
         return str
 
     def reset_margins(self):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2449,6 +2449,10 @@ class Figure(FigureBase):
             Height padding between subplots, expressed as a fraction of the
             subplot width. The total padding ends up being h_pad + hspace.
 
+        compress : boolean
+            Try to compress axes in constrained layout.  Useful when
+            axes aspect ratios make it so that there is substantial
+            white space between them.
         """
 
         todo = ['w_pad', 'h_pad', 'wspace', 'hspace']
@@ -2458,6 +2462,8 @@ class Figure(FigureBase):
             else:
                 self._constrained_layout_pads[td] = (
                     mpl.rcParams['figure.constrained_layout.' + td])
+        self._constrained_layout_pads['compress'] = (
+            kwargs.get('compress', False))
 
     def get_constrained_layout_pads(self, relative=False):
         """
@@ -2477,6 +2483,7 @@ class Figure(FigureBase):
         h_pad = self._constrained_layout_pads['h_pad']
         wspace = self._constrained_layout_pads['wspace']
         hspace = self._constrained_layout_pads['hspace']
+        compress = self._constrained_layout_pads['compress']
 
         if relative and (w_pad is not None or h_pad is not None):
             renderer0 = layoutgrid.get_renderer(self)
@@ -2484,7 +2491,7 @@ class Figure(FigureBase):
             w_pad = w_pad * dpi / renderer0.width
             h_pad = h_pad * dpi / renderer0.height
 
-        return w_pad, h_pad, wspace, hspace
+        return w_pad, h_pad, wspace, hspace, compress
 
     def set_canvas(self, canvas):
         """
@@ -3073,7 +3080,7 @@ class Figure(FigureBase):
                                "or you need to call figure or subplots "
                                "with the constrained_layout=True kwarg.")
             return
-        w_pad, h_pad, wspace, hspace = self.get_constrained_layout_pads()
+        w_pad, h_pad, wspace, hspace, comp = self.get_constrained_layout_pads()
         # convert to unit-relative lengths
         fig = self
         width, height = fig.get_size_inches()
@@ -3081,7 +3088,8 @@ class Figure(FigureBase):
         h_pad = h_pad / height
         if renderer is None:
             renderer = _get_renderer(fig)
-        do_constrained_layout(fig, renderer, h_pad, w_pad, hspace, wspace)
+        do_constrained_layout(fig, renderer, h_pad, w_pad, hspace, wspace,
+                              compress=comp)
 
     def tight_layout(self, *, pad=1.08, h_pad=None, w_pad=None, rect=None):
         """

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -20,16 +20,17 @@ def example_plot(ax, fontsize=12, nodec=False):
         ax.set_yticklabels('')
 
 
-def example_pcolor(ax, fontsize=12):
+def example_pcolor(ax, fontsize=12, hide_labels=False):
     dx, dy = 0.6, 0.6
     y, x = np.mgrid[slice(-3, 3 + dy, dy),
                     slice(-3, 3 + dx, dx)]
     z = (1 - x / 2. + x ** 5 + y ** 3) * np.exp(-x ** 2 - y ** 2)
     pcm = ax.pcolormesh(x, y, z[:-1, :-1], cmap='RdBu_r', vmin=-1., vmax=1.,
                         rasterized=True)
-    ax.set_xlabel('x-label', fontsize=fontsize)
-    ax.set_ylabel('y-label', fontsize=fontsize)
-    ax.set_title('Title', fontsize=fontsize)
+    if not hide_labels:
+        ax.set_xlabel('x-label', fontsize=fontsize)
+        ax.set_ylabel('y-label', fontsize=fontsize)
+        ax.set_title('Title', fontsize=fontsize)
     return pcm
 
 
@@ -555,3 +556,34 @@ def test_align_labels():
                                after_align[1].x0, rtol=0, atol=1e-05)
     # ensure labels do not go off the edge
     assert after_align[0].x0 >= 1
+
+
+def test_compressed1():
+    fig, axs = plt.subplots(3, 2, constrained_layout={'compress': True},
+                            sharex=True, sharey=True)
+    for ax in axs.flat:
+        pc = ax.imshow(np.random.randn(20, 20))
+
+    fig.colorbar(pc, ax=axs)
+    fig.draw_no_output()
+
+    pos = axs[0, 0].get_position()
+    np.testing.assert_allclose(pos.x0, 0.2244, atol=1e-3)
+    pos = axs[0, 1].get_position()
+    np.testing.assert_allclose(pos.x1, 0.6925, atol=1e-3)
+
+    # wider than tall
+    fig, axs = plt.subplots(2, 3, constrained_layout={'compress': True},
+                            sharex=True, sharey=True, figsize=(5, 4))
+    for ax in axs.flat:
+        pc = ax.imshow(np.random.randn(20, 20))
+
+    fig.colorbar(pc, ax=axs)
+    fig.draw_no_output()
+
+    pos = axs[0, 0].get_position()
+    np.testing.assert_allclose(pos.x0, 0.06195, atol=1e-3)
+    np.testing.assert_allclose(pos.y1, 0.8413, atol=1e-3)
+    pos = axs[1, 2].get_position()
+    np.testing.assert_allclose(pos.x1, 0.832587, atol=1e-3)
+    np.testing.assert_allclose(pos.y0, 0.205377, atol=1e-3)

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -52,6 +52,7 @@ clipped.
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import matplotlib.gridspec as gridspec
+from matplotlib.tests.test_constrainedlayout import example_pcolor
 import numpy as np
 
 plt.rcParams['savefig.facecolor'] = "0.8"
@@ -230,8 +231,67 @@ fig.savefig('../../doc/_static/constrained_layout_2b.png',
 #    :align: center
 #
 
+##############################################################################
+# Grids of fixed-aspect axes
+# ==========================
+#
+# Often we want to layout axes with fixed-aspect ratios. This adds an extra
+# constraint to the layout problem, which by default is solved by leaving
+# one dimension with large white space between axes:
+
+fig, axs = plt.subplots(2, 2, constrained_layout=True, figsize=(6, 3))
+for ax in axs.flat:
+    pc = example_pcolor(ax, hide_labels=True)
+    ax.set_aspect(1)
+fig.colorbar(pc, ax=axs)
+fig.suptitle('Fixed-aspect axes')
+
+##################################
+# Now, we could change the size of the figure manually to improve the
+# whitespace, but that requires manual intervention.
+# To address this, we can set ``constrained_layout`` to "compress" the
+# axes:
+fig, axs = plt.subplots(2, 2, constrained_layout={'compress': True},
+                        figsize=(6, 3), sharex=True, sharey=True)
+for ax in axs.flat:
+    pc = example_pcolor(ax, hide_labels=True)
+    ax.set_aspect(1)
+fig.colorbar(pc, ax=axs)
+fig.suptitle('Fixed-aspect axes')
+
+###################################
+# Note this works in the vertical direction as well, though the
+# suptitle stays at the top of the plot:
+fig, axs = plt.subplots(2, 2, constrained_layout={'compress': True},
+                        figsize=(3, 5), sharex=True, sharey=True)
+for ax in axs.flat:
+    pc = example_pcolor(ax, hide_labels=True)
+    ax.set_aspect(1)
+fig.colorbar(pc, ax=axs)
+fig.suptitle('Fixed-aspect axes')
+
+###################################
+# Note if only one row of axes have a fixed aspect, there can still be
+# the need for manually adjusting the figure size, however, in this case
+# widening the figure will make the layout look good again (not shown here)
+
+fig, axs = plt.subplots(2, 2, constrained_layout={'compress': True},
+                        figsize=(4, 6), sharex=True, sharey=True)
+for i in range(2):
+    for j in range(2):
+        ax = axs[i, j]
+        pc = example_pcolor(ax, hide_labels=True)
+        if i == 0:
+            ax.set_title('asp=1')
+            ax.set_aspect(1)
+        else:
+            ax.set_title('asp="auto"')
+fig.colorbar(pc, ax=axs)
+fig.suptitle('Fixed-aspect axes')
+plt.show()
+
 ###############################################################################
-# Padding and Spacing
+# Padding and spacing
 # ===================
 #
 # Padding between axes is controlled in the horizontal by *w_pad* and


### PR DESCRIPTION
## PR Summary

We often have the situation where we have a grid of fixed-aspect axes, and they end up with too much space in one direction or the other:

![CompressFalse](https://user-images.githubusercontent.com/1562854/115167452-86002280-a06c-11eb-94a1-5786b60ac3b8.png)

For simple cases, it is not hard to fix this, as is done with this PR:

![CompressTrue](https://user-images.githubusercontent.com/1562854/115167474-9912f280-a06c-11eb-8372-e64981c5988f.png)

### API:

As with previous efforts at doing this the  API is a bit klunky, but I think it needs to be optional so we need something.

```python
import matplotlib.pyplot as plt
import numpy as np

nrows = 2
ncols = 3
for compress in [False, True]:
    fig, axs = plt.subplots( nrows, ncols, figsize=(4,4),
                            constrained_layout={'compress':compress}, 
                            sharex=True, sharey=True)
    fig.patch.set_facecolor("0.9")
    #fig.set_constrained_layout_pads(compress=True)

    for i in range(nrows):
        for j in range(ncols):
            ax = axs[i, j]
            ax.set_aspect(1)
            pc = ax.pcolormesh(np.random.randn(30, 30))
    fig.colorbar(pc, ax=axs)
    fig.savefig(f'/Users/jklymak/downloads/Compress{compress}.png', dpi=100)
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
