### PR TITLE
For polar plots, report cursor position with correct precision.

### DIFF
--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -410,3 +410,17 @@ def test_axvline_axvspan_do_not_modify_rlims():
     ax.axvline(.5)
     ax.plot([.1, .2])
     assert ax.get_ylim() == (0, .2)
+
+
+def test_cursor_precision():
+    ax = plt.subplot(projection="polar")
+    # Higher radii correspond to higher theta-precisions.
+    assert ax.format_coord(0, 0) == "θ=0π (0°), r=0.000"
+    assert ax.format_coord(0, .1) == "θ=0.00π (0°), r=0.100"
+    assert ax.format_coord(0, 1) == "θ=0.000π (0.0°), r=1.000"
+    assert ax.format_coord(1, 0) == "θ=0.3π (57°), r=0.000"
+    assert ax.format_coord(1, .1) == "θ=0.32π (57°), r=0.100"
+    assert ax.format_coord(1, 1) == "θ=0.318π (57.3°), r=1.000"
+    assert ax.format_coord(2, 0) == "θ=0.6π (115°), r=0.000"
+    assert ax.format_coord(2, .1) == "θ=0.64π (115°), r=0.100"
+    assert ax.format_coord(2, 1) == "θ=0.637π (114.6°), r=1.000"


### PR DESCRIPTION
... similar to what's done for cartesian plots since #16776 (in
ScalarFormatter.format_data_short).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
