### PR TITLE
Simplify _redo_transform_rel_fig.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2011,42 +2011,23 @@ class SubFigure(FigureBase):
             If not None, then the bbox is used for relative bounding box.
             Otherwise it is calculated from the subplotspec.
         """
-
         if bbox is not None:
             self.bbox_relative.p0 = bbox.p0
             self.bbox_relative.p1 = bbox.p1
             return
-
-        gs = self._subplotspec.get_gridspec()
         # need to figure out *where* this subplotspec is.
-        wr = gs.get_width_ratios()
-        hr = gs.get_height_ratios()
-        nrows, ncols = gs.get_geometry()
-        if wr is None:
-            wr = np.ones(ncols)
-        else:
-            wr = np.array(wr)
-        if hr is None:
-            hr = np.ones(nrows)
-        else:
-            hr = np.array(hr)
-        widthf = np.sum(wr[self._subplotspec.colspan]) / np.sum(wr)
-        heightf = np.sum(hr[self._subplotspec.rowspan]) / np.sum(hr)
-
-        x0 = 0
-        if not self._subplotspec.is_first_col():
-            x0 += np.sum(wr[:self._subplotspec.colspan.start]) / np.sum(wr)
-
-        y0 = 0
-        if not self._subplotspec.is_last_row():
-            y0 += 1 - (np.sum(hr[:self._subplotspec.rowspan.stop]) /
-                       np.sum(hr))
-
+        gs = self._subplotspec.get_gridspec()
+        wr = np.asarray(gs.get_width_ratios())
+        hr = np.asarray(gs.get_height_ratios())
+        dx = wr[self._subplotspec.colspan].sum() / wr.sum()
+        dy = hr[self._subplotspec.rowspan].sum() / hr.sum()
+        x0 = wr[:self._subplotspec.colspan.start].sum() / wr.sum()
+        y0 = 1 - hr[:self._subplotspec.rowspan.stop].sum() / hr.sum()
         if self.bbox_relative is None:
-            self.bbox_relative = Bbox.from_bounds(x0, y0, widthf, heightf)
+            self.bbox_relative = Bbox.from_bounds(x0, y0, dx, dy)
         else:
             self.bbox_relative.p0 = (x0, y0)
-            self.bbox_relative.p1 = (x0 + widthf, y0 + heightf)
+            self.bbox_relative.p1 = (x0 + dx, y0 + dy)
 
     def get_constrained_layout(self):
         """


### PR DESCRIPTION
- width_ratios and height_ratios are never None (None gets normalized to
  [1, 1, ...] in the setters).
- We don't need to separately handle the `is_first_row()/is_last_col()`
  cases (the sums will evaluate to 0/1 as needed).
- Naming the width/height dx/dy makes everything line up neatly.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
