### PR TITLE
DOC: move third-party packages to new page

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -18,7 +18,7 @@ Overview
    faq/index.rst
    api/index.rst
    resources/index.rst
-   thirdpartypackages/index.rst
+   Third-party packages <https://matplotlib.org/mpl-third-party/>
    devel/index.rst
 
 .. only:: html

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -290,12 +290,12 @@ Including figures and files
 ---------------------------
 
 Image files can directly included in pages with the ``image::`` directive.
-e.g., :file:`thirdpartypackages/index.rst` displays the images for the third-party
-packages as static images::
+e.g., :file:`tutorials/intermediate/constrainedlayout_guide.py` displays 
+a couple of images as static images::
 
-    .. image:: /_static/toolbar.png
+  # .. image:: /_static/constrained_layout_1b.png
+  #    :align: center
 
-as rendered on the page: :ref:`thirdparty-index`.
 
 Files can be included verbatim.  For instance the ``LICENSE`` file is included
 at :ref:`license-agreement` using ::

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -291,7 +291,7 @@ Including figures and files
 
 Image files can directly included in pages with the ``image::`` directive.
 e.g., :file:`tutorials/intermediate/constrainedlayout_guide.py` displays 
-a couple of images as static images::
+a couple of static images::
 
   # .. image:: /_static/constrained_layout_1b.png
   #    :align: center

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -61,7 +61,7 @@ Matplotlib makes easy things easy and hard things possible.
       Extend
 
       - Explore tailored functionality provided by
-        :doc:`third party packages <thirdpartypackages/index>`
+        `third party packages <https://matplotlib.org/mpl-third-party/>`_
       - Learn more about Matplotlib through the many
         :doc:`external learning resources <resources/index>`
 
@@ -160,7 +160,8 @@ helpers in `.axisartist`.
 Third party packages
 ====================
 
-A large number of :doc:`third party packages <thirdpartypackages/index>`
+A large number of 
+`third party packages <https://matplotlib.org/mpl-third-party/>`_
 extend and build on Matplotlib functionality, including several higher-level
 plotting interfaces (seaborn_, HoloViews_, ggplot_, ...), and a projection
 and mapping toolkit (Cartopy_).

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -2,7 +2,7 @@
 
 .. note:: 
 
-    This page has been moved to <https://matplotlib.org/mpl-third-party> 
+    This page has been moved to <https://matplotlib.org/mpl-third-party>, 
     where you will find an up-to-date list of packages.  
 
 

--- a/doc/thirdpartypackages/index.rst
+++ b/doc/thirdpartypackages/index.rst
@@ -1,4 +1,10 @@
-.. _thirdparty-index:
+:orphan:
+
+.. note:: 
+
+    This page has been moved to <https://matplotlib.org/mpl-third-party> 
+    where you will find an up-to-date list of packages.  
+
 
 ********************
 Third party packages


### PR DESCRIPTION
## PR Summary

We now have a lighter third-party page at https://matplotlib.org/mpl-third-party that we hope will have a lower bar to entry than the current page (https://matplotlib.org/stable/thirdpartypackages/index.html).  This PR moves the page.  



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
