### PR TITLE
Fix axvspan for drawing slices on polar plots.

### DIFF
--- a/doc/api/next_api_changes/behavior/20027-AL.rst
+++ b/doc/api/next_api_changes/behavior/20027-AL.rst
@@ -1,0 +1,3 @@
+``axvspan`` now plots full wedges in polar plots
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... rather than triangles.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -974,6 +974,7 @@ class Axes(_AxesBase):
         verts = [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)]
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(self.get_xaxis_transform(which="grid"))
+        p.get_path()._interpolation_steps = 100
         self.add_patch(p)
         self._request_autoscale_view(scaley=False)
         return p

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -373,3 +373,9 @@ def test_default_thetalocator():
         ticklocs = np.degrees(ax.xaxis.get_majorticklocs()).tolist()
         assert pytest.approx(90) in ticklocs
         assert pytest.approx(100) not in ticklocs
+
+
+def test_axvspan():
+    ax = plt.subplot(projection="polar")
+    span = plt.axvspan(0, np.pi/4)
+    assert span.get_path()._interpolation_steps > 1


### PR DESCRIPTION
There's already special-casing for polar plots in bar() (using the same
`_interpolation_steps = 100`); it seems reasonable to use the same
approach for axvspan (e.g. `polar(); axvspan(0, pi/4)`).

It seems like making axhspan work (basically drawing full rings) is less
easy, but there's an easy enough workaround
(`polar(); bar(0, bottom=1, height=1, width=2*pi)`) as the "x" (theta)
extent is actually known in that case.

`plt.polar(); plt.axvspan(np.pi/4, np.pi/2)`
before:
![old](https://user-images.githubusercontent.com/1322974/115456626-ac1bf300-a223-11eb-8a2b-0250c9f12ee5.png)
after:
![new](https://user-images.githubusercontent.com/1322974/115456635-afaf7a00-a223-11eb-8571-8ca19f56ce0d.png)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
