### PR TITLE
Shorten the repr of scaling transforms.

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -508,14 +508,8 @@ CompositeGenericTransform(
                     IdentityTransform(),
                     IdentityTransform())),
             CompositeAffine2D(
-                Affine2D(
-                    [[1. 0. 0.]
-                     [0. 1. 0.]
-                     [0. 0. 1.]]),
-                Affine2D(
-                    [[1. 0. 0.]
-                     [0. 1. 0.]
-                     [0. 0. 1.]]))),
+                Affine2D().scale(1.0),
+                Affine2D().scale(1.0))),
         PolarTransform(
             PolarAxesSubplot(0.125,0.1;0.775x0.8),
             use_rmin=True,
@@ -537,14 +531,8 @@ CompositeGenericTransform(
                     TransformedBbox(
                         Bbox(x0=0.0, y0=0.0, x1=6.283185307179586, y1=1.0),
                         CompositeAffine2D(
-                            Affine2D(
-                                [[1. 0. 0.]
-                                 [0. 1. 0.]
-                                 [0. 0. 1.]]),
-                            Affine2D(
-                                [[1. 0. 0.]
-                                 [0. 1. 0.]
-                                 [0. 0. 1.]]))),
+                            Affine2D().scale(1.0),
+                            Affine2D().scale(1.0))),
                     LockableBbox(
                         Bbox(x0=0.0, y0=0.0, x1=6.283185307179586, y1=1.0),
                         [[-- --]
@@ -555,10 +543,7 @@ CompositeGenericTransform(
                 BboxTransformTo(
                     TransformedBbox(
                         Bbox(x0=0.0, y0=0.0, x1=8.0, y1=6.0),
-                        Affine2D(
-                            [[80.  0.  0.]
-                             [ 0. 80.  0.]
-                             [ 0.  0.  1.]])))))))"""
+                        Affine2D().scale(80.0)))))))"""
 
 
 def test_transform_single_point():

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1887,7 +1887,14 @@ class Affine2D(Affine2DBase):
         self._mtx = matrix.copy()
         self._invalid = 0
 
-    __str__ = _make_str_method("_mtx")
+    _base_str = _make_str_method("_mtx")
+
+    def __str__(self):
+        return (self._base_str()
+                if (self._mtx != np.diag(np.diag(self._mtx))).any()
+                else f"Affine2D().scale({self._mtx[0, 0]}, {self._mtx[1, 1]})"
+                if self._mtx[0, 0] != self._mtx[1, 1]
+                else f"Affine2D().scale({self._mtx[0, 0]})")
 
     @staticmethod
     def from_values(a, b, c, d, e, f):


### PR DESCRIPTION
Scaling transforms (with just nonzero diagonal terms) are quite common,
and special-casing them makes many transform reprs shorter, helping with
debugging.  See e.g. changes in the test_transforms reference output.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
