### PR TITLE
Cleanup widget examples

### DIFF
--- a/examples/widgets/cursor.py
+++ b/examples/widgets/cursor.py
@@ -12,8 +12,7 @@ import matplotlib.pyplot as plt
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-fig = plt.figure(figsize=(8, 6))
-ax = fig.add_subplot(facecolor='#FFFFCC')
+fig, ax = plt.subplots(figsize=(8, 6))
 
 x, y = 4*(np.random.rand(2, 100) - .5)
 ax.plot(x, y, 'o')

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -14,28 +14,27 @@ from matplotlib.widgets import SpanSelector
 np.random.seed(19680801)
 
 fig, (ax1, ax2) = plt.subplots(2, figsize=(8, 6))
-ax1.set(facecolor='#FFFFCC')
 
 x = np.arange(0.0, 5.0, 0.01)
 y = np.sin(2*np.pi*x) + 0.5*np.random.randn(len(x))
 
-ax1.plot(x, y, '-')
+ax1.plot(x, y)
 ax1.set_ylim(-2, 2)
-ax1.set_title('Press left mouse button and drag to test')
+ax1.set_title('Press left mouse button and drag '
+              'to select a region in the top graph')
 
-ax2.set(facecolor='#FFFFCC')
-line2, = ax2.plot(x, y, '-')
+line2, = ax2.plot([], [])
 
 
 def onselect(xmin, xmax):
     indmin, indmax = np.searchsorted(x, (xmin, xmax))
     indmax = min(len(x) - 1, indmax)
 
-    thisx = x[indmin:indmax]
-    thisy = y[indmin:indmax]
-    line2.set_data(thisx, thisy)
-    ax2.set_xlim(thisx[0], thisx[-1])
-    ax2.set_ylim(thisy.min(), thisy.max())
+    region_x = x[indmin:indmax]
+    region_y = y[indmin:indmax]
+    line2.set_data(region_x, region_y)
+    ax2.set_xlim(region_x[0], region_x[-1])
+    ax2.set_ylim(region_y.min(), region_y.max())
     fig.canvas.draw()
 
 #############################################################################
@@ -47,7 +46,7 @@ def onselect(xmin, xmax):
 
 
 span = SpanSelector(ax1, onselect, 'horizontal', useblit=True,
-                    rectprops=dict(alpha=0.5, facecolor='red'))
+                    rectprops=dict(alpha=0.5, facecolor='tab:blue'))
 # Set useblit=True on most backends for enhanced performance.
 
 


### PR DESCRIPTION
## PR Summary

- don't use 90ish background color. The default style is good enough (actually better IMHO).
- In the span selector:
  - `'-'` is the default style. We don't need to specify it explicitly.
  - It's more logical that the bottom "selected region" plot is empty at the beginning, when nothing has been selected so far.
  - Use blue as a selection color (Nicer appearance IMHO)
  - Some variable renaming.