### PR TITLE
Deprecation warning

### DIFF
--- a/doc/api/next_api_changes/behavior/20046-BB.rst
+++ b/doc/api/next_api_changes/behavior/20046-BB.rst
@@ -1,0 +1,25 @@
+``MatplotlibDeprecationWarning`` now subclasses ``DeprecationWarning``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historically, it has not been possible to filter
+``MatplotlibDeprecationWarning``\s by checking for ``DeprecationWarning``,
+since we subclass ``UserWarning`` directly.
+
+The decision to not subclass DeprecationWarning has to do with a decision from
+core Python in the 2.x days to not show DeprecationWarnings to users. However,
+there is now a more sophisticated filter in place (see
+https://www.python.org/dev/peps/pep-0565/).
+
+Users will now see ``MatplotlibDeprecationWarning`` only during interactive
+sessions, and these can be silenced by the standard mechanism:
+
+.. code:: python
+
+	warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+Library authors must now enable ``DeprecationWarning``\s explicitly in order
+for (non-interactive) CI/CD pipelines to report back these warnings, as is
+standard for the rest of the Python ecosystem:
+
+.. code:: python
+
+	warnings.filterwarnings("always", DeprecationWarning)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,6 @@ import sys
 import warnings
 
 import matplotlib
-from matplotlib._api import MatplotlibDeprecationWarning
 import sphinx
 
 from datetime import datetime
@@ -117,7 +116,7 @@ autosummary_generate = True
 
 # we should ignore warnings coming from importing deprecated modules for
 # autodoc purposes, as this will disappear automatically when they are removed
-warnings.filterwarnings('ignore', category=MatplotlibDeprecationWarning,
+warnings.filterwarnings('ignore', category=DeprecationWarning,
                         module='importlib',  # used by sphinx.autodoc.importer
                         message=r'(\n|.)*module was deprecated.*')
 
@@ -126,7 +125,7 @@ autodoc_default_options = {'members': None, 'undoc-members': None}
 
 # make sure to ignore warnings that stem from simply inspecting deprecated
 # class-level attributes
-warnings.filterwarnings('ignore', category=MatplotlibDeprecationWarning,
+warnings.filterwarnings('ignore', category=DeprecationWarning,
                         module='sphinx.util.inspect')
 
 # missing-references names matches sphinx>=3 behavior, so we can't be nitpicky

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -17,7 +17,7 @@ import math
 import warnings
 
 
-class MatplotlibDeprecationWarning(UserWarning):
+class MatplotlibDeprecationWarning(DeprecationWarning):
     """
     A class for issuing deprecation warnings for Matplotlib users.
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -8,6 +8,7 @@ import warnings
 
 import matplotlib as mpl
 from matplotlib import cbook, rcParams
+from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
@@ -15,7 +16,6 @@ from matplotlib.ticker import AutoMinorLocator, FixedFormatter, ScalarFormatter
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 import matplotlib.gridspec as gridspec
-from matplotlib.cbook import MatplotlibDeprecationWarning
 import numpy as np
 import pytest
 
@@ -150,7 +150,7 @@ def test_figure_legend():
 def test_gca():
     fig = plt.figure()
 
-    with pytest.warns(UserWarning):
+    with pytest.warns(MatplotlibDeprecationWarning):
         # empty call to add_axes() will throw deprecation warning
         assert fig.add_axes() is None
 


### PR DESCRIPTION
## PR Summary

We are currently unable to unintrusively deprecate class-level attributes (because we subclass UserWarning and not DeprecationWarning). Based on a previous dev call, we decided the solution was to "do it anyway". This led to a couple of issues, e.g. #19080 and #19839 and #19850. 

The history of the decision to not subclass DeprecationWarning has to do with a decision from core Python in the 2.x days to not show DeprecationWarnings to users. However, there is now a more sophisticated filter in place (see https://www.python.org/dev/peps/pep-0565/). 

Users that want to see MatplotlibDeprecationWarning in their CI will now have to `export PYTHONWARNING=d`, launch python with `-Wa`, or use warning filters to enable DeprecationWarnings (or MatplotlibDeprecationWarning specifically, depending on their needs).


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
