### PR TITLE
Remove offsetbox APIs deprecated in Matplotlib 3.3.

### DIFF
--- a/doc/api/next_api_changes/removals/20051-AL.rst
+++ b/doc/api/next_api_changes/removals/20051-AL.rst
@@ -1,0 +1,8 @@
+Removal of deprecated ``offsetbox`` APIs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following APIs were removed:
+
+- the *s* kwarg to `.AnnotationBbox.get_fontsize` (which had no effect),
+- the ``DraggableBase.artist_picker`` method (set the artist's picker instead),
+- the ``DraggableBase.on_motion_blit`` method (use `.DraggableBase.on_motion`
+  instead).

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1478,8 +1478,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         self.prop = FontProperties(size=s)
         self.stale = True
 
-    @_api.delete_parameter("3.3", "s")
-    def get_fontsize(self, s=None):
+    def get_fontsize(self):
         """Return the fontsize in points."""
         return self.prop.get_size_in_points()
 
@@ -1618,22 +1617,15 @@ class DraggableBase:
 
     def __init__(self, ref_artist, use_blit=False):
         self.ref_artist = ref_artist
-        self.got_artist = False
-
-        self.canvas = self.ref_artist.figure.canvas
-        self._use_blit = use_blit and self.canvas.supports_blit
-
-        c2 = self.canvas.mpl_connect('pick_event', self.on_pick)
-        c3 = self.canvas.mpl_connect('button_release_event', self.on_release)
-
         if not ref_artist.pickable():
             ref_artist.set_picker(True)
-        overridden_picker = _api.deprecate_method_override(
-            __class__.artist_picker, self, since="3.3",
-            addendum="Directly set the artist's picker if desired.")
-        if overridden_picker is not None:
-            ref_artist.set_picker(overridden_picker)
-        self.cids = [c2, c3]
+        self.got_artist = False
+        self.canvas = self.ref_artist.figure.canvas
+        self._use_blit = use_blit and self.canvas.supports_blit
+        self.cids = [
+            self.canvas.mpl_connect('pick_event', self.on_pick),
+            self.canvas.mpl_connect('button_release_event', self.on_release),
+        ]
 
     def on_motion(self, evt):
         if self._check_still_parented() and self.got_artist:
@@ -1646,16 +1638,6 @@ class DraggableBase:
                 self.canvas.blit()
             else:
                 self.canvas.draw()
-
-    @_api.deprecated("3.3", alternative="self.on_motion")
-    def on_motion_blit(self, evt):
-        if self._check_still_parented() and self.got_artist:
-            dx = evt.x - self.mouse_x
-            dy = evt.y - self.mouse_y
-            self.update_offset(dx, dy)
-            self.canvas.restore_region(self.background)
-            self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
-            self.canvas.blit()
 
     def on_pick(self, evt):
         if self._check_still_parented() and evt.artist == self.ref_artist:
@@ -1699,10 +1681,6 @@ class DraggableBase:
             pass
         else:
             self.canvas.mpl_disconnect(c1)
-
-    @_api.deprecated("3.3", alternative="self.ref_artist.contains")
-    def artist_picker(self, artist, evt):
-        return self.ref_artist.contains(evt)
 
     def save_offset(self):
         pass


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
