### PR TITLE
Remove axes_grid/axisartist APIs deprecated in Matplotlib 3.3.

### DIFF
--- a/doc/api/next_api_changes/removals/20052-AL.rst
+++ b/doc/api/next_api_changes/removals/20052-AL.rst
@@ -1,0 +1,20 @@
+Removal of ``axes_grid``/``axisartist`` APIs deprecated in Matplotlib 3.3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following deprecated APIs have been removed:
+
+- ``CbarAxesBase.cbid`` and ``CbarAxesBase.locator`` (use
+  ``mappable.colorbar_cid`` and ``colorbar.locator`` instead),
+- the ``add_all`` parameter to ``axes_grid.Grid``, ``axes_grid.ImageGrid``,
+  ``axes_rgb.make_rgb_axes``, ``axes_rgb.RGBAxes`` (the APIs always behave as
+  if ``add_all=True``),
+- ``axes_rgb.imshow_rgb`` (use ``imshow(np.dstack([r, g, b]))`` instead),
+- ``RGBAxes.add_RGB_to_figure`` (no replacement),
+- ``RGBAxesBase`` (use ``RGBAxes`` instead),
+- passing ``None``, or no argument, to ``parasite_axes_class_factory``,
+  ``parasite_axes_auxtrans_class_factory``, ``host_axes_class_factory``
+  (pass an explicit base class instead),
+- the ``den`` parameter and attribute of ``angle_helper.LocatorBase`` (it has
+  been renamed to ``nbins``),
+- ``AxisArtist.dpi_transform`` (no replacement),
+- ``grid_finder.MaxNLocator.set_factor`` and ``grid_finder.FixedLocator.set_factor``
+  (the factor is always 1 now).

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -26,24 +26,13 @@ class CbarAxesBase:
         super().__init__(*args, **kwargs)
 
     def colorbar(self, mappable, *, ticks=None, **kwargs):
-
-        if self.orientation in ["top", "bottom"]:
-            orientation = "horizontal"
-        else:
-            orientation = "vertical"
-
+        orientation = (
+            "horizontal" if self.orientation in ["top", "bottom"] else
+            "vertical")
         cb = mpl.colorbar.Colorbar(
             self, mappable, orientation=orientation, ticks=ticks, **kwargs)
-        self._cbid = mappable.colorbar_cid  # deprecated in 3.3.
-        self._locator = cb.locator  # deprecated in 3.3.
-
         self._config_axes()
         return cb
-
-    cbid = _api.deprecate_privatize_attribute(
-        "3.3", alternative="mappable.colorbar_cid")
-    locator = _api.deprecate_privatize_attribute(
-        "3.3", alternative=".colorbar().locator")
 
     def _config_axes(self):
         """Make an axes patch and outline."""
@@ -80,20 +69,18 @@ class Grid:
 
     _defaultAxesClass = Axes
 
-    @_api.delete_parameter("3.3", "add_all")
     def __init__(self, fig,
                  rect,
                  nrows_ncols,
                  ngrids=None,
                  direction="row",
                  axes_pad=0.02,
-                 add_all=True,
+                 *,
                  share_all=False,
                  share_x=True,
                  share_y=True,
                  label_mode="L",
                  axes_class=None,
-                 *,
                  aspect=False,
                  ):
         """
@@ -114,9 +101,6 @@ class Grid:
         axes_pad : float or (float, float), default: 0.02
             Padding or (horizontal padding, vertical padding) between axes, in
             inches.
-        add_all : bool, default: True
-            Whether to add the axes to the figure using `.Figure.add_axes`.
-            This parameter is deprecated.
         share_all : bool, default: False
             Whether all axes share their x- and y-axis.  Overrides *share_x*
             and *share_y*.
@@ -188,9 +172,8 @@ class Grid:
 
         self._init_locators()
 
-        if add_all:
-            for ax in self.axes_all:
-                fig.add_axes(ax)
+        for ax in self.axes_all:
+            fig.add_axes(ax)
 
         self.set_label_mode(label_mode)
 
@@ -335,14 +318,13 @@ class ImageGrid(Grid):
 
     _defaultCbarAxesClass = CbarAxes
 
-    @_api.delete_parameter("3.3", "add_all")
     def __init__(self, fig,
                  rect,
                  nrows_ncols,
                  ngrids=None,
                  direction="row",
                  axes_pad=0.02,
-                 add_all=True,
+                 *,
                  share_all=False,
                  aspect=True,
                  label_mode="L",
@@ -372,9 +354,6 @@ class ImageGrid(Grid):
         axes_pad : float or (float, float), default: 0.02in
             Padding or (horizontal padding, vertical padding) between axes, in
             inches.
-        add_all : bool, default: True
-            Whether to add the axes to the figure using `.Figure.add_axes`.
-            This parameter is deprecated.
         share_all : bool, default: False
             Whether all axes share their x- and y-axis.
         aspect : bool, default: True
@@ -409,22 +388,14 @@ class ImageGrid(Grid):
         self._colorbar_size = cbar_size
         # The colorbar axes are created in _init_locators().
 
-        if add_all:
-            super().__init__(
-                fig, rect, nrows_ncols, ngrids,
-                direction=direction, axes_pad=axes_pad,
-                share_all=share_all, share_x=True, share_y=True, aspect=aspect,
-                label_mode=label_mode, axes_class=axes_class)
-        else:  # Only show deprecation in that case.
-            super().__init__(
-                fig, rect, nrows_ncols, ngrids,
-                direction=direction, axes_pad=axes_pad, add_all=add_all,
-                share_all=share_all, share_x=True, share_y=True, aspect=aspect,
-                label_mode=label_mode, axes_class=axes_class)
+        super().__init__(
+            fig, rect, nrows_ncols, ngrids,
+            direction=direction, axes_pad=axes_pad,
+            share_all=share_all, share_x=True, share_y=True, aspect=aspect,
+            label_mode=label_mode, axes_class=axes_class)
 
-        if add_all:
-            for ax in self.cbar_axes:
-                fig.add_axes(ax)
+        for ax in self.cbar_axes:
+            fig.add_axes(ax)
 
         if cbar_set_cax:
             if self._colorbar_mode == "single":

--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -1,12 +1,10 @@
 import numpy as np
 
-from matplotlib import _api
 from .axes_divider import make_axes_locatable, Size
 from .mpl_axes import Axes
 
 
-@_api.delete_parameter("3.3", "add_all")
-def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True, **kwargs):
+def make_rgb_axes(ax, pad=0.01, axes_class=None, **kwargs):
     """
     Parameters
     ----------
@@ -48,17 +46,11 @@ def make_rgb_axes(ax, pad=0.01, axes_class=None, add_all=True, **kwargs):
 
         ax_rgb.append(ax1)
 
-    if add_all:
-        fig = ax.get_figure()
-        for ax1 in ax_rgb:
-            fig.add_axes(ax1)
+    fig = ax.get_figure()
+    for ax1 in ax_rgb:
+        fig.add_axes(ax1)
 
     return ax_rgb
-
-
-@_api.deprecated("3.3", alternative="ax.imshow(np.dstack([r, g, b]))")
-def imshow_rgb(ax, r, g, b, **kwargs):
-    return ax.imshow(np.dstack([r, g, b]), **kwargs)
 
 
 class RGBAxes:
@@ -91,16 +83,12 @@ class RGBAxes:
 
     _defaultAxesClass = Axes
 
-    @_api.delete_parameter("3.3", "add_all")
-    def __init__(self, *args, pad=0, add_all=True, **kwargs):
+    def __init__(self, *args, pad=0, **kwargs):
         """
         Parameters
         ----------
         pad : float, default: 0
             fraction of the axes height to put as padding.
-        add_all : bool, default: True
-            Whether to add the {rgb, r, g, b} axes to the figure.
-            This parameter is deprecated.
         axes_class : matplotlib.axes.Axes
 
         *args
@@ -110,23 +98,13 @@ class RGBAxes:
         """
         axes_class = kwargs.pop("axes_class", self._defaultAxesClass)
         self.RGB = ax = axes_class(*args, **kwargs)
-        if add_all:
-            ax.get_figure().add_axes(ax)
-        else:
-            kwargs["add_all"] = add_all  # only show deprecation in that case
+        ax.get_figure().add_axes(ax)
         self.R, self.G, self.B = make_rgb_axes(
             ax, pad=pad, axes_class=axes_class, **kwargs)
         # Set the line color and ticks for the axes.
         for ax1 in [self.RGB, self.R, self.G, self.B]:
             ax1.axis[:].line.set_color("w")
             ax1.axis[:].major_ticks.set_markeredgecolor("w")
-
-    @_api.deprecated("3.3")
-    def add_RGB_to_figure(self):
-        """Add red, green and blue axes to the RGB composite's axes figure."""
-        self.RGB.get_figure().add_axes(self.R)
-        self.RGB.get_figure().add_axes(self.G)
-        self.RGB.get_figure().add_axes(self.B)
 
     def imshow_rgb(self, r, g, b, **kwargs):
         """
@@ -161,8 +139,3 @@ class RGBAxes:
         im_g = self.G.imshow(G, **kwargs)
         im_b = self.B.imshow(B, **kwargs)
         return im_rgb, im_r, im_g, im_b
-
-
-@_api.deprecated("3.3", alternative="RGBAxes")
-class RGBAxesBase(RGBAxes):
-    pass

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -95,15 +95,7 @@ class ParasiteAxesBase:
 
 
 @functools.lru_cache(None)
-def parasite_axes_class_factory(axes_class=None):
-    if axes_class is None:
-        _api.warn_deprecated(
-            "3.3", message="Support for passing None to "
-            "parasite_axes_class_factory is deprecated since %(since)s and "
-            "will be removed %(removal)s; explicitly pass the default Axes "
-            "class instead.")
-        axes_class = Axes
-
+def parasite_axes_class_factory(axes_class):
     return type("%sParasite" % axes_class.__name__,
                 (ParasiteAxesBase, axes_class), {})
 
@@ -158,15 +150,8 @@ class ParasiteAxesAuxTransBase:
 
 @_api.deprecated("3.4", alternative="parasite_axes_class_factory")
 @functools.lru_cache(None)
-def parasite_axes_auxtrans_class_factory(axes_class=None):
-    if axes_class is None:
-        _api.warn_deprecated(
-            "3.3", message="Support for passing None to "
-            "parasite_axes_auxtrans_class_factory is deprecated since "
-            "%(since)s and will be removed %(removal)s; explicitly pass the "
-            "default ParasiteAxes class instead.")
-        parasite_axes_class = ParasiteAxes
-    elif not issubclass(axes_class, ParasiteAxesBase):
+def parasite_axes_auxtrans_class_factory(axes_class):
+    if not issubclass(axes_class, ParasiteAxesBase):
         parasite_axes_class = parasite_axes_class_factory(axes_class)
     else:
         parasite_axes_class = axes_class
@@ -326,20 +311,10 @@ class HostAxesBase:
 
 
 @functools.lru_cache(None)
-def host_axes_class_factory(axes_class=None):
-    if axes_class is None:
-        _api.warn_deprecated(
-            "3.3", message="Support for passing None to host_axes_class is "
-            "deprecated since %(since)s and will be removed %(removed)s; "
-            "explicitly pass the default Axes class instead.")
-        axes_class = Axes
-
-    def _get_base_axes(self):
-        return axes_class
-
+def host_axes_class_factory(axes_class):
     return type("%sHostAxes" % axes_class.__name__,
                 (HostAxesBase, axes_class),
-                {'_get_base_axes': _get_base_axes})
+                {'_get_base_axes': lambda self: axes_class})
 
 
 def host_subplot_class_factory(axes_class):

--- a/lib/mpl_toolkits/axisartist/angle_helper.py
+++ b/lib/mpl_toolkits/axisartist/angle_helper.py
@@ -1,7 +1,6 @@
 import numpy as np
 import math
 
-from matplotlib import _api
 from mpl_toolkits.axisartist.grid_finder import ExtremeFinderSimple
 
 
@@ -141,19 +140,9 @@ def select_step360(v1, v2, nv, include_last=True, threshold_factor=3600):
 
 
 class LocatorBase:
-    @_api.rename_parameter("3.3", "den", "nbins")
     def __init__(self, nbins, include_last=True):
         self.nbins = nbins
         self._include_last = include_last
-
-    @_api.deprecated("3.3", alternative="nbins")
-    @property
-    def den(self):
-        return self.nbins
-
-    @den.setter
-    def den(self, v):
-        self.nbins = v
 
     def set_params(self, nbins=None):
         if nbins is not None:

--- a/lib/mpl_toolkits/axisartist/axes_rgb.py
+++ b/lib/mpl_toolkits/axisartist/axes_rgb.py
@@ -1,5 +1,4 @@
-from mpl_toolkits.axes_grid1.axes_rgb import (
-    make_rgb_axes, imshow_rgb, RGBAxes as _RGBAxes)
+from mpl_toolkits.axes_grid1.axes_rgb import make_rgb_axes, RGBAxes as _RGBAxes
 from .axislines import Axes
 
 

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -673,11 +673,6 @@ class AxisArtist(martist.Artist):
         self._axislabel_add_angle = 0.
         self.set_axis_direction(axis_direction)
 
-    @_api.deprecated("3.3")
-    @property
-    def dpi_transform(self):
-        return Affine2D().scale(1 / 72) + self.axes.figure.dpi_scale_trans
-
     # axis direction
 
     def set_axis_direction(self, axis_direction):

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from matplotlib import _api, ticker as mticker
+from matplotlib import ticker as mticker
 from matplotlib.transforms import Bbox, Transform
 from .clip_path import clip_line_to_rect
 
@@ -219,30 +219,20 @@ class MaxNLocator(mticker.MaxNLocator):
         super().__init__(nbins, steps=steps, integer=integer,
                          symmetric=symmetric, prune=prune)
         self.create_dummy_axis()
-        self._factor = 1
 
     def __call__(self, v1, v2):
-        locs = super().tick_values(v1 * self._factor, v2 * self._factor)
-        return np.array(locs), len(locs), self._factor
-
-    @_api.deprecated("3.3")
-    def set_factor(self, f):
-        self._factor = f
+        locs = super().tick_values(v1, v2)
+        return np.array(locs), len(locs), 1  # 1: factor (see angle_helper)
 
 
 class FixedLocator:
     def __init__(self, locs):
         self._locs = locs
-        self._factor = 1
 
     def __call__(self, v1, v2):
-        v1, v2 = sorted([v1 * self._factor, v2 * self._factor])
+        v1, v2 = sorted([v1, v2])
         locs = np.array([l for l in self._locs if v1 <= l <= v2])
-        return locs, len(locs), self._factor
-
-    @_api.deprecated("3.3")
-    def set_factor(self, f):
-        self._factor = f
+        return locs, len(locs), 1  # 1: factor (see angle_helper)
 
 
 # Tick Formatter


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
