### PR TITLE
I changed the offset code for draw_text for RendererAgg fixing issue #13044

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     import dummy_threading as threading
 from contextlib import nullcontext
-from math import radians, cos, sin
+from math import radians, cos, sin, sqrt
 
 import numpy as np
 from PIL import Image
@@ -208,10 +208,13 @@ class RendererAgg(RendererBase):
         xo, yo = font.get_bitmap_offset()
         xo /= 64.0
         yo /= 64.0
+        h = sqrt(xo**2 + yo**2)
         xd = d * sin(radians(angle))
         yd = d * cos(radians(angle))
+        xo = h * cos(radians(angle))
+        yo = h * sin(radians(angle))
         x = round(x + xo + xd)
-        y = round(y + yo + yd)
+        y = round(y + yo - yd)
         self._renderer.draw_text_image(font, x, y + 1, angle, gc)
 
     def get_text_width_height_descent(self, s, prop, ismath):


### PR DESCRIPTION
## PR Summary
I tried to fix issue #13044. This a script where the issue can be reproduced (from @dzh527's example in the PR)

```
import matplotlib.pyplot as plt

fig, axes = plt.subplots(2, 2)
for idx, ax in enumerate(axes.flatten()):
      ax.axvline(.5, linewidth=.5, color='.5')
      ax.axhline(.5, linewidth=.5, color='.5')
      ax.text(
          .5, .5, 'pP', size=50,
          bbox=dict(facecolor='None', edgecolor='red', pad=0),
          rotation=idx*90,
          va='center_baseline',
          rotation_mode='anchor'
      )
```

This is the original output:
<img width="876" alt="original-output" src="https://user-images.githubusercontent.com/46368925/115920251-ecf45180-a447-11eb-94cb-a976403200af.png">

This is the output after our change:
![our-output](https://user-images.githubusercontent.com/46368925/115920305-04cbd580-a448-11eb-8c19-2266938c5cfd.png)

So the difference is caused by the offset in the code,  with xo and yo not accounting for the change in the rotation angle, so every time we rotate the x and y components of the offset are not adjusted accordingly with the angle. That is what we tried to implement. 

I think this broke a lot of tests as we changed the location of any text added to a plot - because even if the angle is 0, the offset components would be different. We haven't modified anything except for the draw_text function in the backend_agg.py. I think the new behavior does change the plots for all types of text added to a plot, but even though it is offset differently, it is equivalent in theory. Also instead of adding yo to y, we subtracted it because that gave the best result and draw_mathtext was implemented like that.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot-related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
