### PR TITLE
[DOC] Add top-level .. module:: definition for matplotlib

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,6 +2,8 @@
 
 .. title:: Matplotlib: Python plotting
 
+.. module:: matplotlib
+
 Matplotlib: Visualization with Python
 -------------------------------------
 


### PR DESCRIPTION
## PR Summary

This PR adds a top-level Sphinx `.. module::` definition for matplotlib to enable intersphinx links to the main matplotlib documentation, like :mod:`matplotlib`. This fixes #20061.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

