### PR TITLE
Expire deprecation of AxesDivider defaulting to zero pads.

### DIFF
--- a/doc/api/next_api_changes/behavior/20064-AL.rst
+++ b/doc/api/next_api_changes/behavior/20064-AL.rst
@@ -1,0 +1,5 @@
+``AxesDivider`` now defaults to rcParams-specified pads
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.AxesDivider.append_axes`, `.AxesDivider.new_horizontal`, and
+`.AxesDivider.new_vertical` now default to paddings specified by
+:rc:`figure.subplot.wspace` and :rc:`figure.subplot.hspace` rather than zero.

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -4,6 +4,7 @@ Helper classes to adjust the positions of multiple axes at drawing time.
 
 import numpy as np
 
+import matplotlib as mpl
 from matplotlib import _api
 from matplotlib.axes import SubplotBase
 from matplotlib.gridspec import SubplotSpec, GridSpec
@@ -434,11 +435,12 @@ class AxesDivider(Divider):
         Parameters
         ----------
         size : :mod:`~mpl_toolkits.axes_grid1.axes_size` or float or str
-            A width of the axes. If float or string is given, *from_any*
-            function is used to create the size, with *ref_size* set to AxesX
-            instance of the current axes.
+            The axes width.  float or str arguments are interpreted as
+            ``axes_size.from_any(size, AxesX(<main_axes>))``.
         pad : :mod:`~mpl_toolkits.axes_grid1.axes_size` or float or str
-            Pad between the axes. It takes same argument as *size*.
+            Padding between the axes.  float or str arguments are interpreted
+            as ``axes_size.from_any(size, AxesX(<main_axes>))``.  Defaults to
+            :rc:`figure.subplot.wspace` times the main axes width.
         pack_start : bool
             If False, the new axes is appended at the end
             of the list, i.e., it became the right-most axes. If True, it is
@@ -450,10 +452,7 @@ class AxesDivider(Divider):
             main axes will be used.
         """
         if pad is None:
-            _api.warn_deprecated(
-                "3.2", message="In a future version, 'pad' will default to "
-                "rcParams['figure.subplot.wspace'].  Set pad=0 to keep the "
-                "old behavior.")
+            pad = mpl.rcParams["figure.subplot.wspace"] * self._xref
         if pad:
             if not isinstance(pad, Size._Base):
                 pad = Size.from_any(pad, fraction_ref=self._xref)
@@ -483,11 +482,12 @@ class AxesDivider(Divider):
         Parameters
         ----------
         size : :mod:`~mpl_toolkits.axes_grid1.axes_size` or float or str
-            A height of the axes. If float or string is given, *from_any*
-            function is used to create the size, with *ref_size* set to AxesX
-            instance of the current axes.
+            The axes height.  float or str arguments are interpreted as
+            ``axes_size.from_any(size, AxesY(<main_axes>))``.
         pad : :mod:`~mpl_toolkits.axes_grid1.axes_size` or float or str
-            Pad between the axes. It takes same argument as *size*.
+            Padding between the axes.  float or str arguments are interpreted
+            as ``axes_size.from_any(size, AxesY(<main_axes>))``.  Defaults to
+            :rc:`figure.subplot.hspace` times the main axes height.
         pack_start : bool
             If False, the new axes is appended at the end
             of the list, i.e., it became the right-most axes. If True, it is
@@ -499,10 +499,7 @@ class AxesDivider(Divider):
             main axes will be used.
         """
         if pad is None:
-            _api.warn_deprecated(
-                "3.2", message="In a future version, 'pad' will default to "
-                "rcParams['figure.subplot.hspace'].  Set pad=0 to keep the "
-                "old behavior.")
+            pad = mpl.rcParams["figure.subplot.hspace"] * self._yref
         if pad:
             if not isinstance(pad, Size._Base):
                 pad = Size.from_any(pad, fraction_ref=self._yref)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -1,7 +1,7 @@
 from itertools import product
 import platform
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib import cbook
 from matplotlib.backend_bases import MouseEvent
@@ -56,9 +56,8 @@ def test_divider_append_axes():
 @image_comparison(['twin_axes_empty_and_removed'], extensions=["png"], tol=1)
 def test_twin_axes_empty_and_removed():
     # Purely cosmetic font changes (avoid overlap)
-    matplotlib.rcParams.update({"font.size": 8})
-    matplotlib.rcParams.update({"xtick.labelsize": 8})
-    matplotlib.rcParams.update({"ytick.labelsize": 8})
+    mpl.rcParams.update(
+        {"font.size": 8, "xtick.labelsize": 8, "ytick.labelsize": 8})
     generators = ["twinx", "twiny", "twin"]
     modifiers = ["", "host invisible", "twin removed", "twin invisible",
                  "twin removed\nhost invisible"]
@@ -348,7 +347,8 @@ def test_anchored_direction_arrows_many_args():
 def test_axes_locatable_position():
     fig, ax = plt.subplots()
     divider = make_axes_locatable(ax)
-    cax = divider.append_axes('right', size='5%', pad='2%')
+    with mpl.rc_context({"figure.subplot.wspace": 0.02}):
+        cax = divider.append_axes('right', size='5%')
     fig.canvas.draw()
     assert np.isclose(cax.get_position(original=False).width,
                       0.03621495327102808)


### PR DESCRIPTION
Note that the semantics of the rcParams are *relative* sizes, so they
should be interpreted as such here too.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
