### PR TITLE
Don't make VBoxDivider inherit from HBoxDivider.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -583,39 +583,67 @@ class AxesDivider(Divider):
             return None
 
 
+# Helper for HBoxDivider/VBoxDivider.
+def _determine_karray(equivalent_sizes, appended_sizes,
+                      max_equivalent_size, total_appended_size):
+    n = len(equivalent_sizes)
+    eq_rs, eq_as = np.asarray(equivalent_sizes).T
+    ap_rs, ap_as = np.asarray(appended_sizes).T
+    A = np.zeros((n + 1, n + 1))
+    B = np.zeros(n + 1)
+    np.fill_diagonal(A[:n, :n], eq_rs)
+    A[:n, -1] = -1
+    A[-1, :-1] = ap_rs
+    B[:n] = -eq_as
+    B[-1] = total_appended_size - sum(ap_as)
+    # A @ K = B: This solves for {k_0, ..., k_{N-1}, H} so that
+    #   eq_r_i * k_i + eq_a_i = H for all i: all axes have the same height
+    #   sum(ap_r_i * k_i + ap_a_i) = total_summed_width: fixed total width
+    # (foo_r_i * k_i + foo_a_i will end up being the size of foo.)
+    karray_H = np.linalg.solve(A, B)
+    karray = karray_H[:-1]
+    H = karray_H[-1]
+    if H > max_equivalent_size:  # Additionally, upper-bound the height.
+        karray = (max_equivalent_size - eq_as) / eq_rs
+    return karray
+
+
+# Helper for HBoxDivider/VBoxDivider.
+def _calc_offsets(appended_sizes, karray):
+    offsets = [0.]
+    for (r, a), k in zip(appended_sizes, karray):
+        offsets.append(offsets[-1] + r*k + a)
+    return offsets
+
+
+# Helper for HBoxDivider/VBoxDivider.
+def _locate(
+        x, y, w, h, equivalent_sizes, appended_sizes, fig_w, fig_h, anchor):
+    karray = _determine_karray(
+        equivalent_sizes, appended_sizes,
+        max_equivalent_size=fig_h * h, total_appended_size=fig_w * w)
+    ox = _calc_offsets(appended_sizes, karray)
+
+    ww = (ox[-1] - ox[0]) / fig_w
+    h0_r, h0_a = equivalent_sizes[0]
+    hh = (karray[0]*h0_r + h0_a) / fig_h
+    pb = mtransforms.Bbox.from_bounds(x, y, w, h)
+    pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
+    pb1_anchored = pb1.anchored(anchor, pb)
+    x0, y0 = pb1_anchored.x0, pb1_anchored.y0
+
+    return x0, y0, ox, hh
+
+
 class HBoxDivider(SubplotDivider):
+    """
+    A `SubplotDivider` for laying out axes horizontally, while ensuring that
+    they have equal heights.
 
-    @staticmethod
-    def _determine_karray(equivalent_sizes, appended_sizes,
-                          max_equivalent_size,
-                          total_appended_size):
-        n = len(equivalent_sizes)
-        eq_rs, eq_as = np.asarray(equivalent_sizes).T
-        ap_rs, ap_as = np.asarray(appended_sizes).T
-        A = np.zeros((n + 1, n + 1))
-        B = np.zeros(n + 1)
-        np.fill_diagonal(A[:n, :n], eq_rs)
-        A[:n, -1] = -1
-        A[-1, :-1] = ap_rs
-        B[:n] = -eq_as
-        B[-1] = total_appended_size - sum(ap_as)
-        # A @ K = B: This solves for {k_0, ..., k_{N-1}, H} so that
-        #   eq_r_i * k_i + eq_a_i = H for all i: all axes have the same height
-        #   sum(ap_r_i * k_i + ap_a_i) = total_appended_size: fixed total width
-        # (foo_r_i * k_i + foo_a_i will end up being the size of foo.)
-        karray_H = np.linalg.solve(A, B)
-        karray = karray_H[:-1]
-        H = karray_H[-1]
-        if H > max_equivalent_size:  # Additionally, upper-bound the height.
-            karray = (max_equivalent_size - eq_as) / eq_rs
-        return karray
-
-    @staticmethod
-    def _calc_offsets(appended_sizes, karray):
-        offsets = [0.]
-        for (r, a), k in zip(appended_sizes, karray):
-            offsets.append(offsets[-1] + r*k + a)
-        return offsets
+    Examples
+    --------
+    .. plot:: gallery/axes_grid1/demo_axes_hbox_divider.py
+    """
 
     def new_locator(self, nx, nx1=None):
         """
@@ -631,52 +659,26 @@ class HBoxDivider(SubplotDivider):
         """
         return AxesLocator(self, nx, 0, nx1, None)
 
-    def _locate(self, x, y, w, h,
-                y_equivalent_sizes, x_appended_sizes,
-                figW, figH):
-        equivalent_sizes = y_equivalent_sizes
-        appended_sizes = x_appended_sizes
-
-        max_equivalent_size = figH * h
-        total_appended_size = figW * w
-        karray = self._determine_karray(equivalent_sizes, appended_sizes,
-                                        max_equivalent_size,
-                                        total_appended_size)
-
-        ox = self._calc_offsets(appended_sizes, karray)
-
-        ww = (ox[-1] - ox[0]) / figW
-        ref_h = equivalent_sizes[0]
-        hh = (karray[0]*ref_h[0] + ref_h[1]) / figH
-        pb = mtransforms.Bbox.from_bounds(x, y, w, h)
-        pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
-        pb1_anchored = pb1.anchored(self.get_anchor(), pb)
-        x0, y0 = pb1_anchored.x0, pb1_anchored.y0
-
-        return x0, y0, ox, hh
-
     def locate(self, nx, ny, nx1=None, ny1=None, axes=None, renderer=None):
         # docstring inherited
         figW, figH = self._fig.get_size_inches()
         x, y, w, h = self.get_position_runtime(axes, renderer)
-
         y_equivalent_sizes = self.get_vertical_sizes(renderer)
         x_appended_sizes = self.get_horizontal_sizes(renderer)
-        x0, y0, ox, hh = self._locate(x, y, w, h,
-                                      y_equivalent_sizes, x_appended_sizes,
-                                      figW, figH)
+        x0, y0, ox, hh = _locate(x, y, w, h,
+                                 y_equivalent_sizes, x_appended_sizes,
+                                 figW, figH, self.get_anchor())
         if nx1 is None:
             nx1 = nx + 1
-
         x1, w1 = x0 + ox[nx] / figW, (ox[nx1] - ox[nx]) / figW
         y1, h1 = y0, hh
-
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
 
 
-class VBoxDivider(HBoxDivider):
+class VBoxDivider(SubplotDivider):
     """
-    The Divider class whose rectangle area is specified as a subplot geometry.
+    A `SubplotDivider` for laying out axes vertically, while ensuring that they
+    have equal widths.
     """
 
     def new_locator(self, ny, ny1=None):
@@ -697,18 +699,15 @@ class VBoxDivider(HBoxDivider):
         # docstring inherited
         figW, figH = self._fig.get_size_inches()
         x, y, w, h = self.get_position_runtime(axes, renderer)
-
         x_equivalent_sizes = self.get_horizontal_sizes(renderer)
         y_appended_sizes = self.get_vertical_sizes(renderer)
-        y0, x0, oy, ww = self._locate(y, x, h, w,
-                                      x_equivalent_sizes, y_appended_sizes,
-                                      figH, figW)
+        y0, x0, oy, ww = _locate(y, x, h, w,
+                                 x_equivalent_sizes, y_appended_sizes,
+                                 figH, figW, self.get_anchor())
         if ny1 is None:
             ny1 = ny + 1
-
         x1, w1 = x0, ww
         y1, h1 = y0 + oy[ny] / figH, (oy[ny1] - oy[ny]) / figH
-
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
 
 


### PR DESCRIPTION
They share some common calculation helpers, but a VBoxDivider is not a
specialization of an HBoxDivider, so just move the helpers out to free
functions (they're staticmethods or nearly so anyways).

Also rename "equivalent" to "equal" and "appended" to "summed", which I
think actually express the constraints better, and are shorter too.

Also document their usage, and PEP8-ify a couple of variables.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
