### PR TITLE
Improve labeling in simple_axes_divider1 example.

### DIFF
--- a/examples/axes_grid1/simple_axes_divider1.py
+++ b/examples/axes_grid1/simple_axes_divider1.py
@@ -2,17 +2,25 @@
 =====================
 Simple Axes Divider 1
 =====================
-
 """
 
 from mpl_toolkits.axes_grid1 import Size, Divider
 import matplotlib.pyplot as plt
 
 
+def label_axes(ax, text):
+    """Place a label at the center of an axes, and remove the axis ticks."""
+    ax.text(.5, .5, text, transform=ax.transAxes,
+            horizontalalignment="center", verticalalignment="center")
+    ax.tick_params(bottom=False, labelbottom=False,
+                   left=False, labelleft=False)
+
+
 ##############################################################################
 # Fixed axes sizes; fixed paddings.
 
 fig = plt.figure(figsize=(6, 6))
+fig.suptitle("Fixed axes sizes, fixed paddings")
 
 # Sizes are in inches.
 horiz = [Size.Fixed(1.), Size.Fixed(.5), Size.Fixed(1.5), Size.Fixed(.5)]
@@ -24,17 +32,19 @@ divider = Divider(fig, rect, horiz, vert, aspect=False)
 
 # The rect parameter will actually be ignored and overridden by axes_locator.
 ax1 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=0, ny=0))
+label_axes(ax1, "nx=0, ny=0")
 ax2 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=0, ny=2))
+label_axes(ax2, "nx=0, ny=2")
 ax3 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=2, ny=2))
+label_axes(ax3, "nx=2, ny=2")
 ax4 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=2, nx1=4, ny=0))
-
-for ax in fig.axes:
-    ax.tick_params(labelbottom=False, labelleft=False)
+label_axes(ax4, "nx=2, nx1=4, ny=0")
 
 ##############################################################################
 # Axes sizes that scale with the figure size; fixed paddings.
 
 fig = plt.figure(figsize=(6, 6))
+fig.suptitle("Scalable axes sizes, fixed paddings")
 
 horiz = [Size.Scaled(1.5), Size.Fixed(.5), Size.Scaled(1.), Size.Scaled(.5)]
 vert = [Size.Scaled(1.), Size.Fixed(.5), Size.Scaled(1.5)]
@@ -45,11 +55,12 @@ divider = Divider(fig, rect, horiz, vert, aspect=False)
 
 # The rect parameter will actually be ignored and overridden by axes_locator.
 ax1 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=0, ny=0))
+label_axes(ax1, "nx=0, ny=0")
 ax2 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=0, ny=2))
+label_axes(ax2, "nx=0, ny=2")
 ax3 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=2, ny=2))
+label_axes(ax3, "nx=2, ny=2")
 ax4 = fig.add_axes(rect, axes_locator=divider.new_locator(nx=2, nx1=4, ny=0))
-
-for ax in fig.axes:
-    ax.tick_params(labelbottom=False, labelleft=False)
+label_axes(ax4, "nx=2, nx1=4, ny=0")
 
 plt.show()


### PR DESCRIPTION
## PR Summary

before
![old](https://user-images.githubusercontent.com/1322974/115994570-e399ef00-a5d7-11eb-98db-a67335083ac6.png)

after
![new](https://user-images.githubusercontent.com/1322974/115994572-e5fc4900-a5d7-11eb-9c42-6dfe9225104e.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
