### PR TITLE
Prepare axes_divider for simpler(?) indexing-based API.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20079-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20079-AL.rst
@@ -1,0 +1,10 @@
+Support for ``nx1 = None`` or ``ny1 = None`` in ``AxesLocator`` and ``Divider.locate``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In :mod:`.axes_grid1.axes_divider`, various internal APIs will stop supporting
+passing ``nx1 = None`` or ``ny1 = None`` to mean ``nx + 1`` or ``ny + 1``, in
+preparation for a possible future API which allows indexing and slicing of
+dividers (possibly ``divider[a:b] == divider.new_locator(a, b)``, but also
+``divider[a:] == divider.new_locator(a, <end>)``).  The user-facing
+`.Divider.new_locator` API is unaffected -- it correctly normalizes ``nx1 = None``
+and ``ny1 = None`` as needed.

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -222,8 +222,16 @@ class Divider:
             x0, y0 = x, y
 
         if nx1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing nx1=None to mean nx+1 is "
+                "deprecated since %(since)s; in a future version, nx1=None "
+                "will mean 'up to the last cell'.")
             nx1 = nx + 1
         if ny1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing ny1=None to mean ny+1 is "
+                "deprecated since %(since)s; in a future version, ny1=None "
+                "will mean 'up to the last cell'.")
             ny1 = ny + 1
 
         x1, w1 = x0 + ox[nx] / figW, (ox[nx1] - ox[nx]) / figW
@@ -245,7 +253,10 @@ class Divider:
         ny, ny1 : int
             Same as *nx* and *nx1*, but for row positions.
         """
-        return AxesLocator(self, nx, ny, nx1, ny1)
+        return AxesLocator(
+            self, nx, ny,
+            nx1 if nx1 is not None else nx + 1,
+            ny1 if ny1 is not None else ny + 1)
 
     def append_size(self, position, size):
         if position == "left":
@@ -275,9 +286,10 @@ class Divider:
 
 class AxesLocator:
     """
-    A simple callable object, initialized with AxesDivider class,
-    returns the position and size of the given cell.
+    A callable object which returns the position and size of a given
+    AxesDivider cell.
     """
+
     def __init__(self, axes_divider, nx, ny, nx1=None, ny1=None):
         """
         Parameters
@@ -299,8 +311,16 @@ class AxesLocator:
         self._nx, self._ny = nx - _xrefindex, ny - _yrefindex
 
         if nx1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing nx1=None to mean nx+1 is "
+                "deprecated since %(since)s; in a future version, nx1=None "
+                "will mean 'up to the last cell'.")
             nx1 = nx + 1
         if ny1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing ny1=None to mean ny+1 is "
+                "deprecated since %(since)s; in a future version, ny1=None "
+                "will mean 'up to the last cell'.")
             ny1 = ny + 1
 
         self._nx1 = nx1 - _xrefindex
@@ -629,7 +649,7 @@ class HBoxDivider(SubplotDivider):
             specified. Otherwise location of columns spanning between *nx*
             to *nx1* (but excluding *nx1*-th column) is specified.
         """
-        return AxesLocator(self, nx, 0, nx1, None)
+        return AxesLocator(self, nx, 0, nx1 if nx1 is not None else nx + 1, 1)
 
     def _locate(self, x, y, w, h,
                 y_equivalent_sizes, x_appended_sizes,
@@ -666,6 +686,10 @@ class HBoxDivider(SubplotDivider):
                                       y_equivalent_sizes, x_appended_sizes,
                                       figW, figH)
         if nx1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing nx1=None to mean nx+1 is "
+                "deprecated since %(since)s; in a future version, nx1=None "
+                "will mean 'up to the last cell'.")
             nx1 = nx + 1
 
         x1, w1 = x0 + ox[nx] / figW, (ox[nx1] - ox[nx]) / figW
@@ -691,7 +715,7 @@ class VBoxDivider(HBoxDivider):
             specified. Otherwise location of rows spanning between *ny*
             to *ny1* (but excluding *ny1*-th row) is specified.
         """
-        return AxesLocator(self, 0, ny, None, ny1)
+        return AxesLocator(self, 0, ny, 1, ny1 if ny1 is not None else ny + 1)
 
     def locate(self, nx, ny, nx1=None, ny1=None, axes=None, renderer=None):
         # docstring inherited
@@ -704,6 +728,10 @@ class VBoxDivider(HBoxDivider):
                                       x_equivalent_sizes, y_appended_sizes,
                                       figH, figW)
         if ny1 is None:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing ny1=None to mean ny+1 is "
+                "deprecated since %(since)s; in a future version, ny1=None "
+                "will mean 'up to the last cell'.")
             ny1 = ny + 1
 
         x1, w1 = x0, ww


### PR DESCRIPTION
See changelog note for motivation.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
