### PR TITLE
Revert "Temporarily switch intersphinx to latest pytest."

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -143,7 +143,7 @@ intersphinx_mapping = {
     'ipykernel': ('https://ipykernel.readthedocs.io/en/latest/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'pytest': ('https://pytest.org/en/latest/', None),
+    'pytest': ('https://pytest.org/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 }


### PR DESCRIPTION
Reverts matplotlib/matplotlib#19389, as pytest 6.2.3 is out now and should fix the reference.