### PR TITLE
Add legend.labelcolor in rcParams

### DIFF
--- a/doc/users/next_whats_new/rcparams_legend.rst
+++ b/doc/users/next_whats_new/rcparams_legend.rst
@@ -1,0 +1,25 @@
+New rcParams for legend: set legend labelcolor globally
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new :rc:`legend.labelcolor` sets the default *labelcolor* argument for
+`.Figure.legend`.  The special values  'linecolor', 'markerfacecolor'
+(or 'mfc'), or 'markeredgecolor' (or 'mec') will cause the legend text to match 
+the corresponding color of marker. 
+
+
+.. plot::
+
+    plt.rcParams['legend.labelcolor'] = 'linecolor'
+
+    # Make some fake data.
+    a = np.arange(0, 3, .02)
+    c = np.exp(a)
+    d = c[::-1]
+
+    fig, ax = plt.subplots()
+    ax.plot(a, c, 'g--', label='Model length')
+    ax.plot(a, d, 'r:', label='Data length')
+
+    ax.legend()
+
+    plt.show()

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -173,11 +173,14 @@ fontsize : int or {'xx-small', 'x-small', 'small', 'medium', 'large', \
     absolute font size in points. String values are relative to the current
     default font size. This argument is only used if *prop* is not specified.
 
-labelcolor : str or list
+labelcolor : str or list, default: :rc:`legend.labelcolor`
     The color of the text in the legend. Either a valid color string
     (for example, 'red'), or a list of color strings. The labelcolor can
     also be made to match the color of the line or marker using 'linecolor',
     'markerfacecolor' (or 'mfc'), or 'markeredgecolor' (or 'mec').
+
+    Labelcolor can be set globally using :rc:`legend.labelcolor`. If None,
+    use :rc:`text.color`.
 
 numpoints : int, default: :rc:`legend.numpoints`
     The number of marker points in the legend when creating a legend
@@ -539,8 +542,11 @@ class Legend(Artist):
             'mec':             ['get_markeredgecolor', 'get_edgecolor'],
         }
         if labelcolor is None:
-            pass
-        elif isinstance(labelcolor, str) and labelcolor in color_getters:
+            if mpl.rcParams['legend.labelcolor'] is not None:
+                labelcolor = mpl.rcParams['legend.labelcolor']
+            else:
+                labelcolor = mpl.rcParams['text.color']
+        if isinstance(labelcolor, str) and labelcolor in color_getters:
             getter_names = color_getters[labelcolor]
             for handle, text in zip(self.legendHandles, self.texts):
                 for getter_name in getter_names:

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -530,6 +530,7 @@
 #legend.scatterpoints: 1        # number of scatter points
 #legend.markerscale:   1.0      # the relative size of legend markers vs. original
 #legend.fontsize:      medium
+#legend.labelcolor:    None
 #legend.title_fontsize: None    # None sets to the same as the default axes.
 
 ## Dimensions as fraction of font size:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -289,6 +289,27 @@ def validate_color_for_prop_cycle(s):
     return validate_color(s)
 
 
+def _validate_color_or_linecolor(s):
+    if cbook._str_equal(s, 'linecolor'):
+        return s
+    elif cbook._str_equal(s, 'mfc') or cbook._str_equal(s, 'markerfacecolor'):
+        return 'markerfacecolor'
+    elif cbook._str_equal(s, 'mec') or cbook._str_equal(s, 'markeredgecolor'):
+        return 'markeredgecolor'
+    elif s is None:
+        return None
+    elif isinstance(s, str) and len(s) == 6 or len(s) == 8:
+        stmp = '#' + s
+        if is_color_like(stmp):
+            return stmp
+        if s.lower() == 'none':
+            return None
+    elif is_color_like(s):
+        return s
+
+    raise ValueError(f'{s!r} does not look like a color arg')
+
+
 def validate_color(s):
     """Return a valid color arg."""
     if isinstance(s, str):
@@ -1017,6 +1038,8 @@ _validators = {
     "legend.scatterpoints":  validate_int,
     "legend.fontsize":       validate_fontsize,
     "legend.title_fontsize": validate_fontsize_None,
+     # color of the legend
+    "legend.labelcolor":     _validate_color_or_linecolor,
      # the relative size of legend markers vs. original
     "legend.markerscale":    validate_float,
     "legend.shadow":         validate_bool,

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -644,6 +644,85 @@ def test_legend_labelcolor_markerfacecolor():
         assert mpl.colors.same_color(text.get_color(), color)
 
 
+@pytest.mark.parametrize('color', ('red', 'none', (.5, .5, .5)))
+def test_legend_labelcolor_rcparam_single(color):
+    # test the rcParams legend.labelcolor for a single color
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3')
+
+    mpl.rcParams['legend.labelcolor'] = color
+    leg = ax.legend()
+    for text in leg.get_texts():
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_labelcolor_rcparam_linecolor():
+    # test the rcParams legend.labelcolor for a linecolor
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1', color='r')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2', color='g')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3', color='b')
+
+    mpl.rcParams['legend.labelcolor'] = 'linecolor'
+    leg = ax.legend()
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_labelcolor_rcparam_markeredgecolor():
+    # test the labelcolor for labelcolor='markeredgecolor'
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1', markeredgecolor='r')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2', markeredgecolor='g')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3', markeredgecolor='b')
+
+    mpl.rcParams['legend.labelcolor'] = 'markeredgecolor'
+    leg = ax.legend()
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_labelcolor_rcparam_markeredgecolor_short():
+    # test the labelcolor for labelcolor='markeredgecolor'
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1', markeredgecolor='r')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2', markeredgecolor='g')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3', markeredgecolor='b')
+
+    mpl.rcParams['legend.labelcolor'] = 'mec'
+    leg = ax.legend()
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_labelcolor_rcparam_markerfacecolor():
+    # test the labelcolor for labelcolor='markeredgecolor'
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1', markerfacecolor='r')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2', markerfacecolor='g')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3', markerfacecolor='b')
+
+    mpl.rcParams['legend.labelcolor'] = 'markerfacecolor'
+    leg = ax.legend()
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_labelcolor_rcparam_markerfacecolor_short():
+    # test the labelcolor for labelcolor='markeredgecolor'
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10), np.arange(10)*1, label='#1', markerfacecolor='r')
+    ax.plot(np.arange(10), np.arange(10)*2, label='#2', markerfacecolor='g')
+    ax.plot(np.arange(10), np.arange(10)*3, label='#3', markerfacecolor='b')
+
+    mpl.rcParams['legend.labelcolor'] = 'mfc'
+    leg = ax.legend()
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
 def test_get_set_draggable():
     legend = plt.legend()
     assert not legend.get_draggable()

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -17,6 +17,7 @@ from matplotlib.rcsetup import (
     validate_bool,
     validate_color,
     validate_colorlist,
+    _validate_color_or_linecolor,
     validate_cycler,
     validate_float,
     validate_fontweight,
@@ -328,6 +329,17 @@ def generate_validator_testcases(valid):
                   ('(0, 1, none)', ValueError),  # cannot cast none to float
                   ('(0, 1, "0.5")', ValueError),  # last one not a float
                   ),
+         },
+        {'validator': _validate_color_or_linecolor,
+         'success': (('linecolor', 'linecolor'),
+                     ('markerfacecolor', 'markerfacecolor'),
+                     ('mfc', 'markerfacecolor'),
+                     ('markeredgecolor', 'markeredgecolor'),
+                     ('mec', 'markeredgecolor')
+                     ),
+         'fail': (('line', ValueError),
+                  ('marker', ValueError)
+                  )
          },
         {'validator': validate_hist_bins,
          'success': (('auto', 'auto'),


### PR DESCRIPTION
## PR Summary


This is a proposal for a new `legend` rcParam.
The `legend.labelcolor` was proposed in #20049. It's for changing the `labelcolor` of all figures(similar to the labelcolor of `plt.legend`)  

Example:
   
    import numpy as np
    import lib.matplotlib.pyplot as plt

    a = np.arange(2, 3, .02)
    c = np.exp(a)
    plt.rcParams['legend.labelcolor'] = 'linecolor'

    fig, ax = plt.subplots()
    ax.plot(a, c, 'g', label='Model length')
    ax.plot(c, a, 'r', label='Data length')

    legend = ax.legend()

    plt.show()

 
![Figure_1](https://user-images.githubusercontent.com/18191158/116163930-1e328300-a6cf-11eb-930b-a57fd24f0def.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
