### PR TITLE
Cleanup tight_layout.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20091-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20091-AL.rst
@@ -1,0 +1,3 @@
+``tight_layout.auto_adjust_subplotpars``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -11,12 +11,12 @@ for some cases (for example, left or right margin is affected by xlabel).
 
 import numpy as np
 
-from matplotlib import _api, rcParams
+from matplotlib import _api, docstring, rcParams
 from matplotlib.font_manager import FontProperties
 from matplotlib.transforms import TransformedBbox, Bbox
 
 
-def auto_adjust_subplotpars(
+def _auto_adjust_subplotpars(
         fig, renderer, nrows_ncols, num1num2_list, subplot_list,
         ax_bbox_list=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
     """
@@ -90,8 +90,6 @@ def auto_adjust_subplotpars(
                                      fig.transFigure.inverted())
 
         row1, col1 = divmod(num1, cols)
-        if num2 is None:
-            num2 = num1
         row2, col2 = divmod(num2, cols)
 
         for row_i in range(row1, row2 + 1):
@@ -172,6 +170,18 @@ def auto_adjust_subplotpars(
             kwargs["hspace"] = vspace / v_axes
 
     return kwargs
+
+
+@_api.deprecated("3.5")
+@docstring.copy(_auto_adjust_subplotpars)
+def auto_adjust_subplotpars(
+        fig, renderer, nrows_ncols, num1num2_list, subplot_list,
+        ax_bbox_list=None, pad=1.08, h_pad=None, w_pad=None, rect=None):
+    num1num2_list = [
+        (n1, n1 if n2 is None else n2) for n1, n2 in num1num2_list]
+    return _auto_adjust_subplotpars(
+        fig, renderer, nrows_ncols, num1num2_list, subplot_list,
+        ax_bbox_list, pad, h_pad, w_pad, rect)
 
 
 def get_renderer(fig):
@@ -298,23 +308,19 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
                                'multiples of one another.')
             return {}
 
-        rowNum1, colNum1 = divmod(num1, cols)
-        if num2 is None:
-            rowNum2, colNum2 = rowNum1, colNum1
-        else:
-            rowNum2, colNum2 = divmod(num2, cols)
+        row1, col1 = divmod(num1, cols)
+        row2, col2 = divmod(num2, cols)
 
-        num1num2_list.append((rowNum1 * div_row * max_ncols +
-                              colNum1 * div_col,
-                              ((rowNum2 + 1) * div_row - 1) * max_ncols +
-                              (colNum2 + 1) * div_col - 1))
+        num1num2_list.append((row1 * div_row * max_ncols + col1 * div_col,
+                              ((row2 + 1) * div_row - 1) * max_ncols +
+                              (col2 + 1) * div_col - 1))
 
-    kwargs = auto_adjust_subplotpars(fig, renderer,
-                                     nrows_ncols=(max_nrows, max_ncols),
-                                     num1num2_list=num1num2_list,
-                                     subplot_list=subplot_list,
-                                     ax_bbox_list=ax_bbox_list,
-                                     pad=pad, h_pad=h_pad, w_pad=w_pad)
+    kwargs = _auto_adjust_subplotpars(fig, renderer,
+                                      nrows_ncols=(max_nrows, max_ncols),
+                                      num1num2_list=num1num2_list,
+                                      subplot_list=subplot_list,
+                                      ax_bbox_list=ax_bbox_list,
+                                      pad=pad, h_pad=h_pad, w_pad=w_pad)
 
     # kwargs can be none if tight_layout fails...
     if rect is not None and kwargs is not None:
@@ -336,12 +342,12 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
         if top is not None:
             top -= (1 - kwargs["top"])
 
-        kwargs = auto_adjust_subplotpars(fig, renderer,
-                                         nrows_ncols=(max_nrows, max_ncols),
-                                         num1num2_list=num1num2_list,
-                                         subplot_list=subplot_list,
-                                         ax_bbox_list=ax_bbox_list,
-                                         pad=pad, h_pad=h_pad, w_pad=w_pad,
-                                         rect=(left, bottom, right, top))
+        kwargs = _auto_adjust_subplotpars(fig, renderer,
+                                          nrows_ncols=(max_nrows, max_ncols),
+                                          num1num2_list=num1num2_list,
+                                          subplot_list=subplot_list,
+                                          ax_bbox_list=ax_bbox_list,
+                                          pad=pad, h_pad=h_pad, w_pad=w_pad,
+                                          rect=(left, bottom, right, top))
 
     return kwargs


### PR DESCRIPTION
- In get_tight_layout_figure, num2 is never None (since 658bbd5).  Also
  rename some variables for pep8.
- auto_adjust_subplotpars could also be adjusted to remove the
  `num2 is None` case, but in theory one could directly pass a
  None-containing argument to it.  On the other hand it seems unlikely
  that anyone is actually directly calling auto_adjust_subplotpars,
  given the complex list of arguments needed (IOW it is clearly just a
  helper for get_tight_layout_figure), so just deprecate the whole
  function as public API, leaving a thin compat wrapper that remove
  None-inputs as needed.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
