### PR TITLE
[RFC] Speed up Axes.bar

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -35,6 +35,7 @@ from matplotlib.axes._base import (
     _AxesBase, _TransformedBoundsLocator, _process_plot_format)
 from matplotlib.axes._secondary_axes import SecondaryAxis
 from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
+from matplotlib.collections import PatchCollection
 
 _log = logging.getLogger(__name__)
 
@@ -2369,8 +2370,9 @@ class Axes(_AxesBase):
                 r.sticky_edges.y.append(b)
             elif orientation == 'horizontal':
                 r.sticky_edges.x.append(l)
-            self.add_patch(r)
             patches.append(r)
+
+        self.add_collection(PatchCollection(patches))
 
         if xerr is not None or yerr is not None:
             if orientation == 'vertical':

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2353,6 +2353,7 @@ class Axes(_AxesBase):
             bottom = y
 
         patches = []
+        colors = []
         args = zip(left, bottom, width, height, color, edgecolor, linewidth,
                    hatch)
         for l, b, w, h, c, e, lw, htch in args:
@@ -2364,6 +2365,7 @@ class Axes(_AxesBase):
                 label='_nolegend_',
                 hatch=htch,
                 )
+            colors.append(c)
             r.update(kwargs)
             r.get_path()._interpolation_steps = 100
             if orientation == 'vertical':
@@ -2372,7 +2374,10 @@ class Axes(_AxesBase):
                 r.sticky_edges.x.append(l)
             patches.append(r)
 
-        self.add_collection(PatchCollection(patches))
+        collection = PatchCollection(patches)
+        collection.set_facecolor(colors)
+
+        self.add_collection(collection)
 
         if xerr is not None or yerr is not None:
             if orientation == 'vertical':

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2353,7 +2353,6 @@ class Axes(_AxesBase):
             bottom = y
 
         patches = []
-        colors = []
         args = zip(left, bottom, width, height, color, edgecolor, linewidth,
                    hatch)
         for l, b, w, h, c, e, lw, htch in args:
@@ -2365,7 +2364,6 @@ class Axes(_AxesBase):
                 label='_nolegend_',
                 hatch=htch,
                 )
-            colors.append(c)
             r.update(kwargs)
             r.get_path()._interpolation_steps = 100
             if orientation == 'vertical':
@@ -2374,10 +2372,7 @@ class Axes(_AxesBase):
                 r.sticky_edges.x.append(l)
             patches.append(r)
 
-        collection = PatchCollection(patches)
-        collection.set_facecolor(colors)
-
-        self.add_collection(collection)
+        self.add_collection(PatchCollection(patches, match_original=True))
 
         if xerr is not None or yerr is not None:
             if orientation == 'vertical':


### PR DESCRIPTION
## PR Summary

Currently Axes.bar calls `self.add_patch` for every bar. This can be quite slow for dense histograms. This PR instead puts the patches into a collection and adds that. This seems to give a large performance increase.

## Details

### Evidence of a speed up

```python
from matplotlib import pyplot as plt
import numpy as np

N = 10_000

x = np.arange(N)
y = np.random.randn(N)

%time plt.bar(x, y)
```

On `master`:

```
CPU times: user 4.97 s, sys: 64.2 ms, total: 5.03 s
Wall time: 5.06 s
```

On this branch:

```
CPU times: user 1.42 s, sys: 27.1 ms, total: 1.44 s
Wall time: 1.47 s
```

### More thoughts

I don't think this counts as an API change. Of the failing tests, all the image comparison ones I've looked at so far don't look different by eye. Some tests fail because they are checking for artists which are now in a different place.

I thought it would be good to get feedback on whether this was a reasonable approach before making more changes. Any thoughts?

# TODO

Based on the failing tests

- [x] Color patches correctly
- [ ] Get legends working (not sure how patches get labels attached)
- [ ] Figure out what's going on with misaligned axis in test_default_edges (bar plot is just floating off the bottom axis)
- [ ] Fix log scaling in `hist`


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).



<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
