### PR TITLE
Remove 3.3 ticker deprecations

### DIFF
--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -169,17 +169,6 @@ Units
    Axis.update_units
 
 
-Incremental navigation
-----------------------
-
-.. autosummary::
-   :toctree: _as_gen
-   :template: autosummary.rst
-   :nosignatures:
-
-   Axis.pan
-   Axis.zoom
-
 XAxis Specific
 --------------
 

--- a/doc/api/next_api_changes/removals/20095-ES.rst
+++ b/doc/api/next_api_changes/removals/20095-ES.rst
@@ -3,3 +3,18 @@ Axis and Locator ``pan`` and ``zoom``
 The unused ``pan`` and ``zoom`` methods of `~.axis.Axis` and `~.ticker.Locator`
 have been removed.  Panning and zooming are now implemented using the
 ``start_pan``, ``drag_pan``, and ``end_pan`` methods of `~.axes.Axes`.
+
+Ticker Locators and Formatters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following deprecated `.Locator`\s and `.Formatter`\s have been removed:
+
+* ``OldScalarFormatter``, ``IndexFormatter`` and ``IndexDateFormatter``; use
+  `.FuncFormatter` instead.
+* ``OldAutoLocator``
+
+The following deprecated properties and methods have been removed:
+
+* ``DateFormatter.illegal_s``
+* ``Locator.refresh()`` and the associated helper methods
+  ``NavigationToolbar2.draw()`` and ``ToolViewsPositions.refresh_locators()``

--- a/doc/api/next_api_changes/removals/20095-ES.rst
+++ b/doc/api/next_api_changes/removals/20095-ES.rst
@@ -1,0 +1,5 @@
+Axis and Locator ``pan`` and ``zoom``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The unused ``pan`` and ``zoom`` methods of `~.axis.Axis` and `~.ticker.Locator`
+have been removed.  Panning and zooming are now implemented using the
+``start_pan``, ``drag_pan``, and ``end_pan`` methods of `~.axes.Axes`.

--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -162,7 +162,7 @@ The ``on_mappable_changed`` and ``update_bruteforce`` methods of
 `~matplotlib.colorbar.Colorbar` are deprecated; both can be replaced by calls
 to `~matplotlib.colorbar.Colorbar.update_normal`.
 
-``OldScalarFormatter``, ``IndexFormatter`` and ``DateIndexFormatter``
+``OldScalarFormatter``, ``IndexFormatter`` and ``IndexDateFormatter``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These formatters are deprecated.  Their functionality can be implemented using
 e.g. `.FuncFormatter`.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1867,16 +1867,6 @@ class Axis(martist.Artist):
         """
         raise NotImplementedError('Derived must override')
 
-    @_api.deprecated("3.3")
-    def pan(self, numsteps):
-        """Pan by *numsteps* (can be positive or negative)."""
-        self.major.locator.pan(numsteps)
-
-    @_api.deprecated("3.3")
-    def zoom(self, direction):
-        """Zoom in/out on axis; if *direction* is >0 zoom in, else zoom out."""
-        self.major.locator.zoom(direction)
-
     def axis_date(self, tz=None):
         """
         Set up axis ticks and labels to treat data along this Axis as dates.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3136,7 +3136,7 @@ class NavigationToolbar2:
             'motion_notify_event', self.mouse_move)
         for ax in self._pan_info.axes:
             ax.end_pan()
-        self._draw()
+        self.canvas.draw_idle()
         self._pan_info = None
         self.push_current()
 
@@ -3198,7 +3198,7 @@ class NavigationToolbar2:
         # "cancel" a zoom action by zooming by less than 5 pixels.
         if ((abs(event.x - start_x) < 5 and event.key != "y")
                 or (abs(event.y - start_y) < 5 and event.key != "x")):
-            self._draw()
+            self.canvas.draw_idle()
             self._zoom_info = None
             return
 
@@ -3213,7 +3213,7 @@ class NavigationToolbar2:
                 (start_x, start_y, event.x, event.y),
                 self._zoom_info.direction, event.key, twinx, twiny)
 
-        self._draw()
+        self.canvas.draw_idle()
         self._zoom_info = None
         self.push_current()
 
@@ -3227,27 +3227,6 @@ class NavigationToolbar2:
                        ax.get_position().frozen()))
                  for ax in self.canvas.figure.axes}))
         self.set_history_buttons()
-
-    # Can be removed once Locator.refresh() is removed, and replaced by an
-    # inline call to self.canvas.draw_idle().
-    def _draw(self):
-        for a in self.canvas.figure.get_axes():
-            xaxis = getattr(a, 'xaxis', None)
-            yaxis = getattr(a, 'yaxis', None)
-            locators = []
-            if xaxis is not None:
-                locators.append(xaxis.get_major_locator())
-                locators.append(xaxis.get_minor_locator())
-            if yaxis is not None:
-                locators.append(yaxis.get_major_locator())
-                locators.append(yaxis.get_minor_locator())
-
-            for loc in locators:
-                mpl.ticker._if_refresh_overridden_call_and_emit_deprec(loc)
-        self.canvas.draw_idle()
-
-    draw = _api.deprecate_privatize_attribute(
-        "3.3", alternative="toolbar.canvas.draw_idle()")
 
     def _update_view(self):
         """

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -166,15 +166,12 @@ The available date formatters are:
   date information.  This is most useful when used with the `AutoDateLocator`.
 
 * `DateFormatter`: use `~datetime.datetime.strftime` format strings.
-
-* `IndexDateFormatter`: date plots with implicit *x* indexing.
 """
 
 import datetime
 import functools
 import logging
 import math
-import re
 
 from dateutil.rrule import (rrule, MO, TU, WE, TH, FR, SA, SU, YEARLY,
                             MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY,
@@ -189,7 +186,7 @@ from matplotlib import _api, cbook, ticker, units
 
 __all__ = ('datestr2num', 'date2num', 'num2date', 'num2timedelta', 'drange',
            'epoch2num', 'num2epoch', 'set_epoch', 'get_epoch', 'DateFormatter',
-           'ConciseDateFormatter', 'IndexDateFormatter', 'AutoDateFormatter',
+           'ConciseDateFormatter', 'AutoDateFormatter',
            'DateLocator', 'RRuleLocator', 'AutoDateLocator', 'YearLocator',
            'MonthLocator', 'WeekdayLocator',
            'DayLocator', 'HourLocator', 'MinuteLocator',
@@ -607,11 +604,6 @@ class DateFormatter(ticker.Formatter):
     `~datetime.datetime.strftime` format string.
     """
 
-    @_api.deprecated("3.3")
-    @property
-    def illegal_s(self):
-        return re.compile(r"((^|[^%])(%%)*%s)")
-
     def __init__(self, fmt, tz=None, *, usetex=None):
         """
         Parameters
@@ -637,33 +629,6 @@ class DateFormatter(ticker.Formatter):
 
     def set_tzinfo(self, tz):
         self.tz = tz
-
-
-@_api.deprecated("3.3")
-class IndexDateFormatter(ticker.Formatter):
-    """Use with `.IndexLocator` to cycle format strings by index."""
-
-    def __init__(self, t, fmt, tz=None):
-        """
-        Parameters
-        ----------
-        t : list of float
-            A sequence of dates (floating point days).
-        fmt : str
-            A `~datetime.datetime.strftime` format string.
-        """
-        if tz is None:
-            tz = _get_rc_timezone()
-        self.t = t
-        self.fmt = fmt
-        self.tz = tz
-
-    def __call__(self, x, pos=0):
-        """Return the label for time *x* at position *pos*."""
-        ind = int(round(x))
-        if ind >= len(self.t) or ind <= 0:
-            return ''
-        return num2date(self.t[ind], self.tz).strftime(self.fmt)
 
 
 class ConciseDateFormatter(ticker.Formatter):

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -17,7 +17,7 @@ import matplotlib as mpl
 
 from matplotlib.dates import (
     date2num, num2date, datestr2num, drange, epoch2num,
-    num2epoch, DateFormatter, IndexDateFormatter, DateLocator,
+    num2epoch, DateFormatter, DateLocator,
     RRuleLocator, YearLocator, MonthLocator, WeekdayLocator, DayLocator,
     HourLocator, MinuteLocator, SecondLocator, rrule, MO, TU, WE, TH, FR,
     SA, SU, YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY, SECONDLY,

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -8,7 +8,6 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib as mpl
-from matplotlib import _api
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
@@ -442,21 +441,6 @@ class TestSymmetricalLogLocator:
         sym.set_params(subs=[2.0], numticks=8)
         assert sym._subs == [2.0]
         assert sym.numticks == 8
-
-
-class TestIndexFormatter:
-    @pytest.mark.parametrize('x, label', [(-2, ''),
-                                          (-1, 'label0'),
-                                          (0, 'label0'),
-                                          (0.5, 'label1'),
-                                          (1, 'label1'),
-                                          (1.5, 'label2'),
-                                          (2, 'label2'),
-                                          (2.5, '')])
-    def test_formatting(self, x, label):
-        with _api.suppress_matplotlib_deprecation_warning():
-            formatter = mticker.IndexFormatter(['label0', 'label1', 'label2'])
-        assert formatter(x) == label
 
 
 class TestScalarFormatter:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1777,34 +1777,6 @@ class Locator(TickHelper):
         return mtransforms.nonsingular(vmin, vmax)
 
     @_api.deprecated("3.3")
-    def pan(self, numsteps):
-        """Pan numticks (can be positive or negative)"""
-        ticks = self()
-        numticks = len(ticks)
-
-        vmin, vmax = self.axis.get_view_interval()
-        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
-        if numticks > 2:
-            step = numsteps * abs(ticks[0] - ticks[1])
-        else:
-            d = abs(vmax - vmin)
-            step = numsteps * d / 6.
-
-        vmin += step
-        vmax += step
-        self.axis.set_view_interval(vmin, vmax, ignore=True)
-
-    @_api.deprecated("3.3")
-    def zoom(self, direction):
-        """Zoom in/out on axis; if direction is >0 zoom in, else zoom out."""
-
-        vmin, vmax = self.axis.get_view_interval()
-        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
-        interval = abs(vmax - vmin)
-        step = 0.1 * interval * direction
-        self.axis.set_view_interval(vmin + step, vmax - step, ignore=True)
-
-    @_api.deprecated("3.3")
     def refresh(self):
         """Refresh internal information based on current limits."""
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -52,10 +52,6 @@ The Locator subclasses defined here are
 :class:`LogitLocator`
     Locator for logit scaling.
 
-:class:`OldAutoLocator`
-    Choose a `MultipleLocator` and dynamically reassign it for intelligent
-    ticking during navigation.
-
 :class:`AutoMinorLocator`
     Locator for minor ticks when the axis is linear and the
     major ticks are uniformly spaced.  Subdivides the major
@@ -102,9 +98,6 @@ operates on a single tick value and returns a string to the axis.
 
 :class:`NullFormatter`
     No labels on the ticks.
-
-:class:`IndexFormatter`
-    Set the strings from a list of labels.
 
 :class:`FixedFormatter`
     Set the strings manually for the labels.
@@ -184,13 +177,12 @@ __all__ = ('TickHelper', 'Formatter', 'FixedFormatter',
            'NullFormatter', 'FuncFormatter', 'FormatStrFormatter',
            'StrMethodFormatter', 'ScalarFormatter', 'LogFormatter',
            'LogFormatterExponent', 'LogFormatterMathtext',
-           'IndexFormatter', 'LogFormatterSciNotation',
+           'LogFormatterSciNotation',
            'LogitFormatter', 'EngFormatter', 'PercentFormatter',
-           'OldScalarFormatter',
            'Locator', 'IndexLocator', 'FixedLocator', 'NullLocator',
            'LinearLocator', 'LogLocator', 'AutoLocator',
            'MultipleLocator', 'MaxNLocator', 'AutoMinorLocator',
-           'SymmetricalLogLocator', 'LogitLocator', 'OldAutoLocator')
+           'SymmetricalLogLocator', 'LogitLocator')
 
 
 class _DummyAxis:
@@ -311,35 +303,6 @@ class Formatter(TickHelper):
         pass
 
 
-@_api.deprecated("3.3")
-class IndexFormatter(Formatter):
-    """
-    Format the position x to the nearest i-th label where ``i = int(x + 0.5)``.
-    Positions where ``i < 0`` or ``i > len(list)`` have no tick labels.
-
-    Parameters
-    ----------
-    labels : list
-        List of labels.
-    """
-    def __init__(self, labels):
-        self.labels = labels
-        self.n = len(labels)
-
-    def __call__(self, x, pos=None):
-        """
-        Return the format for tick value *x* at position pos.
-
-        The position is ignored and the value is rounded to the nearest
-        integer, which is used to look up the label.
-        """
-        i = int(x + 0.5)
-        if i < 0 or i >= self.n:
-            return ''
-        else:
-            return self.labels[i]
-
-
 class NullFormatter(Formatter):
     """Always return the empty string."""
 
@@ -451,40 +414,6 @@ class StrMethodFormatter(Formatter):
         with those exact names.
         """
         return self.fmt.format(x=x, pos=pos)
-
-
-@_api.deprecated("3.3")
-class OldScalarFormatter(Formatter):
-    """
-    Tick location is a plain old number.
-    """
-
-    def __call__(self, x, pos=None):
-        """
-        Return the format for tick val *x* based on the width of the axis.
-
-        The position *pos* is ignored.
-        """
-        xmin, xmax = self.axis.get_view_interval()
-        # If the number is not too big and it's an int, format it as an int.
-        if abs(x) < 1e4 and x == int(x):
-            return '%d' % x
-        d = abs(xmax - xmin)
-        fmt = ('%1.3e' if d < 1e-2 else
-               '%1.3f' if d <= 1 else
-               '%1.2f' if d <= 10 else
-               '%1.1f' if d <= 1e5 else
-               '%1.1e')
-        s = fmt % x
-        tup = s.split('e')
-        if len(tup) == 2:
-            mantissa = tup[0].rstrip('0').rstrip('.')
-            sign = tup[1][0].replace('+', '')
-            exponent = tup[1][1:].lstrip('0')
-            s = '%se%s%s' % (mantissa, sign, exponent)
-        else:
-            s = s.rstrip('0').rstrip('.')
-        return s
 
 
 class ScalarFormatter(Formatter):
@@ -1675,18 +1604,6 @@ class PercentFormatter(Formatter):
         self._symbol = symbol
 
 
-def _if_refresh_overridden_call_and_emit_deprec(locator):
-    if not locator.refresh.__func__.__module__.startswith("matplotlib."):
-        cbook.warn_external(
-            "3.3", message="Automatic calls to Locator.refresh by the draw "
-            "machinery are deprecated since %(since)s and will be removed in "
-            "%(removal)s.  You are using a third-party locator that overrides "
-            "the refresh() method; this locator should instead perform any "
-            "required processing in __call__().")
-    with _api.suppress_matplotlib_deprecation_warning():
-        locator.refresh()
-
-
 class Locator(TickHelper):
     """
     Determine the tick locations;
@@ -1775,10 +1692,6 @@ class Locator(TickHelper):
         Subclasses should override this method to change locator behaviour.
         """
         return mtransforms.nonsingular(vmin, vmax)
-
-    @_api.deprecated("3.3")
-    def refresh(self):
-        """Refresh internal information based on current limits."""
 
 
 class IndexLocator(Locator):
@@ -2938,58 +2851,3 @@ class AutoMinorLocator(Locator):
     def tick_values(self, vmin, vmax):
         raise NotImplementedError('Cannot get tick locations for a '
                                   '%s type.' % type(self))
-
-
-@_api.deprecated("3.3")
-class OldAutoLocator(Locator):
-    """
-    On autoscale this class picks the best MultipleLocator to set the
-    view limits and the tick locs.
-    """
-
-    def __call__(self):
-        # docstring inherited
-        vmin, vmax = self.axis.get_view_interval()
-        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
-        d = abs(vmax - vmin)
-        locator = self.get_locator(d)
-        return self.raise_if_exceeds(locator())
-
-    def tick_values(self, vmin, vmax):
-        raise NotImplementedError('Cannot get tick locations for a '
-                                  '%s type.' % type(self))
-
-    def view_limits(self, vmin, vmax):
-        # docstring inherited
-        d = abs(vmax - vmin)
-        locator = self.get_locator(d)
-        return locator.view_limits(vmin, vmax)
-
-    def get_locator(self, d):
-        """Pick the best locator based on a distance *d*."""
-        d = abs(d)
-        if d <= 0:
-            locator = MultipleLocator(0.2)
-        else:
-
-            try:
-                ld = math.log10(d)
-            except OverflowError as err:
-                raise RuntimeError('AutoLocator illegal data interval '
-                                   'range') from err
-
-            fld = math.floor(ld)
-            base = 10 ** fld
-
-            #if ld==fld:  base = 10**(fld-1)
-            #else:        base = 10**fld
-
-            if d >= 5 * base:
-                ticksize = base
-            elif d >= 2 * base:
-                ticksize = base / 2.0
-            else:
-                ticksize = base / 5.0
-            locator = MultipleLocator(ticksize)
-
-        return locator


### PR DESCRIPTION
## PR Summary

Plus some related Axis things.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).