### PR TITLE
Ignore errors for sip with no setapi.

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -117,7 +117,7 @@ def _setup_pyqt4():
             for _sip_api in _sip_apis:
                 try:
                     sip.setapi(_sip_api, api)
-                except ValueError:
+                except (AttributeError, ValueError):
                     pass
         from PyQt4 import QtCore, QtGui
         import sip  # Always succeeds *after* importing PyQt4.


### PR DESCRIPTION
## PR Summary

Apparently, this happens (see #20040 and related issues) sporadically. We don't care if we can't change the sip API version (if it's already been set), so also stop caring if the `setapi` function doesn't exist. This should simply cause the Qt4 backend to fail correctly later with an `ImportError` instead, and thus fall back to the next backend candidate.

Fixes #20040.

## PR Checklist

- [n/a?] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).