### PR TITLE
Shorten bracket arrowstyle docs.

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3215,7 +3215,7 @@ class ArrowStyle(_Style):
         def __init__(self, bracketA=None, bracketB=None,
                      widthA=1., widthB=1.,
                      lengthA=0.2, lengthB=0.2,
-                     angleA=None, angleB=None,
+                     angleA=0, angleB=0,
                      scaleA=None, scaleB=None):
             self.bracketA, self.bracketB = bracketA, bracketB
             self.widthA, self.widthB = widthA, widthB
@@ -3241,7 +3241,7 @@ class ArrowStyle(_Style):
                            Path.LINETO,
                            Path.LINETO]
 
-            if angle is not None:
+            if angle:
                 trans = transforms.Affine2D().rotate_deg_around(x0, y0, angle)
                 vertices_arrow = trans.transform(vertices_arrow)
 
@@ -3298,32 +3298,18 @@ class ArrowStyle(_Style):
         """An arrow with outward square brackets at both ends."""
 
         def __init__(self,
-                     widthA=1., lengthA=0.2, angleA=None,
-                     widthB=1., lengthB=0.2, angleB=None):
+                     widthA=1., lengthA=0.2, angleA=0,
+                     widthB=1., lengthB=0.2, angleB=0):
             """
             Parameters
             ----------
-            widthA : float, default: 1.0
+            widthA, widthB : float, default: 1.0
                 Width of the bracket.
-
-            lengthA : float, default: 0.2
+            lengthA, lengthB : float, default: 0.2
                 Length of the bracket.
-
-            angleA : float, default: None
-                Angle, in degrees, between the bracket and the line. Zero is
-                perpendicular to the line, and positive measures
-                counterclockwise.
-
-            widthB : float, default: 1.0
-                Width of the bracket.
-
-            lengthB : float, default: 0.2
-                Length of the bracket.
-
-            angleB : float, default: None
-                Angle, in degrees, between the bracket and the line. Zero is
-                perpendicular to the line, and positive measures
-                counterclockwise.
+            angleA, angleB : float, default: 0 degrees
+                Orientation of the bracket, as a counterclockwise angle.
+                0 degrees means perpendicular to the line.
             """
             super().__init__(True, True,
                              widthA=widthA, lengthA=lengthA, angleA=angleA,
@@ -3333,18 +3319,17 @@ class ArrowStyle(_Style):
     class BracketA(_Bracket):
         """An arrow with an outward square bracket at its start."""
 
-        def __init__(self, widthA=1., lengthA=0.2, angleA=None):
+        def __init__(self, widthA=1., lengthA=0.2, angleA=0):
             """
             Parameters
             ----------
             widthA : float, default: 1.0
                 Width of the bracket.
-
             lengthA : float, default: 0.2
                 Length of the bracket.
-
-            angleA : float, default: None
-                Angle between the bracket and the line.
+            angleA : float, default: 0 degrees
+                Orientation of the bracket, as a counterclockwise angle.
+                0 degrees means perpendicular to the line.
             """
             super().__init__(True, None,
                              widthA=widthA, lengthA=lengthA, angleA=angleA)
@@ -3359,14 +3344,11 @@ class ArrowStyle(_Style):
             ----------
             widthB : float, default: 1.0
                 Width of the bracket.
-
             lengthB : float, default: 0.2
                 Length of the bracket.
-
-            angleB : float, default: None
-                Angle, in degrees, between the bracket and the line. Zero is
-                perpendicular to the line, and positive measures
-                counterclockwise.
+            angleB : float, default: 0 degrees
+                Orientation of the bracket, as a counterclockwise angle.
+                0 degrees means perpendicular to the line.
             """
             super().__init__(None, True,
                              widthB=widthB, lengthB=lengthB, angleB=angleB)
@@ -3381,21 +3363,11 @@ class ArrowStyle(_Style):
             """
             Parameters
             ----------
-            widthA : float, default: 1.0
+            widthA, widthB : float, default: 1.0
                 Width of the bracket.
-
-            angleA : float, default: None
-                Angle, in degrees, between the bracket and the line. Zero is
-                perpendicular to the line, and positive measures
-                counterclockwise.
-
-            widthB : float, default: 1.0
-                Width of the bracket.
-
-            angleB : float, default: None
-                Angle, in degrees, between the bracket and the line. Zero is
-                perpendicular to the line, and positive measures
-                counterclockwise.
+            angleA, angleB : float, default: 0 degrees
+                Orientation of the bracket, as a counterclockwise angle.
+                0 degrees means perpendicular to the line.
             """
             super().__init__(True, True,
                              widthA=widthA, lengthA=0, angleA=angleA,


### PR DESCRIPTION
We can still support None angles as synonym to zero, but don't really
need to document them.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
