### PR TITLE
Skip back-and-forth between pixels and points in contour code.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20108-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20108-AL.rst
@@ -1,0 +1,3 @@
+``ContourLabeler.get_label_width``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -242,10 +242,20 @@ class ContourLabeler:
         x, y = XX[ind][hysize], YY[ind][hysize]
         return x, y, ind
 
+    def _get_nth_label_width(self, nth):
+        """Return the width of the *nth* label, in pixels."""
+        fig = self.axes.figure
+        return (
+            text.Text(0, 0,
+                      self.get_text(self.labelLevelList[nth], self.labelFmt),
+                      figure=fig,
+                      size=self.labelFontSizeList[nth],
+                      fontproperties=self.labelFontProps)
+            .get_window_extent(mpl.tight_layout.get_renderer(fig)).width)
+
+    @_api.deprecated("3.5")
     def get_label_width(self, lev, fmt, fsize):
-        """
-        Return the width of the label in points.
-        """
+        """Return the width of the label in points."""
         if not isinstance(lev, str):
             lev = self.get_text(lev, fmt)
         fig = self.axes.figure
@@ -498,11 +508,7 @@ class ContourLabeler:
         lmin = self.labelIndiceList.index(conmin)
 
         # Get label width for rotating labels and breaking contours
-        lw = self.get_label_width(self.labelLevelList[lmin],
-                                  self.labelFmt, self.labelFontSizeList[lmin])
-        # lw is in points.
-        lw *= self.axes.figure.dpi / 72  # scale to screen coordinates
-        # now lw in pixels
+        lw = self._get_nth_label_width(lmin)
 
         # Figure out label rotation.
         rotation, nlc = self.calc_label_rot_and_inline(
@@ -534,14 +540,15 @@ class ContourLabeler:
         else:
             add_label = self.add_label
 
-        for icon, lev, fsize, cvalue in zip(
-                self.labelIndiceList, self.labelLevelList,
-                self.labelFontSizeList, self.labelCValueList):
+        for idx, (icon, lev, cvalue) in enumerate(zip(
+                self.labelIndiceList,
+                self.labelLevelList,
+                self.labelCValueList,
+        )):
 
             con = self.collections[icon]
             trans = con.get_transform()
-            lw = self.get_label_width(lev, self.labelFmt, fsize)
-            lw *= self.axes.figure.dpi / 72  # scale to screen coordinates
+            lw = self._get_nth_label_width(idx)
             additions = []
             paths = con.get_paths()
             for segNum, linepath in enumerate(paths):


### PR DESCRIPTION
Text.get_window_extents returns pixels, which get_label_width converts
to points, only for all call sites to immediately convert back to
pixels.  Just introduce a new internal API which uses pixels throughout.
(We could possibly deprecate get_label_width, but heh.)

Edit: get_label_width is deprecated, per the discussion below.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
