### PR TITLE
Fix trailing text in doctest-syntax plot_directive.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20109-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20109-AL.rst
@@ -1,0 +1,5 @@
+``plot_directive`` internals deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The following helpers in `matplotlib.sphinxext.plot_directive` are deprecated:
+``unescape_doctest`` (use `doctest.script_from_examples` instead),
+``split_code_at_show``, ``run_code``.

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -15,11 +15,16 @@ Plot 2 doesn't use context either; has length 6:
 
     plt.plot(range(6))
 
-Plot 3 has length 4:
+Plot 3 has length 4, and uses doctest syntax:
 
 .. plot::
+    :format: doctest
 
-    plt.plot(range(4))
+    This is a doctest...
+
+    >>> plt.plot(range(4))
+
+    ... isn't it?
 
 Plot 4 shows that a new block with context does not see the variable defined
 in the no-context block:


### PR DESCRIPTION
The problem was that an input like
```
Some text.

>>> python_code()

The end.
```
would get split to
```
Some text.

>>> python_code()
```
and
```
The end.
```
and that unescape_doctest would then believe that `The end.` is already
python code (as it doesn't contain a `>>>`) and try to run it as is.

To fix this, instead of repeatedly calling `contains_doctest` everywhere
to guess whether fragments are doctest or python, just do it once at the
beginning, do the escaping once if needed at the beginning and then call
the new _functions (`_split_code_at_show`, `_run_code`) which don't try to
guess anymore.  Because of the new (non-guessing) semantics these must
go to new functions, so let's make them private and just deprecate the old
(public) ones.

The escaping itself was done by `unescape_doctest`, but that had a
separate bug misparsing
```
This is an example...

>>> some_python()

... isn't it?
```
the last line would get incorrectly misparsed as a line continuation,
despite the blank line in between.  Instead of trying to fix that
ourselves, just use `doctest.script_from_examples` which exactly serves
that purpose.

Closes #11007.
Closes #19111.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
