### PR TITLE
Interactive span selector improvement

### DIFF
--- a/doc/api/next_api_changes/deprecations/20113-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20113-EP.rst
@@ -16,3 +16,4 @@ deprecated:
 - ``drawtype``
 - ``rectprops``
 - ``active_handle``
+- ``interactive``

--- a/doc/api/next_api_changes/deprecations/20113-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20113-EP.rst
@@ -1,0 +1,18 @@
+SpanSelector
+~~~~~~~~~~~~
+``span_stays`` is deprecated, use ``interactive`` argument instead
+Several `~matplotlib.widgets.SpanSelector` class internals have been privatized 
+and deprecated:
+- ``pressv``
+- ``rect``
+- ``rectprops``
+- ``active_handle``
+
+
+Several `~matplotlib.widgets.RectangleSelector` and
+`~matplotlib.widgets.EllipseSelector` class internals have been privatized and
+deprecated:
+- ``to_draw``
+- ``drawtype``
+- ``rectprops``
+- ``active_handle``

--- a/doc/api/next_api_changes/deprecations/20113-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20113-EP.rst
@@ -4,6 +4,7 @@ SpanSelector
 Several `~matplotlib.widgets.SpanSelector` class internals have been privatized 
 and deprecated:
 - ``pressv``
+- ``prev``
 - ``rect``
 - ``rectprops``
 - ``active_handle``

--- a/doc/api/next_api_changes/deprecations/20113-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20113-EP.rst
@@ -7,6 +7,7 @@ and deprecated:
 - ``rect``
 - ``rectprops``
 - ``active_handle``
+- ``span_stays``
 
 
 Several `~matplotlib.widgets.RectangleSelector` and

--- a/doc/users/next_whats_new/widget_dragging.rst
+++ b/doc/users/next_whats_new/widget_dragging.rst
@@ -1,9 +1,12 @@
 Dragging selectors
 ------------------
 
-The `~matplotlib.widgets.RectangleSelector` and
-`~matplotlib.widgets.EllipseSelector` have a new keyword argument,
+The `~matplotlib.widgets.SpanSelector`, `~matplotlib.widgets.RectangleSelector`
+and `~matplotlib.widgets.EllipseSelector` have a new keyword argument,
 *drag_from_anywhere*, which when set to `True` allows you to click and drag
 from anywhere inside the selector to move it. Previously it was only possible
 to move it by either activating the move modifier button, or clicking on the
 central handle.
+
+The size of the `~matplotlib.widgets.SpanSelector` can now be changed using
+the edge handles.

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -16,14 +16,14 @@ np.random.seed(19680801)
 fig, (ax1, ax2) = plt.subplots(2, figsize=(8, 6))
 
 x = np.arange(0.0, 5.0, 0.01)
-y = np.sin(2*np.pi*x) + 0.5*np.random.randn(len(x))
+y = np.sin(2 * np.pi * x) + 0.5 * np.random.randn(len(x))
 
 ax1.plot(x, y)
 ax1.set_ylim(-2, 2)
 ax1.set_title('Press left mouse button and drag '
               'to select a region in the top graph')
 
-line2, = ax2.plot([], [])
+(line2,) = ax2.plot([], [])
 
 
 def onselect(xmin, xmax):
@@ -37,7 +37,8 @@ def onselect(xmin, xmax):
         line2.set_data(region_x, region_y)
         ax2.set_xlim(region_x[0], region_x[-1])
         ax2.set_ylim(region_y.min(), region_y.max())
-        fig.canvas.draw()
+        fig.canvas.draw_idle()
+
 
 #############################################################################
 # .. note::
@@ -47,8 +48,15 @@ def onselect(xmin, xmax):
 #
 
 
-span = SpanSelector(ax1, onselect, 'horizontal', useblit=True,
-                    rectprops=dict(alpha=0.5, facecolor='tab:blue'))
+span = SpanSelector(
+    ax1,
+    onselect,
+    "horizontal",
+    useblit=True,
+    rectprops=dict(alpha=0.5, facecolor="tab:blue"),
+    interactive=True,
+    drag_from_anywhere=True
+)
 # Set useblit=True on most backends for enhanced performance.
 
 

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -23,7 +23,7 @@ ax1.set_ylim(-2, 2)
 ax1.set_title('Press left mouse button and drag '
               'to select a region in the top graph')
 
-(line2,) = ax2.plot([], [])
+line2, = ax2.plot([], [])
 
 
 def onselect(xmin, xmax):

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -243,7 +243,7 @@ def test_span_selector_drag(drag_from_anywhere):
     # giving new value extents = 20, 110
     #
     # If drag_from_anywhere == False, this will create a new span with
-    # value vmin, vmaxextents = 25, 35
+    # value extents = 25, 35
     do_event(tool, 'press', xdata=25, ydata=15, button=1)
     do_event(tool, 'onmove', xdata=35, ydata=25, button=1)
     do_event(tool, 'release', xdata=35, ydata=25, button=1)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -259,6 +259,27 @@ def test_span_selector_drag(drag_from_anywhere):
     assert tool.extents == (175, 185)
 
 
+def test_span_selector_direction():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal', interactive=True)
+    assert tool.direction == 'horizontal'
+    assert tool._edge_handles.direction == 'horizontal'
+
+    with pytest.raises(ValueError):
+        tool = widgets.SpanSelector(ax, onselect, 'invalid_direction')
+
+    tool.direction = 'vertical'
+    assert tool.direction == 'vertical'
+    assert tool._edge_handles.direction == 'vertical'
+
+    with pytest.raises(ValueError):
+        tool.direction = 'invalid_string'
+
+
 def test_tool_line_handle():
     ax = get_ax()
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -222,6 +222,42 @@ def test_span_selector():
     check_span('horizontal', rectprops=dict(fill=True))
 
 
+@pytest.mark.parametrize('drag_from_anywhere', [True, False])
+def test_span_selector_drag(drag_from_anywhere):
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    # Create span
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal', interactive=True,
+                                drag_from_anywhere=drag_from_anywhere)
+    do_event(tool, 'press', xdata=10, ydata=10, button=1)
+    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
+    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+    assert (tool.vmin, tool.vmax) == (10, 100)
+    # Drag inside span
+    #
+    # If drag_from_anywhere == True, this will move the span by 10,
+    # giving new value vmin, vmax = 20, 110
+    #
+    # If drag_from_anywhere == False, this will create a new span with
+    # value vmin, vmax = 25, 35
+    do_event(tool, 'press', xdata=25, ydata=15, button=1)
+    do_event(tool, 'onmove', xdata=35, ydata=25, button=1)
+    do_event(tool, 'release', xdata=35, ydata=25, button=1)
+    if drag_from_anywhere:
+        assert (tool.vmin, tool.vmax) == (20, 110)
+    else:
+        assert (tool.vmin, tool.vmax) == (25, 35)
+
+    # Check that in both cases, dragging outside the span draws a new span
+    do_event(tool, 'press', xdata=175, ydata=185, button=1)
+    do_event(tool, 'onmove', xdata=185, ydata=195, button=1)
+    do_event(tool, 'release', xdata=185, ydata=195, button=1)
+    assert (tool.vmin, tool.vmax) == (175, 185)
+
+
 def check_lasso_selector(**kwargs):
     ax = get_ax()
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -259,6 +259,28 @@ def test_span_selector_drag(drag_from_anywhere):
     assert (tool.vmin, tool.vmax) == (175, 185)
 
 
+def test_tool_line_handle():
+    ax = get_ax()
+
+    positions = [20, 30, 50]
+
+    tool_line_handle = widgets.ToolLineHandles(ax, positions, 'horizontal',
+                                               useblit=False)
+
+    for artist in tool_line_handle.artists:
+        assert not artist.get_animated()
+        assert not artist.get_visible()
+
+    tool_line_handle.set_visible(True)
+    tool_line_handle.set_animated(True)
+
+    for artist in tool_line_handle.artists:
+        assert artist.get_animated()
+        assert artist.get_visible()
+
+    assert tool_line_handle.positions == positions
+
+
 def check_lasso_selector(**kwargs):
     ax = get_ax()
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -236,27 +236,27 @@ def test_span_selector_drag(drag_from_anywhere):
     do_event(tool, 'press', xdata=10, ydata=10, button=1)
     do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
     do_event(tool, 'release', xdata=100, ydata=120, button=1)
-    assert (tool.vmin, tool.vmax) == (10, 100)
+    assert tool.extents == (10, 100)
     # Drag inside span
     #
     # If drag_from_anywhere == True, this will move the span by 10,
-    # giving new value vmin, vmax = 20, 110
+    # giving new value extents = 20, 110
     #
     # If drag_from_anywhere == False, this will create a new span with
-    # value vmin, vmax = 25, 35
+    # value vmin, vmaxextents = 25, 35
     do_event(tool, 'press', xdata=25, ydata=15, button=1)
     do_event(tool, 'onmove', xdata=35, ydata=25, button=1)
     do_event(tool, 'release', xdata=35, ydata=25, button=1)
     if drag_from_anywhere:
-        assert (tool.vmin, tool.vmax) == (20, 110)
+        assert tool.extents == (20, 110)
     else:
-        assert (tool.vmin, tool.vmax) == (25, 35)
+        assert tool.extents == (25, 35)
 
     # Check that in both cases, dragging outside the span draws a new span
     do_event(tool, 'press', xdata=175, ydata=185, button=1)
     do_event(tool, 'onmove', xdata=185, ydata=195, button=1)
     do_event(tool, 'release', xdata=185, ydata=195, button=1)
-    assert (tool.vmin, tool.vmax) == (175, 185)
+    assert tool.extents == (175, 185)
 
 
 def test_tool_line_handle():

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -195,11 +195,11 @@ def check_span(*args, **kwargs):
     def onselect(vmin, vmax):
         ax._got_onselect = True
         assert vmin == 100
-        assert vmax == 150
+        assert vmax == 199
 
     def onmove(vmin, vmax):
         assert vmin == 100
-        assert vmax == 125
+        assert vmax == 199
         ax._got_on_move = True
 
     if 'onmove_callback' in kwargs:
@@ -207,8 +207,9 @@ def check_span(*args, **kwargs):
 
     tool = widgets.SpanSelector(ax, onselect, *args, **kwargs)
     do_event(tool, 'press', xdata=100, ydata=100, button=1)
-    do_event(tool, 'onmove', xdata=125, ydata=125, button=1)
-    do_event(tool, 'release', xdata=150, ydata=150, button=1)
+    # move outside of axis
+    do_event(tool, 'onmove', xdata=199, ydata=199, button=1)
+    do_event(tool, 'release', xdata=250, ydata=250, button=1)
 
     assert ax._got_onselect
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1777,7 +1777,7 @@ class _SelectorWidget(AxesWidget):
 
     def update(self):
         """Draw using blit() or draw_idle(), depending on ``self.useblit``."""
-        if not self.ax.get_visible():
+        if not self.ax.get_visible() or self.ax.figure._cachedRenderer is None:
             return False
         if self.useblit:
             if self.background is not None:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1994,6 +1994,10 @@ class SpanSelector(_SelectorWidget):
         self.visible = True
         self._extents_on_press = None
 
+        # self._pressv is deprecated and we don't use it internally anymore
+        # but we maintain it until it is removed
+        self._pressv = None
+
         self.rectprops = rectprops
         self.onmove_callback = onmove_callback
         self.minspan = minspan
@@ -2056,13 +2060,25 @@ class SpanSelector(_SelectorWidget):
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
+        v = event.xdata if self.direction == 'horizontal' else event.ydata
+        # self._pressv is deprecated but we still need to maintain it
+        self._pressv = v
         if not self.interactive:
-            v = event.xdata if self.direction == 'horizontal' else event.ydata
             self.extents = v, v
 
         self.set_visible(self.visible)
 
         return False
+
+    @_api.deprecated("3.5")
+    @property
+    def pressv(self):
+        return self._pressv
+
+    @_api.deprecated("3.5")
+    @pressv.setter
+    def pressv(self, value):
+        self._pressv = value
 
     def _release(self, event):
         """Button release event handler."""
@@ -2078,6 +2094,9 @@ class SpanSelector(_SelectorWidget):
 
         self.onselect(vmin, vmax)
         self.update()
+
+        # self._pressv is deprecated but we still need to maintain it
+        self._pressv = None
 
         return False
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2119,7 +2119,7 @@ class SpanSelector(_SelectorWidget):
 
         return False
 
-    def draw_shape(self, vmin, vmax):
+    def _draw_shape(self, vmin, vmax):
         if vmin > vmax:
             vmin, vmax = vmax, vmin
         if self.direction == 'horizontal':
@@ -2185,7 +2185,7 @@ class SpanSelector(_SelectorWidget):
     @extents.setter
     def extents(self, extents):
         # Update displayed shape
-        self.draw_shape(*extents)
+        self._draw_shape(*extents)
         # Update displayed handles
         self._edge_handles.set_data(self.extents)
         self.set_visible(self.visible)
@@ -2658,7 +2658,7 @@ class RectangleSelector(_SelectorWidget):
     @extents.setter
     def extents(self, extents):
         # Update displayed shape
-        self.draw_shape(extents)
+        self._draw_shape(extents)
         # Update displayed handles
         self._corner_handles.set_data(*self.corners)
         self._edge_handles.set_data(*self.edge_centers)
@@ -2666,7 +2666,9 @@ class RectangleSelector(_SelectorWidget):
         self.set_visible(self.visible)
         self.update()
 
-    def draw_shape(self, extents):
+    draw_shape = _api.deprecate_privatize_attribute('3.5')
+
+    def _draw_shape(self, extents):
         x0, x1, y0, y1 = extents
         xmin, xmax = sorted([x0, x1])
         ymin, ymax = sorted([y0, y1])
@@ -2784,8 +2786,9 @@ class EllipseSelector(RectangleSelector):
         plt.show()
     """
     _shape_klass = Ellipse
+    draw_shape = _api.deprecate_privatize_attribute('3.5')
 
-    def draw_shape(self, extents):
+    def _draw_shape(self, extents):
         x0, x1, y0, y1 = extents
         xmin, xmax = sorted([x0, x1])
         ymin, ymax = sorted([y0, y1])

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2115,8 +2115,8 @@ class SpanSelector(_SelectorWidget):
             vpress = self.eventpress.ydata
 
         # move existing span
-        # When "dragging from anywhere", the `self._active_handle` is set to 'C'
-        # in _set_active_handle (match notation used in the RectangleSelector)
+        # When "dragging from anywhere", `self._active_handle` is set to 'C'
+        # (match notation used in the RectangleSelector)
         if self._active_handle == 'C' and self._extents_on_press is not None:
             vmin, vmax = self._extents_on_press
             dv = v - vpress
@@ -2261,13 +2261,13 @@ class ToolLineHandles:
 
     def set_visible(self, value):
         """Set the visibility state of the handles artist."""
-        for m in self.artists:
-            m.set_visible(value)
+        for artist in self.artists:
+            artist.set_visible(value)
 
     def set_animated(self, value):
         """Set the animated state of the handles artist."""
-        for m in self.artists:
-            m.set_animated(value)
+        for artist in self.artists:
+            artist.set_animated(value)
 
     def closest(self, x, y):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2170,7 +2170,7 @@ class SpanSelector(_SelectorWidget):
 
     @property
     def vmin(self):
-        """ Get the start span coordinate."""
+        """Get the start span coordinate."""
         if self.direction == 'horizontal':
             vmin = self.rect.get_x()
         else:
@@ -2179,7 +2179,7 @@ class SpanSelector(_SelectorWidget):
 
     @property
     def vmax(self):
-        """ Get the end span coordinate."""
+        """Get the end span coordinate."""
         if self.direction == 'horizontal':
             vmax = self.vmin + self.rect.get_width()
         else:
@@ -2222,10 +2222,10 @@ class ToolLineHandles:
         self.ax = ax
         self._markers = []
         self.direction = direction
-        marker_props.update({'visible':False, 'animated':useblit})
+        marker_props.update({'visible': False, 'animated': useblit})
 
-        line_func = ax.axvline if self.direction == 'horizontal' else ax.axhline
-        self._markers = [line_func(p, **marker_props) for p in positions]
+        line_fun = ax.axvline if self.direction == 'horizontal' else ax.axhline
+        self._markers = [line_fun(p, **marker_props) for p in positions]
 
         self.artists = self._markers
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2038,7 +2038,7 @@ class SpanSelector(_SelectorWidget):
         property(lambda self: self._interactive)
         )
 
-    prev = _api.deprecated("3.5")(property(lambda self: self._prev))
+    prev = _api.deprecate_privatize_attribute("3.5")
 
     def new_axes(self, ax):
         """Set SpanSelector to operate on a new Axes."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1990,7 +1990,7 @@ class SpanSelector(_SelectorWidget):
 
         rectprops['animated'] = self.useblit
 
-        self._direction = direction
+        self.direction = direction
 
         self._rect = None
         self.visible = True
@@ -2114,7 +2114,7 @@ class SpanSelector(_SelectorWidget):
     def direction(self, direction):
         """Set the direction of the span selector."""
         _api.check_in_list(['horizontal', 'vertical'], direction=direction)
-        if direction != self._direction:
+        if hasattr(self, '_direction') and direction != self._direction:
             # remove previous artists
             self._rect.remove()
             if self._interactive:
@@ -2125,6 +2125,8 @@ class SpanSelector(_SelectorWidget):
             self.new_axes(self.ax)
             if self._interactive:
                 self._setup_edge_handle(self._edge_handles._line_props)
+        else:
+            self._direction = direction
 
     def _release(self, event):
         """Button release event handler."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2027,6 +2027,9 @@ class SpanSelector(_SelectorWidget):
         if self._interactive:
             self.artists.extend([line for line in self._edge_handles.artists])
 
+        # prev attritube is deprecated but we still need to maintain it
+        self._prev = (0, 0)
+
     rect = _api.deprecate_privatize_attribute("3.5")
 
     rectprops = _api.deprecate_privatize_attribute("3.5")
@@ -2038,6 +2041,8 @@ class SpanSelector(_SelectorWidget):
     span_stays = _api.deprecated("3.5")(
         property(lambda self: self._interactive)
         )
+
+    prev = _api.deprecated("3.5")(property(lambda self: self._prev))
 
     def new_axes(self, ax):
         """Set SpanSelector to operate on a new Axes."""
@@ -2075,8 +2080,10 @@ class SpanSelector(_SelectorWidget):
             self.update()
 
         v = event.xdata if self.direction == 'horizontal' else event.ydata
-        # self._pressv is deprecated but we still need to maintain it
+        # self._pressv and self._prev are deprecated but we still need to
+        # maintain them
         self._pressv = v
+        self._prev = self._get_data(event)
 
         if self._active_handle is None:
             # when the press event outside the span, we initially set the
@@ -2119,6 +2126,9 @@ class SpanSelector(_SelectorWidget):
 
     def _onmove(self, event):
         """Motion notify event handler."""
+
+        # self._prev are deprecated but we still need to maintain it
+        self._prev = self._get_data(event)
 
         v = event.xdata if self.direction == 'horizontal' else event.ydata
         if self.direction == 'horizontal':

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2073,13 +2073,18 @@ class SpanSelector(_SelectorWidget):
         v = event.xdata if self.direction == 'horizontal' else event.ydata
         # self._pressv is deprecated but we still need to maintain it
         self._pressv = v
+
         if self._active_handle is None:
             # when the press event outside the span, we initially set the
-            # extents to (v, v) and _onmove or _release will follow up
-            # use _draw_shape instead of extents to avoid calling update
-            self._draw_shape(v, v)
-
-        self.set_visible(True)
+            # visibility to False and extents to (v, v)
+            # update will be called when setting the extents
+            self.visible = False
+            self.extents = v, v
+            # We need to set the visibility back, so the span selector will be
+            # drawn when necessary (span width > 0)
+            self.visible = True
+        else:
+            self.set_visible(True)
 
         return False
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1974,6 +1974,7 @@ class SpanSelector(_SelectorWidget):
     See also: :doc:`/gallery/widgets/span_selector`
     """
 
+    @_api.delete_parameter("3.5", "span_stays")
     def __init__(self, ax, onselect, direction, minspan=0, useblit=False,
                  rectprops=None, maxdist=10, marker_props=None,
                  onmove_callback=None, span_stays=False, interactive=False,
@@ -2002,6 +2003,11 @@ class SpanSelector(_SelectorWidget):
         # with Rectangle, etc.
         if span_stays:
             interactive = True
+            _api.warn_deprecated(
+                "3.5", message="Support for span_stays=True is deprecated "
+                               "since %(since)s and will be removed "
+                               "%(removal)s."
+                               "Use interactive=True instead.")
         self.interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
 
@@ -2093,7 +2099,7 @@ class SpanSelector(_SelectorWidget):
         if vmin > vmax:
             vmin, vmax = vmax, vmin
         span = vmax - vmin
-        if self.minspan is not None and span <= self.minspan:
+        if span < self.minspan:
             self.set_visible(False)
             self.update()
             return

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1933,10 +1933,6 @@ class SpanSelector(_SelectorWidget):
     rectprops : dict, default: None
         Dictionary of `matplotlib.patches.Patch` properties.
 
-    maxdist : float, default: 10
-        Distance in pixels within which the interactive tool handles can be
-        activated.
-
     marker_props : dict
         Properties with which the interactive handles are drawn.
 
@@ -1953,6 +1949,10 @@ class SpanSelector(_SelectorWidget):
 
     button : `.MouseButton` or list of `.MouseButton`
         The mouse buttons which activate the span selector.
+
+    maxdist : float, default: 10
+        Distance in pixels within which the interactive tool handles can be
+        activated.
 
     drag_from_anywhere : bool, optional
         If `True`, the widget can be moved by clicking anywhere within
@@ -1976,9 +1976,9 @@ class SpanSelector(_SelectorWidget):
 
     @_api.rename_parameter("3.5", "span_stays", "interactive")
     def __init__(self, ax, onselect, direction, minspan=0, useblit=False,
-                 rectprops=None, maxdist=10, marker_props=None,
-                 onmove_callback=None, interactive=False,
-                 button=None, drag_from_anywhere=False):
+                 rectprops=None, marker_props=None, onmove_callback=None,
+                 interactive=False, button=None,
+                 maxdist=10, drag_from_anywhere=False):
 
         super().__init__(ax, onselect, useblit=useblit, button=button)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2074,7 +2074,10 @@ class SpanSelector(_SelectorWidget):
         # self._pressv is deprecated but we still need to maintain it
         self._pressv = v
         if self._active_handle is None:
-            self.extents = v, v
+            # when the press event outside the span, we initially set the
+            # extents to (v, v) and _onmove or _release will follow up
+            # use _draw_shape instead of extents to avoid calling update
+            self._draw_shape(v, v)
 
         self.set_visible(True)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1923,8 +1923,8 @@ class SpanSelector(_SelectorWidget):
     direction : {"horizontal", "vertical"}
         The direction along which to draw the span selector.
 
-    minspan : float, default: None
-        If selection is less than *minspan*, do not call *onselect*.
+    minspan : float, default: 0
+        If selection is less than or egal to *minspan*, do not call *onselect*.
 
     useblit : bool, default: False
         If True, use the backend-dependent blitting features for faster
@@ -2251,7 +2251,8 @@ class ToolLineHandles:
 
     def set_data(self, positions):
         """
-        Set x positions of handles
+        Set x or y positions of handles, depending if the lines are vertical
+        of horizontal.
 
         Parameters
         ----------

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2005,7 +2005,7 @@ class SpanSelector(_SelectorWidget):
         self.minspan = minspan
 
         self.maxdist = maxdist
-        self.interactive = interactive
+        self._interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
 
         # Reset canvas so that `new_axes` connects events.
@@ -2024,7 +2024,7 @@ class SpanSelector(_SelectorWidget):
 
         self._active_handle = None
 
-        if self.interactive:
+        if self._interactive:
             self.artists.extend([line for line in self._edge_handles.artists])
 
     rect = _api.deprecate_privatize_attribute("3.5")
@@ -2061,12 +2061,12 @@ class SpanSelector(_SelectorWidget):
 
     def _press(self, event):
         """Button press event handler."""
-        if self.interactive and self._rect.get_visible():
+        if self._interactive and self._rect.get_visible():
             self._set_active_handle(event)
         else:
             self._active_handle = None
 
-        if self._active_handle is None or not self.interactive:
+        if self._active_handle is None or not self._interactive:
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
@@ -2090,7 +2090,7 @@ class SpanSelector(_SelectorWidget):
 
     def _release(self, event):
         """Button release event handler."""
-        if not self.interactive:
+        if not self._interactive:
             self._rect.set_visible(False)
 
         vmin, vmax = self.extents
@@ -2462,7 +2462,7 @@ class RectangleSelector(_SelectorWidget):
 
         self._to_draw = None
         self.visible = True
-        self.interactive = interactive
+        self._interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
 
         if drawtype == 'none':  # draw a line but make it invisible
@@ -2534,7 +2534,7 @@ class RectangleSelector(_SelectorWidget):
                         self._corner_handles.artist,
                         self._edge_handles.artist]
 
-        if not self.interactive:
+        if not self._interactive:
             self.artists = [self._to_draw]
 
         self._extents_on_press = None
@@ -2545,20 +2545,22 @@ class RectangleSelector(_SelectorWidget):
 
     active_handle = _api.deprecate_privatize_attribute("3.5")
 
+    interactive = _api.deprecate_privatize_attribute("3.5")
+
     def _press(self, event):
         """Button press event handler."""
         # make the drawn box/line visible get the click-coordinates,
         # button, ...
-        if self.interactive and self._to_draw.get_visible():
+        if self._interactive and self._to_draw.get_visible():
             self._set_active_handle(event)
         else:
             self._active_handle = None
 
-        if self._active_handle is None or not self.interactive:
+        if self._active_handle is None or not self._interactive:
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
-        if not self.interactive:
+        if not self._interactive:
             x = event.xdata
             y = event.ydata
             self.extents = x, x, y, y
@@ -2567,7 +2569,7 @@ class RectangleSelector(_SelectorWidget):
 
     def _release(self, event):
         """Button release event handler."""
-        if not self.interactive:
+        if not self._interactive:
             self._to_draw.set_visible(False)
 
         # update the eventpress and eventrelease with the resulting extents

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1924,7 +1924,8 @@ class SpanSelector(_SelectorWidget):
         The direction along which to draw the span selector.
 
     minspan : float, default: 0
-        If selection is less than or egal to *minspan*, do not call *onselect*.
+        If selection is less than or equal to *minspan*, do not call
+        *onselect*.
 
     useblit : bool, default: False
         If True, use the backend-dependent blitting features for faster
@@ -1949,7 +1950,7 @@ class SpanSelector(_SelectorWidget):
 
     line_props : dict, default: None
         Line properties with which the interactive line are drawn. Only used
-        when `interactive` is True. See `matplotlib.lines.Line2D` for details
+        when *interactive* is True. See `matplotlib.lines.Line2D` for details
         on valid properties.
 
     maxdist : float, default: 10
@@ -2022,7 +2023,7 @@ class SpanSelector(_SelectorWidget):
 
         self._active_handle = None
 
-        # prev attritube is deprecated but we still need to maintain it
+        # prev attribute is deprecated but we still need to maintain it
         self._prev = (0, 0)
 
     rect = _api.deprecate_privatize_attribute("3.5")

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2012,10 +2012,7 @@ class SpanSelector(_SelectorWidget):
         self.new_axes(ax)
 
         # Setup handles
-        if rectprops is None:
-            props = dict(markeredgecolor='r')
-        else:
-            props = dict(markeredgecolor=rectprops.get('edgecolor', 'r'))
+        props = dict(color=rectprops.get('facecolor', 'r'))
         props.update(cbook.normalize_kwargs(marker_props, Line2D._alias_map))
 
         self._edge_order = ['min', 'max']
@@ -2261,19 +2258,12 @@ class ToolLineHandles:
     def __init__(self, ax, positions, direction, marker_props=None,
                  useblit=True):
         self.ax = ax
-        props = {'linestyle': 'none', 'alpha': 1, 'visible': False,
-                 'label': '_nolegend_',
-                 **cbook.normalize_kwargs(marker_props, Line2D._alias_map)}
         self._markers = []
         self.direction = direction
+        marker_props.update({'visible':False})
 
-        for p in positions:
-            if self.direction == 'horizontal':
-                l = ax.axvline(p)
-            else:
-                l = ax.axhline(p)
-            l.set_visible(False)
-            self._markers.append(l)
+        line_func = ax.axvline if self.direction == 'horizontal' else ax.axhline
+        self._markers = [line_func(p, **marker_props) for p in positions]
 
         self.artists = self._markers
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2035,6 +2035,10 @@ class SpanSelector(_SelectorWidget):
 
     pressv = _api.deprecate_privatize_attribute("3.5")
 
+    span_stays = _api.deprecated("3.5")(
+        property(lambda self: self._interactive)
+        )
+
     def new_axes(self, ax):
         """Set SpanSelector to operate on a new Axes."""
         self.ax = ax

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2565,12 +2565,16 @@ class RectangleSelector(_SelectorWidget):
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
-        if not self._interactive:
+        if self._active_handle is None:
             x = event.xdata
             y = event.ydata
+            self.visible = False
             self.extents = x, x, y, y
+            self.visible = True
+        else:
+            self.set_visible(True)
 
-        self.set_visible(self.visible)
+        return False
 
     def _release(self, event):
         """Button release event handler."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1974,10 +1974,10 @@ class SpanSelector(_SelectorWidget):
     See also: :doc:`/gallery/widgets/span_selector`
     """
 
-    @_api.delete_parameter("3.5", "span_stays")
+    @_api.rename_parameter("3.5", "span_stays", "interactive")
     def __init__(self, ax, onselect, direction, minspan=0, useblit=False,
                  rectprops=None, maxdist=10, marker_props=None,
-                 onmove_callback=None, span_stays=False, interactive=False,
+                 onmove_callback=None, interactive=False,
                  button=None, drag_from_anywhere=False):
 
         super().__init__(ax, onselect, useblit=useblit, button=button)
@@ -1999,15 +1999,6 @@ class SpanSelector(_SelectorWidget):
         self.minspan = minspan
 
         self.maxdist = maxdist
-        # Deprecate `span_stays` in favour of interactive to be consistent
-        # with Rectangle, etc.
-        if span_stays:
-            interactive = True
-            _api.warn_deprecated(
-                "3.5", message="Support for span_stays=True is deprecated "
-                               "since %(since)s and will be removed "
-                               "%(removal)s."
-                               "Use interactive=True instead.")
         self.interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1945,6 +1945,7 @@ class SpanSelector(_SelectorWidget):
 
     span_stays : bool, default: False
         If True, the span stays visible after the mouse is released.
+        Deprecated, use interactive instead.
 
     interactive : bool, default: False
         Whether to draw a set of handles that allow interaction with the

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2196,27 +2196,15 @@ class SpanSelector(_SelectorWidget):
         return self._rect.contains(event, radius=0)[0]
 
     @property
-    def vmin(self):
-        """Get the start span coordinate."""
+    def extents(self):
+        """Return extents of the span selector."""
         if self.direction == 'horizontal':
             vmin = self._rect.get_x()
+            vmax = vmin + self._rect.get_width()
         else:
             vmin = self._rect.get_y()
-        return vmin
-
-    @property
-    def vmax(self):
-        """Get the end span coordinate."""
-        if self.direction == 'horizontal':
-            vmax = self.vmin + self._rect.get_width()
-        else:
-            vmax = self.vmin + self._rect.get_height()
-        return vmax
-
-    @property
-    def extents(self):
-        """Return (vmin, vmax)."""
-        return self.vmin, self.vmax
+            vmax = vmin + self._rect.get_height()
+        return vmin, vmax
 
     @extents.setter
     def extents(self, extents):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2022,10 +2022,18 @@ class SpanSelector(_SelectorWidget):
                                              line_props=props,
                                              useblit=self.useblit)
 
-        self.active_handle = None
+        self._active_handle = None
 
         if self.interactive:
             self.artists.extend([line for line in self._edge_handles.artists])
+
+    rect = _api.deprecate_privatize_attribute("3.5")
+
+    rectprops = _api.deprecate_privatize_attribute("3.5")
+
+    active_handle = _api.deprecate_privatize_attribute("3.5")
+
+    pressv = _api.deprecate_privatize_attribute("3.5")
 
     def new_axes(self, ax):
         """Set SpanSelector to operate on a new Axes."""
@@ -2056,9 +2064,9 @@ class SpanSelector(_SelectorWidget):
         if self.interactive and self._rect.get_visible():
             self._set_active_handle(event)
         else:
-            self.active_handle = None
+            self._active_handle = None
 
-        if self.active_handle is None or not self.interactive:
+        if self._active_handle is None or not self.interactive:
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
@@ -2071,26 +2079,6 @@ class SpanSelector(_SelectorWidget):
         self.set_visible(self.visible)
 
         return False
-
-    @_api.deprecated("3.5")
-    @property
-    def rect(self):
-        return self._rect
-
-    @_api.deprecated("3.5")
-    @property
-    def pressv(self):
-        return self._pressv
-
-    @_api.deprecated("3.5")
-    @pressv.setter
-    def pressv(self, value):
-        self._pressv = value
-
-    @_api.deprecated("3.5")
-    @property
-    def rectprops(self):
-        return self._rectprops
 
     @property
     def direction(self):
@@ -2127,18 +2115,18 @@ class SpanSelector(_SelectorWidget):
             vpress = self.eventpress.ydata
 
         # move existing span
-        # When "dragging from anywhere", the `self.active_handle` is set to 'C'
+        # When "dragging from anywhere", the `self._active_handle` is set to 'C'
         # in _set_active_handle (match notation used in the RectangleSelector)
-        if self.active_handle == 'C' and self._extents_on_press is not None:
+        if self._active_handle == 'C' and self._extents_on_press is not None:
             vmin, vmax = self._extents_on_press
             dv = v - vpress
             vmin += dv
             vmax += dv
 
         # resize an existing shape
-        elif self.active_handle and self.active_handle != 'C':
+        elif self._active_handle and self._active_handle != 'C':
             vmin, vmax = self._extents_on_press
-            if self.active_handle == 'min':
+            if self._active_handle == 'min':
                 vmin = v
             else:
                 vmax = v
@@ -2173,20 +2161,20 @@ class SpanSelector(_SelectorWidget):
         # Prioritise center handle over other handles
         # Use 'C' to match the notation used in the RectangleSelector
         if 'move' in self.state:
-            self.active_handle = 'C'
+            self._active_handle = 'C'
         elif e_dist > self.maxdist:
             # Not close to any handles
-            self.active_handle = None
+            self._active_handle = None
             if self.drag_from_anywhere and self._contains(event):
                 # Check if we've clicked inside the region
-                self.active_handle = 'C'
+                self._active_handle = 'C'
                 self._extents_on_press = self.extents
             else:
-                self.active_handle = None
+                self._active_handle = None
                 return
         else:
             # Closest to an edge handle
-            self.active_handle = self._edge_order[e_idx]
+            self._active_handle = self._edge_order[e_idx]
 
         # Save coordinates of rectangle at the start of handle movement.
         self._extents_on_press = self.extents
@@ -2511,7 +2499,7 @@ class RectangleSelector(_SelectorWidget):
 
         _api.check_in_list(['data', 'pixels'], spancoords=spancoords)
         self.spancoords = spancoords
-        self.drawtype = drawtype
+        self._drawtype = drawtype
 
         self.maxdist = maxdist
 
@@ -2536,7 +2524,7 @@ class RectangleSelector(_SelectorWidget):
                                           marker_props=props,
                                           useblit=self.useblit)
 
-        self.active_handle = None
+        self._active_handle = None
 
         self.artists = [self._to_draw, self._center_handle.artist,
                         self._corner_handles.artist,
@@ -2547,10 +2535,11 @@ class RectangleSelector(_SelectorWidget):
 
         self._extents_on_press = None
 
-    @_api.deprecated("3.5")
-    @property
-    def to_draw(self):
-        return self._to_draw
+    to_draw = _api.deprecate_privatize_attribute("3.5")
+
+    drawtype = _api.deprecate_privatize_attribute("3.5")
+
+    active_handle = _api.deprecate_privatize_attribute("3.5")
 
     def _press(self, event):
         """Button press event handler."""
@@ -2559,9 +2548,9 @@ class RectangleSelector(_SelectorWidget):
         if self.interactive and self._to_draw.get_visible():
             self._set_active_handle(event)
         else:
-            self.active_handle = None
+            self._active_handle = None
 
-        if self.active_handle is None or not self.interactive:
+        if self._active_handle is None or not self.interactive:
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
@@ -2601,7 +2590,7 @@ class RectangleSelector(_SelectorWidget):
                                spancoords=self.spancoords)
         # check if drawn distance (if it exists) is not too small in
         # either x or y-direction
-        if (self.drawtype != 'none'
+        if (self._drawtype != 'none'
                 and (self.minspanx is not None and spanx < self.minspanx
                      or self.minspany is not None and spany < self.minspany)):
             for artist in self.artists:
@@ -2618,15 +2607,15 @@ class RectangleSelector(_SelectorWidget):
     def _onmove(self, event):
         """Motion notify event handler."""
         # resize an existing shape
-        if self.active_handle and self.active_handle != 'C':
+        if self._active_handle and self._active_handle != 'C':
             x0, x1, y0, y1 = self._extents_on_press
-            if self.active_handle in ['E', 'W'] + self._corner_order:
+            if self._active_handle in ['E', 'W'] + self._corner_order:
                 x1 = event.xdata
-            if self.active_handle in ['N', 'S'] + self._corner_order:
+            if self._active_handle in ['N', 'S'] + self._corner_order:
                 y1 = event.ydata
 
         # move existing shape
-        elif (('move' in self.state or self.active_handle == 'C' or
+        elif (('move' in self.state or self._active_handle == 'C' or
                (self.drag_from_anywhere and self._contains(event))) and
               self._extents_on_press is not None):
             x0, x1, y0, y1 = self._extents_on_press
@@ -2673,7 +2662,7 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def _rect_bbox(self):
-        if self.drawtype == 'box':
+        if self._drawtype == 'box':
             x0 = self._to_draw.get_x()
             y0 = self._to_draw.get_y()
             width = self._to_draw.get_width()
@@ -2742,13 +2731,13 @@ class RectangleSelector(_SelectorWidget):
         xmax = min(xmax, xlim[1])
         ymax = min(ymax, ylim[1])
 
-        if self.drawtype == 'box':
+        if self._drawtype == 'box':
             self._to_draw.set_x(xmin)
             self._to_draw.set_y(ymin)
             self._to_draw.set_width(xmax - xmin)
             self._to_draw.set_height(ymax - ymin)
 
-        elif self.drawtype == 'line':
+        elif self._drawtype == 'line':
             self._to_draw.set_data([xmin, xmax], [ymin, ymax])
 
     def _set_active_handle(self, event):
@@ -2759,34 +2748,34 @@ class RectangleSelector(_SelectorWidget):
         m_idx, m_dist = self._center_handle.closest(event.x, event.y)
 
         if 'move' in self.state:
-            self.active_handle = 'C'
+            self._active_handle = 'C'
             self._extents_on_press = self.extents
         # Set active handle as closest handle, if mouse click is close enough.
         elif m_dist < self.maxdist * 2:
             # Prioritise center handle over other handles
-            self.active_handle = 'C'
+            self._active_handle = 'C'
         elif c_dist > self.maxdist and e_dist > self.maxdist:
             # Not close to any handles
             if self.drag_from_anywhere and self._contains(event):
                 # Check if we've clicked inside the region
-                self.active_handle = 'C'
+                self._active_handle = 'C'
                 self._extents_on_press = self.extents
             else:
-                self.active_handle = None
+                self._active_handle = None
                 return
         elif c_dist < e_dist:
             # Closest to a corner handle
-            self.active_handle = self._corner_order[c_idx]
+            self._active_handle = self._corner_order[c_idx]
         else:
             # Closest to an edge handle
-            self.active_handle = self._edge_order[e_idx]
+            self._active_handle = self._edge_order[e_idx]
 
         # Save coordinates of rectangle at the start of handle movement.
         x0, x1, y0, y1 = self.extents
         # Switch variables so that only x1 and/or y1 are updated on move.
-        if self.active_handle in ['W', 'SW', 'NW']:
+        if self._active_handle in ['W', 'SW', 'NW']:
             x0, x1 = x1, event.xdata
-        if self.active_handle in ['N', 'NW', 'NE']:
+        if self._active_handle in ['N', 'NW', 'NE']:
             y0, y1 = y1, event.ydata
         self._extents_on_press = x0, x1, y0, y1
 
@@ -2858,7 +2847,7 @@ class EllipseSelector(RectangleSelector):
         a = (xmax - xmin) / 2.
         b = (ymax - ymin) / 2.
 
-        if self.drawtype == 'box':
+        if self._drawtype == 'box':
             self._to_draw.center = center
             self._to_draw.width = 2 * a
             self._to_draw.height = 2 * b
@@ -2870,7 +2859,7 @@ class EllipseSelector(RectangleSelector):
 
     @property
     def _rect_bbox(self):
-        if self.drawtype == 'box':
+        if self._drawtype == 'box':
             x, y = self._to_draw.center
             width = self._to_draw.width
             height = self._to_draw.height

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2073,10 +2073,10 @@ class SpanSelector(_SelectorWidget):
         v = event.xdata if self.direction == 'horizontal' else event.ydata
         # self._pressv is deprecated but we still need to maintain it
         self._pressv = v
-        if not self.interactive:
+        if self._active_handle is None:
             self.extents = v, v
 
-        self.set_visible(self.visible)
+        self.set_visible(True)
 
         return False
 
@@ -2092,7 +2092,7 @@ class SpanSelector(_SelectorWidget):
 
         vmin, vmax = self.extents
         span = vmax - vmin
-        if span < self.minspan:
+        if span <= self.minspan:
             self.set_visible(False)
             self.update()
             return


### PR DESCRIPTION
## PR Summary

This PR updates the `SpanSelector` to make it consistent with `RectangleSelector`:
- Deprecate `span_stays` in favour of `interactive`
- Add edge handle when `interactive=True`
- Add `drag_from_anywhere` option, in line with #19657
- Fix https://github.com/matplotlib/matplotlib/pull/9660
- Improve docstring
- Deprecate `pressv`
- When reviewing the docstrings, I realised that some attributes are not expected to be used by users and should be private - I am happy to revert it back if necessary
  - Privatize `rect`, `rectprops`,  for the `SpanSelector`
  - Privatize  `to_draw`, `drawtype` for the `RectangleSelector
  - Privatize `active_handle` for SpanSelector and RectangleSelector
- Make `direction` a property

If you are happy with the changes, I will do the remaining doc, examples, etc updates.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
