### PR TITLE
Cleanup some "variable assigned but not used" lints.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -150,12 +150,11 @@ def _check_no_collapsed_axes(fig):
     return True
 
 
-def _get_margin_from_padding(object, *, w_pad=0, h_pad=0,
+def _get_margin_from_padding(obj, *, w_pad=0, h_pad=0,
                              hspace=0, wspace=0):
 
-    ss = object._subplotspec
+    ss = obj._subplotspec
     gs = ss.get_gridspec()
-    lg = gs._layoutgrid
 
     if hasattr(gs, 'hspace'):
         _hspace = (gs.hspace if gs.hspace is not None else hspace)
@@ -220,7 +219,6 @@ def _make_layout_margins(fig, renderer, *, w_pad=0, h_pad=0,
 
         margin = _get_margin_from_padding(ax, w_pad=w_pad, h_pad=h_pad,
                                            hspace=hspace, wspace=wspace)
-        margin0 = margin.copy()
         pos, bbox = _get_pos_and_bbox(ax, renderer)
         # the margin is the distance between the bounding box of the axes
         # and its position (plus the padding from above)
@@ -488,9 +486,6 @@ def _reposition_axes(fig, renderer, *, w_pad=0, h_pad=0, hspace=0, wspace=0):
 
         bbox = gs._layoutgrid.get_inner_bbox(rows=ss.rowspan, cols=ss.colspan)
 
-        bboxouter = gs._layoutgrid.get_outer_bbox(rows=ss.rowspan,
-                                                  cols=ss.colspan)
-
         # transform from figure to panel for set_position:
         newbbox = trans_fig_to_subfig.transform_bbox(bbox)
         ax._set_position(newbbox)
@@ -501,8 +496,7 @@ def _reposition_axes(fig, renderer, *, w_pad=0, h_pad=0, hspace=0, wspace=0):
         offset = {'left': 0, 'right': 0, 'bottom': 0, 'top': 0}
         for nn, cbax in enumerate(ax._colorbars[::-1]):
             if ax == cbax._colorbar_info['parents'][0]:
-                margin = _reposition_colorbar(
-                    cbax, renderer, offset=offset)
+                _reposition_colorbar(cbax, renderer, offset=offset)
 
 
 def _reposition_colorbar(cbax, renderer, *, offset=None):
@@ -527,7 +521,6 @@ def _reposition_colorbar(cbax, renderer, *, offset=None):
 
     parents = cbax._colorbar_info['parents']
     gs = parents[0].get_gridspec()
-    ncols, nrows = gs.ncols, gs.nrows
     fig = cbax.figure
     trans_fig_to_subfig = fig.transFigure - fig.transSubfigure
 

--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -312,7 +312,7 @@ def _parse_composites(fh):
             return composites
         vals = line.split(b';')
         cc = vals[0].split()
-        name, numParts = cc[1], _to_int(cc[2])
+        name, _num_parts = cc[1], _to_int(cc[2])
         pccParts = []
         for s in vals[1:-1]:
             pcc = s.split()

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -532,7 +532,6 @@ class PillowWriter(AbstractMovieWriter):
         buf = BytesIO()
         self.fig.savefig(
             buf, **{**savefig_kwargs, "format": "rgba", "dpi": self.dpi})
-        renderer = self.fig.canvas.get_renderer()
         self._frames.append(Image.frombuffer(
             "RGBA", self.frame_size, buf.getbuffer(), "raw", "RGBA", 0, 1))
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -373,7 +373,7 @@ def _get_image_inclusion_command():
         # Don't mess with backslashes on Windows.
         % cbook._get_data_path("images/matplotlib.png").as_posix())
     try:
-        prompt = man._expect_prompt()
+        man._expect_prompt()
         return r"\includegraphics"
     except LatexError:
         # Discard the broken manager.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1379,9 +1379,8 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     location = kw['ticklocation'] = loc_settings['location']
 
     anchor = kw.pop('anchor', loc_settings['anchor'])
-    parent_anchor = kw.pop('panchor', loc_settings['panchor'])
+    panchor = kw.pop('panchor', loc_settings['panchor'])
 
-    parents_iterable = np.iterable(parents)
     # turn parents into a list if it is not already. We do this w/ np
     # because `plt.subplots` can return an ndarray and is natural to
     # pass to `colorbar`.
@@ -1425,8 +1424,8 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         new_posn = shrinking_trans.transform(ax.get_position(original=True))
         new_posn = mtransforms.Bbox(new_posn)
         ax._set_position(new_posn)
-        if parent_anchor is not False:
-            ax.set_anchor(parent_anchor)
+        if panchor is not False:
+            ax.set_anchor(panchor)
 
     cax = fig.add_axes(pbcb, label="<colorbar>")
     for a in parents:
@@ -1437,7 +1436,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         parents=parents,
         shrink=shrink,
         anchor=anchor,
-        panchor=parent_anchor,
+        panchor=panchor,
         fraction=fraction,
         aspect=aspect,
         pad=pad)
@@ -1539,7 +1538,7 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
             aspect = 1 / aspect
 
     parent.set_subplotspec(ss_main)
-    parent.set_anchor(loc_settings["panchor"])
+    parent.set_anchor(panchor)
 
     fig = parent.get_figure()
     cax = fig.add_subplot(ss_cb, label="<colorbar>")

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1414,7 +1414,7 @@ def _load_fontmanager(*, try_read_cache=True):
     if try_read_cache:
         try:
             fm = json_load(fm_path)
-        except Exception as exc:
+        except Exception:
             pass
         else:
             if getattr(fm, "_version", object()) == FontManager.__version__:


### PR DESCRIPTION
Quite a few are left, some for clarity (for now...), others because they
may possibly hint at underlying bugs (e.g. https://github.com/matplotlib/matplotlib/issues/20130).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
