### PR TITLE
DOC: make 2x versions of all gallery figures

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,7 +168,8 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images'),
     'matplotlib_animations': True,
-    'image_srcset': ["2x"],
+    # 3.7 CI doc build should not use hidpi images during the testing phase
+    'image_srcset': [] if sys.version_info[:2] == (3, 7) else ["2x"],
 }
 
 plot_gallery = 'True'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -168,6 +168,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images'),
     'matplotlib_animations': True,
+    'image_srcset': ["2x"],
 }
 
 plot_gallery = 'True'

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -13,6 +13,10 @@ ipython
 ipywidgets
 numpydoc>=0.8
 sphinxcontrib-svg2pdfconverter>=1.1.0
-sphinx-gallery>=0.7
+# sphinx-gallery>=0.7   
+# b41e328 is PR 808 which adds the image_srcset directive.  When this is 
+# released with sphinx gallery, we can change to the last release w/o this feature:
+# sphinx-gallery>0.90
+git+git://github.com/sphinx-gallery/sphinx-gallery@b41e328#egg=sphinx-gallery
 sphinx-copybutton
 scipy


### PR DESCRIPTION
## PR Summary

This adds the `image_srcset` parameter to our doc conf.py  This will require us to use sphinx-gallery dev version, which I'm not exactly sure how to setup on circleCI.  

https://github.com/sphinx-gallery/sphinx-gallery/pull/808

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
