### PR TITLE
More tight_layout cleanups

### DIFF
--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -293,6 +293,12 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
 
     span_pairs = []
     for ss in ss_to_subplots:
+        # The intent here is to support axes from different gridspecs where
+        # one's nrows (or ncols) is a multiple of the other (e.g. 2 and 4),
+        # but this doesn't actually work because the computed wspace, in
+        # relative-axes-height, corresponds to different physical spacings for
+        # the 2-row grid and the 4-row grid.  Still, this code is left, mostly
+        # for backcompat.
         rows, cols = ss.get_gridspec().get_geometry()
         div_row, mod_row = divmod(max_nrows, rows)
         div_col, mod_col = divmod(max_ncols, cols)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -23,10 +23,9 @@ def _auto_adjust_subplotpars(
     Return a dict of subplot parameters to adjust spacing between subplots
     or ``None`` if resulting axes would have zero height or width.
 
-    Note that this function ignores geometry information of subplot
-    itself, but uses what is given by the *nrows_ncols* and *num1num2_list*
-    parameters.  Also, the results could be incorrect if some subplots have
-    ``adjustable=datalim``.
+    Note that this function ignores geometry information of subplot itself, but
+    uses what is given by the *shape* and *subplot_list* parameters.  Also, the
+    results could be incorrect if some subplots have ``adjustable=datalim``.
 
     Parameters
     ----------
@@ -47,11 +46,11 @@ def _auto_adjust_subplotpars(
     """
     rows, cols = shape
 
-    font_size_inches = (
+    font_size_inch = (
         FontProperties(size=rcParams["font.size"]).get_size_in_points() / 72)
-    pad_inches = pad * font_size_inches
-    vpad_inches = h_pad * font_size_inches if h_pad is not None else pad_inches
-    hpad_inches = w_pad * font_size_inches if w_pad is not None else pad_inches
+    pad_inch = pad * font_size_inch
+    vpad_inch = h_pad * font_size_inch if h_pad is not None else pad_inch
+    hpad_inch = w_pad * font_size_inch if w_pad is not None else pad_inch
 
     if len(span_pairs) != len(subplot_list) or len(subplot_list) == 0:
         raise ValueError
@@ -98,42 +97,37 @@ def _auto_adjust_subplotpars(
     # margins can be negative for axes with aspect applied, so use max(, 0) to
     # make them nonnegative.
     if not margin_left:
-        margin_left = (max(hspaces[:, 0].max(), 0)
-                       + pad_inches / fig_width_inch)
+        margin_left = max(hspaces[:, 0].max(), 0) + pad_inch/fig_width_inch
         suplabel = fig._supylabel
         if suplabel and suplabel.get_in_layout():
             rel_width = fig.transFigure.inverted().transform_bbox(
                 suplabel.get_window_extent(renderer)).width
-            margin_left += rel_width + pad_inches / fig_width_inch
-
+            margin_left += rel_width + pad_inch/fig_width_inch
     if not margin_right:
-        margin_right = (max(hspaces[:, -1].max(), 0)
-                        + pad_inches / fig_width_inch)
+        margin_right = max(hspaces[:, -1].max(), 0) + pad_inch/fig_width_inch
     if not margin_top:
-        margin_top = (max(vspaces[0, :].max(), 0)
-                      + pad_inches / fig_height_inch)
+        margin_top = max(vspaces[0, :].max(), 0) + pad_inch/fig_height_inch
         if fig._suptitle and fig._suptitle.get_in_layout():
             rel_height = fig.transFigure.inverted().transform_bbox(
                 fig._suptitle.get_window_extent(renderer)).height
-            margin_top += rel_height + pad_inches / fig_height_inch
+            margin_top += rel_height + pad_inch/fig_height_inch
     if not margin_bottom:
-        margin_bottom = (max(vspaces[-1, :].max(), 0)
-                         + pad_inches / fig_height_inch)
+        margin_bottom = max(vspaces[-1, :].max(), 0) + pad_inch/fig_height_inch
         suplabel = fig._supxlabel
         if suplabel and suplabel.get_in_layout():
             rel_height = fig.transFigure.inverted().transform_bbox(
                 suplabel.get_window_extent(renderer)).height
-            margin_bottom += rel_height + pad_inches / fig_height_inch
+            margin_bottom += rel_height + pad_inch/fig_height_inch
 
     if margin_left + margin_right >= 1:
         _api.warn_external('Tight layout not applied. The left and right '
                            'margins cannot be made large enough to '
-                           'accommodate all axes decorations. ')
+                           'accommodate all axes decorations.')
         return None
     if margin_bottom + margin_top >= 1:
         _api.warn_external('Tight layout not applied. The bottom and top '
                            'margins cannot be made large enough to '
-                           'accommodate all axes decorations. ')
+                           'accommodate all axes decorations.')
         return None
 
     kwargs = dict(left=margin_left,
@@ -142,7 +136,7 @@ def _auto_adjust_subplotpars(
                   top=1 - margin_top)
 
     if cols > 1:
-        hspace = hspaces[:, 1:-1].max() + hpad_inches / fig_width_inch
+        hspace = hspaces[:, 1:-1].max() + hpad_inch / fig_width_inch
         # axes widths:
         h_axes = (1 - margin_right - margin_left - hspace * (cols - 1)) / cols
         if h_axes < 0:
@@ -153,12 +147,12 @@ def _auto_adjust_subplotpars(
         else:
             kwargs["wspace"] = hspace / h_axes
     if rows > 1:
-        vspace = vspaces[1:-1, :].max() + vpad_inches / fig_height_inch
+        vspace = vspaces[1:-1, :].max() + vpad_inch / fig_height_inch
         v_axes = (1 - margin_top - margin_bottom - vspace * (rows - 1)) / rows
         if v_axes < 0:
             _api.warn_external('Tight layout not applied. tight_layout '
                                'cannot make axes height small enough to '
-                               'accommodate all axes decorations')
+                               'accommodate all axes decorations.')
             return None
         else:
             kwargs["hspace"] = vspace / v_axes


### PR DESCRIPTION
1st commit: Small style fixes.

Rename variables (inches->inch) for consistency and make formulas fit in
one line.
Small consistency fixes to warnings messages.
Doc fixes.

2nd commit: Simplify initial calculations in get_tight_layout_figure.

3rd commit: Comment re: non-working case of tight_layout.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
