### PR TITLE
Don't clip clip paths to Figure bbox.

### DIFF
--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -12,7 +12,7 @@ import matplotlib.path as mpath
 import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
 import matplotlib.artist as martist
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 
 def test_patch_transform_of_none():
@@ -119,6 +119,25 @@ def test_clipping():
 
     ax1.set_xlim([-3, 3])
     ax1.set_ylim([-3, 3])
+
+
+@check_figures_equal(extensions=['png'])
+def test_clipping_zoom(fig_test, fig_ref):
+    # This test places the Axes and sets its limits such that the clip path is
+    # outside the figure entirely. This should not break the clip path.
+    ax_test = fig_test.add_axes([0, 0, 1, 1])
+    l, = ax_test.plot([-3, 3], [-3, 3])
+    # Explicit Path instead of a Rectangle uses clip path processing, instead
+    # of a clip box optimization.
+    p = mpath.Path([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]])
+    p = mpatches.PathPatch(p, transform=ax_test.transData)
+    l.set_clip_path(p)
+
+    ax_ref = fig_ref.add_axes([0, 0, 1, 1])
+    ax_ref.plot([-3, 3], [-3, 3])
+
+    ax_ref.set(xlim=(0.5, 0.75), ylim=(0.5, 0.75))
+    ax_test.set(xlim=(0.5, 0.75), ylim=(0.5, 0.75))
 
 
 def test_cull_markers():

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -134,8 +134,10 @@ bool RendererAgg::render_clippath(py::PathIterator &clippath,
 {
     typedef agg::conv_transform<py::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removed_t;
-    typedef PathClipper<nan_removed_t> clipped_t;
-    typedef PathSnapper<clipped_t> snapped_t;
+    /* Unlike normal Paths, the clip path cannot be clipped to the Figure bbox,
+     * because it needs to remain a complete closed path, so there is no
+     * PathClipper<nan_removed_t> step. */
+    typedef PathSnapper<nan_removed_t> snapped_t;
     typedef PathSimplifier<snapped_t> simplify_t;
     typedef agg::conv_curve<simplify_t> curve_t;
 
@@ -151,8 +153,7 @@ bool RendererAgg::render_clippath(py::PathIterator &clippath,
         rendererBaseAlphaMask.clear(agg::gray8(0, 0));
         transformed_path_t transformed_clippath(clippath, trans);
         nan_removed_t nan_removed_clippath(transformed_clippath, true, clippath.has_curves());
-        clipped_t clipped_clippath(nan_removed_clippath, !clippath.has_curves(), width, height);
-        snapped_t snapped_clippath(clipped_clippath, snap_mode, clippath.total_vertices(), 0.0);
+        snapped_t snapped_clippath(nan_removed_clippath, snap_mode, clippath.total_vertices(), 0.0);
         simplify_t simplified_clippath(snapped_clippath,
                                        clippath.should_simplify() && !clippath.has_curves(),
                                        clippath.simplify_threshold());


### PR DESCRIPTION
## PR Summary

This kind of path clipping just cuts the path on the bounding box, which produces an invalid clip path, since it is no longer closed or complete.

Fixes #20127.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).