### PR TITLE
DOC: add example of labelling axes

### DIFF
--- a/examples/text_labels_and_annotations/label_subplots.py
+++ b/examples/text_labels_and_annotations/label_subplots.py
@@ -1,0 +1,70 @@
+"""
+==================
+Labelling subplots
+==================
+
+Labelling subplots is relatively straightforward, and varies,
+so Matplotlib does not have a general method for doing this.
+
+Simplest is putting the label inside the axes.  Note, here
+we use `.pyplot.subplot_mosaic`, and use the subplot labels
+as keys for the subplots, which is a nice convenience.  However,
+the same method works with `.pyplot.subplots` or keys that are
+different than what you want to label the subplot with.
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
+
+fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
+                              constrained_layout=True)
+
+for label, ax in axs.items():
+    # label physical distance in and down:
+    trans = mtransforms.ScaledTranslation(10/72, -5/72, fig.dpi_scale_trans)
+    ax.text(0.0, 1.0, label, transform=ax.transAxes + trans,
+            fontsize='medium', verticalalignment='top', fontfamily='serif',
+            bbox=dict(facecolor='0.7', edgecolor='none', pad=3.0))
+
+plt.show()
+
+##############################################################################
+# We may prefer the labels outside the axes, but still aligned
+# with each other, in which case we use a slightly different transform:
+
+fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
+                              constrained_layout=True)
+
+for label, ax in axs.items():
+    # label physical distance to the left and up:
+    trans = mtransforms.ScaledTranslation(-20/72, 7/72, fig.dpi_scale_trans)
+    ax.text(0.0, 1.0, label, transform=ax.transAxes + trans,
+            fontsize='medium', va='bottom', fontfamily='serif')
+
+plt.show()
+
+##############################################################################
+# If we want it aligned with the title, either incorporate in the title or
+# use the ``loc`` kwarg:
+
+fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
+                              constrained_layout=True)
+
+for label, ax in axs.items():
+    ax.set_title('Normal Title', fontstyle='italic')
+    ax.set_title(label, fontfamily='serif', loc='left', fontsize='medium')
+
+plt.show()
+
+#############################################################################
+#
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.figure.Figure.subplot_mosaic` /
+#      `matplotlib.pyplot.subplot_mosaic`
+#    - `matplotlib.axes.Axes.set_title`
+#    - `matplotlib.axes.Axes.text`
+#    - `matplotlib.transforms.ScaledTranslation`

--- a/examples/text_labels_and_annotations/label_subplots.py
+++ b/examples/text_labels_and_annotations/label_subplots.py
@@ -45,7 +45,7 @@ plt.show()
 
 ##############################################################################
 # If we want it aligned with the title, either incorporate in the title or
-# use the ``loc`` kwarg:
+# use the *loc* keyword argument:
 
 fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
                               constrained_layout=True)


### PR DESCRIPTION
## PR Summary

This new example demos a few approaches to adding labels to subplots, since this is a frequent request. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
