### PR TITLE
FIX: MouseButton representation in boilerplate generated signatures

### DIFF
--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -24,7 +24,29 @@ import textwrap
 import numpy as np
 from matplotlib import _api, mlab
 from matplotlib.axes import Axes
+from matplotlib.backend_bases import MouseButton
 from matplotlib.figure import Figure
+
+
+# we need to define a custom str because py310 change
+# In Python 3.10 the repr and str representation of Enums changed from
+#
+#  str: 'ClassName.NAME' -> 'NAME'
+#  repr: '<ClassName.NAME: value>' -> 'ClassName.NAME'
+#
+# which is more consistent with what str/repr should do, however this breaks
+# boilerplate which needs to get the ClassName.NAME version in all versions of
+# Python. Thus, we locally monkey patch our preferred str representation in
+# here.
+#
+# bpo-40066
+# https://github.com/python/cpython/pull/22392/
+def enum_str_back_compat_patch(self):
+    return f'{type(self).__name__}.{self.name}'
+
+# only monkey patch if we have to.
+if str(MouseButton.LEFT) != 'MouseButton.Left':
+    MouseButton.__str__ = enum_str_back_compat_patch
 
 
 # This is the magic line that must exist in pyplot, after which the boilerplate


### PR DESCRIPTION
## PR Summary

In Python 3.10 the repr and str representation of Enums changed from

 str: 'ClassName.NAME' -> 'NAME'
 repr: '<ClassName.NAME: value>' -> 'ClassName.NAME'

which is more consistent with what str/repr should do, however this breaks
boilerplate which needs to get the ClassName.NAME version in all versions of
Python. Thus, we locally monkey patch our preferred str representation in
here.

bpo-40066
https://github.com/python/cpython/pull/22392/

Other options considered:

 - patch `MouseButton.__str__` in `matplotlib.backend_bases`.  This has the advantage of maintaining stability of `str(MouseButton.Left)` over time, but this feels like something we should not fight upstream on.  If they chose to break this intentionally we should follow them and not make our Enum "special"
 - re-writing https://github.com/matplotlib/matplotlib/blob/f6790c0f5dad161efa81b4779bf1fc5a32c81e27/tools/boilerplate.py#L122-L125 to special case `MouseButton`, but that would more-or-less involve vendoring the str methods from both `inspect.Signature` and `inspect.Parameter` which are about a screen of code in total.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes). (this fixes a failure on py310)
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
