### PR TITLE
Fix wheel builds on CI

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -13,8 +13,8 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      min-numpy-version: "1.17.0"
-      min-numpy-hash: "da/32/1b8f2bb5fb50e4db68543eb85ce37b9fa6660cd05b58bddfafafa7ed62da"
+      min-numpy-version: "1.17.3"
+      min-numpy-hash: "b6/d6/be8f975f5322336f62371c9abeb936d592c98c047ad63035f1b38ae08efe"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -57,7 +57,7 @@ jobs:
           cd numpy-${{ env.min-numpy-version }}
           python -m cibuildwheel --output-dir ../numpy-aarch64-cache
         env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-*"
+          CIBW_BUILD: "cp37-* cp38-*"
           CIBW_ARCHS: aarch64
 
       - name: Copy setup.cfg to configure wheel
@@ -85,20 +85,6 @@ jobs:
           CIBW_BEFORE_BUILD: pip install certifi; pip install --find-links=numpy-aarch64-cache/ numpy==${{ env.min-numpy-version }}
           MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-
-      - name: Build wheels for CPython 3.6
-        run: |
-          python -m cibuildwheel --output-dir dist
-        env:
-          CIBW_BUILD: "cp36-*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-          CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: pip install certifi; pip install --find-links=numpy-aarch64-cache/ numpy==${{ env.min-numpy-version }}
-          MPL_DISABLE_FH4: "yes"
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-        if: >
-          startsWith(github.ref, 'refs/heads/v3.3') ||
-          startsWith(github.ref, 'refs/tags/v3.3')
 
       - name: Build wheels for PyPy
         run: |

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/doc/build/html/index.html
-          circleci-jobs: docs-python36,docs-python37,docs-python38
+          circleci-jobs: docs-python37,docs-python38,docs-python38-min


### PR DESCRIPTION
## PR Summary

The minimum NumPy with Python 3.8 wheels is 1.17.3, so bump CI to use that version. This should be fine since there aren't supposed to be ABI changes in micro releases.

Also drop remnants of 3.6 builds, that are mostly disabled already.

Corresponds to [this test build](https://github.com/QuLogic/matplotlib/actions/runs/808855055), which is working again

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).