### PR TITLE
Create error surface gradient descent plot example

### DIFF
--- a/examples/statistics/error_surface_gradient.py
+++ b/examples/statistics/error_surface_gradient.py
@@ -1,0 +1,61 @@
+"""
+======================================================
+Plot an error surface of gradient descent
+======================================================
+This example shows how to plot an error surface for the 
+descending gradient of a two-dimensional dataset, using 
+the quadratic error as an error function. The gradient 
+method is used to minimize a given function to its local 
+minimum.
+"""
+
+import random, math
+import numpy as np
+
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+import matplotlib.gridspec as gridspec
+
+def error(X, y, w):
+    return 0.5 * np.linalg.norm(X.dot(w) - y)**2
+
+def linear_regression_gradient(X, y, w):
+    return X.T.dot(X.dot(w)-y)
+
+def plot_mesh(X_data, y_data, bounds):
+    (minx,miny),(maxx,maxy) = bounds
+    
+    x_range = np.linspace(minx, maxx, num=50)
+    y_range = np.linspace(miny, maxy, num=50)
+    X, Y = np.meshgrid(x_range, y_range)
+    
+    Z = np.zeros((len(x_range), len(y_range)))
+    
+    for i, w_i in enumerate(x_range):
+        for j, w_j in enumerate(y_range):
+            Z[j,i] = error(X_data, y_data, [w_i, w_j])
+    fig = plt.figure(figsize=(7,5))
+    ax = fig.gca(projection='3d')
+    
+    ax.plot_surface(X, Y, Z, cmap=cm.plasma, linewidth=1, antialiased=True, alpha=0.5)
+    ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10, cmap=cm.plasma, linewidth=1, color='navy')
+    return Z
+
+    
+X = np.array([[0.], [2.], [4.], [6.], [8.], [10.]])
+y = np.array([22.5, 6.0, 4.0, 3.5, 2.2, 1.])  
+
+X_bias = np.hstack((X, np.ones((len(X), 1))))
+
+w = np.random.random(2)/10000
+
+alpha = 0.05
+epoch = 50
+
+for i in range(epoch):
+    linear_regression = linear_regression_gradient(X_bias, y, w)
+    w = w - alpha * linear_regression
+    
+plot_mesh(X_bias, y, [[-7.5, -10], [5, 15]])
+plt.setp(plt.gca(), xlabel='$Weight_1$', ylabel='$Weight_2$', zlabel='$\mathrm{E}(Weight_1,Weight_2)$')
+plt.tight_layout()

--- a/examples/statistics/error_surface_gradient.py
+++ b/examples/statistics/error_surface_gradient.py
@@ -35,7 +35,7 @@ def plot_mesh(X_data, y_data, bounds):
         for j, w_j in enumerate(y_range):
             Z[j,i] = error(X_data, y_data, [w_i, w_j])
     fig = plt.figure(figsize=(7,5))
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(111, projection='3d')
     
     ax.plot_surface(X, Y, Z, cmap=cm.plasma, linewidth=1, antialiased=True, alpha=0.5)
     ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10, cmap=cm.plasma, linewidth=1, color='navy')


### PR DESCRIPTION
This example shows how to plot an error surface for the descending gradient using matplotlib.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
