### PR TITLE
Auto-generate required kwdoc entries into docstring.interpd.

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -658,26 +658,14 @@ are:
 2. as automated as possible so that as properties change, the docs
    are updated automatically.
 
-The function `matplotlib.artist.kwdoc` and the decorator
-``matplotlib.docstring.dedent_interpd`` facilitate this.  They combine Python
-string interpolation in the docstring with the Matplotlib artist introspection
-facility that underlies ``setp`` and ``getp``.  The ``kwdoc`` function gives
-the list of properties as a docstring. In order to use this in another
-docstring, first update the ``matplotlib.docstring.interpd`` object, as seen in
-this example from `matplotlib.lines`:
-
-.. code-block:: python
-
-  # in lines.py
-  docstring.interpd.update(Line2D_kwdoc=artist.kwdoc(Line2D))
-
-Then in any function accepting `~.Line2D` pass-through ``kwargs``, e.g.,
-`matplotlib.axes.Axes.plot`:
+The ``@docstring.interpd`` decorator implements this.  Any function accepting
+`.Line2D` pass-through ``kwargs``, e.g., `matplotlib.axes.Axes.plot`, can list
+a summary of the `.Line2D` properties, as follows:
 
 .. code-block:: python
 
   # in axes.py
-  @docstring.dedent_interpd
+  @docstring.interpd
   def plot(self, *args, **kwargs):
       """
       Some stuff omitted
@@ -702,17 +690,19 @@ Then in any function accepting `~.Line2D` pass-through ``kwargs``, e.g.,
 
           Here is a list of available `.Line2D` properties:
 
-          %(Line2D_kwdoc)s
-
+          %(Line2D:kwdoc)s
       """
 
-Note there is a problem for `~matplotlib.artist.Artist` ``__init__`` methods,
-e.g., `matplotlib.patches.Patch`, which supports ``Patch`` ``kwargs``,
-since the artist inspector cannot work until the class is fully defined and
-we can't modify the ``Patch.__init__.__doc__`` docstring outside the class
-definition.  There are some some manual hacks in this case, violating the
-"single entry point" requirement above -- see the ``docstring.interpd.update``
-calls in `matplotlib.patches`.
+The ``%(Line2D:kwdoc)`` syntax makes ``interpd`` lookup an `.Artist` subclass
+named ``Line2D``, and call `.artist.kwdoc` on that class.  `.artist.kwdoc`
+introspects the subclass and summarizes its properties as a substring, which
+gets interpolated into the docstring.
+
+Note that this scheme does not work for decorating an Artist's ``__init__``, as
+the subclass and its properties are not defined yet at that point.  Instead,
+``@docstring.interpd`` can be used to decorate the class itself -- at that
+point, `.kwdoc` can list the properties and interpolate them into
+``__init__.__doc__``.
 
 
 Inheriting docstrings

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -14,16 +14,15 @@
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.LogitLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MaxNLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MultipleLocator.tick_values:5",
-      "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.OldAutoLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.SymmetricalLogLocator.tick_values:5"
     ],
     "button": [
       "doc/users/prev_whats_new/whats_new_3.1.0.rst:335"
     ],
     "cbar_axes": [
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid.__init__:49",
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:49",
-      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:49"
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid.__init__:45",
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:45",
+      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:45"
     ],
     "eventson": [
       "lib/matplotlib/widgets.py:docstring of matplotlib.widgets.CheckButtons.set_active:4",
@@ -574,6 +573,26 @@
     "get_matrix": [
       "lib/matplotlib/transforms.py:docstring of matplotlib.transforms.Affine2DBase:13"
     ],
+    "matplotlib.collections._CollectionWithSizes.set_sizes": [
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.barbs:172",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.broken_barh:82",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.fill_between:112",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.fill_betweenx:112",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.hexbin:168",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.pcolor:165",
+      "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.quiver:202",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.barbs:172",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.broken_barh:82",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.fill_between:112",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.fill_betweenx:112",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.hexbin:168",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.pcolor:165",
+      "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.quiver:202",
+      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Barbs.__init__:176",
+      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Barbs:206",
+      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Quiver.__init__:206",
+      "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Quiver:239"
+    ],
     "matplotlib.dates.DateFormatter.__call__": [
       "doc/users/prev_whats_new/whats_new_1.5.rst:497"
     ],
@@ -593,11 +612,6 @@
     ],
     "dateutil": [
       "lib/matplotlib/dates.py:docstring of matplotlib.dates:1"
-    ],
-    "matplotlib": [
-      "doc/api/next_api_changes/deprecations/19517-AL.rst:3",
-      "doc/api/prev_api_changes/api_changes_0.91.2.rst:15",
-      "doc/api/prev_api_changes/api_changes_3.4.0/deprecations.rst:58"
     ],
     "matplotlib.ft2font": [
       "doc/api/prev_api_changes/api_changes_0.91.0.rst:34"
@@ -669,9 +683,6 @@
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.violinplot:46",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.violinplot:46"
     ],
-    "Glue": [
-      "lib/matplotlib/mathtext.py:docstring of matplotlib.mathtext.GlueSpec:2"
-    ],
     "Glyph": [
       "doc/gallery/misc/ftface_props.rst:25"
     ],
@@ -716,9 +727,9 @@
       "doc/users/event_handling.rst:179"
     ],
     "Size.from_any": [
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid.__init__:61",
-      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:61",
-      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:61"
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid.__init__:57",
+      "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:57",
+      "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:57"
     ],
     "Timer": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.FigureCanvasBase.new_timer:2",

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -10,7 +10,7 @@ import warnings
 import numpy as np
 
 import matplotlib as mpl
-from . import _api, cbook, docstring
+from . import _api, cbook
 from .path import Path
 from .transforms import (Bbox, IdentityTransform, Transform, TransformedBbox,
                          TransformedPatchPath, TransformedPath)
@@ -1697,6 +1697,3 @@ def kwdoc(artist):
     return ('\n'.join(ai.pprint_setters_rest(leadingspace=4))
             if mpl.rcParams['docstring.hardcopy'] else
             'Properties:\n' + '\n'.join(ai.pprint_setters(leadingspace=4)))
-
-
-docstring.interpd.update(Artist_kwdoc=kwdoc(Artist))

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -43,6 +43,7 @@ _log = logging.getLogger(__name__)
 # All the other methods should go in the _AxesBase class.
 
 
+@docstring.interpd
 class Axes(_AxesBase):
     """
     The `Axes` contains most of the figure elements: `~.axis.Axis`,
@@ -397,7 +398,7 @@ class Axes(_AxesBase):
         **kwargs
             Other keyword arguments are passed on to the `.Rectangle` patch:
 
-            %(Rectangle_kwdoc)s
+            %(Rectangle:kwdoc)s
 
         Returns
         -------
@@ -609,7 +610,7 @@ class Axes(_AxesBase):
         **kwargs : `~matplotlib.text.Text` properties.
             Other miscellaneous text parameters.
 
-            %(Text_kwdoc)s
+            %(Text:kwdoc)s
 
         Examples
         --------
@@ -686,7 +687,7 @@ class Axes(_AxesBase):
             Valid keyword arguments are `.Line2D` properties, with the
             exception of 'transform':
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -753,7 +754,7 @@ class Axes(_AxesBase):
             Valid keyword arguments are `.Line2D` properties, with the
             exception of 'transform':
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -837,7 +838,7 @@ class Axes(_AxesBase):
         **kwargs
             Valid kwargs are `.Line2D` properties
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -905,7 +906,7 @@ class Axes(_AxesBase):
         ----------------
         **kwargs : `~matplotlib.patches.Polygon` properties
 
-        %(Polygon_kwdoc)s
+        %(Polygon:kwdoc)s
 
         See Also
         --------
@@ -953,7 +954,7 @@ class Axes(_AxesBase):
         ----------------
         **kwargs : `~matplotlib.patches.Polygon` properties
 
-        %(Polygon_kwdoc)s
+        %(Polygon:kwdoc)s
 
         See Also
         --------
@@ -1506,7 +1507,7 @@ class Axes(_AxesBase):
 
             Here is a list of available `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -1663,7 +1664,7 @@ class Axes(_AxesBase):
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -2234,7 +2235,7 @@ class Axes(_AxesBase):
 
         **kwargs : `.Rectangle` properties
 
-        %(Rectangle_kwdoc)s
+        %(Rectangle:kwdoc)s
 
         See Also
         --------
@@ -2509,7 +2510,7 @@ class Axes(_AxesBase):
 
         **kwargs : `.Rectangle` properties
 
-        %(Rectangle_kwdoc)s
+        %(Rectangle:kwdoc)s
 
         See Also
         --------
@@ -2697,7 +2698,7 @@ class Axes(_AxesBase):
 
             Supported keywords:
 
-            %(BrokenBarHCollection_kwdoc)s
+            %(BrokenBarHCollection:kwdoc)s
         """
         # process the unit information
         if len(xranges):
@@ -3288,7 +3289,7 @@ class Axes(_AxesBase):
 
             Valid kwargs for the marker properties are `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
         """
         kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
         # anything that comes in as 'None', drop so the default thing
@@ -4740,7 +4741,7 @@ default: :rc:`scatter.edgecolors`
         **kwargs : `~matplotlib.collections.PolyCollection` properties
             All other keyword arguments are passed on to `.PolyCollection`:
 
-            %(PolyCollection_kwdoc)s
+            %(PolyCollection:kwdoc)s
 
         """
         self._process_unit_info([("x", x), ("y", y)], kwargs, convert=False)
@@ -5249,7 +5250,7 @@ default: :rc:`scatter.edgecolors`
             All other keyword arguments are passed on to `.PolyCollection`.
             They control the `.Polygon` properties:
 
-            %(PolyCollection_kwdoc)s
+            %(PolyCollection:kwdoc)s
 
         See Also
         --------
@@ -5847,7 +5848,7 @@ default: :rc:`scatter.edgecolors`
             Additionally, the following arguments are allowed. They are passed
             along to the `~matplotlib.collections.PolyCollection` constructor:
 
-        %(PolyCollection_kwdoc)s
+        %(PolyCollection:kwdoc)s
 
         See Also
         --------
@@ -6092,7 +6093,7 @@ default: :rc:`scatter.edgecolors`
             Additionally, the following arguments are allowed. They are passed
             along to the `~matplotlib.collections.QuadMesh` constructor:
 
-        %(QuadMesh_kwdoc)s
+        %(QuadMesh:kwdoc)s
 
         See Also
         --------
@@ -7133,7 +7134,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -7246,7 +7247,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -7336,7 +7337,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -7413,7 +7414,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -7479,7 +7480,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         See Also
         --------
@@ -7546,7 +7547,7 @@ such objects
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         References
         ----------
@@ -7796,7 +7797,7 @@ such objects
             For the marker style, you can pass any `.Line2D` property except
             for *linestyle*:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
         """
         if marker is None and markersize is None and hasattr(Z, 'tocoo'):
             marker = 's'

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -586,7 +586,7 @@ class _AxesBase(martist.Artist):
         **kwargs
             Other optional keyword arguments:
 
-            %(Axes_kwdoc)s
+            %(Axes:kwdoc)s
 
         Returns
         -------
@@ -3217,7 +3217,7 @@ class _AxesBase(martist.Artist):
 
             Valid keyword arguments are:
 
-            %(Line2D_kwdoc)s
+            %(Line2D:kwdoc)s
 
         Notes
         -----

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,7 +1,6 @@
 import functools
 
-from matplotlib import _api, docstring
-import matplotlib.artist as martist
+from matplotlib import _api
 from matplotlib.axes._axes import Axes
 from matplotlib.gridspec import GridSpec, SubplotSpec
 
@@ -220,9 +219,3 @@ def _picklable_subplot_class_constructor(axes_class):
     """
     subplot_class = subplot_class_factory(axes_class)
     return subplot_class.__new__(subplot_class)
-
-
-docstring.interpd.update(Axes_kwdoc=martist.kwdoc(Axes))
-docstring.dedent_interpd(Axes.__init__)
-
-docstring.interpd.update(Subplot_kwdoc=martist.kwdoc(Axes))

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2097,12 +2097,3 @@ class QuadMesh(Collection):
         gc.restore()
         renderer.close_group(self.__class__.__name__)
         self.stale = False
-
-
-_artist_kwdoc = artist.kwdoc(Collection)
-for k in ('QuadMesh', 'TriMesh', 'PolyCollection', 'BrokenBarHCollection',
-          'RegularPolyCollection', 'PathCollection',
-          'StarPolygonCollection', 'PatchCollection',
-          'CircleCollection', 'Collection',):
-    docstring.interpd.update({f'{k}_kwdoc': _artist_kwdoc})
-docstring.interpd.update(LineCollection_kwdoc=artist.kwdoc(LineCollection))

--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -33,7 +33,7 @@ class Substitution:
     def __init__(self, *args, **kwargs):
         if args and kwargs:
             raise TypeError("Only positional or keyword args are allowed")
-        self.params = args or kwargs
+        self.params = params = args or kwargs
 
     def __call__(self, func):
         if func.__doc__:
@@ -62,6 +62,48 @@ class Substitution:
         return result
 
 
+def _recursive_subclasses(cls):
+    yield cls
+    for subcls in cls.__subclasses__():
+        yield from _recursive_subclasses(subcls)
+
+
+class _ArtistKwdocLoader(dict):
+    def __missing__(self, key):
+        if not key.endswith(":kwdoc"):
+            raise KeyError(key)
+        name = key[:-len(":kwdoc")]
+        from matplotlib.artist import Artist, kwdoc
+        try:
+            cls, = [cls for cls in _recursive_subclasses(Artist)
+                    if cls.__name__ == name]
+        except ValueError as e:
+            raise KeyError(key) from e
+        return self.setdefault(key, kwdoc(cls))
+
+
+class _ArtistPropertiesSubstitution(Substitution):
+    """
+    A `.Substitution` with two additional features:
+
+    - Substitutions of the form ``%(classname:kwdoc)s`` (ending with the
+      literal ":kwdoc" suffix) trigger lookup of an Artist subclass with the
+      given *classname*, and are substituted with the `.kwdoc` of that class.
+    - Decorating a class triggers substitution both on the class docstring and
+      on the class' ``__init__`` docstring (which is a commonly required
+      pattern for Artist subclasses).
+    """
+
+    def __init__(self):
+        self.params = _ArtistKwdocLoader()
+
+    def __call__(self, obj):
+        super().__call__(obj)
+        if isinstance(obj, type) and obj.__init__ != object.__init__:
+            self(obj.__init__)
+        return obj
+
+
 def copy(source):
     """Copy a docstring from another source function (if present)."""
     def do_copy(target):
@@ -73,5 +115,4 @@ def copy(source):
 
 # Create a decorator that will house the various docstring snippets reused
 # throughout Matplotlib.
-interpd = Substitution()
-dedent_interpd = interpd
+dedent_interpd = interpd = _ArtistPropertiesSubstitution()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -23,7 +23,6 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import docstring, projections
-import matplotlib.artist as martist
 from matplotlib.artist import (
     Artist, allow_rasterization, _finalize_rasterization)
 from matplotlib.backend_bases import (
@@ -593,7 +592,7 @@ default: %(va)s
             arguments if another projection is used, see the actual Axes
             class.
 
-            %(Axes_kwdoc)s
+            %(Axes:kwdoc)s
 
         Notes
         -----
@@ -731,7 +730,7 @@ default: %(va)s
             the following table but there might also be other keyword
             arguments if another projection is used.
 
-            %(Axes_kwdoc)s
+            %(Axes:kwdoc)s
 
         See Also
         --------
@@ -1101,7 +1100,7 @@ default: %(va)s
         **kwargs : `~matplotlib.text.Text` properties
             Other miscellaneous text parameters.
 
-            %(Text_kwdoc)s
+            %(Text:kwdoc)s
 
         See Also
         --------
@@ -1484,8 +1483,7 @@ default: %(va)s
         adheres to the given projection etc., and for Axes creation if
         the active Axes does not exist:
 
-        %(Axes_kwdoc)s
-
+        %(Axes:kwdoc)s
         """
         if kwargs:
             _api.warn_deprecated(
@@ -3181,6 +3179,3 @@ def figaspect(arg):
     # the min/max dimensions (we don't want figures 10 feet tall!)
     newsize = np.clip(newsize, figsize_min, figsize_max)
     return newsize
-
-
-docstring.interpd.update(Figure_kwdoc=martist.kwdoc(Figure))

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -195,6 +195,7 @@ def _mark_every_path(markevery, tpath, affine, ax_transform):
         raise ValueError(f"markevery={markevery!r} is not a recognized value")
 
 
+@docstring.interpd
 @cbook._define_aliases({
     "antialiased": ["aa"],
     "color": ["c"],
@@ -299,7 +300,7 @@ class Line2D(Artist):
 
         Additional keyword arguments are `.Line2D` properties:
 
-        %(Line2D_kwdoc)s
+        %(Line2D:kwdoc)s
 
         See :meth:`set_linestyle` for a description of the line styles,
         :meth:`set_marker` for a description of the markers, and
@@ -1524,6 +1525,3 @@ lineStyles = Line2D._lineStyles
 lineMarkers = MarkerStyle.markers
 drawStyles = Line2D.drawStyles
 fillStyles = MarkerStyle.fillstyles
-
-docstring.interpd.update(Line2D_kwdoc=artist.kwdoc(Line2D))
-docstring.interpd(Line2D.__init__)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -23,6 +23,7 @@ from .path import Path
 from ._enums import JoinStyle, CapStyle
 
 
+@docstring.interpd
 @cbook._define_aliases({
     "antialiased": ["aa"],
     "edgecolor": ["ec"],
@@ -70,7 +71,7 @@ class Patch(artist.Artist):
         """
         The following kwarg properties are supported
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__()
 
@@ -631,16 +632,6 @@ class Patch(artist.Artist):
         return x, y
 
 
-_patch_kwdoc = artist.kwdoc(Patch)
-for k in ['Rectangle', 'Circle', 'RegularPolygon', 'Polygon', 'Wedge', 'Arrow',
-          'FancyArrow', 'CirclePolygon', 'Ellipse', 'Arc', 'FancyBboxPatch',
-          'Patch']:
-    docstring.interpd.update({f'{k}_kwdoc': _patch_kwdoc})
-
-# define Patch.__init__ docstring after the class has been added to interpd
-docstring.dedent_interpd(Patch.__init__)
-
-
 class Shadow(Patch):
     def __str__(self):
         return "Shadow(%s)" % (str(self.patch))
@@ -666,7 +657,7 @@ class Shadow(Patch):
         **kwargs
             Properties of the shadow patch. Supported keys are:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         super().__init__()
         self.patch = patch
@@ -751,7 +742,7 @@ class Rectangle(Patch):
         Other Parameters
         ----------------
         **kwargs : `.Patch` properties
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
         self._x0 = xy[0]
@@ -905,7 +896,7 @@ class RegularPolygon(Patch):
         **kwargs
             `Patch` properties:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         self.xy = xy
         self.numvertices = numVertices
@@ -941,7 +932,7 @@ class PathPatch(Patch):
 
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
         self._path = path
@@ -988,7 +979,7 @@ class StepPatch(PathPatch):
 
         Other valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         self.orientation = orientation
         self._edges = np.asarray(edges)
@@ -1078,7 +1069,7 @@ class Polygon(Patch):
 
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
         self._closed = closed
@@ -1174,7 +1165,7 @@ class Wedge(Patch):
 
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
         self.center = center
@@ -1282,7 +1273,7 @@ class Arrow(Patch):
         **kwargs
             Keyword arguments control the `Patch` properties:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
 
         See Also
         --------
@@ -1354,7 +1345,7 @@ class FancyArrow(Polygon):
         **kwargs
             `.Patch` properties:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         self._x = x
         self._y = y
@@ -1496,7 +1487,7 @@ class CirclePolygon(RegularPolygon):
 
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(xy, resolution, radius, orientation=0, **kwargs)
 
@@ -1528,7 +1519,7 @@ class Ellipse(Patch):
         -----
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
 
@@ -1664,7 +1655,7 @@ class Annulus(Patch):
         **kwargs
             Keyword arguments control the `Patch` properties:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
 
@@ -1842,7 +1833,7 @@ class Circle(Ellipse):
 
         Valid keyword arguments are:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         super().__init__(xy, radius * 2, radius * 2, **kwargs)
         self.radius = radius
@@ -1919,7 +1910,7 @@ class Arc(Ellipse):
             with the exception of *fill* and *facecolor* because filling is
             not supported.
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
         fill = kwargs.setdefault('fill', False)
         if fill:
@@ -3838,7 +3829,7 @@ class FancyBboxPatch(Patch):
         ----------------
         **kwargs : `.Patch` properties
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
         """
 
         super().__init__(**kwargs)
@@ -4158,7 +4149,7 @@ default: 'arc3'
         **kwargs : `.Patch` properties, optional
             Here is a list of available `.Patch` properties:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
 
             In contrast to other patches, the default ``capstyle`` and
             ``joinstyle`` for `FancyArrowPatch` are set to ``"round"``.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1023,7 +1023,7 @@ def axes(arg=None, **kwargs):
         arguments if another projection is used, see the actual axes
         class.
 
-        %(Axes_kwdoc)s
+        %(Axes:kwdoc)s
 
     Notes
     -----
@@ -1155,7 +1155,7 @@ def subplot(*args, **kwargs):
         the following table but there might also be other keyword
         arguments if another projection is used.
 
-        %(Axes_kwdoc)s
+        %(Axes:kwdoc)s
 
     Notes
     -----

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -184,7 +184,7 @@ Other Parameters
 **kwargs : `~matplotlib.collections.PolyCollection` properties, optional
     All other keyword arguments are passed on to `.PolyCollection`:
 
-    %(PolyCollection_kwdoc)s
+    %(PolyCollection:kwdoc)s
 
 Returns
 -------
@@ -892,7 +892,7 @@ Other Parameters
     The barbs can further be customized using `.PolyCollection` keyword
     arguments:
 
-    %(PolyCollection_kwdoc)s
+    %(PolyCollection:kwdoc)s
 """ % docstring.interpd.params
 
 docstring.interpd.update(barbs_doc=_barbs_doc)

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -431,7 +431,7 @@ class Sankey:
            properties, listed below.  For example, one may want to use
            ``fill=False`` or ``label="A legend entry"``.
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
 
         See Also
         --------

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -48,7 +48,7 @@ class Spine(mpatches.Patch):
         **kwargs
             Valid keyword arguments are:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         super().__init__(**kwargs)
         self.axes = axes

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -19,7 +19,7 @@ The cell (0, 0) is positioned at the top left.
 Thanks to John Gill for providing the class and table.
 """
 
-from . import _api, artist, docstring
+from . import _api, docstring
 from .artist import Artist, allow_rasterization
 from .patches import Rectangle
 from .text import Text
@@ -177,7 +177,7 @@ class Cell(Rectangle):
 
         Valid keyword arguments are:
 
-        %(Text_kwdoc)s
+        %(Text:kwdoc)s
         """
         self._text.update(kwargs)
         self.stale = True
@@ -639,9 +639,6 @@ class Table(Artist):
         return self._cells
 
 
-docstring.interpd.update(Table_kwdoc=artist.kwdoc(Table))
-
-
 @docstring.dedent_interpd
 def table(ax,
           cellText=None, cellColours=None,
@@ -723,7 +720,7 @@ def table(ax,
     **kwargs
         `.Table` properties.
 
-    %(Table_kwdoc)s
+    %(Table:kwdoc)s
     """
 
     if cellColours is None and cellText is None:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -103,6 +103,7 @@ def _get_textbox(text, renderer):
     return x_box, y_box, w_box, h_box
 
 
+@docstring.interpd
 @cbook._define_aliases({
     "color": ["c"],
     "fontfamily": ["family"],
@@ -146,7 +147,7 @@ class Text(Artist):
 
         Valid keyword arguments are:
 
-        %(Text_kwdoc)s
+        %(Text:kwdoc)s
         """
         super().__init__()
         self._x, self._y = x, y
@@ -1304,10 +1305,6 @@ class Text(Artist):
 
         """
         return self.set_family(fontname)
-
-
-docstring.interpd.update(Text_kwdoc=artist.kwdoc(Text))
-docstring.dedent_interpd(Text.__init__)
 
 
 class OffsetFrom:

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -148,7 +148,7 @@ class BboxPatch(Patch):
         **kwargs
             Patch properties. Valid arguments include:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         if "transform" in kwargs:
             raise ValueError("transform should not be set")
@@ -270,7 +270,7 @@ class BboxConnector(Patch):
         **kwargs
             Patch properties for the line drawn. Valid arguments include:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         if "transform" in kwargs:
             raise ValueError("transform should not be set")
@@ -329,7 +329,7 @@ class BboxConnectorPatch(BboxConnector):
         **kwargs
             Patch properties for the line drawn:
 
-            %(Patch_kwdoc)s
+            %(Patch:kwdoc)s
         """
         if "transform" in kwargs:
             raise ValueError("transform should not be set")
@@ -441,7 +441,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
         Keyword arguments to pass to the constructor of the inset axes.
         Valid arguments include:
 
-        %(Axes_kwdoc)s
+        %(Axes:kwdoc)s
 
     borderpad : float, default: 0.5
         Padding between inset axes and the bbox_to_anchor.
@@ -548,7 +548,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
         Keyword arguments to pass to the constructor of the inset axes.
         Valid arguments include:
 
-        %(Axes_kwdoc)s
+        %(Axes:kwdoc)s
 
     borderpad : float, default: 0.5
         Padding between inset axes and the bbox_to_anchor.
@@ -603,7 +603,7 @@ def mark_inset(parent_axes, inset_axes, loc1, loc2, **kwargs):
     **kwargs
         Patch properties for the lines and box drawn:
 
-        %(Patch_kwdoc)s
+        %(Patch:kwdoc)s
 
     Returns
     -------

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -40,6 +40,7 @@ from . import proj3d
 from . import axis3d
 
 
+@docstring.interpd
 @cbook._define_aliases({
     "xlim3d": ["xlim"], "ylim3d": ["ylim"], "zlim3d": ["zlim"]})
 class Axes3D(Axes):
@@ -90,7 +91,7 @@ class Axes3D(Axes):
         **kwargs
             Other optional keyword arguments:
 
-            %(Axes3D_kwdoc)s
+            %(Axes3D:kwdoc)s
         """
 
         if rect is None:
@@ -3441,10 +3442,6 @@ pivot='tail', normalize=False, **kwargs)
         return stem_container
 
     stem3D = stem
-
-
-docstring.interpd.update(Axes3D_kwdoc=martist.kwdoc(Axes3D))
-docstring.dedent_interpd(Axes3D.__init__)
 
 
 def get_test_data(delta=0.05):


### PR DESCRIPTION
This does two things:

- Replace Foo_kwdoc docstring substitutions by auto-generated
  Foo:kwdoc substitutions, removing the need to explicitly call
  `docstring.interpd.update(Foo_kwdoc=artist.kwdoc(Foo))` for each
  artist.

- Decorating a class with `docstring.interpd` will now also perform
  interpolation over the docstring of the class' `__init__`, making it
  possible to list properties here as well, instead of having to
  manually call `docstring.interpd` after the class has been defined.

The new behavior is also explained in documenting_mpl.rst.  I think it's
slightly more magical, but also easier to explain...

Thoughts?

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
