### PR TITLE
SubplotParams.validate-associated fixes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20170-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20170-AL.rst
@@ -1,0 +1,4 @@
+``SubplotParams.validate``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  Use `.SubplotParams.update` to change `.SubplotParams`
+while always keeping it in a valid state.

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -282,10 +282,10 @@ class deprecate_privatize_attribute:
             attr = _deprecate_privatize_attribute(*args, **kwargs)
 
     where *all* parameters are forwarded to `deprecated`.  This form makes
-    ``attr`` a property which forwards access to ``self._attr`` (same name but
-    with a leading underscore), with a deprecation warning.  Note that the
-    attribute name is derived from *the name this helper is assigned to*.  This
-    helper also works for deprecating methods.
+    ``attr`` a property which forwards read and write access to ``self._attr``
+    (same name but with a leading underscore), with a deprecation warning.
+    Note that the attribute name is derived from *the name this helper is
+    assigned to*.  This helper also works for deprecating methods.
     """
 
     def __init__(self, *args, **kwargs):
@@ -293,7 +293,9 @@ class deprecate_privatize_attribute:
 
     def __set_name__(self, owner, name):
         setattr(owner, name, self.deprecator(
-            property(lambda self: getattr(self, f"_{name}")), name=name))
+            property(lambda self: getattr(self, f"_{name}"),
+                     lambda self, value: setattr(self, f"_{name}", value)),
+            name=name))
 
 
 def rename_parameter(since, old, new, func=None):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -120,6 +120,7 @@ class SubplotParams:
     """
     A class to hold the parameters for a subplot.
     """
+
     def __init__(self, left=None, bottom=None, right=None, top=None,
                  wspace=None, hspace=None):
         """
@@ -146,17 +147,20 @@ class SubplotParams:
             The height of the padding between subplots,
             as a fraction of the average Axes height.
         """
-        self.validate = True
+        self._validate = True
         for key in ["left", "bottom", "right", "top", "wspace", "hspace"]:
             setattr(self, key, mpl.rcParams[f"figure.subplot.{key}"])
         self.update(left, bottom, right, top, wspace, hspace)
+
+    # Also remove _validate after deprecation elapses.
+    validate = _api.deprecate_privatize_attribute("3.5")
 
     def update(self, left=None, bottom=None, right=None, top=None,
                wspace=None, hspace=None):
         """
         Update the dimensions of the passed parameters. *None* means unchanged.
         """
-        if self.validate:
+        if self._validate:
             if ((left if left is not None else self.left)
                     >= (right if right is not None else self.right)):
                 raise ValueError('left cannot be >= right')

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -37,14 +37,19 @@ def test_classproperty_deprecation():
 def test_deprecate_privatize_attribute():
     class C:
         def __init__(self): self._attr = 1
-        def _meth(self, arg): pass
+        def _meth(self, arg): return arg
         attr = _api.deprecate_privatize_attribute("0.0")
         meth = _api.deprecate_privatize_attribute("0.0")
 
+    c = C()
     with pytest.warns(_api.MatplotlibDeprecationWarning):
-        C().attr
+        assert c.attr == 1
     with pytest.warns(_api.MatplotlibDeprecationWarning):
-        C().meth(42)
+        c.attr = 2
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        assert c.attr == 2
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        assert c.meth(42) == 42
 
 
 def test_delete_parameter():


### PR DESCRIPTION
SubplotParams.validate was previously only used in SubplotTool so that
when resetting the SubplotParams, a temporarily invalid SubplotParams
would be ignored.  But the temporary `validate = False` was put at the
wrong place (it should wrap `_on_reset`'s implementation, not its
attachment to `buttonreset`).  Indeed, setting e.g. "left" to 0.0 and
"right" to 0.01 and then pressing reset (when using e.g. tk) would throw
an exception (because "left" would first be reset to 0.125 before
"right" gets reset to 0.9, and the intermediate state is invalid).
Instead, just use the already existing `Widgets.eventson` mechanism to
temporarily disable updates.

Also apply the corresponding change for Qt's own SubplotTool.

Deprecate the then unused (and undocumented) SubplotParams.validate; in
order to keep it writable during the deprecation period, slightly tweak
the implementation of _deprecate_privatize_attribute.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
