### PR TITLE
Fix broken test re: polar tick visibility.

### DIFF
--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -397,7 +397,8 @@ def test_remove_shared_polar(fig_ref, fig_test):
 
 
 def test_shared_polar_keeps_ticklabels():
-    _, axs = plt.subplots(
+    fig, axs = plt.subplots(
         2, 2, subplot_kw=dict(projection="polar"), sharex=True, sharey=True)
-    assert axs[0, 1].xaxis._major_tick_kw["label1On"]
-    assert axs[0, 1].yaxis._major_tick_kw["label1On"]
+    fig.canvas.draw()
+    assert axs[0, 1].xaxis.majorTicks[0].get_visible()
+    assert axs[0, 1].yaxis.majorTicks[0].get_visible()


### PR DESCRIPTION
## PR Summary

Breakage arose from bad interaction between https://github.com/matplotlib/matplotlib/pull/19994 and https://github.com/matplotlib/matplotlib/pull/20161.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
