### PR TITLE
Remove 3.3 deprecations in cbook.

### DIFF
--- a/doc/api/next_api_changes/removals/20188-ES.rst
+++ b/doc/api/next_api_changes/removals/20188-ES.rst
@@ -1,0 +1,10 @@
+Removal of ``cbook`` deprecations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* ``local_over_kwdict`` has been removed; use `.cbook.normalize_kwargs`
+  instead.
+* *required*, *forbidden* and *allowed* parameters of `.cbook.normalize_kwargs`
+  have been removed.
+* Flags containing "U" passed to `.cbook.to_filehandle` and
+  `.cbook.open_file_cm` are no longer accepted. This is consistent with their
+  removal from `open` in Python 3.9.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -315,54 +315,6 @@ class silent_list(list):
             return "<an empty list>"
 
 
-@_api.deprecated("3.3")
-class IgnoredKeywordWarning(UserWarning):
-    """
-    A class for issuing warnings about keyword arguments that will be ignored
-    by Matplotlib.
-    """
-    pass
-
-
-@_api.deprecated("3.3", alternative="normalize_kwargs")
-def local_over_kwdict(local_var, kwargs, *keys):
-    """
-    Enforces the priority of a local variable over potentially conflicting
-    argument(s) from a kwargs dict. The following possible output values are
-    considered in order of priority::
-
-        local_var > kwargs[keys[0]] > ... > kwargs[keys[-1]]
-
-    The first of these whose value is not None will be returned. If all are
-    None then None will be returned. Each key in keys will be removed from the
-    kwargs dict in place.
-
-    Parameters
-    ----------
-    local_var : any object
-        The local variable (highest priority).
-
-    kwargs : dict
-        Dictionary of keyword arguments; modified in place.
-
-    *keys : str(s)
-        Name(s) of keyword arguments to process, in descending order of
-        priority.
-
-    Returns
-    -------
-    any object
-        Either local_var or one of kwargs[key] for key in keys.
-
-    Raises
-    ------
-    IgnoredKeywordWarning
-        For each key in keys that is removed from kwargs but not used as
-        the output value.
-    """
-    return _local_over_kwdict(local_var, kwargs, *keys, IgnoredKeywordWarning)
-
-
 def _local_over_kwdict(
         local_var, kwargs, *keys, warning_cls=MatplotlibDeprecationWarning):
     out = local_var
@@ -449,11 +401,6 @@ def to_filehandle(fname, flag='r', return_opened=False, encoding=None):
     """
     if isinstance(fname, os.PathLike):
         fname = os.fspath(fname)
-    if "U" in flag:
-        _api.warn_deprecated(
-            "3.3", message="Passing a flag containing 'U' to to_filehandle() "
-            "is deprecated since %(since)s and will be removed %(removal)s.")
-        flag = flag.replace("U", "")
     if isinstance(fname, str):
         if fname.endswith('.gz'):
             fh = gzip.open(fname, flag)
@@ -553,15 +500,6 @@ def flatten(seq, scalarp=is_scalar_or_string):
             yield item
         else:
             yield from flatten(item, scalarp)
-
-
-@_api.deprecated("3.3", alternative="os.path.realpath and os.stat")
-@functools.lru_cache()
-def get_realpath_and_stat(path):
-    realpath = os.path.realpath(path)
-    stat = os.stat(realpath)
-    stat_key = (stat.st_ino, stat.st_dev)
-    return realpath, stat_key
 
 
 class maxdict(dict):
@@ -1711,23 +1649,9 @@ def sanitize_sequence(data):
             else data)
 
 
-@_api.delete_parameter("3.3", "required")
-@_api.delete_parameter("3.3", "forbidden")
-@_api.delete_parameter("3.3", "allowed")
-def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
-                     allowed=None):
+def normalize_kwargs(kw, alias_mapping=None):
     """
     Helper function to normalize kwarg inputs.
-
-    The order they are resolved are:
-
-    1. aliasing
-    2. required
-    3. forbidden
-    4. allowed
-
-    This order means that only the canonical names need appear in
-    *allowed*, *forbidden*, *required*.
 
     Parameters
     ----------
@@ -1737,32 +1661,20 @@ def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
         the form ``props=None``.
 
     alias_mapping : dict or Artist subclass or Artist instance, optional
-        A mapping between a canonical name to a list of
-        aliases, in order of precedence from lowest to highest.
+        A mapping between a canonical name to a list of aliases, in order of
+        precedence from lowest to highest.
 
-        If the canonical value is not in the list it is assumed to have
-        the highest priority.
+        If the canonical value is not in the list it is assumed to have the
+        highest priority.
 
         If an Artist subclass or instance is passed, use its properties alias
         mapping.
 
-    required : list of str, optional
-        A list of keys that must be in *kws*.  This parameter is deprecated.
-
-    forbidden : list of str, optional
-        A list of keys which may not be in *kw*.  This parameter is deprecated.
-
-    allowed : list of str, optional
-        A list of allowed fields.  If this not None, then raise if
-        *kw* contains any keys not in the union of *required*
-        and *allowed*.  To allow only the required fields pass in
-        an empty tuple ``allowed=()``.  This parameter is deprecated.
-
     Raises
     ------
     TypeError
-        To match what python raises if invalid args/kwargs are passed to
-        a callable.
+        To match what Python raises if invalid arguments/keyword arguments are
+        passed to a callable.
     """
     from matplotlib.artist import Artist
 
@@ -1789,25 +1701,6 @@ def normalize_kwargs(kw, alias_mapping=None, required=(), forbidden=(),
                             f"{k!r}, which are aliases of one another")
         canonical_to_seen[canonical] = k
         ret[canonical] = v
-
-    fail_keys = [k for k in required if k not in ret]
-    if fail_keys:
-        raise TypeError("The required keys {keys!r} "
-                        "are not in kwargs".format(keys=fail_keys))
-
-    fail_keys = [k for k in forbidden if k in ret]
-    if fail_keys:
-        raise TypeError("The forbidden keys {keys!r} "
-                        "are in kwargs".format(keys=fail_keys))
-
-    if allowed is not None:
-        allowed_set = {*required, *allowed}
-        fail_keys = [k for k in ret if k not in allowed_set]
-        if fail_keys:
-            raise TypeError(
-                "kwargs contains {keys!r} which are not in the required "
-                "{req!r} or allowed {allow!r} keys".format(
-                    keys=fail_keys, req=required, allow=allowed))
 
     return ret
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4086,8 +4086,8 @@ def test_eventplot_colors(colors):
 def test_eventplot_problem_kwargs(recwarn):
     """
     test that 'singular' versions of LineCollection props raise an
-    IgnoredKeywordWarning rather than overriding the 'plural' versions (e.g.
-    to prevent 'color' from overriding 'colors', see issue #4297)
+    MatplotlibDeprecationWarning rather than overriding the 'plural' versions
+    (e.g., to prevent 'color' from overriding 'colors', see issue #4297)
     """
     np.random.seed(0)
 
@@ -4106,7 +4106,6 @@ def test_eventplot_problem_kwargs(recwarn):
                     linestyles=['solid', 'dashed'],
                     linestyle=['dashdot', 'dotted'])
 
-    # check that three IgnoredKeywordWarnings were raised
     assert len(recwarn) == 3
     assert all(issubclass(wi.category, MatplotlibDeprecationWarning)
                for wi in recwarn)

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -374,32 +374,14 @@ def test_sanitize_sequence():
 
 
 fail_mapping = (
-    ({'a': 1}, {'forbidden': ('a')}),
-    ({'a': 1}, {'required': ('b')}),
-    ({'a': 1, 'b': 2}, {'required': ('a'), 'allowed': ()}),
     ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['b']}}),
-    ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['b']}, 'allowed': ('a',)}),
     ({'a': 1, 'b': 2}, {'alias_mapping': {'a': ['a', 'b']}}),
-    ({'a': 1, 'b': 2, 'c': 3},
-     {'alias_mapping': {'a': ['b']}, 'required': ('a', )}),
 )
 
 pass_mapping = (
     (None, {}, {}),
     ({'a': 1, 'b': 2}, {'a': 1, 'b': 2}, {}),
     ({'b': 2}, {'a': 2}, {'alias_mapping': {'a': ['a', 'b']}}),
-    ({'b': 2}, {'a': 2},
-     {'alias_mapping': {'a': ['b']}, 'forbidden': ('b', )}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3},
-     {'required': ('a', ), 'allowed': ('c', )}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3},
-     {'required': ('a', 'c'), 'allowed': ('c', )}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3},
-     {'required': ('a', 'c'), 'allowed': ('a', 'c')}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3},
-     {'required': ('a', 'c'), 'allowed': ()}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3}, {'required': ('a', 'c')}),
-    ({'a': 1, 'c': 3}, {'a': 1, 'c': 3}, {'allowed': ('a', 'c')}),
 )
 
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).