### PR TITLE
Simplify HostAxes.draw and its interaction with ParasiteAxes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20193-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20193-AL.rst
@@ -1,0 +1,3 @@
+``ParasiteAxesBase.get_images_artists``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... has been deprecated.

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -24,6 +24,7 @@ class ParasiteAxesBase:
         martist.setp(self.get_children(), visible=False)
         self._get_lines = self._parent_axes._get_lines
 
+    @_api.deprecated("3.5")
     def get_images_artists(self):
         artists = []
         images = []
@@ -197,27 +198,20 @@ class HostAxesBase:
         return all_handles
 
     def draw(self, renderer):
-
         orig_children_len = len(self._children)
 
-        if hasattr(self, "get_axes_locator"):
-            locator = self.get_axes_locator()
-            if locator:
-                pos = locator(self, renderer)
-                self.set_position(pos, which="active")
-                self.apply_aspect(pos)
-            else:
-                self.apply_aspect()
+        locator = self.get_axes_locator()
+        if locator:
+            pos = locator(self, renderer)
+            self.set_position(pos, which="active")
+            self.apply_aspect(pos)
         else:
             self.apply_aspect()
 
         rect = self.get_position()
-
         for ax in self.parasites:
             ax.apply_aspect(rect)
-            images, artists = ax.get_images_artists()
-            self._children.extend(images)
-            self._children.extend(artists)
+            self._children.extend(ax.get_children())
 
         super().draw(renderer)
         self._children = self._children[:orig_children_len]


### PR DESCRIPTION
- The base Axes class now defines `get_axes_locator`, so there's no need
  for a hasattr() check.
- Now that all artists are stored in a single list, there's no need to
  split the parasite axes' artists by type when pushing them into the
  host's artist list.  Also it's fine to include non-visible artists, as
  they'll be filtered out later.  This means that
  `ParasiteAxesBase.get_images_artists` becomes unused and can be
  deprecated (as it's clearly an internal helper).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
