### PR TITLE
Speedup Line2D marker color setting.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1147,6 +1147,19 @@ class Line2D(Artist):
         self._marker = MarkerStyle(marker, self._marker.get_fillstyle())
         self.stale = True
 
+    def _set_markercolor(self, attr, val):
+        if val is None:
+            val = 'auto'
+        current = getattr(self, attr)
+        if current is None:
+            self.stale = True
+        else:
+            neq = current != val
+            # Much faster than `np.any(current != val)` if no arrays are used.
+            if neq.any() if isinstance(neq, np.ndarray) else neq:
+                self.stale = True
+        setattr(self, attr, val)
+
     def set_markeredgecolor(self, ec):
         """
         Set the marker edge color.
@@ -1155,12 +1168,27 @@ class Line2D(Artist):
         ----------
         ec : color
         """
-        if ec is None:
-            ec = 'auto'
-        if (self._markeredgecolor is None
-                or np.any(self._markeredgecolor != ec)):
-            self.stale = True
-        self._markeredgecolor = ec
+        self._set_markercolor("_markeredgecolor", ec)
+
+    def set_markerfacecolor(self, fc):
+        """
+        Set the marker face color.
+
+        Parameters
+        ----------
+        fc : color
+        """
+        self._set_markercolor("_markerfacecolor", fc)
+
+    def set_markerfacecoloralt(self, fc):
+        """
+        Set the alternate marker face color.
+
+        Parameters
+        ----------
+        fc : color
+        """
+        self._set_markercolor("_markerfacecoloralt", fc)
 
     def set_markeredgewidth(self, ew):
         """
@@ -1176,34 +1204,6 @@ class Line2D(Artist):
         if self._markeredgewidth != ew:
             self.stale = True
         self._markeredgewidth = ew
-
-    def set_markerfacecolor(self, fc):
-        """
-        Set the marker face color.
-
-        Parameters
-        ----------
-        fc : color
-        """
-        if fc is None:
-            fc = 'auto'
-        if np.any(self._markerfacecolor != fc):
-            self.stale = True
-        self._markerfacecolor = fc
-
-    def set_markerfacecoloralt(self, fc):
-        """
-        Set the alternate marker face color.
-
-        Parameters
-        ----------
-        fc : color
-        """
-        if fc is None:
-            fc = 'auto'
-        if np.any(self._markerfacecoloralt != fc):
-            self.stale = True
-        self._markerfacecoloralt = fc
 
     def set_markersize(self, sz):
         """


### PR DESCRIPTION
np.any is quite slow, so avoid it if no numpy arrays are involved.

Because all ticks internally use lines, this change already speeds up
```sh
MPLBACKEND=agg python -mtimeit -s 'from matplotlib.figure import Figure' -- 'Figure().subplots(10, 10)'
```
by ~5%.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
