### PR TITLE
Fix validation of Line2D color.

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1027,8 +1027,7 @@ class Line2D(Artist):
         ----------
         color : color
         """
-        if not cbook._str_equal(color, 'auto'):
-            mcolors._check_color_like(color=color)
+        mcolors._check_color_like(color=color)
         self._color = color
         self.stale = True
 

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -75,10 +75,10 @@ from operator import methodcaller
 
 import numpy as np
 
-from matplotlib import _api, rcParams
+from matplotlib import _api, cbook, rcParams
 import matplotlib.artist as martist
+import matplotlib.colors as mcolors
 import matplotlib.text as mtext
-
 from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
 from matplotlib.patches import PathPatch
@@ -133,6 +133,14 @@ class Ticks(AttributeCopier, Line2D):
     def get_ref_artist(self):
         # docstring inherited
         return self._axis.majorTicks[0].tick1line
+
+    def set_color(self, color):
+        # docstring inherited
+        # Unlike the base Line2D.set_color, this also supports "auto".
+        if not cbook._str_equal(color, "auto"):
+            mcolors._check_color_like(color=color)
+        self._color = color
+        self.stale = True
 
     def get_color(self):
         return self.get_attribute_from_ref_artist("color")


### PR DESCRIPTION
We don't actually support color="auto" (we only support mfc="auto" and
mec="auto", which mean "use the main color").

This can easily be tested using `plt.plot([1, 2], c="auto")` which
crashes.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
