### PR TITLE
Make set_marker{edge,face}color(None) more consistent.

### DIFF
--- a/doc/api/next_api_changes/behavior/20199-AL.rst
+++ b/doc/api/next_api_changes/behavior/20199-AL.rst
@@ -1,0 +1,5 @@
+``Line2D.set_markeredgecolor(None)`` and ``Line2D.set_markerfacecolor(None)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... now set the line property using the corresponding rcParam
+(:rc:`lines.markeredgecolor` and :rc:`lines.markerfacecolor`).  This is
+consistent with other `.Line2D` property setters.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -321,10 +321,6 @@ class Line2D(Artist):
             linestyle = rcParams['lines.linestyle']
         if marker is None:
             marker = rcParams['lines.marker']
-        if markerfacecolor is None:
-            markerfacecolor = rcParams['lines.markerfacecolor']
-        if markeredgecolor is None:
-            markeredgecolor = rcParams['lines.markeredgecolor']
         if color is None:
             color = rcParams['lines.color']
 
@@ -386,9 +382,9 @@ class Line2D(Artist):
         self._markerfacecolor = None
         self._markerfacecoloralt = None
 
-        self.set_markerfacecolor(markerfacecolor)
+        self.set_markerfacecolor(markerfacecolor)  # Normalizes None to rc.
         self.set_markerfacecoloralt(markerfacecoloralt)
-        self.set_markeredgecolor(markeredgecolor)
+        self.set_markeredgecolor(markeredgecolor)  # Normalizes None to rc.
         self.set_markeredgewidth(markeredgewidth)
 
         # update kwargs before updating data to give the caller a
@@ -1146,9 +1142,10 @@ class Line2D(Artist):
         self._marker = MarkerStyle(marker, self._marker.get_fillstyle())
         self.stale = True
 
-    def _set_markercolor(self, attr, val):
+    def _set_markercolor(self, name, has_rcdefault, val):
         if val is None:
-            val = 'auto'
+            val = rcParams[f"lines.{name}"] if has_rcdefault else "auto"
+        attr = f"_{name}"
         current = getattr(self, attr)
         if current is None:
             self.stale = True
@@ -1167,7 +1164,7 @@ class Line2D(Artist):
         ----------
         ec : color
         """
-        self._set_markercolor("_markeredgecolor", ec)
+        self._set_markercolor("markeredgecolor", True, ec)
 
     def set_markerfacecolor(self, fc):
         """
@@ -1177,7 +1174,7 @@ class Line2D(Artist):
         ----------
         fc : color
         """
-        self._set_markercolor("_markerfacecolor", fc)
+        self._set_markercolor("markerfacecolor", True, fc)
 
     def set_markerfacecoloralt(self, fc):
         """
@@ -1187,7 +1184,7 @@ class Line2D(Artist):
         ----------
         fc : color
         """
-        self._set_markercolor("_markerfacecoloralt", fc)
+        self._set_markercolor("markerfacecoloralt", False, fc)
 
     def set_markeredgewidth(self, ew):
         """


### PR DESCRIPTION
Resolving None to mean "the rcParam" is both consistent with the
behavior in `__init__` (which manually maps None to the rcParam) and
with markeredgewidth.  In particular, being consistent with `__init__`
ensures that in
```
from pylab import *; from matplotlib.lines import Line2D
rcParams["lines.markerfacecolor"] = "red"
gca().add_artist(Line2D([.1, .9], [.1, .9], marker="o", markerfacecolor=None))
gca().add_artist(Line2D([.1, .9], [.9, .1], marker="o", mfc=None))
```
both lines use "red" as markerfacecolor (previously, the second one
would go through the setter and use "auto" (i.e. the line's color)
instead).

I guess this should have been done when the rcParams were added in
1d9880c, but missed back then.

(No change for markerfacecoloralt because there's no corresponding
rcParam; perhaps one should be added just for completeness?)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
