### PR TITLE
ci: Export sphinx-gallery run results to CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,8 @@ jobs:
 
       - store_artifacts:
           path: doc/build/html
+      - store_test_results:
+          path: doc/build/test-results
 
   docs-python38-min:
     docker:
@@ -159,6 +161,8 @@ jobs:
 
       - store_artifacts:
           path: doc/build/html
+      - store_test_results:
+          path: doc/build/test-results
 
   docs-python38:
     docker:
@@ -179,6 +183,8 @@ jobs:
 
       - store_artifacts:
           path: doc/build/html
+      - store_test_results:
+          path: doc/build/test-results
 
       - add_ssh_keys:
           fingerprints:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,6 +169,8 @@ sphinx_gallery_conf = {
     'matplotlib_animations': True,
     # 3.7 CI doc build should not use hidpi images during the testing phase
     'image_srcset': [] if sys.version_info[:2] == (3, 7) else ["2x"],
+    'junit': ('../test-results/sphinx-gallery/junit.xml'
+              if 'CIRCLECI' in os.environ else ''),
 }
 
 plot_gallery = 'True'


### PR DESCRIPTION
## PR Summary

This exports sphinx-gallery example run results to CircleCI, so we can get some idea of which examples fail often, etc., as in https://sphinx-gallery.github.io/stable/configuration.html#using-junit-xml-files

It _probably_ won't amount to much, but might as well try it out.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).