### PR TITLE
FIX: correctly handle ax.legend(..., legendcolor='none')

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -550,6 +550,9 @@ class Legend(Artist):
                         break
                     except AttributeError:
                         pass
+        elif isinstance(labelcolor, str) and labelcolor == 'none':
+            for text in self.texts:
+                text.set_color(labelcolor)
         elif np.iterable(labelcolor):
             for text, color in zip(self.texts,
                                    itertools.cycle(

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -583,16 +583,17 @@ def test_legend_title_fontprop_fontsize():
     assert leg5.get_title().get_fontsize() == 20
 
 
-def test_legend_labelcolor_single():
+@pytest.mark.parametrize('color', ('red', 'none', (.5, .5, .5)))
+def test_legend_labelcolor_single(color):
     # test labelcolor for a single color
     fig, ax = plt.subplots()
     ax.plot(np.arange(10), np.arange(10)*1, label='#1')
     ax.plot(np.arange(10), np.arange(10)*2, label='#2')
     ax.plot(np.arange(10), np.arange(10)*3, label='#3')
 
-    leg = ax.legend(labelcolor='red')
+    leg = ax.legend(labelcolor=color)
     for text in leg.get_texts():
-        assert mpl.colors.same_color(text.get_color(), 'red')
+        assert mpl.colors.same_color(text.get_color(), color)
 
 
 def test_legend_labelcolor_list():


### PR DESCRIPTION

## PR Summary

Previously this would result in the label color being ignored because
colors.to_rgba_array('none') results in a 0 length array which in turn has
a 0 length cycle, which results in the zip over texts and colors terminating
before we have touched any of the texts, ignoring the color.

This makes::

     ax.legend(..., legendcolor='none')
     ax.legend(..., legendcolor=['none'])

behave the same

Discovered this while reviewing https://github.com/matplotlib/matplotlib/pull/20084 and trying to demonstrate the difference between `None` and `'none'` in our color conventions.



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
