### PR TITLE
Adding an equals method to colormaps

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -690,6 +690,17 @@ class Colormap:
         cmapobject._global = False
         return cmapobject
 
+    def __eq__(self, other):
+        if (not isinstance(other, Colormap) or self.name != other.name or
+                self.colorbar_extend != other.colorbar_extend):
+            return False
+        # To compare lookup tables the Colormaps have to be initialized
+        if not self._isinit:
+            self._init()
+        if not other._isinit:
+            other._init()
+        return np.array_equal(self._lut, other._lut)
+
     def get_bad(self):
         """Get the color for masked values."""
         if not self._isinit:

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -162,6 +162,29 @@ def test_colormap_copy():
     assert_array_equal(ret1, ret2)
 
 
+def test_colormap_equals():
+    cmap = plt.get_cmap("plasma")
+    cm_copy = cmap.copy()
+    # different object id's
+    assert cm_copy is not cmap
+    # But the same data should be equal
+    assert cm_copy == cmap
+    # Change the copy
+    cm_copy.set_bad('y')
+    assert cm_copy != cmap
+    # Make sure we can compare different sizes without failure
+    cm_copy._lut = cm_copy._lut[:10, :]
+    assert cm_copy != cmap
+    # Test different names are not equal
+    cm_copy = cmap.copy()
+    cm_copy.name = "Test"
+    assert cm_copy != cmap
+    # Test colorbar extends
+    cm_copy = cmap.copy()
+    cm_copy.colorbar_extend = not cmap.colorbar_extend
+    assert cm_copy != cmap
+
+
 def test_colormap_endian():
     """
     GitHub issue #1005: a bug in putmask caused erroneous


### PR DESCRIPTION
## PR Summary

This adds an `__eq__` method to Colormap to test the lookup
tables for equality. This will help for testing whether colormaps are the same even if they aren't the same object.

`plt.get_cmap("Blues") == plt.get_cmap("Blues")` even if they aren't the same object anymore.
Taking just this portion out of the closed #16943.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
