### PR TITLE
Warn user when mathtext font is used for ticks

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -577,6 +577,18 @@ class TestScalarFormatter:
         fmt = sf.format_data_short
         assert fmt(data) == expected
 
+    def test_mathtext_ticks(self):
+        mpl.rcParams.update({
+            'font.family': 'serif',
+            'font.serif': 'cmr10',
+            'axes.formatter.use_mathtext': False
+        })
+
+        with pytest.warns(UserWarning, match='cmr10 font should ideally'):
+            fig, ax = plt.subplots()
+            ax.set_xticks([-1, 0, 1])
+            fig.canvas.draw()
+
 
 class FakeAxis:
     """Allow Formatter to be called without having a "full" plot set up."""

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -475,6 +475,22 @@ class ScalarFormatter(Formatter):
         self._usetex = mpl.rcParams['text.usetex']
         if useMathText is None:
             useMathText = mpl.rcParams['axes.formatter.use_mathtext']
+            if useMathText is False:
+                try:
+                    ufont = mpl.font_manager.findfont(
+                        mpl.font_manager.FontProperties(
+                            mpl.rcParams["font.family"]
+                        ),
+                        fallback_to_default=False,
+                    )
+                except ValueError:
+                    ufont = None
+
+                if ufont == str(cbook._get_data_path("fonts/ttf/cmr10.ttf")):
+                    _api.warn_external(
+                        "cmr10 font should ideally be used with "
+                        "mathtext, set axes.formatter.use_mathtext to True"
+                    )
         self.set_useMathText(useMathText)
         self.orderOfMagnitude = 0
         self.format = ''


### PR DESCRIPTION
## PR Summary
Following up the patch mentioned in https://github.com/matplotlib/matplotlib/pull/18397#pullrequestreview-655033417, w.r.t. @anntzer's original comment https://github.com/matplotlib/matplotlib/pull/18397#issuecomment-826615489
> we could even emit a warning when cmr10 is used in a non-mathtext context, as that seems to be pretty common

When using the "cmr10" font (or possibly more mathtext-fonts) for ticks, one should set `rcParams["axes.formatter.use_mathtext"] = True` to trigger the machinery implemented by https://github.com/matplotlib/matplotlib/pull/18397

Possible improvements:
- Move the warning to an outer scope, for all Formatters (not just ScalarFormatter) - do we need to?
- Include other mathtext-fonts

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
