### PR TITLE
Make QuadMesh arguments with defaults keyword_only

### DIFF
--- a/doc/api/next_api_changes/deprecations/20237-TH.rst
+++ b/doc/api/next_api_changes/deprecations/20237-TH.rst
@@ -13,5 +13,5 @@ In particular:
 
 - *coordinates* must now be a (M, N, 2) array-like. Previously, the grid
   shape was separately specified as (*meshHeight* + 1, *meshWidth* + 1) and
-  *coordnates* could be an array-like of any shape with M * N * 2 elements.
+  *coordinates* could be an array-like of any shape with M * N * 2 elements.
 - all parameters except *coordinates* are keyword-only now.

--- a/doc/api/next_api_changes/deprecations/20237-TH.rst
+++ b/doc/api/next_api_changes/deprecations/20237-TH.rst
@@ -1,0 +1,17 @@
+QuadMesh signature
+~~~~~~~~~~~~~~~~~~
+The ``QuadMesh`` signature ::
+
+    def __init__(meshWidth, meshHeight, coordinates,
+                 antialiased=True, shading=False, **kwargs)
+
+is deprecated and replaced by the new signature ::
+
+    def __init__(coordinates, *, antialiased=True, shading=False, **kwargs)
+
+In particular:
+
+- *coordinates* must now be a (M, N, 2) array-like. Previously, the grid
+  shape was separately specified as (*meshHeight* + 1, *meshWidth* + 1) and
+  *coordnates* could be an array-like of any shape with M * N * 2 elements.
+- all parameters except *coordinates* are keyword-only now.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6164,16 +6164,12 @@ default: :rc:`scatter.edgecolors`
 
         X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
                                             shading=shading, kwargs=kwargs)
-        Ny, Nx = X.shape
-        X = X.ravel()
-        Y = Y.ravel()
-
-        # convert to one dimensional arrays
+        coords = np.stack([X, Y], axis=-1)
+        # convert to one dimensional array
         C = C.ravel()
-        coords = np.column_stack((X, Y)).astype(float, copy=False)
-        collection = mcoll.QuadMesh(Nx - 1, Ny - 1, coords,
-                                    antialiased=antialiased, shading=shading,
-                                    **kwargs)
+
+        collection = mcoll.QuadMesh(
+            coords, antialiased=antialiased, shading=shading, **kwargs)
         snap = kwargs.get('snap', rcParams['pcolormesh.snap'])
         collection.set_snap(snap)
         collection.set_alpha(alpha)
@@ -6183,6 +6179,8 @@ default: :rc:`scatter.edgecolors`
         collection._scale_norm(norm, vmin, vmax)
 
         self.grid(False)
+
+        coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
 
         # Transform from native to data coordinates?
         t = collection._transform
@@ -6360,7 +6358,7 @@ default: :rc:`scatter.edgecolors`
             else:
                 raise ValueError("C must be 2D or 3D")
             collection = mcoll.QuadMesh(
-                nc, nr, coords, **qm_kwargs,
+                coords, **qm_kwargs,
                 alpha=alpha, cmap=cmap, norm=norm,
                 antialiased=False, edgecolors="none")
             self.add_collection(collection, autolim=False)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1968,6 +1968,35 @@ class QuadMesh(Collection):
     """
     Class for the efficient drawing of a quadrilateral mesh.
 
+    A quadrilateral mesh is a grid of M by N adjacent qudrilaterals that are
+    defined via a (M+1, N+1) grid of vertices. The quadrilateral (m, n) is
+    defind by the vertices ::
+
+               (m+1, n) ----------- (m+1, n+1)
+                  /                   /
+                 /                 /
+                /               /
+            (m, n) -------- (m, n+1)
+
+    The mesh need not be regular and the polygons need not be convex.
+
+    Parameters
+    ----------
+    coordinates : (M+1, N+1, 2) array-like
+        The vertices. ``coordinates[m, n]`` specifies the (x, y) coordinates
+        of vertex (m, n).
+
+    antialiased : bool, default: True
+
+    shading : {'flat', 'gouraud'}, default: 'flat'
+
+    Notes
+    -----
+    There exists a deprecated API version ``QuadMesh(M, N, coords)``, where
+    the dimensions are given explicitly and ``coords`` is a (M*N, 2)
+    array-like. This has been deprecated in Matplotlib 3.5. The following
+    describes the semantics of this deprecated API.
+
     A quadrilateral mesh consists of a grid of vertices.
     The dimensions of this array are (*meshWidth* + 1, *meshHeight* + 1).
     Each vertex in the mesh has a different set of "mesh coordinates"
@@ -1991,7 +2020,6 @@ class QuadMesh(Collection):
     vertex at mesh coordinates (0, 0), then the one at (0, 1), then at (0, 2)
     .. (0, meshWidth), (1, 0), (1, 1), and so on.
 
-    *shading* may be 'flat', or 'gouraud'
     """
     def __init__(self, *args, **kwargs):
         # signature deprecation since="3.5": Change to new signature after the
@@ -2020,7 +2048,7 @@ class QuadMesh(Collection):
             _api.warn_deprecated(
                 "3.5",
                 message="This usage of Quadmesh is deprecated: Parameters "
-                        "meshWidth and meshHights will be removed; "
+                        "meshWidth and meshHeights will be removed; "
                         "coordinates must be 2D; all parameters except "
                         "coordinates will be keyword-only.")
             coords = np.asarray(coords, np.float64).reshape((h + 1, w + 1, 2))

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2055,15 +2055,10 @@ class QuadMesh(Collection):
         # end of signature deprecation code
 
         super().__init__(**kwargs)
+        _api.check_shape((None, None, 2), coordinates=coords)
         self._coordinates = coords
-        shape = self._coordinates.shape
-        if (self._coordinates.ndim != 3 or shape[-1] != 2):
-            raise ValueError(
-                "coordinates must be a (N, M, 2) array-like, but got "
-                f"{shape}")
-
-        self._meshWidth = shape[1] - 1
-        self._meshHeight = shape[0] - 1
+        self._meshWidth = self._coordinates.shape[1] - 1
+        self._meshHeight = self._coordinates.shape[0] - 1
         self._antialiased = antialiased
         self._shading = shading
 


### PR DESCRIPTION
## PR Summary

This is in preparation of changing the signature from 

`__init__(self, meshWidth, meshHeight, coordinates, antialiased=True, shading='flat', **kwargs)`

to 

`__init__(self, coordinates, *, antialiased=True, shading='flat', **kwargs)`

See also: https://github.com/matplotlib/matplotlib/pull/18472#issuecomment-841735177


If we want to make this according to deprecation rules this is a multi-step process:

- Make everything after `coordinates` keyword-only. (This PR).
- When that deprecation expires (in 3.7), change to
  `__init__(self, *args, antialiased=True, shading='flat', **kwargs)` and extract `meshWidth, meshHeight, coordinates` from `args, kwargs`. At the same time, deprecate passing `meshWidth, meshHeight, 1d_coordinates` in favor of passing 2D coordinates only.
- When that deprecation expires (in 3.9), change back to `__init__(self, coordinates, *, antialiased=True, shading='flat', **kwargs)`

The in between `*args` step is essential for a smooth transition phase allowing both signatures `width, height, 1d_coordinates` and `2d_coordinates`.

Possible shortcut: Skip the first step and directly go to the `*args` signature. This would be a breaking change, but only for people, who pass `antialiased` as positional argument.

