### PR TITLE
Add comments and format Axis._get_coord_info

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -189,7 +189,7 @@ class Axis(maxis.XAxis):
 
         # Add a small offset between min/max point and the edge of the
         # plot:
-        deltas = (maxs - mins) / 12.0
+        deltas = (maxs - mins) / 12
         mins -= 0.25 * deltas
         maxs += 0.25 * deltas
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -178,13 +178,11 @@ class Axis(maxis.XAxis):
             return len(text) > 4
 
     def _get_coord_info(self, renderer):
-        mins, maxs = np.array(
-            [
-                self.axes.get_xbound(),
-                self.axes.get_ybound(),
-                self.axes.get_zbound(),
-            ]
-        ).T
+        mins, maxs = np.array([
+            self.axes.get_xbound(),
+            self.axes.get_ybound(),
+            self.axes.get_zbound(),
+        ]).T
 
         # Get the mean value for each bound:
         centers = 0.5 * (maxs + mins)

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -178,23 +178,35 @@ class Axis(maxis.XAxis):
             return len(text) > 4
 
     def _get_coord_info(self, renderer):
-        mins, maxs = np.array([
-            self.axes.get_xbound(),
-            self.axes.get_ybound(),
-            self.axes.get_zbound(),
-        ]).T
-        centers = (maxs + mins) / 2.
-        deltas = (maxs - mins) / 12.
-        mins = mins - deltas / 4.
-        maxs = maxs + deltas / 4.
+        mins, maxs = np.array(
+            [
+                self.axes.get_xbound(),
+                self.axes.get_ybound(),
+                self.axes.get_zbound(),
+            ]
+        ).T
 
-        vals = mins[0], maxs[0], mins[1], maxs[1], mins[2], maxs[2]
-        tc = self.axes.tunit_cube(vals, self.axes.M)
-        avgz = [tc[p1][2] + tc[p2][2] + tc[p3][2] + tc[p4][2]
-                for p1, p2, p3, p4 in self._PLANES]
-        highs = np.array([avgz[2*i] < avgz[2*i+1] for i in range(3)])
+        # Get the mean value for each bound:
+        centers = 0.5 * (maxs + mins)
 
-        return mins, maxs, centers, deltas, tc, highs
+        # Add a small offset between min/max point and the edge of the
+        # plot:
+        deltas = (maxs - mins) / 12.0
+        mins -= 0.25 * deltas
+        maxs += 0.25 * deltas
+
+        # Project the bounds along the current position of the cube:
+        bounds = mins[0], maxs[0], mins[1], maxs[1], mins[2], maxs[2]
+        bounds_proj = self.axes.tunit_cube(bounds, self.axes.M)
+
+        # Determine which one of the parallel planes are higher up:
+        highs = np.zeros(3, dtype=bool)
+        for i in range(3):
+            mean_z0 = np.mean(bounds_proj[self._PLANES[2 * i], 2])
+            mean_z1 = np.mean(bounds_proj[self._PLANES[2 * i + 1], 2])
+            highs[i] = mean_z0 < mean_z1
+
+        return mins, maxs, centers, deltas, bounds_proj, highs
 
     def draw_pane(self, renderer):
         renderer.open_group('pane3d', gid=self.get_gid())


### PR DESCRIPTION
## PR Summary
Explain Axis._get_coord_info better by adding comments and an (atleast to me) easier to read format. Should be no change in functionality.

Simplifies review of #19873 once merged. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
