### PR TITLE
Fix blitting selector

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1737,7 +1737,8 @@ class _SelectorWidget(AxesWidget):
                 self.canvas.draw()
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
         if needs_redraw:
-            self.update()
+            for artist in self.artists:
+                self.ax.draw_artist(artist)
 
     def connect_default_events(self):
         """Connect the major canvas events to methods."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1782,6 +1782,8 @@ class _SelectorWidget(AxesWidget):
         if self.useblit:
             if self.background is not None:
                 self.canvas.restore_region(self.background)
+            else:
+                self.update_background(None)
             for artist in self.artists:
                 self.ax.draw_artist(artist)
             self.canvas.blit(self.ax.bbox)


### PR DESCRIPTION
## PR Summary

This PR fixes two bugs with blitting Selectors:
1. A recursive paint loop when resizing the figure with the qt backend.
2. Fix a similar issue as describe in #9660 but for `RectangleSelector`/`EllipseSelector` and `SpanSelector` once #20113 is merged, therefore fixing #9660 too!

### To reproduce 1
Fix in https://github.com/matplotlib/matplotlib/commit/94a2f46f3cf0a6a621833fd3ac31b958e36e4910
From a juptyer qtconsole:
```python
%matplotlib qt
import matplotlib.pyplot as plt
from matplotlib.widgets import RectangleSelector
import numpy as np

values = np.arange(100)

fig = plt.figure()
ax = fig.add_subplot()
ax.plot(values)

span = RectangleSelector(ax, print, useblit=True, interactive=True)

# flush events to get a first draw of the figure before setting the extents
fig.canvas.flush_events()
span.extents = (26, 55, 32, 71)
```
When resizing the figure, the figure is flickering (in spyder the console crashes when a custom DPI scaling is used) and it gives the following error:
```
QWidget::repaint: Recursive repaint detected
QWidget::paintEngine: Should no longer be called
QPainter::begin: Paint device returned engine == 0, type: 1
QPainter::end: Painter not active, aborted
```
My understanding is that calling `_SelectorWidget.ax.blit` in `_SelectorWidget.update_background` (through `_SelectorWidget.update`) when resizing the figure create the recursive repaint loop.

### To reproduce 2
Fix in https://github.com/matplotlib/matplotlib/commit/031f77c1bf8a57c32666c0cb06c521878753ec1f
Adapted from #9660 to reproduce the issue with `RectangleSelector` and this PR uses the fix suggested in https://github.com/matplotlib/matplotlib/pull/9660#issuecomment-353776720 

```python
import sys
from PyQt5.QtWidgets import *
from matplotlib.backends.backend_qt5agg import *
from matplotlib.figure import Figure
from matplotlib.widgets import RectangleSelector

class App(QMainWindow):
    def __init__(self):
        super().__init__()
        self.setCentralWidget(QWidget())
        layout = QVBoxLayout()
        self.centralWidget().setLayout(layout)
        self._fig = Figure()
        self._fig.subplots()
        layout.addWidget(FigureCanvas(self._fig))
        layout.addWidget(QPushButton("span", clicked=self._span_cb))

    def _span_cb(self):
        self._span = RectangleSelector(
            self._fig.axes[0], print, useblit=True)

qapp = QApplication(sys.argv)
app = App()
app.show()
qapp.exec_()
```
The selector is included in the background:
![image](https://user-images.githubusercontent.com/11851990/118841680-6c970400-b8c0-11eb-9b15-e4a0655f0dce.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
