### PR TITLE
Legend edgecolor face

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -31,7 +31,6 @@ from matplotlib import cbook
 from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle
 import matplotlib.collections as mcoll
-import matplotlib.colors as mcolors
 
 
 def update_from_first_child(tgt, src):

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -734,32 +734,30 @@ class HandlerPolyCollection(HandlerBase):
     """
     def _update_prop(self, legend_handle, orig_handle):
         def first_color(colors):
-            if colors is None:
-                return None
-            colors = mcolors.to_rgba_array(colors)
-            if len(colors):
-                return colors[0]
-            else:
-                return "none"
+            if colors.size == 0:
+                return (0, 0, 0, 0)
+            return tuple(colors[0])
 
         def get_first(prop_array):
             if len(prop_array):
                 return prop_array[0]
             else:
                 return None
-        edgecolor = getattr(orig_handle, '_original_edgecolor',
-                            orig_handle.get_edgecolor())
-        legend_handle.set_edgecolor(first_color(edgecolor))
-        facecolor = getattr(orig_handle, '_original_facecolor',
-                            orig_handle.get_facecolor())
-        legend_handle.set_facecolor(first_color(facecolor))
-        legend_handle.set_fill(orig_handle.get_fill())
-        legend_handle.set_hatch(orig_handle.get_hatch())
+
+        # orig_handle is a PolyCollection and legend_handle is a Patch.
+        # Directly set Patch color attributes (must be RGBA tuples).
+        legend_handle._facecolor = first_color(orig_handle.get_facecolor())
+        legend_handle._edgecolor = first_color(orig_handle.get_edgecolor())
+        legend_handle._fill = orig_handle.get_fill()
+        legend_handle._hatch = orig_handle.get_hatch()
+        # Hatch color is anomalous in having no getters and setters.
+        legend_handle._hatch_color = orig_handle._hatch_color
+        # Setters are fine for the remaining attributes.
         legend_handle.set_linewidth(get_first(orig_handle.get_linewidths()))
         legend_handle.set_linestyle(get_first(orig_handle.get_linestyles()))
         legend_handle.set_transform(get_first(orig_handle.get_transforms()))
         legend_handle.set_figure(orig_handle.get_figure())
-        legend_handle.set_alpha(orig_handle.get_alpha())
+        # Alpha is already taken into account by the color attributes.
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -765,3 +765,11 @@ def test_plot_multiple_label_incorrect_length_exception():
         label = ['high', 'low', 'medium']
         fig, ax = plt.subplots()
         ax.plot(x, y, label=label)
+
+
+def test_legend_face_edgecolor():
+    # Smoke test for PolyCollection legend handler with 'face' edgecolor.
+    fig, ax = plt.subplots()
+    ax.fill_between([0, 1, 2], [1, 2, 3], [2, 3, 4],
+                    facecolor='r', edgecolor='face', label='Fill')
+    ax.legend()


### PR DESCRIPTION
## PR Summary
Simplify the legend handler for PolyCollection.

Alternative to #20260; closes #20258.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x ] Has pytest style unit tests (and `pytest` passes).
- [ x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
