### PR TITLE
Api pcolorargs deprecation

### DIFF
--- a/doc/api/next_api_changes/behavior/20268-JMK.rst
+++ b/doc/api/next_api_changes/behavior/20268-JMK.rst
@@ -1,0 +1,11 @@
+pcolor(mesh) shading defaults to auto
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *shading* kwarg for `.Axes.pcolormesh` and `.Axes.pcolor` default 
+has been changed to 'auto'.  
+
+Passing ``Z(M, N)``, ``x(N)``, ``y(M)`` to ``pcolormesh`` with 
+``shading='flat'`` will now raise a ``TypeError``.  Use 
+``shading='auto'`` or ``shading='nearest'`` for ``x`` and ``y``
+to be treated as cell centers, or drop the last column and row 
+of ``Z`` to get the old behavior with ``shading='flat'``.      

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5603,7 +5603,7 @@ default: :rc:`scatter.edgecolors`
         self.add_image(im)
         return im
 
-    def _pcolorargs(self, funcname, *args, shading='flat', **kwargs):
+    def _pcolorargs(self, funcname, *args, shading='auto', **kwargs):
         # - create X and Y if not present;
         # - reshape X and Y as needed if they are 1-D;
         # - check for proper sizes based on `shading` kwarg;
@@ -5675,25 +5675,16 @@ default: :rc:`scatter.edgecolors`
                 shading = 'flat'
 
         if shading == 'flat':
-            if not (ncols in (Nx, Nx - 1) and nrows in (Ny, Ny - 1)):
+            if (Nx, Ny) != (ncols + 1, nrows + 1):
                 raise TypeError('Dimensions of C %s are incompatible with'
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
-            if (ncols == Nx or nrows == Ny):
-                _api.warn_deprecated(
-                    "3.3", message="shading='flat' when X and Y have the same "
-                    "dimensions as C is deprecated since %(since)s.  Either "
-                    "specify the corners of the quadrilaterals with X and Y, "
-                    "or pass shading='auto', 'nearest' or 'gouraud', or set "
-                    "rcParams['pcolor.shading'].  This will become an error "
-                    "%(removal)s.")
-            C = C[:Ny - 1, :Nx - 1]
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
-            if shading in ['nearest', 'auto']:
+            if shading == 'nearest':
                 # grid is specified at the center, so define corners
                 # at the midpoints between the grid centers and then use the
                 # flat algorithm.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -130,7 +130,7 @@
 
 #markers.fillstyle: full  # {full, left, right, bottom, top, none}
 
-#pcolor.shading: flat
+#pcolor.shading: auto
 #pcolormesh.snap: True  # Whether to snap the mesh to pixel boundaries. This is
                         # provided solely to allow old test images to remain
                         # unchanged. Set to False to obtain the previous behavior.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1243,22 +1243,14 @@ def test_pcolornearestunits(fig_test, fig_ref):
     ax.pcolormesh(x2, y2, Z, shading='nearest')
 
 
-@check_figures_equal(extensions=["png"])
-def test_pcolordropdata(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    x = np.arange(0, 10)
-    y = np.arange(0, 4)
+def test_pcolorflaterror():
+    fig, ax = plt.subplots()
+    x = np.arange(0, 9)
+    y = np.arange(0, 3)
     np.random.seed(19680801)
     Z = np.random.randn(3, 9)
-    # fake dropping the data
-    ax.pcolormesh(x[:-1], y[:-1], Z[:-1, :-1], shading='flat')
-
-    ax = fig_ref.subplots()
-    # test dropping the data...
-    x2 = x[:-1]
-    y2 = y[:-1]
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.pcolormesh(x2, y2, Z, shading='flat')
+    with pytest.raises(TypeError, match='Dimensions of C'):
+        ax.pcolormesh(x, y, Z, shading='flat')
 
 
 @check_figures_equal(extensions=["png"])
@@ -1268,13 +1260,15 @@ def test_pcolorauto(fig_test, fig_ref):
     y = np.arange(0, 4)
     np.random.seed(19680801)
     Z = np.random.randn(3, 9)
-    ax.pcolormesh(x, y, Z, shading='auto')
+    # this is the same as flat; note that auto is default
+    ax.pcolormesh(x, y, Z)
 
     ax = fig_ref.subplots()
     # specify the centers
     x2 = x[:-1] + np.diff(x) / 2
     y2 = y[:-1] + np.diff(y) / 2
-    ax.pcolormesh(x2, y2, Z, shading='auto')
+    # this is same as nearest:
+    ax.pcolormesh(x2, y2, Z)
 
 
 @image_comparison(['canonical'])


### PR DESCRIPTION
## PR Summary

Taking `pcolormesh(x, y, Z)`,  in 3.3.0 (#16258) we introduced the `'nearest'` and '`auto`' kwargs for *shading* in pcolor(mesh) to properly allow for *not* dropping the last row and column in the case that cell centres are passed for x and y.  

### In 3.3:
- Default: `'flat'`
- Cell edges: Z.shape = M, N, len(x) = N+1, len(y) = M+1
   - 'flat': x and y specify cell edges
   - 'nearest'/'gouraud': `TypeError`
   - 'auto': 'flat'
- Cell centers: Z.shape = M, N, len(x) = N, len(y) = M
   - 'flat': DeprecationWarning and drop last row and column
   - 'nearest'/'gouraud': x and y specify cell centers
   - 'auto': 'nearest'
 
### In 3.5:
- Default: `'auto'`
- Cell edges: Z.shape = M, N, len(x) = N+1, len(y) = M+1
   - 'flat': x and y specify cell edges
   - 'nearest'/'gouraud': `TypeError`
   - 'auto': 'flat'
- Cell centers: Z.shape = M, N, len(x) = N, len(y) = M
   - 'flat': `TypeError`
   - 'nearest'/'gouraud': x and y specify cell centers
   - 'auto': 'nearest'




## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
