### PR TITLE
De-duplicate fonts in LaTeX preamble.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -110,12 +110,12 @@ class TexManager:
 
         # The following packages and commands need to be included in the latex
         # file's preamble:
-        cmd = [fonts['serif'][1],
-               fonts['sans-serif'][1],
-               fonts['monospace'][1]]
+        cmd = {fonts[family][1]
+               for family in ['serif', 'sans-serif', 'monospace']}
         if self.font_family == 'cursive':
-            cmd.append(fonts['cursive'][1])
-        self._font_preamble = '\n'.join([r'\usepackage{type1cm}', *cmd])
+            cmd.add(fonts['cursive'][1])
+        cmd.add(r'\usepackage{type1cm}')
+        self._font_preamble = '\n'.join(sorted(cmd))
 
         return ''.join(fontconfig)
 


### PR DESCRIPTION
## PR Summary

If the same font is used in sans + serif, then the `usepackage` gets duplicated. This appears harmless, but can be de-duplicated to shorten the produced LaTeX files.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).