### PR TITLE
Fix cursor with toolmanager on GTK3.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -48,6 +48,18 @@ except TypeError as exc:
     cursord = {}  # deprecated in Matplotlib 3.5.
 
 
+@functools.lru_cache()
+def _mpl_to_gtk_cursor(mpl_cursor):
+    name = {
+        cursors.MOVE: "move",
+        cursors.HAND: "pointer",
+        cursors.POINTER: "default",
+        cursors.SELECT_REGION: "crosshair",
+        cursors.WAIT: "wait",
+    }[mpl_cursor]
+    return Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
+
+
 class TimerGTK3(TimerBase):
     """Subclass of `.TimerBase` using GTK3 timer events."""
 
@@ -484,22 +496,10 @@ class NavigationToolbar2GTK3(NavigationToolbar2, Gtk.Toolbar):
         escaped = GLib.markup_escape_text(s)
         self.message.set_markup(f'<small>{escaped}</small>')
 
-    @staticmethod
-    @functools.lru_cache()
-    def _mpl_to_gtk_cursor(mpl_cursor):
-        name = {
-            cursors.MOVE: "move",
-            cursors.HAND: "pointer",
-            cursors.POINTER: "default",
-            cursors.SELECT_REGION: "crosshair",
-            cursors.WAIT: "wait",
-        }[mpl_cursor]
-        return Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
-
     def set_cursor(self, cursor):
         window = self.canvas.get_property("window")
         if window is not None:
-            window.set_cursor(self._mpl_to_gtk_cursor(cursor))
+            window.set_cursor(_mpl_to_gtk_cursor(cursor))
             Gtk.main_iteration()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):


### PR DESCRIPTION
## PR Summary

This was broken in #19441 because toolmanager uses a fake version of the toolbar2 class which doesn't have any static (or otherwise) methods.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).