### PR TITLE
Fix some examples that are skipped in docs build

### DIFF
--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -124,8 +124,10 @@ class Game:
     def __init__(self, ax):
         # create the initial line
         self.ax = ax
-        ax.set_ylim([-1, 1])
+        ax.xaxis.set_visible(False)
         ax.set_xlim([0, 7])
+        ax.yaxis.set_visible(False)
+        ax.set_ylim([-1, 1])
         pad_a_x = 0
         pad_b_x = .50
         pad_a_y = pad_b_y = .30
@@ -168,7 +170,6 @@ class Game:
         self.res = 100.0
         self.on = False
         self.inst = True    # show instructions from the beginning
-        self.background = None
         self.pads = [Pad(pA, pad_a_x, pad_a_y),
                      Pad(pB, pad_b_x, pad_b_y, 'r')]
         self.pucks = []

--- a/examples/event_handling/pipong.py
+++ b/examples/event_handling/pipong.py
@@ -178,7 +178,7 @@ class Game:
                                   verticalalignment='center',
                                   horizontalalignment='center',
                                   multialignment='left',
-                                  textcoords='axes fraction',
+                                  xycoords='axes fraction',
                                   animated=False)
         self.canvas.mpl_connect('key_press_event', self.on_key_press)
 

--- a/examples/user_interfaces/fourier_demo_wx_sgskip.py
+++ b/examples/user_interfaces/fourier_demo_wx_sgskip.py
@@ -70,7 +70,7 @@ class SliderGroup(Knob):
         self.sliderText = wx.TextCtrl(parent, -1, style=wx.TE_PROCESS_ENTER)
         self.slider = wx.Slider(parent, -1)
         # self.slider.SetMax(param.maximum*1000)
-        self.slider.SetRange(0, param.maximum * 1000)
+        self.slider.SetRange(0, int(param.maximum * 1000))
         self.setKnob(param.value)
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
@@ -99,7 +99,7 @@ class SliderGroup(Knob):
 
     def setKnob(self, value):
         self.sliderText.SetValue('%g' % value)
-        self.slider.SetValue(value * 1000)
+        self.slider.SetValue(int(value * 1000))
 
 
 class FourierDemoFrame(wx.Frame):

--- a/examples/user_interfaces/svg_histogram_sgskip.py
+++ b/examples/user_interfaces/svg_histogram_sgskip.py
@@ -149,7 +149,7 @@ function toggle_hist(obj) {
 """ % json.dumps(hist_patches)
 
 # Add a transition effect
-css = tree.getchildren()[0][0]
+css = tree.find('.//{http://www.w3.org/2000/svg}style')
 css.text = css.text + "g {-webkit-transition:opacity 0.4s ease-out;" + \
     "-moz-transition:opacity 0.4s ease-out;}"
 


### PR DESCRIPTION
## PR Summary

These are skipped because they can't be run on the docs build for one reason or another, but they broke at some point.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).