### PR TITLE
Fix ordering of tex font usepackages.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2014,8 +2014,9 @@ def _setattr_cm(obj, **kwargs):
 
 
 class _OrderedSet(collections.abc.MutableSet):
-    def __init__(self):
+    def __init__(self, iterable=()):
         self._od = collections.OrderedDict()
+        self |= iterable
 
     def __contains__(self, key):
         return key in self._od

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -110,8 +110,9 @@ class TexManager:
 
         # The following packages and commands need to be included in the latex
         # file's preamble:
-        cmd = {fonts[family][1]
-               for family in ['serif', 'sans-serif', 'monospace']}
+        cmd = cbook._OrderedSet(
+            fonts[family][1]
+            for family in ['serif', 'sans-serif', 'monospace'])
         if self.font_family == 'cursive':
             cmd.add(fonts['cursive'][1])
         cmd.add(r'\usepackage{type1cm}')


### PR DESCRIPTION
Sets do not maintain insertion order even with recent pythons (try e.g.
`for _ in $(seq 10); do python -c 'print({"a", "b"})'; done`), but we
have `cbook._OrderedSet` for that.

Keeping usepackage order can matter for caching purposes.

Followup to https://github.com/matplotlib/matplotlib/pull/20272.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
