### PR TITLE
Slightly reword intros of mpl_toolkits API docs.

### DIFF
--- a/doc/api/toolkits/axes_grid.rst
+++ b/doc/api/toolkits/axes_grid.rst
@@ -1,26 +1,22 @@
 .. _axes_grid-api-index:
 
-Matplotlib axes_grid Toolkit
-============================
+``mpl_toolkits.axes_grid``
+==========================
 
 .. currentmodule:: mpl_toolkits
 
-
 .. note::
-   AxesGrid toolkit has been a part of matplotlib since v
-   0.99. Originally, the toolkit had a single namespace of
-   *axes_grid*. In more recent version, the toolkit
-   has divided into two separate namespace (*axes_grid1* and *axisartist*).
-   While *axes_grid* namespace is maintained for the backward compatibility,
-   use of *axes_grid1* and *axisartist* is recommended. 
-   For the documentation on ``axes_grid``,
-   see the `previous version of the docs 
-   <https://matplotlib.org/2.0.1/mpl_toolkits/axes_grid/index.html#toolkit-axesgrid-index>`_.
+   AxesGrid has been a part of matplotlib since v 0.99. Originally, the toolkit
+   used the *axes_grid* namespace. In more recent versions, the toolkit
+   has been split into *axes_grid1* and *axisartist*.  While *axes_grid*
+   is maintained for the backward compatibility, use of *axes_grid1* and
+   *axisartist* is recommended.  For the documentation on ``axes_grid``, see
+   the `previous version of the docs`__.
+
+   .. __: https://matplotlib.org/2.0.1/mpl_toolkits/axes_grid/index.html
 
 .. toctree::
     :maxdepth: 1
-    
+
     axes_grid1
     axisartist
-
-

--- a/doc/api/toolkits/axes_grid1.rst
+++ b/doc/api/toolkits/axes_grid1.rst
@@ -1,13 +1,12 @@
 .. module:: mpl_toolkits.axes_grid1
 
-Matplotlib axes_grid1 Toolkit
-=============================
+``mpl_toolkits.axes_grid1``
+===========================
 
-The matplotlib :mod:`mpl_toolkits.axes_grid1` toolkit is a collection of
-helper classes to ease displaying multiple images in matplotlib.  While the
-aspect parameter in matplotlib adjust the position of the single axes,
-axes_grid1 toolkit provides a framework to adjust the position of
-multiple axes according to their aspects.
+:mod:`mpl_toolkits.axes_grid1` provides a framework of helper classes to adjust
+the positioning of multiple fixed-aspect Axes (e.g., displaying images).  It
+can be contrasted with the ``aspect`` property of Matplotlib Axes, which
+adjusts the position of a single Axes.
 
 See :ref:`axes_grid1_users-guide-index` for a guide on the usage of axes_grid1.
 
@@ -32,5 +31,3 @@ See :ref:`axes_grid1_users-guide-index` for a guide on the usage of axes_grid1.
    axes_grid1.inset_locator
    axes_grid1.mpl_axes
    axes_grid1.parasite_axes
-
-

--- a/doc/api/toolkits/axisartist.rst
+++ b/doc/api/toolkits/axisartist.rst
@@ -1,15 +1,15 @@
 .. module:: mpl_toolkits.axisartist
 
-Matplotlib axisartist Toolkit
-=============================
+``mpl_toolkits.axisartist``
+===========================
 
-The *axisartist* namespace includes a derived Axes implementation (
-:class:`mpl_toolkits.axisartist.Axes`). The
-biggest difference is that the artists that are responsible for drawing
-axis lines, ticks, ticklabels, and axis labels are separated out from the
-mpl's Axis class. This change was strongly motivated to support curvilinear grid.
+The *axisartist* namespace provides a derived Axes implementation
+(:class:`mpl_toolkits.axisartist.Axes`), designed to support curvilinear
+grids.  The biggest difference is that the artists that are responsible for
+drawing axis lines, ticks, ticklabels, and axis labels are separated out from
+Matplotlib's Axis class.
 
-You can find a tutorial describing usage of axisartist at the 
+You can find a tutorial describing usage of axisartist at the
 :ref:`axisartist_users-guide-index` user guide.
 
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_curvelinear_grid_001.png
@@ -37,4 +37,3 @@ You can find a tutorial describing usage of axisartist at the
    axisartist.grid_finder
    axisartist.grid_helper_curvelinear
    axisartist.parasite_axes
-


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
