### PR TITLE
Use a GtkApplication in GTK backend.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -51,12 +51,26 @@ except TypeError as exc:
 _application = None
 
 
+def _shutdown_application(app):
+    # The application might prematurely shut down if Ctrl-C'd out of IPython,
+    # so close all windows.
+    for win in app.get_windows():
+        win.destroy()
+    # The PyGObject wrapper incorrectly thinks that None is not allowed, or we
+    # would call this:
+    # Gio.Application.set_default(None)
+    # Instead, we set this property and ignore default applications with it:
+    app._created_by_matplotlib = True
+    global _application
+    _application = None
+
+
 def _create_application():
     global _application
 
     if _application is None:
         app = Gio.Application.get_default()
-        if app is None:
+        if app is None or getattr(app, '_created_by_matplotlib'):
             # display_is_valid returns False only if on Linux and neither X11
             # nor Wayland display can be opened.
             if not mpl._c_internal_utils.display_is_valid():
@@ -66,6 +80,7 @@ def _create_application():
             # The activate signal must be connected, but we don't care for
             # handling it, since we don't do any remote processing.
             _application.connect('activate', lambda *args, **kwargs: None)
+            _application.connect('shutdown', _shutdown_application)
             _application.register()
             cbook._setup_new_guiapp()
         else:
@@ -851,6 +866,8 @@ class _BackendGTK3(_Backend):
         if _application is None:
             return
 
-        _application.run()  # Quits when all added windows close.
-        # Running after quit is undefined, so create a new one next time.
-        _application = None
+        try:
+            _application.run()  # Quits when all added windows close.
+        finally:
+            # Running after quit is undefined, so create a new one next time.
+            _application = None


### PR DESCRIPTION
## PR Summary

Also, stop using `gtk_main*` functions; these were deprecated in GTK3, and no longer exist in GTK4. The lower level GLib functions have always been there, and won't go away.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).