### PR TITLE
Write data parameter docs as regular parameter not as note (v2)

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1256,24 +1256,6 @@ def _label_from_arg(y, default_name):
     return None
 
 
-_DATA_DOC_TITLE = """
-
-Notes
------
-"""
-
-_DATA_DOC_APPENDIX = """
-
-.. note::
-    In addition to the above described arguments, this function can take
-    a *data* keyword argument. If such a *data* argument is given,
-{replaced}
-
-    Objects passed as **data** must support item access (``data[s]``) and
-    membership test (``s in data``).
-"""
-
-
 def _add_data_doc(docstring, replace_names):
     """
     Add documentation for a *data* field to the given docstring.
@@ -1296,17 +1278,35 @@ def _add_data_doc(docstring, replace_names):
             or replace_names is not None and len(replace_names) == 0):
         return docstring
     docstring = inspect.cleandoc(docstring)
-    repl = (
-        ("    every other argument can also be string ``s``, which is\n"
-         "    interpreted as ``data[s]`` (unless this raises an exception).")
-        if replace_names is None else
-        ("    the following arguments can also be string ``s``, which is\n"
-         "    interpreted as ``data[s]`` (unless this raises an exception):\n"
-         "    " + ", ".join(map("*{}*".format, replace_names))) + ".")
-    addendum = _DATA_DOC_APPENDIX.format(replaced=repl)
-    if _DATA_DOC_TITLE not in docstring:
-        addendum = _DATA_DOC_TITLE + addendum
-    return docstring + addendum
+
+    data_doc = ("""\
+    If given, all parameters also accept a string ``s``, which is
+    interpreted as ``data[s]`` (unless this raises an exception).
+
+    Objects passed as **data** must support item access (``data[s]``) and
+    membership test (``s in data``)."""
+                if replace_names is None else ("""\
+    If given, the following parameters also accept a string ``s``, which
+    is interpreted as ``data[s]`` (unless this raises an exception):
+
+    {names}
+
+    Objects passed as **data** must support item access (``data[s]``) and
+    membership test (``s in data``).""".format(
+            names=", ".join(map("*{}*".format, replace_names)))
+        )
+    )
+    # using string replacement instead of formatting has the advantages
+    # 1) simpler indent handling
+    # 2) prevent problems with formatting characters '{', '%' in the docstring
+    if _log.level <= logging.DEBUG:
+        # test_data_parameter_replacement() tests against these log messages
+        # make sure to keep message and test in sync
+        if "data : indexable object, optional" not in docstring:
+            _log.debug("data parameter docstring error: no data parameter")
+        if 'DATA_PARAMETER_PLACEHOLDER' not in docstring:
+            _log.debug("data parameter docstring error: missing placeholder")
+    return docstring.replace('    DATA_PARAMETER_PLACEHOLDER', data_doc)
 
 
 def _preprocess_data(func=None, *, replace_names=None, label_namer=None):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1007,6 +1007,8 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
         **kwargs :  `~matplotlib.collections.LineCollection` properties.
 
         See Also
@@ -1084,6 +1086,8 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
         **kwargs : `~matplotlib.collections.LineCollection` properties.
 
         See Also
@@ -1211,6 +1215,9 @@ class Axes(_AxesBase):
 
             If *positions* is 2D, this can be a sequence with length matching
             the length of *positions*.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs
             Other keyword arguments are line collection properties.  See
@@ -1660,6 +1667,8 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -1730,6 +1739,9 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             All parameters supported by `.plot`.
         """
@@ -1783,6 +1795,9 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             All parameters supported by `.plot`.
         """
@@ -1832,6 +1847,9 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             All parameters supported by `.plot`.
         """
@@ -1898,6 +1916,9 @@ class Axes(_AxesBase):
         marker : str, default: 'o'
             The marker for plotting the data points.
             Only used if *usevlines* is ``False``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs
             Additional parameters are passed to `.Axes.vlines` and
@@ -1972,6 +1993,9 @@ class Axes(_AxesBase):
         marker : str, default: 'o'
             The marker for plotting the data points.
             Only used if *usevlines* is ``False``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs
             Additional parameters are passed to `.Axes.vlines` and
@@ -2083,6 +2107,9 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Additional parameters are the same as those for `.plot`.
 
@@ -2231,6 +2258,9 @@ class Axes(_AxesBase):
 
         log : bool, default: False
             If *True*, set the y-axis to be log scale.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs : `.Rectangle` properties
 
@@ -2682,6 +2712,8 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
         **kwargs : `.BrokenBarHCollection` properties
 
             Each *kwarg* can be either a single argument applying to all
@@ -2800,6 +2832,9 @@ class Axes(_AxesBase):
             significantly increases performance.  If ``False``, defaults to the
             old behavior of using a list of `.Line2D` objects.  This parameter
             may be deprecated in the future.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         Returns
         -------
@@ -3017,6 +3052,9 @@ class Axes(_AxesBase):
 
         rotatelabels : bool, default: False
             Rotate each label to the angle of the corresponding slice if true.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         Returns
         -------
@@ -3273,6 +3311,9 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             All other keyword arguments are passed on to the `~.Axes.plot` call
             drawing the markers. For example, this code makes big red squares
@@ -3667,6 +3708,8 @@ class Axes(_AxesBase):
             The style of the median.
         meanprops : dict, default: None
             The style of the mean.
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         See Also
         --------
@@ -4401,6 +4444,8 @@ default: :rc:`scatter.edgecolors`
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
         **kwargs : `~matplotlib.collections.Collection` properties
 
         See Also
@@ -4686,6 +4731,9 @@ default: :rc:`scatter.edgecolors`
             - `numpy.mean`: average of the points
             - `numpy.sum`: integral of the point values
             - `numpy.amax`: value taken from the largest point
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs : `~matplotlib.collections.PolyCollection` properties
             All other keyword arguments are passed on to `.PolyCollection`:
@@ -5195,6 +5243,9 @@ default: :rc:`scatter.edgecolors`
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             All other keyword arguments are passed on to `.PolyCollection`.
             They control the `.Polygon` properties:
@@ -5506,6 +5557,9 @@ default: :rc:`scatter.edgecolors`
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs : `~matplotlib.artist.Artist` properties
             These parameters are passed on to the constructor of the
             `.AxesImage` artist.
@@ -5802,6 +5856,9 @@ default: :rc:`scatter.edgecolors`
             Stroking the edges may be preferred if *alpha* is 1, but will
             cause artifacts otherwise.
 
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Additionally, the following arguments are allowed. They are passed
             along to the `~matplotlib.collections.PolyCollection` constructor:
@@ -6047,6 +6104,9 @@ default: :rc:`scatter.edgecolors`
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Additionally, the following arguments are allowed. They are passed
             along to the `~matplotlib.collections.QuadMesh` constructor:
@@ -6262,6 +6322,9 @@ default: :rc:`scatter.edgecolors`
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Supported additional parameters depend on the type of grid.
             See return types of *image* for further description.
@@ -6567,6 +6630,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             `~matplotlib.patches.Patch` properties
 
@@ -6888,6 +6954,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             `~matplotlib.patches.StepPatch` properties
 
@@ -7001,6 +7070,9 @@ such objects
         alpha : ``0 <= scalar <= 1`` or ``None``, optional
             The alpha blending value.
 
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Additional parameters are passed along to the
             `~.Axes.pcolormesh` method and `~matplotlib.collections.QuadMesh`
@@ -7088,6 +7160,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7201,6 +7276,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7291,6 +7369,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7368,6 +7449,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7434,6 +7518,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7501,6 +7588,9 @@ such objects
 
         Other Parameters
         ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         **kwargs
             Keyword arguments control the `.Line2D` properties:
 
@@ -7578,6 +7668,9 @@ such objects
             left border of the first bin (*spectrum* column) and *xmax* to the
             right border of the last bin. Note that for *noverlap>0* the width
             of the bins is smaller than those of the segments.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         **kwargs
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
@@ -7923,6 +8016,9 @@ such objects
           scalar, this will be used directly as `kde.factor`.  If a
           callable, it should take a `GaussianKDE` instance as its only
           parameter and return a scalar. If None (default), 'scott' is used.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
         Returns
         -------

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1726,6 +1726,9 @@ class QuadContourSet(ContourSet):
             Hatching is supported in the PostScript, PDF, SVG and Agg
             backends only.
 
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
         Notes
         -----
         1. `.contourf` differs from the MATLAB version in that it does not draw

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -181,6 +181,9 @@ color : color or color sequence, optional
 
 Other Parameters
 ----------------
+data : indexable object, optional
+    DATA_PARAMETER_PLACEHOLDER
+
 **kwargs : `~matplotlib.collections.PolyCollection` properties, optional
     All other keyword arguments are passed on to `.PolyCollection`:
 
@@ -888,6 +891,9 @@ barbs : `~matplotlib.quiver.Barbs`
 
 Other Parameters
 ----------------
+data : indexable object, optional
+    DATA_PARAMETER_PLACEHOLDER
+
 **kwargs
     The barbs can further be customized using `.PolyCollection` keyword
     arguments:

--- a/lib/matplotlib/stackplot.py
+++ b/lib/matplotlib/stackplot.py
@@ -53,6 +53,9 @@ def stackplot(axes, x, *args,
 
         If not specified, the colors from the Axes property cycle will be used.
 
+    data : indexable object, optional
+        DATA_PARAMETER_PLACEHOLDER
+
     **kwargs
         All other keyword arguments are passed to `.Axes.fill_between`.
 

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -67,6 +67,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         Maximum length of streamline in axes coordinates.
     integration_direction : {'forward', 'backward', 'both'}, default: 'both'
         Integrate the streamline in forward, backward or both directions.
+    data : indexable object, optional
+        DATA_PARAMETER_PLACEHOLDER
 
     Returns
     -------

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -1,4 +1,6 @@
 import re
+import subprocess
+import sys
 
 import numpy as np
 import pytest
@@ -197,33 +199,68 @@ def test_more_args_than_pos_parameter():
 def test_docstring_addition():
     @_preprocess_data()
     def funcy(ax, *args, **kwargs):
-        """Funcy does nothing"""
+        """
+        Parameters
+        ----------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        """
 
-    assert re.search(r"every other argument", funcy.__doc__)
-    assert not re.search(r"the following arguments", funcy.__doc__)
+    assert re.search(r"all parameters also accept a string", funcy.__doc__)
+    assert not re.search(r"the following parameters", funcy.__doc__)
 
     @_preprocess_data(replace_names=[])
     def funcy(ax, x, y, z, bar=None):
-        """Funcy does nothing"""
+        """
+        Parameters
+        ----------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        """
 
-    assert not re.search(r"every other argument", funcy.__doc__)
-    assert not re.search(r"the following arguments", funcy.__doc__)
+    assert not re.search(r"all parameters also accept a string", funcy.__doc__)
+    assert not re.search(r"the following parameters", funcy.__doc__)
 
     @_preprocess_data(replace_names=["bar"])
     def funcy(ax, x, y, z, bar=None):
-        """Funcy does nothing"""
+        """
+        Parameters
+        ----------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        """
 
-    assert not re.search(r"every other argument", funcy.__doc__)
-    assert not re.search(r"the following arguments .*: \*bar\*\.",
+    assert not re.search(r"all parameters also accept a string", funcy.__doc__)
+    assert not re.search(r"the following parameters .*: \*bar\*\.",
                          funcy.__doc__)
 
     @_preprocess_data(replace_names=["x", "t"])
     def funcy(ax, x, y, z, t=None):
-        """Funcy does nothing"""
+        """
+        Parameters
+        ----------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        """
 
-    assert not re.search(r"every other argument", funcy.__doc__)
-    assert not re.search(r"the following arguments .*: \*x\*, \*t\*\.",
+    assert not re.search(r"all parameters also accept a string", funcy.__doc__)
+    assert not re.search(r"the following parameters .*: \*x\*, \*t\*\.",
                          funcy.__doc__)
+
+
+def test_data_parameter_replacement():
+    """
+    Test that that the docstring contains the correct *data* parameter stub
+    for all methods that we run _preprocess_data() on.
+    """
+    program = (
+        "import logging; "
+        "logging.basicConfig(level=logging.DEBUG); "
+        "import matplotlib.pyplot as plt"
+    )
+    cmd = [sys.executable, "-c", program]
+    completed_proc = subprocess.run(cmd, text=True, capture_output=True)
+    assert 'data parameter docstring error' not in completed_proc.stderr
 
 
 class TestPlotTypes:


### PR DESCRIPTION
Replaces #19859. This approach uses an explicit template

```
    data : indexable object, optional
        # data_parameter_message
```

in the docstring and does not try to guess a reasonable insertion
position based on the docstring content. This is much simpler.

