### PR TITLE
Simplify font setting in usetex mode

### DIFF
--- a/doc/users/next_whats_new/simplify_font_setting_usetex.rst
+++ b/doc/users/next_whats_new/simplify_font_setting_usetex.rst
@@ -1,0 +1,13 @@
+
+Simplifying the font setting for usetex mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Now the :rc:`font.family` accepts some font names as value for a more
+user-friendly setup.
+
+.. code-block::
+
+    plt.rcParams.update({
+        "text.usetex": True,
+        "font.family": "Helvetica"
+    })

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -30,6 +30,11 @@ def test_fontconfig_preamble():
          r"\usepackage{chancery}", r"\rmfamily"),
         ({"font.family": "monospace", "font.monospace": "courier"},
          r"\usepackage{courier}", r"\ttfamily"),
+        ({"font.family": "helvetica"}, r"\usepackage{helvet}", r"\sffamily"),
+        ({"font.family": "palatino"}, r"\usepackage{mathpazo}", r"\rmfamily"),
+        ({"font.family": "zapf chancery"},
+         r"\usepackage{chancery}", r"\rmfamily"),
+        ({"font.family": "courier"}, r"\usepackage{courier}", r"\ttfamily")
     ])
 def test_font_selection(rc, preamble, family):
     plt.rcParams.update(rc)

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -51,6 +51,27 @@ matplotlibrc use::
       "font.family": "serif",
       "font.serif": ["Palatino"],
   })
+  # It's also possible to use the reduced notation by directly setting font.family:
+  plt.rcParams.update({
+    "text.usetex": True,
+    "font.family": "Helvetica"
+  })
+
+Currently, the supported fonts are:
+
+================= ============================================================
+family            fonts
+================= ============================================================
+``'serif'``         ``'New Century Schoolbook'``, ``'Bookman'``, ``'Times'``,
+                    ``'Palatino'``, ``'Charter'``, ``'Computer Moderm Roman'``
+
+``'sans-serif'``  ``'Helvetica'``, ``'Avant Garde'``, ``'Computer Modern
+                  Serif'``
+
+``'cursive'``     ``'Zapf Chancery'``
+
+``'monospace'``   ``'Courier'``, ``'Computer Modern Typewriter'``
+================= ============================================================
 
 Here is the standard example,
 :doc:`/gallery/text_labels_and_annotations/tex_demo`:


### PR DESCRIPTION
## PR Summary
As suggested in #20289 , create a more user-friendly and simplified version of the font settings for usetex using the `rc::font.family`

Example:
```python
plt.rcParams.update({
    "text.usetex": True,
    "font.family": "Helvetica"
})

t = np.linspace(0.0, 1.0, 100)
s = np.cos(4 * np.pi * t) + 2

fig, ax = plt.subplots(figsize=(6, 4), tight_layout=True)
ax.plot(t, s)

ax.set_xlabel(r'\textbf{time (s)}')
ax.set_ylabel('\\textit{Velocity (\N{DEGREE SIGN}/sec)}', fontsize=16)
ax.set_title(r'\TeX\ is Number $\displaystyle\sum_{n=1}^\infty'
             r'\frac{-e^{i\pi}}{2^n}$!', fontsize=16, color='r')

plt.show()

```


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
