### PR TITLE
Simplify tfm parsing.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -714,15 +714,6 @@ class Vf(Dvi):
         # cs = checksum, ds = design size
 
 
-def _fix2comp(num):
-    """Convert from two's complement to negative."""
-    assert 0 <= num < 2**32
-    if num & 2**31:
-        return num - 2**32
-    else:
-        return num
-
-
 def _mul2012(num1, num2):
     """Multiply two numbers in 20.12 fixed point format."""
     # Separated into a function because >> has surprising precedence
@@ -756,29 +747,23 @@ class Tfm:
         _log.debug('opening tfm file %s', filename)
         with open(filename, 'rb') as file:
             header1 = file.read(24)
-            lh, bc, ec, nw, nh, nd = \
-                struct.unpack('!6H', header1[2:14])
+            lh, bc, ec, nw, nh, nd = struct.unpack('!6H', header1[2:14])
             _log.debug('lh=%d, bc=%d, ec=%d, nw=%d, nh=%d, nd=%d',
                        lh, bc, ec, nw, nh, nd)
             header2 = file.read(4*lh)
-            self.checksum, self.design_size = \
-                struct.unpack('!2I', header2[:8])
+            self.checksum, self.design_size = struct.unpack('!2I', header2[:8])
             # there is also encoding information etc.
             char_info = file.read(4*(ec-bc+1))
-            widths = file.read(4*nw)
-            heights = file.read(4*nh)
-            depths = file.read(4*nd)
-
+            widths = struct.unpack(f'!{nw}i', file.read(4*nw))
+            heights = struct.unpack(f'!{nh}i', file.read(4*nh))
+            depths = struct.unpack(f'!{nd}i', file.read(4*nd))
         self.width, self.height, self.depth = {}, {}, {}
-        widths, heights, depths = \
-            [struct.unpack('!%dI' % (len(x)/4), x)
-             for x in (widths, heights, depths)]
         for idx, char in enumerate(range(bc, ec+1)):
             byte0 = char_info[4*idx]
             byte1 = char_info[4*idx+1]
-            self.width[char] = _fix2comp(widths[byte0])
-            self.height[char] = _fix2comp(heights[byte1 >> 4])
-            self.depth[char] = _fix2comp(depths[byte1 & 0xf])
+            self.width[char] = widths[byte0]
+            self.height[char] = heights[byte1 >> 4]
+            self.depth[char] = depths[byte1 & 0xf]
 
 
 PsFont = namedtuple('PsFont', 'texname psname effects encoding filename')


### PR DESCRIPTION
Directly read as signed int32 ("i") instead of reading as signed int32
and converting to unsigned later using fix2comp.

Simplify parsing of widths/heights/depths.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
