### PR TITLE
Remove tilde in code links where not necessary

### DIFF
--- a/examples/axes_grid1/inset_locator_demo2.py
+++ b/examples/axes_grid1/inset_locator_demo2.py
@@ -3,10 +3,10 @@
 Inset Locator Demo2
 ===================
 
-This Demo shows how to create a zoomed inset via `~.zoomed_inset_axes`.
-In the first subplot an `~.AnchoredSizeBar` shows the zoom effect.
+This Demo shows how to create a zoomed inset via `.zoomed_inset_axes`.
+In the first subplot an `.AnchoredSizeBar` shows the zoom effect.
 In the second subplot a connection to the region of interest is
-created via `~.mark_inset`.
+created via `.mark_inset`.
 """
 
 from matplotlib import cbook

--- a/examples/lines_bars_and_markers/stem_plot.py
+++ b/examples/lines_bars_and_markers/stem_plot.py
@@ -21,7 +21,7 @@ plt.show()
 # The parameters *linefmt*, *markerfmt*, and *basefmt* control basic format
 # properties of the plot. However, in contrast to `~.pyplot.plot` not all
 # properties are configurable via keyword arguments. For more advanced
-# control adapt the line objects returned by `~.pyplot`.
+# control adapt the line objects returned by `.pyplot`.
 
 markerline, stemlines, baseline = plt.stem(
     x, y, linefmt='grey', markerfmt='D', bottom=1.1)

--- a/examples/mplot3d/stem3d_demo.py
+++ b/examples/mplot3d/stem3d_demo.py
@@ -26,7 +26,7 @@ plt.show()
 # *linefmt*, *markerfmt*, and *basefmt* control basic format properties of the
 # plot. However, in contrast to `~.axes3d.Axes3D.plot` not all properties are
 # configurable via keyword arguments. For more advanced control adapt the line
-# objects returned by `~.stem3D`.
+# objects returned by `.stem3D`.
 
 fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
 markerline, stemlines, baseline = ax.stem(

--- a/examples/scales/custom_scale.py
+++ b/examples/scales/custom_scale.py
@@ -6,7 +6,7 @@ Custom scale
 Create a custom scale, by implementing the scaling use for latitude data in a
 Mercator Projection.
 
-Unless you are making special use of the `~.Transform` class, you probably
+Unless you are making special use of the `.Transform` class, you probably
 don't need to use this verbose method, and instead can use `~.scale.FuncScale`
 and the ``'function'`` option of `~.Axes.set_xscale` and `~.Axes.set_yscale`.
 See the last example in :doc:`/gallery/scales/scales`.

--- a/examples/ticks_and_spines/date_concise_formatter.py
+++ b/examples/ticks_and_spines/date_concise_formatter.py
@@ -143,7 +143,7 @@ plt.show()
 # =========================================
 #
 # `.ConciseDateFormatter` doesn't have rcParams entries, but localization
-# can be accomplished by passing kwargs to `~.ConciseDateConverter` and
+# can be accomplished by passing kwargs to `.ConciseDateConverter` and
 # registering the datatypes you will use with the units registry:
 
 import datetime

--- a/examples/ticks_and_spines/date_precision_and_epochs.py
+++ b/examples/ticks_and_spines/date_precision_and_epochs.py
@@ -66,7 +66,7 @@ print('After Roundtrip:  ', date2)
 
 #############################################################################
 # If a user wants to use modern dates at microsecond precision, they
-# can change the epoch using `~.set_epoch`.  However, the epoch has to be
+# can change the epoch using `.set_epoch`.  However, the epoch has to be
 # set before any date operations to prevent confusion between different
 # epochs. Trying to change the epoch later will raise a `RuntimeError`.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1655,7 +1655,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        list of `~.Line2D`
+        list of `.Line2D`
             Objects representing the plotted data.
 
         Other Parameters
@@ -1725,7 +1725,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        list of `~.Line2D`
+        list of `.Line2D`
             Objects representing the plotted data.
 
         Other Parameters
@@ -1778,7 +1778,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        list of `~.Line2D`
+        list of `.Line2D`
             Objects representing the plotted data.
 
         Other Parameters
@@ -1827,7 +1827,7 @@ class Axes(_AxesBase):
 
         Returns
         -------
-        list of `~.Line2D`
+        list of `.Line2D`
             Objects representing the plotted data.
 
         Other Parameters
@@ -4655,7 +4655,7 @@ default: :rc:`scatter.edgecolors`
 
         vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `.Normalize` instance (defaults to
             the respective min/max values of the bins in case of the default
             linear scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -5763,7 +5763,7 @@ default: :rc:`scatter.edgecolors`
 
         vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -5990,7 +5990,7 @@ default: :rc:`scatter.edgecolors`
 
         vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -6240,7 +6240,7 @@ default: :rc:`scatter.edgecolors`
 
         vmin, vmax : float, default: None
             The colorbar range. If *None*, suitable min/max values are
-            automatically chosen by the `~.Normalize` instance (defaults to
+            automatically chosen by the `.Normalize` instance (defaults to
             the respective min/max values of *C* in case of the default linear
             scaling).
             It is deprecated to use *vmin*/*vmax* when *norm* is given.
@@ -6381,7 +6381,7 @@ default: :rc:`scatter.edgecolors`
 
         Parameters
         ----------
-        CS : `~.ContourSet` instance
+        CS : `.ContourSet` instance
             Line contours to label.
 
         levels : array-like, optional

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2165,7 +2165,7 @@ class _AxesBase(martist.Artist):
 
     def add_artist(self, a):
         """
-        Add an `~.Artist` to the Axes; return the artist.
+        Add an `.Artist` to the Axes; return the artist.
 
         Use `add_artist` only for artists for which there is no dedicated
         "add" method; and if necessary, use a method such as `update_datalim`
@@ -2186,7 +2186,7 @@ class _AxesBase(martist.Artist):
 
     def add_child_axes(self, ax):
         """
-        Add an `~.AxesBase` to the axes' children; return the child axes.
+        Add an `.AxesBase` to the axes' children; return the child axes.
 
         This is the lowlevel version.  See `.axes.Axes.inset_axes`.
         """
@@ -2204,7 +2204,7 @@ class _AxesBase(martist.Artist):
 
     def add_collection(self, collection, autolim=True):
         """
-        Add a `~.Collection` to the Axes; return the collection.
+        Add a `.Collection` to the Axes; return the collection.
         """
         self._deprecate_noninstance('add_collection', mcoll.Collection,
                                     collection=collection)
@@ -2238,7 +2238,7 @@ class _AxesBase(martist.Artist):
 
     def add_image(self, image):
         """
-        Add an `~.AxesImage` to the Axes; return the image.
+        Add an `.AxesImage` to the Axes; return the image.
         """
         self._deprecate_noninstance('add_image', mimage.AxesImage, image=image)
         self._set_artist_props(image)
@@ -2272,7 +2272,7 @@ class _AxesBase(martist.Artist):
 
     def _add_text(self, txt):
         """
-        Add a `~.Text` to the Axes; return the text.
+        Add a `.Text` to the Axes; return the text.
         """
         self._deprecate_noninstance('_add_text', mtext.Text, txt=txt)
         self._set_artist_props(txt)
@@ -2327,7 +2327,7 @@ class _AxesBase(martist.Artist):
 
     def add_patch(self, p):
         """
-        Add a `~.Patch` to the Axes; return the patch.
+        Add a `.Patch` to the Axes; return the patch.
         """
         self._deprecate_noninstance('add_patch', mpatches.Patch, p=p)
         self._set_artist_props(p)
@@ -2368,7 +2368,7 @@ class _AxesBase(martist.Artist):
 
     def add_table(self, tab):
         """
-        Add a `~.Table` to the Axes; return the table.
+        Add a `.Table` to the Axes; return the table.
         """
         self._deprecate_noninstance('add_table', mtable.Table, tab=tab)
         self._set_artist_props(tab)
@@ -2379,7 +2379,7 @@ class _AxesBase(martist.Artist):
 
     def add_container(self, container):
         """
-        Add a `~.Container` to the axes' containers; return the container.
+        Add a `.Container` to the axes' containers; return the container.
         """
         label = container.get_label()
         if not label:
@@ -2406,7 +2406,7 @@ class _AxesBase(martist.Artist):
         """
         Recompute the data limits based on current artists.
 
-        At present, `~.Collection` instances are not supported.
+        At present, `.Collection` instances are not supported.
 
         Parameters
         ----------

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1797,7 +1797,7 @@ class Axis(martist.Artist):
 
         Returns
         -------
-        list of `~.Text`
+        list of `.Text`
             The labels.
 
         Other Parameters

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1464,8 +1464,8 @@ class PickEvent(Event):
         (see `.Artist.set_picker`).
     other
         Additional attributes may be present depending on the type of the
-        picked object; e.g., a `~.Line2D` pick may define different extra
-        attributes than a `~.PatchCollection` pick.
+        picked object; e.g., a `.Line2D` pick may define different extra
+        attributes than a `.PatchCollection` pick.
 
     Examples
     --------
@@ -1532,7 +1532,7 @@ class KeyEvent(LocationEvent):
 
 def _get_renderer(figure, print_method=None):
     """
-    Get the renderer that would be used to save a `~.Figure`, and cache it on
+    Get the renderer that would be used to save a `.Figure`, and cache it on
     the figure.
 
     If you need a renderer without any active draw methods use

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1791,7 +1791,7 @@ def _define_aliases(alias_d, cls=None):
     exception will be raised.
 
     The alias map is stored as the ``_alias_map`` attribute on the class and
-    can be used by `~.normalize_kwargs` (which assumes that higher priority
+    can be used by `.normalize_kwargs` (which assumes that higher priority
     aliases come last).
     """
     if cls is None:  # Return the actual class decorator.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1044,8 +1044,8 @@ class PathCollection(_CollectionWithSizes):
             Finally, a `~.ticker.Locator` can be provided.
         fmt : str, `~matplotlib.ticker.Formatter`, or None (default)
             The format or formatter to use for the labels. If a string must be
-            a valid input for a `~.StrMethodFormatter`. If None (the default),
-            use a `~.ScalarFormatter`.
+            a valid input for a `.StrMethodFormatter`. If None (the default),
+            use a `.ScalarFormatter`.
         func : function, default: ``lambda x: x``
             Function to calculate the labels.  Often the size (or color)
             argument to `~.Axes.scatter` will have been pre-processed by the
@@ -1358,7 +1358,7 @@ class LineCollection(Collection):
     Represents a sequence of `.Line2D`\s that should be drawn together.
 
     This class extends `.Collection` to represent a sequence of
-    `~.Line2D`\s instead of just a sequence of `~.Patch`\s.
+    `.Line2D`\s instead of just a sequence of `.Patch`\s.
     Just as in `.Collection`, each property of a *LineCollection* may be either
     a single value or a list of values. This list is then used cyclically for
     each element of the LineCollection, so the property of the ``i``\th element
@@ -1894,7 +1894,7 @@ class TriMesh(Collection):
     @staticmethod
     def convert_mesh_to_paths(tri):
         """
-        Convert a given mesh into a sequence of `~.Path` objects.
+        Convert a given mesh into a sequence of `.Path` objects.
 
         This function is primarily of use to implementers of backends that do
         not directly support meshes.
@@ -1987,7 +1987,7 @@ class QuadMesh(Collection):
     @staticmethod
     def convert_mesh_to_paths(meshWidth, meshHeight, coordinates):
         """
-        Convert a given mesh into a sequence of `~.Path` objects.
+        Convert a given mesh into a sequence of `.Path` objects.
 
         This function is primarily of use to implementers of backends that do
         not directly support quadmeshes.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -24,7 +24,7 @@ In Matplotlib they are drawn into a dedicated `~.axes.Axes`.
     used with figures containing a single axes or with freely placed axes.
 
 :func:`make_axes_gridspec`
-    Create a `~.SubplotBase` suitable for a colorbar. This function should
+    Create a `.SubplotBase` suitable for a colorbar. This function should
     be used for adding a colorbar to a `.GridSpec`.
 """
 
@@ -166,7 +166,7 @@ ax : `~matplotlib.axes.Axes`, list of Axes, optional
 use_gridspec : bool, optional
     If *cax* is ``None``, a new *cax* is created as an instance of Axes.  If
     *ax* is an instance of Subplot and *use_gridspec* is ``True``, *cax* is
-    created as an instance of Subplot using the :mod:`~.gridspec` module.
+    created as an instance of Subplot using the :mod:`.gridspec` module.
 
 Returns
 -------
@@ -1450,7 +1450,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
 def make_axes_gridspec(parent, *, location=None, orientation=None,
                        fraction=0.15, shrink=1.0, aspect=20, **kw):
     """
-    Create a `~.SubplotBase` suitable for a colorbar.
+    Create a `.SubplotBase` suitable for a colorbar.
 
     The axes is placed in the figure of the *parent* axes, by resizing and
     repositioning *parent*.

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -436,7 +436,7 @@ class GridSpec(GridSpecBase):
 
     def get_subplot_params(self, figure=None):
         """
-        Return the `~.SubplotParams` for the GridSpec.
+        Return the `.SubplotParams` for the GridSpec.
 
         In order of precedence the values are taken from
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -208,7 +208,7 @@ frameon : bool, default: :rc:`legend.frameon`
     Whether the legend should be drawn on a patch (frame).
 
 fancybox : bool, default: :rc:`legend.fancybox`
-    Whether round edges should be enabled around the `~.FancyBboxPatch` which
+    Whether round edges should be enabled around the `.FancyBboxPatch` which
     makes up the legend's background.
 
 shadow : bool, default: :rc:`legend.shadow`

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1045,18 +1045,18 @@ class Path:
 def get_path_collection_extents(
         master_transform, paths, transforms, offsets, offset_transform):
     r"""
-    Given a sequence of `Path`\s, `~.Transform`\s objects, and offsets, as
-    found in a `~.PathCollection`, returns the bounding box that encapsulates
+    Given a sequence of `Path`\s, `.Transform`\s objects, and offsets, as
+    found in a `.PathCollection`, returns the bounding box that encapsulates
     all of them.
 
     Parameters
     ----------
-    master_transform : `~.Transform`
+    master_transform : `.Transform`
         Global transformation applied to all paths.
     paths : list of `Path`
-    transforms : list of `~.Affine2D`
+    transforms : list of `.Affine2D`
     offsets : (N, 2) array-like
-    offset_transform : `~.Affine2D`
+    offset_transform : `.Affine2D`
         Transform applied to the offsets before offsetting the path.
 
     Notes

--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -1,6 +1,6 @@
 """
-Defines classes for path effects. The path effects are supported in `~.Text`,
-`~.Line2D` and `~.Patch`.
+Defines classes for path effects. The path effects are supported in `.Text`,
+`.Line2D` and `.Patch`.
 
 .. seealso::
    :doc:`/tutorials/advanced/patheffects_guide`

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1325,7 +1325,7 @@ class PolarAxes(Axes):
         Other Parameters
         ----------------
         **kwargs
-            *kwargs* are optional `~.Text` properties for the labels.
+            *kwargs* are optional `.Text` properties for the labels.
 
         See Also
         --------
@@ -1377,7 +1377,7 @@ class PolarAxes(Axes):
         Other Parameters
         ----------------
         **kwargs
-            *kwargs* are optional `~.Text` properties for the labels.
+            *kwargs* are optional `.Text` properties for the labels.
 
         See Also
         --------

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1911,7 +1911,7 @@ def rgrids(radii=None, labels=None, angle=None, fmt=None, **kwargs):
     Other Parameters
     ----------------
     **kwargs
-        *kwargs* are optional `~.Text` properties for the labels.
+        *kwargs* are optional `.Text` properties for the labels.
 
     See Also
     --------
@@ -1979,7 +1979,7 @@ def thetagrids(angles=None, labels=None, fmt=None, **kwargs):
     Other Parameters
     ----------------
     **kwargs
-        *kwargs* are optional `~.Text` properties for the labels.
+        *kwargs* are optional `.Text` properties for the labels.
 
     See Also
     --------

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -177,7 +177,7 @@ color : color or color sequence, optional
     Explicit color(s) for the arrows. If *C* has been set, *color* has no
     effect.
 
-    This is a synonym for the `~.PolyCollection` *facecolor* parameter.
+    This is a synonym for the `.PolyCollection` *facecolor* parameter.
 
 Other Parameters
 ----------------

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -333,7 +333,7 @@ class TextPath(Path):
                  _interpolation_steps=1, usetex=False):
         r"""
         Create a path from the text. Note that it simply is a path,
-        not an artist. You need to use the `~.PathPatch` (or other artists)
+        not an artist. You need to use the `.PathPatch` (or other artists)
         to draw this path onto the canvas.
 
         Parameters
@@ -420,7 +420,7 @@ class TextPath(Path):
         Update the path if necessary.
 
         The path for the text is initially create with the font size of
-        `~.FONT_SCALE`, and this path is rescaled to other size when necessary.
+        `.FONT_SCALE`, and this path is rescaled to other size when necessary.
         """
         if self._invalid or self._cached_vertices is None:
             tr = (Affine2D()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -279,7 +279,7 @@ class Axes3D(Axes):
         the axes with the data limits.
 
         To simulate having equal aspect in data space, set the ratio
-        of your data limits to match the value of `~.get_box_aspect`.
+        of your data limits to match the value of `.get_box_aspect`.
         To control box aspect ratios use `~.Axes3D.set_box_aspect`.
 
         Parameters

--- a/tutorials/advanced/blitting.py
+++ b/tutorials/advanced/blitting.py
@@ -7,7 +7,7 @@ Faster rendering by using blitting
 <https://en.wikipedia.org/wiki/Bit_blit>`__ in raster graphics that,
 in the context of Matplotlib, can be used to (drastically) improve
 performance of interactive figures. For example, the
-:mod:`~.animation` and :mod:`~.widgets` modules use blitting
+:mod:`.animation` and :mod:`.widgets` modules use blitting
 internally. Here, we demonstrate how to implement your own blitting, outside
 of these classes.
 

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -555,7 +555,7 @@ fig.suptitle('subplot2grid')
 # has some complexity due to the complex ways we can layout a figure.
 #
 # Layout in Matplotlib is carried out with gridspecs
-# via the `~.GridSpec` class. A gridspec is a logical division of the figure
+# via the `.GridSpec` class. A gridspec is a logical division of the figure
 # into rows and columns, with the relative width of the Axes in those
 # rows and columns set by *width_ratios* and *height_ratios*.
 #

--- a/tutorials/intermediate/imshow_extent.py
+++ b/tutorials/intermediate/imshow_extent.py
@@ -7,7 +7,7 @@ which will be color-mapped (based on *norm* and *cmap*) or a 3D RGB(A)
 array which will be used as-is) to a rectangular region in data space.
 The orientation of the image in the final rendering is controlled by
 the *origin* and *extent* kwargs (and attributes on the resulting
-`~.AxesImage` instance) and the data limits of the axes.
+`.AxesImage` instance) and the data limits of the axes.
 
 The *extent* kwarg controls the bounding box in data coordinates that
 the image will fill specified as ``(left, right, bottom, top)`` in

--- a/tutorials/intermediate/legend_guide.py
+++ b/tutorials/intermediate/legend_guide.py
@@ -196,7 +196,7 @@ plt.legend(handler_map={line1: HandlerLine2D(numpoints=4)})
 ###############################################################################
 # As you can see, "Line 1" now has 4 marker points, where "Line 2" has 2 (the
 # default). Try the above code, only change the map's key from ``line1`` to
-# ``type(line1)``. Notice how now both `~.Line2D` instances get 4 markers.
+# ``type(line1)``. Notice how now both `.Line2D` instances get 4 markers.
 #
 # Along with handlers for complex plot types such as errorbars, stem plots
 # and histograms, the default ``handler_map`` has a special ``tuple`` handler


### PR DESCRIPTION
From the [shpinx docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-syntax):

> If you prefix the content with ~, the link text will only be the last component of the target.

If only a single component is given, the tilde doesn't have any effect
(`` `~.foo` `` is the same as `` `.foo` ``), so we can remove it to increase
readability.

