### PR TITLE
Add test for font selection by texmanager.

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+import re
+
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager
+import pytest
 
 
 def test_fontconfig_preamble():
-    """
-    Test that the preamble is included in _fontconfig
-    """
+    """Test that the preamble is included in _fontconfig."""
     plt.rcParams['text.usetex'] = True
 
     tm1 = TexManager()
@@ -16,3 +18,22 @@ def test_fontconfig_preamble():
     font_config2 = tm2.get_font_config()
 
     assert font_config1 != font_config2
+
+
+@pytest.mark.parametrize(
+    "rc, preamble, family", [
+        ({"font.family": "sans-serif", "font.sans-serif": "helvetica"},
+         r"\usepackage{helvet}", r"\sffamily"),
+        ({"font.family": "serif", "font.serif": "palatino"},
+         r"\usepackage{mathpazo}", r"\rmfamily"),
+        ({"font.family": "cursive", "font.cursive": "zapf chancery"},
+         r"\usepackage{chancery}", r"\rmfamily"),
+        ({"font.family": "monospace", "font.monospace": "courier"},
+         r"\usepackage{courier}", r"\ttfamily"),
+    ])
+def test_font_selection(rc, preamble, family):
+    plt.rcParams.update(rc)
+    tm = TexManager()
+    src = Path(tm.make_tex("hello, world", fontsize=12)).read_text()
+    assert preamble in src
+    assert [*re.findall(r"\\\w+family", src)] == [family]


### PR DESCRIPTION
## PR Summary

This can later be expanded for https://github.com/matplotlib/matplotlib/pull/20293.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
