### PR TITLE
Warn if a non-str is passed to an rcParam requiring a str.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20311-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20311-AL.rst
@@ -1,0 +1,5 @@
+rcParams will no longer cast inputs to str
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+After a deprecation period, rcParams that expect a (non-pathlike) str will no
+longer cast non-str inputs using `str`.  This will avoid confusing errors in
+subsequent code if e.g. a list input gets implicitly cast to a str.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -225,11 +225,11 @@ def generate_validator_testcases(valid):
                      (('a', 'b'), ['a', 'b']),
                      (iter(['a', 'b']), ['a', 'b']),
                      (np.array(['a', 'b']), ['a', 'b']),
-                     ((1, 2), ['1', '2']),
-                     (np.array([1, 2]), ['1', '2']),
                      ),
          'fail': ((set(), ValueError),
                   (1, ValueError),
+                  ((1, 2), _api.MatplotlibDeprecationWarning),
+                  (np.array([1, 2]), _api.MatplotlibDeprecationWarning),
                   )
          },
         {'validator': _listify_validator(validate_int, n=2),


### PR DESCRIPTION
See changelog note for motivation.

Closes bug 1 of https://discourse.matplotlib.org/t/issue-rendering-a-latex-formula/21977/2

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
