### PR TITLE
DOC: Fix missing refs in what's new pages

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -16,9 +16,6 @@
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.MultipleLocator.tick_values:5",
       "lib/matplotlib/ticker.py:docstring of matplotlib.ticker.SymmetricalLogLocator.tick_values:5"
     ],
-    "button": [
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:335"
-    ],
     "cbar_axes": [
       "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:45",
       "lib/mpl_toolkits/axisartist/axes_grid.py:docstring of mpl_toolkits.axisartist.axes_grid.ImageGrid:45"
@@ -285,9 +282,6 @@
     "matplotlib.backends.backend_webagg_core.NavigationToolbar2WebAgg": [
       "lib/matplotlib/backends/backend_nbagg.py:docstring of matplotlib.backends.backend_nbagg.NavigationIPy:1"
     ],
-    "matplotlib.cm.Wistia": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:21"
-    ],
     "matplotlib.collections._CollectionWithSizes": [
       "doc/api/artist_api.rst:189",
       "doc/api/collections_api.rst:13",
@@ -481,17 +475,6 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.legend:222"
     ]
   },
-  "py:func": {
-    "matplotlib.Axis.set_ticks_position": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:141"
-    ],
-    "matplotlib.InvertedPolarTransform.transform_non_affine": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:236"
-    ],
-    "matplotlib.axis.Tick.label1On": [
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:409"
-    ]
-  },
   "py:meth": {
     "AbstractPathEffect._update_gc": [
       "lib/matplotlib/patheffects.py:docstring of matplotlib.patheffects.SimpleLineShadow:44",
@@ -535,12 +518,6 @@
     "autoscale_view": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.margins:32"
     ],
-    "colorbar.Colobar.minorticks_off": [
-      "doc/users/prev_whats_new/whats_new_3.0.rst:63"
-    ],
-    "colorbar.Colobar.minorticks_on": [
-      "doc/users/prev_whats_new/whats_new_3.0.rst:63"
-    ],
     "draw_image": [
       "lib/matplotlib/backends/backend_agg.py:docstring of matplotlib.backends.backend_agg.RendererAgg.option_scale_image:2"
     ],
@@ -564,9 +541,6 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.quiver:201",
       "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Barbs:205",
       "lib/matplotlib/quiver.py:docstring of matplotlib.quiver.Quiver:238"
-    ],
-    "matplotlib.dates.DateFormatter.__call__": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:497"
     ],
     "matplotlib.dates.MicrosecondLocator.__call__": [
       "doc/api/prev_api_changes/api_changes_1.5.0.rst:122"
@@ -598,8 +572,7 @@
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes.Axes.use_sticky_edges:2"
     ],
     "ArtistInspector.aliasd": [
-      "doc/api/prev_api_changes/api_changes_3.0.0.rst:332",
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:171"
+      "doc/api/prev_api_changes/api_changes_3.0.0.rst:332"
     ],
     "ArtistInspector.get_aliases": [
       "doc/api/prev_api_changes/api_changes_3.0.0.rst:327"
@@ -633,9 +606,6 @@
     ],
     "Axis._update_ticks": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:1072"
-    ],
-    "Axis.set_tick_params": [
-      "doc/users/prev_whats_new/whats_new_2.1.0.rst:394"
     ],
     "Axis.units": [
       "doc/api/prev_api_changes/api_changes_2.2.0.rst:77"
@@ -707,18 +677,8 @@
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.TimerBase:14"
     ],
     "ToolContainer": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:615",
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ToolContainerBase.remove_toolitem:2",
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ToolContainerBase:20"
-    ],
-    "ToolContainers": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:615"
-    ],
-    "Toolbars": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:615"
-    ],
-    "Tools": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:608"
     ],
     "_read": [
       "lib/matplotlib/dviread.py:docstring of matplotlib.dviread.Vf:20"
@@ -788,9 +748,6 @@
     "fc-list": [
       "lib/matplotlib/font_manager.py:docstring of matplotlib.font_manager.get_fontconfig_fonts:2"
     ],
-    "figure.Figure.canvas.set_window_title()": [
-      "doc/users/prev_whats_new/whats_new_3.0.rst:84"
-    ],
     "figure.bbox": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.legend:128",
       "lib/matplotlib/figure.py:docstring of matplotlib.figure.FigureBase.legend:129",
@@ -807,14 +764,10 @@
     "fmt_ydata": [
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes._base._AxesBase.format_ydata:4"
     ],
-    "font.*": [
-      "doc/users/prev_whats_new/whats_new_1.3.rst:302"
-    ],
     "gaussian_kde": [
       "lib/matplotlib/mlab.py:docstring of matplotlib.mlab.GaussianKDE:32"
     ],
     "get_size": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:223",
       "lib/mpl_toolkits/axes_grid1/axes_size.py:docstring of mpl_toolkits.axes_grid1.axes_size:1"
     ],
     "get_xbound": [
@@ -855,10 +808,6 @@
       "lib/matplotlib/mlab.py:docstring of matplotlib.mlab.GaussianKDE:45",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.violinplot:46"
     ],
-    "labelcolor": [
-      "doc/users/prev_whats_new/whats_new_2.0.0.rst:120",
-      "doc/users/prev_whats_new/whats_new_2.0.0.rst:123"
-    ],
     "legend.Legend.set_draggable()": [
       "doc/api/prev_api_changes/api_changes_3.1.0.rst:499"
     ],
@@ -873,11 +822,6 @@
     ],
     "make_image": [
       "lib/matplotlib/image.py:docstring of matplotlib.image.composite_images:9"
-    ],
-    "markevery": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:212",
-      "doc/users/prev_whats_new/whats_new_1.4.rst:214",
-      "doc/users/prev_whats_new/whats_new_3.0.rst:110"
     ],
     "matplotlib.animation.AVConvBase.output_args": [
       "lib/matplotlib/animation.py:docstring of matplotlib.animation.MovieWriter.isAvailable:1:<autosummary>:1"
@@ -1283,9 +1227,6 @@
     "self.vertices": [
       "lib/matplotlib/path.py:docstring of matplotlib.path.Path.codes:2"
     ],
-    "set_size": [
-      "doc/users/prev_whats_new/whats_new_1.4.rst:223"
-    ],
     "set_xbound": [
       "lib/matplotlib/projections/geo.py:docstring of matplotlib.projections.geo.GeoAxes.set_xlim:49",
       "lib/mpl_toolkits/mplot3d/axes3d.py:docstring of mpl_toolkits.mplot3d.axes3d.Axes3D.get_xlim3d:22"
@@ -1300,9 +1241,6 @@
       "lib/matplotlib/style/__init__.py:docstring of matplotlib.style.core.context:12",
       "lib/matplotlib/style/__init__.py:docstring of matplotlib.style.core.use:19"
     ],
-    "to_html5_video": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:728"
-    ],
     "toggled": [
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.AxisScaleBase.disable:4",
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.AxisScaleBase.enable:4",
@@ -1314,11 +1252,7 @@
     "tool_removed_event": [
       "lib/matplotlib/backend_bases.py:docstring of matplotlib.backend_bases.ToolContainerBase.remove_toolitem:6"
     ],
-    "toolbar": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:615"
-    ],
     "trigger": [
-      "doc/users/prev_whats_new/whats_new_1.5.rst:615",
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolFullScreen.disable:4",
       "lib/matplotlib/backend_tools.py:docstring of matplotlib.backend_tools.ToolFullScreen.enable:4"
     ],

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -1270,9 +1270,6 @@
     "print_xyz": [
       "lib/matplotlib/backends/backend_template.py:docstring of matplotlib.backends.backend_template:22"
     ],
-    "pyplot.set_loglevel": [
-      "doc/users/prev_whats_new/whats_new_3.1.0.rst:374"
-    ],
     "rrulewrapper": [
       "lib/matplotlib/dates.py:docstring of matplotlib.dates:143"
     ],

--- a/doc/users/prev_whats_new/whats_new_1.3.rst
+++ b/doc/users/prev_whats_new/whats_new_1.3.rst
@@ -299,7 +299,7 @@ hard-coded to default to 0, default value of both rcParam values is 0.
 
 Changes to font rcParams
 ````````````````````````
-The `font.*` rcParams now affect only text objects created after the
+The ``font.*`` rcParams now affect only text objects created after the
 rcParam has been set, and will not retroactively affect already
 existing text objects.  This brings their behavior in line with most
 other rcParams.

--- a/doc/users/prev_whats_new/whats_new_1.4.rst
+++ b/doc/users/prev_whats_new/whats_new_1.4.rst
@@ -20,7 +20,7 @@ New colormap
 ------------
 In heatmaps, a green-to-red spectrum is often used to indicate intensity of
 activity, but this can be problematic for the red/green colorblind. A new,
-colorblind-friendly colormap is now available at :class:`matplotlib.cm.Wistia`.
+colorblind-friendly colormap is now available at ``matplotlib.cm.Wistia``.
 This colormap maintains the red/green symbolism while achieving deuteranopic
 legibility through brightness variations. See
 `here <https://github.com/wistia/heatmap-palette>`__
@@ -142,7 +142,7 @@ Added the kwarg 'which' to `.Axes.get_xticklabels`,
 `.Axes.get_yticklabels` and
 `.Axis.get_ticklabels`.  'which' can be 'major', 'minor', or
 'both' select which ticks to return, like
-:func:`~matplotlib.Axis.set_ticks_position`.  If 'which' is `None` then the old
+`~.XAxis.set_ticks_position`.  If 'which' is `None` then the old
 behaviour (controlled by the bool *minor*).
 
 Separate horizontal/vertical axes padding support in ImageGrid
@@ -209,9 +209,9 @@ to their liking.
 This feature was implemented for a software engineering course at the
 University of Toronto, Scarborough, run in Winter 2014 by Anya Tafliovich.
 
-More `markevery` options to show only a subset of markers
+More *markevery* options to show only a subset of markers
 `````````````````````````````````````````````````````````
-Rohan Walker extended the `markevery` property in
+Rohan Walker extended the *markevery* property in
 :class:`~matplotlib.lines.Line2D`.  You can now specify a subset of markers to
 show with an int, slice object, numpy fancy indexing, or float. Using a float
 shows markers at approximately equal display-coordinate-distances along the
@@ -220,7 +220,7 @@ line.
 Added size related functions to specialized `.Collection`\s
 ```````````````````````````````````````````````````````````
 
-Added the `get_size` and `set_size` functions to control the size of
+Added the ``get_size`` and ``set_size`` functions to control the size of
 elements of specialized collections (
 :class:`~matplotlib.collections.AsteriskPolygonCollection`
 :class:`~matplotlib.collections.BrokenBarHCollection`
@@ -234,7 +234,7 @@ elements of specialized collections (
 Fixed the mouse coordinates giving the wrong theta value in Polar graph
 ```````````````````````````````````````````````````````````````````````
 Added code to
-:func:`~matplotlib.InvertedPolarTransform.transform_non_affine`
+`~.polar.InvertedPolarTransform.transform_non_affine`
 to ensure that the calculated theta value was between the range of 0 and 2 * pi
 since the problem was that the value can become negative after applying the
 direction and rotation to the theta calculation.

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -494,8 +494,7 @@ backends.
 
 DateFormatter strftime
 ``````````````````````
-:class:`~matplotlib.dates.DateFormatter`\ 's
-:meth:`~matplotlib.dates.DateFormatter.__call__` method will format
+:class:`~matplotlib.dates.DateFormatter`\ 's ``__call__`` method will format
 a :class:`datetime.datetime` object with the format string passed to
 the formatter's constructor. This method accepts datetimes with years
 before 1900, unlike :meth:`datetime.datetime.strftime`.
@@ -609,12 +608,12 @@ that comes as replacement for `.NavigationToolbar2`
 with the figures.  Before we had the `.NavigationToolbar2` with its own
 tools like ``zoom/pan/home/save/...`` and also we had the shortcuts like
 ``yscale/grid/quit/....``. `.ToolManager` relocate all those actions as
-`Tools` (located in `~matplotlib.backend_tools`), and defines a way to
+Tools (located in `~matplotlib.backend_tools`), and defines a way to
 access/trigger/reconfigure them.
 
-The `Toolbars` are replaced for `ToolContainers` that are just GUI
-interfaces to `trigger` the tools. But don't worry the default
-backends include a `ToolContainer` called `toolbar`
+The Toolbars are replaced by `.ToolContainerBase`\s that are just GUI
+interfaces to trigger the tools. But don't worry the default
+backends include a `.ToolContainerBase` called ``toolbar``
 
 
 .. note::
@@ -726,7 +725,7 @@ default, performing no display. ``html5`` converts the animation to an
 h264 encoded video, which is embedded directly in the notebook.
 
 Users not wishing to use the ``_repr_html_`` display hook can also manually
-call the `to_html5_video` method to get the HTML and display using
+call the `.to_html5_video` method to get the HTML and display using
 IPython's ``HTML`` display class::
 
     from IPython.display import HTML

--- a/doc/users/prev_whats_new/whats_new_2.0.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.0.0.rst
@@ -117,10 +117,11 @@ choropleths, labeled image features, etc.
 
 
 
-Axis offset label now responds to `labelcolor`
+Axis offset label now responds to *labelcolor*
 ----------------------------------------------
 
-Axis offset labels are now colored the same as axis tick markers when `labelcolor` is altered.
+Axis offset labels are now colored the same as axis tick markers when
+*labelcolor* is altered.
 
 Improved offset text choice
 ---------------------------

--- a/doc/users/prev_whats_new/whats_new_2.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_2.1.0.rst
@@ -391,11 +391,11 @@ time and can enhance the visibility of the flow pattern in some use
 cases.
 
 
-`Axis.set_tick_params` now responds to ``rotation``
+``Axis.set_tick_params`` now responds to *rotation*
 ---------------------------------------------------
 
 Bulk setting of tick label rotation is now possible via
-:func:`~matplotlib.axes.Axes.tick_params` using the ``rotation``
+:func:`~matplotlib.axes.Axes.tick_params` using the *rotation*
 keyword.
 
 ::
@@ -406,7 +406,7 @@ keyword.
 Ticklabels are turned off instead of being invisible
 ----------------------------------------------------
 
-Internally, the `.Tick`'s :func:`~matplotlib.axis.Tick.label1On` attribute
+Internally, the `.Tick`'s ``matplotlib.axis.Tick.label1On`` attribute
 is now used to hide tick labels instead of setting the visibility on the tick
 label objects.
 This improves overall performance and fixes some issues.

--- a/doc/users/prev_whats_new/whats_new_3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.0.rst
@@ -60,11 +60,11 @@ frame. Padding and separation parameters can be adjusted.
 Add ``minorticks_on()/off()`` methods for colorbar
 --------------------------------------------------
 
-A new method :meth:`.colorbar.Colobar.minorticks_on` has been added to
+A new method `~.colorbar.ColorbarBase.minorticks_on` has been added to
 correctly display minor ticks on a colorbar. This method doesn't allow the
 minor ticks to extend into the regions beyond vmin and vmax when the *extend*
 keyword argument (used while creating the colorbar) is set to 'both', 'max' or
-'min'. A complementary method :meth:`.colorbar.Colobar.minorticks_off` has
+'min'. A complementary method `~.colorbar.ColorbarBase.minorticks_off` has
 also been added to remove the minor ticks on the colorbar.
 
 
@@ -90,7 +90,7 @@ behaviour has been removed. Now if the file name exists on
 disk, the user is prompted whether or not to overwrite it.
 This eliminates guesswork, and allows intentional
 overwriting, especially when the figure name has been
-manually set using `.figure.Figure.canvas.set_window_title()`.
+manually set using ``figure.canvas.set_window_title()``.
 
 
 Legend now has a *title_fontsize* keyword argument (and rcParam)
@@ -108,7 +108,7 @@ Support for axes.prop_cycle property *markevery* in rcParams
 ------------------------------------------------------------
 
 The Matplotlib ``rcParams`` settings object now supports configuration
-of the attribute :rc:`axes.prop_cycle` with cyclers using the `markevery`
+of the attribute :rc:`axes.prop_cycle` with cyclers using the *markevery*
 Line2D object property. An example of this feature is provided at
 :doc:`/gallery/lines_bars_and_markers/markevery_prop_cycle`.
 

--- a/doc/users/prev_whats_new/whats_new_3.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.1.0.rst
@@ -168,7 +168,7 @@ Return type of ArtistInspector.get_aliases changed
 was used to simulate a set in earlier versions of Python.  It has now been
 replaced by a set, i.e. ``{fullname: {alias1, alias2, ...}}``.
 
-This value is also stored in `.ArtistInspector.aliasd`, which has likewise
+This value is also stored in ``ArtistInspector.aliasd``, which has likewise
 changed.
 
 
@@ -332,7 +332,7 @@ were previously displayed as ``1e+04``.
 MouseEvent button attribute is now an IntEnum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :attr:`button` attribute of `~.MouseEvent` instances can take the values
+The ``button`` attribute of `~.MouseEvent` instances can take the values
 None, 1 (left button), 2 (middle button), 3 (right button), "up" (scroll), and
 "down" (scroll).  For better legibility, the 1, 2, and 3 values are now
 represented using the `enum.IntEnum` class `matplotlib.backend_bases.MouseButton`,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -186,7 +186,7 @@ def uninstall_repl_displayhook():
 draw_all = _pylab_helpers.Gcf.draw_all
 
 
-@functools.wraps(matplotlib.set_loglevel)
+@_copy_docstring_and_deprecators(matplotlib.set_loglevel)
 def set_loglevel(*args, **kwargs):  # Ensure this appears in the pyplot docs.
     return matplotlib.set_loglevel(*args, **kwargs)
 


### PR DESCRIPTION
## PR Summary

Most are simply converting to other styles (italic for arguments, or code style for something that won't be linked), but there are a few things that were not documented and should have been.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).