### PR TITLE
Fix remaining E265 exceptions.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,7 +17,7 @@ ignore =
     E121,E123,E126,E226,E24,E704,W503,W504,
     # Additional ignores:
     E122, E127, E131,
-    E265, E266,
+    E266,
     E305, E306,
     E722, E741,
     F841,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -230,7 +230,7 @@ release = version
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
 today_fmt = '%B %d, %Y'
 
@@ -238,15 +238,15 @@ today_fmt = '%B %d, %Y'
 unused_docs = []
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -268,16 +268,15 @@ github_project_url = "https://github.com/matplotlib/matplotlib/"
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-#html_style = 'matplotlib.css'
 html_style = f'mpl.css?{SHA}'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-#html_logo = 'logo.png'
+# html_logo = 'logo.png'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -296,7 +295,7 @@ html_last_updated_fmt = '%b %d, %Y'
 html_index = 'index.html'
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
@@ -308,11 +307,11 @@ html_sidebars = {
 }
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 html_domain_indices = ["py-modindex"]
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-#html_copy_source = True
+# html_copy_source = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -690,7 +690,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # asksaveasfilename dialog when you choose various save types
         # from the dropdown.  Passing in the empty string seems to
         # work - JDH!
-        #defaultextension = self.canvas.get_default_filetype()
+        # defaultextension = self.canvas.get_default_filetype()
         defaultextension = ''
         initialdir = os.path.expanduser(mpl.rcParams['savefig.directory'])
         initialfile = self.canvas.get_default_filename()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -144,7 +144,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx.add_class("matplotlib-canvas")
 
     def destroy(self):
-        #Gtk.DrawingArea.destroy(self)
         self.close_event()
 
     def scroll_event(self, widget, event):

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -101,9 +101,9 @@ class RendererTemplate(RendererBase):
         # if backend doesn't have dpi, e.g., postscript or svg
         return points
         # elif backend assumes a value for pixels_per_inch
-        #return points/72.0 * self.dpi.get() * pixels_per_inch/72.0
+        # return points/72.0 * self.dpi.get() * pixels_per_inch/72.0
         # else
-        #return points/72.0 * self.dpi.get()
+        # return points/72.0 * self.dpi.get()
 
 
 class GraphicsContextTemplate(GraphicsContextBase):

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -554,7 +554,7 @@ if __name__ == "__main__":
                 (datalist, "Category 2", "Category 2 comment"),
                 (datalist, "Category 3", "Category 3 comment"))
 
-    #--------- datalist example
+    # --------- datalist example
     datalist = create_datalist_example()
 
     def apply_test(data):
@@ -563,11 +563,11 @@ if __name__ == "__main__":
                            comment="This is just an <b>example</b>.",
                            apply=apply_test))
 
-    #--------- datagroup example
+    # --------- datagroup example
     datagroup = create_datagroup_example()
     print("result:", fedit(datagroup, "Global title"))
 
-    #--------- datagroup inside a datagroup example
+    # --------- datagroup inside a datagroup example
     datalist = create_datalist_example()
     datagroup = create_datagroup_example()
     print("result:", fedit(((datagroup, "Title 1", "Tab 1 comment"),

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -309,7 +309,7 @@ class Line2D(Artist):
         """
         super().__init__()
 
-        #convert sequences to numpy arrays
+        # Convert sequences to NumPy arrays.
         if not np.iterable(xdata):
             raise RuntimeError('xdata must be a sequence')
         if not np.iterable(ydata):

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -561,7 +561,6 @@ class PaddedBox(OffsetBox):
         for c in self.get_visible_children():
             c.draw(renderer)
 
-        #bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
         self.stale = False
 
     def update_frame(self, bbox, fontsize=None):
@@ -1449,9 +1448,6 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         if not self._check_xy(None):
             return False, {}
         return self.offsetbox.contains(mouseevent)
-        #if self.arrow_patch is not None:
-        #    a, ainfo=self.arrow_patch.contains(event)
-        #    t = t or a
         # self.arrow_patch is currently not checked as this can be a line - JJ
 
     def get_children(self):
@@ -1534,7 +1530,6 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
 
         # update patch position
         bbox = self.offsetbox.get_window_extent(renderer)
-        #self.offsetbox.set_offset((ox0-_fw*w, oy0-_fh*h))
         self.patch.set_bounds(bbox.x0, bbox.y0,
                               bbox.width, bbox.height)
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -887,7 +887,6 @@ class Text(Artist):
             ``self.figure.dpi`` (*not* the renderer dpi); should be set e.g. if
             to match regions with a figure saved with a custom dpi value.
         """
-        #return _unit_box
         if not self.get_visible():
             return Bbox.unit()
         if dpi is None:

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -1347,7 +1347,7 @@ def _cg(A, b, x0=None, tol=1.e-10, maxiter=1000):
         rho = np.dot(r, w)
         x = x + alpha*p
         beta = rho/rhoold
-        #err = np.linalg.norm(A.dot(x) - b) # absolute accuracy - not used
+        # err = np.linalg.norm(A.dot(x) - b)  # absolute accuracy - not used
         k += 1
     err = np.linalg.norm(A.dot(x) - b)
     return x, err
@@ -1468,7 +1468,7 @@ def _pseudo_inv22sym_vectorized(M):
         tr = M[rank01, 0, 0] + M[rank01, 1, 1]
         tr_zeros = (np.abs(tr) < 1.e-8)
         sq_tr_inv = (1.-tr_zeros) / (tr**2+tr_zeros)
-        #sq_tr_inv = 1. / tr**2
+        # sq_tr_inv = 1. / tr**2
         M_inv[rank01, 0, 0] = M[rank01, 0, 0] * sq_tr_inv
         M_inv[rank01, 0, 1] = M[rank01, 0, 1] * sq_tr_inv
         M_inv[rank01, 1, 0] = M[rank01, 1, 0] * sq_tr_inv

--- a/lib/mpl_toolkits/axes_grid/__init__.py
+++ b/lib/mpl_toolkits/axes_grid/__init__.py
@@ -1,7 +1,6 @@
 from . import axes_size as Size
 from .axes_divider import Divider, SubplotDivider, make_axes_locatable
 from .axes_grid import Grid, ImageGrid, AxesGrid
-#from axes_divider import make_axes_locatable
 from matplotlib import _api
 _api.warn_deprecated(since='2.1',
                      name='mpl_toolkits.axes_grid',

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -648,7 +648,7 @@ class AxisArtist(martist.Artist):
         axes : `mpl_toolkits.axisartist.axislines.Axes`
         helper : `~mpl_toolkits.axisartist.axislines.AxisArtistHelper`
         """
-        #axes is also used to follow the axis attribute (tick color, etc).
+        # axes is also used to follow the axis attribute (tick color, etc).
 
         super().__init__(**kwargs)
 

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -193,11 +193,11 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         if self.nth_coord == 0:
             mask = (e0 <= yy0) & (yy0 <= e1)
-            #xx0, yy0 = xx0[mask], yy0[mask]
+            # xx0, yy0 = xx0[mask], yy0[mask]
             yy0 = yy0[mask]
         elif self.nth_coord == 1:
             mask = (e0 <= xx0) & (xx0 <= e1)
-            #xx0, yy0 = xx0[mask], yy0[mask]
+            # xx0, yy0 = xx0[mask], yy0[mask]
             xx0 = xx0[mask]
 
         def transform_xy(x, y):

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -347,7 +347,7 @@ class Axis(maxis.XAxis):
         # the alignment point is used as the "fulcrum" for rotation.
         self.offsetText.set_rotation_mode('anchor')
 
-        #----------------------------------------------------------------------
+        # ----------------------------------------------------------------------
         # Note: the following statement for determining the proper alignment of
         # the offset text. This was determined entirely by trial-and-error
         # and should not be in any way considered as "the way".  There are


### PR DESCRIPTION
## PR Summary

This resolves the inconsistency that inline comments must start with a space (E262), but block comments are allowed not to.

This is the last followup to #19626 and #19887.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).