### PR TITLE
Fix cla colorbar

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -900,7 +900,8 @@ class ColorbarBase:
 
     def remove(self):
         """Remove this colorbar from the figure."""
-        self.ax.remove()
+        self.ax.inner_ax.remove()
+        self.ax.outer_ax.remove()
 
     def _ticker(self, locator, formatter):
         """

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -244,7 +244,7 @@ class ColorbarAxes(Axes):
         userax : boolean
             True if the user passed `.Figure.colorbar` the axes manually.
         colorbar: ColorbarBase
-            colorbar that this axes is contained in.  
+            colorbar that this axes is contained in.
         """
 
         if userax:
@@ -302,8 +302,6 @@ class ColorbarAxes(Axes):
         else:
             cid = self.colorbar.mappable.colorbar_cid
         self.colorbar.mappable.callbacksSM.disconnect(cid)
-        #self.colorbar.mappable.colorbar = None
-        #self.colorbar.mappable.colorbar_cid = None
 
         self.inner_ax.cla()
         self.outer_ax.cla()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -900,8 +900,7 @@ class ColorbarBase:
 
     def remove(self):
         """Remove this colorbar from the figure."""
-        self.ax.inner_ax.remove()
-        self.ax.outer_ax.remove()
+        self.ax.remove()
 
     def _ticker(self, locator, formatter):
         """

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -771,14 +771,11 @@ def test_colorbar_reuse_axes(fig_ref, fig_test):
     cb = fig_test.colorbar(pc, extend='both')
     cb2 = fig_test.colorbar(pc)
     # Clear and re-use the same colorbar axes
-    print('HERE1:', pc, pc.callbacksSM.callbacks)
     cb.ax.cla()
-    print('HERE2:', pc, pc.callbacksSM.callbacks)
     cb2.ax.cla()
-    print('HERE3:', pc, pc.callbacksSM.callbacks)
         
     cb = fig_test.colorbar(pc, cax=cb.ax)
-    #cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
+    cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
 
 
 def test_inset_colorbar_layout():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -771,10 +771,14 @@ def test_colorbar_reuse_axes(fig_ref, fig_test):
     cb = fig_test.colorbar(pc, extend='both')
     cb2 = fig_test.colorbar(pc)
     # Clear and re-use the same colorbar axes
+    print('HERE1:', pc, pc.callbacksSM.callbacks)
     cb.ax.cla()
+    print('HERE2:', pc, pc.callbacksSM.callbacks)
     cb2.ax.cla()
+    print('HERE3:', pc, pc.callbacksSM.callbacks)
+        
     cb = fig_test.colorbar(pc, cax=cb.ax)
-    cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
+    #cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
 
 
 def test_inset_colorbar_layout():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -773,7 +773,6 @@ def test_colorbar_reuse_axes(fig_ref, fig_test):
     # Clear and re-use the same colorbar axes
     cb.ax.cla()
     cb2.ax.cla()
-        
     cb = fig_test.colorbar(pc, cax=cb.ax)
     cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -759,6 +759,24 @@ def test_axes_handles_same_functions(fig_ref, fig_test):
         caxx.set_position([0.92, 0.1, 0.02, 0.7])
 
 
+@check_figures_equal(extensions=["png"])
+def test_colorbar_reuse_axes(fig_ref, fig_test):
+    ax = fig_ref.add_subplot()
+    pc = ax.imshow(np.arange(100).reshape(10, 10))
+    cb = fig_ref.colorbar(pc)
+    cb2 = fig_ref.colorbar(pc, extend='both')
+
+    ax = fig_test.add_subplot()
+    pc = ax.imshow(np.arange(100).reshape(10, 10))
+    cb = fig_test.colorbar(pc, extend='both')
+    cb2 = fig_test.colorbar(pc)
+    # Clear and re-use the same colorbar axes
+    cb.ax.cla()
+    cb2.ax.cla()
+    cb = fig_test.colorbar(pc, cax=cb.ax)
+    cb2 = fig_test.colorbar(pc, cax=cb2.ax, extend='both')
+
+
 def test_inset_colorbar_layout():
     fig, ax = plt.subplots(constrained_layout=True, figsize=(3, 6))
     pc = ax.imshow(np.arange(100).reshape(10, 10))


### PR DESCRIPTION
## PR Summary

Alternative to #20323.

This allows calling `cb.ax.cla` and reusing the same axes to swap in a new colorbar.  If the colorbar is not filled in, an empty axes with the default facecolor is left where the old one was.  

Co-authored with @greglucas since I stole his test (though he is welcome to disavow the PR ;-))

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
