### PR TITLE
Remove Axis, Tick, and Axes deprecations from 3.3

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -295,7 +295,6 @@ Axis limits and direction
    Axes.get_ylim
 
    Axes.update_datalim
-   Axes.update_datalim_bounds
 
    Axes.set_xbound
    Axes.get_xbound

--- a/doc/api/next_api_changes/removals/20331-ES.rst
+++ b/doc/api/next_api_changes/removals/20331-ES.rst
@@ -1,3 +1,20 @@
+Signatures of `.Artist.draw` and `.Axes.draw`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *inframe* parameter to `.Axes.draw` has been removed.  Use
+`.Axes.redraw_in_frame` instead.
+
+Omitting the *renderer* parameter to `.Axes.draw` is no longer supported.
+Use ``axes.draw_artist(axes)`` instead.
+
+These changes make the signature of the ``draw`` (``artist.draw(renderer)``)
+method consistent across all artists; thus, additional parameters to
+`.Artist.draw` have also been removed.
+
+``Axes.update_datalim_bounds``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This method has been removed.  Use
+``ax.dataLim.set(Bbox.union([ax.dataLim, bounds]))`` instead.
+
 ``{,Symmetrical}LogScale.{,Inverted}LogTransform``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``LogScale.LogTransform``, ``LogScale.InvertedLogTransform``,

--- a/doc/api/next_api_changes/removals/20331-ES.rst
+++ b/doc/api/next_api_changes/removals/20331-ES.rst
@@ -1,3 +1,14 @@
+``Axes.pie`` *radius*, *startangle*, and *normalize* parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing ``None`` as either the *radius* or *startangle* arguments of an
+`.Axes.pie` is no longer accepted; use the explicit defaults of 1 and 0,
+respectively, instead.
+
+Passing ``None`` as the *normalize* argument of `.Axes.pie` (the former
+default) is no longer accepted, and the pie will always be normalized by
+default. If you wish to plot an incomplete pie, explicitly pass
+``normalize=False``.
+
 Signatures of `.Artist.draw` and `.Axes.draw`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The *inframe* parameter to `.Axes.draw` has been removed.  Use

--- a/doc/api/next_api_changes/removals/20331-ES.rst
+++ b/doc/api/next_api_changes/removals/20331-ES.rst
@@ -1,0 +1,13 @@
+Implicit initialization of ``Tick`` attributes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `.Tick` constructor no longer initializes the attributes ``tick1line``,
+``tick2line``, ``gridline``, ``label1``, and ``label2`` via ``_get_tick1line``,
+``_get_tick2line``, ``_get_gridline``, ``_get_text1``, and ``_get_text2``.
+Please directly set the attribute in the subclass' ``__init__`` instead.
+
+Unused parameters
+~~~~~~~~~~~~~~~~~
+The following parameters do not have any effect and have been removed:
+
+- parameter *label* of `.Tick`

--- a/doc/api/next_api_changes/removals/20331-ES.rst
+++ b/doc/api/next_api_changes/removals/20331-ES.rst
@@ -1,3 +1,25 @@
+``{,Symmetrical}LogScale.{,Inverted}LogTransform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``LogScale.LogTransform``, ``LogScale.InvertedLogTransform``,
+``SymmetricalScale.SymmetricalTransform`` and
+``SymmetricalScale.InvertedSymmetricalTransform`` have been removed.  Directly
+access the transform classes from the `matplotlib.scale` module.
+
+log/symlog scale base, ticks, and nonpos specification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`~.Axes.semilogx`, `~.Axes.semilogy`, `~.Axes.loglog`, `.LogScale`, and
+`.SymmetricalLogScale` used to take keyword arguments that depends on the axis
+orientation ("basex" vs "basey", "subsx" vs "subsy", "nonposx" vs "nonposy");
+these parameter names have been removed in favor of "base", "subs",
+"nonpositive".  This removal also affects e.g. ``ax.set_yscale("log",
+basey=...)`` which must now be spelled ``ax.set_yscale("log", base=...)``.
+
+The change from "nonpos" to "nonpositive" also affects `~.scale.LogTransform`,
+`~.scale.InvertedLogTransform`, `~.scale.SymmetricalLogTransform`, etc.
+
+To use *different* bases for the x-axis and y-axis of a `~.Axes.loglog` plot,
+use e.g. ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.
+
 Implicit initialization of ``Tick`` attributes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -27,12 +27,8 @@ def allow_rasterization(draw):
     renderer.
     """
 
-    # Axes has a second (deprecated) argument inframe for its draw method.
-    # args and kwargs are deprecated, but we don't wrap this in
-    # _api.delete_parameter for performance; the relevant deprecation
-    # warning will be emitted by the inner draw() call.
     @wraps(draw)
-    def draw_wrapper(artist, renderer, *args, **kwargs):
+    def draw_wrapper(artist, renderer):
         try:
             if artist.get_rasterized():
                 if renderer._raster_depth == 0 and not renderer._rasterizing:
@@ -49,7 +45,7 @@ def allow_rasterization(draw):
             if artist.get_agg_filter() is not None:
                 renderer.start_filter()
 
-            return draw(artist, renderer, *args, **kwargs)
+            return draw(artist, renderer)
         finally:
             if artist.get_agg_filter() is not None:
                 renderer.stop_filter(artist.get_agg_filter())
@@ -929,9 +925,7 @@ class Artist:
         self._agg_filter = filter_func
         self.stale = True
 
-    @_api.delete_parameter("3.3", "args")
-    @_api.delete_parameter("3.3", "kwargs")
-    def draw(self, renderer, *args, **kwargs):
+    def draw(self, renderer):
         """
         Draw the Artist (and its children) using the given renderer.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2980,7 +2980,7 @@ class Axes(_AxesBase):
             autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
             startangle=0, radius=1, counterclock=True,
             wedgeprops=None, textprops=None, center=(0, 0),
-            frame=False, rotatelabels=False, *, normalize=None):
+            frame=False, rotatelabels=False, *, normalize=True):
         """
         Plot a pie chart.
 
@@ -3021,18 +3021,10 @@ class Axes(_AxesBase):
         shadow : bool, default: False
             Draw a shadow beneath the pie.
 
-        normalize : None or bool, default: None
+        normalize : bool, default: True
             When *True*, always make a full pie by normalizing x so that
             ``sum(x) == 1``. *False* makes a partial pie if ``sum(x) <= 1``
             and raises a `ValueError` for ``sum(x) > 1``.
-
-            When *None*, defaults to *True* if ``sum(x) >= 1`` and *False* if
-            ``sum(x) < 1``.
-
-            Please note that the previous default value of *None* is now
-            deprecated, and the default will change to *True* in the next
-            release. Please pass ``normalize=False`` explicitly if you want to
-            draw a partial pie.
 
         labeldistance : float or None, default: 1.1
             The radial distance at which the pie labels are drawn.
@@ -3102,17 +3094,6 @@ class Axes(_AxesBase):
 
         sx = x.sum()
 
-        if normalize is None:
-            if sx < 1:
-                _api.warn_deprecated(
-                    "3.3", message="normalize=None does not normalize "
-                    "if the sum is less than 1 but this behavior "
-                    "is deprecated since %(since)s until %(removal)s. "
-                    "After the deprecation "
-                    "period the default value will be normalize=True. "
-                    "To prevent normalization pass normalize=False ")
-            else:
-                normalize = True
         if normalize:
             x = x / sx
         elif sx > 1:
@@ -3133,20 +3114,11 @@ class Axes(_AxesBase):
             def get_next_color():
                 return next(color_cycle)
 
-        if radius is None:
-            _api.warn_deprecated(
-                "3.3", message="Support for passing a radius of None to mean "
-                "1 is deprecated since %(since)s and will be removed "
-                "%(removal)s.")
-            radius = 1
+        _api.check_isinstance(Number, radius=radius, startangle=startangle)
+        if radius <= 0:
+            raise ValueError(f'radius must be a positive number, not {radius}')
 
         # Starting theta1 is the start fraction of the circle
-        if startangle is None:
-            _api.warn_deprecated(
-                "3.3", message="Support for passing a startangle of None to "
-                "mean 0 is deprecated since %(since)s and will be removed "
-                "%(removal)s.")
-            startangle = 0
         theta1 = startangle / 360
 
         if wedgeprops is None:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2459,19 +2459,6 @@ class _AxesBase(martist.Artist):
                                          updatex=updatex, updatey=updatey)
         self.ignore_existing_data_limits = False
 
-    @_api.deprecated(
-        "3.3", alternative="ax.dataLim.set(Bbox.union([ax.dataLim, bounds]))")
-    def update_datalim_bounds(self, bounds):
-        """
-        Extend the `~.Axes.datalim` Bbox to include the given
-        `~matplotlib.transforms.Bbox`.
-
-        Parameters
-        ----------
-        bounds : `~matplotlib.transforms.Bbox`
-        """
-        self.dataLim.set(mtransforms.Bbox.union([self.dataLim, bounds]))
-
     def _process_unit_info(self, datasets=None, kwargs=None, *, convert=True):
         """
         Set axis units based on *datasets* and *kwargs*, and optionally apply
@@ -3011,17 +2998,8 @@ class _AxesBase(martist.Artist):
 
     # Drawing
     @martist.allow_rasterization
-    @_api.delete_parameter(
-        "3.3", "inframe", alternative="Axes.redraw_in_frame()")
-    def draw(self, renderer=None, inframe=False):
+    def draw(self, renderer):
         # docstring inherited
-        if renderer is None:
-            _api.warn_deprecated(
-                "3.3", message="Support for not passing the 'renderer' "
-                "parameter to Axes.draw() is deprecated since %(since)s and "
-                "will be removed %(removal)s.  Use axes.draw_artist(axes) "
-                "instead.")
-            renderer = self.figure._cachedRenderer
         if renderer is None:
             raise RuntimeError('No renderer defined')
         if not self.get_visible():
@@ -3054,14 +3032,9 @@ class _AxesBase(martist.Artist):
 
         self._update_title_position(renderer)
 
-        if not self.axison or inframe:
+        if not self.axison:
             for _axis in self._get_axis_list():
                 artists.remove(_axis)
-
-        if inframe:
-            artists.remove(self.title)
-            artists.remove(self._left_title)
-            artists.remove(self._right_title)
 
         if not self.figure.canvas.is_saving():
             artists = [

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -54,8 +54,7 @@ class Tick(martist.Artist):
         The right/top tick label.
 
     """
-    @_api.delete_parameter("3.3", "label")
-    def __init__(self, axes, loc, label=None,
+    def __init__(self, axes, loc, *,
                  size=None,  # points
                  width=None,
                  color=None,
@@ -175,18 +174,6 @@ class Tick(martist.Artist):
 
         self._apply_tickdir(tickdir)
 
-        for meth, attr in [("_get_tick1line", "tick1line"),
-                           ("_get_tick2line", "tick2line"),
-                           ("_get_gridline", "gridline"),
-                           ("_get_text1", "label1"),
-                           ("_get_text2", "label2")]:
-            overridden_method = _api.deprecate_method_override(
-                getattr(__class__, meth), self, since="3.3", message="Relying "
-                f"on {meth} to initialize Tick.{attr} is deprecated since "
-                f"%(since)s and will not work %(removal)s; please directly "
-                f"set the attribute in the subclass' __init__ instead.")
-            if overridden_method:
-                setattr(self, attr, overridden_method())
         for artist in [self.tick1line, self.tick2line, self.gridline,
                        self.label1, self.label2]:
             self._set_artist_props(artist)

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -246,10 +246,6 @@ class ThetaLocator(mticker.Locator):
         else:
             return np.deg2rad(self.base())
 
-    @_api.deprecated("3.3")
-    def pan(self, numsteps):
-        return self.base.pan(numsteps)
-
     def refresh(self):
         # docstring inherited
         return self.base.refresh()
@@ -257,10 +253,6 @@ class ThetaLocator(mticker.Locator):
     def view_limits(self, vmin, vmax):
         vmin, vmax = np.rad2deg((vmin, vmax))
         return np.deg2rad(self.base.view_limits(vmin, vmax))
-
-    @_api.deprecated("3.3")
-    def zoom(self, direction):
-        return self.base.zoom(direction)
 
 
 class ThetaTick(maxis.XTick):
@@ -436,19 +428,6 @@ class RadialLocator(mticker.Locator):
                 if self._axes.get_rmin() <= rorigin:
                     return [tick for tick in self.base() if tick > rorigin]
         return self.base()
-
-    @_api.deprecated("3.3")
-    def pan(self, numsteps):
-        return self.base.pan(numsteps)
-
-    @_api.deprecated("3.3")
-    def zoom(self, direction):
-        return self.base.zoom(direction)
-
-    @_api.deprecated("3.3")
-    def refresh(self):
-        # docstring inherited
-        return self.base.refresh()
 
     def nonsingular(self, vmin, vmax):
         # docstring inherited
@@ -951,9 +930,7 @@ class PolarAxes(Axes):
             pad_shift = _ThetaShift(self, pad, 'min')
         return self._yaxis_text_transform + pad_shift, 'center', halign
 
-    @_api.delete_parameter("3.3", "args")
-    @_api.delete_parameter("3.3", "kwargs")
-    def draw(self, renderer, *args, **kwargs):
+    def draw(self, renderer):
         self._unstale_viewLim()
         thetamin, thetamax = np.rad2deg(self._realViewLim.intervalx)
         if thetamin > thetamax:
@@ -997,7 +974,7 @@ class PolarAxes(Axes):
             self.yaxis.reset_ticks()
             self.yaxis.set_clip_path(self.patch)
 
-        super().draw(renderer, *args, **kwargs)
+        super().draw(renderer)
 
     def _gen_axes_patch(self):
         return mpatches.Wedge((0.5, 0.5), 0.5, 0.0, 360.0)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2995,7 +2995,7 @@ def pie(
         pctdistance=0.6, shadow=False, labeldistance=1.1,
         startangle=0, radius=1, counterclock=True, wedgeprops=None,
         textprops=None, center=(0, 0), frame=False,
-        rotatelabels=False, *, normalize=None, data=None):
+        rotatelabels=False, *, normalize=True, data=None):
     return gca().pie(
         x, explode=explode, labels=labels, colors=colors,
         autopct=autopct, pctdistance=pctdistance, shadow=shadow,

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -202,7 +202,6 @@ class FuncScale(ScaleBase):
 class LogTransform(Transform):
     input_dims = output_dims = 1
 
-    @_api.rename_parameter("3.3", "nonpos", "nonpositive")
     def __init__(self, base, nonpositive='clip'):
         super().__init__()
         if base <= 0 or base == 1:
@@ -264,17 +263,7 @@ class LogScale(ScaleBase):
     """
     name = 'log'
 
-    @_api.deprecated("3.3", alternative="scale.LogTransform")
-    @property
-    def LogTransform(self):
-        return LogTransform
-
-    @_api.deprecated("3.3", alternative="scale.InvertedLogTransform")
-    @property
-    def InvertedLogTransform(self):
-        return InvertedLogTransform
-
-    def __init__(self, axis, **kwargs):
+    def __init__(self, axis, *, base=10, subs=None, nonpositive="clip"):
         """
         Parameters
         ----------
@@ -290,18 +279,6 @@ class LogScale(ScaleBase):
             in a log10 scale, ``[2, 3, 4, 5, 6, 7, 8, 9]`` will place 8
             logarithmically spaced minor ticks between each major tick.
         """
-        # After the deprecation, the whole (outer) __init__ can be replaced by
-        # def __init__(self, axis, *, base=10, subs=None, nonpositive="clip")
-        # The following is to emit the right warnings depending on the axis
-        # used, as the *old* kwarg names depended on the axis.
-        axis_name = getattr(axis, "axis_name", "x")
-        @_api.rename_parameter("3.3", f"base{axis_name}", "base")
-        @_api.rename_parameter("3.3", f"subs{axis_name}", "subs")
-        @_api.rename_parameter("3.3", f"nonpos{axis_name}", "nonpositive")
-        def __init__(*, base=10, subs=None, nonpositive="clip"):
-            return base, subs, nonpositive
-
-        base, subs, nonpositive = __init__(**kwargs)
         self._transform = LogTransform(base, nonpositive)
         self.subs = subs
 
@@ -460,28 +437,7 @@ class SymmetricalLogScale(ScaleBase):
     """
     name = 'symlog'
 
-    @_api.deprecated("3.3", alternative="scale.SymmetricalLogTransform")
-    @property
-    def SymmetricalLogTransform(self):
-        return SymmetricalLogTransform
-
-    @_api.deprecated(
-        "3.3", alternative="scale.InvertedSymmetricalLogTransform")
-    @property
-    def InvertedSymmetricalLogTransform(self):
-        return InvertedSymmetricalLogTransform
-
-    def __init__(self, axis, **kwargs):
-        axis_name = getattr(axis, "axis_name", "x")
-        # See explanation in LogScale.__init__.
-        @_api.rename_parameter("3.3", f"base{axis_name}", "base")
-        @_api.rename_parameter("3.3", f"linthresh{axis_name}", "linthresh")
-        @_api.rename_parameter("3.3", f"subs{axis_name}", "subs")
-        @_api.rename_parameter("3.3", f"linscale{axis_name}", "linscale")
-        def __init__(*, base=10, linthresh=2, subs=None, linscale=1):
-            return base, linthresh, subs, linscale
-
-        base, linthresh, subs, linscale = __init__(**kwargs)
+    def __init__(self, axis, *, base=10, linthresh=2, subs=None, linscale=1):
         self._transform = SymmetricalLogTransform(base, linthresh, linscale)
         self.subs = subs
 
@@ -505,7 +461,6 @@ class SymmetricalLogScale(ScaleBase):
 class LogitTransform(Transform):
     input_dims = output_dims = 1
 
-    @_api.rename_parameter("3.3", "nonpos", "nonpositive")
     def __init__(self, nonpositive='mask'):
         super().__init__()
         _api.check_in_list(['mask', 'clip'], nonpositive=nonpositive)
@@ -531,7 +486,6 @@ class LogitTransform(Transform):
 class LogisticTransform(Transform):
     input_dims = output_dims = 1
 
-    @_api.rename_parameter("3.3", "nonpos", "nonpositive")
     def __init__(self, nonpositive='mask'):
         super().__init__()
         self._nonpositive = nonpositive
@@ -556,7 +510,6 @@ class LogitScale(ScaleBase):
     """
     name = 'logit'
 
-    @_api.rename_parameter("3.3", "nonpos", "nonpositive")
     def __init__(self, axis, nonpositive='mask', *,
                  one_half=r"\frac{1}{2}", use_overline=False):
         r"""

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5099,12 +5099,6 @@ def test_pie_get_negative_values():
         ax.pie([5, 5, -3], explode=[0, .1, .2])
 
 
-def test_normalize_kwarg_warn_pie():
-    fig, ax = plt.subplots()
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax.pie(x=[0], normalize=None)
-
-
 def test_normalize_kwarg_pie():
     fig, ax = plt.subplots()
     x = [0.3, 0.3, 0.1]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5577,38 +5577,26 @@ def test_loglog():
     ax.tick_params(length=15, width=2, which='minor')
 
 
-@pytest.mark.parametrize("new_api", [False, True])
 @image_comparison(["test_loglog_nonpos.png"], remove_text=True, style='mpl20')
-def test_loglog_nonpos(new_api):
+def test_loglog_nonpos():
     fig, axs = plt.subplots(3, 3)
     x = np.arange(1, 11)
     y = x**3
     y[7] = -3.
     x[4] = -10
-    for (i, j), ax in np.ndenumerate(axs):
-        mcx = ['mask', 'clip', ''][j]
-        mcy = ['mask', 'clip', ''][i]
-        if new_api:
-            if mcx == mcy:
-                if mcx:
-                    ax.loglog(x, y**3, lw=2, nonpositive=mcx)
-                else:
-                    ax.loglog(x, y**3, lw=2)
+    for (mcy, mcx), ax in zip(product(['mask', 'clip', ''], repeat=2),
+                              axs.flat):
+        if mcx == mcy:
+            if mcx:
+                ax.loglog(x, y**3, lw=2, nonpositive=mcx)
             else:
                 ax.loglog(x, y**3, lw=2)
-                if mcx:
-                    ax.set_xscale("log", nonpositive=mcx)
-                if mcy:
-                    ax.set_yscale("log", nonpositive=mcy)
         else:
-            kws = {}
+            ax.loglog(x, y**3, lw=2)
             if mcx:
-                kws['nonposx'] = mcx
+                ax.set_xscale("log", nonpositive=mcx)
             if mcy:
-                kws['nonposy'] = mcy
-            with (pytest.warns(MatplotlibDeprecationWarning) if kws
-                  else nullcontext()):
-                ax.loglog(x, y**3, lw=2, **kws)
+                ax.set_yscale("log", nonpositive=mcy)
 
 
 @pytest.mark.style('default')


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).