### PR TITLE
Quadmesh's default value of shading is now set to 'flat' instead of False

### DIFF
--- a/doc/api/next_api_changes/deprecations/20237-TH.rst
+++ b/doc/api/next_api_changes/deprecations/20237-TH.rst
@@ -3,11 +3,11 @@ QuadMesh signature
 The ``QuadMesh`` signature ::
 
     def __init__(meshWidth, meshHeight, coordinates,
-                 antialiased=True, shading=False, **kwargs)
+                 antialiased=True, shading='flat', **kwargs)
 
 is deprecated and replaced by the new signature ::
 
-    def __init__(coordinates, *, antialiased=True, shading=False, **kwargs)
+    def __init__(coordinates, *, antialiased=True, shading='flat', **kwargs)
 
 In particular:
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2002,7 +2002,7 @@ class QuadMesh(Collection):
             # The following raises a TypeError iif the args don't match.
             w, h, coords, antialiased, shading, kwargs = (
                 lambda meshWidth, meshHeight, coordinates, antialiased=True,
-                       shading=False, **kwargs:
+                       shading='flat', **kwargs:
                 (meshWidth, meshHeight, coordinates, antialiased, shading,
                  kwargs))(*args, **kwargs)
         except TypeError as exc:
@@ -2010,7 +2010,7 @@ class QuadMesh(Collection):
             # If the following raises a TypeError (i.e. args don't match),
             # just let it propagate.
             coords, antialiased, shading, kwargs = (
-                lambda coordinates, antialiased=True, shading=False, **kwargs:
+                lambda coordinates, antialiased=True, shading='flat', **kwargs:
                 (coordinates, antialiased, shading, kwargs))(*args, **kwargs)
             coords = np.asarray(coords, np.float64)
         else:  # The old signature matched.

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -743,7 +743,6 @@ def test_quadmesh_deprecated_signature(
     qmesh = QuadMesh(coords, **kwargs)
     qmesh.set_array(C)
     ax.add_collection(qmesh)
-
     assert qmesh._shading == 'flat'
 
     ax = fig_ref.add_subplot()
@@ -756,6 +755,7 @@ def test_quadmesh_deprecated_signature(
                          **kwargs)
     qmesh.set_array(C.flatten() if flat_ref else C)
     ax.add_collection(qmesh)
+    assert qmesh._shading == 'flat'
 
 
 @check_figures_equal(extensions=['png'])

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -744,6 +744,8 @@ def test_quadmesh_deprecated_signature(
     qmesh.set_array(C)
     ax.add_collection(qmesh)
 
+    assert qmesh._shading == 'flat'
+
     ax = fig_ref.add_subplot()
     ax.set(xlim=(0, 5), ylim=(0, 4))
     if 'transform' in kwargs:


### PR DESCRIPTION
## PR Summary

Fixes #20322 

The default value is now updated and tests for both the old and new Quadmesh signatures for their default value.
I've also updated the previous faulty changelog.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
