### PR TITLE
Remove need for ConversionInterface to support unitless values.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20334-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20334-AL.rst
@@ -1,0 +1,11 @@
+``ConversionInterface.convert`` no longer needs to accept unitless values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, custom subclasses of `.units.ConversionInterface` needed to
+implement a ``convert`` method that not only accepted instances of the
+unit, but also unitless values (which are passed through as is).  This is
+no longer the case (``convert`` is never called with a unitless value),
+and such support in `.StrCategoryConverter` is deprecated.  Likewise, the
+`.ConversionInterface.is_numlike` helper is deprecated.
+
+Consider calling `.Axis.convert_units` instead, which still supports unitless
+values.

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -343,8 +343,6 @@ class BasicUnitConverter(units.ConversionInterface):
 
     @staticmethod
     def convert(val, unit, axis):
-        if units.ConversionInterface.is_numlike(val):
-            return val
         if np.iterable(val):
             if isinstance(val, np.ma.MaskedArray):
                 val = val.astype(float).filled(np.nan)

--- a/examples/units/evans_test.py
+++ b/examples/units/evans_test.py
@@ -48,9 +48,6 @@ class FooConverter(units.ConversionInterface):
 
         If *obj* is a sequence, return the converted sequence.
         """
-        if units.ConversionInterface.is_numlike(obj):
-            return obj
-
         if np.iterable(obj):
             return [o.value(unit) for o in obj]
         else:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2273,9 +2273,7 @@ class XAxis(Axis):
             if self.converter is not None:
                 info = self.converter.axisinfo(self.units, self)
                 if info.default_limits is not None:
-                    valmin, valmax = info.default_limits
-                    xmin = self.converter.convert(valmin, self.units, self)
-                    xmax = self.converter.convert(valmax, self.units, self)
+                    xmin, xmax = self.convert_units(info.default_limits)
             if not dataMutated:
                 self.axes.dataLim.intervalx = xmin, xmax
             if not viewMutated:
@@ -2538,9 +2536,7 @@ class YAxis(Axis):
             if self.converter is not None:
                 info = self.converter.axisinfo(self.units, self)
                 if info.default_limits is not None:
-                    valmin, valmax = info.default_limits
-                    ymin = self.converter.convert(valmin, self.units, self)
-                    ymax = self.converter.convert(valmax, self.units, self)
+                    ymin, ymax = self.convert_units(info.default_limits)
             if not dataMutated:
                 self.axes.dataLim.intervaly = ymin, ymax
             if not viewMutated:

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -54,9 +54,15 @@ class StrCategoryConverter(units.ConversionInterface):
         # dtype = object preserves numerical pass throughs
         values = np.atleast_1d(np.array(value, dtype=object))
         # pass through sequence of non binary numbers
-        if all(units.ConversionInterface.is_numlike(v)
-               and not isinstance(v, (str, bytes))
-               for v in values):
+        with _api.suppress_matplotlib_deprecation_warning():
+            is_numlike = all(units.ConversionInterface.is_numlike(v)
+                             and not isinstance(v, (str, bytes))
+                             for v in values)
+        if is_numlike:
+            _api.warn_deprecated(
+                "3.5", message="Support for passing numbers through unit "
+                "converters is deprecated since %(since)s and support will be "
+                "removed %(removal)s; use Axis.convert_units instead.")
             return np.asarray(values, dtype=float)
         # force an update so it also does type checking
         unit.update(values)

--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -81,8 +81,6 @@ class EpochConverter(units.ConversionInterface):
 
         if not cbook.is_scalar_or_string(value):
             return [EpochConverter.convert(x, unit, axis) for x in value]
-        if units.ConversionInterface.is_numlike(value):
-            return value
         if unit is None:
             unit = EpochConverter.default_units(value, axis)
         if isinstance(value, U.Duration):

--- a/lib/matplotlib/testing/jpl_units/StrConverter.py
+++ b/lib/matplotlib/testing/jpl_units/StrConverter.py
@@ -27,9 +27,6 @@ class StrConverter(units.ConversionInterface):
     def convert(value, unit, axis):
         # docstring inherited
 
-        if units.ConversionInterface.is_numlike(value):
-            return value
-
         if value == []:
             return []
 

--- a/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
@@ -66,11 +66,6 @@ class UnitDblConverter(units.ConversionInterface):
         # docstring inherited
         if not cbook.is_scalar_or_string(value):
             return [UnitDblConverter.convert(x, unit, axis) for x in value]
-        # If the incoming value behaves like a number,
-        # then just return it because we don't know how to convert it
-        # (or it is already converted)
-        if units.ConversionInterface.is_numlike(value):
-            return value
         # If no units were specified, then get the default units to use.
         if unit is None:
             unit = UnitDblConverter.default_units(value, axis)

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 
+from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import matplotlib.category as cat
@@ -100,12 +101,14 @@ class TestStrCategoryConverter:
         assert self.cc.convert(value, self.unit, self.ax) == 0
 
     def test_convert_one_number(self):
-        actual = self.cc.convert(0.0, self.unit, self.ax)
+        with pytest.warns(MatplotlibDeprecationWarning):
+            actual = self.cc.convert(0.0, self.unit, self.ax)
         np.testing.assert_allclose(actual, np.array([0.]))
 
     def test_convert_float_array(self):
         data = np.array([1, 2, 3], dtype=float)
-        actual = self.cc.convert(data, self.unit, self.ax)
+        with pytest.warns(MatplotlibDeprecationWarning):
+            actual = self.cc.convert(data, self.unit, self.ax)
         np.testing.assert_allclose(actual, np.array([1., 2., 3.]))
 
     @pytest.mark.parametrize("fvals", fvalues, ids=fids)

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -48,7 +48,7 @@ from numbers import Number
 import numpy as np
 from numpy import ma
 
-from matplotlib import cbook
+from matplotlib import _api, cbook
 
 
 class ConversionError(TypeError):
@@ -134,6 +134,7 @@ class ConversionInterface:
         return obj
 
     @staticmethod
+    @_api.deprecated("3.5")
     def is_numlike(x):
         """
         The Matplotlib datalim, autoscaling, locators etc work with scalars


### PR DESCRIPTION
This avoids having each ConversionInterface.convert having to start by
doing the same call to is_numlike.

(Axis.convert_units, which should be the user-facing entry point, checks
_is_natively_supported first, which prevents unitless values from being
sent to ConversionInterface.convert.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
