### PR TITLE
Cleanup autoscale-related docstrings.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2540,27 +2540,21 @@ class _AxesBase(martist.Artist):
         return self.patch.contains(mouseevent)[0]
 
     def get_autoscale_on(self):
-        """
-        Get whether autoscaling is applied for both axes on plot commands
-        """
+        """Return True if each axis is autoscaled, False otherwise."""
         return self._autoscaleXon and self._autoscaleYon
 
     def get_autoscalex_on(self):
-        """
-        Get whether autoscaling for the x-axis is applied on plot commands
-        """
+        """Return whether the x-axis is autoscaled."""
         return self._autoscaleXon
 
     def get_autoscaley_on(self):
-        """
-        Get whether autoscaling for the y-axis is applied on plot commands
-        """
+        """Return whether the y-axis is autoscaled."""
         return self._autoscaleYon
 
     def set_autoscale_on(self, b):
         """
-        Set whether autoscaling is applied to axes on the next draw or call to
-        `.Axes.autoscale_view`.
+        Set whether autoscaling is applied to each axis on the next draw or
+        call to `.Axes.autoscale_view`.
 
         Parameters
         ----------
@@ -2571,8 +2565,8 @@ class _AxesBase(martist.Artist):
 
     def set_autoscalex_on(self, b):
         """
-        Set whether autoscaling for the x-axis is applied to axes on the next
-        draw or call to `.Axes.autoscale_view`.
+        Set whether the x-axis is autoscaled on the next draw or call to
+        `.Axes.autoscale_view`.
 
         Parameters
         ----------
@@ -2582,8 +2576,8 @@ class _AxesBase(martist.Artist):
 
     def set_autoscaley_on(self, b):
         """
-        Set whether autoscaling for the y-axis is applied to axes on the next
-        draw or call to `.Axes.autoscale_view`.
+        Set whether the y-axis is autoscaled on the next draw or call to
+        `.Axes.autoscale_view`.
 
         Parameters
         ----------

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -539,31 +539,22 @@ class Axes3D(Axes):
         pass
 
     def get_autoscale_on(self):
-        """
-        Get whether autoscaling is applied for all axes on plot commands
-        """
+        # docstring inherited
         return super().get_autoscale_on() and self.get_autoscalez_on()
 
     def get_autoscalez_on(self):
-        """
-        Get whether autoscaling for the z-axis is applied on plot commands
-        """
+        """Return whether the z-axis is autoscaled."""
         return self._autoscaleZon
 
     def set_autoscale_on(self, b):
-        """
-        Set whether autoscaling is applied on plot commands
-
-        Parameters
-        ----------
-        b : bool
-        """
+        # docstring inherited
         super().set_autoscale_on(b)
         self.set_autoscalez_on(b)
 
     def set_autoscalez_on(self, b):
         """
-        Set whether autoscaling for the z-axis is applied on plot commands
+        Set whether the z-axis is autoscaled on the next draw or call to
+        `.Axes.autoscale_view`.
 
         Parameters
         ----------


### PR DESCRIPTION
Autoscaling is not applied (anymore) when a plot command is executed,
but at draw time (or when explicitly calling autoscale_view()).

(Re: get_autoscale_on: I usually prefer the "Return whether..." wording,
but here it would make unclear what happens if only some axes are
autoscaled.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
