### PR TITLE
Clarify/Improve docs on family-names vs generic-families

### DIFF
--- a/examples/text_labels_and_annotations/font_family_rc_sgskip.py
+++ b/examples/text_labels_and_annotations/font_family_rc_sgskip.py
@@ -3,11 +3,17 @@
 Configuring the font family
 ===========================
 
-You can explicitly set which font family is picked up for a given font
-style (e.g., 'serif', 'sans-serif', or 'monospace').
+You can explicitly set which font family is picked up, either by specifying
+family names of fonts installed on user's system, or generic-families
+(e.g., 'serif', 'sans-serif', 'monospace', 'fantasy' or 'cursive'),
+or a combination of both.
+(see :doc:`font tutorial </tutorials/text/text_props>`)
 
-In the example below, we only allow one font family (Tahoma) for the
-sans-serif font style.  The default family is set with the font.family rcparam,
+In the example below, we are overriding the default sans-serif generic family
+to include a specific (Tahoma) font. (Note that the best way to achieve this
+would simply be to prepend 'Tahoma' in 'font.family')
+
+The default family is set with the font.family rcparam,
 e.g. ::
 
   rcParams['font.family'] = 'sans-serif'

--- a/tutorials/text/text_props.py
+++ b/tutorials/text/text_props.py
@@ -149,9 +149,9 @@ plt.show()
 # +---------------------+----------------------------------------------------+
 # | rcParam             | usage                                              |
 # +=====================+====================================================+
-# | ``'font.family'``   | List of either names of font or ``{'cursive',      |
-# |                     | 'fantasy', 'monospace', 'sans', 'sans serif',      |
-# |                     | 'sans-serif', 'serif'}``.                          |
+# | ``'font.family'``   | List of font families (installed on user's machine)|
+# |                     | and/or ``{'cursive', 'fantasy', 'monospace',       |
+# |                     | 'sans', 'sans serif', 'sans-serif', 'serif'}``.    |
 # |                     |                                                    |
 # +---------------------+----------------------------------------------------+
 # |  ``'font.style'``   | The default style, ex ``'normal'``,                |
@@ -174,13 +174,18 @@ plt.show()
 # |                     | this size.                                         |
 # +---------------------+----------------------------------------------------+
 #
-# The mapping between the family aliases (``{'cursive', 'fantasy',
-# 'monospace', 'sans', 'sans serif', 'sans-serif', 'serif'}``) and actual font names
+# Matplotlib can use font families installed on the user's computer, i.e.
+# Helvetica, Times, etc. Font families can also be specified with
+# generic-family aliases like (``{'cursive', 'fantasy', 'monospace',
+# 'sans', 'sans serif', 'sans-serif', 'serif'}``).
+#
+# The mapping between the generic family aliases and actual font families
+# (mentioned at :doc:`default rcParams </tutorials/introductory/customizing>`)
 # is controlled by the following rcParams:
 #
 #
 # +------------------------------------------+--------------------------------+
-# | family alias                             | rcParam with mappings          |
+# | CSS-based generic-family alias           | rcParam with mappings          |
 # +==========================================+================================+
 # | ``'serif'``                              | ``'font.serif'``               |
 # +------------------------------------------+--------------------------------+
@@ -194,7 +199,15 @@ plt.show()
 # +------------------------------------------+--------------------------------+
 #
 #
-# which are lists of font names.
+# If any of generic family names appear in ``'font.family'``, we replace that entry
+# by all the entries in the corresponding rcParam mapping.
+# For example: ::
+#
+#    matplotlib.rcParams['font.family'] = ['Family1', 'serif', 'Family2']
+#    matplotlib.rcParams['font.serif'] = ['SerifFamily1', 'SerifFamily2']
+#
+#    # This is effectively translated to:
+#    matplotlib.rcParams['font.family'] = ['Family1', 'SerifFamily1', 'SerifFamily2', 'Family2']
 #
 # Text with non-latin glyphs
 # ==========================
@@ -204,14 +217,26 @@ plt.show()
 # Korean, or Japanese.
 #
 # To set the default font to be one that supports the code points you
-# need, prepend the font name to ``'font.family'`` or the desired alias
-# lists ::
+# need, prepend the font name to ``'font.family'`` (recommended), or to the
+# desired alias lists. ::
 #
-#    matplotlib.rcParams['font.sans-serif'] = ['Source Han Sans TW', 'sans-serif']
+#    # first method
+#    matplotlib.rcParams['font.family'] = ['Source Han Sans TW', 'sans-serif']
 #
-# or set it in your :file:`.matplotlibrc` file::
+#    # second method
+#    matplotlib.rcParams['font.family'] = ['sans-serif']
+#    matplotlib.rcParams['sans-serif'] = ['Source Han Sans TW', ...]
 #
-#    font.sans-serif: Source Han Sans TW, Arial, sans-serif
+# The generic family alias lists contain fonts that are either shipped
+# alongside Matplotlib (so they have 100% chance of being found), or fonts
+# which have a very high probability of being present in most systems.
+#
+# A good practice when setting custom font families is to append
+# a generic-family to the font-family list as a last resort.
+#
+# You can also set it in your :file:`.matplotlibrc` file::
+#
+#    font.family: Source Han Sans TW, Arial, sans-serif
 #
 # To control the font used on per-artist basis use the *name*, *fontname* or
 # *fontproperties* keyword arguments documented :doc:`above


### PR DESCRIPTION
## PR Summary
Coming from the answer at https://discourse.matplotlib.org/t/fonts-and-font-families/22132 and a brief discussion with @anntzer, this PR modifies the content of font docs (and one example, for which I have a slight niggle against - because it's not really the most obvious and best way to guide a user into setting font family).

Hopefully, we might be moving font stuff out from this [very long page](https://matplotlib.org/stable/tutorials/text/text_props.html), and probably a better example in future.


This is possibly the beginning of handling https://github.com/matplotlib/matplotlib/issues/5941.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
