### PR TITLE
Remove incorrect statement about data-kwarg interface.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1281,18 +1281,12 @@ def _add_data_doc(docstring, replace_names):
 
     data_doc = ("""\
     If given, all parameters also accept a string ``s``, which is
-    interpreted as ``data[s]`` (unless this raises an exception).
-
-    Objects passed as **data** must support item access (``data[s]``) and
-    membership test (``s in data``)."""
+    interpreted as ``data[s]`` (unless this raises an exception)."""
                 if replace_names is None else f"""\
-    If given, the following parameters also accept a string ``s``, which
-    is interpreted as ``data[s]`` (unless this raises an exception):
+    If given, the following parameters also accept a string ``s``, which is
+    interpreted as ``data[s]`` (unless this raises an exception):
 
-    {', '.join(map('*{}*'.format, replace_names))}
-
-    Objects passed as **data** must support item access (``data[s]``) and
-    membership test (``s in data``).""")
+    {', '.join(map('*{}*'.format, replace_names))}""")
     # using string replacement instead of formatting has the advantages
     # 1) simpler indent handling
     # 2) prevent problems with formatting characters '{', '%' in the docstring


### PR DESCRIPTION
We don't actually require `data` to support `key in data`; we only ever
try `data[key]` (treating any exception as meaning "`key` is not in
`data`, use its value directly").  This can be checked e.g. by creating
a custom type that supports `__getitem__` but throws on `in` checks, and
verify that it can be used as `data`:
```python
class T: __getitem__ = lambda self, k: {"foo": 1, "bar": 2}[k]
l, = plt.plot("foo", "bar", data=T())
l.get_xydata()  # == [[1, 2]]
"foo" in T()  # raises
```

So delete the statement about `s in data`; the statement about `data[s]`
can also be removed as it is clearly implied by the fact that "`s` is
interpreted as `data[s]`".

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
