### PR TITLE
Merge Colorbar and ColorbarBase.

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.0.rst
@@ -60,11 +60,11 @@ frame. Padding and separation parameters can be adjusted.
 Add ``minorticks_on()/off()`` methods for colorbar
 --------------------------------------------------
 
-A new method `~.colorbar.ColorbarBase.minorticks_on` has been added to
+A new method ``ColorbarBase.minorticks_on`` has been added to
 correctly display minor ticks on a colorbar. This method doesn't allow the
 minor ticks to extend into the regions beyond vmin and vmax when the *extend*
 keyword argument (used while creating the colorbar) is set to 'both', 'max' or
-'min'. A complementary method `~.colorbar.ColorbarBase.minorticks_off` has
+'min'. A complementary method ``ColorbarBase.minorticks_off`` has
 also been added to remove the minor ticks on the colorbar.
 
 

--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -285,7 +285,7 @@ Align labels to Axes edges
 --------------------------
 
 `~.axes.Axes.set_xlabel`, `~.axes.Axes.set_ylabel` and
-`.ColorbarBase.set_label` support a parameter ``loc`` for simplified
+``ColorbarBase.set_label`` support a parameter ``loc`` for simplified
 positioning. For the xlabel, the supported values are 'left', 'center', or
 'right'. For the ylabel, the supported values are 'bottom', 'center', or
 'top'.

--- a/examples/color/colorbar_basics.py
+++ b/examples/color/colorbar_basics.py
@@ -54,5 +54,5 @@ plt.show()
 #
 #    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
 #    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
-#    - `matplotlib.colorbar.ColorbarBase.minorticks_on`
-#    - `matplotlib.colorbar.ColorbarBase.minorticks_off`
+#    - `matplotlib.colorbar.Colorbar.minorticks_on`
+#    - `matplotlib.colorbar.Colorbar.minorticks_off`

--- a/examples/images_contours_and_fields/image_masked.py
+++ b/examples/images_contours_and_fields/image_masked.py
@@ -79,4 +79,4 @@ plt.show()
 #    - `matplotlib.axes.Axes.imshow` / `matplotlib.pyplot.imshow`
 #    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
 #    - `matplotlib.colors.BoundaryNorm`
-#    - `matplotlib.colorbar.ColorbarBase.set_label`
+#    - `matplotlib.colorbar.Colorbar.set_label`

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -785,3 +785,10 @@ def test_twoslope_colorbar():
                        np.arange(100).reshape(10, 10),
                        norm=norm, cmap='RdBu_r')
     fig.colorbar(pc)
+
+
+@check_figures_equal(extensions=["png"])
+def test_remove_cb_whose_mappable_has_no_figure(fig_ref, fig_test):
+    ax = fig_test.add_subplot()
+    cb = fig_test.colorbar(cm.ScalarMappable(), cax=ax)
+    cb.remove()


### PR DESCRIPTION
ColorbarBase differs from Colorbar in that it is not associated with a
ScalarMappable (but constructed from explicit cmap/norm), but we already
document in Figure.colorbar that the preferred way to draw colorbars not
associated with an existing artist is to create an empty ScalarMappable
to provide `norm` and `cmap`.

Hence, likewise merge Colorbar and ColorbarBase (creating the
ScalarMappable on-the-fly if no mappable is passed to the constructor),
which should make the APIs clearer.  (Note that we are already
discouraging users to directly call either class' constructors,
anyways).  We could deprecate the backcompat APIs (i.e., the
`ColorbarBase` alias, the `cmap` and `norm` kwargs, and the different
semantics of `add_lines`), but that can be done later; this PR should be
entirely backcompatible.

(See also #17189.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
