### PR TITLE
Updates example and docstring to encourage the use of functools.partial in FuncAnimation

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -130,6 +130,7 @@ function. ::
    import numpy as np
    import matplotlib.pyplot as plt
    from matplotlib.animation import FuncAnimation
+   from functools import partial
 
    fig, ax = plt.subplots()
    xdata, ydata = [], []

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -148,9 +148,9 @@ function. ::
 
    xdata, ydata = [], []
    ani = FuncAnimation(
-   fig, partial(update, x=xdata, y=ydata),
-   frames=np.linspace(0, 2 * np.pi, 128),
-   init_func=init, blit=True)
+       fig, partial(update, x=xdata, y=ydata),
+       frames=np.linspace(0, 2 * np.pi, 128),
+       init_func=init, blit=True)
 
    plt.show()
 

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -103,6 +103,7 @@ artist at a global scope and let Python sort things out.  For example ::
    import numpy as np
    import matplotlib.pyplot as plt
    from matplotlib.animation import FuncAnimation
+   from functools import partial
 
    fig, ax = plt.subplots()
    xdata, ydata = [], []
@@ -124,7 +125,35 @@ artist at a global scope and let Python sort things out.  For example ::
    plt.show()
 
 The second method is to use `functools.partial` to 'bind' artists to
-function.  A third method is to use closures to build up the required
+function. ::
+
+   import numpy as np
+   import matplotlib.pyplot as plt
+   from matplotlib.animation import FuncAnimation
+
+   fig, ax = plt.subplots()
+   xdata, ydata = [], []
+   ln, = plt.plot([], [], 'ro')
+
+   def init():
+       ax.set_xlim(0, 2*np.pi)
+       ax.set_ylim(-1, 1)
+       return ln,
+
+   def update(frame):
+       xdata.append(frame)
+       ydata.append(np.sin(frame))
+       ln.set_data(xdata, ydata)
+       return ln,
+
+   ani = FuncAnimation(
+    fig, partial(update, offset=-0.5),
+    frames=np.linspace(0, 2 * np.pi, 128),
+    init_func=init, blit=True)
+
+   plt.show()
+
+A third method is to use closures to build up the required
 artists and functions.  A fourth method is to create a class.
 
 Examples

--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -124,7 +124,7 @@ artist at a global scope and let Python sort things out.  For example ::
                        init_func=init, blit=True)
    plt.show()
 
-The second method is to use `functools.partial` to 'bind' artists to
+The second method is to use `functools.partial` to pass arguments to the
 function. ::
 
    import numpy as np
@@ -133,24 +133,24 @@ function. ::
    from functools import partial
 
    fig, ax = plt.subplots()
-   xdata, ydata = [], []
    ln, = plt.plot([], [], 'ro')
 
    def init():
-       ax.set_xlim(0, 2*np.pi)
-       ax.set_ylim(-1, 1)
-       return ln,
+      ax.set_xlim(0, 2*np.pi)
+      ax.set_ylim(-1, 1)
+      return ln,
 
-   def update(frame):
-       xdata.append(frame)
-       ydata.append(np.sin(frame))
-       ln.set_data(xdata, ydata)
-       return ln,
+   def update(frame, x, y):
+      x.append(frame)
+      y.append(np.sin(frame))
+      ln.set_data(xdata, ydata)
+      return ln,
 
+   xdata, ydata = [], []
    ani = FuncAnimation(
-    fig, partial(update, offset=-0.5),
-    frames=np.linspace(0, 2 * np.pi, 128),
-    init_func=init, blit=True)
+   fig, partial(update, x=xdata, y=ydata),
+   frames=np.linspace(0, 2 * np.pi, 128),
+   init_func=init, blit=True)
 
    plt.show()
 

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1623,7 +1623,7 @@ class FuncAnimation(TimedAnimation):
 
     fargs : tuple or None, optional
         Additional arguments to pass to each call to *func*. Note: the use of
-        `functools.partial` is preferred over fargs.
+        `functools.partial` is preferred over *fargs*.
 
     save_count : int, default: 100
         Fallback for the number of values from *frames* to cache. This is

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1622,7 +1622,8 @@ class FuncAnimation(TimedAnimation):
         value is unused if ``blit == False`` and may be omitted in that case.
 
     fargs : tuple or None, optional
-        Additional arguments to pass to each call to *func*.
+        Additional arguments to pass to each call to *func*. Note: the use of
+        `functools.partial` is preferred over fargs.
 
     save_count : int, default: 100
         Fallback for the number of values from *frames* to cache. This is


### PR DESCRIPTION
Closes #20326 
Example for FuncAnimation is updated with the use of `functools.partial`.
A note is added in the docstring as well to use partial instead of fargs.