### PR TITLE
Add parse_math in Text and default it False for TextBox

### DIFF
--- a/doc/api/next_api_changes/behavior/20367-AG.rst
+++ b/doc/api/next_api_changes/behavior/20367-AG.rst
@@ -1,0 +1,12 @@
+``Text``
+~~~~~~~~
+
+``Text`` objects now allow a **parse_math** keyword-only argument
+which defaults to True. When it is passed as False, that text object
+will consider the string as a literal and will not try to parse it
+as a mathtext object.
+
+``TextBox``
+-----------
+``TextBox`` now defaults its text object's **parse_math** argument
+as False. 

--- a/doc/api/next_api_changes/behavior/20367-AG.rst
+++ b/doc/api/next_api_changes/behavior/20367-AG.rst
@@ -1,12 +1,12 @@
-``Text``
-~~~~~~~~
+``Text`` allows a boolean *parse_math*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``Text`` objects now allow a **parse_math** keyword-only argument
+`.Text` objects now allow a *parse_math* keyword-only argument
 which defaults to True. When it is passed as False, that text object
 will consider the string as a literal and will not try to parse it
 as a mathtext object.
 
-``TextBox``
------------
-``TextBox`` now defaults its text object's **parse_math** argument
+``TextBox`` defaults it to False
+--------------------------------
+`.TextBox` now defaults its text object's *parse_math** argument
 as False. 

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -738,6 +738,6 @@ def test_parse_math():
     ax.text(0, 0, r"$ \wrong{math} $", parse_math=False)
     fig.canvas.draw()
 
+    ax.text(0, 0, r"$ \wrong{math} $", parse_math=True)
     with pytest.raises(ValueError, match='Unknown symbol'):
-        ax.text(0, 0, r"$ \wrong{math} $", parse_math=True)
         fig.canvas.draw()

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -731,3 +731,13 @@ def test_unsupported_script(recwarn):
         [warn.message.args for warn in recwarn] ==
         [(r"Glyph 2534 (\N{BENGALI DIGIT ZERO}) missing from current font.",),
          (r"Matplotlib currently does not support Bengali natively.",)])
+
+
+def test_parse_math():
+    fig, ax = plt.subplots()
+    ax.text(0, 0, r"$ \wrong{math} $", parse_math=False)
+    fig.canvas.draw()
+
+    with pytest.raises(ValueError, match='Unknown symbol'):
+        ax.text(0, 0, r"$ \wrong{math} $", parse_math=True)
+        fig.canvas.draw()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1240,7 +1240,9 @@ class Text(Artist):
             if s == " ":
                 s = r"\ "
             return s, "TeX"
-        elif self.get_parse_math() and cbook.is_math_text(s):
+        elif not self.get_parse_math():
+            return s, False
+        elif cbook.is_math_text(s):
             return s, True
         else:
             return s.replace(r"\$", "$"), False

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -123,9 +123,9 @@ class Text(Artist):
                  linespacing=None,
                  rotation_mode=None,
                  usetex=None,          # defaults to rcParams['text.usetex']
-                 override_math=False,
                  wrap=False,
                  transform_rotates_text=False,
+                 parse_math=True,
                  **kwargs
                  ):
         """
@@ -143,7 +143,7 @@ class Text(Artist):
             color if color is not None else mpl.rcParams["text.color"])
         self.set_fontproperties(fontproperties)
         self.set_usetex(usetex)
-        self.set_override_math(override_math)
+        self.set_parse_math(parse_math)
         self.set_wrap(wrap)
         self.set_verticalalignment(verticalalignment)
         self.set_horizontalalignment(horizontalalignment)
@@ -1239,7 +1239,7 @@ class Text(Artist):
             if s == " ":
                 s = r"\ "
             return s, "TeX"
-        elif not self.get_override_math() and cbook.is_math_text(s):
+        elif self.get_parse_math() and cbook.is_math_text(s):
             return s, True
         else:
             return s.replace(r"\$", "$"), False
@@ -1276,21 +1276,24 @@ class Text(Artist):
         """Return whether this `Text` object uses TeX for rendering."""
         return self._usetex
 
-    def set_override_math(self, override_math):
+    def set_parse_math(self, parse_math):
         """
+        Override switch to enable/disable any mathtext
+        parsing for the given `Text` object.
+
         Parameters
         ----------
-        override_math : bool
-            Whether to override mathtext parsing with the normal parsing
+        parse_math : bool
+            Whether to consider mathtext parsing for the string
         """
-        self._override_math = bool(override_math)
+        self._parse_math = bool(parse_math)
 
-    def get_override_math(self):
+    def get_parse_math(self):
         """
-        Return whether this `Text` object is supposed to
-        override mathtext parsing with normal parsing.
+        Return whether mathtext parsing is considered
+        for this `Text` object.
         """
-        return self._override_math
+        return self._parse_math
 
     def set_fontname(self, fontname):
         """

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -123,6 +123,7 @@ class Text(Artist):
                  linespacing=None,
                  rotation_mode=None,
                  usetex=None,          # defaults to rcParams['text.usetex']
+                 override_math=False,
                  wrap=False,
                  transform_rotates_text=False,
                  **kwargs
@@ -142,6 +143,7 @@ class Text(Artist):
             color if color is not None else mpl.rcParams["text.color"])
         self.set_fontproperties(fontproperties)
         self.set_usetex(usetex)
+        self.set_override_math(override_math)
         self.set_wrap(wrap)
         self.set_verticalalignment(verticalalignment)
         self.set_horizontalalignment(horizontalalignment)
@@ -1237,7 +1239,7 @@ class Text(Artist):
             if s == " ":
                 s = r"\ "
             return s, "TeX"
-        elif cbook.is_math_text(s):
+        elif not self.get_override_math() and cbook.is_math_text(s):
             return s, True
         else:
             return s.replace(r"\$", "$"), False
@@ -1273,6 +1275,22 @@ class Text(Artist):
     def get_usetex(self):
         """Return whether this `Text` object uses TeX for rendering."""
         return self._usetex
+
+    def set_override_math(self, override_math):
+        """
+        Parameters
+        ----------
+        override_math : bool
+            Whether to override mathtext parsing with the normal parsing
+        """
+        self._override_math = bool(override_math)
+
+    def get_override_math(self):
+        """
+        Return whether this `Text` object is supposed to
+        override mathtext parsing with normal parsing.
+        """
+        return self._override_math
 
     def set_fontname(self, fontname):
         """

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -125,6 +125,7 @@ class Text(Artist):
                  usetex=None,          # defaults to rcParams['text.usetex']
                  wrap=False,
                  transform_rotates_text=False,
+                 *,
                  parse_math=True,
                  **kwargs
                  ):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1019,8 +1019,9 @@ class TextBox(AxesWidget):
             -label_pad, 0.5, label, transform=ax.transAxes,
             verticalalignment='center', horizontalalignment='right')
         self.text_disp = self.ax.text(
-            self.DIST_FROM_LEFT, 0.5, initial, transform=self.ax.transAxes,
-            verticalalignment='center', horizontalalignment='left')
+            self.DIST_FROM_LEFT, 0.5, initial,
+            transform=self.ax.transAxes, verticalalignment='center',
+            horizontalalignment='left', override_math=True)
 
         self._observers = cbook.CallbackRegistry()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1018,10 +1018,12 @@ class TextBox(AxesWidget):
         self.label = ax.text(
             -label_pad, 0.5, label, transform=ax.transAxes,
             verticalalignment='center', horizontalalignment='right')
+
+        # TextBox's text object should not parse mathtext at all.
         self.text_disp = self.ax.text(
             self.DIST_FROM_LEFT, 0.5, initial,
             transform=self.ax.transAxes, verticalalignment='center',
-            horizontalalignment='left', override_math=True)
+            horizontalalignment='left', parse_math=False)
 
         self._observers = cbook.CallbackRegistry()
 


### PR DESCRIPTION
## PR Summary
Following up the comment: https://github.com/matplotlib/matplotlib/issues/20266#issuecomment-854794023, this PR adds a `override_math` to Text objects, and make TextBox's text object default it to True.

This resolves https://github.com/matplotlib/matplotlib/issues/20266.
It does not allow GUI to go in invalid state when there's invalid mathtext in it, because it isn't parsed at all.
(also allows folks to override mathtext _at all_ in their text objects)

Interactive trial:
```python
import matplotlib.pyplot as plt
from matplotlib.widgets import TextBox

fig, ax = plt.subplots()
fig.subplots_adjust(left=0.25, top=0.55, bottom=0.45)
text_box = TextBox(ax, "Something in '\$ \$'")                       # try typing wrong mathtext here

plt.show()
```

Static trial:
```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.text(1, 2, "$$")
plt.show()
```

Needs a changenote (API change) and tests, but let's wait for a review before that.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
