### PR TITLE
Switch version scheme to release-branch-semver.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,7 +336,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         else []
     ),
     use_scm_version={
-        "version_scheme": "post-release",
+        "version_scheme": "release-branch-semver",
         "local_scheme": "node-and-date",
         "write_to": "lib/matplotlib/_version.py",
         "parentdir_prefix_version": "matplotlib-",


### PR DESCRIPTION
## PR Summary

While setuptools-scm does not yet support our branch naming scheme for release branches, it will soon [1]. And we won't have to worry about that until we actually branch for 3.5.0, since the v3.4.x branch doesn't use it.

[1] https://github.com/pypa/setuptools_scm/pull/573

Fixes #19419.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).