### PR TITLE
Handle direction="column" in axes_grid.Grid

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -98,7 +98,8 @@ class Grid:
             If not None, only the first *ngrids* axes in the grid are created.
         direction : {"row", "column"}, default: "row"
             Whether axes are created in row-major ("row by row") or
-            column-major order ("column by column").
+            column-major order ("column by column").  This also affects the
+            order in which axes are accessed using indexing (``grid[index]``).
         axes_pad : float or (float, float), default: 0.02
             Padding or (horizontal padding, vertical padding) between axes, in
             inches.
@@ -166,7 +167,8 @@ class Grid:
                 sharey = axes_array[row, 0] if share_y else None
             axes_array[row, col] = axes_class(
                 fig, rect, sharex=sharex, sharey=sharey)
-        self.axes_all = axes_array.ravel().tolist()
+        self.axes_all = axes_array.ravel(
+            order="C" if self._direction == "row" else "F").tolist()
         self.axes_column = axes_array.T.tolist()
         self.axes_row = axes_array.tolist()
         self.axes_llc = self.axes_column[0][-1]

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -11,7 +11,9 @@ from matplotlib.testing.decorators import (
     image_comparison, remove_ticks_and_titles)
 
 from mpl_toolkits.axes_grid1 import (
-    axes_size as Size, host_subplot, make_axes_locatable, Grid, AxesGrid, ImageGrid)
+    axes_size as Size,
+    host_subplot, make_axes_locatable,
+    Grid, AxesGrid, ImageGrid)
 from mpl_toolkits.axes_grid1.anchored_artists import (
     AnchoredSizeBar, AnchoredDirectionArrows)
 from mpl_toolkits.axes_grid1.axes_divider import HBoxDivider

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -11,7 +11,7 @@ from matplotlib.testing.decorators import (
     image_comparison, remove_ticks_and_titles)
 
 from mpl_toolkits.axes_grid1 import (
-    axes_size as Size, host_subplot, make_axes_locatable, AxesGrid, ImageGrid)
+    axes_size as Size, host_subplot, make_axes_locatable, Grid, AxesGrid, ImageGrid)
 from mpl_toolkits.axes_grid1.anchored_artists import (
     AnchoredSizeBar, AnchoredDirectionArrows)
 from mpl_toolkits.axes_grid1.axes_divider import HBoxDivider
@@ -470,3 +470,25 @@ def test_axes_class_tuple():
     fig = plt.figure()
     axes_class = (mpl_toolkits.axes_grid1.mpl_axes.Axes, {})
     gr = AxesGrid(fig, 111, nrows_ncols=(1, 1), axes_class=axes_class)
+
+
+def test_grid_axes_lists():
+    """Test Grid axes_all, axes_row and axes_column relationship."""
+    fig = plt.figure()
+    grid = Grid(fig, 111, (2, 3), direction="row")
+    assert_array_equal(grid, grid.axes_all)
+    assert_array_equal(grid.axes_row, np.transpose(grid.axes_column))
+    assert_array_equal(grid, np.ravel(grid.axes_row), "row")
+    grid = Grid(fig, 111, (2, 3), direction="column")
+    assert_array_equal(grid, np.ravel(grid.axes_column), "column")
+
+
+def test_grid_axes_position():
+    """Test positioning of the axes in Grid."""
+    fig = plt.figure()
+    for dir in ("row", "column"):
+        grid = Grid(fig, 111, (2, 2), direction=dir)
+        loc = [ax.get_axes_locator() for ax in np.ravel(grid.axes_row)]
+        assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny, dir
+        assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny, dir
+        assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny, dir

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -483,12 +483,12 @@ def test_grid_axes_lists():
     assert_array_equal(grid, np.ravel(grid.axes_column), "column")
 
 
-def test_grid_axes_position():
+@pytest.mark.parametrize('direction', ('row', 'column'))
+def test_grid_axes_position(direction):
     """Test positioning of the axes in Grid."""
     fig = plt.figure()
-    for dir in ("row", "column"):
-        grid = Grid(fig, 111, (2, 2), direction=dir)
-        loc = [ax.get_axes_locator() for ax in np.ravel(grid.axes_row)]
-        assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny, dir
-        assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny, dir
-        assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny, dir
+    grid = Grid(fig, 111, (2, 2), direction=direction)
+    loc = [ax.get_axes_locator() for ax in np.ravel(grid.axes_row)]
+    assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny
+    assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny
+    assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny


### PR DESCRIPTION
## PR Summary

- fixes #20372: `axes_all` axes are sorted by order of creation
- uniform description of `direction` in the docstrings of `Grid` and `ImageGrid`


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
