### PR TITLE
Check modification times of included RST files

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -429,14 +429,23 @@ class ImageFile:
         return [self.filename(fmt) for fmt in self.formats]
 
 
-def out_of_date(original, derived):
+def out_of_date(original, derived, includes=None):
     """
-    Return whether *derived* is out-of-date relative to *original*, both of
-    which are full file paths.
+    Return whether *derived* is out-of-date relative to *original* or any of
+    the RST files included in it using the RST include directive (*includes*).
+    *derived* and *original* are full paths, and *includes* is optionally a
+    list of full paths which may have been included in the *original*.
     """
-    return (not os.path.exists(derived) or
-            (os.path.exists(original) and
-             os.stat(derived).st_mtime < os.stat(original).st_mtime))
+    if includes is None:
+        includes = []
+    files_to_check = [original, *includes]
+
+    def out_of_date_one(original, derived):
+        return (not os.path.exists(derived) or
+                (os.path.exists(original) and
+                 os.stat(derived).st_mtime < os.stat(original).st_mtime))
+
+    return any(out_of_date_one(f, derived) for f in files_to_check)
 
 
 class PlotError(RuntimeError):
@@ -532,7 +541,8 @@ def get_plot_formats(config):
 
 def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False,
-                   close_figs=False):
+                   close_figs=False,
+                   code_includes=None):
     """
     Run a pyplot script and save the images in *output_dir*.
 
@@ -742,6 +752,25 @@ def run(arguments, content, options, state_machine, state, lineno):
         build_dir_link = build_dir
     source_link = dest_dir_link + '/' + output_base + source_ext
 
+    # get list of included rst files so that the output is updated when any
+    # plots in the included files change. These attributes are modified by the
+    # include directive (see the docutils.parsers.rst.directives.misc module).
+    try:
+        source_file_includes = [os.path.join(os.getcwd(), t[0])
+                                for t in state.document.include_log]
+    except AttributeError:
+        # the document.include_log attribute only exists in docutils >=0.17,
+        # before that we need to inspect the state machine
+        possible_sources = [os.path.join(setup.confdir, t[0])
+                            for t in state_machine.input_lines.items]
+        source_file_includes = [f for f in set(possible_sources)
+                                if os.path.isfile(f)]
+    # remove the source file itself from the includes
+    try:
+        source_file_includes.remove(source_file_name)
+    except ValueError:
+        pass
+
     # make figures
     try:
         results = render_figures(code,
@@ -752,7 +781,8 @@ def run(arguments, content, options, state_machine, state, lineno):
                                  function_name,
                                  config,
                                  context_reset=context_opt == 'reset',
-                                 close_figs=context_opt == 'close-figs')
+                                 close_figs=context_opt == 'close-figs',
+                                 code_includes=source_file_includes)
         errors = []
     except PlotError as err:
         reporter = state.memo.reporter

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -559,7 +559,8 @@ def render_figures(code, code_path, output_dir, output_base, context,
     all_exists = True
     img = ImageFile(output_base, output_dir)
     for format, dpi in formats:
-        if out_of_date(code_path, img.filename(format)):
+        if context or out_of_date(code_path, img.filename(format),
+                                  includes=code_includes):
             all_exists = False
             break
         img.formats.append(format)
@@ -579,7 +580,8 @@ def render_figures(code, code_path, output_dir, output_base, context,
             else:
                 img = ImageFile('%s_%02d' % (output_base, j), output_dir)
             for fmt, dpi in formats:
-                if out_of_date(code_path, img.filename(fmt)):
+                if context or out_of_date(code_path, img.filename(fmt),
+                                          includes=code_includes):
                     all_exists = False
                     break
                 img.formats.append(fmt)

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 from subprocess import Popen, PIPE
 import sys
+import shutil
 
 import pytest
 
@@ -13,26 +14,20 @@ pytest.importorskip('sphinx')
 
 
 def test_tinypages(tmpdir):
-    tmp_path = Path(tmpdir)
-    html_dir = tmp_path / 'html'
-    doctree_dir = tmp_path / 'doctrees'
+    source_dir = Path(tmpdir) / 'src'
+    shutil.copytree(str(Path(__file__).parent / 'tinypages'), str(source_dir))
+    html_dir = source_dir / '_build' / 'html'
+    doctree_dir = source_dir / 'doctrees'
+
     # Build the pages with warnings turned into errors
-    cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
-           '-d', str(doctree_dir),
-           str(Path(__file__).parent / 'tinypages'), str(html_dir)]
-    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True,
-                 env={**os.environ, "MPLBACKEND": ""})
-    out, err = proc.communicate()
-
-    assert proc.returncode == 0, \
-        f"sphinx build failed with stdout:\n{out}\nstderr:\n{err}\n"
-    if err:
-        pytest.fail(f"sphinx build emitted the following warnings:\n{err}")
-
-    assert html_dir.is_dir()
+    build_sphinx_html(source_dir, doctree_dir, html_dir)
 
     def plot_file(num):
         return html_dir / f'some_plots-{num}.png'
+
+    def plot_directive_file(num):
+        # This is always next to the doctree dir.
+        return doctree_dir.parent / 'plot_directive' / f'some_plots-{num}.png'
 
     range_10, range_6, range_4 = [plot_file(i) for i in range(1, 4)]
     # Plot 5 is range(6) plot
@@ -48,6 +43,7 @@ def test_tinypages(tmpdir):
     assert filecmp.cmp(range_4, plot_file(13))
     # Plot 14 has included source
     html_contents = (html_dir / 'some_plots.html').read_bytes()
+
     assert b'# Only a comment' in html_contents
     # check plot defined in external file.
     assert filecmp.cmp(range_4, html_dir / 'range4.png')
@@ -62,3 +58,47 @@ def test_tinypages(tmpdir):
     assert b'plot-directive my-class my-other-class' in html_contents
     # check that the multi-image caption is applied twice
     assert html_contents.count(b'This caption applies to both plots.') == 2
+    # Plot 21 is range(6) plot via an include directive. But because some of
+    # the previous plots are repeated, the argument to plot_file() is only 17.
+    assert filecmp.cmp(range_6, plot_file(17))
+
+    # Modify the included plot
+    with open(str(source_dir / 'included_plot_21.rst'), 'r') as file:
+        contents = file.read()
+    contents = contents.replace('plt.plot(range(6))', 'plt.plot(range(4))')
+    with open(str(source_dir / 'included_plot_21.rst'), 'w') as file:
+        file.write(contents)
+    # Build the pages again and check that the modified file was updated
+    modification_times = [plot_directive_file(i).stat().st_mtime
+                          for i in (1, 2, 3, 5)]
+    build_sphinx_html(source_dir, doctree_dir, html_dir)
+    assert filecmp.cmp(range_4, plot_file(17))
+    # Check that the plots in the plot_directive folder weren't changed.
+    # (plot_directive_file(1) won't be modified, but it will be copied to html/
+    # upon compilation, so plot_file(1) will be modified)
+    assert plot_directive_file(1).stat().st_mtime == modification_times[0]
+    assert plot_directive_file(2).stat().st_mtime == modification_times[1]
+    assert plot_directive_file(3).stat().st_mtime == modification_times[2]
+    assert filecmp.cmp(range_10, plot_file(1))
+    assert filecmp.cmp(range_6, plot_file(2))
+    assert filecmp.cmp(range_4, plot_file(3))
+    # Make sure that figures marked with context are re-created (but that the
+    # contents are the same)
+    assert plot_directive_file(5).stat().st_mtime > modification_times[3]
+    assert filecmp.cmp(range_6, plot_file(5))
+
+
+def build_sphinx_html(source_dir, doctree_dir, html_dir):
+    # Build the pages with warnings turned into errors
+    cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
+           '-d', str(doctree_dir), str(source_dir), str(html_dir)]
+    proc = Popen(cmd, stdout=PIPE, stderr=PIPE, universal_newlines=True,
+                 env={**os.environ, "MPLBACKEND": ""})
+    out, err = proc.communicate()
+
+    assert proc.returncode == 0, \
+        f"sphinx build failed with stdout:\n{out}\nstderr:\n{err}\n"
+    if err:
+        pytest.fail(f"sphinx build emitted the following warnings:\n{err}")
+
+    assert html_dir.is_dir()

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -3,9 +3,9 @@
 import filecmp
 import os
 from pathlib import Path
+import shutil
 from subprocess import Popen, PIPE
 import sys
-import shutil
 
 import pytest
 
@@ -15,7 +15,7 @@ pytest.importorskip('sphinx')
 
 def test_tinypages(tmpdir):
     source_dir = Path(tmpdir) / 'src'
-    shutil.copytree(str(Path(__file__).parent / 'tinypages'), str(source_dir))
+    shutil.copytree(Path(__file__).parent / 'tinypages', source_dir)
     html_dir = source_dir / '_build' / 'html'
     doctree_dir = source_dir / 'doctrees'
 
@@ -63,11 +63,9 @@ def test_tinypages(tmpdir):
     assert filecmp.cmp(range_6, plot_file(17))
 
     # Modify the included plot
-    with open(str(source_dir / 'included_plot_21.rst'), 'r') as file:
-        contents = file.read()
+    contents = (source_dir / 'included_plot_21.rst').read_text()
     contents = contents.replace('plt.plot(range(6))', 'plt.plot(range(4))')
-    with open(str(source_dir / 'included_plot_21.rst'), 'w') as file:
-        file.write(contents)
+    (source_dir / 'included_plot_21.rst').write_text(contents)
     # Build the pages again and check that the modified file was updated
     modification_times = [plot_directive_file(i).stat().st_mtime
                           for i in (1, 2, 3, 5)]

--- a/lib/matplotlib/tests/tinypages/included_plot_21.rst
+++ b/lib/matplotlib/tests/tinypages/included_plot_21.rst
@@ -1,0 +1,6 @@
+Plot 21 has length 6
+
+.. plot::
+
+    plt.plot(range(6))
+

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -166,3 +166,8 @@ scenario:
 
    plt.figure()
    plt.plot(range(4))
+ 
+Plot 21 is generated via an include directive:
+
+.. include:: included_plot_21.rst
+


### PR DESCRIPTION
Fixes #17860. Briefly, to reproduce this bug:

1. Create a file `included.rst` with a plot inside it.

2. Create a file `index.rst` containing the include directive
    `.. include:: included.rst`.

3. Build Sphinx documentation.

4. Modify the plotting code inside `included.rst`, but don't touch
   `index.rst`.

5. Rebuild the Sphinx documentation. Because `index.rst` wasn't touched,
   plot_directive thinks that it's up-to-date and thus the image doesn't
   need to be re-created.

This commit fixes the issue by checking the modification times not only
of the source file (`index.rst` in this case), but also of the file(s)
included within it (`included.rst`).

## PR Summary

The commit message contains most of the info, but I attach some extra detail here just in case people come across it and find it useful. There are a couple of ways to get the included files:

**Method 1**

Since docutils 0.17, there is an attribute `state.document.include_log` which is a list of tuples containing the names of any files that were included, which is exactly what we want.

```
[('index.rst', (None, None, None, None), 4.611686018427388e+18),
 ('included.rst', (None, None, None, None), 21)]
```

**Method 2**

Directly inspect `state_machine.input_lines.items`, which is a list of tuples `(source, offset)`. If a RST file is included, then we can get its filename (relative to the top-level Sphinx directory) in `source`. For example, this is what `plot_directive` can when I place `.. include:: included.rst` inside the file `~/test/plot_dir/index.rst`:

```
[('included.rst', 2),
 ('included.rst', 3),
 ('included.rst', 4),
 ('included.rst', 5),
 ('included.rst', 6),
 ('included.rst', 7), 
 ('included.rst', 8),
 ('included.rst', 9),
 ('included.rst', 10),
 ('included.rst', 11),
 ('included.rst', 12),
 ('internal padding after included.rst', 13),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 7),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 8),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 9),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 10),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 11),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 12),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 13),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 14),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 15),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 16),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 17),
 ('/Users/yongrenjie/test/plot_dir/index.rst', 18)
]
```

The issue with this is that there's the 'internal padding after...' line which we would have to filter out, and I'm not sure what other directives (if any) might also add some junk to this list. I got around this by first removing duplicates and then checking which of the entries were valid files.

I feel like Method 2 is a bit fragile, so I made it as a fallback:

```
try:
    # method 1...
except AttributeError:    # indicates docutils <=0.16
    # method 2...
```

I've tested this all the way back to docutils 0.14 and it seems to be pretty reliable.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] **N/A** Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] **N/A** New features are documented, with examples if plot related.
- [x] **N/A** Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] **N/A** New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] **N/A** API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
