### PR TITLE
Prevent corrections and completions in search field

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -63,7 +63,7 @@
             <li><a href="{{ pathto('devel/index') }}">Contributing</a></li>
             <li class="nav-right">
                 <form class="search" action="{{ pathto('search') }}" method="get">
-                <input type="text" name="q" aria-labelledby="searchlabel" placeholder="Search"/>
+                <input type="text" name="q" aria-labelledby="searchlabel" placeholder="Search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
                 </form>
             </li>
         </ul>

--- a/doc/_templates/search.html
+++ b/doc/_templates/search.html
@@ -17,7 +17,7 @@
     "codex ellipse".
   </p>
   <form action="" method="get">
-    <input type="text" name="q" value="" />
+    <input type="text" name="q" value="" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
     <input type="submit" value="{{ _('search') }}" />
     <span id="search-progress" style="padding-left: 10px"></span>
   </form>


### PR DESCRIPTION
In particular mobile browsers use correction mechanisms on input fields. Search will often be done with technical terms or even class/method/etc names that these correction mechanisms do not know, resulting in unwanted changes. This PR deactivates these correction mechanisms.

I've also reported this upstream to sphinx at https://github.com/sphinx-doc/sphinx/pull/9307. See there for more background.

Our current theme uses customized templates, so we have to adapt this ourselves.

You can check that this is working by accessing the CI built docs with a mobile device, and compare that with the released docs.

Note: I know the theme may be changing in the near future. But even if this does not make it to a release, it would be a win for me. I often quickly search the dev-docs on mobile when responding to an issue and correction drives me nuts.
