### PR TITLE
Type42 subsetting in PS/PDF

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,8 +145,7 @@ jobs:
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
-            cycler kiwisolver numpy packaging pillow pyparsing python-dateutil \
-            setuptools-scm \
+            cycler fonttools kiwisolver numpy pillow pyparsing python-dateutil setuptools-scm \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,8 @@ jobs:
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
-            cycler fonttools kiwisolver numpy pillow pyparsing python-dateutil setuptools-scm \
+            cycler fonttools kiwisolver numpy packaging pillow pyparsing \
+            python-dateutil setuptools-scm \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}
 

--- a/doc/api/next_api_changes/development/20391-AG.rst
+++ b/doc/api/next_api_changes/development/20391-AG.rst
@@ -1,0 +1,8 @@
+fontTools for type 42 subsetting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new dependency known as `fontTools <https://fonttools.readthedocs.io/>`_
+is integrated in with Maptlotlib 3.5
+
+It is designed to be used with PS/EPS and PDF documents; and handles
+Type 42 font subsetting.

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -22,6 +22,7 @@ reference.
 * `kiwisolver <https://github.com/nucleic/kiwi>`_ (>= 1.0.1)
 * `Pillow <https://pillow.readthedocs.io/en/latest/>`_ (>= 6.2)
 * `pyparsing <https://pypi.org/project/pyparsing/>`_ (>=2.2.1)
+* `fontTools <https://fonttools.readthedocs.io/en/latest/>`_ (>=4.22.0)
 
 
 .. _optional_dependencies:

--- a/doc/users/next_whats_new/subsetting.rst
+++ b/doc/users/next_whats_new/subsetting.rst
@@ -1,0 +1,22 @@
+Type 42 Subsetting is now enabled for PDF/PS backends
+-----------------------------------------------------
+
+`~matplotlib.backends.backend_pdf` and `~matplotlib.backends.backend_ps` now use
+a unified Type 42 font subsetting interface, with the help of `fontTools <https://fonttools.readthedocs.io/en/latest/>`_
+
+Set `~matplotlib.RcParams`'s *fonttype* value as ``42`` to trigger this workflow:
+
+.. code-block::
+
+    # for PDF backend
+    plt.rcParams['pdf.fonttype'] = 42
+
+    # for PS backend
+    plt.rcParams['ps.fonttype'] = 42
+
+
+    fig, ax = plt.subplots()
+    ax.text(0.4, 0.5, 'subsetted document is smaller in size!')
+
+    fig.savefig("document.pdf")
+    fig.savefig("document.ps")

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -19,26 +19,33 @@ def _cached_get_afm_from_fname(fname):
         return AFM(fh)
 
 
-def getSubset(fontfile, characters):
+def get_glyphs_subset(fontfile, characters):
     """
     Subset a TTF font
 
     Reads the named fontfile and restricts the font to the characters.
     Returns a serialization of the subset font as file-like object.
+
+    Parameters
+    ----------
+    symbol : str
+        Path to the font file
+    characters : str
+        Continuous set of characters to include in subset
     """
 
     options = subset.Options(glyph_names=True, recommended_glyphs=True)
+
+    # prevent subsetting FontForge Timestamp table
     options.drop_tables += ['FFTM']
-    font = subset.load_font(fontfile, options)
-    try:
+
+    with subset.load_font(fontfile, options) as font:
         subsetter = subset.Subsetter(options=options)
         subsetter.populate(text=characters)
         subsetter.subset(font)
         fh = BytesIO()
         font.save(fh, reorderTables=False)
         return fh
-    finally:
-        font.close()
 
 
 class CharacterTracker:

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -19,12 +19,12 @@ def _cached_get_afm_from_fname(fname):
         return AFM(fh)
 
 
-def getSubset(self, fontfile, characters):
+def getSubset(fontfile, characters):
     """
     Subset a TTF font
 
     Reads the named fontfile and restricts the font to the characters.
-    Returns a serialization of the subset font as bytes.
+    Returns a serialization of the subset font as file-like object.
     """
 
     options = subset.Options(glyph_names=True, recommended_glyphs=True)
@@ -36,7 +36,7 @@ def getSubset(self, fontfile, characters):
         subsetter.subset(font)
         fh = BytesIO()
         font.save(fh, reorderTables=False)
-        return fh.getvalue()
+        return fh
     finally:
         font.close()
 

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -36,8 +36,8 @@ def get_glyphs_subset(fontfile, characters):
 
     options = subset.Options(glyph_names=True, recommended_glyphs=True)
 
-    # prevent subsetting FontForge Timestamp table
-    options.drop_tables += ['FFTM']
+    # prevent subsetting FontForge Timestamp and other tables
+    options.drop_tables += ['FFTM', 'PfEd']
 
     with subset.load_font(fontfile, options) as font:
         subsetter = subset.Subsetter(options=options)

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1217,7 +1217,7 @@ end"""
                 filename, "".join(chr(c) for c in characters)
             )
             _log.debug(
-                "SUBSET %s %d ↦ %d", filename,
+                "SUBSET %s %d -> %d", filename,
                 os.stat(filename).st_size, fontdata.getbuffer().nbytes
             )
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -13,7 +13,9 @@ import itertools
 import logging
 import math
 import os
+import random
 import re
+import string
 import struct
 import time
 import types
@@ -768,6 +770,13 @@ class PdfFile:
                    }
         self.pageAnnotations.append(theNote)
 
+    def _get_subsetted_psname(self, ps_name):
+        # first three characters as MPL
+        prefix = "MPL"
+        # rest 3 random characters
+        rand = ''.join(random.choice(string.ascii_uppercase) for x in range(3))
+        return prefix + rand + "+" + ps_name
+
     def finalize(self):
         """Write out the various deferred objects and the pdf end matter."""
 
@@ -1360,7 +1369,8 @@ end"""
 
         # Beginning of main embedTTF function...
 
-        ps_name = font.postscript_name.encode('ascii', 'replace')
+        ps_name = self._get_subsetted_psname(font.postscript_name)
+        ps_name = ps_name.encode('ascii', 'replace')
         ps_name = Name(ps_name)
         pclt = font.get_sfnt_table('pclt') or {'capHeight': 0, 'xHeight': 0}
         post = font.get_sfnt_table('post') or {'italicAngle': (0, 0)}

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1239,6 +1239,9 @@ end"""
                 os.stat(filename).st_size, fontdata.getbuffer().nbytes
             )
 
+            # We need this ref for XObjects
+            full_font = font
+
             # reload the font object from the subset
             # (all the necessary data could probably be obtained directly
             # using fontLib.ttLib)
@@ -1325,10 +1328,10 @@ end"""
             glyph_ids = []
             for ccode in characters:
                 if not _font_supports_char(fonttype, chr(ccode)):
-                    gind = font.get_char_index(ccode)
+                    gind = full_font.get_char_index(ccode)
                     glyph_ids.append(gind)
 
-            bbox = [cvt(x, nearest=False) for x in font.bbox]
+            bbox = [cvt(x, nearest=False) for x in full_font.bbox]
             rawcharprocs = _get_pdf_charprocs(filename, glyph_ids)
             for charname in sorted(rawcharprocs):
                 stream = rawcharprocs[charname]

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1409,8 +1409,9 @@ end"""
     @classmethod
     def getSubset(self, fontfile, characters):
         """
-        Read TTF font from the given file and subset it for the given characters.
+        Subset a TTF font
 
+        Reads the named fontfile and restricts the font to the characters.
         Returns a serialization of the subset font as bytes.
         """
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1211,15 +1211,21 @@ end"""
             wObject = self.reserveObject('Type 0 widths')
             toUnicodeMapObject = self.reserveObject('ToUnicode map')
 
-            print(f"SUBSET {filename} characters: {''.join(chr(c) for c in characters)}")
-            fontdata = self.getSubset(filename, ''.join(chr(c) for c in characters))
-            print(f'SUBSET {filename} {os.stat(filename).st_size} -> {len(fontdata)}')
+            print(f"SUBSET {filename} characters: "
+                  f"{''.join(chr(c) for c in characters)}")
+            fontdata = self.getSubset(
+                filename,
+                ''.join(chr(c) for c in characters)
+            )
+            print(f'SUBSET {filename} {os.stat(filename).st_size}'
+                  f' ↦ {len(fontdata)}')
 
             # reload the font object from the subset
-            # (all the necessary data could probably be obtained directly using fontLib.ttLib)
+            # (all the necessary data could probably be obtained directly
+            # using fontLib.ttLib)
             with tempfile.NamedTemporaryFile(suffix='.ttf') as tmp:
                 tmp.write(fontdata)
-                tmp.seek(0,0)
+                tmp.seek(0, 0)
                 font = FT2Font(tmp.name)
 
             cidFontDict = {
@@ -1402,9 +1408,11 @@ end"""
 
     @classmethod
     def getSubset(self, fontfile, characters):
-        """Read TTF font from the given file and subset it for the given characters.
+        """
+        Read TTF font from the given file and subset it for the given characters.
 
-        Returns a serialization of the subset font as bytes."""
+        Returns a serialization of the subset font as bytes.
+        """
 
         options = subset.Options(glyph_names=True, recommended_glyphs=True)
         options.drop_tables += ['FFTM']

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -8,20 +8,17 @@ import codecs
 from datetime import datetime
 from enum import Enum
 from functools import total_ordering
-from io import BytesIO
 import itertools
 import logging
 import math
 import os
 import re
 import struct
-import tempfile
 import time
 import types
 import warnings
 import zlib
 
-from fontTools import subset
 import numpy as np
 from PIL import Image
 
@@ -1213,7 +1210,7 @@ end"""
 
             print(f"SUBSET {filename} characters: "
                   f"{''.join(chr(c) for c in characters)}")
-            fontdata = self.getSubset(
+            fontdata = _backend_pdf_ps.getSubset(
                 filename,
                 ''.join(chr(c) for c in characters)
             )
@@ -1405,28 +1402,6 @@ end"""
             return embedTTFType3(font, characters, descriptor)
         elif fonttype == 42:
             return embedTTFType42(font, characters, descriptor)
-
-    @classmethod
-    def getSubset(self, fontfile, characters):
-        """
-        Subset a TTF font
-
-        Reads the named fontfile and restricts the font to the characters.
-        Returns a serialization of the subset font as bytes.
-        """
-
-        options = subset.Options(glyph_names=True, recommended_glyphs=True)
-        options.drop_tables += ['FFTM']
-        font = subset.load_font(fontfile, options)
-        try:
-            subsetter = subset.Subsetter(options=options)
-            subsetter.populate(text=characters)
-            subsetter.subset(font)
-            fh = BytesIO()
-            font.save(fh, reorderTables=False)
-            return fh.getvalue()
-        finally:
-            font.close()
 
     def alphaState(self, alpha):
         """Return name of an ExtGState that sets alpha to the given value."""

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1209,14 +1209,17 @@ end"""
             wObject = self.reserveObject('Type 0 widths')
             toUnicodeMapObject = self.reserveObject('ToUnicode map')
 
-            _log.debug(f"SUBSET {filename} characters: "
-                       f"{''.join(chr(c) for c in characters)}")
-            fontdata = _backend_pdf_ps.getSubset(
-                filename,
-                ''.join(chr(c) for c in characters)
+            _log.debug(
+                "SUBSET %s characters: %s",
+                filename, "".join(chr(c) for c in characters)
             )
-            _log.debug(f'SUBSET {filename} {os.stat(filename).st_size}'
-                       f' ↦ {fontdata.getbuffer().nbytes}')
+            fontdata = _backend_pdf_ps.get_glyphs_subset(
+                filename, "".join(chr(c) for c in characters)
+            )
+            _log.debug(
+                "SUBSET %s %d ↦ %d", filename,
+                os.stat(filename).st_size, fontdata.getbuffer().nbytes
+            )
 
             # reload the font object from the subset
             # (all the necessary data could probably be obtained directly

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -965,7 +965,7 @@ class FigureCanvasPS(FigureCanvasBase):
                             _log.debug(
                                 f"SUBSET {font_path} "
                                 f"{os.stat(font_path).st_size} "
-                                f"↦ {len(fontdata)}"
+                                f"↦ {fontdata.getbuffer().nbytes}"
                             )
 
                             # give ttconv a subsetted font
@@ -973,12 +973,14 @@ class FigureCanvasPS(FigureCanvasBase):
                             with tempfile.NamedTemporaryFile(
                                 suffix=".ttf"
                             ) as tmp:
-                                tmp.write(fontdata)
-                                tmp.seek(0, 0)
-                                font = FT2Font(tmp.name)
+                                font = FT2Font(fontdata)
                                 glyph_ids = [
                                     font.get_char_index(c) for c in chars
                                 ]
+                                tmp.write(fontdata.getvalue())
+                                tmp.seek(0, 0)
+                                # TODO: allow convert_ttf_to_ps
+                                # to input file objects (BytesIO)
                                 convert_ttf_to_ps(
                                     os.fsencode(tmp.name),
                                     fh,

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -978,7 +978,6 @@ class FigureCanvasPS(FigureCanvasBase):
                                     font.get_char_index(c) for c in chars
                                 ]
                                 tmp.write(fontdata.getvalue())
-                                tmp.seek(0, 0)
                                 # TODO: allow convert_ttf_to_ps
                                 # to input file objects (BytesIO)
                                 convert_ttf_to_ps(

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -978,6 +978,8 @@ class FigureCanvasPS(FigureCanvasBase):
                                     font.get_char_index(c) for c in chars
                                 ]
                                 tmp.write(fontdata.getvalue())
+                                tmp.flush()
+
                                 # TODO: allow convert_ttf_to_ps
                                 # to input file objects (BytesIO)
                                 convert_ttf_to_ps(

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -956,16 +956,16 @@ class FigureCanvasPS(FigureCanvasBase):
                     else:
                         try:
                             _log.debug(
-                                f"SUBSET {font_path} characters: "
-                                f"{''.join(chr(c) for c in chars)}"
+                                "SUBSET %s characters: %s", font_path,
+                                ''.join(chr(c) for c in chars)
                             )
-                            fontdata = _backend_pdf_ps.getSubset(
+                            fontdata = _backend_pdf_ps.get_glyphs_subset(
                                 font_path, "".join(chr(c) for c in chars)
                             )
                             _log.debug(
-                                f"SUBSET {font_path} "
-                                f"{os.stat(font_path).st_size} "
-                                f"↦ {fontdata.getbuffer().nbytes}"
+                                "SUBSET %s %d ↦ %d", font_path,
+                                os.stat(font_path).st_size,
+                                fontdata.getbuffer().nbytes
                             )
 
                             # give ttconv a subsetted font

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -7,7 +7,7 @@ import datetime
 from enum import Enum
 import functools
 import glob
-from io import BytesIO, StringIO, TextIOWrapper
+from io import StringIO, TextIOWrapper
 import logging
 import math
 import os
@@ -18,7 +18,6 @@ import shutil
 from tempfile import TemporaryDirectory
 import time
 
-from fontTools import subset
 import numpy as np
 
 import matplotlib as mpl
@@ -960,7 +959,7 @@ class FigureCanvasPS(FigureCanvasBase):
                                 f"SUBSET {font_path} characters: "
                                 f"{''.join(chr(c) for c in chars)}"
                             )
-                            fontdata = getSubset(
+                            fontdata = _backend_pdf_ps.getSubset(
                                 font_path, "".join(chr(c) for c in chars)
                             )
                             _log.debug(

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -963,7 +963,7 @@ class FigureCanvasPS(FigureCanvasBase):
                                 font_path, "".join(chr(c) for c in chars)
                             )
                             _log.debug(
-                                "SUBSET %s %d ↦ %d", font_path,
+                                "SUBSET %s %d -> %d", font_path,
                                 os.stat(font_path).st_size,
                                 fontdata.getbuffer().nbytes
                             )

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -970,20 +970,21 @@ class FigureCanvasPS(FigureCanvasBase):
 
                             # give ttconv a subsetted font
                             # along with updated glyph_ids
-                            with tempfile.NamedTemporaryFile(
-                                suffix=".ttf"
-                            ) as tmp:
+                            with TemporaryDirectory() as tmpdir:
+                                tmpfile = os.path.join(tmpdir, "tmp.ttf")
                                 font = FT2Font(fontdata)
                                 glyph_ids = [
                                     font.get_char_index(c) for c in chars
                                 ]
-                                tmp.write(fontdata.getvalue())
-                                tmp.flush()
+
+                                with open(tmpfile, 'wb') as tmp:
+                                    tmp.write(fontdata.getvalue())
+                                    tmp.flush()
 
                                 # TODO: allow convert_ttf_to_ps
                                 # to input file objects (BytesIO)
                                 convert_ttf_to_ps(
-                                    os.fsencode(tmp.name),
+                                    os.fsencode(tmpfile),
                                     fh,
                                     fonttype,
                                     glyph_ids,

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -19,6 +19,7 @@ def pytest_configure(config):
         ("markers", "pytz: Tests that require pytz to be installed."),
         ("markers", "network: Tests that reach out to the network."),
         ("filterwarnings", "error"),
+        #("filterwarnings", "error"),  # fontTools.subset raises a pointless DeprecationWarning
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -19,8 +19,6 @@ def pytest_configure(config):
         ("markers", "pytz: Tests that require pytz to be installed."),
         ("markers", "network: Tests that reach out to the network."),
         ("filterwarnings", "error"),
-        ("filterwarnings",
-         "ignore:.*The py23 module has been deprecated:DeprecationWarning"),
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -19,6 +19,8 @@ def pytest_configure(config):
         ("markers", "pytz: Tests that require pytz to be installed."),
         ("markers", "network: Tests that reach out to the network."),
         ("filterwarnings", "error"),
+        ("filterwarnings",
+         "ignore:.*The py23 module has been deprecated:DeprecationWarning"),
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -19,7 +19,8 @@ def pytest_configure(config):
         ("markers", "pytz: Tests that require pytz to be installed."),
         ("markers", "network: Tests that reach out to the network."),
         ("filterwarnings", "error"),
-        #("filterwarnings", "error"),  # fontTools.subset raises a pointless DeprecationWarning
+        ("filterwarnings",
+         "ignore:.*The py23 module has been deprecated:DeprecationWarning"),
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -12,11 +12,8 @@ import matplotlib as mpl
 from matplotlib import dviread, pyplot as plt, checkdep_usetex, rcParams
 from matplotlib.cbook import _get_data_path
 from matplotlib.ft2font import FT2Font
-
-# Weird py23 deprecation warning from fonttools
-with pytest.warns(DeprecationWarning):
-    from matplotlib.backends._backend_pdf_ps import get_glyphs_subset
-    from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.backends._backend_pdf_ps import get_glyphs_subset
+from matplotlib.backends.backend_pdf import PdfPages
 
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
@@ -350,7 +347,7 @@ def test_kerning():
 
 def test_glyphs_subset():
     fpath = str(_get_data_path("fonts/ttf/DejaVuSerif.ttf"))
-    chars = "these should be subsetted!"
+    chars = "these should be subsetted! 1234567890"
 
     # non-subsetted FT2Font
     nosubfont = FT2Font(fpath)
@@ -364,7 +361,7 @@ def test_glyphs_subset():
     subcmap = subfont.get_charmap()
 
     # all unique chars must be available in subsetted font
-    assert set(chars).issuperset(set([chr(key) for key in subcmap.keys()]))
+    assert set(chars).issubset(set([chr(key) for key in subcmap.keys()]))
 
     # subsetted font's charmap should have less (or equal) entries
     assert len(subcmap) <= len(nosubcmap)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -361,10 +361,10 @@ def test_glyphs_subset():
     subcmap = subfont.get_charmap()
 
     # all unique chars must be available in subsetted font
-    assert set(chars).issubset(set([chr(key) for key in subcmap.keys()]))
+    assert set(chars) == set(chr(key) for key in subcmap.keys())
 
-    # subsetted font's charmap should have less (or equal) entries
-    assert len(subcmap) <= len(nosubcmap)
+    # subsetted font's charmap should have less entries
+    assert len(subcmap) < len(nosubcmap)
 
     # since both objects are assigned same characters
     assert subfont.get_num_glyphs() == nosubfont.get_num_glyphs()

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -207,3 +207,18 @@ def test_type42_font_without_prep():
     mpl.rcParams["mathtext.fontset"] = "stix"
 
     plt.figtext(0.5, 0.5, "Mass $m$")
+
+
+@pytest.mark.parametrize('fonttype', ["3", "42"])
+def test_fonttype(fonttype):
+    mpl.rcParams["ps.fonttype"] = fonttype
+    fig, ax = plt.subplots()
+
+    ax.text(0.25, 0.5, "Forty-two is the answer to everything!")
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="ps")
+
+    test = b'/FontType ' + bytes(f"{fonttype}", encoding='utf-8') + b' def'
+
+    assert re.search(test, buf.getvalue(), re.MULTILINE)

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -7,3 +7,4 @@ packaging==20.0
 pillow==6.2.0
 pyparsing==2.2.1
 python-dateutil==2.7
+fonttools==4.13.0

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -7,4 +7,4 @@ packaging==20.0
 pillow==6.2.0
 pyparsing==2.2.1
 python-dateutil==2.7
-fonttools==4.13.0
+fonttools==4.22.0

--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     ],
     install_requires=[
         "cycler>=0.10",
+        "fonttools>=4.13.0,<5.0",
         "kiwisolver>=1.0.1",
         "numpy>=1.17",
         "packaging>=20.0",

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
     ],
     install_requires=[
         "cycler>=0.10",
-        "fonttools>=4.13.0,<5.0",
+        "fonttools>=4.22.0",
         "kiwisolver>=1.0.1",
         "numpy>=1.17",
         "packaging>=20.0",

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -164,7 +164,7 @@ static PyMethodDef ttconv_methods[] =
         "font data will be written to.\n"
         "fonttype may be either 3 or 42.  Type 3 is a \"raw Postscript\" font. "
         "Type 42 is an embedded Truetype font.  Glyph subsetting is not supported "
-        "for Type 42 fonts.\n"
+        "for Type 42 fonts within this module (needs to be done externally).\n"
         "glyph_ids (optional) is a list of glyph ids (integers) to keep when "
         "subsetting to a Type 3 font.  If glyph_ids is not provided or is None, "
         "then all glyphs will be included.  If any of the glyphs specified are "


### PR DESCRIPTION
## PR Summary
This PR is a fresh rebase from https://github.com/matplotlib/matplotlib/pull/18143.

- Adds a dependency: [`fonttools`](https://github.com/fonttools/fonttools) to handle font subsetting for us
  (we already have an external ttconv dependency, which does not handle subsetting)
- Interfaces a `getSubset` utility to get file-like objects containing subsetted font data

Possibly fixes https://github.com/matplotlib/matplotlib/issues/11303 (large file sizes)
Fixes https://github.com/matplotlib/matplotlib/issues/18191.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
