### PR TITLE
Make pdftex.map parsing stricter

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -908,8 +908,6 @@ class PsfontsMap:
                     basename = unquoted
             elif quoted:
                 special = quoted
-        if basename is None:
-            basename = tfmname
         effects = {}
         if special:
             words = reversed(special.split())
@@ -918,6 +916,24 @@ class PsfontsMap:
                     effects["slant"] = float(next(words))
                 elif word == b"ExtendFont":
                     effects["extend"] = float(next(words))
+
+        # Verify some properties of the line that would cause it to be ignored
+        # otherwise.
+        is_t1 = False
+        if fontfile is not None:
+            if not fontfile.endswith((b".ttf", b".ttc", b".otf"):
+                is_t1 = True
+        elif basename is not None:
+            is_t1 = True
+        if not is_t1 and ("slant" in effects or "extend" in effects):
+            return
+        if abs(effects.get("slant", 0)) > 1:
+            return
+        if abs(effects.get("extend", 0)) > 2:
+            return
+
+        if basename is None:
+            basename = tfmname
         if encodingfile is not None and not encodingfile.startswith(b"/"):
             encodingfile = find_tex_file(encodingfile)
         if fontfile is not None and not fontfile.startswith(b"/"):

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -884,6 +884,7 @@ class PsfontsMap:
         if not line or line.startswith((b" ", b"%", b"*", b";", b"#")):
             return
         tfmname = basename = special = encodingfile = fontfile = None
+        is_subsetted = is_t1 = is_truetype = False
         matches = re.finditer(br'"([^"]*)(?:"|$)|(\S+)', line)
         for match in matches:
             quoted, unquoted = match.groups()
@@ -902,6 +903,7 @@ class PsfontsMap:
                         encodingfile = word
                     else:
                         fontfile = word
+                        is_subsetted = True
                 elif tfmname is None:
                     tfmname = unquoted
                 elif basename is None:
@@ -919,12 +921,15 @@ class PsfontsMap:
 
         # Verify some properties of the line that would cause it to be ignored
         # otherwise.
-        is_t1 = False
         if fontfile is not None:
-            if not fontfile.endswith((b".ttf", b".ttc", b".otf"):
+            if fontfile.endswith((b".ttf", b".ttc")):
+                is_truetype = True
+            elif not fontfile.endswith(b".otf"):
                 is_t1 = True
         elif basename is not None:
             is_t1 = True
+        if is_truetype and is_subsetted and encodingfile is None:
+            return
         if not is_t1 and ("slant" in effects or "extend" in effects):
             return
         if abs(effects.get("slant", 0)) > 1:

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -939,9 +939,9 @@ class PsfontsMap:
 
         if basename is None:
             basename = tfmname
-        if encodingfile is not None and not encodingfile.startswith(b"/"):
+        if encodingfile is not None:
             encodingfile = find_tex_file(encodingfile)
-        if fontfile is not None and not fontfile.startswith(b"/"):
+        if fontfile is not None:
             fontfile = find_tex_file(fontfile)
         self._parsed[tfmname] = PsFont(
             texname=tfmname, psname=basename, effects=effects,

--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -8,3 +8,6 @@ TeXfont6 PSfont6
 TeXfont7 PSfont7 < font7.enc
 TeXfont8 PSfont8 <<font8.pfb
 TeXfont9 </absolute/font9.pfb
+% Only the first of a duplicate key is used.
+TeXfontA PSfontA1
+TeXfontA PSfontA2

--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -2,7 +2,7 @@
 TeXfont1 PSfont1 <font1.pfb <font1.enc
 TeXfont2 PSfont2 <font2.enc <font2.pfa
 TeXfont3 PSfont3 "1.23 UnknownEffect" <[enc3.foo < font3.pfa
-TeXfont4 PSfont4 "-0.1 SlantFont 2.2 ExtendFont" <font4.enc <font4.pfa
+TeXfont4 PSfont4 "-0.1 SlantFont 1.2 ExtendFont" <font4.enc <font4.pfa
 TeXfont5 PSfont5 <encoding1.enc <encoding2.enc <font5.pfb
 TeXfont6 PSfont6
 TeXfont7 PSfont7 < font7.enc
@@ -11,3 +11,16 @@ TeXfont9 </absolute/font9.pfb
 % Only the first of a duplicate key is used.
 TeXfontA PSfontA1
 TeXfontA PSfontA2
+%
+% Check SlantFont/ExtendFont
+%
+% Options are only allowed on T1 fonts (3 TrueType, 1 bitmap, and 1 T1 below).
+TeXfontB PSfontB1 "-0.1 SlantFont 1.2 ExtendFont" <fontB1.ttf
+TeXfontB PSfontB2 "-0.1 SlantFont" <fontB1.ttc
+TeXfontB PSfontB3 "1.2 ExtendFont" <fontB1.otf
+TeXfontB "0.1 SlantFont 1.2 ExtendFont"
+% Also, only within range ±1 / ±2.
+TeXfontB PSfontB4 "1.1 SlantFont 1.2 ExtendFont"
+TeXfontB PSfontB5 "0.1 SlantFont 2.2 ExtendFont"
+% This is the only one that works:
+TeXfontB PSfontB6

--- a/lib/matplotlib/tests/baseline_images/dviread/test.map
+++ b/lib/matplotlib/tests/baseline_images/dviread/test.map
@@ -15,12 +15,19 @@ TeXfontA PSfontA2
 % Check SlantFont/ExtendFont
 %
 % Options are only allowed on T1 fonts (3 TrueType, 1 bitmap, and 1 T1 below).
-TeXfontB PSfontB1 "-0.1 SlantFont 1.2 ExtendFont" <fontB1.ttf
-TeXfontB PSfontB2 "-0.1 SlantFont" <fontB1.ttc
-TeXfontB PSfontB3 "1.2 ExtendFont" <fontB1.otf
+TeXfontB PSfontB1 "-0.1 SlantFont 1.2 ExtendFont" <fontB1.enc <fontB1.ttf
+TeXfontB PSfontB2 "-0.1 SlantFont" <fontB2.enc <fontB2.ttc
+TeXfontB PSfontB3 "1.2 ExtendFont" <fontB3.enc <fontB3.otf
 TeXfontB "0.1 SlantFont 1.2 ExtendFont"
 % Also, only within range ±1 / ±2.
 TeXfontB PSfontB4 "1.1 SlantFont 1.2 ExtendFont"
 TeXfontB PSfontB5 "0.1 SlantFont 2.2 ExtendFont"
 % This is the only one that works:
 TeXfontB PSfontB6
+%
+% Invalid TrueType entry.
+%
+% Must have encodingfile if subsetted.
+TeXfontC PSfontC1 <fontC1.ttf
+TeXfontC PSfontC2 <fontC2.ttc
+TeXfontC PSfontC3 <fontC3.ttf <8r.enc

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -50,6 +50,9 @@ def test_PsfontsMap(monkeypatch):
     # Slant/Extend only works for T1 fonts.
     entry = fontmap[b'TeXfontB']
     assert entry.psname == b'PSfontB6'
+    # Subsetted TrueType must have encoding.
+    entry = fontmap[b'TeXfontC']
+    assert entry.psname == b'PSfontC3'
     # Missing font
     with pytest.raises(KeyError, match='no-such-font'):
         fontmap[b'no-such-font']

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -28,7 +28,7 @@ def test_PsfontsMap(monkeypatch):
         else:
             assert entry.filename == b'font%d.pfb' % n
         if n == 4:
-            assert entry.effects == {'slant': -0.1, 'extend': 2.2}
+            assert entry.effects == {'slant': -0.1, 'extend': 1.2}
         else:
             assert entry.effects == {}
     # Some special cases
@@ -47,6 +47,9 @@ def test_PsfontsMap(monkeypatch):
     # First of duplicates only.
     entry = fontmap[b'TeXfontA']
     assert entry.psname == b'PSfontA1'
+    # Slant/Extend only works for T1 fonts.
+    entry = fontmap[b'TeXfontB']
+    assert entry.psname == b'PSfontB6'
     # Missing font
     with pytest.raises(KeyError, match='no-such-font'):
         fontmap[b'no-such-font']

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -44,6 +44,9 @@ def test_PsfontsMap(monkeypatch):
     entry = fontmap[b'TeXfont9']
     assert entry.psname == b'TeXfont9'
     assert entry.filename == b'/absolute/font9.pfb'
+    # First of duplicates only.
+    entry = fontmap[b'TeXfontA']
+    assert entry.psname == b'PSfontA1'
     # Missing font
     with pytest.raises(KeyError, match='no-such-font'):
         fontmap[b'no-such-font']


### PR DESCRIPTION
## PR Summary

A test has started failing in Fedora Rawhide with Texlive 2021; while I think there are some issues in the `pdftex.map` there (see [my investigation here](https://bugzilla.redhat.com/show_bug.cgi?id=1965547)), I found the parser in Matplotlib to be a bit laxer than it should be. Annoyingly, `dvipdfm` and `pdflatex` appear to use different parsers for this file, but I chose to emulate what `pdflatex` does, as it appears to match what's in the pdfTeX manual, which we claim to follow.

Some more details are available in the commit messages, but behaviour copied from `pdflatex` include:
* ignoring duplicate lines
* ignoring lines with out of range *special* entries, or on the wrong font type
* failing on subset TrueType fonts without encoding files

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).