### PR TITLE
FIX: if we have already subclassed mixin class just return

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2211,6 +2211,10 @@ def _make_class_factory(mixin_class, fmt, attr_name=None):
 
     @functools.lru_cache(None)
     def class_factory(axes_class):
+        # if we have already wrapped this class, declare victory!
+        if issubclass(axes_class, mixin_class):
+            return axes_class
+
         # The parameter is named "axes_class" for backcompat but is really just
         # a base class; no axes semantics are used.
         base_class = axes_class

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -5,6 +5,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
+import matplotlib.axes as maxes
 
 
 def check_shared(axs, x_shared, y_shared):
@@ -219,3 +220,8 @@ def test_dont_mutate_kwargs():
                            gridspec_kw=gridspec_kw)
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
+
+
+def test_subplot_factory_reapplication():
+    assert maxes.subplot_class_factory(maxes.Axes) is maxes.Subplot
+    assert maxes.subplot_class_factory(maxes.Subplot) is maxes.Subplot


### PR DESCRIPTION
## PR Summary

If subplot_class_factory is passed a base class that already sub-classes
the mixin class, simply return the base class.

This will allow third-party packages to derive from maxes.Subplot rather
than maxes.Axes which will allow easier (by ensuring that our classes
and the third-party classes do not mix in the mro).

This allows a fix to https://github.com/lukelbd/proplot/issues/248 by changing which mpl class they inherit from (which brings them closer inline with the mpl36 goal of merging the subplot logic fulling into Axes

Currently we have:

```
# class CartesianAxes(maxes.Axes)
In [10]: matplotlib.axes.subplot_class_factory(proplot.axes.CartesianAxes).mro()
Out[10]: 
[matplotlib.axes._subplots.CartesianAxesSubplot,
 matplotlib.axes._subplots.SubplotBase,
 proplot.axes.cartesian.CartesianAxes,
 proplot.axes.base.Axes,
 matplotlib.axes._axes.Axes,
 matplotlib.axes._base._AxesBase,
 matplotlib.artist.Artist,
 object]
```￼

with this PR + changing the inheritance in proplot we have: 

￼```
# class CartesianAxes(maxes.Subplot)
In [4]: matplotlib.axes.subplot_class_factory(proplot.axes.CartesianAxes).mro()
Out[4]: 
[proplot.axes.cartesian.CartesianAxes,
 proplot.axes.base.Axes,
 matplotlib.axes._subplots.AxesSubplot,
 matplotlib.axes._subplots.SubplotBase,
 matplotlib.axes._axes.Axes,
 matplotlib.axes._base._AxesBase,
 matplotlib.artist.Artist,
 object]
```

The key detail is that in the first case the resoltion order bounces through mpl -> proplot -> mpl which means the code above / below `supre().__init__(...)` calls gets interleaved between the two code bases.  This means that when the call to `super().__init__()` returns in the proplot code they can not assume that the Axes is fully initialized (because any code that runs after the super() on the mpl side may will not have run yet becaues it will run after the proplot `__init__` returns).  In the second case all of the proplot classes are before all of our classes so that if proplot does `super().__init__(...)` they can assume that the object is in a, from mpl's point of view, fully initialized and consistent state.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

