### PR TITLE
Backport PR #20403: FIX: if we have already subclassed mixin class ju…

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -175,6 +175,7 @@ def subplot_class_factory(axes_class=None):
             "is deprecated since %(since)s; explicitly pass the default Axes "
             "class instead. This will become an error %(removal)s.")
         axes_class = Axes
+
     try:
         # Avoid creating two different instances of GeoAxesSubplot...
         # Only a temporary backcompat fix.  This should be removed in
@@ -182,6 +183,10 @@ def subplot_class_factory(axes_class=None):
         return next(cls for cls in SubplotBase.__subclasses__()
                     if cls.__bases__ == (SubplotBase, axes_class))
     except StopIteration:
+        # if we have already wrapped this class, declare victory!
+        if issubclass(axes_class, SubplotBase):
+            return axes_class
+
         return type("%sSubplot" % axes_class.__name__,
                     (SubplotBase, axes_class),
                     {'_axes_class': axes_class})

--- a/lib/matplotlib/tests/test_subplots.py
+++ b/lib/matplotlib/tests/test_subplots.py
@@ -5,6 +5,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
+import matplotlib.axes as maxes
 
 
 def check_shared(axs, x_shared, y_shared):
@@ -195,3 +196,8 @@ def test_dont_mutate_kwargs():
                            gridspec_kw=gridspec_kw)
     assert subplot_kw == {'sharex': 'all'}
     assert gridspec_kw == {'width_ratios': [1, 2]}
+
+
+def test_subplot_factory_reapplication():
+    assert maxes.subplot_class_factory(maxes.Axes) is maxes.Subplot
+    assert maxes.subplot_class_factory(maxes.Subplot) is maxes.Subplot


### PR DESCRIPTION
…st return

Merge pull request #20403 from tacaswell/noop_subplot_class_factory

FIX: if we have already subclassed mixin class just return

Conflicts:
	lib/matplotlib/cbook/__init__.py
          - logic is in axes/_subplots.py on this branch

