### PR TITLE
PGF: Clip lines/markers to maximum LaTeX dimensions.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -426,8 +426,12 @@ class RendererPgf(RendererBase):
                             fill=rgbFace is not None)
         writeln(self.fh, r"}")
 
+        maxcoord = 16383 / 72.27 * self.dpi  # Max dimensions in LaTeX.
+        clip = (-maxcoord, -maxcoord, maxcoord, maxcoord)
+
         # draw marker for each vertex
-        for point, code in path.iter_segments(trans, simplify=False):
+        for point, code in path.iter_segments(trans, simplify=False,
+                                              clip=clip):
             x, y = point[0] * f, point[1] * f
             writeln(self.fh, r"\begin{pgfscope}")
             writeln(self.fh, r"\pgfsys@transformshift{%fin}{%fin}" % (x, y))
@@ -564,11 +568,13 @@ class RendererPgf(RendererBase):
         f = 1. / self.dpi
         # check for clip box / ignore clip for filled paths
         bbox = gc.get_clip_rectangle() if gc else None
+        maxcoord = 16383 / 72.27 * self.dpi  # Max dimensions in LaTeX.
         if bbox and (rgbFace is None):
             p1, p2 = bbox.get_points()
-            clip = (p1[0], p1[1], p2[0], p2[1])
+            clip = (max(p1[0], -maxcoord), max(p1[1], -maxcoord),
+                    min(p2[0], maxcoord), min(p2[1], maxcoord))
         else:
-            clip = None
+            clip = (-maxcoord, -maxcoord, maxcoord, maxcoord)
         # build path
         for points, code in path.iter_segments(transform, clip=clip):
             if code == Path.MOVETO:

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -150,11 +150,19 @@ def test_rcupdate():
 @pytest.mark.style('default')
 @pytest.mark.backend('pgf')
 def test_pathclip():
+    np.random.seed(19680801)
     mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
-    plt.plot([0., 1e100], [0., 1e100])
-    plt.xlim(0, 1)
-    plt.ylim(0, 1)
-    plt.savefig(BytesIO(), format="pdf")  # No image comparison.
+    fig, axs = plt.subplots(1, 2)
+
+    axs[0].plot([0., 1e100], [0., 1e100])
+    axs[0].set_xlim(0, 1)
+    axs[0].set_ylim(0, 1)
+
+    axs[1].scatter([0, 1], [1, 1])
+    axs[1].hist(np.random.normal(size=1000), bins=20, range=[-10, 10])
+    axs[1].set_xscale('log')
+
+    fig.savefig(BytesIO(), format="pdf")  # No image comparison.
 
 
 # test mixed mode rendering


### PR DESCRIPTION
## PR Summary

This has been open for many years without any change to LaTeX, so it seems unlikely they are going to change how their parsing works.

Note that this does add clipping for filled paths, which we normally don't do, but it's so so far away, I don't think it'll be a problem.

Fixes #4482.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).