### PR TITLE
ENH: add colorbar info to gridspec cbar

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -274,7 +274,9 @@ class ColorbarAxes(Axes):
         self.outer_ax.set_yticks = self.inner_ax.set_yticks
         for attr in ["get_position", "set_position", "set_aspect"]:
             setattr(self, attr, getattr(self.outer_ax, attr))
+        self._colorbar_info = None  # used for mpl-created axes
         if userax:
+            self._colorbar_info = 'user'
             # point the parent's methods all at this axes...
             parent.__dict__ = self.__dict__
 
@@ -1487,6 +1489,15 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
     fig = parent.get_figure()
     cax = fig.add_subplot(ss_cb, label="<colorbar>")
     cax.set_aspect(aspect, anchor=loc_settings["anchor"], adjustable='box')
+    cax._colorbar_info = dict(
+        location=location,
+        parents=[parent],
+        shrink=shrink,
+        anchor=anchor,
+        panchor=panchor,
+        fraction=fraction,
+        aspect=aspect,
+        pad=pad)
     return cax, kw
 
 


### PR DESCRIPTION
## PR Summary

Non-gridspec colorbar axes have a `_colorbar_info` appended to them, but the gridspec and user-supplied ones do not.  This PR adds the attribute to all colorbar axes, and is set to `'user'` if the axes is provided by the user.

This is helpful in cases where we want to tell if an axes is a colorbar or not, though all colorbar axes should also be of type `ColorbarAxes`, so maybe not strictly needed...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
