### PR TITLE
Fix missing Patch3DCollection._z_markers_idx

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -462,6 +462,7 @@ class Patch3DCollection(PatchCollection):
             xs = []
             ys = []
         self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
+        self._z_markers_idx = slice(-1)
         self._vzs = None
         self.stale = True
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -601,22 +601,26 @@ def test_patch_modification():
 @check_figures_equal(extensions=['png'])
 def test_patch_collection_modification(fig_test, fig_ref):
     # Test that modifying Patch3DCollection properties after creation works.
-    patch = Circle((0, 0), 0.05)
-    c = art3d.Patch3DCollection([patch], linewidths=3)
+    patch1 = Circle((0, 0), 0.05)
+    patch2 = Circle((0.1, 0.1), 0.03)
+    facecolors = np.array([[0., 0.5, 0., 1.], [0.5, 0., 0., 0.5]])
+    c = art3d.Patch3DCollection([patch1, patch2], linewidths=3)
 
     ax_test = fig_test.add_subplot(projection='3d')
     ax_test.add_collection3d(c)
     c.set_edgecolor('C2')
-    c.set_facecolor('C3')
+    c.set_facecolor(facecolors)
     c.set_alpha(0.7)
     assert c.get_depthshade()
     c.set_depthshade(False)
     assert not c.get_depthshade()
 
-    patch = Circle((0, 0), 0.05)
-    c = art3d.Patch3DCollection([patch], linewidths=3,
-                                edgecolor='C2', facecolor='C3', alpha=0.7,
-                                depthshade=False)
+    patch1 = Circle((0, 0), 0.05)
+    patch2 = Circle((0.1, 0.1), 0.03)
+    facecolors = np.array([[0., 0.5, 0., 1.], [0.5, 0., 0., 0.5]])
+    c = art3d.Patch3DCollection([patch1, patch2], linewidths=3,
+                                edgecolor='C2', facecolor=facecolors,
+                                alpha=0.7, depthshade=False)
 
     ax_ref = fig_ref.add_subplot(projection='3d')
     ax_ref.add_collection3d(c)


### PR DESCRIPTION
## PR Summary

The issue is introduced by commit f888285: attribute `Patch3DCollection._z_markers_idx` is used within `_maybe_depth_shade_and_sort_colors()` function, but is never assigned.

The same changes were done in the `Path3DCollection` class, but there attribute is set correctly within `set_3d_properties()` function. Assuming this is the expected behaviour, this commit also sets `_z_markers_idx` in `Patch3DCollection.set_3d_properties()`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
