### PR TITLE
Add a select_overload helper for signature-overloaded functions.

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -189,6 +189,58 @@ def check_getitem(_mapping, **kwargs):
             .format(v, k, ', '.join(map(repr, mapping)))) from None
 
 
+def select_matching_signature(funcs, *args, **kwargs):
+    """
+    Select and call the function that accepts ``*args, **kwargs``.
+
+    *funcs* is a list of functions which should not raise any exception (other
+    than `TypeError` if the arguments passed do not match their signature).
+
+    `select_matching_signature` tries to call each of the functions in *funcs*
+    with ``*args, **kwargs`` (in the order in which they are given).  Calls
+    that fail with a `TypeError` are silently skipped.  As soon as a call
+    succeeds, `select_matching_signature` returns its return value.  If no
+    function accepts ``*args, **kwargs``, then the `TypeError` raised by the
+    last failing call is re-raised.
+
+    Callers should normally make sure that any ``*args, **kwargs`` can only
+    bind a single *func* (to avoid any ambiguity), although this is not checked
+    by `select_matching_signature`.
+
+    Notes
+    -----
+    `select_matching_signature` is intended to help implementing
+    signature-overloaded functions.  In general, such functions should be
+    avoided, except for back-compatibility concerns.  A typical use pattern is
+    ::
+
+        def my_func(*args, **kwargs):
+            params = select_matching_signature(
+                [lambda old1, old2: locals(), lambda new: locals()],
+                *args, **kwargs)
+            if "old1" in params:
+                warn_deprecated(...)
+                old1, old2 = params.values()  # note that locals() is ordered.
+            else:
+                new, = params.values()
+            # do things with params
+
+    which allows *my_func* to be called either with two parameters (*old1* and
+    *old2*) or a single one (*new*).  Note that the new signature is given
+    last, so that callers get a `TypeError` corresponding to the new signature
+    if the arguments they passed in do not match any signature.
+    """
+    # Rather than relying on locals() ordering, one could have just used func's
+    # signature (``bound = inspect.signature(func).bind(*args, **kwargs);
+    # bound.apply_defaults(); return bound``) but that is significantly slower.
+    for i, func in enumerate(funcs):
+        try:
+            return func(*args, **kwargs)
+        except TypeError:
+            if i == len(funcs) - 1:
+                raise
+
+
 def warn_external(message, category=None):
     """
     `warnings.warn` wrapper that sets *stacklevel* to "outside Matplotlib".

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1994,32 +1994,23 @@ class QuadMesh(Collection):
         # signature deprecation since="3.5": Change to new signature after the
         # deprecation has expired. Also remove setting __init__.__signature__,
         # and remove the Notes from the docstring.
-        #
-        # We use lambdas to parse *args, **kwargs through the respective old
-        # and new signatures.
-        try:
-            # Old signature:
-            # The following raises a TypeError iif the args don't match.
-            w, h, coords, antialiased, shading, kwargs = (
+        params = _api.select_matching_signature(
+            [
                 lambda meshWidth, meshHeight, coordinates, antialiased=True,
-                       shading='flat', **kwargs:
-                (meshWidth, meshHeight, coordinates, antialiased, shading,
-                 kwargs))(*args, **kwargs)
-        except TypeError as exc:
-            # New signature:
-            # If the following raises a TypeError (i.e. args don't match),
-            # just let it propagate.
-            coords, antialiased, shading, kwargs = (
+                       shading='flat', **kwargs: locals(),
                 lambda coordinates, antialiased=True, shading='flat', **kwargs:
-                (coordinates, antialiased, shading, kwargs))(*args, **kwargs)
-            coords = np.asarray(coords, np.float64)
-        else:  # The old signature matched.
+                       locals()
+            ],
+            *args, **kwargs).values()
+        *old_w_h, coords, antialiased, shading, kwargs = params
+        if old_w_h:  # The old signature matched.
             _api.warn_deprecated(
                 "3.5",
                 message="This usage of Quadmesh is deprecated: Parameters "
                         "meshWidth and meshHeights will be removed; "
                         "coordinates must be 2D; all parameters except "
                         "coordinates will be keyword-only.")
+            w, h = old_w_h
             coords = np.asarray(coords, np.float64).reshape((h + 1, w + 1, 2))
         kwargs.setdefault("pickradius", 0)
         # end of signature deprecation code


### PR DESCRIPTION
## PR Summary

This was suggested by @jklymak in https://github.com/matplotlib/matplotlib/pull/20354#discussion_r650115059.  That PR is not merged yet, so right now the only use site is the QuadMesh constructor.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
