### PR TITLE
Add missing super __init__ in subclasses

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1272,9 +1272,8 @@ class TwoSlopeNorm(Normalize):
             array([0., 0.25, 0.5, 0.625, 0.75, 0.875, 1.0])
         """
 
+        super().__init__(vmin=vmin, vmax=vmax)
         self.vcenter = vcenter
-        self.vmin = vmin
-        self.vmax = vmax
         if vcenter is not None and vmax is not None and vcenter >= vmax:
             raise ValueError('vmin, vcenter, and vmax must be in '
                              'ascending order')
@@ -1353,12 +1352,10 @@ class CenteredNorm(Normalize):
             >>> norm(data)
             array([0.25, 0.5 , 1.  ])
         """
+        super().__init__(vmin=None, vmax=None, clip=clip)
         self._vcenter = vcenter
-        self.vmin = None
-        self.vmax = None
         # calling the halfrange setter to set vmin and vmax
         self.halfrange = halfrange
-        self.clip = clip
 
     def _set_vmin_vmax(self):
         """
@@ -1696,9 +1693,7 @@ class BoundaryNorm(Normalize):
         """
         if clip and extend != 'neither':
             raise ValueError("'clip=True' is not compatible with 'extend'")
-        self.clip = clip
-        self.vmin = boundaries[0]
-        self.vmax = boundaries[-1]
+        super().__init__(vmin=boundaries[0], vmax=boundaries[-1], clip=clip)
         self.boundaries = np.asarray(boundaries)
         self.N = len(self.boundaries)
         if self.N < 2:

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1668,9 +1668,9 @@ class MicrosecondLocator(DateLocator):
         example, if ``interval=2``, mark every second microsecond.
 
         """
+        super().__init__(tz=tz)
         self._interval = interval
         self._wrapped_locator = ticker.MultipleLocator(interval)
-        self.tz = tz
 
     def set_axis(self, axis):
         self._wrapped_locator.set_axis(axis)

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -189,6 +189,7 @@ class MathtextBackendPs(MathtextBackend):
         "_PSResult", "width height depth pswriter used_characters")
 
     def __init__(self):
+        super().__init__()
         self.pswriter = StringIO()
         self.lastfont = None
 
@@ -230,6 +231,7 @@ class MathtextBackendPdf(MathtextBackend):
         "_PDFResult", "width height depth glyphs rects used_characters")
 
     def __init__(self):
+        super().__init__()
         self.glyphs = []
         self.rects = []
 
@@ -260,6 +262,7 @@ class MathtextBackendSvg(MathtextBackend):
     backend.
     """
     def __init__(self):
+        super().__init__()
         self.svg_glyphs = []
         self.svg_rects = []
 
@@ -293,6 +296,7 @@ class MathtextBackendPath(MathtextBackend):
     _Result = namedtuple("_Result", "width height depth glyphs rects")
 
     def __init__(self):
+        super().__init__()
         self.glyphs = []
         self.rects = []
 
@@ -320,6 +324,7 @@ class MathtextBackendCairo(MathtextBackend):
     """
 
     def __init__(self):
+        super().__init__()
         self.glyphs = []
         self.rects = []
 

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 import numpy as np
 
-from matplotlib import _text_helpers, dviread, font_manager, rcParams
+from matplotlib import _text_helpers, dviread, font_manager
 from matplotlib.font_manager import FontProperties, get_font
 from matplotlib.ft2font import LOAD_NO_HINTING, LOAD_TARGET_LIGHT
 from matplotlib.mathtext import MathTextParser
@@ -385,11 +385,11 @@ class TextPath(Path):
 
         self._cached_vertices = None
         s, ismath = Text(usetex=usetex)._preprocess_math(s)
-        self._vertices, self._codes = text_to_path.get_text_path(
-            prop, s, ismath=ismath)
+        super().__init__(
+            *text_to_path.get_text_path(prop, s, ismath=ismath),
+            _interpolation_steps=_interpolation_steps,
+            readonly=True)
         self._should_simplify = False
-        self._simplify_threshold = rcParams['path.simplify_threshold']
-        self._interpolation_steps = _interpolation_steps
 
     def set_size(self, size):
         """Set the text size."""
@@ -427,4 +427,5 @@ class TextPath(Path):
                   .scale(self._size / text_to_path.FONT_SCALE)
                   .translate(*self._xy))
             self._cached_vertices = tr.transform(self._vertices)
+            self._cached_vertices.flags.writeable = False
             self._invalid = False


### PR DESCRIPTION
## PR Summary

These can cause issues for some static checks (I noticed them in LGTM), and mostly the code in the super `__init__` is duplicated in the subclass.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).