### PR TITLE
Use packaging to do version comparisons.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,8 @@ jobs:
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
-            cycler kiwisolver numpy pillow pyparsing python-dateutil setuptools-scm \
+            cycler kiwisolver numpy packaging pillow pyparsing python-dateutil \
+            setuptools-scm \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}
 

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -5,10 +5,10 @@ Basic Units
 
 """
 
-from distutils.version import LooseVersion
 import math
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 import matplotlib.units as units
 import matplotlib.ticker as ticker
@@ -155,7 +155,7 @@ class TaggedValue(metaclass=TaggedValueMeta):
     def __len__(self):
         return len(self.value)
 
-    if LooseVersion(np.__version__) >= '1.20':
+    if parse_version(np.__version__) >= parse_version('1.20'):
         def __getitem__(self, key):
             return TaggedValue(self.value[key], self.unit)
 

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -11,10 +11,11 @@ The selection logic is as follows:
 - otherwise, use whatever the rcParams indicate.
 """
 
-from distutils.version import LooseVersion
 import os
 import platform
 import sys
+
+from packaging.version import parse as parse_version
 
 import matplotlib as mpl
 
@@ -102,8 +103,8 @@ else:  # We should not get there.
 # Fixes issues with Big Sur
 # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
 if (sys.platform == 'darwin' and
-        LooseVersion(platform.mac_ver()[0]) >= LooseVersion("10.16") and
-        LooseVersion(QtCore.qVersion()) < LooseVersion("5.15.2") and
+        parse_version(platform.mac_ver()[0]) >= parse_version("10.16") and
+        parse_version(QtCore.qVersion()) < parse_version("5.15.2") and
         "QT_MAC_WANTS_LAYER" not in os.environ):
     os.environ["QT_MAC_WANTS_LAYER"] = "1"
 

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -167,7 +167,7 @@ class _GSConverter(_Converter):
 
 class _SVGConverter(_Converter):
     def __call__(self, orig, dest):
-        old_inkscape = mpl._get_executable_info("inkscape").version < "1"
+        old_inkscape = mpl._get_executable_info("inkscape").version.major < 1
         terminator = b"\n>" if old_inkscape else b"> "
         if not hasattr(self, "_tmpdir"):
             self._tmpdir = TemporaryDirectory()

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -1,5 +1,4 @@
 import contextlib
-from distutils.version import StrictVersion
 import functools
 import inspect
 import os
@@ -9,6 +8,8 @@ import string
 import sys
 import unittest
 import warnings
+
+from packaging.version import parse as parse_version
 
 import matplotlib.style
 import matplotlib.units
@@ -92,20 +93,20 @@ def check_freetype_version(ver):
 
     if isinstance(ver, str):
         ver = (ver, ver)
-    ver = [StrictVersion(x) for x in ver]
-    found = StrictVersion(ft2font.__freetype_version__)
+    ver = [parse_version(x) for x in ver]
+    found = parse_version(ft2font.__freetype_version__)
 
     return ver[0] <= found <= ver[1]
 
 
 def _checked_on_freetype_version(required_freetype_version):
     import pytest
-    reason = ("Mismatched version of freetype. "
-              "Test requires '%s', you have '%s'" %
-              (required_freetype_version, ft2font.__freetype_version__))
     return pytest.mark.xfail(
         not check_freetype_version(required_freetype_version),
-        reason=reason, raises=ImageComparisonFailure, strict=False)
+        reason=f"Mismatched version of freetype. "
+               f"Test requires '{required_freetype_version}', "
+               f"you have '{ft2font.__freetype_version__}'",
+        raises=ImageComparisonFailure, strict=False)
 
 
 def remove_ticks_and_titles(figure):

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -4,6 +4,7 @@ import os
 import shutil
 
 import numpy as np
+from packaging.version import parse as parse_version
 import pytest
 
 import matplotlib as mpl
@@ -88,7 +89,8 @@ def test_xelatex():
 
 
 try:
-    _old_gs_version = mpl._get_executable_info('gs').version < '9.50'
+    _old_gs_version = \
+        mpl._get_executable_info('gs').version < parse_version('9.50')
 except mpl.ExecutableNotFoundError:
     _old_gs_version = True
 

--- a/lib/matplotlib/tests/tinypages/conf.py
+++ b/lib/matplotlib/tests/tinypages/conf.py
@@ -1,5 +1,5 @@
 import sphinx
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 # -- General configuration ------------------------------------------------
 
@@ -16,7 +16,7 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ----------------------------------------------
 
-if LooseVersion(sphinx.__version__) >= LooseVersion('1.3'):
+if parse_version(sphinx.__version__) >= parse_version('1.3'):
     html_theme = 'classic'
 else:
     html_theme = 'default'

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -29,6 +29,7 @@ import subprocess
 from tempfile import TemporaryDirectory
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 import matplotlib as mpl
 from matplotlib import _api, cbook, dviread, rcParams
@@ -270,8 +271,9 @@ class TexManager:
             # dvipng 1.16 has a bug (fixed in f3ff241) that breaks --freetype0
             # mode, so for it we keep FreeType enabled; the image will be
             # slightly off.
+            bad_ver = parse_version("1.16")
             if (getattr(mpl, "_called_from_pytest", False)
-                    and mpl._get_executable_info("dvipng").version != "1.16"):
+                    and mpl._get_executable_info("dvipng").version != bad_ver):
                 cmd.insert(1, "--freetype0")
             self._run_checked_subprocess(cmd, tex)
         return pngfile

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -3,6 +3,7 @@
 cycler==0.10
 kiwisolver==1.0.1
 numpy==1.17.0
+packaging==20.0
 pillow==6.2.0
 pyparsing==2.2.1
 python-dateutil==2.7

--- a/setup.py
+++ b/setup.py
@@ -327,6 +327,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         "cycler>=0.10",
         "kiwisolver>=1.0.1",
         "numpy>=1.17",
+        "packaging>=20.0",
         "pillow>=6.2.0",
         "pyparsing>=2.2.1",
         "python-dateutil>=2.7",


### PR DESCRIPTION
## PR Summary

... as `distutils` is deprecated in Python 3.10.

~~Since this is somewhat lower-level, I picked a minimum version on the same timescale as Python support, namely about 3 years ago.~~ Minimum version is ~12 months ago, since this is a Python-only package and all relevant downstreams appear to have it.

Maybe this should get an API note or something?

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).