### PR TITLE
Fix dvi baseline detector when `\usepackage{chemformula}` is used.

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -81,16 +81,18 @@ def test_minus_no_descent(fontsize):
     assert len({*heights.values()}) == 1
 
 
-@pytest.mark.skipif(not _has_tex_package('xcolor'),
-                    reason='xcolor is not available')
-def test_usetex_xcolor():
+@pytest.mark.parametrize('pkg', ['xcolor', 'chemformula'])
+def test_usetex_packages(pkg):
+    if not _has_tex_package(pkg):
+        pytest.skip(f'{pkg} is not available')
     mpl.rcParams['text.usetex'] = True
 
     fig = plt.figure()
     text = fig.text(0.5, 0.5, "Some text 0123456789")
     fig.canvas.draw()
 
-    mpl.rcParams['text.latex.preamble'] = r'\usepackage[dvipsnames]{xcolor}'
+    mpl.rcParams['text.latex.preamble'] = (
+        r'\PassOptionsToPackage{dvipsnames}{xcolor}\usepackage{%s}' % pkg)
     fig = plt.figure()
     text2 = fig.text(0.5, 0.5, "Some text 0123456789")
     fig.canvas.draw()


### PR DESCRIPTION
It's a bit a whack-a-mole, but heh...

Closes https://github.com/matplotlib/matplotlib/issues/20440.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
