### PR TITLE
Add initial TextBox widget testing

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -254,6 +254,27 @@ def test_CheckButtons():
     check.disconnect(cid)
 
 
+def check_TextBox():
+    def submit(text):
+        tool.set_val('x**1')
+
+    def change(text):
+        tool.color = '1.0'
+    ax = get_ax()
+    tool = widgets.TextBox(ax, 'Evaluate', color='.95', initial='x**2')
+    assert tool.text == 'x**2'
+    tool.on_submit(submit)
+    tool.on_text_change(change)
+    tool.begin_typing(tool.text)
+    tool.stop_typing()
+    assert tool.text == 'x**1'
+    assert tool.color == '1.0'
+
+
+def test_TextBox():
+    check_TextBox()
+
+
 @image_comparison(['check_radio_buttons.png'], style='mpl20', remove_text=True)
 def test_check_radio_buttons_image():
     # Remove this line when this test image is regenerated.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -254,25 +254,29 @@ def test_CheckButtons():
     check.disconnect(cid)
 
 
-def check_TextBox():
-    def submit(text):
-        tool.set_val('x**1')
-
-    def change(text):
-        tool.color = '1.0'
+def test_TextBox():
+    from unittest.mock import Mock
+    submit_event = Mock()
+    text_change_event = Mock()
     ax = get_ax()
-    tool = widgets.TextBox(ax, 'Evaluate', color='.95', initial='x**2')
+
+    tool = widgets.TextBox(ax, 'Evaluate')
+    tool.on_submit(submit_event)
+    tool.on_text_change(text_change_event)
+    tool.set_val('x**2')
+
     assert tool.text == 'x**2'
-    tool.on_submit(submit)
-    tool.on_text_change(change)
+    assert text_change_event.call_count == 1
+
     tool.begin_typing(tool.text)
     tool.stop_typing()
-    assert tool.text == 'x**1'
-    assert tool.color == '1.0'
 
+    assert submit_event.call_count == 2
+    do_event(tool, '_click')
+    do_event(tool, '_keypress', key='+')
+    do_event(tool, '_keypress', key='5')
 
-def test_TextBox():
-    check_TextBox()
+    assert text_change_event.call_count == 3
 
 
 @image_comparison(['check_radio_buttons.png'], style='mpl20', remove_text=True)


### PR DESCRIPTION
## PR Summary
This PR addresses the test coverage of TextBox widget on [Issue #20370](https://github.com/matplotlib/matplotlib/issues/20370). This is my first contributing issue, so I grabbed initial approach by the issue opener. I would gladly change whatever is needed.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
