### PR TITLE
Remove `Tick.apply_tickdir` from 3.4 deprecations.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.4.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.4.0/deprecations.rst
@@ -63,12 +63,6 @@ similar replacements.
 ``STYLE_FILE_PATTERN``, ``load_base_library``, and ``iter_user_libraries`` are
 deprecated.
 
-``Tick.apply_tickdir`` is deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``apply_tickdir`` didn't actually update the tick markers on the existing
-Line2D objects used to draw the ticks; use `.Axis.set_tick_params` instead.
-
 ``dpi_cor`` property of `.FancyArrowPatch`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## PR Summary

I'm not sure why I put this in here, but it is to be deprecated in 3.5, and there's no trace of a deprecation in 3.4.2.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).