### PR TITLE
Tell LGTM to use Python 3 explicitly.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,16 +3,16 @@ extraction:
     python_setup:
       version: 3
 path_classifiers:
-    examples:
-        # Exclude example files from analysis by tagging them.
-        # We intentionally use multiple imports and unused variables in the
-        # examples to make them more explicit. These generate a lot of alerts.
-        # Since lgtm does not yet support suppressing selected alerts per
-        # file, we currently deactivate analysis completely here. May be
-        # reactivated when we can selectively suppress
-        # - py/import-and-import-from
-        # - py/repeated-import
-        # - py/unused-local-variable
-        # - py/multiple-definition
-        - examples
-        - tutorials
+  examples:
+    # Exclude example files from analysis by tagging them.
+    # We intentionally use multiple imports and unused variables in the
+    # examples to make them more explicit. These generate a lot of alerts.
+    # Since lgtm does not yet support suppressing selected alerts per
+    # file, we currently deactivate analysis completely here. May be
+    # reactivated when we can selectively suppress
+    # - py/import-and-import-from
+    # - py/repeated-import
+    # - py/unused-local-variable
+    # - py/multiple-definition
+    - examples
+    - tutorials

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,3 +1,7 @@
+extraction:
+  python:
+    python_setup:
+      version: 3
 path_classifiers:
     examples:
         # Exclude example files from analysis by tagging them.


### PR DESCRIPTION
## PR Summary

I'm not sure if this affects the Python analysis (it might as there are some strange 'issues'), but the C/C++ analysis is definitely broken due to using Python 2 to build.

Also, re-indent the file consistently with YAML conventions.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).