### PR TITLE
Make lack of support more explicit for non-postscript fonts + usetex.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20474-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20474-AL.rst
@@ -1,0 +1,2 @@
+``dviread.PsfontsMap`` now raises LookupError instead of KeyError for missing fonts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -27,7 +27,6 @@ import re
 import struct
 import subprocess
 import sys
-import textwrap
 
 import numpy as np
 
@@ -852,14 +851,12 @@ class PsfontsMap:
         try:
             return self._parsed[texname]
         except KeyError:
-            fmt = ('An associated PostScript font (required by Matplotlib) '
-                   'could not be found for TeX font {0!r} in {1!r}.  This '
-                   'problem can often be solved by installing a suitable '
-                   'PostScript font package in your TeX package manager.')
-            _log.info(textwrap.fill(
-                fmt.format(texname.decode('ascii'), self._filename),
-                break_on_hyphens=False, break_long_words=False))
-            raise
+            raise LookupError(
+                f"An associated PostScript font (required by Matplotlib) "
+                f"could not be found for TeX font {texname.decode('ascii')!r} "
+                f"in {self._filename!r}; this problem can often be solved by "
+                f"installing a suitable PostScript font package in your TeX "
+                f"package manager") from None
 
     def _parse_and_cache_line(self, line):
         """

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -54,9 +54,9 @@ def test_PsfontsMap(monkeypatch):
     entry = fontmap[b'TeXfontC']
     assert entry.psname == b'PSfontC3'
     # Missing font
-    with pytest.raises(KeyError, match='no-such-font'):
+    with pytest.raises(LookupError, match='no-such-font'):
         fontmap[b'no-such-font']
-    with pytest.raises(KeyError, match='%'):
+    with pytest.raises(LookupError, match='%'):
         fontmap[b'%']
 
 


### PR DESCRIPTION
The info-level log can easily be hidden, and the KeyError may look like
a bug on Matplotlib's side.  Instead, explicitly raise an exception
whose error message states that Matplotlib doesn't currently support
certain cases.  (https://github.com/matplotlib/matplotlib/issues/20469)

Use a LookupError (a parent class of KeyError, so a slight API break)
rather than a KeyError as KeyError formats its argument as if it was the
missing key (calling repr on it), which would not be the case here.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
