### PR TITLE
remove _master attribute from FigureCanvasTk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -209,14 +209,13 @@ class FigureCanvasTk(FigureCanvasBase):
                 self.close_event()
         root.bind("<Destroy>", filter_destroy, "+")
 
-        self._master = master
         self._tkcanvas.focus_set()
 
     def _update_device_pixel_ratio(self, event=None):
         # Tk gives scaling with respect to 72 DPI, but most (all?) screens are
         # scaled vs 96 dpi, and pixel ratio settings are given in whole
         # percentages, so round to 2 digits.
-        ratio = round(self._master.call('tk', 'scaling') / (96 / 72), 2)
+        ratio = round(self._tkcanvas.tk.call('tk', 'scaling') / (96 / 72), 2)
         if self._set_device_pixel_ratio(ratio):
             # The easiest way to resize the canvas is to resize the canvas
             # widget itself, since we implement all the logic for resizing the
@@ -367,7 +366,7 @@ class FigureCanvasTk(FigureCanvasBase):
 
     def flush_events(self):
         # docstring inherited
-        self._master.update()
+        self._tkcanvas.update()
 
     def start_event_loop(self, timeout=0):
         # docstring inherited
@@ -379,14 +378,14 @@ class FigureCanvasTk(FigureCanvasBase):
             else:
                 self._event_loop_id = self._tkcanvas.after_idle(
                     self.stop_event_loop)
-        self._master.mainloop()
+        self._tkcanvas.mainloop()
 
     def stop_event_loop(self):
         # docstring inherited
         if self._event_loop_id:
-            self._master.after_cancel(self._event_loop_id)
+            self._tkcanvas.after_cancel(self._event_loop_id)
             self._event_loop_id = None
-        self._master.quit()
+        self._tkcanvas.quit()
 
 
 class FigureManagerTk(FigureManagerBase):


### PR DESCRIPTION


## PR Summary
The nominal parent widget of `FigureCanvasTk` can sometimes have a `call` method and sometimes not, occasionally breaking `_update_device_pixel_ratio`. However, the class has complete control over what `_tkcanvas` is, and `_tkcanvas` can substitute for all uses of `_master`.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
