### PR TITLE
Deprecate Colorbar.patch.

### DIFF
--- a/doc/api/next_api_changes/behavior/20054-JMK.rst
+++ b/doc/api/next_api_changes/behavior/20054-JMK.rst
@@ -5,3 +5,8 @@ If a colorbar has lines added to it (e.g. for contour lines), these will
 no longer be clipped.  This is an improvement for lines on the edge of
 the colorbar, but could lead to lines off the colorbar if the limits of
 the colorbar are changed.
+
+``Colorbar.patch`` is deprecated
+================================
+
+This attribute is not correctly updated anymore.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -451,10 +451,11 @@ class Colorbar:
             spine.set_visible(False)
         self.outline = self.ax.spines['outline'] = _ColorbarSpine(self.ax)
         self._short_axis().set_visible(False)
-        self.patch = mpatches.Polygon(
+        # Only kept for backcompat; remove after deprecation of .patch elapses.
+        self._patch = mpatches.Polygon(
             np.empty((0, 2)),
             color=mpl.rcParams['axes.facecolor'], linewidth=0.01, zorder=-1)
-        ax.add_artist(self.patch)
+        ax.add_artist(self._patch)
 
         self.dividers = collections.LineCollection(
             [],
@@ -486,6 +487,9 @@ class Colorbar:
 
         if isinstance(mappable, contour.ContourSet) and not mappable.filled:
             self.add_lines(mappable)
+
+    # Also remove ._patch after deprecation elapses.
+    patch = _api.deprecate_privatize_attribute("3.5")
 
     def update_normal(self, mappable):
         """


### PR DESCRIPTION
It is not used at all anymore (its vertices are not even set correctly)
since the switch to ColorbarAxes.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
