### PR TITLE
FIX: ColorbarAxes properly in the axes stack

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -227,9 +227,9 @@ class ColorbarAxes(Axes):
             True if the user passed `.Figure.colorbar` the axes manually.
         """
 
+        fig = parent.figure
         if userax:
             # copy position:
-            fig = parent.figure
             outer_ax = fig.add_axes(parent.get_position())
             # copy the locator if one exists:
             outer_ax._axes_locator = parent._axes_locator
@@ -243,11 +243,17 @@ class ColorbarAxes(Axes):
         else:
             outer_ax = parent
 
+        # swap axes in the stack:
+        fig._localaxes.remove(outer_ax)
+        fig._axstack.remove(outer_ax)
+        fig._localaxes.add(self)
+        fig._axstack.add(self)
         inner_ax = outer_ax.inset_axes([0, 0, 1, 1])
         self.__dict__.update(inner_ax.__dict__)
 
         self.outer_ax = outer_ax
         self.inner_ax = inner_ax
+
         self.outer_ax.xaxis.set_visible(False)
         self.outer_ax.yaxis.set_visible(False)
         self.outer_ax.set_facecolor('none')
@@ -268,6 +274,9 @@ class ColorbarAxes(Axes):
         """
         self.inner_ax._axes_locator = _TransformedBoundsLocator(
             bounds, self.outer_ax.transAxes)
+
+    def draw(self, renderer):
+        self.outer_ax.draw(renderer)
 
 
 class _ColorbarSpine(mspines.Spine):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -260,9 +260,15 @@ class ColorbarAxes(Axes):
         self.outer_ax.tick_params = self.inner_ax.tick_params
         self.outer_ax.set_xticks = self.inner_ax.set_xticks
         self.outer_ax.set_yticks = self.inner_ax.set_yticks
-        for attr in ["get_position", "set_position", "set_aspect"]:
+        for attr in ["get_position", "set_aspect", 
+                     "_remove_method", "_set_position",
+                     "set_position"]:
             setattr(self, attr, getattr(self.outer_ax, attr))
         self._colorbar_info = None  # used for mpl-created axes
+        if hasattr(self.outer_ax, "get_subplotspec"):
+            attr = "get_subplotspec"
+            setattr(self, attr, getattr(self.outer_ax, attr))
+
         if userax:
             self._colorbar_info = 'user'
             # point the parent's methods all at this axes...
@@ -277,6 +283,7 @@ class ColorbarAxes(Axes):
 
     def draw(self, renderer):
         self.outer_ax.draw(renderer)
+
 
 
 class _ColorbarSpine(mspines.Spine):
@@ -954,12 +961,11 @@ class Colorbar:
     def remove(self):
         """
         Remove this colorbar from the figure.
-
+        
         If the colorbar was created with ``use_gridspec=True`` the previous
         gridspec is restored.
         """
-        self.ax.inner_ax.remove()
-        self.ax.outer_ax.remove()
+        self.ax.remove()
 
         self.mappable.callbacksSM.disconnect(self.mappable.colorbar_cid)
         self.mappable.colorbar = None

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -260,8 +260,8 @@ class ColorbarAxes(Axes):
         self.outer_ax.tick_params = self.inner_ax.tick_params
         self.outer_ax.set_xticks = self.inner_ax.set_xticks
         self.outer_ax.set_yticks = self.inner_ax.set_yticks
-        for attr in ["get_position", "set_aspect", 
-                     "_remove_method", "_set_position",
+        for attr in ["get_position", "set_aspect",
+                    "_remove_method", "_set_position",
                      "set_position"]:
             setattr(self, attr, getattr(self.outer_ax, attr))
         self._colorbar_info = None  # used for mpl-created axes
@@ -283,7 +283,6 @@ class ColorbarAxes(Axes):
 
     def draw(self, renderer):
         self.outer_ax.draw(renderer)
-
 
 
 class _ColorbarSpine(mspines.Spine):
@@ -961,7 +960,7 @@ class Colorbar:
     def remove(self):
         """
         Remove this colorbar from the figure.
-        
+
         If the colorbar was created with ``use_gridspec=True`` the previous
         gridspec is restored.
         """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1200,7 +1200,7 @@ default: %(va)s
                 "disabling constrained_layout.")
         self.subplotpars.update(left, bottom, right, top, wspace, hspace)
         for ax in self.axes:
-            if isinstance(ax, SubplotBase):
+            if hasattr(ax, 'get_subplotspec'):
                 ax._set_position(ax.get_subplotspec().get_position(self))
         self.stale = True
 

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -3,7 +3,6 @@ import functools
 
 import numpy as np
 
-import matplotlib as mpl
 from matplotlib import _api
 from matplotlib.gridspec import SubplotSpec
 
@@ -29,19 +28,9 @@ class CbarAxesBase:
         orientation = (
             "horizontal" if self.orientation in ["top", "bottom"] else
             "vertical")
-        kwargs['userax'] = False
-        cb = mpl.colorbar.Colorbar(
-            self, mappable, orientation=orientation, ticks=ticks, **kwargs)
-        self._config_axes()
+        cb = self.figure.colorbar(mappable, cax=self, orientation=orientation,
+                                  ticks=ticks, **kwargs)
         return cb
-
-    def _config_axes(self):
-        """Make an axes patch and outline."""
-        ax = self
-        ax.set_navigate(False)
-        ax.axis[:].toggle(all=False)
-        b = self._default_label_on
-        ax.axis[self.orientation].toggle(all=b)
 
     def toggle_label(self, b):
         self._default_label_on = b
@@ -49,8 +38,9 @@ class CbarAxesBase:
         axis.toggle(ticklabels=b, label=b)
 
     def cla(self):
+        orientation = self.orientation
         super().cla()
-        self._config_axes()
+        self.orientation = orientation
 
 
 class CbarAxes(CbarAxesBase, Axes):


### PR DESCRIPTION
## PR Summary

Closes #20479

ColorbarAxes was not sitting in the figure Axes stacks correctly - rather cb.outer_axes was still in the queue.  Which worked fine, but didn't make mouseevents pass through properly.  

The solution here is to swap cb.ax for cb.outer_axes in the figure axes stacks, and to redefine `draw` on the ColorbarAxes to draw the outer axes first (i.e. set the aspect ratio and size of the bounding box for the colorbar).

I was testing on the following, though the real test is simply that cb.ax appears in the figure axes list now:

```python
import numpy as np
import matplotlib.pyplot as plt
#from matplotlib.backend_bases import MouseButton

def pick_fn(mouseevent):
    if mouseevent.inaxes is colorbar.ax:
        print('pick\n\nPICKKKKKKK')
        print(mouseevent.ydata, mouseevent.button)


def motion_fn(mouseevent):
    if mouseevent.inaxes is colorbar.ax:
        print(mouseevent.ydata, mouseevent.button)
        pass


fig, ax = plt.subplots()
canvas = fig.canvas
arr = np.random.randn(100, 100)
axesimage = plt.imshow(arr)
colorbar = plt.colorbar(axesimage, ax=ax, use_gridspec=True)

# helps you see what value you are about to set the range to
colorbar.ax.set_navigate(True)

canvas.mpl_connect("motion_notify_event", motion_fn)
colorbar.ax.set_picker(True)
canvas.mpl_connect("button_press_event", pick_fn)

plt.show()
```
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
