### PR TITLE
DOC: hexbin 'extent' must be 4-tuple of float, not float

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4648,7 +4648,7 @@ default: :rc:`scatter.edgecolors`
             left of the y-axis.
 
         extent : 4-tuple of float, default: *None*
-            The limits of the bins. The default assigns the limits
+            The limits of the bins (xmin, xmax, ymin, ymax) . The default assigns the limits
             based on *gridsize*, *x*, *y*, *xscale* and *yscale*.
 
             If *xscale* or *yscale* is set to 'log', the limits are

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4647,7 +4647,7 @@ default: :rc:`scatter.edgecolors`
             colormapped rectangles along the bottom of the x-axis and
             left of the y-axis.
 
-        extent : float, default: *None*
+        extent : 4-tuple of float, default: *None*
             The limits of the bins. The default assigns the limits
             based on *gridsize*, *x*, *y*, *xscale* and *yscale*.
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4657,8 +4657,6 @@ default: :rc:`scatter.edgecolors`
             x-limits of 1 and 50 in 'linear' scale and y-limits
             of 10 and 1000 in 'log' scale, enter (1, 50, 1, 3).
 
-            Order of scalars is (left, right, bottom, top).
-
         Returns
         -------
         `~matplotlib.collections.PolyCollection`

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4648,8 +4648,9 @@ default: :rc:`scatter.edgecolors`
             left of the y-axis.
 
         extent : 4-tuple of float, default: *None*
-            The limits of the bins (xmin, xmax, ymin, ymax) . The default assigns the limits
-            based on *gridsize*, *x*, *y*, *xscale* and *yscale*.
+            The limits of the bins (xmin, xmax, ymin, ymax).
+            The default assigns the limits based on
+            *gridsize*, *x*, *y*, *xscale* and *yscale*.
 
             If *xscale* or *yscale* is set to 'log', the limits are
             expected to be the exponent for a power of 10. E.g. for


### PR DESCRIPTION
## PR Summary

In this PR I want to fix the docstring for the hexbin parameter `extent`:

https://github.com/matplotlib/matplotlib/blob/2a3037fdefa2daab0b5e27cc400c6d9453bc091b/lib/matplotlib/axes/_axes.py#L4650

It previously said "float", but it actually wants a 4-tuple of floats, as evident from the code:

https://github.com/matplotlib/matplotlib/blob/2a3037fdefa2daab0b5e27cc400c6d9453bc091b/lib/matplotlib/axes/_axes.py#L4755-L4756



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
