### PR TITLE
[with findfont diff] Parsing all families in font_manager

### DIFF
--- a/examples/misc/logos2.py
+++ b/examples/misc/logos2.py
@@ -20,10 +20,10 @@ MPL_BLUE = '#11557c'
 def get_font_properties():
     # The original font is Calibri, if that is not installed, we fall back
     # to Carlito, which is metrically equivalent.
-    if 'Calibri' in matplotlib.font_manager.findfont('Calibri:bold'):
+    if 'Calibri' in matplotlib.font_manager.findfont('Calibri:bold').keys():
         return matplotlib.font_manager.FontProperties(family='Calibri',
                                                       weight='bold')
-    if 'Carlito' in matplotlib.font_manager.findfont('Carlito:bold'):
+    if 'Carlito' in matplotlib.font_manager.findfont('Carlito:bold').keys():
         print('Original font not found. Falling back to Carlito. '
               'The logo text will not be in the correct font.')
         return matplotlib.font_manager.FontProperties(family='Carlito',

--- a/examples/text_labels_and_annotations/font_table.py
+++ b/examples/text_labels_and_annotations/font_table.py
@@ -34,6 +34,7 @@ def print_glyphs(path):
     """
     if path is None:
         path = fm.findfont(fm.FontProperties())  # The default font.
+        path = next(iter(path.values()))  # Get the first filepath
 
     font = FT2Font(path)
 
@@ -60,6 +61,7 @@ def draw_font_table(path):
     """
     if path is None:
         path = fm.findfont(fm.FontProperties())  # The default font.
+        path = next(iter(path.values()))  # Get the first filepath
 
     font = FT2Font(path)
     # A charmap is a mapping of "character codes" (in the sense of a character

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -242,6 +242,9 @@ class TruetypeFonts(Fonts):
     def _get_font(self, font):
         if font in self.fontmap:
             basename = self.fontmap[font]
+            # TODO: allow multiple fonts
+            # for now settle with the first element
+            basename = next(iter(basename.values()))
         else:
             basename = font
         cached_font = self._fonts.get(basename)

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -108,6 +108,10 @@ class RendererPDFPSBase(RendererBase):
     def _get_font_afm(self, prop):
         fname = font_manager.findfont(
             prop, fontext="afm", directory=self._afm_font_dir)
+
+        # TODO: allow multiple font caching
+        # for now pass the first font
+        fname = next(iter(fname.values()))
         return _cached_get_afm_from_fname(fname)
 
     def _get_font_ttf(self, prop):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -830,9 +830,9 @@ class PdfFile:
         if isinstance(fontprop, str):
             filename = fontprop
         else:
-            if mpl.rcParams['pdf.use14corefonts']:
-                filename = findfont(
-                    fontprop, fontext='afm', directory=RendererPdf._afm_font_dir)
+            if mpl.rcParams["pdf.use14corefonts"]:
+                filename = findfont(fontprop, fontext="afm",
+                                    directory=RendererPdf._afm_font_dir)
             else:
                 filename = findfont(fontprop)
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -829,11 +829,16 @@ class PdfFile:
 
         if isinstance(fontprop, str):
             filename = fontprop
-        elif mpl.rcParams['pdf.use14corefonts']:
-            filename = findfont(
-                fontprop, fontext='afm', directory=RendererPdf._afm_font_dir)
         else:
-            filename = findfont(fontprop)
+            if mpl.rcParams['pdf.use14corefonts']:
+                filename = findfont(
+                    fontprop, fontext='afm', directory=RendererPdf._afm_font_dir)
+            else:
+                filename = findfont(fontprop)
+
+            # TODO: allow multiple fonts for PDF backend
+            # for now settle with the first element
+            filename = next(iter(filename.values()))
 
         Fx = self.fontNames.get(filename)
         if Fx is None:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -50,7 +50,13 @@ def get_fontspec():
         for family, command in zip(families, commands):
             # 1) Forward slashes also work on Windows, so don't mess with
             # backslashes.  2) The dirname needs to include a separator.
-            path = pathlib.Path(fm.findfont(family))
+            path = fm.findfont(family)
+
+            # TODO: Allow multiple fonts
+            # for now stick with the first font
+            path = next(iter(path.values()))
+
+            path = pathlib.Path(path)
             latex_fontspec.append(r"\%s{%s}[Path=\detokenize{%s}]" % (
                 command, path.name, path.parent.as_posix() + "/"))
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1098,7 +1098,9 @@ class FontManager:
     def defaultFont(self):
         # Lazily evaluated (findfont then caches the result) to avoid including
         # the venv path in the json serialization.
-        return {ext: self.findfont(family, fontext=ext)
+
+        # TODO: allow embedding multiple fonts
+        return {ext: next(iter(self.findfont(family, fontext=ext).values()))
                 for ext, family in self.defaultFamily.items()}
 
     def get_default_weight(self):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1020,19 +1020,6 @@ def json_load(filename):
         return json.load(fh, object_hook=_json_decode)
 
 
-class FontsPath:
-    """Class to hold the result of findfont"""
-    def __init__(self, file_paths):
-        self._filepaths = None
-        self.set_filepaths(file_paths)
-
-    def set_filepaths(self, file_paths):
-        self._filepaths = file_paths
-
-    def get_filepaths(self):
-        return self._filepaths
-
-
 def _normalize_font_family(family):
     if isinstance(family, str):
         family = [family]
@@ -1335,16 +1322,16 @@ class FontManager:
                 FontProperties._from_any(prop), fontext, directory,
                 fallback_to_default, rebuild_if_missing, rc_params)
 
-            # if fontfile isn't found, fpath will be a FontsPath object
-            if isinstance(fpath, FontsPath):
-                fbpaths.update(fpath.get_filepaths())
+            # if fontfile isn't found, fpath will be an OrderedDict
+            if isinstance(fpath, OrderedDict):
+                fbpaths.update(fpath)
             else:
                 fpaths[ffamily[fidx]] = fpath
 
         # append fallback font(s) to the very end
         fpaths.update(fbpaths)
 
-        return FontsPath(fpaths)
+        return fpaths
 
 
     @lru_cache()
@@ -1457,9 +1444,9 @@ if hasattr(os, "register_at_fork"):
 def get_font(filename, hinting_factor=None):
     # Resolving the path avoids embedding the font twice in pdf/ps output if a
     # single font is selected using two different relative paths.
-    if isinstance(filename, FontsPath):
+    if isinstance(filename, OrderedDict):
         filenames = []
-        for fname in filename.get_filepaths().values():
+        for fname in filename.values():
             filenames.append(_cached_realpath(fname))
     else:
         filenames = [_cached_realpath(filename)]

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1315,13 +1315,13 @@ class FontManager:
         # the other for fallback paths
         fpaths, fbpaths = OrderedDict(), OrderedDict()
         for fidx in range(len(ffamily)):
-            prop = prop.copy()
+            cprop = prop.copy()
 
             # set current prop's family
-            prop.set_family(ffamily[fidx])
+            cprop.set_family(ffamily[fidx])
 
             fpath = self._findfont_cached(
-                FontProperties._from_any(prop), fontext, directory,
+                FontProperties._from_any(cprop), fontext, directory,
                 fallback_to_default, rebuild_if_missing, rc_params)
 
             # if fontfile isn't found, fpath will be an OrderedDict

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1333,7 +1333,6 @@ class FontManager:
 
         return fpaths
 
-
     @lru_cache()
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
                          rebuild_if_missing, rc_params):

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -24,7 +24,8 @@ def test_font_priority():
             'font.sans-serif':
             ['cmmi10', 'Bitstream Vera Sans']}):
         font = findfont(FontProperties(family=["sans-serif"]))
-    assert Path(font).name == 'cmmi10.ttf'
+    # first font should be cmmi10.ttf
+    assert Path(next(iter(font.values()))).name == 'cmmi10.ttf'
 
     # Smoketest get_charmap, which isn't used internally anymore
     font = get_font(font)
@@ -110,7 +111,7 @@ def test_utf16m_sfnt():
 
 def test_find_ttc():
     fp = FontProperties(family=["WenQuanYi Zen Hei"])
-    if Path(findfont(fp)).name != "wqy-zenhei.ttc":
+    if "wqy-zenhei.ttc" not in map(lambda x: Path(x).name, findfont(fp)):
         pytest.skip("Font may be missing")
 
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -225,6 +225,8 @@ def test_mathfont_rendering(baseline_images, fontset, index, text):
 
 def test_fontinfo():
     fontpath = mpl.font_manager.findfont("DejaVu Sans")
+    # get the first element
+    fontpath = next(iter(fontpath.values()))
     font = mpl.ft2font.FT2Font(fontpath)
     table = font.get_sfnt_table("head")
     assert table['version'] == (1, 0)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -27,7 +27,7 @@ def test_font_styles():
     def find_matplotlib_font(**kw):
         prop = FontProperties(**kw)
         path = findfont(prop, directory=mpl.get_data_path())
-        return FontProperties(fname=path)
+        return FontProperties(fname=next(iter(path.values())))
 
     from matplotlib.font_manager import FontProperties, findfont
     warnings.filterwarnings(
@@ -198,6 +198,7 @@ def test_antialiasing():
 
 def test_afm_kerning():
     fn = mpl.font_manager.findfont("Helvetica", fontext="afm")
+    fn = next(iter(fn.values()))
     with open(fn, 'rb') as fh:
         afm = mpl.afm.AFM(fh)
     assert afm.string_width_height('VAVAVAVAVAVA') == (7174.0, 718)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -488,7 +488,10 @@ class ScalarFormatter(Formatter):
                 except ValueError:
                     ufont = None
 
-                if str(cbook._get_data_path("fonts/ttf/cmr10.ttf")) in ufont:
+                if (
+                    ufont is not None and
+                    str(cbook._get_data_path("fonts/ttf/cmr10.ttf")) in ufont
+                ):
                     _api.warn_external(
                         "cmr10 font should ideally be used with "
                         "mathtext, set axes.formatter.use_mathtext to True"

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -483,10 +483,12 @@ class ScalarFormatter(Formatter):
                         ),
                         fallback_to_default=False,
                     )
+                    # visit all values
+                    ufont = ufont.values()
                 except ValueError:
                     ufont = None
 
-                if ufont == str(cbook._get_data_path("fonts/ttf/cmr10.ttf")):
+                if str(cbook._get_data_path("fonts/ttf/cmr10.ttf")) in ufont:
                     _api.warn_external(
                         "cmr10 font should ideally be used with "
                         "mathtext, set axes.formatter.use_mathtext to True"


### PR DESCRIPTION
## PR Summary
#### This is the beginning of migrating from Matplotlib's "Font-First" approach to a "Text-First" approach.

The very first step is to parse all families in font manager. Previously, we only parsed families until we find a font file, and the rest of the backends are accustomed to just a single font file (which needs changing)

I'm _hoping_ this breaks many tests, so as to know exactly what to fix at other places.

- Change the return signature of `findfont`, from simple 'str' to 'OrderedDict'
- This OrderedDict would contain fonts defined by `font.family`
    - which are present on the system
    - but also append "fallback fonts" in the end. (which is triggered if a certain font family is not found in the system)
 
I've added a bunch of To-Dos (future PRs) and some fixes at some places.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
