### PR TITLE
Add rc_context to customizing tutorial

### DIFF
--- a/examples/lines_bars_and_markers/linestyles.py
+++ b/examples/lines_bars_and_markers/linestyles.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 
 linestyle_str = [
      ('solid', 'solid'),      # Same as (0, ()) or '-'
-     ('dotted', 'dotted'),    # Same as (0, (1, 1)) or '.'
+     ('dotted', 'dotted'),    # Same as (0, (1, 1)) or ':'
      ('dashed', 'dashed'),    # Same as '--'
      ('dashdot', 'dashdot')]  # Same as '-.'
 

--- a/tutorials/introductory/customizing.py
+++ b/tutorials/introductory/customizing.py
@@ -139,6 +139,27 @@ mpl.rc('lines', linewidth=4, linestyle='-.')
 plt.plot(data)
 
 ###############################################################################
+# Temporary rc settings
+# ---------------------
+#
+# The :data:`matplotlib.rcParams` object can also be changed temporarily using
+# the `matplotlib.rc_context` context manager:
+
+with mpl.rc_context({'lines.linewidth': 2, 'lines.linestyle': ':'}):
+    plt.plot(data)
+
+###############################################################################
+# `matplotlib.rc_context` can also be used as a decorator to modify the
+# defaults within a function:
+
+
+@mpl.rc_context({'lines.linewidth': 3, 'lines.linestyle': '-'})
+def plotting_function():
+    plt.plot(data)
+
+plotting_function()
+
+###############################################################################
 # `matplotlib.rcdefaults` will restore the standard Matplotlib
 # default settings.
 #


### PR DESCRIPTION
## PR Summary

`rc_context` is really useful and I think it deserves a mention in the "Customizing" tutorial.  While I was checking which options to use, I realised the comment in the linestyles example was wrong, so fixed it while I was there.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
