### PR TITLE
Fix calls to np.ma.masked_where

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1545,11 +1545,11 @@ class LogNorm(Normalize):
 
     def autoscale(self, A):
         # docstring inherited.
-        super().autoscale(np.ma.masked_less_equal(A, 0, copy=False))
+        super().autoscale(np.ma.array(A, mask=(A <= 0)))
 
     def autoscale_None(self, A):
         # docstring inherited.
-        super().autoscale_None(np.ma.masked_less_equal(A, 0, copy=False))
+        super().autoscale_None(np.ma.array(A, mask=(A <= 0)))
 
 
 @_make_norm_from_scale(

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -1158,8 +1158,10 @@ class Barbs(mcollections.PolyCollection):
         return barb_list
 
     def set_UVC(self, U, V, C=None):
-        self.u = ma.masked_invalid(U, copy=False).ravel()
-        self.v = ma.masked_invalid(V, copy=False).ravel()
+        # We need to ensure we have a copy, not a reference to an array that
+        # might change before draw().
+        self.u = ma.masked_invalid(U, copy=True).ravel()
+        self.v = ma.masked_invalid(V, copy=True).ravel()
 
         # Flip needs to have the same number of entries as everything else.
         # Use broadcast_to to avoid a bloated array of identical values.
@@ -1170,7 +1172,7 @@ class Barbs(mcollections.PolyCollection):
             flip = self.flip
 
         if C is not None:
-            c = ma.masked_invalid(C, copy=False).ravel()
+            c = ma.masked_invalid(C, copy=True).ravel()
             x, y, u, v, c, flip = cbook.delete_masked_points(
                 self.x.ravel(), self.y.ravel(), self.u, self.v, c,
                 flip.ravel())

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1233,6 +1233,34 @@ def test_imshow_quantitynd():
     fig.canvas.draw()
 
 
+@check_figures_equal(extensions=['png'])
+def test_norm_change(fig_test, fig_ref):
+    # LogNorm should not mask anything invalid permanently.
+    data = np.full((5, 5), 1, dtype=np.float64)
+    data[0:2, :] = -1
+
+    masked_data = np.ma.array(data, mask=False)
+    masked_data.mask[0:2, 0:2] = True
+
+    cmap = plt.get_cmap('viridis').with_extremes(under='w')
+
+    ax = fig_test.subplots()
+    im = ax.imshow(data, norm=colors.LogNorm(vmin=0.5, vmax=1),
+                   extent=(0, 5, 0, 5), interpolation='nearest', cmap=cmap)
+    im.set_norm(colors.Normalize(vmin=-2, vmax=2))
+    im = ax.imshow(masked_data, norm=colors.LogNorm(vmin=0.5, vmax=1),
+                   extent=(5, 10, 5, 10), interpolation='nearest', cmap=cmap)
+    im.set_norm(colors.Normalize(vmin=-2, vmax=2))
+    ax.set(xlim=(0, 10), ylim=(0, 10))
+
+    ax = fig_ref.subplots()
+    ax.imshow(data, norm=colors.Normalize(vmin=-2, vmax=2),
+              extent=(0, 5, 0, 5), interpolation='nearest', cmap=cmap)
+    ax.imshow(masked_data, norm=colors.Normalize(vmin=-2, vmax=2),
+              extent=(5, 10, 5, 10), interpolation='nearest', cmap=cmap)
+    ax.set(xlim=(0, 10), ylim=(0, 10))
+
+
 @pytest.mark.parametrize('x', [-1, 1])
 @check_figures_equal(extensions=['png'])
 def test_huge_range_log(fig_test, fig_ref, x):

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -202,6 +202,17 @@ def test_barbs_flip():
              flip_barb=Y < 0)
 
 
+def test_barb_copy():
+    fig, ax = plt.subplots()
+    u = np.array([1.1])
+    v = np.array([2.2])
+    b0 = ax.barbs([1], [1], u, v)
+    u[0] = 0
+    assert b0.u[0] == 1.1
+    v[0] = 0
+    assert b0.v[0] == 2.2
+
+
 def test_bad_masked_sizes():
     """Test error handling when given differing sized masked arrays."""
     x = np.arange(3)


### PR DESCRIPTION
## PR Summary

Due to numpy/numpy#18967, I've audited all our calls to `np.ma.masked_*(copy=False)`. When the input comes directly from the user, or is already stored somewhere already, then we don't want these calls to modify the existing values.

This affects `np.ma.masked_where` and all _simple_ wrappers around it like `masked_less_equal`. It does _not_ affect `masked_invalid`, which continues to not modify the input. I have asked upstream https://github.com/numpy/numpy/issues/19332 whether that is intended. If they intend to change `masked_invalid` also, then we will need to make a few more changes like this, but we are mostly okay.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
