### PR TITLE
 Support sketch_params in pgf backend

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -684,7 +684,7 @@ class Artist:
             \\usepgflibrary{decorations.pathmorphing}
 
         This also applies to PGF backend + PDF output, where this must be added
-        to `pgf.preamble` manually. The PGF backend uses the `randomness`
+        to *pgf.preamble* manually. The PGF backend uses the *randomness*
         argument as a seed and not as described below. Pass the same seed to
         obtain the same random shape.
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -679,7 +679,6 @@ class Artist:
 
         Requires the following preamble when using the PGF backend:
 
-            \\usepackage{pgf}
             \\usepgfmodule{decorations}
             \\usepgflibrary{decorations.pathmorphing}
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -677,16 +677,6 @@ class Artist:
         """
         Set the sketch parameters.
 
-        Requires the following preamble when using the PGF backend::
-
-            \\usepgfmodule{decorations}
-            \\usepgflibrary{decorations.pathmorphing}
-
-        This also applies to PGF backend + PDF output, where this must be added
-        to *pgf.preamble* manually. The PGF backend uses the *randomness*
-        argument as a seed and not as described below. Pass the same seed to
-        obtain the same random shape.
-
         Parameters
         ----------
         scale : float, optional
@@ -699,6 +689,9 @@ class Artist:
         randomness : float, optional
             The scale factor by which the length is shrunken or
             expanded (default 16.0)
+
+            The PGF backend uses this argument as an RNG seed and not as
+            described above. Using the same seed yields the same random shape.
 
             .. ACCEPTS: (scale: float, length: float, randomness: float)
         """

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -677,7 +677,7 @@ class Artist:
         """
         Set the sketch parameters.
 
-        Requires the following preamble when using the PGF backend:
+        Requires the following preamble when using the PGF backend::
 
             \\usepgfmodule{decorations}
             \\usepgflibrary{decorations.pathmorphing}

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -677,6 +677,17 @@ class Artist:
         """
         Set the sketch parameters.
 
+        Requires the following preamble when using the PGF backend:
+
+            \\usepackage{pgf}
+            \\usepgfmodule{decorations}
+            \\usepgflibrary{decorations.pathmorphing}
+
+        This also applies to PGF backend + PDF output, where this must be added
+        to `pgf.preamble` manually. The PGF backend uses the `randomness`
+        argument as a seed and not as described below. Pass the same seed to
+        obtain the same random shape.
+
         Parameters
         ----------
         scale : float, optional

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -611,13 +611,16 @@ class RendererPgf(RendererBase):
             # -> Use "randomness" as PRNG seed to allow the user to force the
             # same shape on multiple sketched lines
             scale, length, randomness = sketch_params
+            # make PGF output visually similar to matplotlib's sketched lines
+            adjustment_a = 0.5
+            adjustment_b = 2
             if scale is not None:
                 # PGF guarantees that repeated loading is a no-op
                 writeln(self.fh, r"\usepgfmodule{decorations}")
                 writeln(self.fh, r"\usepgflibrary{decorations.pathmorphing}")
                 writeln(self.fh, r"\pgfkeys{/pgf/decoration/.cd, "
-                        f"segment length = {(length * f):f}in, "
-                        f"amplitude = {(scale * f):f}in}}")
+                        f"segment length = {(length * f * adjustment_a):f}in, "
+                        f"amplitude = {(scale * f * adjustment_b):f}in}}")
                 writeln(self.fh, f"\\pgfmathsetseed{{{int(randomness)}}}")
                 writeln(self.fh, r"\pgfdecoratecurrentpath{random steps}")
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -603,10 +603,13 @@ class RendererPgf(RendererBase):
         # apply pgf decorators
         sketch_params = gc.get_sketch_params() if gc else None
         if sketch_params is not None:
-            # Only "length" directly maps to "segment length" in PGF's API
-            # The others are combined in "amplitude" -> Use "randomness" as
-            # PRNG seed to allow the user to force the same shape on multiple
-            # sketched lines
+            # Only "length" directly maps to "segment length" in PGF's API.
+            # PGF uses "amplitude" to pass the combined deviation in both x-
+            # and y-direction, while matplotlib only varies the length of the
+            # wiggle along the line ("randomness" and "length" parameters)
+            # and has a separate "scale" argument for the amplitude.
+            # -> Use "randomness" as PRNG seed to allow the user to force the
+            # same shape on multiple sketched lines
             scale, length, randomness = sketch_params
             if scale is not None:
                 writeln(self.fh, r"\pgfkeys{/pgf/decoration/.cd, "

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -600,6 +600,21 @@ class RendererPgf(RendererBase):
                         r"{\pgfqpoint{%fin}{%fin}}"
                         % coords)
 
+        # apply pgf decorators
+        sketch_params = gc.get_sketch_params() if gc else None
+        if sketch_params is not None:
+            # Only "length" directly maps to "segment length" in PGF's API
+            # The others are combined in "amplitude" -> Use "randomness" as
+            # PRNG seed to allow the user to force the same shape on multiple
+            # sketched lines
+            scale, length, randomness = sketch_params
+            if scale is not None:
+                writeln(self.fh, r"\pgfkeys{/pgf/decoration/.cd, "
+                        f"segment length = {(length * f):f}in, "
+                        f"amplitude = {(scale * f):f}in}}")
+                writeln(self.fh, f"\\pgfmathsetseed{{{int(randomness)}}}")
+                writeln(self.fh, r"\pgfdecoratecurrentpath{random steps}")
+
     def _pgf_path_draw(self, stroke=True, fill=False):
         actions = []
         if stroke:

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -611,16 +611,16 @@ class RendererPgf(RendererBase):
             # -> Use "randomness" as PRNG seed to allow the user to force the
             # same shape on multiple sketched lines
             scale, length, randomness = sketch_params
-            # make PGF output visually similar to matplotlib's sketched lines
-            adjustment_a = 0.5
-            adjustment_b = 2
             if scale is not None:
+                # make PGF output visually similar to matplotlib's sketched lines
+                length *= 0.5
+                scale *= 2
                 # PGF guarantees that repeated loading is a no-op
                 writeln(self.fh, r"\usepgfmodule{decorations}")
                 writeln(self.fh, r"\usepgflibrary{decorations.pathmorphing}")
                 writeln(self.fh, r"\pgfkeys{/pgf/decoration/.cd, "
-                        f"segment length = {(length * f * adjustment_a):f}in, "
-                        f"amplitude = {(scale * f * adjustment_b):f}in}}")
+                        f"segment length = {(length * f):f}in, "
+                        f"amplitude = {(scale * f):f}in}}")
                 writeln(self.fh, f"\\pgfmathsetseed{{{int(randomness)}}}")
                 writeln(self.fh, r"\pgfdecoratecurrentpath{random steps}")
 

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -612,6 +612,9 @@ class RendererPgf(RendererBase):
             # same shape on multiple sketched lines
             scale, length, randomness = sketch_params
             if scale is not None:
+                # PGF guarantees that repeated loading is a no-op
+                writeln(self.fh, r"\usepgfmodule{decorations}")
+                writeln(self.fh, r"\usepgflibrary{decorations.pathmorphing}")
                 writeln(self.fh, r"\pgfkeys{/pgf/decoration/.cd, "
                         f"segment length = {(length * f):f}in, "
                         f"amplitude = {(scale * f):f}in}}")

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -612,7 +612,7 @@ class RendererPgf(RendererBase):
             # same shape on multiple sketched lines
             scale, length, randomness = sketch_params
             if scale is not None:
-                # make PGF output visually similar to matplotlib's sketched lines
+                # make matplotlib and PGF rendering visually similar
                 length *= 0.5
                 scale *= 2
                 # PGF guarantees that repeated loading is a no-op

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -337,3 +337,38 @@ def test_minus_signs_with_tex(fig_test, fig_ref, texsystem):
     mpl.rcParams["pgf.texsystem"] = texsystem
     fig_test.text(.5, .5, "$-1$")
     fig_ref.text(.5, .5, "$\N{MINUS SIGN}1$")
+
+
+@pytest.mark.backend("pgf")
+def test_sketch_params():
+    fig, ax = plt.subplots(figsize=[3, 3])
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_frame_on(False)
+    handle = ax.plot([0, 1])[0]
+    handle.set_sketch_params(scale=5, length=30, randomness=42)
+
+    with BytesIO() as fd:
+        fig.savefig(fd, format='pgf')
+        buf = fd.getvalue().decode()
+
+    baseline = r"""\begin{pgfscope}%
+\pgfpathrectangle{\pgfqpoint{0.375000in}{0.300000in}}""" \
+    r"""{\pgfqpoint{2.325000in}{2.400000in}}%
+\pgfusepath{clip}%
+\pgfsetrectcap%
+\pgfsetroundjoin%
+\pgfsetlinewidth{1.003750pt}%
+\definecolor{currentstroke}{rgb}{0.000000,0.000000,1.000000}%
+\pgfsetstrokecolor{currentstroke}%
+\pgfsetdash{}{0pt}%
+\pgfpathmoveto{\pgfqpoint{0.375000in}{0.300000in}}%
+\pgfpathlineto{\pgfqpoint{2.700000in}{2.700000in}}%
+\pgfkeys{/pgf/decoration/.cd, """ \
+    r"""segment length = 0.300000in, amplitude = 0.050000in}%
+\pgfmathsetseed{42}%
+\pgfdecoratecurrentpath{random steps}%
+\pgfusepath{stroke}%
+\end{pgfscope}%"""
+    # check that \pgfkeys{/pgf/decoration/.cd, ...} is in path definition
+    assert baseline in buf

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -341,34 +341,24 @@ def test_minus_signs_with_tex(fig_test, fig_ref, texsystem):
 
 @pytest.mark.backend("pgf")
 def test_sketch_params():
-    fig, ax = plt.subplots(figsize=[3, 3])
+    fig, ax = plt.subplots(figsize=(3, 3))
     ax.set_xticks([])
     ax.set_yticks([])
     ax.set_frame_on(False)
-    handle = ax.plot([0, 1])[0]
+    handle, = ax.plot([0, 1])
     handle.set_sketch_params(scale=5, length=30, randomness=42)
 
     with BytesIO() as fd:
         fig.savefig(fd, format='pgf')
         buf = fd.getvalue().decode()
 
-    baseline = r"""\begin{pgfscope}%
-\pgfpathrectangle{\pgfqpoint{0.375000in}{0.300000in}}""" \
-    r"""{\pgfqpoint{2.325000in}{2.400000in}}%
-\pgfusepath{clip}%
-\pgfsetrectcap%
-\pgfsetroundjoin%
-\pgfsetlinewidth{1.003750pt}%
-\definecolor{currentstroke}{rgb}{0.000000,0.000000,1.000000}%
-\pgfsetstrokecolor{currentstroke}%
-\pgfsetdash{}{0pt}%
-\pgfpathmoveto{\pgfqpoint{0.375000in}{0.300000in}}%
+    baseline = r"""\pgfpathmoveto{\pgfqpoint{0.375000in}{0.300000in}}%
 \pgfpathlineto{\pgfqpoint{2.700000in}{2.700000in}}%
 \pgfkeys{/pgf/decoration/.cd, """ \
     r"""segment length = 0.300000in, amplitude = 0.050000in}%
 \pgfmathsetseed{42}%
 \pgfdecoratecurrentpath{random steps}%
-\pgfusepath{stroke}%
-\end{pgfscope}%"""
-    # check that \pgfkeys{/pgf/decoration/.cd, ...} is in path definition
+\pgfusepath{stroke}%"""
+    # \pgfdecoratecurrentpath must be after the path definition and before the
+    # path is used (\pgfusepath)
     assert baseline in buf

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -357,7 +357,7 @@ def test_sketch_params():
 \usepgfmodule{decorations}%
 \usepgflibrary{decorations.pathmorphing}%
 \pgfkeys{/pgf/decoration/.cd, """ \
-    r"""segment length = 0.300000in, amplitude = 0.050000in}%
+    r"""segment length = 0.150000in, amplitude = 0.100000in}%
 \pgfmathsetseed{42}%
 \pgfdecoratecurrentpath{random steps}%
 \pgfusepath{stroke}%"""

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -354,6 +354,8 @@ def test_sketch_params():
 
     baseline = r"""\pgfpathmoveto{\pgfqpoint{0.375000in}{0.300000in}}%
 \pgfpathlineto{\pgfqpoint{2.700000in}{2.700000in}}%
+\usepgfmodule{decorations}%
+\usepgflibrary{decorations.pathmorphing}%
 \pgfkeys{/pgf/decoration/.cd, """ \
     r"""segment length = 0.300000in, amplitude = 0.050000in}%
 \pgfmathsetseed{42}%


### PR DESCRIPTION
## PR Summary

Fixes matplotlib#20516

PGF's `random steps` decoration seems to be the most similar,
but does not exactly match the behaviour described in matplotlib's docs.
Therefore I repurposed the `randomness` argument as a seed to give
control on how the line looks afterwards:

### before 
![current](https://user-images.githubusercontent.com/37397269/123407735-907af300-d5ac-11eb-8fba-6e54d171de45.png)

### after 
with same seed for both lines: 

![wanted](https://user-images.githubusercontent.com/37397269/123407761-9a9cf180-d5ac-11eb-9bd0-432bac4de25c.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

I only tested this with '3.0.2', though.