### PR TITLE
Rename (N, M) -> (M, N) array-like

### DIFF
--- a/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -107,11 +107,11 @@ def heatmap(data, row_labels, col_labels, ax=None,
     Parameters
     ----------
     data
-        A 2D numpy array of shape (N, M).
+        A 2D numpy array of shape (M, N).
     row_labels
-        A list or array of length N with the labels for the rows.
+        A list or array of length M with the labels for the rows.
     col_labels
-        A list or array of length M with the labels for the columns.
+        A list or array of length N with the labels for the columns.
     ax
         A `matplotlib.axes.Axes` instance to which the heatmap is plotted.  If
         not provided, use current axes or create a new one.  Optional.

--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -86,7 +86,7 @@ def stack_hist(ax, stacked_data, sty_cycle, bottoms=None,
         The axes to add artists too
 
     stacked_data : array or Mapping
-        A (N, M) shaped array.  The first dimension will be iterated over to
+        A (M, N) shaped array.  The first dimension will be iterated over to
         compute histograms row-wise
 
     sty_cycle : Cycler or operable of dict

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1577,13 +1577,13 @@ class QuadContourSet(ContourSet):
 
             *X* and *Y* must both be 2D with the same shape as *Z* (e.g.
             created via `numpy.meshgrid`), or they must both be 1-D such
-            that ``len(X) == M`` is the number of columns in *Z* and
-            ``len(Y) == N`` is the number of rows in *Z*.
+            that ``len(X) == N`` is the number of columns in *Z* and
+            ``len(Y) == M`` is the number of rows in *Z*.
 
             If not given, they are assumed to be integer indices, i.e.
-            ``X = range(M)``, ``Y = range(N)``.
+            ``X = range(N)``, ``Y = range(M)``.
 
-        Z : (N, M) array-like
+        Z : (M, N) array-like
             The height values over which the contour is drawn.
 
         levels : int or array-like, optional


### PR DESCRIPTION
It's a quasi-convention to use the letters and ordering (M, N) for a
2D matrix; i.e. M rows and N columns. We already use this convention in
the majority of cases. This switches the letter ordering in some
remaining cases.

Note that this is a pure renaming without change of semantics.