### PR TITLE
Don't sort boxstyles/arrowstyles/etc. alphabetically.

### DIFF
--- a/examples/shapes_and_collections/fancybox_demo.py
+++ b/examples/shapes_and_collections/fancybox_demo.py
@@ -21,7 +21,7 @@ figheight = (spacing * len(styles) + .5)
 fig = plt.figure(figsize=(4 / 1.5, figheight / 1.5))
 fontsize = 0.3 * 72
 
-for i, stylename in enumerate(sorted(styles)):
+for i, stylename in enumerate(styles):
     fig.text(0.5, (spacing * (len(styles) - i) - 0.5) / figheight, stylename,
              ha="center",
              size=fontsize,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2138,7 +2138,7 @@ def _simpleprint_styles(_styles):
     {stylename: styleclass}, return a string rep of the list of keys.
     Used to update the documentation.
     """
-    return "[{}]".format("|".join(map(" '{}' ".format, sorted(_styles))))
+    return "[{}]".format("|".join(map(" '{}' ".format, _styles)))
 
 
 class _Style:
@@ -2184,7 +2184,7 @@ class _Style:
                     f'``{name}``',
                     # [1:-1] drops the surrounding parentheses.
                     str(inspect.signature(cls))[1:-1] or 'None')
-                   for name, cls in sorted(cls._style_list.items())]]
+                   for name, cls in cls._style_list.items()]]
         # Convert to rst table.
         col_len = [max(len(cell) for cell in column) for column in zip(*table)]
         table_formatstr = '  '.join('=' * cl for cl in col_len)


### PR DESCRIPTION
We now have source order, which should be more semantically more
meaningful.

Split out of #20531; see also #20430.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
