### PR TITLE
Show box/arrowstyle parameters in reference examples.

### DIFF
--- a/examples/shapes_and_collections/fancybox_demo.py
+++ b/examples/shapes_and_collections/fancybox_demo.py
@@ -6,6 +6,8 @@ Drawing fancy boxes
 The following examples show how to plot boxes with different visual properties.
 """
 
+import inspect
+
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import matplotlib.patches as mpatch
@@ -15,17 +17,26 @@ from matplotlib.patches import FancyBboxPatch
 # First we'll show some sample boxes with fancybox.
 
 styles = mpatch.BoxStyle.get_styles()
-spacing = 1.2
-
-figheight = (spacing * len(styles) + .5)
-fig = plt.figure(figsize=(4 / 1.5, figheight / 1.5))
-fontsize = 0.3 * 72
-
-for i, stylename in enumerate(styles):
-    fig.text(0.5, (spacing * (len(styles) - i) - 0.5) / figheight, stylename,
-             ha="center",
-             size=fontsize,
-             bbox=dict(boxstyle=stylename, fc="w", ec="k"))
+ncol = 2
+nrow = (len(styles) + 1) // ncol
+axs = (plt.figure(figsize=(3 * ncol, 1 + nrow))
+       .add_gridspec(1 + nrow, ncol, wspace=.5).subplots())
+for ax in axs.flat:
+    ax.set_axis_off()
+for ax in axs[0, :]:
+    ax.text(.2, .5, "boxstyle",
+            transform=ax.transAxes, size="large", color="tab:blue",
+            horizontalalignment="right", verticalalignment="center")
+    ax.text(.4, .5, "default parameters",
+            transform=ax.transAxes,
+            horizontalalignment="left", verticalalignment="center")
+for ax, (stylename, stylecls) in zip(axs[1:, :].T.flat, styles.items()):
+    ax.text(.2, .5, stylename, bbox=dict(boxstyle=stylename, fc="w", ec="k"),
+            transform=ax.transAxes, size="large", color="tab:blue",
+            horizontalalignment="right", verticalalignment="center")
+    ax.text(.4, .5, str(inspect.signature(stylecls))[1:-1].replace(", ", "\n"),
+            transform=ax.transAxes,
+            horizontalalignment="left", verticalalignment="center")
 
 
 ###############################################################################

--- a/examples/text_labels_and_annotations/fancyarrow_demo.py
+++ b/examples/text_labels_and_annotations/fancyarrow_demo.py
@@ -6,38 +6,41 @@ Annotation arrow style reference
 Overview of the arrow styles available in `~.Axes.annotate`.
 """
 
+import inspect
+
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 
 styles = mpatches.ArrowStyle.get_styles()
-
 ncol = 2
 nrow = (len(styles) + 1) // ncol
-figheight = (nrow + 0.5)
-fig = plt.figure(figsize=(4 * ncol / 1.5, figheight / 1.5))
-fontsize = 0.2 * 70
-
-ax = fig.add_axes([0, 0, 1, 1], frameon=False)
-ax.set(xlim=(0, 4 * ncol), ylim=(0, figheight))
-
-for i, (stylename, styleclass) in enumerate(styles.items()):
-    x = 3.2 + (i // nrow) * 4
-    y = (figheight - 0.7 - i % nrow)  # /figheight
-    p = mpatches.Circle((x, y), 0.2)
-    ax.add_patch(p)
-
-    ax.annotate(stylename, (x, y),
-                (x - 1.2, y),
-                ha="right", va="center",
-                size=fontsize,
-                arrowprops=dict(arrowstyle=stylename,
-                                patchB=p,
-                                shrinkA=5,
-                                shrinkB=5,
-                                fc="k", ec="k",
-                                connectionstyle="arc3,rad=-0.05",
-                                ),
+axs = (plt.figure(figsize=(4 * ncol, 1 + nrow))
+       .add_gridspec(1 + nrow, ncol,
+                     wspace=.5, left=.1, right=.9, bottom=0, top=1).subplots())
+for ax in axs.flat:
+    ax.set_axis_off()
+for ax in axs[0, :]:
+    ax.text(0, .5, "arrowstyle",
+            transform=ax.transAxes, size="large", color="tab:blue",
+            horizontalalignment="center", verticalalignment="center")
+    ax.text(.5, .5, "default parameters",
+            transform=ax.transAxes,
+            horizontalalignment="left", verticalalignment="center")
+for ax, (stylename, stylecls) in zip(axs[1:, :].T.flat, styles.items()):
+    l, = ax.plot(.35, .5, "ok", transform=ax.transAxes)
+    ax.annotate(stylename, (.35, .5), (0, .5),
+                xycoords="axes fraction", textcoords="axes fraction",
+                size="large", color="tab:blue",
+                horizontalalignment="center", verticalalignment="center",
+                arrowprops=dict(
+                    arrowstyle=stylename, connectionstyle="arc3,rad=-0.05",
+                    color="k", shrinkA=5, shrinkB=5, patchB=l,
+                ),
                 bbox=dict(boxstyle="square", fc="w"))
+    ax.text(.5, .5,
+            str(inspect.signature(stylecls))[1:-1].replace(", ", "\n"),
+            transform=ax.transAxes,
+            horizontalalignment="left", verticalalignment="center")
 
 plt.show()
 


### PR DESCRIPTION
This will allow later removing the table of values in the annotation
tutorial.

Also, draw things each in their axes and in axes coordinates, to
simplify the code.

Split out of #20531.

Before:
![oldbox](https://user-images.githubusercontent.com/1322974/123626376-1303ec80-d811-11eb-82b8-fae9a7b421e3.png)
![oldarrow](https://user-images.githubusercontent.com/1322974/123626369-113a2900-d811-11eb-8297-28a409f98de0.png)

After:
![newbox](https://user-images.githubusercontent.com/1322974/123626397-1ac39100-d811-11eb-8f13-95955b25c716.png)
![newarrow](https://user-images.githubusercontent.com/1322974/123626404-1bf4be00-d811-11eb-8296-e2ae0f7e7b1a.png)

In https://github.com/matplotlib/matplotlib/pull/20531#discussion_r659373062 @timhoffm has argued against the addition of all parameters; I think specifically for the example the effect may be neutral or indeed perhaps slightly negative, but the point is actually to remove the tables at https://github.com/matplotlib/matplotlib/blob/60ff0d4543f5b7e8fae4cc2afe23c9e52a1190ef/tutorials/text/annotations.py#L139-L151 and https://github.com/matplotlib/matplotlib/blob/60ff0d4543f5b7e8fae4cc2afe23c9e52a1190ef/tutorials/text/annotations.py#L241-L256 which can easily go out of sync and aren't particularly nice in the rendered docs either.

(Effectively, we have the problem that the example serves both as a standalone example and to generate a figure for the narrative tutorial, but I don't think it's worth duplicating the code to have two separate versions for the two tasks.)

Thoughts?

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
