### PR TITLE
Fix ScalarFormatter.format_ticks for non-ordered tick locations.

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -464,3 +464,13 @@ def test_contour_line_start_on_corner_edge():
     cbar = fig.colorbar(filled)
     lines = ax.contour(x, y, z, corner_mask=True, colors='k')
     cbar.add_lines(lines)
+
+
+@pytest.mark.style("default")
+def test_contour_autolabel_beyond_powerlimits():
+    ax = plt.figure().add_subplot()
+    cs = plt.contour(np.geomspace(1e-6, 1e-4, 100).reshape(10, 10),
+                     levels=[.25e-5, 1e-5, 4e-5])
+    ax.clabel(cs)
+    # Currently, the exponent is missing, but that may be fixed in the future.
+    assert {text.get_text() for text in ax.texts} == {"0.25", "1.00", "4.00"}

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -817,10 +817,7 @@ class ScalarFormatter(Formatter):
         if self.offset:
             oom = math.floor(math.log10(vmax - vmin))
         else:
-            if locs[0] > locs[-1]:
-                val = locs[0]
-            else:
-                val = locs[-1]
+            val = locs.max()
             if val == 0:
                 oom = 0
             else:


### PR DESCRIPTION
Non-ordered "ticks" locations can be used when using ScalarFormatter to
format contour lines.  Perhaps ContourLabeler.get_text could arrange for
the "ticks" to be ordered, but it's much easier to just support
non-ordered ticks in ScalarFormatter.

Fixes partially #20529: the lowest contour is now correctly printed as 0.25, not 2.5.  (The exponents are still missing, though.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
