### PR TITLE
Deprecate `@pytest.mark.style(...)`.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20543-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20543-AL.rst
@@ -1,0 +1,3 @@
+``@pytest.mark.style`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Use ``@mpl.style.context``, which has the same effect.

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -13,7 +13,8 @@ def pytest_configure(config):
         ("markers", "flaky: (Provided by pytest-rerunfailures.)"),
         ("markers", "timeout: (Provided by pytest-timeout.)"),
         ("markers", "backend: Set alternate Matplotlib backend temporarily."),
-        ("markers", "style: Set alternate Matplotlib style temporarily."),
+        ("markers",
+         "style: Set alternate Matplotlib style temporarily (deprecated)."),
         ("markers", "baseline_images: Compare output against references."),
         ("markers", "pytz: Tests that require pytz to be installed."),
         ("markers", "network: Tests that reach out to the network."),
@@ -65,6 +66,8 @@ def mpl_test_settings(request):
         if style_marker is not None:
             assert len(style_marker.args) == 1, \
                 "Marker 'style' must specify 1 style."
+            _api.warn_deprecated("3.5", name="style", obj_type="pytest marker",
+                                 alternative="@mpl.style.context(...)")
             style, = style_marker.args
 
         matplotlib.testing.setup()

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -18,7 +18,6 @@ from matplotlib import cbook
 from matplotlib import ft2font
 from matplotlib import pyplot as plt
 from matplotlib import ticker
-
 from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 
@@ -220,7 +219,7 @@ def _pytest_image_comparison(baseline_images, extensions, tol,
 
         @functools.wraps(func)
         @pytest.mark.parametrize('extension', extensions)
-        @pytest.mark.style(style)
+        @matplotlib.style.context(style)
         @_checked_on_freetype_version(freetype_version)
         @functools.wraps(func)
         def wrapper(*args, extension, request, **kwargs):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -457,7 +457,7 @@ def test_autoscale_tiny_range():
         ax.plot([0, 1], [1, 1 + y1])
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_autoscale_tight():
     fig, ax = plt.subplots(1, 1)
     ax.plot([1, 2, 3, 4])
@@ -467,7 +467,7 @@ def test_autoscale_tight():
     assert_allclose(ax.get_ylim(), (1.0, 4.0))
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_autoscale_log_shared():
     # related to github #7587
     # array starts at zero to trigger _minpos handling
@@ -485,7 +485,7 @@ def test_autoscale_log_shared():
     assert_allclose(ax2.get_ylim(), (x[0], x[-1]))
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_use_sticky_edges():
     fig, ax = plt.subplots()
     ax.imshow([[0, 1], [2, 3]], origin='lower')
@@ -822,7 +822,7 @@ def test_nonfinite_limits():
     ax.plot(x, y)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.parametrize('plot_fun',
                          ['scatter', 'plot', 'fill_between'])
 @check_figures_equal(extensions=["png"])
@@ -1696,8 +1696,8 @@ def test_bar_pandas_indexed(pd):
     ax.bar(df.x, 1., width=df.width)
 
 
+@mpl.style.context('default')
 @check_figures_equal()
-@pytest.mark.style('default')
 def test_bar_hatches(fig_test, fig_ref):
     ax_test = fig_test.subplots()
     ax_ref = fig_ref.subplots()
@@ -2190,7 +2190,7 @@ class TestScatter:
                                                    [0.5, 0.5, 0.5, 1]])
         assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
 
-    @pytest.mark.style('default')
+    @mpl.style.context('default')
     def test_scatter_unfillable(self):
         coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
                            marker='x',
@@ -2340,7 +2340,7 @@ class TestScatter:
                     c=c_case, edgecolors="black", kwargs={}, xsize=xsize,
                     get_next_color_func=get_next_color)
 
-    @pytest.mark.style('default')
+    @mpl.style.context('default')
     @check_figures_equal(extensions=["png"])
     def test_scatter_single_color_c(self, fig_test, fig_ref):
         rgb = [[1, 0.5, 0.05]]
@@ -5575,7 +5575,7 @@ def test_loglog_nonpos():
                 ax.set_yscale("log", nonpositive=mcy)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_axes_margins():
     fig, ax = plt.subplots()
     ax.plot([0, 1, 2, 3])
@@ -6060,7 +6060,7 @@ def test_tick_param_label_rotation():
         assert text.get_rotation() == 35
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_fillbetween_cycle():
     fig, ax = plt.subplots()
 
@@ -6878,7 +6878,7 @@ def test_polar_interpolation_steps_variable_r(fig_test, fig_ref):
         np.linspace(0, np.pi/2, 101), np.linspace(1, 2, 101))
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_autoscale_tiny_sticky():
     fig, ax = plt.subplots()
     ax.bar(0, 1e-9)
@@ -6908,7 +6908,7 @@ def test_ytickcolor_is_not_yticklabelcolor():
 
 @pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings
                                   if size is not None] + [8, 10, 12])
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_relative_ticklabel_sizes(size):
     mpl.rcParams['xtick.labelsize'] = size
     mpl.rcParams['ytick.labelsize'] = size
@@ -7066,7 +7066,7 @@ def test_patch_bounds():  # PR 19078
         np.array((-0.525, -(bot+0.05), 1.05, bot+0.1)), ax.dataLim.bounds, 16)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_warn_ignored_scatter_kwargs():
     with pytest.warns(UserWarning,
                       match=r"You passed a edgecolor/edgecolors"):

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -308,7 +308,7 @@ def test_missing_psfont(monkeypatch):
         fig.savefig(tmpfile, format='pdf')
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @check_figures_equal(extensions=["pdf", "eps"])
 def test_pdf_eps_savefig_when_color_is_none(fig_test, fig_ref):
     ax_test = fig_test.add_subplot()

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -118,7 +118,7 @@ def test_pdflatex():
 # test updating the rc parameters for each figure
 @needs_xelatex
 @needs_pdflatex
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_rcupdate():
     rc_sets = [{'font.family': 'sans-serif',
@@ -149,7 +149,7 @@ def test_rcupdate():
 
 # test backend-side clipping, since large numbers are not supported by TeX
 @needs_xelatex
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_pathclip():
     np.random.seed(19680801)
@@ -179,7 +179,7 @@ def test_mixedmode():
 
 # test bbox_inches clipping
 @needs_xelatex
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_bbox_inches():
     mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
@@ -192,7 +192,7 @@ def test_bbox_inches():
                    tol=0)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.backend('pgf')
 @pytest.mark.parametrize('system', [
     pytest.param('lualatex', marks=[needs_lualatex]),
@@ -234,7 +234,7 @@ def test_pdf_pages(system):
         assert pdf.get_pagecount() == 3
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.backend('pgf')
 @pytest.mark.parametrize('system', [
     pytest.param('lualatex', marks=[needs_lualatex]),

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -198,7 +198,7 @@ def test_missing_psfont(monkeypatch):
 
 
 # Use Computer Modern Sans Serif, not Helvetica (which has no \textwon).
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @needs_usetex
 def test_unicode_won():
     fig = Figure()

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -2,6 +2,7 @@
 import pytest
 import numpy as np
 
+import matplotlib as mpl
 from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
@@ -281,7 +282,7 @@ class TestPlotTypes:
             plotter(ax, xdata, [1, 2])
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @check_figures_equal(extensions=["png"])
 def test_overriding_units_in_plot(fig_test, fig_ref):
     from datetime import datetime

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -304,7 +304,7 @@ def test_add_collection():
     assert ax.dataLim.bounds == bounds
 
 
-@pytest.mark.style('mpl20')
+@mpl.style.context('mpl20')
 @check_figures_equal(extensions=['png'])
 def test_collection_log_datalim(fig_test, fig_ref):
     # Data limits should respect the minimum x/y when using log scale.
@@ -515,7 +515,7 @@ def test_pandas_indexing(pd):
     Collection(antialiaseds=aa)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_lslw_bcast():
     col = mcollections.PathCollection([])
     col.set_linestyles(['-', '-'])
@@ -529,7 +529,7 @@ def test_lslw_bcast():
     assert (col.get_linewidths() == [1, 2, 3]).all()
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_capstyle():
     col = mcollections.PathCollection([], capstyle='round')
     assert col.get_capstyle() == 'round'
@@ -537,7 +537,7 @@ def test_capstyle():
     assert col.get_capstyle() == 'butt'
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_joinstyle():
     col = mcollections.PathCollection([], joinstyle='round')
     assert col.get_joinstyle() == 'round'
@@ -933,7 +933,7 @@ def test_legend_inverse_size_label_relationship():
     assert_array_almost_equal(handle_sizes, legend_sizes, decimal=1)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @pytest.mark.parametrize('pcfunc', [plt.pcolor, plt.pcolormesh])
 def test_color_logic(pcfunc):
     z = np.arange(12).reshape(3, 4)

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -466,7 +466,7 @@ def test_contour_line_start_on_corner_edge():
     cbar.add_lines(lines)
 
 
-@pytest.mark.style("default")
+@mpl.style.context("default")
 def test_contour_autolabel_beyond_powerlimits():
     ax = plt.figure().add_subplot()
     cs = plt.contour(np.geomspace(1e-6, 1e-4, 100).reshape(10, 10),

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -409,7 +409,7 @@ def test_autofmt_xdate(which):
             assert int(label.get_rotation()) == angle
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_change_dpi():
     fig = plt.figure(figsize=(4, 4))
     fig.draw_no_output()
@@ -598,7 +598,7 @@ def test_removed_axis():
     fig.canvas.draw()
 
 
-@pytest.mark.style('mpl20')
+@mpl.style.context('mpl20')
 def test_picking_does_not_stale():
     fig, ax = plt.subplots()
     col = ax.scatter([0], [0], [1000], picker=True)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1117,7 +1117,7 @@ def test_image_array_alpha_validation():
         plt.imshow(np.zeros((2, 2)), alpha=[1, 1])
 
 
-@pytest.mark.style('mpl20')
+@mpl.style.context('mpl20')
 def test_exact_vmin():
     cmap = copy(plt.cm.get_cmap("autumn_r"))
     cmap.set_under(color="lightgrey")

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
+import matplotlib as mpl
 from matplotlib.patches import (Annulus, Patch, Polygon, Rectangle,
                                 FancyArrowPatch)
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -12,7 +13,7 @@ from matplotlib.transforms import Bbox
 import matplotlib.pyplot as plt
 from matplotlib import (
     collections as mcollections, colors as mcolors, patches as mpatches,
-    path as mpath, style as mstyle, transforms as mtransforms, rcParams)
+    path as mpath, transforms as mtransforms, rcParams)
 
 import sys
 on_win = (sys.platform == 'win32')
@@ -197,7 +198,7 @@ def test_patch_alpha_override():
     ax.set_ylim([-1, 2])
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_patch_color_none():
     # Make sure the alpha kwarg does not override 'none' facecolor.
     # Addresses issue #7478.
@@ -410,7 +411,7 @@ def test_multi_color_hatch():
     ax.autoscale(False)
 
     for i in range(5):
-        with mstyle.context({'hatch.color': 'C{}'.format(i)}):
+        with mpl.style.context({'hatch.color': 'C{}'.format(i)}):
             r = Rectangle((i - .8 / 2, 5), .8, 1, hatch='//', fc='none')
         ax.add_patch(r)
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -672,7 +672,7 @@ class TestLogFormatterSciNotation:
         (10, 500000, '$\\mathdefault{5\\times10^{5}}$'),
     ]
 
-    @pytest.mark.style('default')
+    @mpl.style.context('default')
     @pytest.mark.parametrize('base, value, expected', test_data)
     def test_basic(self, base, value, expected):
         formatter = mticker.LogFormatterSciNotation(base=base)
@@ -833,7 +833,7 @@ class TestLogFormatter:
         label_test = [fmt(x) != '' for x in minor_tlocs]
         assert label_test == label_expected
 
-    @pytest.mark.style('default')
+    @mpl.style.context('default')
     def test_sublabel(self):
         # test label locator
         fig, ax = plt.subplots()
@@ -1368,7 +1368,7 @@ def test_bad_locator_subs(sub):
 
 
 @pytest.mark.parametrize('numticks', [1, 2, 3, 9])
-@pytest.mark.style('default')
+@mpl.style.context('default')
 def test_small_range_loglocator(numticks):
     ll = mticker.LogLocator()
     ll.set_params(numticks=numticks)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1403,7 +1403,7 @@ def test_pan():
     assert z_center != pytest.approx(z_center0)
 
 
-@pytest.mark.style('default')
+@mpl.style.context('default')
 @check_figures_equal(extensions=["png"])
 def test_scalarmap_update(fig_test, fig_ref):
 


### PR DESCRIPTION
`@mpl.style.context` can be used in the same way (and is just as
greppable), but doesn't require any support from the pytest machinery.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
