### PR TITLE
Improve tutorial figures in the new theme

### DIFF
--- a/examples/axes_grid1/simple_axes_divider1.py
+++ b/examples/axes_grid1/simple_axes_divider1.py
@@ -18,48 +18,51 @@ def label_axes(ax, text):
                    left=False, labelleft=False)
 
 
-fig = plt.figure(figsize=(12, 6))
-sfs = fig.subfigures(1, 2)
+##############################################################################
+# Fixed axes sizes; fixed paddings.
 
+fig = plt.figure(figsize=(6, 6))
+fig.suptitle("Fixed axes sizes, fixed paddings")
 
-sfs[0].suptitle("Fixed axes sizes, fixed paddings")
 # Sizes are in inches.
 horiz = [Size.Fixed(1.), Size.Fixed(.5), Size.Fixed(1.5), Size.Fixed(.5)]
 vert = [Size.Fixed(1.5), Size.Fixed(.5), Size.Fixed(1.)]
 
 rect = (0.1, 0.1, 0.8, 0.8)
 # Divide the axes rectangle into a grid with sizes specified by horiz * vert.
-div = Divider(sfs[0], rect, horiz, vert, aspect=False)
+div = Divider(fig, rect, horiz, vert, aspect=False)
 
 # The rect parameter will actually be ignored and overridden by axes_locator.
-ax1 = sfs[0].add_axes(rect, axes_locator=div.new_locator(nx=0, ny=0))
+ax1 = fig.add_axes(rect, axes_locator=div.new_locator(nx=0, ny=0))
 label_axes(ax1, "nx=0, ny=0")
-ax2 = sfs[0].add_axes(rect, axes_locator=div.new_locator(nx=0, ny=2))
+ax2 = fig.add_axes(rect, axes_locator=div.new_locator(nx=0, ny=2))
 label_axes(ax2, "nx=0, ny=2")
-ax3 = sfs[0].add_axes(rect, axes_locator=div.new_locator(nx=2, ny=2))
+ax3 = fig.add_axes(rect, axes_locator=div.new_locator(nx=2, ny=2))
 label_axes(ax3, "nx=2, ny=2")
-ax4 = sfs[0].add_axes(rect, axes_locator=div.new_locator(nx=2, nx1=4, ny=0))
+ax4 = fig.add_axes(rect, axes_locator=div.new_locator(nx=2, nx1=4, ny=0))
 label_axes(ax4, "nx=2, nx1=4, ny=0")
 
+##############################################################################
+# Axes sizes that scale with the figure size; fixed paddings.
 
-sfs[1].suptitle("Scalable axes sizes, fixed paddings")
-# Fixed sizes are in inches, scaled sizes are relative.
+fig = plt.figure(figsize=(6, 6))
+fig.suptitle("Scalable axes sizes, fixed paddings")
+
 horiz = [Size.Scaled(1.5), Size.Fixed(.5), Size.Scaled(1.), Size.Scaled(.5)]
 vert = [Size.Scaled(1.), Size.Fixed(.5), Size.Scaled(1.5)]
 
 rect = (0.1, 0.1, 0.8, 0.8)
 # Divide the axes rectangle into a grid with sizes specified by horiz * vert.
-div = Divider(sfs[1], rect, horiz, vert, aspect=False)
+div = Divider(fig, rect, horiz, vert, aspect=False)
 
 # The rect parameter will actually be ignored and overridden by axes_locator.
-ax1 = sfs[1].add_axes(rect, axes_locator=div.new_locator(nx=0, ny=0))
+ax1 = fig.add_axes(rect, axes_locator=div.new_locator(nx=0, ny=0))
 label_axes(ax1, "nx=0, ny=0")
-ax2 = sfs[1].add_axes(rect, axes_locator=div.new_locator(nx=0, ny=2))
+ax2 = fig.add_axes(rect, axes_locator=div.new_locator(nx=0, ny=2))
 label_axes(ax2, "nx=0, ny=2")
-ax3 = sfs[1].add_axes(rect, axes_locator=div.new_locator(nx=2, ny=2))
+ax3 = fig.add_axes(rect, axes_locator=div.new_locator(nx=2, ny=2))
 label_axes(ax3, "nx=2, ny=2")
-ax4 = sfs[1].add_axes(rect, axes_locator=div.new_locator(nx=2, nx1=4, ny=0))
+ax4 = fig.add_axes(rect, axes_locator=div.new_locator(nx=2, nx1=4, ny=0))
 label_axes(ax4, "nx=2, nx1=4, ny=0")
-
 
 plt.show()

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -30,7 +30,7 @@ def demo_con_style(ax, connectionstyle):
             transform=ax.transAxes, ha="left", va="top")
 
 
-fig, axs = plt.subplots(3, 5, figsize=(8, 4.8))
+fig, axs = plt.subplots(3, 5, figsize=(7, 6.3), constrained_layout=True)
 demo_con_style(axs[0, 0], "angle3,angleA=90,angleB=0")
 demo_con_style(axs[1, 0], "angle3,angleA=0,angleB=90")
 demo_con_style(axs[0, 1], "arc3,rad=0.")
@@ -47,8 +47,8 @@ demo_con_style(axs[1, 4], "bar,fraction=-0.3")
 demo_con_style(axs[2, 4], "bar,angle=180,fraction=-0.2")
 
 for ax in axs.flat:
-    ax.set(xlim=(0, 1), ylim=(0, 1), xticks=[], yticks=[], aspect=1)
-fig.tight_layout(pad=0.2)
+    ax.set(xlim=(0, 1), ylim=(0, 1.25), xticks=[], yticks=[], aspect=1.25)
+fig.set_constrained_layout_pads(wspace=0, hspace=0, w_pad=0, h_pad=0)
 
 plt.show()
 

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -48,7 +48,7 @@ print(viridis(0.56))
 # ListedColormap
 # --------------
 #
-# `.ListedColormap` s store their color values in a ``.colors`` attribute.
+# `.ListedColormap`\s store their color values in a ``.colors`` attribute.
 # The list of colors that comprise the colormap can be directly accessed using
 # the ``colors`` property,
 # or it can be accessed indirectly by calling  ``viridis`` with an array
@@ -68,7 +68,7 @@ print('viridis(np.linspace(0, 1, 12))', viridis(np.linspace(0, 1, 12)))
 ##############################################################################
 # LinearSegmentedColormap
 # -----------------------
-# `.LinearSegmentedColormap` s do not have a ``.colors`` attribute.
+# `.LinearSegmentedColormap`\s do not have a ``.colors`` attribute.
 # However, one may still call the colormap with an integer array, or with a
 # float array between 0 and 1.
 
@@ -114,7 +114,7 @@ plot_examples([cmap])
 
 ##############################################################################
 # In fact, that list may contain any valid
-# :doc:`matplotlib color specification </tutorials/colors/colors>`.
+# :doc:`Matplotlib color specification </tutorials/colors/colors>`.
 # Particularly useful for creating custom colormaps are Nx4 numpy arrays.
 # Because with the variety of numpy operations that we can do on a such an
 # array, carpentry of new colormaps from existing colormaps become quite
@@ -168,7 +168,7 @@ plot_examples([viridis, newcmp])
 # Creating linear segmented colormaps
 # ===================================
 #
-# `.LinearSegmentedColormap` class specifies colormaps using anchor points
+# The `.LinearSegmentedColormap` class specifies colormaps using anchor points
 # between which RGB(A) values are interpolated.
 #
 # The format to specify these colormaps allows discontinuities at the anchor
@@ -177,7 +177,7 @@ plot_examples([viridis, newcmp])
 # ``yleft[i]`` and ``yright[i]`` are the values of the color on either
 # side of the anchor point.
 #
-# If there are no discontinuities, then ``yleft[i]=yright[i]``:
+# If there are no discontinuities, then ``yleft[i] == yright[i]``:
 
 cdict = {'red':   [[0.0,  0.0, 0.0],
                    [0.5,  1.0, 1.0],
@@ -221,9 +221,10 @@ plot_linearmap(cdict)
 #
 # In the example below there is a discontinuity in red at 0.5.  The
 # interpolation between 0 and 0.5 goes from 0.3 to 1, and between 0.5 and 1
-# it goes from 0.9 to 1.  Note that red[0, 1], and red[2, 2] are both
-# superfluous to the interpolation because red[0, 1] is the value to the
-# left of 0, and red[2, 2] is the value to the right of 1.0.
+# it goes from 0.9 to 1.  Note that ``red[0, 1]``, and ``red[2, 2]`` are both
+# superfluous to the interpolation because ``red[0, 1]`` (i.e., ``yleft[0]``)
+# is the value to the left of 0, and ``red[2, 2]`` (i.e., ``yright[2]``) is the
+# value to the right of 1, which are outside the color mapping domain.
 
 cdict['red'] = [[0.0,  0.0, 0.3],
                 [0.5,  1.0, 0.9],
@@ -234,7 +235,7 @@ plot_linearmap(cdict)
 # Directly creating a segmented colormap from a list
 # --------------------------------------------------
 #
-# The above described is a very versatile approach, but admittedly a bit
+# The approach described above is very versatile, but admittedly a bit
 # cumbersome to implement. For some basic cases, the use of
 # `.LinearSegmentedColormap.from_list` may be easier. This creates a segmented
 # colormap with equal spacings from a supplied list of colors.
@@ -243,8 +244,8 @@ colors = ["darkorange", "gold", "lawngreen", "lightseagreen"]
 cmap1 = LinearSegmentedColormap.from_list("mycmap", colors)
 
 #############################################################################
-# If desired, the nodes of the colormap can be given as numbers
-# between 0 and 1. E.g. one could have the reddish part take more space in the
+# If desired, the nodes of the colormap can be given as numbers between 0 and
+# 1. For example, one could have the reddish part take more space in the
 # colormap.
 
 nodes = [0.0, 0.4, 0.8, 1.0]

--- a/tutorials/colors/colormaps.py
+++ b/tutorials/colors/colormaps.py
@@ -47,6 +47,8 @@ An excellent starting resource for learning about human perception of colormaps
 is from [IBM]_.
 
 
+.. _color-colormaps_reference:
+
 Classes of colormaps
 ====================
 
@@ -82,7 +84,38 @@ from matplotlib import cm
 from colorspacious import cspace_converter
 
 
+###############################################################################
+#
+# First, we'll show the range of each colormap. Note that some seem
+# to change more "quickly" than others.
+
 cmaps = {}
+
+gradient = np.linspace(0, 1, 256)
+gradient = np.vstack((gradient, gradient))
+
+
+def plot_color_gradients(category, cmap_list):
+    # Create figure and adjust figure height to number of colormaps
+    nrows = len(cmap_list)
+    figh = 0.35 + 0.15 + (nrows + (nrows - 1) * 0.1) * 0.22
+    fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6.4, figh))
+    fig.subplots_adjust(top=1 - 0.35 / figh, bottom=0.15 / figh,
+                        left=0.2, right=0.99)
+    axs[0].set_title(f'{category} colormaps', fontsize=14)
+
+    for ax, name in zip(axs, cmap_list):
+        ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
+        ax.text(-0.01, 0.5, name, va='center', ha='right', fontsize=10,
+                transform=ax.transAxes)
+
+    # Turn off *all* ticks & spines, not just the ones with colormaps.
+    for ax in axs:
+        ax.set_axis_off()
+
+    # Save colormap list for later.
+    cmaps[category] = cmap_list
+
 
 ###############################################################################
 # Sequential
@@ -96,13 +129,15 @@ cmaps = {}
 # amongst the colormaps: some are approximately linear in :math:`L^*` and others
 # are more curved.
 
-cmaps['Perceptually Uniform Sequential'] = [
-            'viridis', 'plasma', 'inferno', 'magma', 'cividis']
+plot_color_gradients('Perceptually Uniform Sequential',
+                     ['viridis', 'plasma', 'inferno', 'magma', 'cividis'])
 
-cmaps['Sequential'] = [
-            'Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
-            'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
-            'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn']
+###############################################################################
+
+plot_color_gradients('Sequential',
+                     ['Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
+                      'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
+                      'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn'])
 
 ###############################################################################
 # Sequential2
@@ -116,10 +151,10 @@ cmaps['Sequential'] = [
 # banding of the data in those values in the colormap (see [mycarta-banding]_ for
 # an excellent example of this).
 
-cmaps['Sequential (2)'] = [
-            'binary', 'gist_yarg', 'gist_gray', 'gray', 'bone', 'pink',
-            'spring', 'summer', 'autumn', 'winter', 'cool', 'Wistia',
-            'hot', 'afmhot', 'gist_heat', 'copper']
+plot_color_gradients('Sequential (2)',
+                     ['binary', 'gist_yarg', 'gist_gray', 'gray', 'bone',
+                      'pink', 'spring', 'summer', 'autumn', 'winter', 'cool',
+                      'Wistia', 'hot', 'afmhot', 'gist_heat', 'copper'])
 
 ###############################################################################
 # Diverging
@@ -132,9 +167,9 @@ cmaps['Sequential (2)'] = [
 # measures, BrBG and RdBu are good options. coolwarm is a good option, but it
 # doesn't span a wide range of :math:`L^*` values (see grayscale section below).
 
-cmaps['Diverging'] = [
-            'PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
-            'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic']
+plot_color_gradients('Diverging',
+                     ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu', 'RdYlBu',
+                      'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic'])
 
 ###############################################################################
 # Cyclic
@@ -154,7 +189,7 @@ cmaps['Diverging'] = [
 # for viewers to see perceptually. See an extension on this idea at
 # [mycarta-jet]_.
 
-cmaps['Cyclic'] = ['twilight', 'twilight_shifted', 'hsv']
+plot_color_gradients('Cyclic', ['twilight', 'twilight_shifted', 'hsv'])
 
 ###############################################################################
 # Qualitative
@@ -165,9 +200,10 @@ cmaps['Cyclic'] = ['twilight', 'twilight_shifted', 'hsv']
 # the place throughout the colormap, and are clearly not monotonically increasing.
 # These would not be good options for use as perceptual colormaps.
 
-cmaps['Qualitative'] = ['Pastel1', 'Pastel2', 'Paired', 'Accent',
-                        'Dark2', 'Set1', 'Set2', 'Set3',
-                        'tab10', 'tab20', 'tab20b', 'tab20c']
+plot_color_gradients('Qualitative',
+                     ['Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2',
+                      'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b',
+                      'tab20c'])
 
 ###############################################################################
 # Miscellaneous
@@ -189,43 +225,12 @@ cmaps['Qualitative'] = ['Pastel1', 'Pastel2', 'Paired', 'Accent',
 # poor choice for representing data for viewers to see perceptually. See an
 # extension on this idea at [mycarta-jet]_ and [turbo]_.
 
-cmaps['Miscellaneous'] = [
-            'flag', 'prism', 'ocean', 'gist_earth', 'terrain', 'gist_stern',
-            'gnuplot', 'gnuplot2', 'CMRmap', 'cubehelix', 'brg',
-            'gist_rainbow', 'rainbow', 'jet', 'turbo', 'nipy_spectral',
-            'gist_ncar']
 
-###############################################################################
-# .. _color-colormaps_reference:
-#
-# First, we'll show the range of each colormap. Note that some seem
-# to change more "quickly" than others.
-
-gradient = np.linspace(0, 1, 256)
-gradient = np.vstack((gradient, gradient))
-
-
-def plot_color_gradients(cmap_category, cmap_list):
-    # Create figure and adjust figure height to number of colormaps
-    nrows = len(cmap_list)
-    figh = 0.35 + 0.15 + (nrows + (nrows - 1) * 0.1) * 0.22
-    fig, axs = plt.subplots(nrows=nrows + 1, figsize=(6.4, figh))
-    fig.subplots_adjust(top=1 - 0.35 / figh, bottom=0.15 / figh,
-                        left=0.2, right=0.99)
-    axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
-
-    for ax, name in zip(axs, cmap_list):
-        ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
-        ax.text(-0.01, 0.5, name, va='center', ha='right', fontsize=10,
-                transform=ax.transAxes)
-
-    # Turn off *all* ticks & spines, not just the ones with colormaps.
-    for ax in axs:
-        ax.set_axis_off()
-
-
-for cmap_category, cmap_list in cmaps.items():
-    plot_color_gradients(cmap_category, cmap_list)
+plot_color_gradients('Miscellaneous',
+                     ['flag', 'prism', 'ocean', 'gist_earth', 'terrain',
+                      'gist_stern', 'gnuplot', 'gnuplot2', 'CMRmap',
+                      'cubehelix', 'brg', 'gist_rainbow', 'rainbow', 'jet',
+                      'turbo', 'nipy_spectral', 'gist_ncar'])
 
 plt.show()
 

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -160,11 +160,11 @@ demo('seaborn')
 # The visual below shows name collisions. Color names where color values agree
 # are in bold.
 
-import matplotlib._color_data as mcd
+import matplotlib.colors as mcolors
 import matplotlib.patches as mpatch
 
-overlap = {name for name in mcd.CSS4_COLORS
-           if "xkcd:" + name in mcd.XKCD_COLORS}
+overlap = {name for name in mcolors.CSS4_COLORS
+           if f'xkcd:{name}' in mcolors.XKCD_COLORS}
 
 fig = plt.figure(figsize=[9, 5])
 ax = fig.add_axes([0, 0, 1, 1])
@@ -173,23 +173,30 @@ n_groups = 3
 n_rows = len(overlap) // n_groups + 1
 
 for j, color_name in enumerate(sorted(overlap)):
-    css4 = mcd.CSS4_COLORS[color_name]
-    xkcd = mcd.XKCD_COLORS["xkcd:" + color_name].upper()
+    css4 = mcolors.CSS4_COLORS[color_name]
+    xkcd = mcolors.XKCD_COLORS[f'xkcd:{color_name}'].upper()
+
+    # Pick text colour based on perceived luminance.
+    rgba = mcolors.to_rgba_array([css4, xkcd])
+    luma = 0.299 * rgba[:, 0] + 0.587 * rgba[:, 1] + 0.114 * rgba[:, 2]
+    css4_text_color = 'k' if luma[0] > 0.5 else 'w'
+    xkcd_text_color = 'k' if luma[1] > 0.5 else 'w'
 
     col_shift = (j // n_rows) * 3
     y_pos = j % n_rows
-    text_args = dict(va='center', fontsize=10,
-                     weight='bold' if css4 == xkcd else None)
+    text_args = dict(fontsize=10, weight='bold' if css4 == xkcd else None)
     ax.add_patch(mpatch.Rectangle((0 + col_shift, y_pos), 1, 1, color=css4))
     ax.add_patch(mpatch.Rectangle((1 + col_shift, y_pos), 1, 1, color=xkcd))
-    ax.text(0 + col_shift, y_pos + .5, '  ' + css4, alpha=0.5, **text_args)
-    ax.text(1 + col_shift, y_pos + .5, '  ' + xkcd, alpha=0.5, **text_args)
-    ax.text(2 + col_shift, y_pos + .5, '  ' + color_name, **text_args)
+    ax.text(0.5 + col_shift, y_pos + .7, css4,
+            color=css4_text_color, ha='center', **text_args)
+    ax.text(1.5 + col_shift, y_pos + .7, xkcd,
+            color=xkcd_text_color, ha='center', **text_args)
+    ax.text(2 + col_shift, y_pos + .7, f'  {color_name}', **text_args)
 
 for g in range(n_groups):
     ax.hlines(range(n_rows), 3*g, 3*g + 2.8, color='0.7', linewidth=1)
-    ax.text(0.5 + 3*g, -0.5, 'X11', ha='center', va='center')
-    ax.text(1.5 + 3*g, -0.5, 'xkcd', ha='center', va='center')
+    ax.text(0.5 + 3*g, -0.3, 'X11/CSS4', ha='center')
+    ax.text(1.5 + 3*g, -0.3, 'xkcd', ha='center')
 
 ax.set_xlim(0, 3 * n_groups)
 ax.set_ylim(n_rows, -1)

--- a/tutorials/introductory/sample_plots.py
+++ b/tutorials/introductory/sample_plots.py
@@ -17,9 +17,6 @@ Here's how to create a line plot with text labels using
 .. figure:: ../../gallery/lines_bars_and_markers/images/sphx_glr_simple_plot_001.png
    :target: ../../gallery/lines_bars_and_markers/simple_plot.html
    :align: center
-   :scale: 50
-
-   Simple Plot
 
 .. _screenshots_subplot_demo:
 
@@ -32,9 +29,6 @@ Multiple axes (i.e. subplots) are created with the
 .. figure:: ../../gallery/subplots_axes_and_figures/images/sphx_glr_subplot_001.png
    :target: ../../gallery/subplots_axes_and_figures/subplot.html
    :align: center
-   :scale: 50
-
-   Subplot
 
 .. _screenshots_images_demo:
 
@@ -47,7 +41,6 @@ horizontal dimensions) using the :func:`~matplotlib.pyplot.imshow` function.
 .. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_image_demo_003.png
    :target: ../../gallery/images_contours_and_fields/image_demo.html
    :align: center
-   :scale: 50
 
    Example of using :func:`~matplotlib.pyplot.imshow` to display a CT scan
 
@@ -66,9 +59,6 @@ the same data:
 .. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_pcolormesh_levels_001.png
    :target: ../../gallery/images_contours_and_fields/pcolormesh_levels.html
    :align: center
-   :scale: 50
-
-   Example comparing :func:`~matplotlib.pyplot.pcolormesh` and :func:`~matplotlib.pyplot.contour` for plotting two-dimensional data
 
 .. _screenshots_histogram_demo:
 
@@ -81,10 +71,6 @@ histograms and returns the bin counts or probabilities:
 .. figure:: ../../gallery/statistics/images/sphx_glr_histogram_features_001.png
    :target: ../../gallery/statistics/histogram_features.html
    :align: center
-   :scale: 50
-
-   Histogram Features
-
 
 .. _screenshots_path_demo:
 
@@ -97,9 +83,6 @@ You can add arbitrary paths in Matplotlib using the
 .. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_path_patch_001.png
    :target: ../../gallery/shapes_and_collections/path_patch.html
    :align: center
-   :scale: 50
-
-   Path Patch
 
 .. _screenshots_mplot3d_surface:
 
@@ -113,9 +96,6 @@ including surface, wireframe, scatter, and bar charts.
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_surface3d_001.png
    :target: ../../gallery/mplot3d/surface3d.html
    :align: center
-   :scale: 50
-
-   Surface3d
 
 Thanks to John Porter, Jonathon Taylor, Reinier Heeres, and Ben Root for
 the `.mplot3d` toolkit. This toolkit is included with all standard Matplotlib
@@ -135,7 +115,6 @@ such as the speed or local intensity of the vector field.
 .. figure:: ../../gallery/images_contours_and_fields/images/sphx_glr_plot_streamplot_001.png
    :target: ../../gallery/images_contours_and_fields/plot_streamplot.html
    :align: center
-   :scale: 50
 
    Streamplot with various plotting options.
 
@@ -156,9 +135,6 @@ an extremely accurate 8-spline approximation to elliptical arcs (see
 .. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_ellipse_demo_001.png
    :target: ../../gallery/shapes_and_collections/ellipse_demo.html
    :align: center
-   :scale: 50
-
-   Ellipse Demo
 
 .. _screenshots_barchart_demo:
 
@@ -171,9 +147,6 @@ includes customizations such as error bars:
 .. figure:: ../../gallery/statistics/images/sphx_glr_barchart_demo_001.png
    :target: ../../gallery/statistics/barchart_demo.html
    :align: center
-   :scale: 50
-
-   Barchart Demo
 
 You can also create stacked bars
 (`bar_stacked.py <../../gallery/lines_bars_and_markers/bar_stacked.html>`_),
@@ -195,9 +168,6 @@ a few lines of code.
 .. figure:: ../../gallery/pie_and_polar_charts/images/sphx_glr_pie_features_001.png
    :target: ../../gallery/pie_and_polar_charts/pie_features.html
    :align: center
-   :scale: 50
-
-   Pie Features
 
 .. _screenshots_table_demo:
 
@@ -210,13 +180,8 @@ to an axes.
 .. figure:: ../../gallery/misc/images/sphx_glr_table_demo_001.png
    :target: ../../gallery/misc/table_demo.html
    :align: center
-   :scale: 50
-
-   Table Demo
-
 
 .. _screenshots_scatter_demo:
-
 
 Scatter plots
 =============
@@ -230,10 +195,6 @@ alpha attribute is used to make semitransparent circle markers.
 .. figure:: ../../gallery/lines_bars_and_markers/images/sphx_glr_scatter_demo2_001.png
    :target: ../../gallery/lines_bars_and_markers/scatter_demo2.html
    :align: center
-   :scale: 50
-
-   Scatter Demo2
-
 
 .. _screenshots_slider_demo:
 
@@ -248,7 +209,6 @@ and widgets.  See :mod:`matplotlib.widgets` and the
 .. figure:: ../../gallery/widgets/images/sphx_glr_slider_demo_001.png
    :target: ../../gallery/widgets/slider_demo.html
    :align: center
-   :scale: 50
 
    Slider and radio-button GUI.
 
@@ -264,9 +224,6 @@ plot filled curves and polygons:
 .. figure:: ../../gallery/lines_bars_and_markers/images/sphx_glr_fill_001.png
    :target: ../../gallery/lines_bars_and_markers/fill.html
    :align: center
-   :scale: 50
-
-   Fill
 
 Thanks to Andrew Straw for adding this function.
 
@@ -281,9 +238,6 @@ tick formatters for both.
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_date_001.png
    :target: ../../gallery/text_labels_and_annotations/date.html
    :align: center
-   :scale: 50
-
-   Date
 
 See :mod:`matplotlib.ticker` and :mod:`matplotlib.dates` for details and usage.
 
@@ -301,9 +255,6 @@ logarithmic plots.
 .. figure:: ../../gallery/scales/images/sphx_glr_log_demo_001.png
    :target: ../../gallery/scales/log_demo.html
    :align: center
-   :scale: 50
-
-   Log Demo
 
 Thanks to Andrew Straw, Darren Dale and Gregory Lielens for contributions
 log-scaling infrastructure.
@@ -318,9 +269,6 @@ The :func:`~matplotlib.pyplot.polar` function generates polar plots.
 .. figure:: ../../gallery/pie_and_polar_charts/images/sphx_glr_polar_demo_001.png
    :target: ../../gallery/pie_and_polar_charts/polar_demo.html
    :align: center
-   :scale: 50
-
-   Polar Demo
 
 .. _screenshots_legend_demo:
 
@@ -335,7 +283,6 @@ functions.
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_legend_001.png
    :target: ../../gallery/text_labels_and_annotations/legend.html
    :align: center
-   :scale: 50
 
    Legend
 
@@ -355,9 +302,6 @@ fonts.  See the :mod:`matplotlib.mathtext` module for additional details.
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_mathtext_examples_001.png
    :target: ../../gallery/text_labels_and_annotations/mathtext_examples.html
    :align: center
-   :scale: 50
-
-   Mathtext Examples
 
 Matplotlib's mathtext infrastructure is an independent implementation and
 does not require TeX or any external packages installed on your computer. See
@@ -376,9 +320,6 @@ rendering of strings with the *usetex* option.
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_tex_demo_001.png
    :target: ../../gallery/text_labels_and_annotations/tex_demo.html
    :align: center
-   :scale: 50
-
-   Tex Demo
 
 .. _screenshots_eeg_demo:
 
@@ -390,6 +331,7 @@ Here is a screenshot of an EEG viewer called `pbrain
 <https://github.com/nipy/pbrain>`__.
 
 .. image:: ../../_static/eeg_small.png
+   :align: center
 
 The lower axes uses :func:`~matplotlib.pyplot.specgram`
 to plot the spectrogram of one of the EEG channels.
@@ -411,9 +353,6 @@ Just for fun, Matplotlib supports plotting in the style of `xkcd
 .. figure:: ../../gallery/showcase/images/sphx_glr_xkcd_001.png
    :target: ../../gallery/showcase/xkcd.html
    :align: center
-   :scale: 50
-
-   xkcd
 
 Subplot example
 ===============

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -28,7 +28,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/pyplots/images/sphx_glr_annotation_basic_001.png
 #    :target: ../../gallery/pyplots/annotation_basic.html
 #    :align: center
-#    :scale: 50
 #
 # In this example, both the *xy* (arrow tip) and *xytext* locations
 # (text location) are in data coordinates.  There are a variety of other
@@ -90,7 +89,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/pyplots/images/sphx_glr_annotation_polar_001.png
 #    :target: ../../gallery/pyplots/annotation_polar.html
 #    :align: center
-#    :scale: 50
 #
 # For more on all the wild and wonderful things you can do with
 # annotations, including fancy arrows, see :ref:`plotting-guide-annotation`
@@ -114,7 +112,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_text_arrow_001.png
 #    :target: ../../gallery/userdemo/annotate_text_arrow.html
 #    :align: center
-#    :scale: 50
 #
 # `~.Axes.text` takes a *bbox* keyword argument, which draws a box around the
 # text::
@@ -153,7 +150,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/shapes_and_collections/images/sphx_glr_fancybox_demo_001.png
 #    :target: ../../gallery/shapes_and_collections/fancybox_demo.html
 #    :align: center
-#    :scale: 50
 #
 # Note that the attribute arguments can be specified within the style
 # name with separating comma (this form can be used as "boxstyle" value
@@ -191,7 +187,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple01_001.png
 #    :target: ../../gallery/userdemo/annotate_simple01.html
 #    :align: center
-#    :scale: 50
 #
 # The arrow is drawn as follows:
 #
@@ -206,7 +201,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_explain_001.png
 #    :target: ../../gallery/userdemo/annotate_explain.html
 #    :align: center
-#    :scale: 50
 #
 # The creation of the connecting path between two points is controlled by
 # ``connectionstyle`` key and the following styles are available.
@@ -233,7 +227,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_connectionstyle_demo_001.png
 #    :target: ../../gallery/userdemo/connectionstyle_demo.html
 #    :align: center
-#    :scale: 50
 #
 # The connecting path (after clipping and shrinking) is then mutated to
 # an arrow patch, according to the given ``arrowstyle``.
@@ -258,7 +251,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_fancyarrow_demo_001.png
 #    :target: ../../gallery/text_labels_and_annotations/fancyarrow_demo.html
 #    :align: center
-#    :scale: 50
 #
 # Some arrowstyles only work with connection styles that generate a
 # quadratic-spline segment. They are ``fancy``, ``simple``, and ``wedge``.
@@ -271,7 +263,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple02_001.png
 #    :target: ../../gallery/userdemo/annotate_simple02.html
 #    :align: center
-#    :scale: 50
 #
 # As with `~.Axes.text`, a box around the text can be drawn using the *bbox*
 # argument.
@@ -279,7 +270,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple03_001.png
 #    :target: ../../gallery/userdemo/annotate_simple03.html
 #    :align: center
-#    :scale: 50
 #
 # By default, the starting point is set to the center of the text
 # extent.  This can be adjusted with ``relpos`` key value. The values
@@ -289,7 +279,6 @@ from matplotlib import pyplot as plt
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple04_001.png
 #    :target: ../../gallery/userdemo/annotate_simple04.html
 #    :align: center
-#    :scale: 50
 #
 # Placing Artist at the anchored location of the Axes
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -366,7 +355,6 @@ ax.add_artist(box)
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_anchored_box04_001.png
 #    :target: ../../gallery/userdemo/anchored_box04.html
 #    :align: center
-#    :scale: 50
 #
 # Note that unlike the legend, the ``bbox_transform`` is set
 # to IdentityTransform by default.
@@ -409,7 +397,6 @@ ax.add_artist(box)
 #    .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple_coord01_001.png
 #       :target: ../../gallery/userdemo/annotate_simple_coord01.html
 #       :align: center
-#       :scale: 50
 #
 #    Note that you must ensure that the extent of the coordinate artist (*an1* in
 #    above example) is determined before *an2* gets drawn. Usually, this means
@@ -439,7 +426,6 @@ ax.add_artist(box)
 #    .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple_coord02_001.png
 #       :target: ../../gallery/userdemo/annotate_simple_coord02.html
 #       :align: center
-#       :scale: 50
 #
 # 5. Sometimes, you want your annotation with some "offset points", not from the
 #    annotated point but from some other point.  `.text.OffsetFrom` is a helper
@@ -448,7 +434,6 @@ ax.add_artist(box)
 #    .. figure:: ../../gallery/userdemo/images/sphx_glr_annotate_simple_coord03_001.png
 #       :target: ../../gallery/userdemo/annotate_simple_coord03.html
 #       :align: center
-#       :scale: 50
 #
 #    You may take a look at this example
 #    :doc:`/gallery/text_labels_and_annotations/annotation_demo`.
@@ -472,7 +457,6 @@ ax.add_artist(box)
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_connect_simple01_001.png
 #    :target: ../../gallery/userdemo/connect_simple01.html
 #    :align: center
-#    :scale: 50
 #
 # Here, we added the ConnectionPatch to the *figure* (with `~.Figure.add_artist`)
 # rather than to either axes: this ensures that it is drawn on top of both axes,
@@ -492,7 +476,6 @@ ax.add_artist(box)
 # .. figure:: ../../gallery/subplots_axes_and_figures/images/sphx_glr_axes_zoom_effect_001.png
 #    :target: ../../gallery/subplots_axes_and_figures/axes_zoom_effect.html
 #    :align: center
-#    :scale: 50
 #
 # Define Custom BoxStyle
 # ~~~~~~~~~~~~~~~~~~~~~~
@@ -518,7 +501,6 @@ ax.add_artist(box)
 # .. figure:: ../../gallery/userdemo/images/sphx_glr_custom_boxstyle01_001.png
 #    :target: ../../gallery/userdemo/custom_boxstyle01.html
 #    :align: center
-#    :scale: 50
 #
 # Similarly, you can define a custom ConnectionStyle and a custom ArrowStyle.
 # See the source code of ``lib/matplotlib/patches.py`` and check

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -355,5 +355,4 @@ Here is an example illustrating many of these features in context.
 .. figure:: ../../gallery/pyplots/images/sphx_glr_pyplot_mathtext_001.png
    :target: ../../gallery/pyplots/pyplot_mathtext.html
    :align: center
-   :scale: 50
 """

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -79,7 +79,6 @@ Here is the standard example,
 .. figure:: ../../gallery/text_labels_and_annotations/images/sphx_glr_tex_demo_001.png
    :target: ../../gallery/text_labels_and_annotations/tex_demo.html
    :align: center
-   :scale: 50
 
 Note that display math mode (``$$ e=mc^2 $$``) is not supported, but adding the
 command ``\displaystyle``, as in the above demo, will produce the same results.

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -19,7 +19,6 @@ Overview of :mod:`mpl_toolkits.axes_grid1`
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_demo_axes_grid_001.png
    :target: ../../gallery/axes_grid1/demo_axes_grid.html
    :align: center
-   :scale: 50
 
 axes_grid1
 ==========
@@ -36,7 +35,6 @@ its docs for detailed API information.
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_axesgrid_001.png
    :target: ../../gallery/axes_grid1/simple_axesgrid.html
    :align: center
-   :scale: 50
 
 * The position of each axes is determined at the drawing time (see
   AxesDivider_), so that the size of the entire grid fits in the
@@ -53,14 +51,12 @@ its docs for detailed API information.
   .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_axesgrid2_001.png
      :target: ../../gallery/axes_grid1/simple_axesgrid2.html
      :align: center
-     :scale: 50
 
 The examples below show what you can do with ImageGrid.
 
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_demo_axes_grid_001.png
    :target: ../../gallery/axes_grid1/demo_axes_grid.html
    :align: center
-   :scale: 50
 
 AxesDivider Class
 -----------------
@@ -86,7 +82,6 @@ colorbar whose height (or width) in sync with the master axes
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_colorbar_001.png
    :target: ../../gallery/axes_grid1/simple_colorbar.html
    :align: center
-   :scale: 50
 
 scatter_hist.py with AxesDivider
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,7 +109,6 @@ See the full source code below.
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_scatter_hist_locatable_axes_001.png
    :target: ../../gallery/axes_grid1/scatter_hist_locatable_axes.html
    :align: center
-   :scale: 50
 
 The :doc:`/gallery/axes_grid1/scatter_hist_locatable_axes` using the
 AxesDivider has some advantages over the
@@ -150,7 +144,6 @@ Example 1. twinx
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_parasite_simple_001.png
    :target: ../../gallery/axes_grid1/parasite_simple.html
    :align: center
-   :scale: 50
 
 Example 2. twin
 ~~~~~~~~~~~~~~~
@@ -168,7 +161,6 @@ tick-formatter for bottom(or left)-axis. ::
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_axisline4_001.png
    :target: ../../gallery/axes_grid1/simple_axisline4.html
    :align: center
-   :scale: 50
 
 A more sophisticated example using twin. Note that if you change the
 x-limit in the host axes, the x-limit of the parasite axes will change
@@ -177,7 +169,6 @@ accordingly.
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_parasite_simple2_001.png
    :target: ../../gallery/axes_grid1/parasite_simple2.html
    :align: center
-   :scale: 50
 
 AnchoredArtists
 ---------------
@@ -191,7 +182,6 @@ the ellipse in the example below will have width and height in data coordinate.
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_anchored_artists_001.png
    :target: ../../gallery/axes_grid1/simple_anchored_artists.html
    :align: center
-   :scale: 50
 
 InsetLocator
 ------------
@@ -227,7 +217,6 @@ useful to mark the zoomed area on the parent axes:
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_inset_locator_demo_001.png
    :target: ../../gallery/axes_grid1/inset_locator_demo.html
    :align: center
-   :scale: 50
 
 `.inset_locator.mark_inset` allows marking the location of the area represented
 by the inset axes:
@@ -235,7 +224,6 @@ by the inset axes:
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_inset_locator_demo2_001.png
    :target: ../../gallery/axes_grid1/inset_locator_demo2.html
    :align: center
-   :scale: 50
 
 RGBAxes
 -------
@@ -255,7 +243,6 @@ yaxis of each axes are shared. ::
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_demo_axes_rgb_001.png
    :target: ../../gallery/axes_grid1/demo_axes_rgb.html
    :align: center
-   :scale: 50
 
 AxesDivider
 ===========
@@ -334,7 +321,6 @@ See the example,
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_axes_divider1_001.png
    :target: ../../gallery/axes_grid1/simple_axes_divider1.html
    :align: center
-   :scale: 50
 
 You can also adjust the size of each axes according to its x or y
 data limits (AxesX and AxesY).
@@ -342,5 +328,4 @@ data limits (AxesX and AxesY).
 .. figure:: ../../gallery/axes_grid1/images/sphx_glr_simple_axes_divider3_001.png
    :target: ../../gallery/axes_grid1/simple_axes_divider3.html
    :align: center
-   :scale: 50
 """

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -20,7 +20,6 @@ curved coordinate systems.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_floating_axis_001.png
    :target: ../../gallery/axisartist/demo_floating_axis.html
    :align: center
-   :scale: 50
 
 Since it uses special artists, some Matplotlib commands that work on
 Axes.xaxis and Axes.yaxis may not work.
@@ -66,7 +65,6 @@ For example, you can hide the right and top spines using::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_simple_axisline3_001.png
    :target: ../../gallery/axisartist/simple_axisline3.html
    :align: center
-   :scale: 50
 
 It is also possible to add a horizontal axis. For example, you may have an
 horizontal axis at y=0 (in data coordinate). ::
@@ -76,7 +74,6 @@ horizontal axis at y=0 (in data coordinate). ::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_simple_axisartist1_001.png
    :target: ../../gallery/axisartist/simple_axisartist1.html
    :align: center
-   :scale: 50
 
 Or a fixed axis with some offset ::
 
@@ -100,7 +97,6 @@ Here is an example that uses ParasiteAxes.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_parasite_axes2_001.png
    :target: ../../gallery/axisartist/demo_parasite_axes2.html
    :align: center
-   :scale: 50
 
 Curvilinear Grid
 ----------------
@@ -111,7 +107,6 @@ and ticks.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_curvelinear_grid_001.png
    :target: ../../gallery/axisartist/demo_curvelinear_grid.html
    :align: center
-   :scale: 50
 
 Floating Axes
 -------------
@@ -122,7 +117,6 @@ floating axis.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_floating_axes_001.png
    :target: ../../gallery/axisartist/demo_floating_axes.html
    :align: center
-   :scale: 50
 
 axisartist namespace
 ====================
@@ -155,7 +149,6 @@ In summary, all these changes was to support
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_floating_axis_001.png
    :target: ../../gallery/axisartist/demo_floating_axis.html
    :align: center
-   :scale: 50
 
 *mpl_toolkits.axisartist.Axes* class defines a *axis* attribute, which
 is a dictionary of AxisArtist instances. By default, the dictionary
@@ -317,7 +310,6 @@ using "set_axis_direction" method. ::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_simple_axis_direction01_001.png
    :target: ../../gallery/axisartist/simple_axis_direction01.html
    :align: center
-   :scale: 50
 
 The parameter for set_axis_direction is one of ["left", "right",
 "bottom", "top"].
@@ -343,7 +335,6 @@ You must understand some underlying concept of directions.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_axis_direction_001.png
    :target: ../../gallery/axisartist/axis_direction.html
    :align: center
-   :scale: 50
 
 On the other hand, there is a concept of "axis_direction". This is a
 default setting of above properties for each, "bottom", "left", "top",
@@ -369,7 +360,6 @@ direction can be more clear with curved axis.
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_axis_direction_001.png
    :target: ../../gallery/axisartist/demo_axis_direction.html
    :align: center
-   :scale: 50
 
 The axis_direction can be adjusted in the AxisArtist level, or in the
 level of its child artists, i.e., ticks, ticklabels, and axis-label. ::
@@ -401,7 +391,6 @@ default direction). ::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_simple_axis_direction03_001.png
    :target: ../../gallery/axisartist/simple_axis_direction03.html
    :align: center
-   :scale: 50
 
 So, in summary,
 
@@ -437,7 +426,6 @@ Alignment of TickLabels are treated specially. See below
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_ticklabel_alignment_001.png
    :target: ../../gallery/axisartist/demo_ticklabel_alignment.html
    :align: center
-   :scale: 50
 
 Adjusting pad
 -------------
@@ -453,7 +441,6 @@ Or ticklabels and axis-label ::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_simple_axis_pad_001.png
    :target: ../../gallery/axisartist/simple_axis_pad.html
    :align: center
-   :scale: 50
 
 GridHelper
 ==========
@@ -540,7 +527,6 @@ coordinates, or you may use Parasite Axes for convenience.::
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_curvelinear_grid_001.png
    :target: ../../gallery/axisartist/demo_curvelinear_grid.html
    :align: center
-   :scale: 50
 
 FloatingAxis
 ============

--- a/tutorials/toolkits/mplot3d.py
+++ b/tutorials/toolkits/mplot3d.py
@@ -22,7 +22,6 @@ Multiple 3D subplots can be added on the same figure, as for 2D subplots.
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_subplot3d_001.png
    :target: ../../gallery/mplot3d/subplot3d.html
    :align: center
-   :scale: 50
 
 .. versionchanged:: 1.0.0
    Prior to Matplotlib 1.0.0, only a single `.Axes3D` could be created per
@@ -39,79 +38,79 @@ toolkit.
 .. _plot3d:
 
 Line plots
-====================
-.. automethod:: Axes3D.plot
+==========
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_lines3d_001.png
    :target: ../../gallery/mplot3d/lines3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.plot
 
 .. _scatter3d:
 
 Scatter plots
 =============
-.. automethod:: Axes3D.scatter
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_scatter3d_001.png
    :target: ../../gallery/mplot3d/scatter3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.scatter
 
 .. _wireframe:
 
 Wireframe plots
 ===============
-.. automethod:: Axes3D.plot_wireframe
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_wire3d_001.png
    :target: ../../gallery/mplot3d/wire3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.plot_wireframe
 
 .. _surface:
 
 Surface plots
 =============
-.. automethod:: Axes3D.plot_surface
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_surface3d_001.png
    :target: ../../gallery/mplot3d/surface3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.plot_surface
 
 .. _trisurface:
 
 Tri-Surface plots
 =================
-.. automethod:: Axes3D.plot_trisurf
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_trisurf3d_001.png
    :target: ../../gallery/mplot3d/trisurf3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.plot_trisurf
 
 .. _contour3d:
 
 Contour plots
 =============
-.. automethod:: Axes3D.contour
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_contour3d_001.png
    :target: ../../gallery/mplot3d/contour3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.contour
 
 .. _contourf3d:
 
 Filled contour plots
 ====================
-.. automethod:: Axes3D.contourf
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_contourf3d_001.png
    :target: ../../gallery/mplot3d/contourf3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.contourf
 
 .. versionadded:: 1.1.0
    The feature demoed in the second contourf3d example was enabled as a
@@ -120,53 +119,52 @@ Filled contour plots
 .. _polygon3d:
 
 Polygon plots
-====================
-.. automethod:: Axes3D.add_collection3d
+=============
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_polys3d_001.png
    :target: ../../gallery/mplot3d/polys3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.add_collection3d
 
 .. _bar3d:
 
 Bar plots
-====================
-.. automethod:: Axes3D.bar
+=========
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_bars3d_001.png
    :target: ../../gallery/mplot3d/bars3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.bar
 
 .. _quiver3d:
 
 Quiver
-====================
-.. automethod:: Axes3D.quiver
+======
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_quiver3d_001.png
    :target: ../../gallery/mplot3d/quiver3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.quiver
 
 .. _2dcollections3d:
 
 2D plots in 3D
-====================
+==============
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_2dcollections3d_001.png
    :target: ../../gallery/mplot3d/2dcollections3d.html
    :align: center
-   :scale: 50
 
 .. _text3d:
 
 Text
-====================
-.. automethod:: Axes3D.text
+====
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_text3d_001.png
    :target: ../../gallery/mplot3d/text3d.html
    :align: center
-   :scale: 50
+
+.. automethod:: Axes3D.text
 """


### PR DESCRIPTION
## PR Summary

Figures were originally 50% scale, but this looks tiny in the new theme. Mostly this undoes that, plus some tweaks in examples so that they don't end up too wide at 100%. For example, there's no need for this to be so small:

![image](https://user-images.githubusercontent.com/302469/123762089-71bc7b00-d890-11eb-95b9-5205bd1eebd7.png)

As done in other PRs, this also drops captions which seem pretty uninformative.

Finally, it makes some tweaks to some of the colour figures, by
a) moving colormaps to their respective tutorial sections
<details>
<summary>(preventing sphinx-gallery from treating them as a list and half-sizing them, like this)</summary>
![image](https://user-images.githubusercontent.com/302469/123762691-0aeb9180-d891-11eb-9b4c-2faa5d793e13.png)
</details>
b) and improving the xkcd vs CSS colour comparison chart by changing the text colour to contrast the background, plus some tweaks to make better alignment:
<details>

![image](https://user-images.githubusercontent.com/302469/123762995-5867fe80-d891-11eb-8b1e-ee0a416b0231.png)
</details>

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).