### PR TITLE
Raise if passed invalid kwargs to set_constrained_layout_pads.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2406,40 +2406,43 @@ class Figure(FigureBase):
 
         self.stale = True
 
-    def set_constrained_layout_pads(self, **kwargs):
+    def set_constrained_layout_pads(self, *, w_pad=None, h_pad=None,
+                                    wspace=None, hspace=None):
         """
-        Set padding for ``constrained_layout``.  Note the kwargs can be passed
-        as a dictionary ``fig.set_constrained_layout(**paddict)``.
+        Set padding for ``constrained_layout``.
+
+        Tip: The parameters can be passed from a dictionary by using
+        ``fig.set_constrained_layout(**pad_dict)``.
 
         See :doc:`/tutorials/intermediate/constrainedlayout_guide`.
 
         Parameters
         ----------
-        w_pad : float
+        w_pad : float, default: :rc:`figure.constrained_layout.w_pad`
             Width padding in inches.  This is the pad around Axes
             and is meant to make sure there is enough room for fonts to
             look good.  Defaults to 3 pts = 0.04167 inches
 
-        h_pad : float
+        h_pad : float, default: :rc:`figure.constrained_layout.h_pad`
             Height padding in inches. Defaults to 3 pts.
 
-        wspace : float
+        wspace : float, default: :rc:`figure.constrained_layout.wspace`
             Width padding between subplots, expressed as a fraction of the
             subplot width.  The total padding ends up being w_pad + wspace.
 
-        hspace : float
+        hspace : float, default: :rc:`figure.constrained_layout.hspace`
             Height padding between subplots, expressed as a fraction of the
             subplot width. The total padding ends up being h_pad + hspace.
 
         """
 
-        todo = ['w_pad', 'h_pad', 'wspace', 'hspace']
-        for td in todo:
-            if td in kwargs and kwargs[td] is not None:
-                self._constrained_layout_pads[td] = kwargs[td]
+        for name, size in zip(['w_pad', 'h_pad', 'wspace', 'hspace'],
+                              [w_pad, h_pad, wspace, hspace]):
+            if size is not None:
+                self._constrained_layout_pads[name] = size
             else:
-                self._constrained_layout_pads[td] = (
-                    mpl.rcParams['figure.constrained_layout.' + td])
+                self._constrained_layout_pads[name] = (
+                    mpl.rcParams[f'figure.constrained_layout.{name}'])
 
     def get_constrained_layout_pads(self, relative=False):
         """

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -252,6 +252,8 @@ def test_constrained_layout13():
     for ax in axs.flat:
         pcm = example_pcolor(ax, fontsize=12)
         fig.colorbar(pcm, ax=ax, shrink=0.6, aspect=20., pad=0.02)
+    with pytest.raises(TypeError, match='unexpected keyword argument'):
+        fig.set_constrained_layout_pads(wpad=1, hpad=2)
     fig.set_constrained_layout_pads(w_pad=24./72., h_pad=24./72.)
 
 


### PR DESCRIPTION
## PR Summary

I was trying to pass `wpad` and wondering why it didn't seem to do anything... No deprecation because constrained layout is still 'experimental'.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).