### PR TITLE
[without findfont diff] Parsing all families in font_manager

### DIFF
--- a/doc/users/fonts.rst
+++ b/doc/users/fonts.rst
@@ -134,7 +134,7 @@ Are we reinventing the wheel?
 Internally, a feasible response to the question of 'reinventing the
 wheel would be, well, Yes *and No*. The font-matching algorithm used
 by Matplotlib has been *inspired* by web browsers, more specifically,
-`CSS Specifications <http://www.w3.org/TR/1998/REC-CSS2-19980512/>`_!
+`CSS Specifications <http://www.w3.org/TR/1998/REC-CSS2-19980512/>`_.
 
 Currently, the simplest way (and the only way) to tell Matplotlib what fonts
 you want it to use for your document is via the **font.family** rcParam,
@@ -144,7 +144,7 @@ This is similar to how one tells a browser to use multiple font families
 (specified in their order of preference) for their HTML webpages. By using
 **font-family** in their stylesheet, users can essentially trigger a very
 useful feature provided by browers, known as Font-Fallback. For example, the
-following snippet in an HTMl markup would:
+following snippet in an HTML markup would:
 
 .. code-block:: html
 
@@ -163,14 +163,15 @@ following snippet in an HTMl markup would:
 For every character/glyph in *"some text"*, the browser will iterate through
 the whole list of font-families, and check whether that character/glyph is
 available in that font-family. As soon as a font is found which has the
-required glyph(s), the browser moves on to the next character.
+required glyph(s), the browser uses that font to render that character, and
+subsequently moves on to the next character.
 
 How does Matplotlib achieve this?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Well, Matplotlib doesn't achieve this, *yet*. It was initially only designed to
-use a **single font** throughout the document, i.e., no matter how many
-families you pass to **font.family** rcParam, Matplotlib would use the very
-first font it's able to find on your system, and try to render all your
+Currently, Matplotlib can't render a multi-font document. It was initially
+only designed to use a **single font** throughout the document, i.e., no matter
+how many families you pass to **font.family** rcParam, Matplotlib would use the
+very first font it's able to find on your system, and try to render all your
 characters/glyphs from that *and only that* font.
 
 .. note::

--- a/doc/users/fonts.rst
+++ b/doc/users/fonts.rst
@@ -128,3 +128,58 @@ This is especially helpful to generate *really lightweight* documents.::
   free versions of the proprietary fonts.
 
   This also violates the *what-you-see-is-what-you-get* feature of Matplotlib.
+
+Are we reinventing the wheel?
+-----------------------------
+Internally, a feasible response to the question of 'reinventing the
+wheel would be, well, Yes *and No*. The font-matching algorithm used
+by Matplotlib has been *inspired* by web browsers, more specifically,
+`CSS Specifications <http://www.w3.org/TR/1998/REC-CSS2-19980512/>`_!
+
+Currently, the simplest way (and the only way) to tell Matplotlib what fonts
+you want it to use for your document is via the **font.family** rcParam,
+see :doc:`Customizing text properties </tutorials/text/text_props>`.
+
+This is similar to how one tells a browser to use multiple font families
+(specified in their order of preference) for their HTML webpages. By using
+**font-family** in their stylesheet, users can essentially trigger a very
+useful feature provided by browers, known as Font-Fallback. For example, the
+following snippet in an HTMl markup would:
+
+.. code-block:: html
+
+  <style>
+    someTag {
+      font-family: Arial, Helvetica, sans-serif;
+    }
+  </style>
+
+  <!-- somewhere in the main body -->
+  <someTag>
+    some text
+  </someTag>
+
+
+For every character/glyph in *"some text"*, the browser will iterate through
+the whole list of font-families, and check whether that character/glyph is
+available in that font-family. As soon as a font is found which has the
+required glyph(s), the browser moves on to the next character.
+
+How does Matplotlib achieve this?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Well, Matplotlib doesn't achieve this, *yet*. It was initially only designed to
+use a **single font** throughout the document, i.e., no matter how many
+families you pass to **font.family** rcParam, Matplotlib would use the very
+first font it's able to find on your system, and try to render all your
+characters/glyphs from that *and only that* font.
+
+.. note::
+  This is, because the internal font matching was written/adapted
+  from a very old `CSS1 spec <http://www.w3.org/TR/1998/REC-CSS2-19980512/>`_,
+  **written in 1998**!
+
+  However, allowing multiple fonts for a single document (also enabling
+  Font-Fallback) is one of the goals for 2021's Google Summer of Code project.
+
+  `Read more on Matplotblog <https://matplotlib.org/matplotblog/>`_!
+

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -35,7 +35,7 @@ from matplotlib import colors as mcolors
 from matplotlib.backend_bases import (
     _Backend, _check_savefig_extra_args, FigureCanvasBase, FigureManagerBase,
     RendererBase)
-from matplotlib.font_manager import findfont, get_font
+from matplotlib.font_manager import get_font, find_fontsprop
 from matplotlib.ft2font import (LOAD_FORCE_AUTOHINT, LOAD_NO_HINTING,
                                 LOAD_DEFAULT, LOAD_NO_AUTOHINT)
 from matplotlib.mathtext import MathTextParser
@@ -251,8 +251,8 @@ class RendererAgg(RendererBase):
         """
         Get the font for text instance t, caching for efficiency
         """
-        fname = findfont(prop)
-        font = get_font(fname)
+        finterface = find_fontsprop(prop)
+        font = get_font(finterface)
 
         font.clear()
         size = prop.get_size_in_points()

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1395,7 +1395,6 @@ class FontManager:
 
         return fpaths
 
-
     @lru_cache()
     def _findfontsprop_cached(
         self, family, prop, fontext, directory,
@@ -1419,7 +1418,6 @@ class FontManager:
                     _log.warning(
                         'findfont: Font family \'%s\' not found.', family
                     )
-
 
     @lru_cache()
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1305,10 +1305,6 @@ class FontManager:
         rc_params = tuple(tuple(rcParams[key]) for key in [
             "font.serif", "font.sans-serif", "font.cursive", "font.fantasy",
             "font.monospace"])
-
-        if not isinstance(prop, FontProperties):
-            prop = FontProperties._from_any(prop)
-
         return self._findfont_cached(
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)
@@ -1410,6 +1406,8 @@ class FontManager:
     @lru_cache()
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
                          rebuild_if_missing, rc_params):
+
+        prop = FontProperties._from_any(prop)
 
         fname = prop.get_file()
         if fname is not None:


### PR DESCRIPTION
## PR Summary
#### Short Note:
This is a newer and more dynamic approach than https://github.com/matplotlib/matplotlib/pull/20496, which changed findfont's API, thus breaking a lot of backends.
A much more flexible approach would be to gradually move the different backends to `find_fontsprop` instead of `findfont`, since the new function is built _over_ the existing API and acts as a middleware.

#### Quoting previous PR:
This is the beginning of migrating from Matplotlib's "Font-First" approach to a "Text-First" approach.
The very first step is to parse all families in font manager. Previously, we only parsed families until we find a font file, and the rest of the backends are accustomed to just a single font file (which needs changing)

---
OrderedDict would contain fonts defined by font.family
- which are present on the system
- but also append "fallback fonts" in the end. (which is triggered if a certain font family is not found in the system)## PR Checklist

---
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
