### PR TITLE
Fix the way to get xs length in set_3d_properties()

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -172,7 +172,7 @@ class Line3D(lines.Line2D):
     def set_3d_properties(self, zs=0, zdir='z'):
         xs = self.get_xdata()
         ys = self.get_ydata()
-        zs = np.broadcast_to(zs, xs.shape)
+        zs = np.broadcast_to(zs, len(xs))
         self._verts3d = juggle_axes(xs, ys, zs, zdir)
         self.stale = True
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1119,6 +1119,12 @@ def test_line3d_set_get_data_3d():
     np.testing.assert_array_equal((x, y, z), line.get_data_3d())
     line.set_data_3d(x2, y2, z2)
     np.testing.assert_array_equal((x2, y2, z2), line.get_data_3d())
+    line.set_xdata(x)
+    line.set_ydata(y)
+    line.set_3d_properties(zs=z, zdir='z')
+    np.testing.assert_array_equal((x, y, z), line.get_data_3d())
+    line.set_3d_properties(zs=0, zdir='z')
+    np.testing.assert_array_equal((x, y, np.zeros_like(z)), line.get_data_3d())
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
The `xs` is a 1D array that may not have a `shape` attribute.

```python
lines_3d.set_xdata([0, 1])
lines_3d.set_ydata([0, 1])
lines_3d.set_3d_properties([0, 1], zdir='z') # 💥 AttributeError: 'list' object has no attribute 'shape'
```
