### PR TITLE
Fix deprecation of encoding in plot_directive.

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -197,7 +197,7 @@ def _option_format(arg):
 
 
 def _deprecated_option_encoding(arg):
-    _api.warn_deprecated("3.5", "encoding", obj_type="option")
+    _api.warn_deprecated("3.5", name="encoding", obj_type="option")
     return directives.encoding(arg)
 
 

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -120,9 +120,11 @@ Plot 14 uses ``include-source``:
 
     # Only a comment
 
-Plot 15 uses an external file with the plot commands and a caption:
+Plot 15 uses an external file with the plot commands and a caption (the
+encoding is ignored and just verifies the deprecation is not broken):
 
 .. plot:: range4.py
+   :encoding: utf-8
 
    This is the caption for plot 15.
 


### PR DESCRIPTION
## PR Summary

As noted in https://github.com/matplotlib/matplotlib/pull/20540#pullrequestreview-695559714

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).