### PR TITLE
Fix limits in plot types example hist(x)

### DIFF
--- a/plot_types/stats/hist_plot.py
+++ b/plot_types/stats/hist_plot.py
@@ -20,6 +20,6 @@ fig, ax = plt.subplots()
 ax.hist(x, bins=8, linewidth=0.5, edgecolor="white")
 
 ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
-       ylim=(0, 8), yticks=np.arange(1, 8))
+       ylim=(0, 56), yticks=np.linspace(0, 56, 9))
 
 plt.show()


### PR DESCRIPTION
hist(x) has a natural y-scale due to the counts. We don't want to
rescale that manually or reduce the sample size (which would make the
distribution not look so nice). So instead we scale up the axis limits.

Previous:
![grafik](https://user-images.githubusercontent.com/2836374/124188292-5daa9080-dabf-11eb-815f-d844b93d762f.png)

Now:
![grafik](https://user-images.githubusercontent.com/2836374/124197611-3956b000-dacf-11eb-9db7-74aeafa87fe7.png)
