### PR TITLE
Expire deprecation of passing nbins to MaxNLocator in two ways

### DIFF
--- a/doc/api/next_api_changes/removals/20563-TH.rst
+++ b/doc/api/next_api_changes/removals/20563-TH.rst
@@ -1,0 +1,4 @@
+MaxNLocator passing *nbins* in two ways
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`~.ticker.MaxNLocator` does not accept a positional parameter and the keyword
+argument *nbins* simultaneously because they specify the same quantity.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1987,7 +1987,7 @@ class MaxNLocator(Locator):
                           prune=None,
                           min_n_ticks=2)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, nbins=None, **kwargs):
         """
         Parameters
         ----------
@@ -2024,17 +2024,8 @@ class MaxNLocator(Locator):
             Relax *nbins* and *integer* constraints if necessary to obtain
             this minimum number of ticks.
         """
-        if args:
-            if 'nbins' in kwargs:
-                _api.deprecated("3.1",
-                                message='Calling MaxNLocator with positional '
-                                        'and keyword parameter *nbins* is '
-                                        'considered an error and will fail '
-                                        'in future versions of matplotlib.')
-            kwargs['nbins'] = args[0]
-            if len(args) > 1:
-                raise ValueError(
-                    "Keywords are required for all arguments except 'nbins'")
+        if nbins is not None:
+            kwargs['nbins'] = nbins
         self.set_params(**{**self.default_params, **kwargs})
 
     @staticmethod


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
