### PR TITLE
Backout pillow=8.3.0 due to a crash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         "kiwisolver>=1.0.1",
         "numpy>=1.17",
         "packaging>=20.0",
-        "pillow>=6.2.0",
+        "pillow>=6.2.0,!=8.3.0",
         "pyparsing>=2.2.1",
         "python-dateutil>=2.7",
     ] + (


### PR DESCRIPTION
See https://github.com/python-pillow/Pillow/issues/5571


