### PR TITLE
Reduce vertical margins in property tables

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -207,3 +207,9 @@ does not float with it.
     visibility: hidden;
 
 }
+
+
+table.property-table th,
+table.property-table td {
+    padding: 4px 10px;
+}


### PR DESCRIPTION
## PR Summary

I feel the reduced spacing is still not too dense, but it allows to show more content in these quite long tables.

before:
![grafik](https://user-images.githubusercontent.com/2836374/124368677-8ff4f300-dc63-11eb-9687-2822d7ce68dc.png)

after:
![grafik](https://user-images.githubusercontent.com/2836374/124368689-a733e080-dc63-11eb-8a92-e900f03865a5.png)
