### PR TITLE
Switch default ArrowStyle angle values from None to zero.

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3475,7 +3475,7 @@ class ArrowStyle(_Style):
     class BracketB(_Bracket):
         """An arrow with an outward square bracket at its end."""
 
-        def __init__(self, widthB=1., lengthB=0.2, angleB=None):
+        def __init__(self, widthB=1., lengthB=0.2, angleB=0):
             """
             Parameters
             ----------
@@ -3516,9 +3516,7 @@ class ArrowStyle(_Style):
     class BarAB(_Bracket):
         """An arrow with vertical bars ``|`` at both ends."""
 
-        def __init__(self,
-                     widthA=1., angleA=None,
-                     widthB=1., angleB=None):
+        def __init__(self, widthA=1., angleA=0, widthB=1., angleB=0):
             """
             Parameters
             ----------


### PR DESCRIPTION
... which are synonymous, but zero is more explicit (and also consistent
with BracketA and BracketAB).  (None is still supported as input, so
there's no backompat break.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
