### PR TITLE
Add tricontourf hatching example

### DIFF
--- a/examples/images_contours_and_fields/tricontour_demo.py
+++ b/examples/images_contours_and_fields/tricontour_demo.py
@@ -45,6 +45,41 @@ fig1.colorbar(tcf)
 ax1.tricontour(triang, z, colors='k')
 ax1.set_title('Contour plot of Delaunay triangulation')
 
+
+###############################################################################
+# You could also specify hatching patterns along with different cmaps.
+
+fig2, ax2 = plt.subplots()
+ax2.set_aspect("equal")
+tcf = ax2.tricontourf(
+    triang,
+    z,
+    hatches=["*", "-", "/", "//", "\\", None],
+    cmap="cividis"
+)
+fig2.colorbar(tcf)
+ax2.tricontour(triang, z, linestyles="solid", colors="k", linewidths=2.0)
+ax2.set_title("Hatched Contour plot of Delaunay triangulation")
+
+###############################################################################
+# You could also generate hatching patterns labeled with no color.
+
+fig3, ax3 = plt.subplots()
+n_levels = 7
+tcf = ax3.tricontourf(
+    triang,
+    z,
+    n_levels,
+    colors="none",
+    hatches=[".", "/", "\\", None, "\\\\", "*"],
+)
+ax3.tricontour(triang, z, n_levels, colors="black", linestyles="-")
+
+
+# create a legend for the contour set
+artists, labels = tcf.legend_elements(str_format="{:2.1f}".format)
+ax3.legend(artists, labels, handleheight=2, framealpha=1)
+
 ###############################################################################
 # You can specify your own triangulation rather than perform a Delaunay
 # triangulation of the points, where each triangle is given by the indices of
@@ -101,13 +136,13 @@ triangles = np.asarray([
 # object if the same triangulation was to be used more than once to save
 # duplicated calculations.
 
-fig2, ax2 = plt.subplots()
-ax2.set_aspect('equal')
-tcf = ax2.tricontourf(x, y, triangles, z)
-fig2.colorbar(tcf)
-ax2.set_title('Contour plot of user-specified triangulation')
-ax2.set_xlabel('Longitude (degrees)')
-ax2.set_ylabel('Latitude (degrees)')
+fig4, ax4 = plt.subplots()
+ax4.set_aspect('equal')
+tcf = ax4.tricontourf(x, y, triangles, z)
+fig4.colorbar(tcf)
+ax4.set_title('Contour plot of user-specified triangulation')
+ax4.set_xlabel('Longitude (degrees)')
+ax4.set_ylabel('Latitude (degrees)')
 
 plt.show()
 
@@ -120,3 +155,6 @@ plt.show()
 #
 #    - `matplotlib.axes.Axes.tricontourf` / `matplotlib.pyplot.tricontourf`
 #    - `matplotlib.tri.Triangulation`
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`
+#    - `matplotlib.axes.Axes.legend` / `matplotlib.pyplot.legend`
+#    - `matplotlib.contour.ContourSet.legend_elements`


### PR DESCRIPTION
## PR Summary
Addresses #19431 to add example of hatching use for tricontourf plots. I tried to follow other tri/contour examples to maintain consistency. 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [] Has pytest style unit tests (and `pytest` passes).
- [] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [] New features are documented, with examples if plot related.
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
