### PR TITLE
FIX: do not simplify path in LineCollection.get_segments

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1461,7 +1461,14 @@ class LineCollection(Collection):
         segments = []
 
         for path in self._paths:
-            vertices = [vertex for vertex, _ in path.iter_segments()]
+            vertices = [
+                vertex
+                for vertex, _
+                # Never simplify here, we want to get the data-space values
+                # back and there in no way to know the "right" simplification
+                # threshold so never try.
+                in path.iter_segments(simplify=False)
+            ]
             vertices = np.asarray(vertices)
             segments.append(vertices)
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1039,3 +1039,12 @@ def test_quadmesh_cursor_data():
         x, y = ax.transData.transform([-1, 101])
         event = MouseEvent('motion_notify_event', fig.canvas, x, y)
         assert qm.get_cursor_data(event) is None
+
+
+def test_get_segments():
+    segments = np.tile(np.linspace(0, 1, 256), (2, 1)).T
+    lc = LineCollection([segments])
+
+    readback, = lc.get_segments()
+    # these should comeback un-changed!
+    assert np.all(segments == readback)


### PR DESCRIPTION
## PR Summary

Internally all Collection flavors boil down to calling
renderer.draw_path_collection and the sub-classes primarily provide nicer
user-facing APIs to fabricate the paths that will be passed down to the
renderer.

In LineCollection rather than tracking both the user supplied data and the
internal Path objects, we just keep the Path objects and re-extract segments on
demand.

To do this we use Path.iter_segments with defaults to asking the path if it
should simplify the path (that is drop points that do not matter which is in
turn defined by if the deflection away from "straight" is greater than some
threshold). The Path objects we are holding have values in data-space, but the
default value of "what is the threshold for 'not mattering'" is tuned to make
sense in to pixel space (1/9).  By passing `simplify=False` to `iter_segments`
we over-ride the Path object's notion of if it should be simplified (which by
default is controlled by the simplify
threshold (rcParams['path.simplify_threshold']), rcParams['path.simplify'] ,
how long the path is, and if there are any quadratic or Bézier codes in the
path) to never simplify.

In this application we never want to simplify because we do not know enough of
the context when this is called to know what the "right" simplification
threshold is and because we expect `set_segments` and `get_segments` to
round-trip.

closes #20551


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
